### PR TITLE
Add additional sni support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ GEM
       rex-core
       rex-struct2
       rex-text
-    rex-core (0.1.33)
+    rex-core (0.1.34)
     rex-encoder (0.1.8)
       metasm
       rex-arch
@@ -476,15 +476,16 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.60)
+    rex-socket (0.1.61)
       dnsruby
       rex-core
-    rex-sslscan (0.1.11)
+    rex-sslscan (0.1.12)
       rex-core
       rex-socket
       rex-text
     rex-struct2 (0.1.5)
-    rex-text (0.2.60)
+    rex-text (0.2.61)
+      bigdecimal
     rex-zip (0.1.6)
       rex-text
     rexml (3.4.1)

--- a/lib/anemone/rex_http.rb
+++ b/lib/anemone/rex_http.rb
@@ -198,6 +198,7 @@ module Anemone
     conn.set_config(
       'vhost'      => virtual_host(url),
       'agent'      => user_agent,
+      'ssl_server_name_indication' => @opts[:ssl_server_name_indication],
       'domain'     => @opts[:domain]
     )
 

--- a/lib/msf/core/auxiliary/http_crawler.rb
+++ b/lib/msf/core/auxiliary/http_crawler.rb
@@ -37,13 +37,12 @@ module Auxiliary::HttpCrawler
         OptInt.new('RequestTimeout', [false, 'The maximum number of seconds to wait for a reply', 15]),
         OptInt.new('RedirectLimit', [false, 'The maximum number of redirects for a single request', 5]),
         OptInt.new('RetryLimit', [false, 'The maximum number of attempts for a single request', 5]),
-        OptString.new('UserAgent', [true, 'The User-Agent header to use for all requests',
-          "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
-        ]),
+        OptString.new('UserAgent', [true, 'The User-Agent header to use for all requests', Rex::UserAgent.random]),
         OptString.new('BasicAuthUser', [false, 'The HTTP username to specify for basic authentication']),
         OptString.new('BasicAuthPass', [false, 'The HTTP password to specify for basic authentication']),
         OptString.new('HTTPAdditionalHeaders', [false, "A list of additional headers to send (separated by \\x01)"]),
         OptString.new('HTTPCookie', [false, "A HTTP cookie header to send with each request"]),
+        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
         Opt::SSLVersion
       ], self.class
     )
@@ -115,6 +114,7 @@ module Auxiliary::HttpCrawler
 
     t.merge!({
       :vhost    => vhost,
+      :ssl_server_name_indication  => datastore['SSLServerNameIndication'] || vhost,
       :host     => rhost,
       :port     => rport,
       :ssl      => ssl,
@@ -269,6 +269,7 @@ module Auxiliary::HttpCrawler
   def crawler_options(t)
     opts = {}
     opts[:user_agent]      = datastore['UserAgent']
+    opts[:ssl_server_name_indication] = datastore['SSLServerNameIndication']
     opts[:verbose]         = false
     opts[:threads]         = max_crawl_threads
     opts[:obey_robots_txt] = false

--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -118,6 +118,7 @@ class Auxiliary::Web::HTTP
 
     c.set_config({
       'vhost' => opts[:target].vhost,
+      'ssl_server_name_indication' => opts[:target].vhost,
       'agent' => opts[:user_agent] || Rex::UserAgent.session_agent,
       'domain' => domain
     })

--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -118,7 +118,7 @@ class Auxiliary::Web::HTTP
 
     c.set_config({
       'vhost' => opts[:target].vhost,
-      'ssl_server_name_indication' => opts[:target].vhost,
+      'ssl_server_name_indication' => opts[:target].ssl_server_name_indication || opts[:target].vhost,
       'agent' => opts[:user_agent] || Rex::UserAgent.session_agent,
       'domain' => domain
     })

--- a/lib/msf/core/auxiliary/web/target.rb
+++ b/lib/msf/core/auxiliary/web/target.rb
@@ -33,6 +33,9 @@ class Auxiliary::Web::Target
   # Virtual host as a String.
   attr_accessor :vhost
 
+  # @return String SSL/TLS Server Name Indication (SNI)
+  attr_accessor :ssl_server_name_indication
+
   # String URI path.
   attr_accessor :path
 
@@ -64,6 +67,7 @@ class Auxiliary::Web::Target
   #           :port
   #           :forms
   #           :auditable
+  #           :ssl_server_name_indication
   #
   def initialize( options = {} )
     update( options )
@@ -79,6 +83,7 @@ class Auxiliary::Web::Target
   #           :port
   #           :forms
   #           :auditable
+  #           :ssl_server_name_indication
   #
   def update( options = {} )
     options.each { |k, v| send( "#{k}=", v ) }


### PR DESCRIPTION
Related to https://github.com/rapid7/metasploit-framework/pull/16499

Required PRs
- https://github.com/rapid7/rex-sslscan/pull/11
- https://github.com/rapid7/metasploit-framework/pull/20148
- rapid7/pro#4144

## Verification

Before - ssl connect fails

```
msf-pro auxiliary(scanner/http/crawler) > run rhosts=54.85.30.225 rport=443 ssl=true
[*] Running module against 54.85.30.225
[*] Crawling https://54.85.30.225:443/...
[-] Error accessing page SSL_connect returned=1 errno=0 peeraddr=54.85.30.225:443 state=error: tlsv1 unrecognized name
[-] [00001/00500]    ERR - 54.85.30.225 - https://54.85.30.225/
[*] Crawl of https://54.85.30.225:443/ complete
[*] Auxiliary module execution completed
```

![image](https://github.com/user-attachments/assets/7dd0f00c-a79c-4ed6-b3d1-8835faad7015)


After - SSL connect passes

```
msf-pro auxiliary(scanner/http/crawler) > run rhosts=54.85.30.225 rport=443 ssl=true sslservernameindication=nvd.nist.gov vhost=nvd.nist.gov
[*] Running module against 54.85.30.225
[*] Crawling https://nvd.nist.gov:443/...
[*] [00001/00500]    200 - nvd.nist.gov - https://nvd.nist.gov/
[*] [00002/00500]    200 - nvd.nist.gov - https://nvd.nist.gov/site-scripts/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css
[*] [00003/00500]    200 - nvd.nist.gov - https://nvd.nist.gov/site-scripts/font-awesome/css/font-awesome.min.css
[*] [00004/00500]    200 - nvd.nist.gov - https://nvd.nist.gov/site-media/bootstrap/css/bootstrap-theme.min.css
```

![image](https://github.com/user-attachments/assets/fb747d19-472b-48f1-9ede-7a9d30763df7)

![image](https://github.com/user-attachments/assets/8d1c5bda-0e13-43db-acf6-ee842918853b)
