### PR TITLE
Add SOCKS5H Proxy Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,7 +482,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.61)
+    rex-socket (0.1.62)
       dnsruby
       rex-core
     rex-sslscan (0.1.13)

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -35,8 +35,8 @@ module Msf
     end
 
     # @return [OptString]
-    def self.Proxies(default=nil, required=false, desc="A proxy chain of format type:host:port[,type:host:port][...]")
-      Msf::OptString.new(__method__.to_s, [ required, desc, default ])
+    def self.Proxies(default=nil, required=false, desc="A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: #{Rex::Socket::Proxies.supported_types.join(', ')}")
+      Msf::OptProxies.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptRhosts]

--- a/lib/msf/core/opt_address.rb
+++ b/lib/msf/core/opt_address.rb
@@ -12,7 +12,7 @@ class OptAddress < OptBase
     return 'address'
   end
 
-  def valid?(value, check_empty: true)
+  def valid?(value, check_empty: true, datastore: nil)
     return false if check_empty && empty_required_value?(value)
     return false unless value.kind_of?(String) or value.kind_of?(NilClass)
 

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -39,7 +39,7 @@ class OptAddressLocal < OptAddress
     sorted_addrs.any? ? sorted_addrs.first : ''
   end
 
-  def valid?(value, check_empty: true)
+  def valid?(value, check_empty: true, datastore: nil)
     return false if check_empty && empty_required_value?(value)
     return false unless value.kind_of?(String) || value.kind_of?(NilClass)
 

--- a/lib/msf/core/opt_address_range.rb
+++ b/lib/msf/core/opt_address_range.rb
@@ -36,7 +36,7 @@ class OptAddressRange < OptBase
     return value
   end
 
-  def valid?(value, check_empty: true)
+  def valid?(value, check_empty: true, datastore: nil)
     return false if check_empty && empty_required_value?(value)
     return false unless value.kind_of?(String) or value.kind_of?(NilClass)
 

--- a/lib/msf/core/opt_address_routable.rb
+++ b/lib/msf/core/opt_address_routable.rb
@@ -9,7 +9,7 @@ module Msf
   ###
   class OptAddressRoutable < OptAddress
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       return false if Rex::Socket.is_ip_addr?(value) && Rex::Socket.addr_atoi(value) == 0
       super
     end

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -116,7 +116,7 @@ module Msf
     #
     # If it's required and the value is nil or empty, then it's not valid.
     #
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       if check_empty && required?
         # required variable not set
         return false if (value.nil? || value.to_s.empty?)

--- a/lib/msf/core/opt_bool.rb
+++ b/lib/msf/core/opt_bool.rb
@@ -16,7 +16,7 @@ module Msf
       return 'bool'
     end
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       return false if check_empty && empty_required_value?(value)
       return true if value.nil? && !required?
 

--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -17,7 +17,7 @@ module Msf
       super
     end
 
-    def valid?(value = self.value, check_empty: true)
+    def valid?(value = self.value, check_empty: true, datastore: nil)
       return false if check_empty && empty_required_value?(value)
       return true if value.nil? && !required?
       return false if value.nil?

--- a/lib/msf/core/opt_float.rb
+++ b/lib/msf/core/opt_float.rb
@@ -15,7 +15,7 @@ module Msf
       Float(value) if value.present? && valid?(value)
     end
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       return false if check_empty && empty_required_value?(value)
       Float(value) rescue return false if value.present?
       super

--- a/lib/msf/core/opt_int.rb
+++ b/lib/msf/core/opt_int.rb
@@ -19,7 +19,7 @@ module Msf
       end
     end
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       return false if check_empty && empty_required_value?(value)
       return false if value.present? && !value.to_s.match(/^0x[0-9a-fA-F]+$|^-?\d+$/)
       super

--- a/lib/msf/core/opt_meterpreter_debug_logging.rb
+++ b/lib/msf/core/opt_meterpreter_debug_logging.rb
@@ -19,7 +19,7 @@ module Msf
       true
     end
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       return false if !super(value, check_empty: check_empty)
 
       begin

--- a/lib/msf/core/opt_path.rb
+++ b/lib/msf/core/opt_path.rb
@@ -21,7 +21,7 @@ class OptPath < OptBase
   end
 
   # Generally, 'value' should be a file that exists.
-  def valid?(value, check_empty: true)
+  def valid?(value, check_empty: true, datastore: nil)
     return false if check_empty && empty_required_value?(value)
     if value and !value.empty?
       if value =~ /^memory:\s*([0-9]+)/i

--- a/lib/msf/core/opt_port.rb
+++ b/lib/msf/core/opt_port.rb
@@ -12,7 +12,7 @@ class OptPort < OptInt
     return 'port'
   end
 
-  def valid?(value, check_empty: true)
+  def valid?(value, check_empty: true, datastore: nil)
     port = normalize(value).to_i
     super && port <= 65535 && port >= 0
   end

--- a/lib/msf/core/opt_proxies.rb
+++ b/lib/msf/core/opt_proxies.rb
@@ -1,0 +1,35 @@
+# -*- coding: binary -*-
+
+module Msf
+
+###
+#
+# Proxies option
+#
+###
+class OptProxies < OptBase
+
+  def type
+    'proxies'
+  end
+
+  def validate_on_assignment?
+    true
+  end
+
+  def normalize(value)
+    value
+  end
+
+  def valid?(value, check_empty: true, datastore: nil)
+    return false if check_empty && empty_required_value?(value)
+
+    parsed = Rex::Socket::Proxies.parse(value)
+    allowed_types = Rex::Socket::Proxies.supported_types
+    parsed.all? do |type, host, port|
+      allowed_types.include?(type) && host.present? && port.present?
+    end
+  end
+end
+
+end

--- a/lib/msf/core/opt_proxies.rb
+++ b/lib/msf/core/opt_proxies.rb
@@ -24,11 +24,13 @@ class OptProxies < OptBase
   def valid?(value, check_empty: true, datastore: nil)
     return false if check_empty && empty_required_value?(value)
 
-    parsed = Rex::Socket::Proxies.parse(value)
-    allowed_types = Rex::Socket::Proxies.supported_types
-    parsed.all? do |type, host, port|
-      allowed_types.include?(type) && host.present? && port.present?
+    begin
+      Rex::Socket::Proxies.parse(value)
+    rescue Rex::RuntimeError
+      return false
     end
+
+    true
   end
 end
 

--- a/lib/msf/core/opt_regexp.rb
+++ b/lib/msf/core/opt_regexp.rb
@@ -12,7 +12,7 @@ class OptRegexp < OptBase
     return 'regexp'
   end
 
-  def valid?(value, check_empty: true)
+  def valid?(value, check_empty: true, datastore: nil)
     if check_empty && empty_required_value?(value)
       return false
     elsif value.nil?

--- a/lib/msf/core/opt_rhosts.rb
+++ b/lib/msf/core/opt_rhosts.rb
@@ -19,12 +19,13 @@ module Msf
       value
     end
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       return false if check_empty && empty_required_value?(value)
       return false unless value.is_a?(String) || value.is_a?(NilClass)
 
-      if !value.nil? && value.empty? == false
-        return Msf::RhostsWalker.new(value).valid?
+      if !value.nil? && !value.empty?
+        rhost_walker = datastore ? Msf::RhostsWalker.new(value, datastore) : Msf::RhostsWalker.new(value)
+        return rhost_walker.valid?
       end
 
       super

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -34,7 +34,7 @@ class OptString < OptBase
     value
   end
 
-  def valid?(value=self.value, check_empty: true)
+  def valid?(value=self.value, check_empty: true, datastore: nil)
     value = normalize(value)
     return false if check_empty && empty_required_value?(value)
     return false if invalid_value_length?(value)

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -198,7 +198,7 @@ module Msf
     def validate(datastore)
       # First mutate the datastore and normalize all valid values before validating permutations of RHOST/etc.
       each_pair do |name, option|
-        if option.valid?(datastore[name]) && (val = option.normalize(datastore[name])) != nil
+        if option.valid?(datastore[name], datastore: datastore) && (val = option.normalize(datastore[name])) != nil
           # This *will* result in a module that previously used the
           # global datastore to have its local datastore set, which
           # means that changing the global datastore and re-running
@@ -233,7 +233,7 @@ module Msf
 
         rhosts_walker.each do |datastore|
           each_pair do |name, option|
-            unless option.valid?(datastore[name])
+            unless option.valid?(datastore[name], datastore: datastore)
               error_options << name
               if rhosts_count > 1
                 error_reasons[name] << "for rhosts value #{datastore['UNPARSED_RHOSTS']}"
@@ -249,7 +249,7 @@ module Msf
       else
         error_options = []
         each_pair do |name, option|
-          unless option.valid?(datastore[name])
+          unless option.valid?(datastore[name], datastore: datastore)
             error_options << name
           end
         end

--- a/lib/msf/core/rhosts_walker.rb
+++ b/lib/msf/core/rhosts_walker.rb
@@ -403,8 +403,13 @@ module Msf
     # @return [Boolean] True if DNS resolution should be performed the RHOST values, false otherwise
     def perform_dns_resolution?(datastore)
       # If a socks proxy has been configured, don't perform DNS resolution - so that it instead happens via the proxy
-      # rex-socket does not currently support socks4a. SAPNI may need to be added to this list.
-      !(datastore['PROXIES'].to_s.include?(Rex::Socket::Proxies::ProxyType::HTTP) || datastore['PROXIES'].to_s.include?(Rex::Socket::Proxies::ProxyType::SOCKS5))
+      return true unless datastore['PROXIES'].present?
+
+      last_proxy = Rex::Socket::Proxies.parse(datastore['PROXIES']).last
+      [
+        Rex::Socket::Proxies::ProxyType::HTTP,
+        Rex::Socket::Proxies::ProxyType::SOCKS5H
+      ].exclude?(last_proxy.scheme)
     end
 
     def set_hostname(datastore, result, hostname)

--- a/spec/lib/msf/core/opt_proxies_spec.rb
+++ b/spec/lib/msf/core/opt_proxies_spec.rb
@@ -1,0 +1,27 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::OptProxies do
+
+  valid_values = [
+    nil,
+    '',
+    '            ',
+    'socks5:198.51.100.1:1080',
+    'socks4:198.51.100.1:1080',
+    'http:198.51.100.1:8080,socks4:198.51.100.1:1080',
+    'http:198.51.100.1:8080,       socks4:198.51.100.1:1080',
+    'sapni:198.51.100.1:8080,       socks4:198.51.100.1:1080',
+  ].map { |value| { value: value, normalized: value } }
+
+  invalid_values = [
+    { :value => 123 },
+    { :value => 'foo(' },
+    { :value => 'foo:198.51.100.1:8080' },
+    { :value => 'foo:198.51.100.18080' },
+    { :value => 'foo::' },
+  ]
+
+  it_behaves_like "an option", valid_values, invalid_values, 'proxies'
+end

--- a/spec/lib/msf/core/opt_spec.rb
+++ b/spec/lib/msf/core/opt_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Msf::Opt do
 
     context 'Proxies' do
       subject { described_class::Proxies }
-      it { is_expected.to be_a(Msf::OptString) }
+      it { is_expected.to be_a(Msf::OptProxies) }
     end
 
     context 'RHOST' do
@@ -89,7 +89,7 @@ RSpec.describe Msf::Opt do
 
     context 'Proxies()' do
       subject { described_class::Proxies(default) }
-      it { is_expected.to be_a(Msf::OptString) }
+      it { is_expected.to be_a(Msf::OptProxies) }
       specify 'sets default' do
         expect(subject.default).to eq(default)
       end

--- a/spec/lib/msf/core/rhosts_walker_spec.rb
+++ b/spec/lib/msf/core/rhosts_walker_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Msf::RhostsWalker do
   before(:each) do
     @temp_files = []
 
-    allow(::Addrinfo).to receive(:getaddrinfo).with('nonexistent.com', 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM) do |*_args|
+    allow(::Addrinfo).to receive(:getaddrinfo).with('nonexistent.example.com', 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM) do |*_args|
       []
     end
     allow(::Addrinfo).to receive(:getaddrinfo).with('example.com', 0, ::Socket::AF_UNSPEC, ::Socket::SOCK_STREAM) do |*_args|
@@ -427,6 +427,21 @@ RSpec.describe Msf::RhostsWalker do
       { 'RHOSTS' => 'https://example.com:9000/foo', 'expected' => 1 },
       { 'RHOSTS' => 'cidr:/30:https://user:pass@multiple_ips.example.com:9000/foo', 'expected' => 8 },
 
+      # Perform DNS resolution by default
+      { 'RHOSTS' => 'https://user:pass@multiple_ips.example.com:9000/foo', 'PROXIES' => 'http:198.51.100.1:1080', 'expected' => 1 },
+
+      # Skip DNS resolution when socks5 proxy present
+      { 'RHOSTS' => 'https://user:pass@multiple_ips.example.com:9000/foo', 'PROXIES' => 'socks5:198.51.100.1:1080', 'expected' => 1 },
+
+      # Skip DNS resolution when http proxy present
+      { 'RHOSTS' => 'https://user:pass@multiple_ips.example.com:9000/foo', 'PROXIES' => 'http:198.51.100.1:1080', 'expected' => 1 },
+
+      # Perform DNS resolution if socks4 proxy present - as rex-socket doesn't support socks4a
+      { 'RHOSTS' => 'https://user:pass@multiple_ips.example.com:9000/foo', 'PROXIES' => 'socks4:198.51.100.1:1080', 'expected' => 2 },
+
+      # Perform DNS resolution if SAPNI proxy present - this can be removed if it causes issues
+      { 'RHOSTS' => 'https://user:pass@multiple_ips.example.com:9000/foo', 'PROXIES' => 'socks4:198.51.100.1:1080', 'expected' => 2 },
+
       # Edge cases
       { 'expected' => 0 },
       { 'RHOSTS' => nil, 'expected' => 0 },
@@ -437,8 +452,10 @@ RSpec.describe Msf::RhostsWalker do
       { 'RHOSTS' => '127.0.0.1 http:| 127.0.0.1', 'expected' => 2 },
       { 'RHOSTS' => '127.0.0.1 unknown_protocol://127.0.0.1 ftpz://127.0.0.1', 'expected' => 1 },
     ].each do |test|
-      it "counts #{test['RHOSTS'].inspect} as being #{test['expected']}" do
-        expect(described_class.new(test['RHOSTS'], aux_mod.datastore).count).to eq(test['expected'])
+      it "counts #{test['RHOSTS'].inspect} with PROXIES #{test['PROXIES'].inspect} as being #{test['expected']}" do
+        datastore = aux_mod.datastore
+        datastore['PROXIES'] = test['PROXIES'] if test.key?('PROXIES')
+        expect(described_class.new(test['RHOSTS'], datastore).count).to eq(test['expected'])
       end
     end
   end
@@ -471,7 +488,7 @@ RSpec.describe Msf::RhostsWalker do
       { 'RHOSTS' => 'cidr:%eth2:127.0.0.1', 'expected' => [Msf::RhostsWalker::Error.new('cidr:%eth2:127.0.0.1', cause: Msf::RhostsWalker::InvalidCIDRError.new)] },
 
       # host resolution
-      { 'RHOSTS' => 'https://nonexistent.com:9000/foo', 'expected' => [Msf::RhostsWalker::Error.new('https://nonexistent.com:9000/foo', cause: Msf::RhostsWalker::RhostResolveError.new)] },
+      { 'RHOSTS' => 'https://nonexistent.example.com:9000/foo', 'expected' => [Msf::RhostsWalker::Error.new('https://nonexistent.example.com:9000/foo', cause: Msf::RhostsWalker::RhostResolveError.new)] },
     ].each do |test|
       it "handles the input #{test['RHOSTS'].inspect} as having the errors #{test['expected']}" do
         aux_mod.datastore['RHOSTS'] = test['RHOSTS']
@@ -548,6 +565,16 @@ RSpec.describe Msf::RhostsWalker do
       expected = [
         { 'RHOSTNAME' => 'multiple_ips.example.com', 'RHOSTS' => '198.51.100.1', 'RPORT' => 80, 'VHOST' => 'multiple_ips.example.com', 'SSL' => false, 'HttpUsername' => '', 'HttpPassword' => '', 'TARGETURI' => '/foo' },
         { 'RHOSTNAME' => 'multiple_ips.example.com', 'RHOSTS' => '203.0.113.1', 'RPORT' => 80, 'VHOST' => 'multiple_ips.example.com', 'SSL' => false, 'HttpUsername' => '', 'HttpPassword' => '', 'TARGETURI' => '/foo' }
+      ]
+      expect(each_host_for(http_mod)).to have_datastore_values(expected)
+      expect(each_error_for(http_mod)).to be_empty
+    end
+
+    it 'enumerates a single host without performing DNS resolution if a socks5 proxy is registered' do
+      http_mod.datastore['RHOSTS'] = 'http://multiple_ips.example.com/foo'
+      http_mod.datastore['PROXIES'] = 'socks5:198.51.100.1:1080'
+      expected = [
+        { 'RHOSTNAME' => 'multiple_ips.example.com', 'RHOSTS' => 'multiple_ips.example.com', 'RPORT' => 80, 'VHOST' => 'multiple_ips.example.com', 'SSL' => false, 'HttpUsername' => '', 'HttpPassword' => '', 'TARGETURI' => '/foo' },
       ]
       expect(each_host_for(http_mod)).to have_datastore_values(expected)
       expect(each_error_for(http_mod)).to be_empty
@@ -669,6 +696,19 @@ RSpec.describe Msf::RhostsWalker do
       expect(each_error_for(kerberos_mod)).to be_empty
     end
 
+    it 'allows the user to specify a rhostname even if socks5 proxy is registered' do
+      kerberos_mod.datastore['RHOSTS'] = '192.0.2.2'
+      kerberos_mod.datastore['RHOSTNAME'] = 'example.com'
+      kerberos_mod.datastore['PROXIES'] = 'socks5:198.51.100.1:1080'
+
+      expected = [
+        { "RHOSTNAME"=> 'example.com', "RHOSTS"=>"192.0.2.2" }
+      ]
+
+      expect(each_host_for(kerberos_mod)).to have_datastore_values(expected)
+      expect(each_error_for(kerberos_mod)).to be_empty
+    end
+
     it 'preserves a RHOSTNAME even if RHOSTS resolved with a hostname' do
       kerberos_mod.datastore['RHOSTS'] = 'multiple_ips.example.com'
       kerberos_mod.datastore['RHOSTNAME'] = 'example.com'
@@ -676,6 +716,19 @@ RSpec.describe Msf::RhostsWalker do
       expected = [
         {"RHOSTNAME"=> "example.com", "RHOSTS"=>"198.51.100.1"},
         {"RHOSTNAME"=> "example.com", "RHOSTS"=>"203.0.113.1"}
+      ]
+
+      expect(each_host_for(kerberos_mod)).to have_datastore_values(expected)
+      expect(each_error_for(kerberos_mod)).to be_empty
+    end
+
+    it 'preserves a RHOSTNAME even if RHOSTS is set and a socks5 proxy is registered' do
+      kerberos_mod.datastore['RHOSTS'] = 'multiple_ips.example.com'
+      kerberos_mod.datastore['RHOSTNAME'] = 'example.com'
+      kerberos_mod.datastore['PROXIES'] = 'socks5:198.51.100.1:1080'
+
+      expected = [
+        {"RHOSTNAME"=> "example.com", "RHOSTS"=>"multiple_ips.example.com"},
       ]
 
       expect(each_host_for(kerberos_mod)).to have_datastore_values(expected)
@@ -908,6 +961,18 @@ RSpec.describe Msf::RhostsWalker do
           { 'RHOSTNAME' => 'example.com', 'RHOSTS' => '192.0.2.2', 'RPORT' => 5432, 'USERNAME' => 'postgres', 'PASSWORD' => '', 'DATABASE' => 'template1' },
           { 'RHOSTNAME' => 'example.com', 'RHOSTS' => '192.0.2.2', 'RPORT' => 5432, 'USERNAME' => 'user', 'PASSWORD' => 'a b c', 'DATABASE' => 'template1' },
           { 'RHOSTNAME' => 'example.com', 'RHOSTS' => '192.0.2.2', 'RPORT' => 9001, 'USERNAME' => 'user', 'PASSWORD' => 'a b c', 'DATABASE' => 'database_name' }
+        ]
+        expect(each_error_for(postgres_mod)).to be_empty
+        expect(each_host_for(postgres_mod)).to have_datastore_values(expected)
+      end
+
+      it 'enumerates postgres schemes and avoids DNS resolution if a socks5 proxy is registered' do
+        postgres_mod.datastore['RHOSTS'] = 'postgres://postgres:@example.com "postgres://user:a b c@example.com/" "postgres://user:a b c@example.com:9001/database_name"'
+        postgres_mod.datastore['PROXIES'] = 'socks5:198.51.100.1:1080'
+        expected = [
+          { 'RHOSTNAME' => 'example.com', 'RHOSTS' => 'example.com', 'RPORT' => 5432, 'USERNAME' => 'postgres', 'PASSWORD' => '', 'DATABASE' => 'template1' },
+          { 'RHOSTNAME' => 'example.com', 'RHOSTS' => 'example.com', 'RPORT' => 5432, 'USERNAME' => 'user', 'PASSWORD' => 'a b c', 'DATABASE' => 'template1' },
+          { 'RHOSTNAME' => 'example.com', 'RHOSTS' => 'example.com', 'RPORT' => 9001, 'USERNAME' => 'user', 'PASSWORD' => 'a b c', 'DATABASE' => 'database_name' }
         ]
         expect(each_error_for(postgres_mod)).to be_empty
         expect(each_host_for(postgres_mod)).to have_datastore_values(expected)


### PR DESCRIPTION
This adds support for the SOCKS5H proxy convention which is an unofficial standard whereby the proxy client (Metasploit) does not resolve hostnames to IP address itself but rather sends the hostname to the proxy server for resolution. Metasploit has floundered on it's approach for handling DNS resolution and proxies in the past. Currently when a module is run, the hostname is passed to `Msf::RhostsWalker` which will resolve it itself to ensure that if a hostname maps to multiple IP address, the module is run for each. This PR retains this functionality but allows it to be bypassed when a SOCKS5H or HTTP proxy is in use. Both of these proxy server types can resolve hostnames themselves. This does mean that if a user is targeting a hostname that resolves to multiple IP addresses (e.g. `google.com`) that it the module will only run against one target if a DNS-resolving proxy is in use. If no proxy is in use, the module will run against all targets.

Requires changes from rapid7/rex-socket#76

Fixes #19641 

## Verification

- [x] Start a SOCKS5 proxy server for testing: `podman run --rm --name socks5 -p 1080:1080 serjs/go-socks5-proxy`
- [x] Start wireshark to verify resolution is happening for Metasploit or from the proxy server (use the filter: `socks.command == 1` to see connection requests, then see if there's an IP address or hostname)
- [x] Start `msfconsole`
- [x] Test the `connect` command
    - [x] Banner grab from GitHub's SSH service: `connect -p 'socks5://localhost' github.com 22`
    - [x] Repeat the process but use SOCKS5H so the proxy server handles hostname resolution: `connect -p 'socks5h://localhost' github.com 22`
- [x] Test a module, a simple example is `auxiliary/scanner/http/http_version`
    - [x] Run the module with a SOCKS5 proxy: `run RHOSTS=github.com Proxies=socks5://localhost`
    - [x] Repeat the process using SOCKS5H to see the change: `run RHOSTS=github.com Proxies=socks5h://localhost:1080`