### PR TITLE
modules/post/osx: Resolve RuboCop violations

### DIFF
--- a/modules/post/osx/admin/say.rb
+++ b/modules/post/osx/admin/say.rb
@@ -19,7 +19,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'sinn3r'],
         'Platform' => [ 'osx' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [AUDIO_EFFECTS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -34,7 +39,7 @@ class MetasploitModule < Msf::Post
   def exec(cmd)
     tries = 0
     begin
-      out = cmd_exec(cmd).chomp
+      cmd_exec(cmd).chomp
     rescue ::Timeout::Error => e
       tries += 1
       if tries < 3

--- a/modules/post/osx/capture/keylog_recorder.rb
+++ b/modules/post/osx/capture/keylog_recorder.rb
@@ -39,7 +39,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'joev'],
         'Platform' => [ 'osx'],
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/osx/capture/screen.rb
+++ b/modules/post/osx/capture/screen.rb
@@ -20,7 +20,12 @@ class MetasploitModule < Msf::Post
           'Peter Toth <globetother[at]gmail.com>' # ported windows version to osx
         ],
         'Platform' => [ 'osx' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'Reliability' => []
+        }
       )
     )
 
@@ -65,8 +70,7 @@ class MetasploitModule < Msf::Post
       Rex.sleep(delay) unless num <= 0
 
       begin
-        # This is an OSX module, so mkdir -p should be fine
-        cmd_exec("mkdir -p #{tmp_path}")
+        mkdir(tmp_path)
         filename = Rex::Text.rand_text_alpha(7)
         file = "#{tmp_path}/#{filename}"
         cmd_exec("#{exe_path} -x -C -t #{file_type} #{file}")
@@ -75,7 +79,7 @@ class MetasploitModule < Msf::Post
       rescue ::Rex::Post::Meterpreter::RequestError => e
         print_error('Error taking the screenshot')
         vprint_error("#{e.class} #{e} #{e.backtrace}")
-        return
+        break
       end
 
       unless data
@@ -92,12 +96,12 @@ class MetasploitModule < Msf::Post
       rescue ::IOError, ::Errno::ENOENT => e
         print_error('Error storing screenshot')
         vprint_error("#{e.class} #{e} #{e.backtrace}")
-        return
+        break
       end
     end
 
     print_status('Screen Capturing Complete')
-    if file_locations && !file_locations.empty?
+    unless file_locations.blank?
       print_status('Use "loot -t screen_capture.screenshot" to see file locations of your newly acquired loot')
     end
   end

--- a/modules/post/osx/gather/autologin_password.rb
+++ b/modules/post/osx/gather/autologin_password.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::OSX::Priv
 
-  # extract/verify by by XORing your kcpassword with your password
+  # extract/verify by XORing your kcpassword with your password
   AUTOLOGIN_XOR_KEY = [0x7D, 0x89, 0x52, 0x23, 0xD2, 0xBC, 0xDD, 0xEA, 0xA3, 0xB9, 0x1F]
 
   def initialize(info = {})
@@ -26,9 +26,14 @@ class MetasploitModule < Msf::Post
         'Author' => [ 'joev' ],
         'Platform' => [ 'osx' ],
         'References' => [
-          ['URL', 'http://www.brock-family.org/gavin/perl/kcpassword.html']
+          ['URL', 'https://web.archive.org/web/20180408062145/http://www.brock-family.org/gavin/perl/kcpassword.html'],
         ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/osx/gather/enum_airport.rb
+++ b/modules/post/osx/gather/enum_airport.rb
@@ -18,7 +18,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'sinn3r'],
         'Platform' => [ 'osx' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -26,7 +31,7 @@ class MetasploitModule < Msf::Post
   def exec(cmd)
     tries = 0
     begin
-      out = cmd_exec(cmd).chomp
+      cmd_exec(cmd).chomp
     rescue ::Timeout::Error => e
       tries += 1
       if tries < 3

--- a/modules/post/osx/gather/enum_chicken_vnc_profile.rb
+++ b/modules/post/osx/gather/enum_chicken_vnc_profile.rb
@@ -19,7 +19,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'sinn3r'],
         'Platform' => [ 'osx' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -35,7 +40,7 @@ class MetasploitModule < Msf::Post
   def exec(cmd)
     tries = 0
     begin
-      out = cmd_exec(cmd).chomp
+      cmd_exec(cmd).chomp
     rescue ::Timeout::Error => e
       tries += 1
       if tries < 3
@@ -61,8 +66,7 @@ class MetasploitModule < Msf::Post
 
   def locate_chicken
     dir('/Applications/').each do |folder|
-      m = folder.match(/Chicken of the VNC\.app/)
-      return true
+      return true if folder.match(/Chicken of the VNC\.app/)
     end
 
     return false
@@ -70,11 +74,12 @@ class MetasploitModule < Msf::Post
 
   def get_profile_plist(user)
     f = exec("cat /Users/#{user}/Library/Preferences/com.geekspiff.chickenofthevnc.plist")
+
     if f =~ /No such file or directory/
       return nil
-    else
-      return f
     end
+
+    f
   end
 
   def save(file)
@@ -96,9 +101,9 @@ class MetasploitModule < Msf::Post
     if !locate_chicken
       print_error("#{@peer} - Chicken of the VNC is not installed")
       return
-    else
-      print_status("#{@peer} - Chicken of the VNC found")
     end
+
+    print_status("#{@peer} - Chicken of the VNC found")
 
     plist = get_profile_plist(user)
     if plist.nil?

--- a/modules/post/osx/gather/enum_colloquy.rb
+++ b/modules/post/osx/gather/enum_colloquy.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Post
           ['CHATS', { 'Description' => 'Collect chat logs with a pattern' } ],
           ['ALL', { 'Description' => 'Collect both the plists and chat logs' }]
         ],
-        'DefaultAction' => 'ALL'
+        'DefaultAction' => 'ALL',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 
@@ -42,12 +47,11 @@ class MetasploitModule < Msf::Post
 
   #
   # Parse a plst file to XML format:
-  # http://hints.macworld.com/article.php?story=20050430105126392
+  # https://web.archive.org/web/20141112034745/http://hints.macworld.com/article.php?story=20050430105126392
   #
   def plutil(filename)
     exec("plutil -convert xml1 #{filename}")
-    data = exec("cat #{filename}")
-    return data
+    exec("cat #{filename}")
   end
 
   def get_chatlogs(base)
@@ -125,7 +129,7 @@ class MetasploitModule < Msf::Post
   def exec(cmd)
     tries = 0
     begin
-      out = cmd_exec(cmd).chomp
+      cmd_exec(cmd).chomp
     rescue ::Timeout::Error => e
       tries += 1
       if tries < 3
@@ -150,6 +154,10 @@ class MetasploitModule < Msf::Post
     @peer = "#{session.session_host}:#{session.session_port}"
     user = whoami
 
+    # Examples:
+    # /Users/[user]/Library/Preferences/info.colloquy.plist
+    # /Users/[user]/Documents/Colloquy Transcripts
+    # /Users/[user]/Documents/Colloquy Transcripts//[server]/[contact] 10-13-11.colloquyTranscript
     transcripts_path = "/Users/#{user}/Documents/Colloquy Transcripts/"
     prefs_path = "/Users/#{user}/Library/Preferences/info.colloquy.plist"
 
@@ -160,11 +168,3 @@ class MetasploitModule < Msf::Post
     save(:chatlogs, chatlogs) if !chatlogs.nil? && !chatlogs.empty?
   end
 end
-
-=begin
-/Users/[user]/Documents/Colloquy Transcripts
-/Users/[user]/Library/Preferences/info.colloquy.plist
-
-Transcript example:
-/Users/[username]/Documents/Colloquy Transcripts//[server]/[contact] 10-13-11.colloquyTranscript
-=end

--- a/modules/post/osx/gather/enum_keychain.rb
+++ b/modules/post/osx/gather/enum_keychain.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'ipwnstuff <e[at]ipwnstuff.com>', 'joev' ],
         'Platform' => [ 'osx' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'Reliability' => []
+        }
       )
     )
 
@@ -44,7 +49,7 @@ class MetasploitModule < Msf::Post
   end
 
   def enum_accounts(_keychains)
-    user = cmd_exec('whoami').chomp
+    cmd_exec('whoami').chomp
     out = cmd_exec("security dump | egrep 'acct|desc|srvr|svce'")
 
     accounts = []
@@ -94,12 +99,14 @@ class MetasploitModule < Msf::Post
   end
 
   def save(data, kind = 'Keychain information')
-    l = store_loot('macosx.keychain.info',
-                   'plain/text',
-                   session,
-                   data,
-                   'keychain_info.txt',
-                   'Mac Keychain Account/Server/Service/Description')
+    l = store_loot(
+      'macosx.keychain.info',
+      'plain/text',
+      session,
+      data,
+      'keychain_info.txt',
+      'Mac Keychain Account/Server/Service/Description'
+    )
 
     print_good("#{@peer} - #{kind} saved in #{l}")
   end
@@ -113,7 +120,7 @@ class MetasploitModule < Msf::Post
       return
     end
 
-    user = cmd_exec('/usr/bin/whoami').chomp
+    cmd_exec('/usr/bin/whoami').chomp
     accounts = enum_accounts(keychains)
     save(accounts)
 
@@ -130,7 +137,7 @@ class MetasploitModule < Msf::Post
         begin
           count = JSON.parse(passwords).count
           print_good("Successfully stole #{count} passwords")
-        rescue JSON::ParserError => e
+        rescue JSON::ParserError
           print_error('Response was not valid JSON')
         end
       else

--- a/modules/post/osx/gather/enum_messages.rb
+++ b/modules/post/osx/gather/enum_messages.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Post
           ['LATEST', { 'Description' => 'Collect the latest message' }],
           ['ALL', { 'Description' => 'Collect all Messages data' }]
         ],
-        'DefaultAction' => 'ALL'
+        'DefaultAction' => 'ALL',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 
@@ -46,18 +51,12 @@ class MetasploitModule < Msf::Post
 
     # Check file exists
     messages_path = "/Users/#{user}/Library/Messages/chat.db"
-    if file_exist?(messages_path)
-      print_good("#{peer} - Messages DB found: #{messages_path}")
-    else
+
+    unless file_exist?(messages_path)
       fail_with(Failure::Unknown, "#{peer} - Messages DB does not exist")
     end
 
-    # Check messages.  And then set the default profile path
-    unless messages_path
-      fail_with(Failure::Unknown, "#{peer} - Unable to find messages, will not continue")
-    end
-
-    print_good("#{peer} - Found Messages file: #{messages_path}")
+    print_good("#{peer} - Messages DB found: #{messages_path}")
 
     files = []
 

--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Post
           'joev'
         ],
         'Platform' => [ 'osx' ],
-        'SessionTypes' => %w[shell meterpreter]
+        'SessionTypes' => %w[shell meterpreter],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
     register_options([
@@ -41,7 +46,6 @@ class MetasploitModule < Msf::Post
     ])
   end
 
-  # Run Method for when run command is issued
   def run
     unless is_root?
       fail_with(Failure::BadConfig, 'Insufficient Privileges: must be running as root to dump the hashes')
@@ -227,6 +231,6 @@ class MetasploitModule < Msf::Post
 
   # @return [String] version string (e.g. 10.8.5)
   def ver_num
-    @product_version ||= get_sysinfo['ProductVersion']
+    @ver_num ||= get_sysinfo['ProductVersion']
   end
 end

--- a/modules/post/osx/gather/password_prompt_spoof.rb
+++ b/modules/post/osx/gather/password_prompt_spoof.rb
@@ -25,7 +25,12 @@ class MetasploitModule < Msf::Post
         'References' => [
           ['URL', 'http://blog.packetheader.net/2011/10/fun-with-applescript.html']
         ],
-        'SessionTypes' => [ 'shell', 'meterpreter' ]
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -79,9 +84,9 @@ class MetasploitModule < Msf::Post
 
     print_status("Running module against #{host}")
 
-    dir = '/tmp/.' + Rex::Text.rand_text_alpha((rand(6..13)))
-    creds_osa = dir + '/' + Rex::Text.rand_text_alpha((rand(6..13)))
-    pass_file = dir + '/' + Rex::Text.rand_text_alpha((rand(6..13)))
+    dir = '/tmp/.' + Rex::Text.rand_text_alpha(6..13)
+    creds_osa = dir + '/' + Rex::Text.rand_text_alpha(6..13)
+    pass_file = dir + '/' + Rex::Text.rand_text_alpha(6..13)
 
     username = cmd_exec('/usr/bin/whoami').strip
     cmd_exec('umask 0077')
@@ -131,10 +136,9 @@ class MetasploitModule < Msf::Post
 
   # applescript that displays the actual password prompt dialog
   def creds_script(pass_file)
-    textcreds = datastore['TEXTCREDS']
-    ascript = %(
+    %(
 set filename to "#{pass_file}"
-set myprompt to "#{textcreds}"
+set myprompt to "#{datastore['TEXTCREDS']}"
 set ans to "Cancel"
 repeat
   try

--- a/modules/post/osx/gather/safari_lastsession.rb
+++ b/modules/post/osx/gather/safari_lastsession.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter', 'shell' ],
         'References' => [
           ['URL', 'http://www.securelist.com/en/blog/8168/Loophole_in_Safari']
-        ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -173,10 +178,10 @@ class MetasploitModule < Msf::Post
     if lastsession.blank?
       print_error("#{peer} - LastSession.plist not found")
       return
-    else
-      p = store_loot('osx.lastsession.plist', 'text/plain', session, lastsession, 'LastSession.plist.xml')
-      print_good("#{peer} - LastSession.plist stored in: #{p}")
     end
+
+    p = store_loot('osx.lastsession.plist', 'text/plain', session, lastsession, 'LastSession.plist.xml')
+    print_good("#{peer} - LastSession.plist stored in: #{p}")
 
 #
 # If this is an unpatched version, we try to extract creds

--- a/modules/post/osx/gather/vnc_password_osx.rb
+++ b/modules/post/osx/gather/vnc_password_osx.rb
@@ -18,15 +18,18 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'Kevin Gonzalvo <interhack[at]gmail.com>'],
         'Platform' => [ 'osx' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
 
   def decrypt_hash(hash)
-    if hash.nil? || hash.empty?
-      return nil
-    end
+    return if hash.blank?
 
     aux = ['1734516E8BA8C5E2FF1C39567390ADCA'].pack('H*')
     fixedkey = aux.unpack('C*')
@@ -38,6 +41,7 @@ class MetasploitModule < Msf::Post
     for data in fixedkey
       str += (data ^ array_pwd.shift).chr
     end
+
     return str.delete("\0")
   end
 
@@ -45,25 +49,28 @@ class MetasploitModule < Msf::Post
     unless is_root?
       fail_with(Failure::NoAccess, 'Root privileges are required to read VNC password file')
     end
+
     print_status('Checking VNC Password...')
     vncsettings_path = '/Library/Preferences/com.apple.VNCSettings.txt'
     passwd_encrypt = read_file(vncsettings_path.to_s)
     final_passwd = decrypt_hash(passwd_encrypt.to_s)
-    if !final_passwd.nil?
-      print_good("Password Found: #{final_passwd}")
-      pass_file = store_loot('osx.vnc.password', 'text/plain', session, final_passwd, 'passwd.pwd', 'OSX VNC Password')
-      print_good("Password data stored as loot in: #{pass_file}")
-      credential_data = {
-        origin_type: :session,
-        session_id: session_db_id,
-        post_reference_name: fullname,
-        private_type: :password,
-        private_data: final_passwd.to_s,
-        workspace_id: myworkspace_id
-      }
-      create_credential(credential_data)
-    else
+
+    if final_passwd.nil?
       print_error('Password not found')
+      return
     end
+
+    print_good("Password Found: #{final_passwd}")
+    pass_file = store_loot('osx.vnc.password', 'text/plain', session, final_passwd, 'passwd.pwd', 'OSX VNC Password')
+    print_good("Password data stored as loot in: #{pass_file}")
+    credential_data = {
+      origin_type: :session,
+      session_id: session_db_id,
+      post_reference_name: fullname,
+      private_type: :password,
+      private_data: final_passwd.to_s,
+      workspace_id: myworkspace_id
+    }
+    create_credential(credential_data)
   end
 end

--- a/modules/post/osx/manage/mount_share.rb
+++ b/modules/post/osx/manage/mount_share.rb
@@ -37,7 +37,12 @@ class MetasploitModule < Msf::Post
           [ 'MOUNT', { 'Description' => 'Mount a network shared volume using stored credentials' } ],
           [ 'UMOUNT', { 'Description' => 'Unmount a mounted volume' } ]
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/osx/manage/record_mic.rb
+++ b/modules/post/osx/manage/record_mic.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Post
           [ 'LIST', { 'Description' => 'Show a list of microphones' } ],
           [ 'RECORD', { 'Description' => 'Record from a selected audio input' } ]
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/osx/manage/sonic_pi.rb
+++ b/modules/post/osx/manage/sonic_pi.rb
@@ -35,7 +35,9 @@ class MetasploitModule < Msf::Post
         ],
         'DefaultAction' => 'Run',
         'Notes' => {
-          'SideEffects' => [AUDIO_EFFECTS, SCREEN_EFFECTS]
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [AUDIO_EFFECTS, SCREEN_EFFECTS],
+          'Reliability' => []
         }
       )
     )

--- a/modules/post/osx/manage/vpn.rb
+++ b/modules/post/osx/manage/vpn.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Post
           [ 'CONNECT', { 'Description' => 'Connect to a VPN using stored credentials' } ],
           [ 'DISCONNECT', { 'Description' => 'Disconnect from a VPN' } ]
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/post/osx/manage/webcam.rb
+++ b/modules/post/osx/manage/webcam.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Post
         'Description' => %q{
           This module will allow the user to detect installed webcams (with
           the LIST action), take a snapshot (with the SNAPSHOT action), or
-          record a webcam and mic (with the RECORD action)
+          record a webcam and mic (with the RECORD action).
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'joev'],
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Post
           [ 'SNAPSHOT', { 'Description' => 'Take a snapshot with the webcam' } ],
           [ 'RECORD', { 'Description' => 'Record with the webcam' } ]
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

This also fixes a couple of bugs:

* modules/post/osx/gather/enum_osx.rb - incorrectly chekced `.ssh` instead of `.gnupg` when checking for GPG keys
* modules/post/osx/gather/enum_chicken_vnc_profile.rb - `locate_chicken` always returned `true`
