### PR TITLE
Change check for redirect in wordpress_login to be less specific

### DIFF
--- a/lib/msf/core/exploit/remote/http/wordpress/login.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/login.rb
@@ -14,7 +14,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Login
         'uri' => wordpress_url_login,
         'vars_post' => wordpress_helper_login_post_data(user, pass, redirect)
     }, timeout)
-    if res && res.redirect? && res.redirection && res.redirection.to_s.include?(redirect)
+    if res && res.redirect? && res.redirection&.path.end_with?(redirect)
       cookies = res.get_cookies
       # Check if a valid wordpress cookie is returned
       return cookies if

--- a/lib/msf/core/exploit/remote/http/wordpress/login.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/login.rb
@@ -14,7 +14,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Login
         'uri' => wordpress_url_login,
         'vars_post' => wordpress_helper_login_post_data(user, pass, redirect)
     }, timeout)
-    if res && res.redirect? && res.redirection && res.redirection.to_s == redirect
+    if res && res.redirect? && res.redirection && res.redirection.to_s.include?(redirect)
       cookies = res.get_cookies
       # Check if a valid wordpress cookie is returned
       return cookies if


### PR DESCRIPTION
While testing https://github.com/rapid7/metasploit-framework/pull/20146, I noticed that the exploit failed on my Windows wordpress target.  It failed because when creating the wordpress site, I guess I made a subsite called `mysite`.  This broke the `wordpress_login` method because we feed it a redirect, and since there was already a redirect on my taget site, the redirects did not match exactly- the redirect was `/mysite/<random_string>` rather than `random_string`

The response still contained all the information needed and by checking for the presence of the proper redirect rather than the absolute value, the exploit worked fine.  Admittedly, I have no idea of this will break anything, but I feel like it might break _less_.

I installed my Windows target with XAMPP and this guide: https://wpengine.com/resources/wordpress-xampp/
