### PR TITLE
modules/auxiliary/parser: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/parser/unattend.rb
+++ b/modules/auxiliary/parser/unattend.rb
@@ -3,29 +3,35 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'        => 'Auxilliary Parser Windows Unattend Passwords',
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Auxiliary Parser Windows Unattend Passwords',
         'Description' => %q{
-        This module parses Unattend files in the target directory.
+          This module parses Windows answer files (Unattend files) in the target directory.
 
-        See also: post/windows/gather/enum_unattend
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        =>
-        [
+          See also: post/windows/gather/enum_unattend
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Ben Campbell',
         ],
-      'References'    =>
-        [
+        'References' => [
           ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-8.1-and-8/ff715801(v=win.10)'],
           ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-vista/cc749415(v=ws.10)'],
-          ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732280(v=ws.10)']
+          ['URL', 'https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc732280(v=ws.10)'],
+          ['URL', 'https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/update-windows-settings-and-scripts-create-your-own-answer-file-sxs?view=windows-11'],
         ],
-    ))
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options([
       OptPath.new('PATH', [true, 'Directory or file to parse.']),
@@ -35,9 +41,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if datastore['RECURSIVE']
-      ext = "**/*.xml"
+      ext = '**/*.xml'
     else
-      ext = "/*.xml"
+      ext = '/*.xml'
     end
 
     if datastore['PATH'].ends_with?('.xml')
@@ -64,4 +70,3 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 end
-


### PR DESCRIPTION
All violations resolved with `rubocop -a`, except notes.

Also fixes a spelling error in the module name.
