### PR TITLE
Msf::PayloadSet#recalculate: Replace delete_if with replace(slice(...))

### DIFF
--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -66,7 +66,6 @@ class PayloadSet < ModuleSet
   # of singles, stagers, and stages.
   #
   def recalculate
-    old_keys = self.keys
     new_keys = []
 
     # Recalculate single payloads
@@ -119,9 +118,7 @@ class PayloadSet < ModuleSet
 
     # Blow away anything that was cached but didn't exist during the
     # recalculation
-    self.delete_if do |k, _v|
-      !!(old_keys.include?(k) and not new_keys.include?(k))
-    end
+    replace(slice(*new_keys))
 
     flush_blob_cache
   end


### PR DESCRIPTION
tl/dr: Minor change turns four lines of code into one, decreases number of RuboCop violations, removes a temporary `Array` of ~1,600 elements from startup, and gains a negligible speed boost at startup.

---

`Msf::PayloadSet#recalculate` is called when loading modules during Framework startup.

Old keys are cleared from the `PayloadSet` cache by looping through `PayloadSet.keys` with `delete_if` to remove all keys not present during recalculation:

https://github.com/rapid7/metasploit-framework/blob/b1101e96f39d7c5790fef7bf39789292388fe048/lib/msf/core/payload_set.rb#L120-L124

This PR replaces the `delete_if` loop with:

```ruby
replace(slice(*new_keys))
```

`replace(slice(...))` is shorter and significantly faster than `delete_if` (although arguably slightly less intuitive for readers not familiar with Ruby).

Given that `recalculate` is called only once during startup, the time saving is negligible. Regardless, here's `delete_if` vs `replace(slice(...)` benchmarked:

<details>
<p>

```
# ./bench.rb 
                      user     system      total        real
delete_if         0.315595   0.001403   0.316998 (  0.318102)
replace           0.001409   0.000000   0.001409 (  0.001419)
```

```ruby
#!/usr/bin/env ruby
# Benchmark generated by copilot
require 'benchmark'

class CustomHash < Hash
  def filter_delete_if!(old_keys, new_keys)
    self.delete_if { |k, _v| old_keys.include?(k) && !new_keys.include?(k) }
  end

  def filter_replace!(new_keys)
    replace(slice(*new_keys))
  end
end

# Generate test data
hash_size = 10_000
original_hash = CustomHash.new
hash_size.times { |i| original_hash[i] = rand(1000) }

old_keys = (0..hash_size/2).to_a
new_keys = (hash_size/4..hash_size*3/4).to_a

Benchmark.bm(15) do |bm|
  bm.report("delete_if") do
    test_hash = original_hash.dup
    test_hash.filter_delete_if!(old_keys, new_keys)
  end

  bm.report("replace") do
    test_hash = original_hash.dup
    test_hash.filter_replace!(new_keys)
  end
end
```
</p>
</details>

Additionally, switching to `replace(slice(...))` saves us having to track the existing Hash keys (`old_keys`) as an `Array` of ~1,600 elements. This is no longer necessary and has been removed.

Also, the existing code unnecessarily used double negation (`!!`) which is a RuboCop violation (`Style/DoubleNegation`). This has been removed.
