### PR TITLE
Fix typo in bypassuac_fodhelper.rb

### DIFF
--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     handler(client)
 
-    print_status('Cleaining up registry keys ...')
+    print_status('Cleaning up registry keys ...')
     unless exist_delegate
       registry_deleteval(FODHELPER_WRITE_KEY, EXEC_REG_DELEGATE_VAL, registry_view)
     end


### PR DESCRIPTION
Fix little typo in bypassuac_fodhelper.rb inside a print.