### PR TITLE
modules/exploits/unix/fileformat: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
+++ b/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
@@ -9,48 +9,51 @@ class MetasploitModule < Msf::Exploit
   include Msf::Exploit::FILEFORMAT
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'             => 'Ghostscript Type Confusion Arbitrary Command Execution',
-      'Description'      => %q{
-        This module exploits a type confusion vulnerability in Ghostscript that can
-        be exploited to obtain arbitrary command execution. This vulnerability affects
-        Ghostscript versions 9.21 and earlier and can be exploited through libraries
-        such as ImageMagick and Pillow.
-      },
-      'Author'           => [
-        'Atlassian Security Team', # Vulnerability discovery
-        'hdm'                      # Metasploit module
-      ],
-      'References'       => [
-        %w{CVE 2017-8291},
-        %w{URL https://bugs.ghostscript.com/show_bug.cgi?id=697808},
-        %w{URL https://seclists.org/oss-sec/2017/q2/148},
-        %w{URL http://web.archive.org/web/20240723023227/https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=04b37bbce174eed24edec7ad5b920eb93db4d47d},
-        %w{URL http://web.archive.org/web/20240703041152/https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=4f83478c88c2e05d6e8d79ca4557eb039354d2f3}
-      ],
-      'DisclosureDate'   => '2017-04-27',
-      'License'          => MSF_LICENSE,
-      'Platform'         => 'unix',
-      'Arch'             => ARCH_CMD,
-      'Privileged'       => false,
-      'Payload'          => {
-        'BadChars'       => "\x22\x27\x5c)(" # ", ', \, (, and )
-      },
-      'Targets'          => [
-        ['EPS file',  template: 'msf.eps']
-      ],
-      'DefaultTarget'    => 0,
-      'Notes'            => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [],
-        'Reliability' => [],
-        'AKA'            => ['ghostbutt'],
-        'RelatedModules' => [
-          'exploit/multi/fileformat/ghostscript_failed_restore',
-          'exploit/unix/fileformat/imagemagick_delegate'
-        ]
-      }
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Ghostscript Type Confusion Arbitrary Command Execution',
+        'Description' => %q{
+          This module exploits a type confusion vulnerability in Ghostscript that can
+          be exploited to obtain arbitrary command execution. This vulnerability affects
+          Ghostscript versions 9.21 and earlier and can be exploited through libraries
+          such as ImageMagick and Pillow.
+        },
+        'Author' => [
+          'Atlassian Security Team', # Vulnerability discovery
+          'hdm'                      # Metasploit module
+        ],
+        'References' => [
+          %w[CVE 2017-8291],
+          %w[URL https://bugs.ghostscript.com/show_bug.cgi?id=697808],
+          %w[URL https://seclists.org/oss-sec/2017/q2/148],
+          %w[URL http://web.archive.org/web/20240723023227/https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=04b37bbce174eed24edec7ad5b920eb93db4d47d],
+          %w[URL http://web.archive.org/web/20240703041152/https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=4f83478c88c2e05d6e8d79ca4557eb039354d2f3]
+        ],
+        'DisclosureDate' => '2017-04-27',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => false,
+        'Payload' => {
+          'BadChars' => "\x22\x27\x5c)(" # ", ', \, (, and )
+        },
+        'Targets' => [
+          ['EPS file', { template: 'msf.eps' }]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => [],
+          'AKA' => ['ghostbutt'],
+          'RelatedModules' => [
+            'exploit/multi/fileformat/ghostscript_failed_restore',
+            'exploit/unix/fileformat/imagemagick_delegate'
+          ]
+        }
+      )
+    )
 
     register_options([
       OptString.new('FILENAME', [true, 'Output file', 'msf.eps'])

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -9,71 +9,74 @@ class MetasploitModule < Msf::Exploit
   include Msf::Exploit::FILEFORMAT
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'             => 'ImageMagick Delegate Arbitrary Command Execution',
-      'Description'      => %q{
-        This module exploits a shell command injection in the way "delegates"
-        (commands for converting files) are processed in ImageMagick versions
-        <= 7.0.1-0 and <= 6.9.3-9 (legacy).
+    super(
+      update_info(
+        info,
+        'Name' => 'ImageMagick Delegate Arbitrary Command Execution',
+        'Description' => %q{
+          This module exploits a shell command injection in the way "delegates"
+          (commands for converting files) are processed in ImageMagick versions
+          <= 7.0.1-0 and <= 6.9.3-9 (legacy).
 
-        Since ImageMagick uses file magic to detect file format, you can create
-        a .png (for example) which is actually a crafted SVG (for example) that
-        triggers the command injection.
+          Since ImageMagick uses file magic to detect file format, you can create
+          a .png (for example) which is actually a crafted SVG (for example) that
+          triggers the command injection.
 
-        The PostScript (PS) target leverages a Ghostscript -dSAFER bypass
-        (discovered by taviso) to achieve RCE in the Ghostscript delegate.
-        Ghostscript versions 9.18 and later are affected. This target is
-        provided as is and will not be updated to track additional vulns.
+          The PostScript (PS) target leverages a Ghostscript -dSAFER bypass
+          (discovered by taviso) to achieve RCE in the Ghostscript delegate.
+          Ghostscript versions 9.18 and later are affected. This target is
+          provided as is and will not be updated to track additional vulns.
 
-        If USE_POPEN is set to true, a |-prefixed command will be used for the
-        exploit. No delegates are involved in this exploitation.
-      },
-      'Author'           => [
-        'stewie',            # Vulnerability discovery
-        'Nikolay Ermishkin', # Vulnerability discovery
-        'Tavis Ormandy',     # Vulnerability discovery
-        'wvu',               # Metasploit module
-        'hdm'                # Metasploit module
-      ],
-      'References'       => [
-        %w{CVE 2016-3714},
-        %w{CVE 2016-7976},
-        %w{URL https://imagetragick.com/},
-        %w{URL https://seclists.org/oss-sec/2016/q2/205},
-        %w{URL https://seclists.org/oss-sec/2016/q3/682},
-        %w{URL https://github.com/ImageMagick/ImageMagick/commit/06c41ab},
-        %w{URL https://github.com/ImageMagick/ImageMagick/commit/a347456},
-        %w{URL http://permalink.gmane.org/gmane.comp.security.oss.general/19669}
-      ],
-      'DisclosureDate'   => '2016-05-03',
-      'License'          => MSF_LICENSE,
-      'Platform'         => 'unix',
-      'Arch'             => ARCH_CMD,
-      'Privileged'       => false,
-      'Payload'          => {
-        'BadChars'       => "\x22\x27\x5c" # ", ', and \
-      },
-      'Targets'          => [
-        ['SVG file', template: 'msf.svg'], # convert msf.png msf.svg
-        ['MVG file', template: 'msf.mvg'], # convert msf.svg msf.mvg
-        ['PS file',  template: 'msf.ps']   # PoC from taviso
-      ],
-      'DefaultTarget'    => 0,
-      'Notes'            => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [],
-        'Reliability' => [],
-        'AKA' => ['ImageTragick'],
-        'RelatedModules' => [
-          'exploit/unix/fileformat/ghostscript_type_confusion',
-          'exploit/multi/fileformat/ghostscript_failed_restore'
-        ]
-      }
-    ))
+          If USE_POPEN is set to true, a |-prefixed command will be used for the
+          exploit. No delegates are involved in this exploitation.
+        },
+        'Author' => [
+          'stewie',            # Vulnerability discovery
+          'Nikolay Ermishkin', # Vulnerability discovery
+          'Tavis Ormandy',     # Vulnerability discovery
+          'wvu',               # Metasploit module
+          'hdm'                # Metasploit module
+        ],
+        'References' => [
+          %w[CVE 2016-3714],
+          %w[CVE 2016-7976],
+          %w[URL https://imagetragick.com/],
+          %w[URL https://seclists.org/oss-sec/2016/q2/205],
+          %w[URL https://seclists.org/oss-sec/2016/q3/682],
+          %w[URL https://github.com/ImageMagick/ImageMagick/commit/06c41ab],
+          %w[URL https://github.com/ImageMagick/ImageMagick/commit/a347456],
+          %w[URL http://permalink.gmane.org/gmane.comp.security.oss.general/19669]
+        ],
+        'DisclosureDate' => '2016-05-03',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => false,
+        'Payload' => {
+          'BadChars' => "\x22\x27\x5c" # ", ', and \
+        },
+        'Targets' => [
+          ['SVG file', { template: 'msf.svg' }], # convert msf.png msf.svg
+          ['MVG file', { template: 'msf.mvg' }], # convert msf.svg msf.mvg
+          ['PS file', { template: 'msf.ps' }] # PoC from taviso
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => [],
+          'AKA' => ['ImageTragick'],
+          'RelatedModules' => [
+            'exploit/unix/fileformat/ghostscript_type_confusion',
+            'exploit/multi/fileformat/ghostscript_failed_restore'
+          ]
+        }
+      )
+    )
 
     register_options([
       OptString.new('FILENAME', [true, 'Output file', 'msf.png']),
-      OptBool.new('USE_POPEN',  [false, 'Use popen() vector', true])
+      OptBool.new('USE_POPEN', [false, 'Use popen() vector', true])
     ])
   end
 


### PR DESCRIPTION
All violations resolved with `rubocop -a`.
