### PR TITLE
Fix the smb_to_ldap module's missing target option

### DIFF
--- a/documentation/modules/auxiliary/server/relay/esc8.md
+++ b/documentation/modules/auxiliary/server/relay/esc8.md
@@ -10,7 +10,7 @@ on a given template.
     * See https://docs.metasploit.com/docs/pentesting/active-directory/ad-certificates/overview.html#setting-up-a-esc8-vulnerable-host
 2. Start `msfconsole`
 2. Do: `use auxiliary/server/relay/esc8`
-3. Set the `RELAY_TARGETS` option to the AD CS Web Enrollment server
+3. Set the `RHOSTS` option to the AD CS Web Enrollment server
 4. Run the module and wait for a request to be relayed
 
 ## Options

--- a/documentation/modules/auxiliary/server/relay/smb_to_ldap.md
+++ b/documentation/modules/auxiliary/server/relay/smb_to_ldap.md
@@ -2,7 +2,7 @@
 
 This module supports running an SMB server which validates credentials, and
 then attempts to execute a relay attack against an LDAP server on the
-configured RELAY_TARGETS hosts.
+configured RHOSTS hosts.
 
 It is not possible to relay NTLMv2 to LDAP due to the Message Integrity Check
 (MIC). As a result, this will only work with NTLMv1. The module takes care of
@@ -65,11 +65,11 @@ HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa
     LmCompatibilityLevel    REG_DWORD    0x2
 ```
 
-Finally run the relay server on msfconsole, setting the `RELAY_TARGETS` option
+Finally run the relay server on msfconsole, setting the `RHOSTS` option
 to the Domain Controller IP address.
 
 ```
-run verbose=true RELAY_TARGETS=192.168.232.110
+run verbose=true RHOSTS=192.168.232.110
 ```
 
 You will have to coerce the Domain Computer and force it to authenticate to the
@@ -78,7 +78,7 @@ msfconsole server (see an example below).
 
 ## Options
 
-### RELAY_TARGETS
+### RHOSTS
 
 Target address range or CIDR identifier to relay to.
 
@@ -107,7 +107,7 @@ The domain name used during SMB exchange.
 ### Start the relay server
 ```
 msf6 > use auxiliary/server/relay/smb_to_ldap
-msf6 auxiliary(server/relay/smb_to_ldap) > run verbose=true RELAY_TARGETS=192.168.232.110
+msf6 auxiliary(server/relay/smb_to_ldap) > run verbose=true RHOSTS=192.168.232.110
 [*] Auxiliary module running as background job 0.
 msf6 auxiliary(server/relay/smb_to_ldap) >
 [*] SMB Server is running. Listening on 0.0.0.0:445

--- a/documentation/modules/exploit/windows/smb/smb_relay.md
+++ b/documentation/modules/exploit/windows/smb/smb_relay.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 This module supports running an SMB server which validates credentials, and then attempts to
-execute a relay attack against the configured RELAY_TARGETS hosts.
+execute a relay attack against the configured RHOSTS hosts.
 
 Supports SMBv2, SMBv3, and captures NTLMv1 as well as NTLMv2 hashes.
 SMBv1 is not supported - please see https://github.com/rapid7/metasploit-framework/issues/16261
@@ -75,7 +75,7 @@ flowchart LR
 
 ## Options
 
-### RELAY_TARGETS
+### RHOSTS
 
 Target address range or CIDR identifier to relay to
 
@@ -162,8 +162,8 @@ Active sessions
 Multiple targets can be relayed to:
 
 ```
-msf6 exploit(windows/smb/smb_relay) > set RELAY_TARGETS 192.168.123.4 192.168.123.25
-RELAY_TARGETS => 192.168.123.4 192.168.123.25
+msf6 exploit(windows/smb/smb_relay) > set RHOSTS 192.168.123.4 192.168.123.25
+RHOSTS => 192.168.123.4 192.168.123.25
 msf6 exploit(windows/smb/smb_relay) >
 [*] Started reverse TCP handler on 192.168.123.1:4444
 [*] JTR hashes will be split into two files depending on the hash format.
@@ -261,8 +261,8 @@ Server:
 ```
 msf6 exploit(windows/smb/smb_relay) > set JOHNPWFILE ./relay_results.txt
 JOHNPWFILE => ./relay_results.txt
-msf6 exploit(windows/smb/smb_relay) > set RELAY_TARGETS 192.168.123.4 192.168.123.25
-RELAY_TARGETS => 192.168.123.4 192.168.123.25
+msf6 exploit(windows/smb/smb_relay) > set RHOSTS 192.168.123.4 192.168.123.25
+RHOSTS => 192.168.123.4 192.168.123.25
 msf6 exploit(windows/smb/smb_relay) > run
 [*] Exploit running as background job 9.
 [*] Exploit completed, but no session was created.

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     Msf::Exploit::Remote::SMB::Relay::TargetList.new(
       (datastore['SSL'] ? :https : :http),
       datastore['RPORT'],
-      datastore['RELAY_TARGETS'],
+      datastore['RHOSTS'],
       datastore['TARGETURI'],
       randomize_targets: datastore['RANDOMIZE_TARGETS']
     )

--- a/modules/auxiliary/server/relay/smb_to_ldap.rb
+++ b/modules/auxiliary/server/relay/smb_to_ldap.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           This module supports running an SMB server which validates credentials, and
           then attempts to execute a relay attack against an LDAP server on the
-          configured RELAY_TARGETS hosts.
+          configured RHOSTS hosts.
 
           It is not possible to relay NTLMv2 to LDAP due to the Message Integrity Check
           (MIC). As a result, this will only work with NTLMv1. The module takes care of
@@ -59,15 +59,13 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('SessionKeepalive', [true, 'Time (in seconds) for sending protocol-level keepalive messages', 10 * 60])
       ]
     )
-
-    deregister_options('RHOSTS')
   end
 
   def relay_targets
     Msf::Exploit::Remote::SMB::Relay::TargetList.new(
       :ldap, # TODO: look into LDAPs
       datastore['RPORT'],
-      datastore['RELAY_TARGETS'],
+      datastore['RHOSTS'],
       datastore['TARGETURI'],
       randomize_targets: datastore['RANDOMIZE_TARGETS'],
       drop_mic_only: true,
@@ -78,9 +76,6 @@ class MetasploitModule < Msf::Auxiliary
   def check_options
     unless framework.features.enabled?(Msf::FeatureManager::LDAP_SESSION_TYPE)
       fail_with(Failure::BadConfig, 'This module requires the `ldap_session_type` feature to be enabled. Please enable this feature using `features set ldap_session_type true`')
-    end
-    if datastore['RHOSTS'].present?
-      print_warning('Warning: RHOSTS datastore value has been set which is not supported by this module. Please verify RELAY_TARGETS is set correctly.')
     end
   end
 


### PR DESCRIPTION
When PR #19639 was landed it removed the `RELAY_TARGETS` datastore option because it was no longer necessary and instead changed the pattern to use `RHOSTS` as most modules do. That particular PR took a while to land and in the mean time the `smb_to_ldap` relay module was submitted. By the time RELAY_TARGETS were removed, the smb_to_ldap module had already been landed but had not been updated resulting in it currently being broken. This PR fixes the `smb_to_ldap` module by registering the RHOSTS option.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/server/relay/smb_to_ldap`
- [ ] `set RHOSTS` to the LDAP server
- [ ] Test the module and see that it works

For the victim system that is being relayed from, the original PR #19832 has a helpful note about how to make it vulnerable:

> The Domain Computer will need to be configured to use NTLMv1 by setting the following registry key to a value less or equal to 2:
>
> ```
> PS > reg add HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -v LmCompatibilityLevel /t REG_DWORD /d 0x2 /f
> ```
>
> ```
> PS > reg query HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -v LmCompatibilityLevel
> HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa
>     LmCompatibilityLevel    REG_DWORD    0x2
> ```
 
I found this insufficient however. A Windows 11 24H2 build 26100 system wasn't able to work. I was able to get a Server 2019 v1809 build 17763 server to work though. My best guess is that instructions require a system less than something between builds 17763 and 26100. @jheysel-r7 noted that his test system at the time was build 19045, so more accurately, it's probably 19045 - 26100.