### PR TITLE
Revert "Adds network capture decryption support to http scanners"

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -334,7 +334,6 @@ module Metasploit
           rport = opts['rport'] || port
           cli_ssl = opts['ssl'] || ssl
           cli_ssl_version = opts['ssl_version'] || ssl_version
-          cli_sslkeylogfile = opts['SSLKeyLogFile'] || sslkeylogfile
           cli_proxies = opts['proxies'] || proxies
           username = opts['credential'] ? opts['credential'].public : http_username
           password = opts['credential'] ? opts['credential'].private : http_password
@@ -358,8 +357,7 @@ module Metasploit
             username,
             password,
             kerberos_authenticator: kerberos_authenticator,
-            subscriber: http_logger_subscriber,
-            sslkeylogfile: cli_sslkeylogfile
+            subscriber: http_logger_subscriber
           )
           configure_http_client(cli)
 

--- a/lib/metasploit/framework/login_scanner/rex_socket.rb
+++ b/lib/metasploit/framework/login_scanner/rex_socket.rb
@@ -21,9 +21,6 @@ module Metasploit
           # @!attribute ssl_verify_mode
           #   @return [String] the SSL certification verification mechanism
           attr_accessor :ssl_verify_mode
-          # @!attribute sslkeylogfile
-          #   @return [String, nil] The SSL key log file path
-          attr_accessor :sslkeylogfile
           # @!attribute ssl_cipher
           #   @return [String] The SSL cipher to use for the context
           attr_accessor :ssl_cipher

--- a/lib/msf/core/auxiliary/login_scanner.rb
+++ b/lib/msf/core/auxiliary/login_scanner.rb
@@ -20,7 +20,6 @@ module Msf
           proxies: datastore['Proxies'],
           stop_on_success: datastore['STOP_ON_SUCCESS'],
           bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-          sslkeylogfile: datastore['SSLKeyLogFile'],
           framework: framework,
           framework_module: self,
           local_port: datastore['CPORT'],

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -184,7 +184,7 @@ module Rex
             'Context' => context,
             'SSL' => ssl,
             'SSLVersion' => ssl_version,
-            'SSLKeyLogFile' => config['SSLKeyLogFile'] || sslkeylogfile,
+            'SSLKeyLogFile' => sslkeylogfile,
             'Proxies' => proxies,
             'Timeout' => timeout,
             'Comm' => comm


### PR DESCRIPTION
Reverts https://github.com/rapid7/metasploit-framework/pull/20080 due to issues only found once merged and CI tested both Postgres and LDAP.

LDAP failures:

```
[read] msf6 auxiliary(scanner/ldap/ldap_login) > 
[write] run PASS_FILE= USER_FILE= CreateSession=true ldapusername='DEV-AD\Administrator' ldappassword=admin123! rhost=127.0.0.1 rport=389 ssl=false
[read] [-] Auxiliary failed: NoMethodError undefined method `sslkeylogfile=' for #<Metasploit::Framework::LoginScanner::LDAP:0x00007f3d0d9941b0 @host="127.0.0.1", @port=389, @proxies=nil, @stop_on_success=false, @bruteforce_speed=5>
[read] [-] Call stack:
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:86:in `public_send'
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:86:in `block in initialize'
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:85:in `each'
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:85:in `initialize'
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/modules/auxiliary/scanner/ldap/ldap_login.rb:1[40](https://github.com/rapid7/metasploit-framework/actions/runs/14773815518/job/41478398437#step:7:41):in `new'
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/modules/auxiliary/scanner/ldap/ldap_login.rb:140:in `run_host'
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:116:in `block (2 levels) in run'
[read] [-]   /home/runner/work/metasploit-framework/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[read] [*] Auxiliary module execution completed
```