### PR TITLE
Adds additional support for network capture decryption

### DIFF
--- a/.github/workflows/ldap_acceptance.yml
+++ b/.github/workflows/ldap_acceptance.yml
@@ -33,6 +33,8 @@ on:
       - 'metsploit-framework.gemspec'
       - 'Gemfile.lock'
       - '**/**ldap**'
+      - 'lib/metasploit/framework/tcp/**'
+      - 'lib/metasploit/framework/login_scanner/**'
       - 'spec/acceptance/**'
       - 'spec/support/acceptance/**'
       - 'spec/acceptance_spec_helper.rb'

--- a/.github/workflows/postgres_acceptance.yml
+++ b/.github/workflows/postgres_acceptance.yml
@@ -33,6 +33,8 @@ on:
       - 'metsploit-framework.gemspec'
       - 'Gemfile.lock'
       - '**/**postgres**'
+      - 'lib/metasploit/framework/tcp/**'
+      - 'lib/metasploit/framework/login_scanner/**'
       - 'spec/acceptance/**'
       - 'spec/support/acceptance/**'
       - 'spec/acceptance_spec_helper.rb'

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -45,6 +45,9 @@ module Metasploit
           # @!attribute bruteforce_speed
           #   @return [Integer] The desired speed, with 5 being 'fast' and 0 being 'slow.'
           attr_accessor :bruteforce_speed
+          # @!attribute sslkeylogfile
+          #   @return [String] The SSL key log file path
+          attr_accessor :sslkeylogfile
 
           validates :connection_timeout,
                     presence: true,

--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -77,7 +77,7 @@ module Metasploit
           }
 
           begin
-            client = Rex::Proto::MSSQL::Client.new(framework_module, framework, host, port, proxies)
+            client = Rex::Proto::MSSQL::Client.new(framework_module, framework, host, port, proxies, sslkeylogfile: sslkeylogfile)
             if client.mssql_login(credential.public, credential.private, '', credential.realm)
               result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
               if use_client_as_proof

--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -89,6 +89,7 @@ module Metasploit
               'SSL'           =>  dossl,
               'SSLVersion'    =>  opts['SSLVersion'] || ssl_version,
               'SSLVerifyMode' =>  opts['SSLVerifyMode'] || ssl_verify_mode,
+              'SSLKeyLogFile' =>  opts['SSLKeyLogFile'] || sslkeylogfile,
               'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
               'Proxies'       => proxies,
               'Timeout'       => (opts['ConnectTimeout'] || connection_timeout || 10).to_i,

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -38,6 +38,7 @@ module Auxiliary::AuthBrute
       OptBool.new('REMOVE_USERPASS_FILE', [ true, "Automatically delete the USERPASS_FILE on module completion", false]),
       OptBool.new('PASSWORD_SPRAY', [true, "Reverse the credential pairing order. For each password, attempt every possible user.", false]),
       OptInt.new('TRANSITION_DELAY', [false, "Amount of time (in minutes) to delay before transitioning to the next user in the array (or password when PASSWORD_SPRAY=true)", 0]),
+      OptString.new('SSLKeyLogFile', [ false, 'The SSL key log file', ENV['SSLKeyLogFile']]),
       OptInt.new('MaxGuessesPerService', [ false, "Maximum number of credentials to try per service instance. If set to zero or a non-number, this option will not be used.", 0]), # Tracked in @@guesses_per_service
       OptInt.new('MaxMinutesPerService', [ false, "Maximum time in minutes to bruteforce the service instance. If set to zero or a non-number, this option will not be used.", 0]), # Tracked in @@brute_start_time
       OptInt.new('MaxGuessesPerUser', [ false, %q{

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -25,6 +25,9 @@ module Rex
         attr_accessor :ssl_version
         attr_accessor :ssl_verify_mode
         attr_accessor :ssl_cipher
+        # @!attribute sslkeylogfile
+        #   @return [String] The SSL key log file path
+        attr_accessor :sslkeylogfile
         attr_accessor :proxies
         attr_accessor :connection_timeout
         attr_accessor :send_lm
@@ -50,7 +53,7 @@ module Rex
         #   @return [String] The database name this client is currently connected to.
         attr_accessor :current_database
 
-        def initialize(framework_module, framework, rhost, rport = 1433, proxies = nil)
+        def initialize(framework_module, framework, rhost, rport = 1433, proxies = nil, sslkeylogfile: nil)
           @framework_module       = framework_module
           @framework              = framework
           @connection_timeout     = framework_module.datastore['ConnectTimeout']      || 30
@@ -68,6 +71,7 @@ module Rex
           @rhost = rhost
           @rport = rport
           @proxies = proxies
+          @sslkeylogfile = sslkeylogfile
           @current_database = ''
         end
 
@@ -336,7 +340,7 @@ module Rex
             # upon receiving the ntlm_negociate request it send an ntlm_challenge but the status flag of the tds packet header
             # is set to STATUS_NORMAL and not STATUS_END_OF_MESSAGE, then internally it waits for the ntlm_authentification
             if tdsencryption == true
-               proxy = TDSSSLProxy.new(sock)
+               proxy = TDSSSLProxy.new(sock, sslkeylogfile: sslkeylogfile)
                proxy.setup_ssl
                resp = proxy.send_recv(pkt)
             else
@@ -454,7 +458,7 @@ module Rex
             pkt = "\x10\x01" + [pkt.length + 8].pack('n') + [0].pack('n') + [1].pack('C') + "\x00" + pkt
 
             if self.tdsencryption == true
-              proxy = TDSSSLProxy.new(sock)
+              proxy = TDSSSLProxy.new(sock, sslkeylogfile: sslkeylogfile)
               proxy.setup_ssl
               resp = mssql_ssl_send_recv(pkt, proxy)
               proxy.cleanup


### PR DESCRIPTION
> [!NOTE] 
I have updated the workflows for Postgres and LDAP to now be ran when changes are made to login scanner or TCP. In aim off avoiding what happened in https://github.com/rapid7/metasploit-framework/pull/20114 were those were on ran once merged even those changes in the areas above caused the workflows to fail.

This PR combines https://github.com/rapid7/metasploit-framework/pull/20114 and https://github.com/rapid7/metasploit-framework/pull/20099. As https://github.com/rapid7/metasploit-framework/pull/20114 was failing once merged and I decided to combine them together to make testing easier. Can be split again if preferred 👍 

This pull request adds enhanced support for network capture decryption for http scanner modules as well as login scanner modules. By writing to the `sslkeylogfile` it enables network capture decryption which is useful to decrypt TLS traffic in Wireshark.

This is a follow on to https://github.com/rapid7/metasploit-framework/pull/20024 and https://github.com/rapid7/rex-socket/pull/74. 

This pull request adds enhanced support for network capture decryption for login scanner modules. By writing to the `sslkeylogfile` it enables network capture decryption which is useful to decrypt TLS traffic in Wireshark.

This is a follow on to https://github.com/rapid7/metasploit-framework/pull/20024, https://github.com/rapid7/metasploit-framework/pull/20080 and https://github.com/rapid7/rex-socket/pull/74. 

I have also update the workflows for Postgres and LDAP to now be ran when changes are made to login scanner or TCP. In aim off avoiding what happened in https://github.com/rapid7/metasploit-framework/pull/20114 were those were on ran once merged even those changes in the areas above caused the workflows to fail.

## Testing
Tested against the following modules:
- `scanner/acpp/login`
- `scanner/ftp/ftp_login`
- `scanner/mysql/mysql_login`
- `scanner/afp/afp_login`
- `scanner/db2/db2_auth`
- `scanner/mqtt/connect`
- `scanner/pop3/pop3_login`
- `scanner/telnet/brocade_enable_login`
- `scanner/telnet/telnet_login`
- `scanner/vmware/vmauthd_login`
- `scanner/vnc/vnc_login`
- `scanner/mssql/mssql_login`

As well as testing completed previous here: https://github.com/rapid7/metasploit-framework/pull/20080#issuecomment-2839297261

## Verification

- [ ] Start `msfconsole`
- [ ] Test the changes against some `scanner/*/*_login` modules.
- [ ] The modules should complete
- [ ] Run `ls -la` and you should now see a file called `sslkeylogfile.txt`
- [ ] Code changes are sane