### PR TITLE
modules/post: Resolve RuboCop violations and typos

### DIFF
--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Post
 
         hiddenWindow.location = 'about:blank';
         var src = (#{JSON.unparse({ src: js })}).src;
-        var key = "#{Rex::Text.rand_text_alphanumeric(rand(8..19))}";
+        var key = "#{Rex::Text.rand_text_alphanumeric(8..19)}";
 
         hiddenWindow[key] = true;
         hiddenWindow.location = "#{datastore['URL']}";

--- a/modules/post/linux/gather/f5_loot_mcp.rb
+++ b/modules/post/linux/gather/f5_loot_mcp.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Post
         ],
         'DisclosureDate' => '2022-11-16',
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/post/linux/gather/mimipenguin.rb
+++ b/modules/post/linux/gather/mimipenguin.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
         'DisclosureDate' => '2018-05-23',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         },

--- a/modules/post/linux/gather/rancher_audit_log_leak.rb
+++ b/modules/post/linux/gather/rancher_audit_log_leak.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
         ],
         'DisclosureDate' => '2024-02-08',
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/post/linux/manage/disable_clamav.rb
+++ b/modules/post/linux/manage/disable_clamav.rb
@@ -4,7 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Post
-  Rank = ExcellentRanking
   include Msf::Post::File
   include Msf::Post::Unix
 

--- a/modules/post/multi/gather/dbeaver.rb
+++ b/modules/post/multi/gather/dbeaver.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Post
         'Platform' => [ 'linux', 'win', 'osx', 'unix'],
         'SessionTypes' => [ 'meterpreter', 'shell', 'powershell' ],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/post/multi/gather/electerm.rb
+++ b/modules/post/multi/gather/electerm.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Post
         'Platform' => [ 'linux', 'win', 'osx', 'unix'],
         'SessionTypes' => [ 'meterpreter', 'shell', 'powershell' ],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Post
 
     omnija = nil             # non meterpreter download
     org_file = 'omni.ja'     # key file
-    new_file = Rex::Text.rand_text_alpha(rand(5..7)) + '.ja'
+    new_file = Rex::Text.rand_text_alpha(5..7) + '.ja'
     temp_file = 'orgomni.ja' # backup of key file
 
     # Sets @paths

--- a/modules/post/multi/gather/minio_client.rb
+++ b/modules/post/multi/gather/minio_client.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Post
         'Platform' => [ 'win', 'linux', 'osx', 'unix' ],
         'SessionTypes' => %w[meterpreter powershell shell],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/post/multi/gather/wlan_geolocate.rb
+++ b/modules/post/multi/gather/wlan_geolocate.rb
@@ -229,7 +229,7 @@ class MetasploitModule < Msf::Post
   rescue Rex::TimeoutError, Rex::Post::Meterpreter::RequestError => e
     vprint_error(e.message)
   rescue StandardError => e
-    print_status("The following Error was encountered: #{e.class} #{e}")
+    print_status("The following error was encountered: #{e.class} #{e}")
   end
 
 end

--- a/modules/post/multi/gather/wowza_streaming_engine_creds.rb
+++ b/modules/post/multi/gather/wowza_streaming_engine_creds.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Post
         'Platform' => %w[win linux osx unix],
         'SessionTypes' => %w[meterpreter powershell shell],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/post/multi/general/close.rb
+++ b/modules/post/multi/general/close.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Post
         'Platform' => %w[linux osx unix win],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SERVICE_DOWN],
           'SideEffects' => [],
           'Reliability' => []
         }

--- a/modules/post/multi/manage/screensaver.rb
+++ b/modules/post/multi/manage/screensaver.rb
@@ -22,6 +22,7 @@ class MetasploitModule < Msf::Post
         ],
         'Platform' => [ 'linux', 'osx', 'win', 'unix', 'solaris' ],
         'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'DefaultAction' => 'LOCK',
         'Actions' => [
           [ 'LOCK', { 'Description' => 'Lock the current session' } ],
           [ 'UNLOCK', { 'Description' => 'Unlock the current session' } ],
@@ -33,8 +34,8 @@ class MetasploitModule < Msf::Post
         ],
         'Notes' => {
           'Reliability' => [ ],
-          'Stability' => [ ],
-          'SideEffects' => [ ]
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [SCREEN_EFFECTS]
         }
       )
     )

--- a/modules/post/osx/gather/enum_keychain.rb
+++ b/modules/post/osx/gather/enum_keychain.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter', 'shell' ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS],
           'Reliability' => []
         }
       )

--- a/modules/post/windows/gather/bloodhound.rb
+++ b/modules/post/windows/gather/bloodhound.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Post
         'Notes' => {
           'AKA' => ['sharphound'],
           'SideEffects' => [ARTIFACTS_ON_DISK],
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => []
         }
       )

--- a/modules/post/windows/gather/credentials/moba_xterm.rb
+++ b/modules/post/windows/gather/credentials/moba_xterm.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         },

--- a/modules/post/windows/gather/credentials/navicat.rb
+++ b/modules/post/windows/gather/credentials/navicat.rb
@@ -11,12 +11,13 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   # secret_key = Digest::SHA1.digest('3DC5CA39')
   SECRET_KEY = "B\xCE\xB2q\xA5\xE4X\xB7J\xEA\x93\x94y\"5C\x91\x873@".freeze
+
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Windows Gather Navicat Passwords',
-        'Description' => %q{ This module will find and decrypt stored Navicat passwords },
+        'Description' => %q{ This module will find and decrypt stored Navicat passwords. },
         'License' => MSF_LICENSE,
         'References' => [
           [ 'URL', 'https://github.com/HyperSine/how-does-navicat-encrypt-password'],
@@ -29,7 +30,7 @@ class MetasploitModule < Msf::Post
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter', 'shell'],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter' ],
         'Notes' => {
           'Reliability' => [],
-          'Stability' => [],
+          'Stability' => [ CRASH_SAFE ],
           'SideEffects' => [ IOC_IN_LOGS ]
         },
         'Compat' => {

--- a/modules/post/windows/gather/credentials/viber.rb
+++ b/modules/post/windows/gather/credentials/viber.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Post
           path: 'AppData',
           dir: 'ViberPC',
           artifact_file_name: '*.jpg',
-          description: 'Collects all images of contacts and sent recieved',
+          description: 'Collects all images of contacts and sent received',
           credential_type: 'image'
         }
       ]

--- a/modules/post/windows/gather/credentials/xchat.rb
+++ b/modules/post/windows/gather/credentials/xchat.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Post
           path: 'AppData',
           dir: 'X-Chat 2',
           artifact_file_name: '*.txt',
-          description: 'Collects all chatting conversations of sent and recieved',
+          description: 'Collects all chatting conversations of sent and received',
           credential_type: 'text',
           regex_search: [
             {

--- a/modules/post/windows/gather/forensics/recovery_files.rb
+++ b/modules/post/windows/gather/forensics/recovery_files.rb
@@ -252,7 +252,7 @@ class MetasploitModule < Msf::Post
     end
   end
 
-  # Recieve the MFT data runs and list/save the deleted files
+  # Receive the MFT data runs and list/save the deleted files
   # Useful cheat_sheet to understand the MFT structure:  http://www.writeblocked.org/resources/ntfs_cheat_sheets.pdf
   # Recap of each of the attributes: http://runenordvik.com/doc/MFT-table.pdf
   def deleted_files(data_runs, handle, files)

--- a/modules/post/windows/manage/kerberos_tickets.rb
+++ b/modules/post/windows/manage/kerberos_tickets.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Post
         ],
         'DefaultAction' => 'DUMP_TICKETS',
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         },

--- a/modules/post/windows/wlan/wlan_current_connection.rb
+++ b/modules/post/windows/wlan/wlan_current_connection.rb
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Post
     signal = @host_process.memory.read(pointer, 4)
     connection['signal'] = signal.unpack('V')[0]
 
-    # Grabs the recieve rate value
+    # Grabs the receive rate value
     pointer = (pointer + 4)
     rxrate = @host_process.memory.read(pointer, 4)
     connection['rxrate'] = rxrate.unpack('V')[0]

--- a/modules/post/windows/wlan/wlan_disconnect.rb
+++ b/modules/post/windows/wlan/wlan_disconnect.rb
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Post
     signal = @host_process.memory.read(pointer, 4)
     connection['signal'] = signal.unpack('V')[0]
 
-    # Grabs the recieve rate value
+    # Grabs the receive rate value
     pointer = (pointer + 4)
     rxrate = @host_process.memory.read(pointer, 4)
     connection['rxrate'] = rxrate.unpack('V')[0]


### PR DESCRIPTION
Fixes for notes and "recieve" typo, mostly.

Also removes `ExcellentRanking` from a `Post` module. This module is intended to disable a service, thus disqualifying it from `ExcellentRanking`. Additionally, as the module is a `Post` module not intended to get a session, the ranking is [meaningless](https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html).
