### PR TITLE
Update web crawlers to support HTTP logging

### DIFF
--- a/lib/anemone/rex_http.rb
+++ b/lib/anemone/rex_http.rb
@@ -191,8 +191,9 @@ module Anemone
       url.scheme == "https",
       @opts[:ssl_version],
       @opts[:proxies],
-                    @opts[:username],
-                    @opts[:password]
+      @opts[:username],
+      @opts[:password],
+      subscriber: @opts[:http_subscriber]
     )
 
     conn.set_config(

--- a/lib/msf/core/auxiliary/http_crawler.rb
+++ b/lib/msf/core/auxiliary/http_crawler.rb
@@ -283,6 +283,7 @@ module Auxiliary::HttpCrawler
     opts[:module]              = self
     opts[:timeout]             = get_connection_timeout
     opts[:dirbust]             = dirbust?
+    opts[:http_subscriber] = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: self)
 
     if (t[:headers] and t[:headers].length > 0)
       opts[:inject_headers] = t[:headers]

--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -113,7 +113,8 @@ class Auxiliary::Web::HTTP
       'Auto',
       nil,
       username,
-      password
+      password,
+      subscriber: opts[:http_subscriber]
     )
 
     c.set_config({

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -19,9 +19,8 @@ module Rex
 
         #
         # Creates a new client instance
-        # @param http_trace_proc_request [Proc] A proc object passed to log HTTP requests if HTTP-Trace is set
-        # @param http_trace_proc_response [Proc] A proc object passed to log HTTP responses if HTTP-Trace is set
         #
+        # @param [Rex::Proto::Http::HttpSubscriber] subscriber A subscriber to Http requests/responses
         def initialize(host, port = 80, context = {}, ssl = nil, ssl_version = nil, proxies = nil, username = '', password = '', kerberos_authenticator: nil, comm: nil, subscriber: nil, sslkeylogfile: nil)
           self.hostname = host
           self.port = port.to_i

--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -18,6 +18,9 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options([
       OptString.new('ExcludePathPatterns', [false, 'Newline-separated list of path patterns to ignore (\'*\' is a wildcard)']),
+      OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
+      OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
+      OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu']),
     ])
     @for_each_page_blocks = []
   end


### PR DESCRIPTION
Updates the web crawling modules to support HTTP logging

## Verification

![image](https://github.com/user-attachments/assets/23bc9147-fe20-4df4-9567-a9624d4e3a4e)
