### PR TITLE
Action run arg

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -65,6 +65,7 @@ module Exploit
 
       # Import options from the OptionStr or Option hash.
       exploit._import_extra_options(opts)
+      exploit.datastore['ACTION'] = opts['Action'] if opts['Action']
       opts['Payload'] ||= exploit.datastore['Payload']
 
       unless opts['Quiet']

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -124,6 +124,7 @@ class Exploit
       mod.options.include?('rhosts')
 
     opts = {
+      'Action'      => args[:action],
       'Encoder'     => args[:encoder] || mod_with_opts.datastore['ENCODER'],
       'Payload'     => args[:payload] || mod_with_opts.datastore['PAYLOAD'],
       'Target'      => args[:target] || mod_with_opts.datastore['TARGET'],

--- a/lib/msf/ui/console/module_argument_parsing.rb
+++ b/lib/msf/ui/console/module_argument_parsing.rb
@@ -61,7 +61,7 @@ module ModuleArgumentParsing
     help_cmd = proc do |_result|
       cmd_exploit_help
     end
-    parse_opts(@@exploit_opts, args, help_cmd: help_cmd)&.except(:action)
+    parse_opts(@@exploit_opts, args, help_cmd: help_cmd)
   end
 
   def print_module_run_or_check_usage(command:, description: nil, options: @@module_opts)
@@ -149,7 +149,11 @@ module ModuleArgumentParsing
 
         if resembles_datastore_assignment?(val)
           name, val = val.split('=', 2)
-          append_datastore_option(datastore_options, name, val)
+          if name.upcase == 'ACTION'
+            result[:action] = val
+          else
+            append_datastore_option(datastore_options, name, val)
+          end
         elsif resembles_rhost_value?(val)
           append_datastore_option(datastore_options, 'RHOSTS', val)
         else

--- a/spec/msf/ui/console/module_argument_parsing_spec.rb
+++ b/spec/msf/ui/console/module_argument_parsing_spec.rb
@@ -65,6 +65,18 @@ RSpec.shared_examples_for 'a command which parses datastore values' do |opts|
       expect(subject.send(opts[:method_name], ['-o', 'RHOSTS=192.168.172.1', '-o', 'RPORT=1337', '-o', 'rhosts=192.168.172.2'])).to include(expected_result)
     end
 
+    it 'allows setting action inline' do
+      expected_result = {
+        datastore_options: {
+          'RHOSTS' => '192.168.172.1',
+          'RPORT' => '1337',
+        }
+      }
+      expected_result[:action] = 'action-name' unless opts[:method_name] == 'parse_check_opts'
+      result = subject.send(opts[:method_name], ['RHOSTS=192.168.172.1', 'RPORT=1337', 'action=action-name'])
+      expect(result).to include(expected_result)
+    end
+
     it 'parses the option str directly into its components' do
       expected_result = {
         datastore_options: {
@@ -344,6 +356,7 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
     it 'handles no arguments being supplied' do
       args = []
       expected_result = {
+        action: nil,
         jobify: false,
         quiet: false,
         datastore_options: {}
@@ -377,6 +390,7 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
         'example.com'
       ]
       expected_result = {
+        action: nil,
         jobify: false,
         quiet: true,
         datastore_options: {


### PR DESCRIPTION
This resolves #19969 - allow for a more intuitive syntax for specifying the action in a `run` command line.

It was (and still is) possible to set the action with `-a WRITE`, but this is pretty hidden behaviour, and the intuitive approach would be just to set it like other datastore parameters. So this PR now allows:

`run param1=value param2=value ACTION=WRITE`

in addition to the existing 

`run param1=value param2=value -a WRITE`

I haven't implemented support for this in `check`, as it didn't seem relevant.

## Verification

- [x] Start `msfconsole`
- [x] Use a module with multiple actions. Should test for:
- [x] Auxiliary (e.g. `auxiliary/admin/dcerpc/samr_account`)
- [x] Exploit (e.g. `smb/smb_relay`)
- [x] Post (e.g. `post/windows/manage/kerberos_tickets`)
- [x] Run each module with setting `action=Some_action` in the command line
- [x] Ensure it overrides the value set with `set action some_other_value`