### PR TITLE
Ensure thinkphp rce runs on metasploit pro

### DIFF
--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -88,6 +88,12 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
+  # The CmdStager mixin implicitly includes the HttpServer mixin which opts this module out of auto-exploitation
+  # https://github.com/rapid7/metasploit-framework/blob/72ae91e4bc763da378bbd5be104f642f9d7eebc1/lib/msf/core/exploit/remote/http_server.rb#L53-L58
+  def autofilter
+    true
+  end
+
   # PoC version check using the first <span> from the ThinkPHP copyright:
   #
   #   wvu@kharak:~$ curl -vs "http://127.0.0.1:8080/index.php?s=$((RANDOM))" | xmllint --html --xpath 'substring-after(//div[@class = "copyright"]/span[1]/text(), "V")' -


### PR DESCRIPTION
Fixes a bug in the thinkphp rce module that opted it out of auto-exploitation in Metasploit Pro

## Verification

- Ensure CI passes
- Tested within Pro:

### Before

The module is skipped as part of the exploit workflow:

![image](https://github.com/user-attachments/assets/ab076717-ac9f-4d94-8994-c7338bb9c169)

![image](https://github.com/user-attachments/assets/dc7b865d-4d88-4c7a-86b7-b0856127de96)

### After:

The module is run as expected and we get a shell:

![image](https://github.com/user-attachments/assets/a4470242-d921-443b-884a-989f5a58d082)