### PR TITLE
Fix broken cache generation

### DIFF
--- a/modules/post/firefox/manage/webcam_chat.rb
+++ b/modules/post/firefox/manage/webcam_chat.rb
@@ -22,13 +22,13 @@ class MetasploitModule < Msf::Post
         'References' => [
           [ 'URL', 'http://www.rapid7.com/db/modules/exploit/firefox/local/exec_shellcode' ]
         ],
-        'DisclosureDate' => '2014-05-13'
-      ),
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [SCREEN_EFFECTS],
-        'Reliability' => []
-      }
+        'DisclosureDate' => '2014-05-13',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [SCREEN_EFFECTS],
+          'Reliability' => []
+        }
+      )
     )
 
     register_options([


### PR DESCRIPTION
This module currently fails to load, causing the module cache to break:

> [2025-05-01T10:02:40.005Z] [-] resource (tools/automation/cache/wait_for_cache.rc)> Ruby Error: ArgumentError wrong number of arguments (given 2, expected 0..1) ["/r7-source/lib/msf/core/exploit/jsobfu.rb:8:in `initialize'", "/r7-source/modules/post/firefox/manage/webcam_chat.rb:13:in `initialize'", "/r7-source/lib/msf/core/module_set.rb:37:in `new'", "/r7-source/lib/msf/core/module_set.rb:37:in `create'", "/r7-source/lib/msf/core/modules/metadata/cache.rb:59:in `block (3 levels) in refresh_metadata'", "/r7-source/lib/msf/core/modules/metadata/cache.rb:55:in `each'", "/r7-source/lib/msf/core/modules/metadata/cache.rb:55:in `block (2 levels) in refresh_metadata'", "/r7-source/lib/msf/core/modules/metadata/cache.rb:52:in `each'", "/r7-source/lib/msf/core/modules/metadata/cache.rb:52:in `block in refresh_metadata'", "/r7-source/lib/msf/core/modules/metadata/cache.rb:50:in `synchronize'", "/r7-source/lib/msf/core/modules/metadata/cache.rb:50:in `refresh_metadata'", "/r7-source/lib/msf/core/module_manager/cache.rb:143:in `refresh_cache_from_module_files'", "(eval):6:in `load_resource'", "/r7-source/lib/rex/ui/text/resource.rb:60:in `eval'", "/r7-source/lib/rex/ui/text/resource.rb:60:in `load_resource'", "/r7-source/lib/msf/ui/console/driver.rb:185:in `block in initialize'", "/r7-source/lib/msf/ui/console/driver.rb:184:in `each'", "/r7-source/lib/msf/ui/console/driver.rb:184:in `initialize'", "/r7-source/lib/metasploit/framework/command/console.rb:66:in `new'", "/r7-source/lib/metasploit/framework/command/console.rb:66:in `driver'", "/r7-source/lib/metasploit/framework/command/console.rb:54:in `start'", "/r7-source/lib/metasploit/framework/command/base.rb:82:in `start'", "./msfconsole:23:in `<main>'"]

Small change to: https://github.com/rapid7/metasploit-framework/pull/20101

## Verification

### Before

```
msf6 exploit(irix/lpd/tagprinter_exec) > use firefox webcam_chat

Matching Modules
================

   #  Name                             Disclosure Date  Rank    Check  Description
   -  ----                             ---------------  ----    -----  -----------
   0  post/firefox/manage/webcam_chat  2014-05-13       normal  No     Firefox Webcam Chat on Privileged Javascript Shell


Interact with a module by name or index. For example info 0, use 0 or use post/firefox/manage/webcam_chat

[*] Using post/firefox/manage/webcam_chat
[-] Error while running command use: wrong number of arguments (given 2, expected 0..1)

Call stack:
/foo/metasploit-framework/lib/msf/core/exploit/jsobfu.rb:8:in `initialize'
/foo/metasploit-framework/modules/post/firefox/manage/webcam_chat.rb:13:in `initialize'
/foo/metasploit-framework/lib/msf/core/module_set.rb:37:in `new'
/foo/metasploit-framework/lib/msf/core/module_set.rb:37:in `create'
```

### After

```
msf6 exploit(irix/lpd/tagprinter_exec) > use firefox webcam_chat

Matching Modules
================

   #  Name                             Disclosure Date  Rank    Check  Description
   -  ----                             ---------------  ----    -----  -----------
   0  post/firefox/manage/webcam_chat  2014-05-13       normal  No     Firefox Webcam Chat on Privileged Javascript Shell


Interact with a module by name or index. For example info 0, use 0 or use post/firefox/manage/webcam_chat

[*] Using post/firefox/manage/webcam_chat
msf6 post(firefox/manage/webcam_chat) > info

       Name: Firefox Webcam Chat on Privileged JavaScript Shell
     Module: post/firefox/manage/webcam_chat
   Platform: 
       Arch: 
       Rank: Normal
  Disclosed: 2014-05-13
```