### PR TITLE
modules/post/firefox: Resolve RuboCop violations

### DIFF
--- a/modules/post/firefox/gather/cookies.rb
+++ b/modules/post/firefox/gather/cookies.rb
@@ -12,13 +12,18 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Firefox Gather Cookies from Privileged Javascript Shell',
+        'Name' => 'Firefox Gather Cookies from Privileged JavaScript Shell',
         'Description' => %q{
-          This module allows collection of cookies from a Firefox Privileged Javascript Shell.
+          This module allows collection of cookies from a Firefox Privileged JavaScript Shell.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'joev' ],
-        'DisclosureDate' => '2014-03-26'
+        'DisclosureDate' => '2014-03-26',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 
@@ -38,7 +43,7 @@ class MetasploitModule < Msf::Post
 
         file = store_loot('firefox.cookies.json', 'text/json', rhost, results)
         print_good("Saved #{cookies.length} cookies to #{file}")
-      rescue JSON::ParserError => e
+      rescue JSON::ParserError
         print_warning(results)
       end
     end

--- a/modules/post/firefox/gather/history.rb
+++ b/modules/post/firefox/gather/history.rb
@@ -12,14 +12,19 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Firefox Gather History from Privileged Javascript Shell',
+        'Name' => 'Firefox Gather History from Privileged JavaScript Shell',
         'Description' => %q{
           This module allows collection of the entire browser history from a Firefox
-          Privileged Javascript Shell.
+          Privileged JavaScript Shell.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'joev' ],
-        'DisclosureDate' => '2014-04-11'
+        'DisclosureDate' => '2014-04-11',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 
@@ -39,7 +44,7 @@ class MetasploitModule < Msf::Post
 
         file = store_loot('firefox.history.json', 'text/json', rhost, history.to_json)
         print_good("Saved #{history.length} history entries to #{file}")
-      rescue JSON::ParserError => e
+      rescue JSON::ParserError
         print_warning(results)
       end
     end

--- a/modules/post/firefox/gather/passwords.rb
+++ b/modules/post/firefox/gather/passwords.rb
@@ -13,13 +13,18 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Firefox Gather Passwords from Privileged Javascript Shell',
+        'Name' => 'Firefox Gather Passwords from Privileged JavaScript Shell',
         'Description' => %q{
-          This module allows collection of passwords from a Firefox Privileged Javascript Shell.
+          This module allows collection of passwords from a Firefox Privileged JavaScript Shell.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'joev' ],
-        'DisclosureDate' => '2014-04-11'
+        'DisclosureDate' => '2014-04-11',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 
@@ -43,7 +48,7 @@ class MetasploitModule < Msf::Post
         else
           print_warning('No passwords were found in Firefox.')
         end
-      rescue JSON::ParserError => e
+      rescue JSON::ParserError
         print_warning(results)
       end
     end

--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -22,7 +22,12 @@ class MetasploitModule < Msf::Post
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'joev' ],
-        'Platform' => [ 'firefox' ]
+        'Platform' => [ 'firefox' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/firefox/manage/webcam_chat.rb
+++ b/modules/post/firefox/manage/webcam_chat.rb
@@ -13,9 +13,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Firefox Webcam Chat on Privileged Javascript Shell',
+        'Name' => 'Firefox Webcam Chat on Privileged JavaScript Shell',
         'Description' => %q{
-          This module allows streaming a webcam from a privileged Firefox Javascript shell.
+          This module allows streaming a webcam from a privileged Firefox JavaScript shell.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'joev' ],
@@ -23,7 +23,12 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'http://www.rapid7.com/db/modules/exploit/firefox/local/exec_shellcode' ]
         ],
         'DisclosureDate' => '2014-05-13'
-      )
+      ),
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [SCREEN_EFFECTS],
+        'Reliability' => []
+      }
     )
 
     register_options([


### PR DESCRIPTION
RuboCop violations resolved with `rubocop -a`, except notes.
