### PR TITLE
Move auxiliary/docx/word_unc_injector module to auxiliary/fileformat/

### DIFF
--- a/modules/auxiliary/fileformat/word_unc_injector.rb
+++ b/modules/auxiliary/fileformat/word_unc_injector.rb
@@ -8,6 +8,9 @@ require 'rex/zip'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::FILEFORMAT
+  include Msf::Module::Deprecated
+
+  moved_from 'auxiliary/docx/word_unc_injector'
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
This module belongs in the `auxiliary/fileformat/` directory.

* The module is intended to capture NetNTLM hashes via embedded UNC paths. We have several very similar modules for this purpose, all located in the `fileformat` directory.
* There are no other modules in the `auxiliary/docx` directory.
* We typically categorize based on software name, rather than file extension (`docx`).
