### PR TITLE
modules/post/windows/gather/credentials: Update PackRat module descriptions

### DIFF
--- a/modules/post/windows/gather/credentials/adi_irc.rb
+++ b/modules/post/windows/gather/credentials/adi_irc.rb
@@ -47,12 +47,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Adi IRC credential gatherer',
+        'Name' => 'Adi IRC Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored on AdiIRC Client in a windows remote host.
+          This module searches for credentials stored on AdiIRC Client on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/aim.rb
+++ b/modules/post/windows/gather/credentials/aim.rb
@@ -71,11 +71,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Aim credential gatherer',
+        'Name' => 'Aim Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Aim credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/carotdav_ftp.rb
+++ b/modules/post/windows/gather/credentials/carotdav_ftp.rb
@@ -39,12 +39,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'CarotDAV credential gatherer',
+        'Name' => 'CarotDAV Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored on CarotDAV FTP Client in a windows remote host.
+          This module searches for credentials stored on CarotDAV FTP Client on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/chrome.rb
+++ b/modules/post/windows/gather/credentials/chrome.rb
@@ -88,12 +88,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Chrome credential gatherer',
+        'Name' => 'Chrome Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored on Chrome in a windows remote host.
+          This module searches for credentials stored on Chrome on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/comodo.rb
+++ b/modules/post/windows/gather/credentials/comodo.rb
@@ -120,12 +120,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Comodo credential gatherer',
+        'Name' => 'Comodo Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored in Comodo on a remote Windows host.
+          This module searches for credentials stored in Comodo on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/coolnovo.rb
+++ b/modules/post/windows/gather/credentials/coolnovo.rb
@@ -50,11 +50,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Coolnovo credential gatherer',
+        'Name' => 'Coolnovo Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Coolnovo credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/digsby.rb
+++ b/modules/post/windows/gather/credentials/digsby.rb
@@ -45,11 +45,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Digsby credential gatherer',
+        'Name' => 'Digsby Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Digsby credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/flock.rb
+++ b/modules/post/windows/gather/credentials/flock.rb
@@ -66,12 +66,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Flock credential gatherer',
+        'Name' => 'Flock Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored in Flock on a remote Windows host.
+          This module searches for credentials stored in Flock on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/gadugadu.rb
+++ b/modules/post/windows/gather/credentials/gadugadu.rb
@@ -46,11 +46,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Gadugadu credential gatherer',
+        'Name' => 'Gadugadu Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Gadugadu credentials on a Windows host. Gadu-Gadu is a Polish instant messaging client using a proprietary protocol. Gadu-Gadu was the most popular IM service in Poland.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/halloy_irc.rb
+++ b/modules/post/windows/gather/credentials/halloy_irc.rb
@@ -38,12 +38,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Halloy IRC credential gatherer',
+        'Name' => 'Halloy IRC Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored on Halloy IRC Client in a windows remote host.
+          This module searches for credentials stored on Halloy IRC Client on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/icq.rb
+++ b/modules/post/windows/gather/credentials/icq.rb
@@ -71,11 +71,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'ICQ credential gatherer',
+        'Name' => 'ICQ Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for ICQ credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/ie.rb
+++ b/modules/post/windows/gather/credentials/ie.rb
@@ -27,12 +27,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Ie credential gatherer',
+        'Name' => 'Internet Explorer Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for ie credentials on a Windows host.
+          This module searches for Internet Explorer credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/incredimail.rb
+++ b/modules/post/windows/gather/credentials/incredimail.rb
@@ -46,11 +46,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Incredimail credential gatherer',
+        'Name' => 'Incredimail Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Incredimail credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/kakaotalk.rb
+++ b/modules/post/windows/gather/credentials/kakaotalk.rb
@@ -44,11 +44,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'KakaoTalk credential gatherer',
+        'Name' => 'KakaoTalk Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for KakaoTalk credentials on a Windows host. KakaoTalk is a popular mobile messaging app most widely used in South Korea.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/kmeleon.rb
+++ b/modules/post/windows/gather/credentials/kmeleon.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Post
           path: 'AppData',
           dir: 'K-Meleon',
           artifact_file_name: 'cert8.db',
-          description: "K-Melon's saved Username and Passwords",
+          description: "K-Meleon's saved Username and Passwords",
           credential_type: 'database'
         },
         {
@@ -104,12 +104,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Kmeleon credential gatherer',
+        'Name' => 'K-Meleon Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for K-meleon credentials on a Windows host.
+          This module searches for K-Meleon credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/line.rb
+++ b/modules/post/windows/gather/credentials/line.rb
@@ -77,12 +77,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'LINE credential gatherer',
+        'Name' => 'LINE Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials in LINE desktop application on a remote Windows host. LINE is the most popular Instant Messenger app in Japan.
+          This module searches for credentials in LINE desktop application on a Windows host. LINE is the most popular Instant Messenger app in Japan.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/maxthon.rb
+++ b/modules/post/windows/gather/credentials/maxthon.rb
@@ -47,11 +47,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Maxthon credential gatherer',
+        'Name' => 'Maxthon Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Maxthon credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/miranda.rb
+++ b/modules/post/windows/gather/credentials/miranda.rb
@@ -47,11 +47,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Miranda credential gatherer',
+        'Name' => 'Miranda Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Miranda credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/opera.rb
+++ b/modules/post/windows/gather/credentials/opera.rb
@@ -97,11 +97,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Opera credential gatherer',
+        'Name' => 'Opera Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Opera credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/operamail.rb
+++ b/modules/post/windows/gather/credentials/operamail.rb
@@ -72,11 +72,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Operamail credential gatherer',
+        'Name' => 'Operamail Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Operamail credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/postbox.rb
+++ b/modules/post/windows/gather/credentials/postbox.rb
@@ -306,11 +306,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Postbox credential gatherer',
+        'Name' => 'Postbox Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Postbox credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/qq.rb
+++ b/modules/post/windows/gather/credentials/qq.rb
@@ -29,11 +29,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'QQ credential gatherer',
+        'Name' => 'QQ Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for QQ credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/quassel_irc.rb
+++ b/modules/post/windows/gather/credentials/quassel_irc.rb
@@ -43,12 +43,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Quassel IRC credential gatherer',
+        'Name' => 'Quassel IRC Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored on Quassel IRC Client in a windows remote host.
+          This module searches for credentials stored on Quassel IRC Client on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/redis_desktop_manager.rb
+++ b/modules/post/windows/gather/credentials/redis_desktop_manager.rb
@@ -41,11 +41,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'RedisDesktopManager credential gatherer',
+        'Name' => 'RedisDesktopManager Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for RedisDesktopManager credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/safari.rb
+++ b/modules/post/windows/gather/credentials/safari.rb
@@ -62,12 +62,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Safari credential gatherer',
+        'Name' => 'Safari Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for safari credentials on a Windows host.
+          This module searches for Safari credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/seamonkey.rb
+++ b/modules/post/windows/gather/credentials/seamonkey.rb
@@ -116,11 +116,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Seamonkey credential gatherer',
+        'Name' => 'Seamonkey Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for seamonkey credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/srware.rb
+++ b/modules/post/windows/gather/credentials/srware.rb
@@ -81,11 +81,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Srware credential gatherer',
+        'Name' => 'Srware Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Srware credentials on a Windows host. SRWare Iron is a Chromium-based web browser developed by the German company SRWare.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/sylpheed.rb
+++ b/modules/post/windows/gather/credentials/sylpheed.rb
@@ -39,12 +39,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Sylpheed email credential gatherer',
+        'Name' => 'Sylpheed Email Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials stored on Sylpheed email client in a windows remote host.
+          This module searches for credentials stored on Sylpheed email client on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/tango.rb
+++ b/modules/post/windows/gather/credentials/tango.rb
@@ -75,12 +75,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Tango credential gatherer',
+        'Name' => 'Tango Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for Tango credentials on a Windows host. Tango is a third-party, cross platform messaging application software for smartphones developed by TangoME, Inc.t
+          This module searches for Tango credentials on a Windows host. Tango is a third-party, cross platform messaging application software for smartphones developed by TangoME, Inc.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/thunderbird.rb
+++ b/modules/post/windows/gather/credentials/thunderbird.rb
@@ -186,12 +186,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Thunderbird credential gatherer',
+        'Name' => 'Thunderbird Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for thunderbird credentials on a Windows host.
+          This module searches for Thunderbird credentials on a Windows host.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/tlen.rb
+++ b/modules/post/windows/gather/credentials/tlen.rb
@@ -54,11 +54,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Tlen credential gatherer',
+        'Name' => 'Tlen Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Tlen credentials on a Windows host. Tlen is a free Polish instant messaging service.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/viber.rb
+++ b/modules/post/windows/gather/credentials/viber.rb
@@ -45,12 +45,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Viber credential gatherer',
+        'Name' => 'Viber Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for credentials in Viber desktop application on a remote Windows host. Viber is a cross-platform voice over IP and instant messaging software application.
+          This module searches for credentials in Viber desktop application on a Windows host. Viber is a cross-platform voice over IP and instant messaging software application.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/windows/gather/credentials/windowslivemail.rb
+++ b/modules/post/windows/gather/credentials/windowslivemail.rb
@@ -47,11 +47,8 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Windows Live Mail credential gatherer',
+        'Name' => 'Windows Live Mail Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
           This module searches for Windows Live Mail credentials on a Windows host.
         },
         'License' => MSF_LICENSE,

--- a/modules/post/windows/gather/credentials/xchat.rb
+++ b/modules/post/windows/gather/credentials/xchat.rb
@@ -47,12 +47,9 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'XChat credential gatherer',
+        'Name' => 'XChat Credential Gatherer',
         'Description' => %q{
-          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-          Further details can be found in the module documentation.
-          This module searches for Xchat credentials on a Windows host. XChat is an IRC chat program for both Linux and Windows.
+          This module searches for XChat credentials on a Windows host. XChat is an IRC chat program for both Linux and Windows.
         },
         'License' => MSF_LICENSE,
         'Author' => [


### PR DESCRIPTION
* Removes the PackRat mixin description from all PackRat modules. There is no reason to describe the mixin within every module.
* Capitalizes module names; ie: `ICQ Credential Gatherer`
