### PR TITLE
Remove end of life ubuntu gh action

### DIFF
--- a/.github/workflows/shared_gem_verify.yml
+++ b/.github/workflows/shared_gem_verify.yml
@@ -26,7 +26,6 @@ jobs:
           - '3.3'
           - '3.4'
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-latest


### PR DESCRIPTION
Remove end of life ubuntu gh action

![image](https://github.com/user-attachments/assets/afa28793-5df0-4eb3-ba0e-534b2966d8a6)


## Verification

Ensure CI passes