### PR TITLE
Rubocop: Enable Layout/SpaceBeforeBrackets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,10 +25,7 @@ require:
   - ./lib/rubocop/cop/lint/detect_invalid_pack_directives.rb
 
 Layout/SpaceBeforeBrackets:
-  Description: >-
-    Disabled as it generates invalid code:
-      https://github.com/rubocop-hq/rubocop/issues/9499
-  Enabled: false
+  Enabled: true
 
 Lint/AmbiguousAssignment:
   Enabled: true


### PR DESCRIPTION
This rule was disabled due to a [bug](https://github.com/rubocop/rubocop/issues/9499) in Rubocop which was patched in 2021.

Auto-corrected code generated by this rule should be safe in patched versions of Rubocop.

We currently pin Rubocop to version 1.67.0 which was [released](https://github.com/rubocop/rubocop/releases/tag/v1.67.0) in 2024:

https://github.com/rapid7/metasploit-framework/blob/b251fc1b635dc07c66cc3848983bdcbeaa08a81f/Gemfile.lock#L520

**Edit:** We have since bumped the Rubocop version to 1.75.6; however, @adfoster-r7 rightly points out that this bug was in fact *not* fixed. This PR is blocked.
