### PR TITLE
Msf::Module::Platform#find_platform: Match known platforms before search

### DIFF
--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -53,6 +53,78 @@ class Msf::Module::Platform
     # remove any whitespace and downcase
     str = str.gsub(' ', '').downcase
 
+    # Match known platforms first, then fall back to string matching
+    case str
+    when 'windows', 'win'
+      return Msf::Module::Platform::Windows
+    when 'linux'
+      return Msf::Module::Platform::Linux
+    when 'unix'
+      return Msf::Module::Platform::Unix
+    when 'osx'
+      return Msf::Module::Platform::OSX
+    when 'solaris'
+      return Msf::Module::Platform::Solaris
+    when 'freebsd'
+      return Msf::Module::Platform::FreeBSD
+    when 'netware'
+      return Msf::Module::Platform::Netware
+    when 'bsd'
+      return Msf::Module::Platform::BSD
+    when 'openbsd'
+      return Msf::Module::Platform::OpenBSD
+    when 'android'
+      return Msf::Module::Platform::Android
+    when 'java'
+      return Msf::Module::Platform::Java
+    when 'r'
+      return Msf::Module::Platform::R
+    when 'ruby'
+      return Msf::Module::Platform::Ruby
+    when 'cisco'
+      return Msf::Module::Platform::Cisco
+    when 'juniper'
+      return Msf::Module::Platform::Juniper
+    when 'unifi'
+      return Msf::Module::Platform::Unifi
+    when 'brocade'
+      return Msf::Module::Platform::Brocade
+    when 'mikrotik'
+      return Msf::Module::Platform::Mikrotik
+    when 'arista'
+      return Msf::Module::Platform::Arista
+    when 'bsdi'
+      return Msf::Module::Platform::BSDi
+    when 'netbsd'
+      return Msf::Module::Platform::NetBSD
+    when 'aix'
+      return Msf::Module::Platform::AIX
+    when 'hpux'
+      return Msf::Module::Platform::HPUX
+    when 'irix'
+      return Msf::Module::Platform::Irix
+    when 'php'
+      return Msf::Module::Platform::PHP
+    when 'javascript'
+      return Msf::Module::Platform::JavaScript
+    when 'python'
+      return Msf::Module::Platform::Python
+    when 'nodejs'
+      return Msf::Module::Platform::NodeJS
+    when 'firefox'
+      return Msf::Module::Platform::Firefox
+    when 'mainframe'
+      return Msf::Module::Platform::Mainframe
+    when 'multi'
+      return Msf::Module::Platform::Multi
+    when 'hardware'
+      return Msf::Module::Platform::Hardware
+    when 'apple_ios'
+      return Msf::Module::Platform::Apple_iOS
+    when 'unknown'
+      return Msf::Module::Platform::Unknown
+    end
+
     # Start at the base platform module
     mod = ::Msf::Module::Platform
 


### PR DESCRIPTION
Profiling reveals a lot of time is spent parsing module platforms in `Msf::Module::Platform#find_platform` during startup.

```
# stackprof stackprof-output.dump  | head -n 15
==================================
  Mode: cpu(1000)
  Samples: 4176 (1.07% miss rate)
  GC: 578 (13.84%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       659  (15.8%)         427  (10.2%)     Kernel.require
       327   (7.8%)         327   (7.8%)     (marking)
       251   (6.0%)         251   (6.0%)     (sweeping)
       279   (6.7%)         200   (4.8%)     Msf::DataStore#import_options
       178   (4.3%)         167   (4.0%)     Msf::OptBase#initialize
       384   (9.2%)         164   (3.9%)     Msf::Module::Platform.find_portion
       486  (11.6%)         116   (2.8%)     Hash#each
        86   (2.1%)          86   (2.1%)     Hash#store
      2522  (60.4%)          81   (1.9%)     Class#new
```

```
# stackprof stackprof-output.dump --method 'Msf::Module::Platform.find_portion' | head 
Msf::Module::Platform.find_portion (/root/Desktop/metasploit-framework/lib/msf/core/module/platform.rb:133)
  samples:   164 self (3.9%)  /    384 total (9.2%)
  callers:
     384  (  100.0%)  Msf::Module::Platform.find_platform
     233  (   60.7%)  Hash#each
  callees (220 total):
     349  (  158.6%)  Hash#each
      70  (   31.8%)  String#[]
      20  (    9.1%)  Module#const_defined?
       8  (    3.6%)  Integer#==
```

The `Msf::Module::Platform` class was introduced in a commit titled ["Wow this is overly complex, I suckx0r"](https://github.com/rapid7/metasploit-framework/commit/cd38d6e9f5d5be5b904f0410a63370e9010c1ba6) in 2005. The `find_platform` method was added in a commit titled ["Hmmm"](https://github.com/rapid7/metasploit-framework/commit/5634b3e83e8036708bf7ee2116820eebb4950516) on the following day.

This allows us to dynamically define supported platforms as a string within module metadata (using the `Platform` key). Platforms can also be defined abbreviated (ie, `win`); however, `win` appears to be the only abbreviation we use for any platform.

The basic structure of the `find_platform` method has not changed since it was introduced. It calls `find_portion` in a loop, which in turn performs multiple comparisons and iterates through abbreviations in an attempt to match the string to a platform.

Searching platform names and abbreviations is an unnecessarily complex method to map platform strings to classes. There are only ~30 platforms in Metasploit. Most callers of this method do not need this functionality and could simply use a Hash lookup table.

These methods were authored in 2005 when Metasploit contained far fewer modules. Now this method is called approximately 37 thousand (!) times during startup. Due to the ever-increasing number of modules, this behaviour will cause the startup time to grow.

For now, this PR uses simple string matching for known platforms which **consistently decreases startup time by about 10%** on my system.

In the long term, a simple `Hash` defined in `lib/msf/core/constants.rb` could be used to lookup platforms, here and elsewhere, instead.


---

# Before

```
# for i in {1..5}; do time ./msfconsole -q -x exit ; done

real    0m18.954s
user    0m17.593s
sys     0m1.254s

real    0m17.101s
user    0m15.842s
sys     0m1.142s

real    0m16.766s
user    0m15.363s
sys     0m1.272s

real    0m16.633s
user    0m15.316s
sys     0m1.205s

real    0m18.484s
user    0m17.086s
sys     0m1.269s
```

# After

```
# for i in {1..5}; do time ./msfconsole -q -x exit ; done

real    0m13.931s
user    0m12.702s
sys     0m1.161s

real    0m14.854s
user    0m13.459s
sys     0m1.331s

real    0m15.845s
user    0m14.537s
sys     0m1.169s

real    0m15.510s
user    0m14.191s
sys     0m1.210s

real    0m14.129s
user    0m12.862s
sys     0m1.179s
```
