### PR TITLE
Msf::Module::UUID: Generate UUID using UUID_CHARS.sample(8).join 

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -114,7 +114,6 @@ module Msf
       @module_info_copy = info.dup
 
       self.module_info = info
-      generate_uuid
 
       set_defaults
 

--- a/lib/msf/core/module/uuid.rb
+++ b/lib/msf/core/module/uuid.rb
@@ -1,13 +1,17 @@
-require 'rex/text'
-
+# NOTE: Metasploit does not use real UUIDs currently.
+# To modify this to be a real UUID we will need to do a database migration.
+# See: https://github.com/rapid7/metasploit-framework/pull/20170
 module Msf::Module::UUID
+  UUID_CHARS = [*('a'..'z'), *('0'..'9')].freeze
+  private_constant :UUID_CHARS
+
   #
   # Attributes
   #
 
   # @return [String] A unique identifier for this module instance
   def uuid
-    @uuid ||= generate_uuid
+    @uuid ||= UUID_CHARS.sample(8).join
   end
 
   protected
@@ -18,13 +22,4 @@ module Msf::Module::UUID
 
   # @!attribute [w] uuid
   attr_writer :uuid
-
-
-  #
-  # Instance Methods
-  #
-
-  def generate_uuid
-    self.uuid = Rex::Text.rand_text_alphanumeric(8).downcase
-  end
 end

--- a/lib/msf/core/module/uuid.rb
+++ b/lib/msf/core/module/uuid.rb
@@ -5,9 +5,10 @@ module Msf::Module::UUID
   # Attributes
   #
 
-  # @!attribute [r] uuid
-  #   A unique identifier for this module instance
-  attr_reader :uuid
+  # @return [String] A unique identifier for this module instance
+  def uuid
+    @uuid ||= generate_uuid
+  end
 
   protected
 


### PR DESCRIPTION
Module UUIDs were added in commit https://github.com/rapid7/metasploit-framework/commit/9277f060a70561721e5be72176b1274c9ad38e87 titled "Store a uuid for each module, track this in sessions" in 2011. Module UUIDs differ between Metasploit runs, as they are dynamically generated at runtime using `Msf::Module::UUID#generate_uuid`.

This method was authored in 2011 when Metasploit contained far fewer modules. Now this method is called approximately 27 thousand (!) times during startup. Due to the ever-increasing number of modules, this behaviour will cause the startup time to grow.

The UUIDs are generated with `Rex::Text.rand_text_alphanumeric(8).downcase`, which does not generate standard UUIDs.

https://github.com/rapid7/metasploit-framework/blob/57032a30e2279bfe2dc9e029416a3ea206b788aa/lib/msf/core/module/uuid.rb#L27

The generated UUID is 8 characters in length (64bit). Most of the key space is wasted, as only 36 values (a-z and 0-9) of 256 are used.

Generating collisions is unlikely, and the impact to startup time is minimal, but the computation is needlessly expensive and wasteful:

* `rand_text_alphanumeric` returns mixed-case alphanumic characters, but we ultimately discard uppercase `A-Z`
* `rand_text_alphanumeric` constructs an array, then calls `Rex::Text#rand_base`,[1] which:
  * needlessly deals with bad characters,[2] of which there are none
  * performs a bunch of expensive array operations (join, pack, uniq) and appends to an array in a loop[2]


All we really want is a unique value that is unlikely to cause collisions. If UUID collisions or speed were an issue we could pre-compute values (which has the added benefit of consistency between Metasploit runs).

Instead, this PR replaces `Rex::Text.rand_text_alphanumeric` with `SecureRandom.uuid` which is significantly faster (almost 10x :rocket:):

```ruby
#!/usr/bin/env/ruby
require 'benchmark'
require 'securerandom'
require 'rex/text'

n = 100_000

Benchmark.bm(20) do |bm|
  bm.report('Rex::Text.rand_text') do
    n.times { uuid = Rex::Text.rand_text_alphanumeric(8).downcase }
  end

  bm.report('SecureRandom.uuid') do
    n.times { uuid = SecureRandom.uuid }
  end
end
```

Benchmarked on a system with 2 cores and 4GB RAM:

* 100,000 iterations:

```
                           user     system      total        real
Rex::Text.rand_text    2.484292   0.017122   2.501414 (  2.522912)
SecureRandom.uuid      0.300432   0.040074   0.340506 (  0.341532)
```

* 27,000 iterations:

```
                           user     system      total        real
Rex::Text.rand_text    0.681830   0.003688   0.685518 (  0.692985)
SecureRandom.uuid      0.083827   0.011939   0.095766 (  0.095777)
```

This does not introduce an extra dependency as we already use SecureRandom in Framework:

```
# grep -rn securerandom lib/
lib/msf/base/sessions/encrypted_shell.rb:2:require 'securerandom'
lib/msf/base/sessions/mettle_config.rb:4:require 'securerandom'
lib/msf/core/modules/external/message.rb:4:require 'securerandom'
lib/msf/core/exploit/remote/tincd_exploit_client.rb:1:require 'securerandom'
lib/msf/core/db_manager/user.rb:2:require 'securerandom'
lib/msf/core/module/uuid.rb:2:require 'securerandom'
lib/msf/core/payload/windows/encrypted_payload_opts.rb:1:require 'securerandom'
lib/msf/core/web_services/json_rpc_app.rb:1:require 'securerandom'
lib/msf/core/web_services/metasploit_api_app.rb:1:require 'securerandom'
lib/metasploit/framework/spec/threads/logger.rb:5:require 'securerandom'
lib/metasploit/framework/obfuscation/crandomizer/utility.rb:2:require 'securerandom'
lib/rex/post/meterpreter/pivot.rb:4:require 'securerandom'
lib/rex/payloads/meterpreter/config.rb:4:require 'securerandom'
```


**Note**: I'm not sure what effect this change will have on Metasploit Pro, if any.
**Note**: Maybe there is a reason we only want UUIDs to be only 8 characters? If so, we could simply truncate the generated UUID. This would still be much faster than using `Rex::Text`.


---

[1] https://github.com/rapid7/rex-text/blob/0d30d394c4378dbaddf7b489f0d22c2db4024ec7/lib/rex/text/rand.rb#L110-L118
[2] https://github.com/rapid7/rex-text/blob/0d30d394c4378dbaddf7b489f0d22c2db4024ec7/lib/rex/text/rand.rb#L144-L151
