### PR TITLE
modules/auxiliary/analyze: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -21,6 +21,11 @@ class MetasploitModule < Msf::Auxiliary
         # ['hashcat', 'Description' => 'Use Hashcat'], # removed for simplicity
       ],
       'DefaultAction' => 'john',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
     deregister_options('ITERATION_TIMEOUT')
     deregister_options('CUSTOM_WORDLIST')

--- a/modules/auxiliary/analyze/crack_aix.rb
+++ b/modules/auxiliary/analyze/crack_aix.rb
@@ -27,6 +27,11 @@ class MetasploitModule < Msf::Auxiliary
         ['hashcat', { 'Description' => 'Use Hashcat' }],
       ],
       'DefaultAction' => 'john',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -48,37 +53,38 @@ class MetasploitModule < Msf::Auxiliary
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
-  def run
-    def check_results(passwords, results, hash_type, method)
-      passwords.each do |password_line|
-        password_line.chomp!
-        next if password_line.blank?
+  def check_results(passwords, results, hash_type, method)
+    passwords.each do |password_line|
+      password_line.chomp!
+      next if password_line.blank?
 
-        fields = password_line.split(':')
-        # If we don't have an expected minimum number of fields, this is probably not a hash line
-        next unless fields.count >= 3
+      fields = password_line.split(':')
+      # If we don't have an expected minimum number of fields, this is probably not a hash line
+      next unless fields.count >= 3
 
-        cred = { 'hash_type' => hash_type, 'method' => method }
-        if action.name == 'john'
-          cred['username'] = fields.shift
-          cred['core_id'] = fields.pop
-          4.times { fields.pop } # Get rid of extra :
-          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-        elsif action.name == 'hashcat'
-          cred['core_id'] = fields.shift
-          cred['hash'] = fields.shift
-          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-          next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
+      cred = { 'hash_type' => hash_type, 'method' => method }
+      if action.name == 'john'
+        cred['username'] = fields.shift
+        cred['core_id'] = fields.pop
+        4.times { fields.pop } # Get rid of extra :
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+      elsif action.name == 'hashcat'
+        cred['core_id'] = fields.shift
+        cred['hash'] = fields.shift
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+        next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
 
-          # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
-          # so we can now just go grab the username from the DB
-          cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
-        end
-        results = process_cracker_results(results, cred)
+        # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
+        # so we can now just go grab the username from the DB
+        cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
       end
-      results
+      results = process_cracker_results(results, cred)
     end
 
+    results
+  end
+
+  def run
     tbl = tbl = cracker_results_table
 
     hash_types_to_crack = ['descrypt']

--- a/modules/auxiliary/analyze/crack_databases.rb
+++ b/modules/auxiliary/analyze/crack_databases.rb
@@ -36,6 +36,11 @@ class MetasploitModule < Msf::Auxiliary
         ['hashcat', { 'Description' => 'Use Hashcat' }],
       ],
       'DefaultAction' => 'john',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -61,52 +66,49 @@ class MetasploitModule < Msf::Auxiliary
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
-  def run
-    def check_results(passwords, results, hash_type, method)
-      passwords.each do |password_line|
-        password_line.chomp!
-        next if password_line.blank?
+  def check_results(passwords, results, hash_type, method)
+    passwords.each do |password_line|
+      password_line.chomp!
+      next if password_line.blank?
 
-        fields = password_line.split(':')
-        cred = { 'hash_type' => hash_type, 'method' => method }
+      fields = password_line.split(':')
+      cred = { 'hash_type' => hash_type, 'method' => method }
 
-        if action.name == 'john'
-          next unless fields.count >= 3
+      if action.name == 'john'
+        next unless fields.count >= 3
 
+        cred['username'] = fields.shift
+        cred['core_id'] = fields.pop
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+      elsif action.name == 'hashcat'
+        next unless fields.count >= 2
+
+        cred['core_id'] = fields.shift
+        case hash_type
+        when 'dynamic_1034'
+          # for postgres we get 4 fields, id:hash:un:pass.
+          cred['hash'] = fields.shift
           cred['username'] = fields.shift
-          cred['core_id'] = fields.pop
-          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-        elsif action.name == 'hashcat'
-          next unless fields.count >= 2
-
-          case hash_type
-          when 'dynamic_1034'
-            # for postgres we get 4 fields, id:hash:un:pass.
-            cred['core_id'] = fields.shift
-            cred['hash'] = fields.shift
-            cred['username'] = fields.shift
-            cred['password'] = fields.join(':')
-          when 'oracle11', 'raw-sha1,oracle'
-            cred['core_id'] = fields.shift
-            cred['hash'] = "#{fields.shift}#{fields.shift}" # we pull the first two fields, hash and salt
-            cred['password'] = fields.join(':')
-          else
-            cred['core_id'] = fields.shift
-            cred['hash'] = fields.shift
-            cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-          end
-
-          next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
-
-          # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
-          # so we can now just go grab the username from the DB
-          cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
+        when 'oracle11', 'raw-sha1,oracle'
+          cred['hash'] = "#{fields.shift}#{fields.shift}" # we pull the first two fields, hash and salt
+        else
+          cred['hash'] = fields.shift
         end
-        results = process_cracker_results(results, cred)
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+
+        next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
+
+        # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
+        # so we can now just go grab the username from the DB
+        cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
       end
-      results
+      results = process_cracker_results(results, cred)
     end
 
+    results
+  end
+
+  def run
     tbl = tbl = cracker_results_table
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex

--- a/modules/auxiliary/analyze/crack_linux.rb
+++ b/modules/auxiliary/analyze/crack_linux.rb
@@ -34,6 +34,11 @@ class MetasploitModule < Msf::Auxiliary
         ['hashcat', { 'Description' => 'Use Hashcat' }],
       ],
       'DefaultAction' => 'john',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -61,39 +66,40 @@ class MetasploitModule < Msf::Auxiliary
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
-  def run
-    def check_results(passwords, results, hash_type, method)
-      passwords.each do |password_line|
-        password_line.chomp!
-        next if password_line.blank?
+  def check_results(passwords, results, hash_type, method)
+    passwords.each do |password_line|
+      password_line.chomp!
+      next if password_line.blank?
 
-        fields = password_line.split(':')
-        cred = { 'hash_type' => hash_type, 'method' => method }
+      fields = password_line.split(':')
+      cred = { 'hash_type' => hash_type, 'method' => method }
 
-        if action.name == 'john'
-          next unless fields.count >= 3 # If we don't have an expected minimum number of fields, this is probably not a hash line
+      if action.name == 'john'
+        next unless fields.count >= 3 # If we don't have an expected minimum number of fields, this is probably not a hash line
 
-          cred['username'] = fields.shift
-          cred['core_id'] = fields.pop
-          4.times { fields.pop } # Get rid of extra :
-          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-        elsif action.name == 'hashcat'
-          next unless fields.count >= 2 # If we don't have an expected minimum number of fields, this is probably not a hash line
+        cred['username'] = fields.shift
+        cred['core_id'] = fields.pop
+        4.times { fields.pop } # Get rid of extra :
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+      elsif action.name == 'hashcat'
+        next unless fields.count >= 2 # If we don't have an expected minimum number of fields, this is probably not a hash line
 
-          cred['core_id'] = fields.shift
-          cred['hash'] = fields.shift
-          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-          next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
+        cred['core_id'] = fields.shift
+        cred['hash'] = fields.shift
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+        next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
 
-          # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
-          # so we can now just go grab the username from the DB
-          cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
-        end
-        results = process_cracker_results(results, cred)
+        # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
+        # so we can now just go grab the username from the DB
+        cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
       end
-      results
+      results = process_cracker_results(results, cred)
     end
 
+    results
+  end
+
+  def run
     tbl = tbl = cracker_results_table
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -26,16 +26,21 @@ class MetasploitModule < Msf::Auxiliary
         ['hashcat', { 'Description' => 'Use Hashcat' }],
       ],
       'DefaultAction' => 'john',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options(
       [
-        OptBool.new('ATLASSIAN',[false, 'Include Atlassian hashes', true]),
-        OptBool.new('MEDIAWIKI',[false, 'Include MediaWiki hashes', true]),
-        OptBool.new('PHPASS',[false, 'Include Wordpress/PHPass, Joomla, phpBB3 hashes', true]),
-        OptBool.new('PBKDF2',[false, 'Apache Superset, some Flask and Werkzeug apps hashes', true]),
-        OptBool.new('INCREMENTAL',[false, 'Run in incremental mode', true]),
-        OptBool.new('WORDLIST',[false, 'Run in wordlist mode', true])
+        OptBool.new('ATLASSIAN', [false, 'Include Atlassian hashes', true]),
+        OptBool.new('MEDIAWIKI', [false, 'Include MediaWiki hashes', true]),
+        OptBool.new('PHPASS', [false, 'Include Wordpress/PHPass, Joomla, phpBB3 hashes', true]),
+        OptBool.new('PBKDF2', [false, 'Apache Superset, some Flask and Werkzeug apps hashes', true]),
+        OptBool.new('INCREMENTAL', [false, 'Run in incremental mode', true]),
+        OptBool.new('WORDLIST', [false, 'Run in wordlist mode', true])
       ]
     )
   end
@@ -51,38 +56,39 @@ class MetasploitModule < Msf::Auxiliary
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
-  def run
-    def check_results(passwords, results, hash_type, method)
-      passwords.each do |password_line|
-        password_line.chomp!
-        next if password_line.blank?
+  def check_results(passwords, results, hash_type, method)
+    passwords.each do |password_line|
+      password_line.chomp!
+      next if password_line.blank?
 
-        fields = password_line.split(':')
-        cred = { 'hash_type' => hash_type, 'method' => method }
-        # If we don't have an expected minimum number of fields, this is probably not a hash line
-        if action.name == 'john'
-          next unless fields.count >= 3
+      fields = password_line.split(':')
+      cred = { 'hash_type' => hash_type, 'method' => method }
+      # If we don't have an expected minimum number of fields, this is probably not a hash line
+      if action.name == 'john'
+        next unless fields.count >= 3
 
-          cred['username'] = fields.shift
-          cred['core_id'] = fields.pop
-          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-        elsif action.name == 'hashcat'
-          next unless fields.count >= 2
+        cred['username'] = fields.shift
+        cred['core_id'] = fields.pop
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+      elsif action.name == 'hashcat'
+        next unless fields.count >= 2
 
-          cred['core_id'] = fields.shift
-          cred['hash'] = fields.shift
-          cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-          next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
+        cred['core_id'] = fields.shift
+        cred['hash'] = fields.shift
+        cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
+        next if cred['core_id'].include?("Hashfile '") && cred['core_id'].include?("' on line ") # skip error lines
 
-          # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
-          # so we can now just go grab the username from the DB
-          cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
-        end
-        results = process_cracker_results(results, cred)
+        # we don't have the username since we overloaded it with the core_id (since its a better fit for us)
+        # so we can now just go grab the username from the DB
+        cred['username'] = framework.db.creds(workspace: myworkspace, id: cred['core_id'])[0].public.username
       end
-      results
+      results = process_cracker_results(results, cred)
     end
 
+    results
+  end
+
+  def run
     tbl = tbl = cracker_results_table
 
     hash_types_to_crack = []


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

Several of these modules used nested methods, which is a violation. Based on code comments, this was likely to override methods from a mixin; however, nesting methods is unnecessary, as any method defined in the module namespace will take precedence over methods in the mixin by the same name.
