### PR TITLE
Fix issue that prevented to correctly register exploit attempts

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1475,7 +1475,7 @@ class Exploit < Msf::Module
       :run_id      => self.datastore['RUN_ID']
     }
 
-    if self.datastore['RHOST'] and self.options['RHOST']
+    if self.datastore['RHOST'] && (self.options['RHOST'] || self.options['RHOSTS'])
       info[:host] = self.datastore['RHOST']
     end
 

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -243,8 +243,9 @@ protected
       (exploit.passive? == false and exploit.handler_enabled?)
       begin
         self.session = payload.wait_for_session(delay)
-      rescue ::Interrupt
+      rescue ::Interrupt, Timeout::ExitException
         # Don't let interrupt pass upward
+        # We also want report a failure when the Timeout expires
       end
     end
 


### PR DESCRIPTION
This fixes an issue that prevented failed exploit attempt to be registered in the `ExploitAttempt` data model.

## Steps
- create a new workspace (e.g. `workspace -a exploit_attempt`)
- select an exploit module (e.g. `use exploit/windows/smb/psexec`
- run a successful exploit (e.g. get a session with `psexec`)
- run `irb` command
- run `framework.db.hosts({}).first.exploit_attempts`
- check that the exploit attempt has been registered
- exit irb
- run a failing exploit (e.g. `psexec` with wrong credentials or wrong `RPORT`)
- run the same command with `irb`
- check the failed attempt is registered with information in the `fail_detail` field.

## Without this fix
Failed attempt are not registered

## With this fix
Failed attempt are registered

## Scenario
Example of successful and failed attempts:
```
>> framework.db.hosts({}).first.exploit_attempts
>>
=>
[#<Mdm::ExploitAttempt:0x0000700d902cb1a0
  id: 56,
  host_id: 13,
  service_id: nil,
  vuln_id: 14,
  attempted_at: 2025-04-30 17:19:39.806944 UTC,
  exploited: true,
  fail_reason: nil,
  username: "n00tmeg",
  module: "exploit/windows/smb/psexec",
  session_id: 28,
  loot_id: nil,
  port: 445,
  proto: "tcp",
  fail_detail: nil>,
 #<Mdm::ExploitAttempt:0x0000700d902ca660
  id: 57,
  host_id: 13,
  service_id: nil,
  vuln_id: 14,
  attempted_at: 2025-04-30 17:22:14.496027 UTC,
  exploited: false,
  fail_reason: "no-access",
  username: "n00tmeg",
  module: "exploit/windows/smb/psexec",
  session_id: nil,
  loot_id: nil,
  port: 445,
  proto: "tcp",
  fail_detail: "Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.">]
```