### PR TITLE
Msf::Post::Linux::Kernel: Add yama_ptrace_scope method

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -335,6 +335,26 @@ module Msf
         end
 
         #
+        # Returns Yama LSM ptrace scope level
+        #
+        # @return [Integer] Yama ptrace scope level (0 if disabled or not installed)
+        # @raise [RuntimeError] If execution fails.
+        #
+        def yama_ptrace_scope
+          ptrace_scope = read_file('/proc/sys/kernel/yama/ptrace_scope').to_s.strip
+
+          return 0 unless ptrace_scope
+
+          level = ptrace_scope.scan(/\A(\d+)\z/).flatten.first.to_i
+
+          return 0 unless level
+
+          level
+        rescue StandardError
+          raise 'Could not determine Yama scope'
+        end
+
+        #
         # Returns true if Yama is installed
         #
         # @return [Boolean]
@@ -356,9 +376,7 @@ module Msf
         # @raise [RuntimeError] If execution fails.
         #
         def yama_enabled?
-          return false unless yama_installed?
-
-          !read_file('/proc/sys/kernel/yama/ptrace_scope').to_s.strip.eql? '0'
+          yama_ptrace_scope > 0
         rescue StandardError
           raise 'Could not determine Yama status'
         end


### PR DESCRIPTION
Add `yama_ptrace_scope` method.

Yama `ptrace_scope` supports [multiple levels](https://www.kernel.org/doc/Documentation/security/Yama.txt). Currently, all modules in framework check only if Yama is enabled. We may want to use more granular checks in the future.

Using the new `yama_ptrace_scope` method in `yama_enabled?` allows us to decrease the number of `read_file` calls from 2 to 1.
