### PR TITLE
Update windows 2019 CI usage

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -63,21 +63,23 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-2022
           - ubuntu-latest
         ruby:
-          - '3.2'
+          - '3.4'
         include:
           # Powershell
-          - { command_shell: { name: powershell }, os: windows-2019 }
-          - { command_shell: { name: powershell }, os: windows-2022 }
+          - { command_shell: { name: powershell }, ruby: '3.4', os: windows-2022 }
+          - { command_shell: { name: powershell }, ruby: '3.4', os: windows-2025 }
 
           # Linux
-          - { command_shell: { name: linux }, os: ubuntu-latest }
+          - { command_shell: { name: linux }, ruby: '3.4', os: ubuntu-latest }
 
           # CMD
-          - { command_shell: { name: cmd }, os: windows-2019 }
-          - { command_shell: { name: cmd }, os: windows-2022 }
+          - { command_shell: { name: cmd }, ruby: '3.4', os: windows-2022 }
+
+          # TODO: Tests currently fail:
+          # - { command_shell: { name: cmd }, ruby: '3.4', os: windows-2025 }
 
     runs-on: ${{ matrix.os }}
 
@@ -131,7 +133,7 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
 
-      - name: Setup Ruby
+      - name: Setup '${{ matrix.ruby }}' Ruby
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
         uses: ruby/setup-ruby@v1
@@ -191,7 +193,8 @@ jobs:
           BUNDLE_FORCE_RUBY_PLATFORM: true
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '${{ matrix.ruby }}'
+          # use the default version from the .ruby-version file
+          ruby-version: '.ruby-version'
           bundler-cache: true
           cache-version: 4
 

--- a/.github/workflows/shared_gem_verify.yml
+++ b/.github/workflows/shared_gem_verify.yml
@@ -29,7 +29,8 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-latest
-          - windows-2019
+          - windows-2022
+          - windows-2025
           - macos-13
 
     env:

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -68,10 +68,10 @@ jobs:
       matrix:
         os:
           - macos-13
-          - windows-2019
+          - windows-2022
           - ubuntu-latest
         ruby:
-          - '3.2'
+          - '3.4'
         meterpreter:
           # Python
           - { name: python, runtime_version: 3.8 }
@@ -87,8 +87,9 @@ jobs:
           - { name: php, runtime_version: 8.3 }
         include:
           # Windows Meterpreter
-          - { meterpreter: { name: windows_meterpreter }, os: windows-2019 }
-          - { meterpreter: { name: windows_meterpreter }, os: windows-2022 }
+          - { meterpreter: { name: windows_meterpreter }, ruby: '3.4', os: windows-2022 }
+          # TODO: Screenshotting behavior fails:
+          # - { meterpreter: { name: windows_meterpreter }, ruby: '3.4', os: windows-2025 }
 
           # Mettle
           - { meterpreter: { name: mettle }, os: macos-13 }
@@ -268,6 +269,15 @@ jobs:
       - name: Build Windows payloads via Visual Studio 2022 Build (Windows)
         shell: cmd
         if: ${{ matrix.meterpreter.name == 'windows_meterpreter' && matrix.os == 'windows-2022' && inputs.build_metasploit_payloads }}
+        run: |
+          cd c/meterpreter
+          git submodule init && git submodule update
+          make.bat
+        working-directory: metasploit-payloads
+
+      - name: Build Windows payloads via Visual Studio 2025 Build (Windows)
+        shell: cmd
+        if: ${{ matrix.meterpreter.name == 'windows_meterpreter' && matrix.os == 'windows-2025' && inputs.build_metasploit_payloads }}
         run: |
           cd c/meterpreter
           git submodule init && git submodule update

--- a/spec/support/acceptance/session/python.rb
+++ b/spec/support/acceptance/session/python.rb
@@ -53,12 +53,21 @@ module Acceptance::Session
               "[-] [should stop W32Time] FAILED: should stop W32Time",
               "[-] [should stop W32Time] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
               "[-] [should list services] FAILED: should list services",
-              "[-] [should list services] Exception: NoMethodError: undefined method `service' for nil:NilClass",
+              # Ruby 3.2
+              ["[-] [should list services] Exception: NoMethodError: undefined method `service' for nil:NilClass", { flaky: true }],
+              # Ruby 3.4 - https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/#Compatibility%20issues
+              ["[-] [should list services] Exception: NoMethodError: undefined method 'service' for nil", { flaky: true }],
               "[-] [should return info on a given service winmgmt] FAILED: should return info on a given service winmgmt",
-              "[-] [should return info on a given service winmgmt] Exception: NoMethodError: undefined method `service' for nil:NilClass",
+              # Ruby 3.2
+              ["[-] [should return info on a given service winmgmt] Exception: NoMethodError: undefined method `service' for nil:NilClass", { flaky: true }],
+              # Ruby 3.4 - https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/#Compatibility%20issues
+              ["[-] [should return info on a given service winmgmt] Exception: NoMethodError: undefined method 'service' for nil", { flaky: true }],
               "[-] FAILED: should create a service testes",
               "[-] [should return info on the newly-created service testes] FAILED: should return info on the newly-created service testes",
-              "[-] [should return info on the newly-created service testes] Exception: NoMethodError: undefined method `service' for nil:NilClass",
+              # Ruby 3.2
+              ["[-] [should return info on the newly-created service testes] Exception: NoMethodError: undefined method `service' for nil:NilClass", { flaky: true }],
+              # Ruby 3.4 - https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/#Compatibility%20issues
+              ["[-] [should return info on the newly-created service testes] Exception: NoMethodError: undefined method 'service' for nil", { flaky: true }],
               "[-] [should delete the new service testes] FAILED: should delete the new service testes",
               "[-] [should delete the new service testes] Exception: RuntimeError: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error for value 0x6.",
               "[-] [should return status on a given service winmgmt] FAILED: should return status on a given service winmgmt",
@@ -101,10 +110,16 @@ module Acceptance::Session
           },
           windows: {
             known_failures: [
-              "[-] [should return clipboard jpg dimensions] FAILED: should return clipboard jpg dimensions",
-              "[-] [should return clipboard jpg dimensions] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass",
-              "[-] [should download clipboard jpg data] FAILED: should download clipboard jpg data",
-              "[-] [should download clipboard jpg data] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass"
+              # Ruby 3.2
+              ["[-] [should return clipboard jpg dimensions] FAILED: should return clipboard jpg dimensions", { flaky: true }],
+              ["[-] [should return clipboard jpg dimensions] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass", { flaky: true }],
+              ["[-] [should download clipboard jpg data] FAILED: should download clipboard jpg data", { flaky: true }],
+              ["[-] [should download clipboard jpg data] Exception: NoMethodError: undefined method `clipboard' for nil:NilClass", { flaky: true }],
+              # Ruby 3.4 - https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/#Compatibility%20issues
+              ["[-] [should return clipboard jpg dimensions] FAILED: should return clipboard jpg dimensions", { flaky: true }],
+              ["[-] [should return clipboard jpg dimensions] Exception: NoMethodError: undefined method 'clipboard' for nil", { flaky: true }],
+              ["[-] [should download clipboard jpg data] FAILED: should download clipboard jpg data", { flaky: true }],
+              ["[-] [should download clipboard jpg data] Exception: NoMethodError: undefined method 'clipboard' for nil", { flaky: true }],
             ]
           }
         }


### PR DESCRIPTION
Update windows 2019 CI usage as it's EOL soon https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#:~:text=Windows%20Server%202019%20is%20closing%20down&text=This%20image%20will%20be%20fully,%2D2022%20or%20windows%2D2025%20.

Also bumps to Ruby 3.4 within the tests instead of Ruby 3.2 as there is an issue with compilation of nokogiri and sqlite:


<details>
<summary>stack trace</summary>

```
current directory:
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/nokogiri-1.18.3/ext/nokogiri
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/bin/ruby.exe extconf.rb
checking for whether -std=c99 is accepted as CFLAGS... yes
checking for whether -Wno-declaration-after-statement is accepted as CFLAGS...
yes
checking for whether -O2 is accepted as CFLAGS... yes
checking for whether -g is accepted as CFLAGS... yes
checking for whether -Winline is accepted as CFLAGS... yes
checking for whether -Wmissing-noreturn is accepted as CFLAGS... yes
checking for whether -Wconversion is accepted as CFLAGS... no
checking for whether  "-Idummypath" is accepted as CPPFLAGS... yes
Building nokogiri using packaged libraries.
Static linking is enabled.
Cross build is disabled.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=C:/hostedtoolcache/windows/Ruby/3.2.8/x64/bin/$(RUBY_BASE_NAME)
	--help
	--clean
	--prevent-strip
	--enable-system-libraries
	--disable-system-libraries
	--use-system-libraries
	--enable-system-libraries
	--disable-system-libraries
	--use-system-libraries
	--enable-static
	--disable-static
	--enable-cross-build
	--disable-cross-build
	--enable-cross-build
	--disable-cross-build
	--enable-xml2-legacy
	--disable-xml2-legacy
	--with-zlib-dir
	--without-zlib-dir
	--with-zlib-include
	--without-zlib-include=${zlib-dir}/include
	--with-zlib-lib
	--without-zlib-lib=${zlib-dir}/lib
	--enable-xml2-legacy
	--disable-xml2-legacy
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require': 127: The specified procedure could not be found.   -
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/date-3.4.1/lib/date_core.so
(LoadError)
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/date-3.4.1/lib/date.rb:4:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/time.rb:4:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/open-uri.rb:4:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/mini_portile2-2.8.8/lib/mini_portile2/mini_portile.rb:7:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/mini_portile2-2.8.8/lib/mini_portile2.rb:2:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
	from extconf.rb:[449](https://github.com/rapid7/metasploit-framework/actions/runs/14970079371/job/42048824480#step:7:456):in `process_recipe'
	from extconf.rb:778:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can
be found here:

D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/extensions/x64-mingw-ucrt/3.2.0/nokogiri-1.18.3/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/nokogiri-1.18.3
for inspection.
Results logged to
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/extensions/x64-mingw-ucrt/3.2.0/nokogiri-1.18.3/gem_make.out

C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:119:in
`run'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/ext_conf_builder.rb:28:in
`build'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:187:in
`build_extension'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:221:in
`block in build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:218:in
`each'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:218:in
`build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/installer.rb:846:in
`build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/rubygems_gem_installer.rb:76:in
`build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/rubygems_gem_installer.rb:28:in
`install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/source/rubygems.rb:205:in
`install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/gem_installer.rb:54:in
`install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/parallel_installer.rb:132:in
`do_install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/parallel_installer.rb:123:in
`block in worker_pool'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:62:in
`apply_func'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:57:in
`block in process_queue'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:54:in
`loop'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:54:in
`process_queue'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:90:in
`block (2 levels) in create_threads'

An error occurred while installing nokogiri (1.18.3), and Bundler cannot
continue.

In Gemfile:
  factory_bot_rails was resolved to 6.4.4, which depends on
    railties was resolved to 7.1.5.1, which depends on
      actionpack was resolved to 7.1.5.1, which depends on
        actionview was resolved to 7.1.5.1, which depends on
          rails-dom-testing was resolved to 2.2.0, which depends on
            nokogiri


Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/sqlite3-1.7.3/ext/sqlite3
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/bin/ruby.exe extconf.rb
Building sqlite3-ruby using packaged sqlite3.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=C:/hostedtoolcache/windows/Ruby/3.2.8/x64/bin/$(RUBY_BASE_NAME)
	--help
	--download-dependencies
	--with-sqlcipher
	--without-sqlcipher
	--with-sqlcipher-dir
	--without-sqlcipher-dir
	--with-sqlcipher-include
	--without-sqlcipher-include
	--with-sqlcipher-lib
	--without-sqlcipher-lib
	--enable-system-libraries
	--disable-system-libraries
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require': 127: The specified procedure could not be found.   -
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/date-3.4.1/lib/date_core.so
(LoadError)
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/date-3.4.1/lib/date.rb:4:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/time.rb:4:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/open-uri.rb:4:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in
`require'
from
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/mini_portile2-2.8.8/lib/mini_portile2/mini_portile.rb:7:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
from
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/mini_portile2-2.8.8/lib/mini_portile2.rb:2:in
`<top (required)>'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in
`require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in
`rescue in require'
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:40:in
`require'
	from extconf.rb:139:in `minimal_recipe'
	from extconf.rb:51:in `configure_packaged_libraries'
	from extconf.rb:17:in `configure'
	from extconf.rb:285:in `<main>'
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require': cannot load such file -- mini_portile2 (LoadError)
from
<internal:C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in
`require'
	from extconf.rb:139:in `minimal_recipe'
	from extconf.rb:51:in `configure_packaged_libraries'
	from extconf.rb:17:in `configure'
	from extconf.rb:285:in `<main>'

extconf failed, exit code 1

Gem files will remain installed in
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/gems/sqlite3-1.7.3
for inspection.
Results logged to
D:/a/metasploit-framework/metasploit-framework/metasploit-framework/vendor/bundle/ruby/3.2.0/extensions/x64-mingw-ucrt/3.2.0/sqlite3-1.7.3/gem_make.out

C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:119:in
`run'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/ext_conf_builder.rb:28:in
`build'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:187:in
`build_extension'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:221:in
`block in build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:218:in
`each'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/ext/builder.rb:218:in
`build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/3.2.0/rubygems/installer.rb:846:in
`build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/rubygems_gem_installer.rb:76:in
`build_extensions'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/rubygems_gem_installer.rb:28:in
`install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/source/rubygems.rb:205:in
`install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/gem_installer.rb:54:in
`install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/parallel_installer.rb:132:in
`do_install'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/installer/parallel_installer.rb:123:in
`block in worker_pool'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:62:in
`apply_func'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:57:in
`block in process_queue'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:54:in
`loop'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:54:in
`process_queue'
C:/hostedtoolcache/windows/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.10/lib/bundler/worker.rb:90:in
`block (2 levels) in create_threads'

An error occurred while installing sqlite3 (1.7.3), and Bundler cannot continue.

In Gemfile:
  metasploit-framework was resolved to 6.4.63, which depends on
    sqlite3
```

</details>

Which we tracked down to this dependency graph:

![image](https://github.com/user-attachments/assets/cfba3989-07c3-443c-a584-3784cdd42f92)

Likely caused by net-imap including `date` as a gem that needs compiled:

https://github.com/ruby/net-imap/blob/dc8004de050678483ed6f1879a43e3b76aa77ccd/net-imap.gemspec#L37

There's an issue here to remove it: https://github.com/ruby/net-imap/issues/96

## Verification

Ensure CI passes