### PR TITLE
Adds network capture decryption support to http scanners

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -334,6 +334,7 @@ module Metasploit
           rport = opts['rport'] || port
           cli_ssl = opts['ssl'] || ssl
           cli_ssl_version = opts['ssl_version'] || ssl_version
+          cli_sslkeylogfile = opts['SSLKeyLogFile'] || sslkeylogfile
           cli_proxies = opts['proxies'] || proxies
           username = opts['credential'] ? opts['credential'].public : http_username
           password = opts['credential'] ? opts['credential'].private : http_password
@@ -357,7 +358,8 @@ module Metasploit
             username,
             password,
             kerberos_authenticator: kerberos_authenticator,
-            subscriber: http_logger_subscriber
+            subscriber: http_logger_subscriber,
+            sslkeylogfile: cli_sslkeylogfile
           )
           configure_http_client(cli)
 

--- a/lib/metasploit/framework/login_scanner/rex_socket.rb
+++ b/lib/metasploit/framework/login_scanner/rex_socket.rb
@@ -21,6 +21,9 @@ module Metasploit
           # @!attribute ssl_verify_mode
           #   @return [String] the SSL certification verification mechanism
           attr_accessor :ssl_verify_mode
+          # @!attribute sslkeylogfile
+          #   @return [String, nil] The SSL key log file path
+          attr_accessor :sslkeylogfile
           # @!attribute ssl_cipher
           #   @return [String] The SSL cipher to use for the context
           attr_accessor :ssl_cipher

--- a/lib/msf/core/auxiliary/login_scanner.rb
+++ b/lib/msf/core/auxiliary/login_scanner.rb
@@ -20,6 +20,7 @@ module Msf
           proxies: datastore['Proxies'],
           stop_on_success: datastore['STOP_ON_SUCCESS'],
           bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+          sslkeylogfile: datastore['SSLKeyLogFile'],
           framework: framework,
           framework_module: self,
           local_port: datastore['CPORT'],

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -184,7 +184,7 @@ module Rex
             'Context' => context,
             'SSL' => ssl,
             'SSLVersion' => ssl_version,
-            'SSLKeyLogFile' => sslkeylogfile,
+            'SSLKeyLogFile' => config['SSLKeyLogFile'] || sslkeylogfile,
             'Proxies' => proxies,
             'Timeout' => timeout,
             'Comm' => comm


### PR DESCRIPTION
This pull request adds enhanced support for network capture decryption for http scanner modules. By writing to the `sslkeylogfile` it enables network capture decryption which is useful to decrypt TLS traffic in Wireshark.

This is a follow on to https://github.com/rapid7/metasploit-framework/pull/20024 and https://github.com/rapid7/rex-socket/pull/74. 

## Verification

- [ ] Start `msfconsole`
- [ ] Test the changes against some `scanner/http/*` modules.
- [ ] The modules should complete
- [ ] Run `ls -la` and you should now see a file called `sslkeylogfile.txt`
- [ ] Code changes are sane