### PR TITLE
modules/auxiliary/bnat: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -7,55 +7,54 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'         => 'BNAT Router',
-      'Description'  => %q{
+      'Name' => 'BNAT Router',
+      'Description' => %q{
           This module will properly route BNAT traffic and allow for connections to be
         established to machines on ports which might not otherwise be accessible.},
-      'Author'       =>
-        [
-            'bannedit',
-            'Jonathan Claudius',
-        ],
-      'License'      => MSF_LICENSE,
-      'References'   =>
-        [
-          [ 'URL', 'https://github.com/claudijd/bnat' ],
-          [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
-        ]
+      'Author' => [
+        'bannedit',
+        'Jonathan Claudius',
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'https://github.com/claudijd/bnat' ],
+        ['URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
+      ]
     )
     register_options(
-        [
-          OptString.new('OUTINF',    [true, 'The external interface connected to the internet', 'eth1']),
-          OptString.new('ININF',     [true, 'The internal interface connected to the network', 'eth2']),
-          OptString.new('CLIENTIP',  [true, 'The ip of the client behind the BNAT router', '192.168.3.2']),
-          OptString.new('SERVERIP',  [true, 'The ip of the server you are targeting', '1.1.2.1']),
-          OptString.new('BNATIP',    [true, 'The ip of the bnat response you are getting', '1.1.2.2']),
-        ])
+      [
+        OptString.new('OUTINF', [true, 'The external interface connected to the internet', 'eth1']),
+        OptString.new('ININF', [true, 'The internal interface connected to the network', 'eth2']),
+        OptString.new('CLIENTIP', [true, 'The ip of the client behind the BNAT router', '192.168.3.2']),
+        OptString.new('SERVERIP', [true, 'The ip of the server you are targeting', '1.1.2.1']),
+        OptString.new('BNATIP', [true, 'The ip of the bnat response you are getting', '1.1.2.2']),
+      ]
+    )
   end
 
   def run
     clientip = datastore['CLIENTIP']
     serverip = datastore['SERVERIP']
-    bnatip =   datastore['BNATIP']
-    outint =   datastore['OUTINF']
-    inint =    datastore['ININF']
+    bnatip = datastore['BNATIP']
+    outint = datastore['OUTINF']
+    inint = datastore['ININF']
 
-    clientmac = arp2(clientip,inint)
+    clientmac = arp2(clientip, inint)
     print_line("Obtained Client MAC: #{clientmac}")
-    servermac = arp2(serverip,outint)
+    servermac = arp2(serverip, outint)
     print_line("Obtained Server MAC: #{servermac}")
-    bnatmac = arp2(bnatip,outint)
+    bnatmac = arp2(bnatip, outint)
     print_line("Obtained BNAT MAC: #{bnatmac}\n\n")
 
     # Create Interface Specific Configs
-    outconfig = PacketFu::Config.new(PacketFu::Utils.ifconfig ":#{outint}").config
-    inconfig =  PacketFu::Config.new(PacketFu::Utils.ifconfig ":#{inint}").config
+    outconfig = PacketFu::Config.new(PacketFu::Utils.ifconfig(":#{outint}")).config
+    inconfig = PacketFu::Config.new(PacketFu::Utils.ifconfig(":#{inint}")).config
 
     # Set Captures for Traffic coming from Outside and from Inside respectively
-    outpcap = PacketFu::Capture.new( :iface => "#{outint}", :start => true, :filter => "tcp and src #{bnatip}" )
+    outpcap = PacketFu::Capture.new(iface: outint.to_s, start: true, filter: "tcp and src #{bnatip}")
     print_line("Now listening on #{outint}...")
 
-    inpcap = PacketFu::Capture.new( :iface => "#{inint}", :start => true, :filter => "tcp and src #{clientip} and dst #{serverip}" )
+    inpcap = PacketFu::Capture.new(iface: inint.to_s, start: true, filter: "tcp and src #{clientip} and dst #{serverip}")
     print_line("Now listening on #{inint}...\n\n")
 
     # Start Thread from Outside Processing
@@ -65,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
           packet = PacketFu::Packet.parse(pkt)
 
           # Build a shell packet that will never hit the wire as a hack to get desired mac's
-          shell_pkt = PacketFu::TCPPacket.new(:config => inconfig, :timeout => 0.1, :flavor => "Windows")
+          shell_pkt = PacketFu::TCPPacket.new(config: inconfig, timeout: 0.1, flavor: 'Windows')
           shell_pkt.ip_daddr = clientip
           shell_pkt.recalc
 
@@ -75,9 +74,9 @@ class MetasploitModule < Msf::Auxiliary
           packet.eth_saddr = shell_pkt.eth_saddr
           packet.eth_daddr = clientmac
           packet.recalc
-          inj = PacketFu::Inject.new( :iface => "#{inint}", :config => inconfig )
-          inj.a2w(:array => [packet.to_s])
-          print_status("inpacket processed")
+          inj = PacketFu::Inject.new(iface: inint.to_s, config: inconfig)
+          inj.a2w(array: [packet.to_s])
+          print_status('inpacket processed')
         end
       end
     end
@@ -97,23 +96,23 @@ class MetasploitModule < Msf::Auxiliary
           end
 
           # Build a shell packet that will never hit the wire as a hack to get desired mac's
-          shell_pkt = PacketFu::TCPPacket.new(:config=>outconfig, :timeout=> 0.1, :flavor=>"Windows")
+          shell_pkt = PacketFu::TCPPacket.new(config: outconfig, timeout: 0.1, flavor: 'Windows')
           shell_pkt.ip_daddr = serverip
           shell_pkt.recalc
 
           # Mangle Received Packet and Drop on the Wire
           packet.eth_saddr = shell_pkt.eth_saddr
-          packet.ip_saddr=shell_pkt.ip_saddr
+          packet.ip_saddr = shell_pkt.ip_saddr
           packet.recalc
-          inj = PacketFu::Inject.new( :iface => "#{outint}", :config =>outconfig )
-          inj.a2w(:array => [packet.to_s])
+          inj = PacketFu::Inject.new(iface: outint.to_s, config: outconfig)
+          inj.a2w(array: [packet.to_s])
 
           # Trigger Cisco SPI Vulnerability by Double-tapping the SYN
           if packet.tcp_flags.syn == 1 && packet.tcp_flags.ack == 0
             select(nil, nil, nil, 0.75)
-            inj.a2w(:array => [packet.to_s])
+            inj.a2w(array: [packet.to_s])
           end
-          print_status("outpacket processed")
+          print_status('outpacket processed')
         end
       end
     end
@@ -121,23 +120,23 @@ class MetasploitModule < Msf::Auxiliary
     fromin.join
   end
 
-  def arp2(target_ip,int)
-    config = PacketFu::Config.new(PacketFu::Utils.ifconfig ":#{int}").config
-    arp_pkt = PacketFu::ARPPacket.new(:flavor => "Windows")
+  def arp2(target_ip, int)
+    config = PacketFu::Config.new(PacketFu::Utils.ifconfig(":#{int}")).config
+    arp_pkt = PacketFu::ARPPacket.new(flavor: 'Windows')
     arp_pkt.eth_saddr = arp_pkt.arp_saddr_mac = config[:eth_saddr]
-    arp_pkt.eth_daddr = "ff:ff:ff:ff:ff:ff"
-    arp_pkt.arp_daddr_mac = "00:00:00:00:00:00"
+    arp_pkt.eth_daddr = 'ff:ff:ff:ff:ff:ff'
+    arp_pkt.arp_daddr_mac = '00:00:00:00:00:00'
     arp_pkt.arp_saddr_ip = config[:ip_saddr]
     arp_pkt.arp_daddr_ip = target_ip
-    cap = PacketFu::Capture.new(:iface => config[:iface], :start => true, :filter => "arp src #{target_ip} and ether dst #{arp_pkt.eth_saddr}")
-    injarp = PacketFu::Inject.new(:iface => config[:iface])
-    injarp.a2w(:array => [arp_pkt.to_s])
+    cap = PacketFu::Capture.new(iface: config[:iface], start: true, filter: "arp src #{target_ip} and ether dst #{arp_pkt.eth_saddr}")
+    injarp = PacketFu::Inject.new(iface: config[:iface])
+    injarp.a2w(array: [arp_pkt.to_s])
     target_mac = nil
 
     while target_mac.nil?
       if cap.save > 0
         arp_response = PacketFu::Packet.parse(cap.array[0])
-        target_mac = arp_response.arp_saddr_mac if arp_response.arp_saddr_ip = target_ip
+        target_mac = arp_response.arp_saddr_mac if arp_response.arp_saddr_ip == target_ip
       end
       select(nil, nil, nil, 0.1) # Check for a response ten times per second.
     end

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -9,34 +9,32 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'         => 'BNAT Scanner',
-      'Description'  => %q{
+      'Name' => 'BNAT Scanner',
+      'Description' => %q{
           This module is a scanner which can detect Broken NAT (network address translation)
         implementations, which could result in an inability to reach ports on remote
         machines. Typically, these ports will appear in nmap scans as 'filtered'/'closed'.
-        },
-      'Author'       =>
-        [
-          'bannedit',
-          'Jonathan Claudius <jclaudius[at]trustwave.com>',
-        ],
-      'License'      => MSF_LICENSE,
-      'References'   =>
-        [
-          [ 'URL', 'https://github.com/claudijd/bnat'],
-          [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
-        ]
+      },
+      'Author' => [
+        'bannedit',
+        'Jonathan Claudius <jclaudius[at]trustwave.com>',
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'https://github.com/claudijd/bnat'],
+        ['URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
+      ]
     )
 
     register_options(
-        [
-          OptString.new('PORTS', [true, "Ports to scan (e.g. 22-25,80,110-900)", "21,22,23,80,443"]),
-          OptString.new('INTERFACE', [true, "The name of the interface", "eth0"]),
-          OptInt.new('TIMEOUT', [true, "The reply read timeout in milliseconds", 500])
-        ])
+      [
+        OptString.new('PORTS', [true, 'Ports to scan (e.g. 22-25,80,110-900)', '21,22,23,80,443']),
+        OptString.new('INTERFACE', [true, 'The name of the interface', 'eth0']),
+        OptInt.new('TIMEOUT', [true, 'The reply read timeout in milliseconds', 500])
+      ]
+    )
 
-    deregister_options('FILTER','PCAPFILE','SNAPLEN')
-
+    deregister_options('FILTER', 'PCAPFILE', 'SNAPLEN')
   end
 
   def probe_reply(pcap, to)
@@ -46,48 +44,51 @@ class MetasploitModule < Msf::Auxiliary
         pcap.each do |r|
           pkt = PacketFu::Packet.parse(r)
           next unless pkt.is_tcp?
+
           reply = pkt
           break
         end
       end
-      rescue Timeout::Error
+    rescue Timeout::Error => e
+      vprint_error(e.message)
     end
     return reply
   end
 
   def generate_probe(ip)
-    ftypes = %w{windows, linux, freebsd}
-    @flavor = ftypes[rand(ftypes.length)]
-    config = PacketFu::Utils.whoami?(:iface => datastore['INTERFACE'])
-    p = PacketFu::TCPPacket.new(:config => config)
+    ftypes = %w[windows linux freebsd]
+    @flavor = ftypes.sample
+    config = PacketFu::Utils.whoami?(iface: datastore['INTERFACE'])
+    p = PacketFu::TCPPacket.new(config: config)
     p.ip_daddr = ip
     p.tcp_flags.syn = 1
     return p
   end
 
   def run_host(ip)
+    ports = Rex::Socket.portspec_crack(datastore['PORTS'])
+
+    if ports.empty?
+      raise Msf::OptionValidateError, ['PORTS']
+    end
+
     open_pcap
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0
 
     p = generate_probe(ip)
-    pcap = self.capture
+    pcap = capture
 
-    ports = Rex::Socket.portspec_crack(datastore['PORTS'])
-
-    if ports.empty?
-      raise Msf::OptionValidateError.new(['PORTS'])
-    end
-
-    ports.each_with_index do |port,i|
+    ports.each_with_index do |port, _i|
       p.tcp_dst = port
-      p.tcp_src = rand(64511)+1024
-      p.tcp_seq = rand(64511)+1024
+      p.tcp_src = rand(1024..65534)
+      p.tcp_seq = rand(1024..65534)
       p.recalc
 
       ackbpf = "tcp [8:4] == 0x#{(p.tcp_seq + 1).to_s(16)}"
       pcap.setfilter("tcp and tcp[13] == 18 and not host #{ip} and src port #{p.tcp_dst} and dst port #{p.tcp_src} and #{ackbpf}")
       break unless capture_sendto(p, ip)
+
       reply = probe_reply(pcap, to)
       next if reply.nil?
 


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

Also likely fixes a bug. Here, inside a inside a conditional statement in `auxiliary/bnat/bnat_router`, the module sets a property of the ARP *response* to the target IP address:

https://github.com/rapid7/metasploit-framework/blob/03e2d25ac943c177dc54c68ecff2a3170996689b/modules/auxiliary/bnat/bnat_router.rb#L140

Although untested, it is highly likely that the original intention was to check if `arp_response.arp_saddr_ip == target_ip`, rather than check if the assignment was successful. This has been fixed.
