### PR TITLE
Update ruby prof version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development do
   # memory profiling
   gem 'memory_profiler'
   # cpu profiling
-  gem 'ruby-prof', '1.4.2'
+  gem 'ruby-prof'
   # Metasploit::Aggregator external session proxy
   # disabled during 2.5 transition until aggregator is available
   # gem 'metasploit-aggregator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,7 @@ GEM
       parser (>= 3.3.1.0)
     ruby-macho (4.1.0)
     ruby-mysql (4.2.0)
-    ruby-prof (1.4.2)
+    ruby-prof (1.7.1)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
@@ -624,7 +624,7 @@ DEPENDENCIES
   rspec-rails
   rspec-rerun
   rubocop (= 1.67.0)
-  ruby-prof (= 1.4.2)
+  ruby-prof
   simplecov (= 0.18.2)
   test-prof
   timecop


### PR DESCRIPTION
Update Ruby-prof version to support Ruby 3.3+

## Verification

```
$ METASPLOIT_CPU_PROFILE=true ./msfconsole -x exit 
...
Generating CPU dump /var/folders/wp/fp12h8q13kq7mvf4mll72c140000gq/T/msf-profile-2025051209261520250512-43766-egz22j/cpu
```