### PR TITLE
spec: acceptance: remove RHOST_REGEX constant

### DIFF
--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -3,8 +3,6 @@ require 'acceptance_spec_helper'
 RSpec.describe 'LDAP modules' do
   include_context 'wait_for_expect'
 
-  RHOST_REGEX = /\d+\.\d+\.\d+\.\d+:\d+/
-
   tests = {
     ldap: {
       target: {

--- a/spec/acceptance/mysql_spec.rb
+++ b/spec/acceptance/mysql_spec.rb
@@ -3,8 +3,6 @@ require 'acceptance_spec_helper'
 RSpec.describe 'MySQL sessions and MySQL modules' do
   include_context 'wait_for_expect'
 
-  RHOST_REGEX = /\d+\.\d+\.\d+\.\d+:\d+/
-
   tests = {
     mysql: {
       target: {
@@ -49,7 +47,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
           lines: {
             all: {
               required: [
-                /#{RHOST_REGEX} is running MySQL \d+.\d+.*/
+                /\d+\.\d+\.\d+\.\d+:\d+ is running MySQL \d+.\d+.*/
               ]
             },
           }

--- a/spec/acceptance/smb_spec.rb
+++ b/spec/acceptance/smb_spec.rb
@@ -3,8 +3,6 @@ require 'acceptance_spec_helper'
 RSpec.describe 'SMB sessions and SMB modules' do
   include_context 'wait_for_expect'
 
-  RHOST_REGEX = /\d+\.\d+\.\d+\.\d+:\d+/
-
   tests = {
     smb: {
       target: {


### PR DESCRIPTION
`RHOST_REGEX` is defined in the global namespace but unused, with the exception of `spec/acceptance/mysql_spec.rb` where it was used only once. Removing it prevents printing warnings:

```
/home/runner/work/metasploit-framework/metasploit-framework/spec/acceptance/mysql_spec.rb:6: warning: already initialized constant RHOST_REGEX
/home/runner/work/metasploit-framework/metasploit-framework/spec/acceptance/ldap_spec.rb:6: warning: previous definition of RHOST_REGEX was here
/home/runner/work/metasploit-framework/metasploit-framework/spec/acceptance/smb_spec.rb:6: warning: already initialized constant RHOST_REGEX
/home/runner/work/metasploit-framework/metasploit-framework/spec/acceptance/mysql_spec.rb:6: warning: previous definition of RHOST_REGEX was here
```

