### PR TITLE
modules/post/windows/gather/credentials: Resolve RuboCop violations

### DIFF
--- a/modules/post/windows/gather/credentials/adi_irc.rb
+++ b/modules/post/windows/gather/credentials/adi_irc.rb
@@ -4,7 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -53,7 +52,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored on AdiIRC Client in a windows remote host.
+          This module searches for credentials stored on AdiIRC Client in a windows remote host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -94,6 +93,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/aim.rb
+++ b/modules/post/windows/gather/credentials/aim.rb
@@ -1,12 +1,9 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -79,7 +76,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Aim credentials on a windows remote host.
+          This module searches for Aim credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -124,6 +121,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/avira_password.rb
+++ b/modules/post/windows/gather/credentials/avira_password.rb
@@ -19,6 +19,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'Robert Kugler / robertchrk'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -35,8 +40,9 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    print_status('Checking default location...')
-    check_programdata('C:\\ProgramData\\Avira\\Antivirus\\CONFIG\\AVWIN.INI')
+    path = 'C:\\ProgramData\\Avira\\Antivirus\\CONFIG\\AVWIN.INI'
+    print_status("Checking default location (#{path}) ...")
+    check_programdata(path)
   end
 
   def check_programdata(path)

--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -22,6 +22,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'juan vazquez'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/carotdav_ftp.rb
+++ b/modules/post/windows/gather/credentials/carotdav_ftp.rb
@@ -4,7 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -45,7 +44,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored on CarotDAV FTP Client in a windows remote host.
+          This module searches for credentials stored on CarotDAV FTP Client in a windows remote host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -86,6 +85,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/chrome.rb
+++ b/modules/post/windows/gather/credentials/chrome.rb
@@ -1,16 +1,12 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
-
   include Msf::Exploit::Deprecated
 
   deprecated nil, 'The post/windows/gather/enum_browsers module now supersedes this module'
@@ -97,7 +93,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored on Chrome in a windows remote host.
+          This module searches for credentials stored on Chrome in a windows remote host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -142,6 +138,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/comodo.rb
+++ b/modules/post/windows/gather/credentials/comodo.rb
@@ -1,15 +1,13 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+
   ARTIFACTS =
     {
       application: 'comodo',
@@ -127,7 +125,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored in Comodo on a windows remote host.
+          This module searches for credentials stored in Comodo on a remote Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -153,9 +151,12 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
-                                                          k[:filetypes]
-                                                        end.uniq.unshift('All')
+          false,
+          'Type of artifacts to collect',
+          'All',
+          ARTIFACTS[:gatherable_artifacts].map do |k|
+            k[:filetypes]
+          end.uniq.unshift('All')
         ])
       ]
     )
@@ -172,6 +173,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status('PackRat credential sweep completed')
   end
 end

--- a/modules/post/windows/gather/credentials/coolnovo.rb
+++ b/modules/post/windows/gather/credentials/coolnovo.rb
@@ -1,12 +1,9 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -48,6 +45,7 @@ class MetasploitModule < Msf::Post
 
       ]
     }.freeze
+
   def initialize(info = {})
     super(
       update_info(
@@ -57,7 +55,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Coolnovo credentials on a windows remote host.
+          This module searches for Coolnovo credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -102,6 +100,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/coreftp.rb
+++ b/modules/post/windows/gather/credentials/coreftp.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -81,7 +86,7 @@ class MetasploitModule < Msf::Post
 
           # Merge in the service data and create our Login
           login_data.merge!(service_data)
-          login = create_credential_login(login_data)
+          create_credential_login(login_data)
         end
       rescue StandardError
         print_error("Cannot Access User SID: #{hive['HKU']}")

--- a/modules/post/windows/gather/credentials/digsby.rb
+++ b/modules/post/windows/gather/credentials/digsby.rb
@@ -1,12 +1,9 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -43,6 +40,7 @@ class MetasploitModule < Msf::Post
         }
       ]
     }.freeze
+
   def initialize(info = {})
     super(
       update_info(
@@ -52,7 +50,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Digsby credentials on a windows remote host.
+          This module searches for Digsby credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -97,6 +95,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -28,6 +28,11 @@ class MetasploitModule < Msf::Post
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -114,7 +119,7 @@ class MetasploitModule < Msf::Post
   end
 
   def ntdsutil_method
-    tmp_path = "#{get_env('%WINDIR%')}\\Temp\\#{Rex::Text.rand_text_alpha((rand(8) + 6))}"
+    tmp_path = "#{get_env('%WINDIR%')}\\Temp\\#{Rex::Text.rand_text_alpha(6..13)}"
     command_arguments = "\"activate instance ntds\" \"ifm\" \"Create Full #{tmp_path}\" quit quit"
     result = cmd_exec('ntdsutil.exe', command_arguments, 90)
     if result.include? 'IFM media created successfully'
@@ -195,7 +200,7 @@ class MetasploitModule < Msf::Post
     print_status "Getting Details of ShadowCopy #{id}"
     sc_details = get_sc_details(id)
     sc_path = "#{sc_details['DeviceObject']}\\#{location}\\ntds.dit"
-    target_path = "#{get_env('%WINDIR%')}\\Temp\\#{Rex::Text.rand_text_alpha((rand(8) + 6))}"
+    target_path = "#{get_env('%WINDIR%')}\\Temp\\#{Rex::Text.rand_text_alpha(6..13)}"
     print_status "Moving ntds.dit to #{target_path}"
     move_file(sc_path, target_path)
     target_path

--- a/modules/post/windows/gather/credentials/dynazip_log.rb
+++ b/modules/post/windows/gather/credentials/dynazip_log.rb
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Post
         ],
         'DisclosureDate' => '2001-03-27',
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter', 'shell']
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/enum_laps.rb
+++ b/modules/post/windows/gather/credentials/enum_laps.rb
@@ -31,6 +31,11 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -24,6 +24,11 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -134,12 +139,12 @@ class MetasploitModule < Msf::Post
     else
       print_status('No Picasa credentials found.')
     end
-  rescue ::Exception => e
+  rescue StandardError => e
     print_error("An error has occurred: #{e}")
   end
 
   def run
-    uid = session.sys.config.getuid  # Decryption only works in context of user's account.
+    uid = session.sys.config.getuid # Decryption only works in context of user's account.
 
     if is_system?
       print_error("This module is running under #{uid}.")

--- a/modules/post/windows/gather/credentials/epo_sql.rb
+++ b/modules/post/windows/gather/credentials/epo_sql.rb
@@ -23,6 +23,11 @@ class MetasploitModule < Msf::Post
         'Author' => ['Nathan Einwechter <neinwechter[at]gmail.com>'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -21,6 +21,11 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -50,7 +55,7 @@ class MetasploitModule < Msf::Post
 
     progfiles_env = session.sys.config.getenvs('ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432')
     locations = []
-    progfiles_env.each do |_k, v|
+    progfiles_env.each_value do |v|
       next if v.blank?
 
       locations << v + '\\FileZilla Server\\'
@@ -81,7 +86,7 @@ class MetasploitModule < Msf::Post
     paths = []
     begin
       locations.each do |location|
-        print_status("Checking for Filezilla Server directory in: #{location}")
+        print_status("Checking for FileZilla Server directory in: #{location}")
         begin
           session.fs.dir.foreach(location.to_s) do |fdir|
             ['FileZilla Server.xml', 'FileZilla Server Interface.xml'].each do |xmlfile|
@@ -96,7 +101,7 @@ class MetasploitModule < Msf::Post
           vprint_error(e.message)
         end
       end
-    rescue ::Exception => e
+    rescue StandardError => e
       print_error(e.to_s)
       return
     end
@@ -193,8 +198,6 @@ class MetasploitModule < Msf::Post
     creds.each do |cred|
       credentials << [cred['host'], cred['port'], cred['user'], cred['password'], cred['ssl']]
 
-      session.db_record ? (source_id = session.db_record.id) : (source_id = nil)
-
       service_data = {
         address: session.session_host,
         port: config['ftp_port'],
@@ -235,8 +238,6 @@ class MetasploitModule < Msf::Post
         perm['dirsubdirs'], perm['autocreate'], perm['home']
       ]
     end
-
-    session.db_record ? (source_id = session.db_record.id) : (source_id = nil)
 
     # report the goods!
     if config['admin_pass'] == '<none>'

--- a/modules/post/windows/gather/credentials/flashfxp.rb
+++ b/modules/post/windows/gather/credentials/flashfxp.rb
@@ -21,6 +21,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/flock.rb
+++ b/modules/post/windows/gather/credentials/flock.rb
@@ -1,12 +1,9 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -74,7 +71,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored in Flock on a windows remote host.
+          This module searches for credentials stored in Flock on a remote Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -119,6 +116,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/ftpnavigator.rb
+++ b/modules/post/windows/gather/credentials/ftpnavigator.rb
@@ -20,6 +20,11 @@ class MetasploitModule < Msf::Post
         'Author' => ['theLightCosine'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/ftpx.rb
+++ b/modules/post/windows/gather/credentials/ftpx.rb
@@ -21,6 +21,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'bcoles' ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/gadugadu.rb
+++ b/modules/post/windows/gather/credentials/gadugadu.rb
@@ -1,12 +1,9 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -54,7 +51,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Gadugadu credentials on a windows remote host. Gadu-Gadu is a Polish instant messaging client using a proprietary protocol. Gadu-Gadu was the most popular IM service in Poland.
+          This module searches for Gadugadu credentials on a Windows host. Gadu-Gadu is a Polish instant messaging client using a proprietary protocol. Gadu-Gadu was the most popular IM service in Poland.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -99,6 +96,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/halloy_irc.rb
+++ b/modules/post/windows/gather/credentials/halloy_irc.rb
@@ -3,7 +3,6 @@
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -44,7 +43,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored on Halloy IRC Client in a windows remote host.
+          This module searches for credentials stored on Halloy IRC Client in a windows remote host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -85,6 +84,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/heidisql.rb
+++ b/modules/post/windows/gather/credentials/heidisql.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['h0ng10'],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -114,7 +119,7 @@ class MetasploitModule < Msf::Post
 
           # Merge in the service data and create our Login
           login_data.merge!(service_data)
-          login = create_credential_login(login_data)
+          create_credential_login(login_data)
 
           # if we have a MySQL via SSH connection, we need to store the SSH credentials as well
           next unless db_type == 2
@@ -151,7 +156,7 @@ class MetasploitModule < Msf::Post
 
           # Merge in the service data and create our Login
           login_data.merge!(service_data)
-          login = create_credential_login(login_data)
+          create_credential_login(login_data)
         end
       rescue ::Rex::Post::Meterpreter::RequestError => e
         elog(e)

--- a/modules/post/windows/gather/credentials/icq.rb
+++ b/modules/post/windows/gather/credentials/icq.rb
@@ -1,12 +1,9 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -79,7 +76,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for ICQ credentials on a windows remote host.
+          This module searches for ICQ credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -124,6 +121,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/idm.rb
+++ b/modules/post/windows/gather/credentials/idm.rb
@@ -25,7 +25,12 @@ class MetasploitModule < Msf::Post
           'Unknown', # SecurityXploded Team, www.SecurityXploded.com
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -43,16 +48,17 @@ class MetasploitModule < Msf::Post
     )
 
     registry_enumkeys('HKU').each do |k|
-      next unless k.include? 'S-1-5-21'
-      next if k.include? '_Classes'
+      next unless k.include?('S-1-5-21')
+      next if k.include?('_Classes')
 
       print_status("Looking at Key #{k}")
 
       begin
         subkeys = registry_enumkeys("HKU\\#{k}\\Software\\DownloadManager\\Passwords\\")
+
         if subkeys.nil? || subkeys.empty?
           print_status('IDM not installed for this user.')
-          return
+          next
         end
 
         subkeys.each do |site|
@@ -75,7 +81,7 @@ class MetasploitModule < Msf::Post
           'Internet Download Manager User Credentials'
         )
         print_good("IDM user credentials saved in: #{path}")
-      rescue ::Exception => e
+      rescue StandardError => e
         print_error("An error has occurred: #{e}")
       end
     end

--- a/modules/post/windows/gather/credentials/ie.rb
+++ b/modules/post/windows/gather/credentials/ie.rb
@@ -1,12 +1,9 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -35,7 +32,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for ie credentials on a windows remote host.
+          This module searches for ie credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -80,6 +77,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/imail.rb
+++ b/modules/post/windows/gather/credentials/imail.rb
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Post
           ['EDB', '11331'],
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/windows/gather/credentials/imvu.rb
+++ b/modules/post/windows/gather/credentials/imvu.rb
@@ -24,12 +24,19 @@ class MetasploitModule < Msf::Post
         ],
         'License' => MSF_LICENSE,
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
 
   def run
+    fail_with(Failure::BadConfig, 'Only meterpreter sessions are supported by this module') unless session.type == 'meterpreter'
+
     creds = Rex::Text::Table.new(
       'Header' => 'IMVU Credentials',
       'Indent' => 1,

--- a/modules/post/windows/gather/credentials/incredimail.rb
+++ b/modules/post/windows/gather/credentials/incredimail.rb
@@ -1,48 +1,46 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-ARTIFACTS =
-  {
-    application: 'incredimail',
-    app_category: 'emails',
-    gatherable_artifacts: [
-      {
-        filetypes: 'email_logs',
-        path: 'LocalAppData',
-        dir: 'IM',
-        artifact_file_name: 'msg.iml',
-        description: 'IncrediMail sent and received emails',
-        credential_type: 'text',
-        regex_search: [
-          {
-            extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
-            extraction_type: 'credentials',
-            regex: [
-              '(?i-mx:password.*)',
-              '(?i-mx:username.*)'
-            ]
-          },
-          {
-            extraction_description: 'searches for Email TO/FROM address',
-            extraction_type: 'Email addresses',
-            regex: [
-              '(?i-mx:to:.*)',
-              '(?i-mx:from:.*)'
-            ]
-          }
-        ]
-      }
-    ]
-  }.freeze
-
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
+
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+
+  ARTIFACTS =
+    {
+      application: 'incredimail',
+      app_category: 'emails',
+      gatherable_artifacts: [
+        {
+          filetypes: 'email_logs',
+          path: 'LocalAppData',
+          dir: 'IM',
+          artifact_file_name: 'msg.iml',
+          description: 'IncrediMail sent and received emails',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
     super(
@@ -53,7 +51,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Incredimail credentials on a windows remote host.
+          This module searches for Incredimail credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -98,6 +96,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/kakaotalk.rb
+++ b/modules/post/windows/gather/credentials/kakaotalk.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -50,7 +49,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for KakaoTalk credentials on a windows remote host. KakaoTalk is a popular mobile messaging app most widely used in South Korea.
+          This module searches for KakaoTalk credentials on a Windows host. KakaoTalk is a popular mobile messaging app most widely used in South Korea.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -91,6 +90,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/kmeleon.rb
+++ b/modules/post/windows/gather/credentials/kmeleon.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -110,7 +109,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for K-meleon credentials on a windows remote host.
+          This module searches for K-meleon credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -151,6 +150,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/line.rb
+++ b/modules/post/windows/gather/credentials/line.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -83,7 +82,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials in LINE desktop application on a windows remote host. LINE is the most popular Instant Messenger app in Japan.
+          This module searches for credentials in LINE desktop application on a remote Windows host. LINE is the most popular Instant Messenger app in Japan.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -124,6 +123,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/maxthon.rb
+++ b/modules/post/windows/gather/credentials/maxthon.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -53,7 +52,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Maxthon credentials on a windows remote host.
+          This module searches for Maxthon credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -94,6 +93,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/mcafee_vse_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mcafee_vse_hashdump.rb
@@ -34,13 +34,19 @@ class MetasploitModule < Msf::Post
           ['URL', 'https://www.dionach.com/blog/disabling-mcafee-on-access-scanning']
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
 
   def run
-    print_status("Looking for McAfee VSE password hashes on #{sysinfo['Computer']} ...")
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Looking for McAfee VSE password hashes on #{hostname} (#{session.session_host}) ...")
 
     vse_keys = enum_vse_keys
     if vse_keys.empty?

--- a/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
+++ b/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
       update_info(
         info,
         'Name' => 'Windows Gather MDaemonEmailServer Credential Cracking',
-        'Description' => 'Finds and cracks the stored passwords of MDaemon Email Server',
+        'Description' => 'Finds and cracks the stored passwords of MDaemon Email Server.',
         'References' => [
           ['BID', '4686']
         ],
@@ -22,6 +22,11 @@ class MetasploitModule < Msf::Post
         'Platform' => ['win'],
         'Arch' => [ARCH_X86, ARCH_X64],
         'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -55,7 +60,7 @@ class MetasploitModule < Msf::Post
 
     progfiles_env = session.sys.config.getenvs('SYSTEMDRIVE', 'HOMEDRIVE', 'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432')
     locations = ['C:\MDaemon\App']
-    progfiles_env.each do |_k, v|
+    progfiles_env.each_value do |v|
       vprint_status("Searching MDaemon installation at #{v}")
       if session.fs.dir.entries(v).include? 'MDaemon'
         vprint_status("Found MDaemon installation at #{v}")

--- a/modules/post/windows/gather/credentials/miranda.rb
+++ b/modules/post/windows/gather/credentials/miranda.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -53,7 +52,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Miranda credentials on a windows remote host.
+          This module searches for Miranda credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -94,6 +93,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, module_info['artifacts'])
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/mremote.rb
+++ b/modules/post/windows/gather/credentials/mremote.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Post
           'mubix' # Helped write the Decryption Routine
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -48,18 +53,16 @@ class MetasploitModule < Msf::Post
 
   def get_xml(path)
     print_status("Looking for #{path}")
-    begin
-      if file_exist?(path)
-        condata = read_file(path)
-        loot_path = store_loot('mremote.creds', 'text/xml', session, condata, path)
-        vprint_good("confCons.xml saved to #{loot_path}")
-        parse_xml(condata)
-        print_status("Finished processing #{path}")
-      end
-    rescue Rex::Post::Meterpreter::RequestError
-      print_status("The file #{path} either could not be read or does not exist")
-      return
-    end
+
+    return unless file_exist?(path)
+
+    condata = read_file(path)
+    loot_path = store_loot('mremote.creds', 'text/xml', session, condata, path)
+    vprint_good("confCons.xml saved to #{loot_path}")
+    parse_xml(condata)
+    print_status("Finished processing #{path}")
+  rescue Rex::Post::Meterpreter::RequestError
+    print_status("The file #{path} either could not be read or does not exist")
   end
 
   def parse_xml(data)

--- a/modules/post/windows/gather/credentials/mssql_local_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mssql_local_hashdump.rb
@@ -27,6 +27,11 @@ class MetasploitModule < Msf::Post
         'References' => [
           ['URL', 'https://www.dionach.com/blog/easily-grabbing-microsoft-sql-server-password-hashes']
         ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -45,11 +50,11 @@ class MetasploitModule < Msf::Post
   end
 
   def run
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
+
     # Set instance name (if specified)
     instance = datastore['INSTANCE'].to_s
-
-    # Display target
-    print_status("Running module against #{sysinfo['Computer']}")
 
     # Identify available native SQL client
     get_sql_client

--- a/modules/post/windows/gather/credentials/nimbuzz.rb
+++ b/modules/post/windows/gather/credentials/nimbuzz.rb
@@ -22,7 +22,12 @@ class MetasploitModule < Msf::Post
           'Unknown', # SecurityXploded Team, www.SecurityXploded.com
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -39,15 +44,15 @@ class MetasploitModule < Msf::Post
     )
 
     registry_enumkeys('HKU').each do |k|
-      next unless k.include? 'S-1-5-21'
-      next if k.include? '_Classes'
+      next unless k.include?('S-1-5-21')
+      next if k.include?('_Classes')
 
       vprint_status("Looking at Key #{k}")
       subkeys = registry_enumkeys("HKU\\#{k}\\Software\\Nimbuzz\\")
 
       if subkeys.nil? || (subkeys == '')
         print_status('Nimbuzz Instant Messenger not installed for this user.')
-        return
+        next
       end
 
       user = registry_getvaldata("HKU\\#{k}\\Software\\Nimbuzz\\PCClient\\Application\\", 'Username') || ''

--- a/modules/post/windows/gather/credentials/opera.rb
+++ b/modules/post/windows/gather/credentials/opera.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -103,7 +102,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Opera credentials on a windows remote host.
+          This module searches for Opera credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -144,6 +143,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/operamail.rb
+++ b/modules/post/windows/gather/credentials/operamail.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -78,7 +77,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Operamail credentials on a windows remote host.
+          This module searches for Operamail credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -119,6 +118,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -27,6 +27,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'Justin Cacak' ], # Updated to work with newer versions of Outlook (2013, 2016, Office 365)
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/postbox.rb
+++ b/modules/post/windows/gather/credentials/postbox.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -312,7 +311,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Postbox credentials on a windows remote host.
+          This module searches for Postbox credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -353,6 +352,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/qq.rb
+++ b/modules/post/windows/gather/credentials/qq.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -35,7 +34,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for QQ credentials on a windows remote host.
+          This module searches for QQ credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -76,6 +75,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/quassel_irc.rb
+++ b/modules/post/windows/gather/credentials/quassel_irc.rb
@@ -4,7 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -49,7 +48,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored on Quassel IRC Client in a windows remote host.
+          This module searches for credentials stored on Quassel IRC Client in a windows remote host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -90,6 +89,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/razer_synapse.rb
+++ b/modules/post/windows/gather/credentials/razer_synapse.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://github.com/pasv/Testing/blob/master/Razer_decode.py' ]
         ],
         'SessionTypes' => [ 'meterpreter' ],
-        'Platform' => [ 'win' ]
+        'Platform' => [ 'win' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/razorsql.rb
+++ b/modules/post/windows/gather/credentials/razorsql.rb
@@ -26,6 +26,11 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/rdc_manager_creds.rb
+++ b/modules/post/windows/gather/credentials/rdc_manager_creds.rb
@@ -32,6 +32,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'Tom Sellers <tom[at]fadedcode.net>'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/redis_desktop_manager.rb
+++ b/modules/post/windows/gather/credentials/redis_desktop_manager.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -47,7 +46,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for RedisDesktopManager credentials on a windows remote host.
+          This module searches for RedisDesktopManager credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'References' => [
@@ -88,6 +87,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/safari.rb
+++ b/modules/post/windows/gather/credentials/safari.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -68,7 +67,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for safari credentials on a windows remote host.
+          This module searches for safari credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -109,6 +108,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/seamonkey.rb
+++ b/modules/post/windows/gather/credentials/seamonkey.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -122,7 +121,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for seamonkey credentials on a windows remote host.
+          This module searches for seamonkey credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -163,6 +162,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/skype.rb
+++ b/modules/post/windows/gather/credentials/skype.rb
@@ -33,6 +33,11 @@ class MetasploitModule < Msf::Post
           ['URL', 'https://web.archive.org/web/20140207115406/http://insecurety.net/?p=427'],
           ['URL', 'https://github.com/skypeopensource/tools']
         ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -84,9 +89,9 @@ puts hash.hexdigest
       addr = Rex::Text.pack_int64le(mem)
       len = Rex::Text.pack_int64le(data.length)
       ret = session.railgun.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 16)
-      pData = ret['pDataOut'].unpack('VVVV')
-      len = pData[0] + (pData[1] << 32)
-      addr = pData[2] + (pData[3] << 32)
+      pdata = ret['pDataOut'].unpack('VVVV')
+      len = pdata[0] + (pdata[1] << 32)
+      addr = pdata[2] + (pdata[3] << 32)
     end
 
     return '' if len == 0
@@ -157,7 +162,6 @@ puts hash.hexdigest
   end
 
   def get_config_creds(salt)
-    users = []
     appdatapath = expand_path('%AppData%') + '\\Skype'
     print_status('Checking for config files in %APPDATA%')
     users = get_config_users(appdatapath)
@@ -181,7 +185,7 @@ puts hash.hexdigest
   def run
     salt = get_salt
     if !salt.nil?
-      creds = get_config_creds(salt)
+      get_config_creds(salt)
     else
       print_error 'No salt found. Cannot continue without salt, exiting'
     end

--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Post
           ['URL', 'http://www.gironsec.com/blog/tag/cracking-smartermail/']
         ],
         'Platform' => ['win'],
-        'SessionTypes' => ['meterpreter', 'shell']
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -48,7 +53,7 @@ class MetasploitModule < Msf::Post
     decipher.update(encrypted) + decipher.final
   end
 
-  def get_bound_port(data)
+  def bound_port(data)
     port = nil
 
     begin
@@ -61,16 +66,16 @@ class MetasploitModule < Msf::Post
     port
   end
 
-  def get_remote_drive
-    @drive ||= expand_path('%SystemDrive%').strip
+  def system_drive
+    @system_drive ||= expand_path('%SystemDrive%').strip
   end
 
-  def get_web_server_port
+  def web_server_port
     ['Program Files (x86)', 'Program Files'].each do |program_dir|
-      path = %(#{get_remote_drive}\\#{program_dir}\\SmarterTools\\SmarterMail\\Web Server\\Settings.json).strip
+      path = %(#{system_drive}\\#{program_dir}\\SmarterTools\\SmarterMail\\Web Server\\Settings.json).strip
       if file?(path)
         data = read_file(path)
-        return get_bound_port(data)
+        return bound_port(data)
       end
     end
 
@@ -80,11 +85,11 @@ class MetasploitModule < Msf::Post
   #
   # Find SmarterMail 'mailConfig.xml' config file
   #
-  def get_mail_config_path
+  def mail_config_path
     found_path = ''
 
     ['Program Files (x86)', 'Program Files'].each do |program_dir|
-      path = %(#{get_remote_drive}\\#{program_dir}\\SmarterTools\\SmarterMail\\Service\\mailConfig.xml).strip
+      path = %(#{system_drive}\\#{program_dir}\\SmarterTools\\SmarterMail\\Service\\mailConfig.xml).strip
       vprint_status "#{peer} - Checking for SmarterMail config file: #{path}"
       if file?(path)
         found_path = path
@@ -171,7 +176,7 @@ class MetasploitModule < Msf::Post
   #
   def run
     # check for SmartMail config file
-    config_path = get_mail_config_path
+    config_path = mail_config_path
     if config_path.blank?
       print_error "#{peer} - Could not find SmarterMail config file"
       return
@@ -185,7 +190,7 @@ class MetasploitModule < Msf::Post
     end
 
     # report result
-    port = get_web_server_port || 9998 # Default is 9998
+    port = web_server_port || 9998 # Default is 9998
     user = result[:username]
     pass = result[:password]
     type = result[:private_type]

--- a/modules/post/windows/gather/credentials/smartftp.rb
+++ b/modules/post/windows/gather/credentials/smartftp.rb
@@ -23,6 +23,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -113,11 +118,7 @@ class MetasploitModule < Msf::Post
       pass = decrypt(epassword)
 
       print_good("HOST: #{host} PORT: #{port} USER: #{user} PASS: #{pass}")
-      if session.db_record
-        source_id = session.db_record.id
-      else
-        source_id = nil
-      end
+
       service_data = {
         address: host,
         port: port,
@@ -144,7 +145,7 @@ class MetasploitModule < Msf::Post
       }
 
       login_data.merge!(service_data)
-      login = create_credential_login(login_data)
+      create_credential_login(login_data)
     end
   end
 
@@ -161,12 +162,12 @@ class MetasploitModule < Msf::Post
 
     acquirecontext = advapi32.CryptAcquireContextW(4, nil, ms_enhanced_prov, prov_rsa_full, crypt_verify_context)
     createhash = advapi32.CryptCreateHash(acquirecontext['phProv'], alg_md5, 0, 0, 4)
-    hashdata = advapi32.CryptHashData(createhash['phHash'], 'SmartFTP', 16, 0)
+    # hashdata = advapi32.CryptHashData(createhash['phHash'], 'SmartFTP', 16, 0)
     derivekey = advapi32.CryptDeriveKey(acquirecontext['phProv'], alg_rc4, createhash['phHash'], 0x00800000, 4)
     decrypted = advapi32.CryptDecrypt(derivekey['phKey'], 0, true, 0, cipher, cipher.length)
-    destroyhash = advapi32.CryptDestroyHash(createhash['phHash'])
-    destroykey = advapi32.CryptDestroyKey(derivekey['phKey'])
-    releasecontext = advapi32.CryptReleaseContext(acquirecontext['phProv'], 0)
+    # destroyhash = advapi32.CryptDestroyHash(createhash['phHash'])
+    # destroykey = advapi32.CryptDestroyKey(derivekey['phKey'])
+    # releasecontext = advapi32.CryptReleaseContext(acquirecontext['phProv'], 0)
 
     data = decrypted['pbData']
     data.gsub!(/\x00/, '')

--- a/modules/post/windows/gather/credentials/spark_im.rb
+++ b/modules/post/windows/gather/credentials/spark_im.rb
@@ -27,6 +27,11 @@ class MetasploitModule < Msf::Post
         'References' => [
           [ 'URL', 'http://adamcaudill.com/2012/07/27/decrypting-spark-saved-passwords/']
         ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -107,7 +112,6 @@ class MetasploitModule < Msf::Post
     create_credential_login(login_data)
   end
 
-  # main control method
   def run
     grab_user_profiles.each do |user|
       next if user['AppData'].nil?
@@ -129,12 +133,12 @@ class MetasploitModule < Msf::Post
 
       # look for lines containing string 'password'
       password = contents.split("\n").grep(/password/)
-      if password.nil?
+      if password.blank?
         # file doesn't contain a password
         print_status("#{file} does not contain any saved passwords")
         # close file and return
         config.close
-        return
+        next
       end
 
       # store the hash close the file

--- a/modules/post/windows/gather/credentials/srware.rb
+++ b/modules/post/windows/gather/credentials/srware.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -87,7 +86,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Srware credentials on a windows remote host. SRWare Iron is a Chromium-based web browser developed by the German company SRWare.
+          This module searches for Srware credentials on a Windows host. SRWare Iron is a Chromium-based web browser developed by the German company SRWare.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -128,6 +127,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/sso.rb
+++ b/modules/post/windows/gather/credentials/sso.rb
@@ -23,6 +23,11 @@ class MetasploitModule < Msf::Post
         'Author' => ['Ben Campbell'],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -36,7 +41,7 @@ class MetasploitModule < Msf::Post
 
   def run
     if sysinfo.nil?
-      print_error('This module is only available in a windows meterpreter session.')
+      print_error('This module is only available in a Windows meterpreter session.')
       return
     end
 
@@ -52,7 +57,7 @@ class MetasploitModule < Msf::Post
       begin
         client.core.use('kiwi')
       rescue Errno::ENOENT
-        print_error('This module is only available in a windows meterpreter session.')
+        print_error('This module is only available in a Windows meterpreter session.')
         return
       end
     end
@@ -101,7 +106,7 @@ class MetasploitModule < Msf::Post
   end
 
   def report_creds(domain, user, pass)
-    return if (user.empty? || pass.empty?)
+    return if user.empty? || pass.empty?
     return if pass.include?('n.a.')
 
     # Assemble data about the credential objects we will be creating

--- a/modules/post/windows/gather/credentials/steam.rb
+++ b/modules/post/windows/gather/credentials/steam.rb
@@ -20,6 +20,11 @@ class MetasploitModule < Msf::Post
         'Author' => ['Nikolai Rusakov <nikolai.rusakov[at]gmail.com>'],
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -67,18 +72,16 @@ class MetasploitModule < Msf::Post
       if sad =~ /RememberPassword\W*"1"/
         print_status("RememberPassword is set! Accountname is #{u_rx.match(sad)[1]}")
         scd = read_file("#{path}\\#{steamconfig}")
-        steam_app_data_path = store_loot('steam.config', 'text/plain', session, sad, filename = steamappdata)
+        steam_app_data_path = store_loot('steam.config', 'text/plain', session, sad, steamappdata)
         print_good("The file SteamAppData.vdf has been stored on #{steam_app_data_path}")
-        steam_config_path = store_loot('steam.config', 'text/plain', session, scd, filename = steamconfig)
+        steam_config_path = store_loot('steam.config', 'text/plain', session, scd, steamconfig)
         print_good("The file config.vdf has been stored on #{steam_config_path}")
         print_status('Steam configs harvested successfully!')
       else
         print_error('RememberPassword is not set, exiting.')
-        return
       end
     else
       print_error('Steam configs not found.')
-      return
     end
   end
 end

--- a/modules/post/windows/gather/credentials/sylpheed.rb
+++ b/modules/post/windows/gather/credentials/sylpheed.rb
@@ -4,7 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Post
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -45,7 +44,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials stored on Sylpheed email client in a windows remote host.
+          This module searches for credentials stored on Sylpheed email client in a windows remote host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -86,6 +85,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/tango.rb
+++ b/modules/post/windows/gather/credentials/tango.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -81,7 +80,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Tango credentials on a windows remote host. Tango is a third-party, cross platform messaging application software for smartphones developed by TangoME, Inc.t
+          This module searches for Tango credentials on a Windows host. Tango is a third-party, cross platform messaging application software for smartphones developed by TangoME, Inc.t
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -122,6 +121,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/teamviewer_passwords.rb
+++ b/modules/post/windows/gather/credentials/teamviewer_passwords.rb
@@ -23,6 +23,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'Nic Losby <blurbdust[at]gmail.com>', 'Kali-Team <kali-team[at]qq.com>'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -69,7 +74,7 @@ class MetasploitModule < Msf::Post
       { value: 'LicenseKeyAES', description: 'Perpetual License Key' }, # for <= v14
     ]
 
-    keys.each do |parent_key, _child_key|
+    keys.each_key do |parent_key|
       locations.each do |location|
         secret = registry_getvaldata(parent_key, location[:value])
         next if secret.nil?

--- a/modules/post/windows/gather/credentials/thunderbird.rb
+++ b/modules/post/windows/gather/credentials/thunderbird.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -192,7 +191,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for thunderbird credentials on a windows remote host.
+          This module searches for thunderbird credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -233,6 +232,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/tlen.rb
+++ b/modules/post/windows/gather/credentials/tlen.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -60,7 +59,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Tlen credentials on a windows remote host. Tlen is a free Polish instant messaging service.
+          This module searches for Tlen credentials on a Windows host. Tlen is a free Polish instant messaging service.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -101,6 +100,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -23,6 +23,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'Justin Cacak'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -97,13 +102,6 @@ class MetasploitModule < Msf::Post
       print_status("     Username: #{http_proxy_username}")
       print_status("     Password: #{http_proxy_password}")
       print_status('')
-    end
-
-    # Report proxy creds
-    if session.db_record
-      source_id = session.db_record.id
-    else
-      source_id = nil
     end
 
     report_cred(
@@ -213,13 +211,6 @@ class MetasploitModule < Msf::Post
     print_status("     User Name: #{user_name}")
     print_status("     Password: #{password}")
     print_status('')
-
-    # Report
-    if session.db_record
-      source_id = session.db_record.id
-    else
-      source_id = nil
-    end
 
     report_cred(
       ip: ::Rex::Socket.resolv_to_dotted(host), # XXX: Workaround for unresolved hostnames

--- a/modules/post/windows/gather/credentials/total_commander.rb
+++ b/modules/post/windows/gather/credentials/total_commander.rb
@@ -22,6 +22,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -172,11 +177,6 @@ class MetasploitModule < Msf::Post
       (host, port) = host.split(':')
       port = 21 if port.nil?
       print_good("*** Host: #{host} Port: #{port} User: #{username}  Password: #{passwd} ***")
-      if session.db_record
-        source_id = session.db_record.id
-      else
-        source_id = nil
-      end
 
       report_cred(
         ip: host,
@@ -188,9 +188,9 @@ class MetasploitModule < Msf::Post
     end
   end
 
-  def seed(nMax)
+  def seed(nmax)
     @vseed = ((@vseed * 0x8088405) & 0xffffffff) + 1
-    return (((@vseed * nMax) >> 32) & 0xffffffff)
+    return (((@vseed * nmax) >> 32) & 0xffffffff)
   end
 
   def shift(n1, n2)

--- a/modules/post/windows/gather/credentials/trillian.rb
+++ b/modules/post/windows/gather/credentials/trillian.rb
@@ -24,6 +24,11 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -41,8 +46,10 @@ class MetasploitModule < Msf::Post
 
   def run
     grab_user_profiles.each do |user|
-      accounts = user['AppData'] + '\\Trillian\\users\\global\\accounts.ini'
       next if user['AppData'].nil?
+
+      accounts = user['AppData'] + '\\Trillian\\users\\global\\accounts.ini'
+
       next if accounts.empty?
 
       stat = begin
@@ -96,7 +103,7 @@ class MetasploitModule < Msf::Post
       'Trillian Instant Messenger User Credentials'
     )
     print_good("Trillian Instant Messenger user credentials saved in: #{path}")
-  rescue ::Exception => e
+  rescue StandardError => e
     print_error("An error has occurred: #{e}")
   end
 

--- a/modules/post/windows/gather/credentials/viber.rb
+++ b/modules/post/windows/gather/credentials/viber.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -51,7 +50,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for credentials in Viber desktop application on a windows remote host. Viber is a cross-platform voice over IP and instant messaging software application.
+          This module searches for credentials in Viber desktop application on a remote Windows host. Viber is a cross-platform voice over IP and instant messaging software application.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -92,6 +91,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/windows_autologin.rb
+++ b/modules/post/windows/gather/credentials/windows_autologin.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Post
         'References' => [
           [ 'URL', 'http://support.microsoft.com/kb/315231' ],
           [ 'URL', 'http://core.yehg.net/lab/#tools.exploits' ]
-        ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end

--- a/modules/post/windows/gather/credentials/windowslivemail.rb
+++ b/modules/post/windows/gather/credentials/windowslivemail.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -53,7 +52,7 @@ class MetasploitModule < Msf::Post
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Windows Live Mail credentials on a windows remote host.
+          This module searches for Windows Live Mail credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -94,6 +93,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status 'PackRat credential sweep completed'
   end
 end

--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -25,6 +25,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/wsftp_client.rb
+++ b/modules/post/windows/gather/credentials/wsftp_client.rb
@@ -21,6 +21,11 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'theLightCosine'],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        },
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[

--- a/modules/post/windows/gather/credentials/xchat.rb
+++ b/modules/post/windows/gather/credentials/xchat.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Post
 
-  # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
@@ -48,12 +47,12 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Xchat credential gatherer',
+        'Name' => 'XChat credential gatherer',
         'Description' => %q{
           PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
           PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
           Further details can be found in the module documentation.
-          This is a module that searches for Xchat credentials on a windows remote host. XChat is an IRC chat program for both Linux and Windows.
+          This module searches for Xchat credentials on a Windows host. XChat is an IRC chat program for both Linux and Windows.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -94,6 +93,6 @@ class MetasploitModule < Msf::Post
       run_packrat(userprofile, ARTIFACTS)
     end
 
-    print_status 'PackRat credential sweep Completed'
+    print_status('PackRat credential sweep completed')
   end
 end


### PR DESCRIPTION
Most violations were resolved with `rubocop -A`, except notes.

A large PR, but some trivial changes to module descriptions were applied with `sed` and are identical across many modules.

* Enhancement: Adds module notes.
* Enhancement: Updates a few module reference URLs.
* Code quality: Some manual code cleanup was performed.
* Code quality: Fixes a few typos.
* Bug fix: Several modules used `return` instead of `next` while looping through registry keys or files for each user on the system. This caused the module to bail out as soon as it encountered a user which didn't have the expected key/file, rather than continuing for the remaining users. These have been fixed:
  * modules/post/windows/gather/credentials/idm.rb
  * modules/post/windows/gather/credentials/nimbuzz.rb
  * modules/post/windows/gather/credentials/spark_im.rb
