### PR TITLE
Msf::OptionContainer: Replace `.sorted` Array attribute with `self.sort`

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -50,10 +50,16 @@ module Msf
     # as necessary.
     #
     def initialize(opts = {})
-      self.sorted = []
       self.groups = {}
 
       add_options(opts)
+    end
+
+    #
+    # Return the sorted array of options.
+    #
+    def sorted
+      self.sort
     end
 
     #
@@ -116,10 +122,6 @@ module Msf
     # @param [String] name the option name
     def remove_option(name)
       delete(name)
-      sorted.each_with_index { |e, idx|
-        sorted[idx] = nil if (e[0] == name)
-      }
-      sorted.delete(nil)
     end
 
     #
@@ -170,9 +172,6 @@ module Msf
       option.owner    = owner
 
       self.store(option.name, option)
-
-      # Re-calculate the sorted list
-      self.sorted = self.sort
     end
 
     #
@@ -330,17 +329,10 @@ module Msf
       groups.delete(group_name)
     end
 
-    #
-    # The sorted array of options.
-    #
-    attr_reader :sorted
-
     # @return [Hash<String, Msf::OptionGroup>]
     attr_reader :groups
 
     protected
-
-    attr_writer :sorted # :nodoc:
 
     attr_writer :groups
   end

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -78,7 +78,7 @@ module Msf
             return res
           end
 
-          mod.options.sorted.each do |e|
+          mod.options.each do |e|
             name, _opt = e
             res << name
           end
@@ -101,7 +101,7 @@ module Msf
           if ((mod.exploit? || mod.evasion?) && mod.datastore['PAYLOAD'])
             p = framework.payloads.create(mod.datastore['PAYLOAD'])
             if p
-              p.options.sorted.each do |e|
+              p.options.each do |e|
                 name, _opt = e
                 res << name
               end
@@ -119,7 +119,8 @@ module Msf
               end
             end
           end
-          return res
+
+          return res.sort
         end
 
         #


### PR DESCRIPTION
tl/dr: This PR removes the pre-calculated `Msf::OptionContainer.sorted` attribute, favoring dynamic sorting at runtime instead.

---

Profiling reveals a lot of time is spent parsing module options in `Msf::OptionContainer#add_option` during startup.

```
# stackprof stackprof-output.dump.old | head
==================================
  Mode: cpu(1000)
  Samples: 11742 (0.84% miss rate)
  GC: 1279 (10.89%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1824  (15.5%)        1660  (14.1%)     Array#<=>
       719   (6.1%)         719   (6.1%)     (sweeping)
      3889  (33.1%)         604   (5.1%)     Enumerable.sort
       560   (4.8%)         560   (4.8%)     (marking)
```

```
# stackprof stackprof-output.dump.old --method 'Enumerable' | head
Enumerable.sort (<cfunc>:1)
  samples:   604 self (5.1%)  /   3889 total (33.1%)
  callers:
    3886  (   99.9%)  Msf::OptionContainer#add_option
     134  (    3.4%)  Array#each
       3  (    0.1%)  Msf::Modules::Metadata::Store#update_store
  callees (3285 total):
    1824  (   55.5%)  Array#<=>
    1595  (   48.6%)  Msf::OptionContainer#each
  code:
```

Commit https://github.com/rapid7/metasploit-framework/commit/0e357337a5f1a4f824b7cc15dcb65fab61a1aae6 introduced a `sorted` attribute to the `OptionContainer` class (extends `Hash`). This attribute contains a sorted `Array` of options. The commit was authored in 2005 when Metasploit contained far fewer modules. The commit provided no justification for the addition of this attribute; however, other newly introduced code in the same commit uses the `sorted` attribute when serializing the module options as text. The intention was clearly to prevent unnecessary re-sorting.

This requires duplicating, sorting, then storing the options `Hash` as a sorted `Array` for every module at startup. Additionally, `sorted` is re-sorted every time an option is added (or removed), which is performed one-at-a-time during module initialization.

Due to the ever-increasing number of modules, this behaviour will cause the startup time to grow. On my development VM with 2 cores and 4 GB of RAM, `msfconsole` takes approximately 30 seconds to start (although using `--defer-module-loads` decreases load time to ~5 seconds).

Although it would be nice to store a pre-calculated list of sorted options, I believe it is not worth the startup processing cost and memory impact, which impact every user who is not aware of the speedup offered by `--defer-module-loads`.

**Removing the option sorting decreases startup time by about 30%**.

Currently the only places we use the `sorted` property are here:

```
# fgrep -rn .sorted lib/
lib/msf/ui/console/module_option_tab_completion.rb:81:          mod.options.sorted.each do |e|
lib/msf/ui/console/module_option_tab_completion.rb:104:              p.options.sorted.each do |e|
lib/msf/base/serializer/json.rb:183:        mod.options.sorted.each do |entry|
```

For tab completion, as modules have less than 100 options, performing a dynamic sort of module options at runtime should have a negligible impact. Additionally, if it does pose an issue, the existing tab completion code could be improved by sorting the *result* (`res`) before returning, rather than needlessly sorting the options before parsing. **Edit:** I've updated this PR to include this change. Options are not sorted - instead, the results are sorted.

For the JSON serialization, this seems to be used only by RPC (or when printing module info to terminal, which is unlikely to have a noticeable impact). For RPC, I'm doubtful that this will realistically pose an issue in practice. Of course, RPC is intended to be used by machines, so if sorting is important, the RPC client can take care of sorting the options for humans.

---

# Before

```
# for i in {1..5}; do time ./msfconsole -q -x exit ; done

real    0m29.268s
user    0m27.754s
sys     0m1.427s

real    0m29.225s
user    0m27.898s
sys     0m1.242s

real    0m29.563s
user    0m28.150s
sys     0m1.311s

real    0m30.127s
user    0m28.837s
sys     0m1.180s

real    0m29.632s
user    0m28.146s
sys     0m1.367s
```

# After

```
# for i in {1..5}; do time ./msfconsole -q -x exit ; done

real    0m20.388s
user    0m18.859s
sys     0m1.422s

real    0m21.187s
user    0m19.591s
sys     0m1.496s

real    0m17.688s
user    0m16.131s
sys     0m1.392s

real    0m19.522s
user    0m18.157s
sys     0m1.208s

real    0m19.419s
user    0m17.970s
sys     0m1.295s
```
