### PR TITLE
fix DidYouMean notfound

### DIFF
--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -345,6 +345,7 @@ autoload :BinData, 'bindata'
 autoload :RubySMB, 'ruby_smb'
 autoload :MetasploitPayloads, 'metasploit-payloads'
 autoload :PacketFu, 'packetfu'
+autoload :DidYouMean, 'did_you_mean'
 
 require 'rexml/document'
 # Load IO#expect moneypatch


### PR DESCRIPTION
Fixed the issue that DidYouMean was not loaded, which caused msfconsole to exit abnormally when the command did not exist.
```ruby
msf6 payload(python/meterpreter/reverse_tcp_uuid) > job
metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:596:in 'Rex::Ui::Text::DispatcherShell#unknown_command': uninitialized constant Rex::Ui::Text::DispatcherShell::DidYouMean (NameError)
        from metasploit-framework/lib/msf/ui/console/driver.rb:541:in 'Msf::Ui::Console::Driver#unknown_command'
        from metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:566:in 'Rex::Ui::Text::DispatcherShell#run_single'
        from metasploit-framework/lib/rex/ui/text/shell.rb:165:in 'block in Rex::Ui::Text::Shell#run'
        from metasploit-framework/lib/rex/ui/text/shell.rb:309:in 'block in Rex::Ui::Text::Shell#with_history_manager_context'
        from metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:35:in 'Rex::Ui::Text::Shell::HistoryManager#with_context'
        from metasploit-framework/lib/rex/ui/text/shell.rb:306:in 'Rex::Ui::Text::Shell#with_history_manager_context'
        from metasploit-framework/lib/rex/ui/text/shell.rb:133:in 'Rex::Ui::Text::Shell#run'
        from metasploit-framework/lib/metasploit/framework/command/console.rb:54:in 'Metasploit::Framework::Command::Console#start'
        from metasploit-framework/lib/metasploit/framework/command/base.rb:82:in 'Metasploit::Framework::Command::Base.start'
        from ./msfconsole:23:in '<main>'
```

`ruby 3.4.2 `