### PR TITLE
Modules: Remove quotes surrounding quoted license constant

### DIFF
--- a/modules/evasion/windows/applocker_evasion_install_util.rb
+++ b/modules/evasion/windows/applocker_evasion_install_util.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Evasion
           'Nick Tyrer <@NickTyrer>', # module development
           'Casey Smith' # install_util bypass research
         ],
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [['Microsoft Windows', {}]],

--- a/modules/evasion/windows/applocker_evasion_msbuild.rb
+++ b/modules/evasion/windows/applocker_evasion_msbuild.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Evasion
           'Nick Tyrer <@NickTyrer>', # module development
           'Casey Smith' # msbuild bypass research
         ],
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [['Microsoft Windows', {}]],

--- a/modules/evasion/windows/applocker_evasion_presentationhost.rb
+++ b/modules/evasion/windows/applocker_evasion_presentationhost.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Evasion
           'Nick Tyrer <@NickTyrer>', # module development
           'Casey Smith' # presentationhost bypass research
         ],
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_X86],
         'Targets' => [['Microsoft Windows', {}]]

--- a/modules/evasion/windows/applocker_evasion_regasm_regsvcs.rb
+++ b/modules/evasion/windows/applocker_evasion_regasm_regsvcs.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Evasion
           'Nick Tyrer <@NickTyrer>', # module development
           'Casey Smith' # regasm_regsvcs bypass research
         ],
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [['Microsoft Windows', {}]],

--- a/modules/evasion/windows/applocker_evasion_workflow_compiler.rb
+++ b/modules/evasion/windows/applocker_evasion_workflow_compiler.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Evasion
           'Nick Tyrer <@NickTyrer>', # module development
           'Matt Graeber' # workflow_compiler bypass research
         ],
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [['Microsoft Windows', {}]],

--- a/modules/post/windows/gather/bitlocker_fvek.rb
+++ b/modules/post/windows/gather/bitlocker_fvek.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Post
           This module enumerates ways to decrypt Bitlocker volume and if a recovery key is stored locally
           or can be generated, dump the Bitlocker master key (FVEK)
         },
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
         'Author' => ['Danil Bazin <danil.bazin[at]hsc.fr>'], # @danilbaz

--- a/modules/post/windows/gather/file_from_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_from_raw_ntfs.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Post
           such as open file with write lock. Because it avoids the usual file locking issues, it can
           be used to retrieve files such as NTDS.dit.
         },
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
         'Author' => ['Danil Bazin <danil.bazin[at]hsc.fr>'], # @danilbaz


### PR DESCRIPTION
These weren't picked up by the tests due to two separate bugs in the spec.

I'll patch these bugs once this PR lands.
