### PR TITLE
modules/post/android: Resolve RuboCop violations

### DIFF
--- a/modules/post/android/capture/screen.rb
+++ b/modules/post/android/capture/screen.rb
@@ -18,7 +18,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'timwr' ],
         'Platform' => [ 'android' ],
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/android/gather/sub_info.rb
+++ b/modules/post/android/gather/sub_info.rb
@@ -13,26 +13,26 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        {
-          'Name' => 'extracts subscriber info from target device',
-          'Description' => %q{
-            This module displays the subscriber info stored on the target phone.
-            It uses call service to get values of each transaction code like imei etc.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => ['Auxilus'],
-          'SessionTypes' => [ 'meterpreter', 'shell' ],
-          'Platform' => 'android'
+        'Name' => 'Extract Subscriber Info',
+        'Description' => %q{
+          This module displays the subscriber info stored on the target phone.
+          It uses call service to get values of each transaction code like IMEI, etc.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Auxilus'],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Platform' => 'android',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
         }
       )
     )
   end
 
   def run
-    unless is_root?
-      print_error('This module requires root permissions.')
-      return
-    end
+    fail_with(Failure::NoAccess, 'This module requires root permissions.') unless is_root?
 
     @transaction_codes ||= [
       'DeviceId',
@@ -65,12 +65,10 @@ class MetasploitModule < Msf::Post
       'IsimChallengeResponse',
       'IccSimChallengeResponse'
     ]
-    values ||= []
     arr ||= []
     for code in 1..@transaction_codes.length do
       print_status("using code : #{code}")
-      cmd = "service call iphonesubinfo #{code}"
-      block = cmd_exec(cmd)
+      block = cmd_exec("service call iphonesubinfo #{code}")
       value, tc = get_val(block, code)
       arr << [tc, value]
     end

--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -13,35 +13,38 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        {
-          'Name' => 'Android Settings Remove Device Locks (4.0-4.3)',
-          'Description' => %q{
-            This module exploits a bug in the Android 4.0 to 4.3 com.android.settings.ChooseLockGeneric class.
-            Any unprivileged app can exploit this vulnerability to remove the lockscreen.
-            A logic flaw / design error exists in the settings application that allows an Intent from any
-            application to clear the screen lock. The user may see that the Settings application has crashed,
-            and the phone can then be unlocked by a swipe.
-            This vulnerability was patched in Android 4.4.
-          },
-          'License' => MSF_LICENSE,
-          'Author' => [
-            'CureSec', # discovery
-            'timwr' # metasploit module
-          ],
-          'References' => [
-            [ 'CVE', '2013-6271' ],
-            [ 'URL', 'http://blog.curesec.com/article/blog/26.html' ],
-            [ 'URL', 'http://www.curesec.com/data/advisories/Curesec-2013-1011.pdf' ]
-          ],
-          'SessionTypes' => [ 'meterpreter', 'shell' ],
-          'Platform' => 'android',
-          'DisclosureDate' => '2013-10-11',
-          'Compat' => {
-            'Meterpreter' => {
-              'Commands' => %w[
-                android_*
-              ]
-            }
+        'Name' => 'Android Settings Remove Device Locks (4.0-4.3)',
+        'Description' => %q{
+          This module exploits a bug in the Android 4.0 to 4.3 com.android.settings.ChooseLockGeneric class.
+          Any unprivileged app can exploit this vulnerability to remove the lockscreen.
+          A logic flaw / design error exists in the settings application that allows an Intent from any
+          application to clear the screen lock. The user may see that the Settings application has crashed,
+          and the phone can then be unlocked by a swipe.
+          This vulnerability was patched in Android 4.4.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'CureSec', # discovery
+          'timwr' # metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2013-6271' ],
+          [ 'URL', 'http://blog.curesec.com/article/blog/26.html' ],
+          [ 'URL', 'http://www.curesec.com/data/advisories/Curesec-2013-1011.pdf' ]
+        ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Platform' => 'android',
+        'DisclosureDate' => '2013-10-11',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [CONFIG_CHANGES, SCREEN_EFFECTS],
+          'Reliability' => []
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              android_*
+            ]
           }
         }
       )

--- a/modules/post/android/manage/remove_lock_root.rb
+++ b/modules/post/android/manage/remove_lock_root.rb
@@ -11,28 +11,28 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        {
-          'Name' => 'Android Root Remove Device Locks (root)',
-          'Description' => %q{
-            This module uses root privileges to remove the device lock.
-            In some cases the original lock method will still be present but any key/gesture will
-            unlock the device.
-          },
-          'Privileged' => true,
-          'License' => MSF_LICENSE,
-          'Author' => [ 'timwr' ],
-          'SessionTypes' => [ 'meterpreter', 'shell' ],
-          'Platform' => 'android'
+        'Name' => 'Android Root Remove Device Locks (root)',
+        'Description' => %q{
+          This module uses root privileges to remove the device lock.
+          In some cases the original lock method will still be present but any key/gesture will
+          unlock the device.
+        },
+        'Privileged' => true,
+        'License' => MSF_LICENSE,
+        'Author' => [ 'timwr' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Platform' => 'android',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES, SCREEN_EFFECTS],
+          'Reliability' => []
         }
       )
     )
   end
 
   def run
-    unless is_root?
-      print_error('This module requires root permissions.')
-      return
-    end
+    fail_with(Failure::NoAccess, 'This module requires root permissions.') unless is_root?
 
     %w[
       /data/system/password.key


### PR DESCRIPTION
Resolve RuboCop violations and add notes.

In `hashdump`, a `return` is replaced with `next`. Use of `return` was a violation. Based on the surrounding code, the error was non-fatal, thus `next` is acceptable.

Two modules were renamed to ensure consistent capitalisation and grammar in line with existing modules.

* `extracts subscriber info from target device` -> `Extract Subscriber Info`
* `Displays wireless SSIDs and PSKs` -> `Gather Wireless SSIDs and PSKs`
