### PR TITLE
modules/auxiliary/admin/networking: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/admin/networking/arista_config.rb
+++ b/modules/auxiliary/admin/networking/arista_config.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'Author' => [ 'h00die' ],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
         }

--- a/modules/auxiliary/admin/networking/brocade_config.rb
+++ b/modules/auxiliary/admin/networking/brocade_config.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Brocade
   include Msf::Exploit::Deprecated
@@ -18,7 +17,12 @@ class MetasploitModule < Msf::Auxiliary
           This module imports a Brocade device configuration.
         },
         'License' => MSF_LICENSE,
-        'Author' => ['h00die']
+        'Author' => ['h00die'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 
@@ -29,7 +33,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(22)
       ]
     )
-
   end
 
   def run

--- a/modules/auxiliary/admin/networking/cisco_asa_extrabacon.rb
+++ b/modules/auxiliary/admin/networking/cisco_asa_extrabacon.rb
@@ -38,7 +38,10 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'DefaultAction' => 'PASS_DISABLE',
       'Notes' => {
-        'AKA' => ['EXTRABACON']
+        'AKA' => ['EXTRABACON'],
+        'Stability' => [],
+        'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+        'Reliability' => []
       }
     )
 

--- a/modules/auxiliary/admin/networking/cisco_config.rb
+++ b/modules/auxiliary/admin/networking/cisco_config.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Cisco
   include Msf::Exploit::Deprecated
@@ -18,7 +17,12 @@ class MetasploitModule < Msf::Auxiliary
           This module imports a Cisco IOS or NXOS device configuration.
         },
         'License' => MSF_LICENSE,
-        'Author' => ['h00die']
+        'Author' => ['h00die'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
       )
     )
 
@@ -29,7 +33,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(22)
       ]
     )
-
   end
 
   def run

--- a/modules/auxiliary/admin/networking/cisco_dcnm_download.rb
+++ b/modules/auxiliary/admin/networking/cisco_dcnm_download.rb
@@ -23,21 +23,24 @@ class MetasploitModule < Msf::Auxiliary
           work on a few versions below 10.4(2). Only version 11.0(1) requires authentication to exploit
           (see References to understand why).
         },
-        'Author' =>
-          [
-            'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
-          ],
+        'Author' => [
+          'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and Metasploit module
+        ],
         'License' => MSF_LICENSE,
-        'References' =>
-          [
-            [ 'CVE', '2019-1619' ],
-            [ 'CVE', '2019-1621' ],
-            [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190626-dcnm-bypass' ],
-            [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190626-dcnm-file-dwnld' ],
-            [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/Cisco/cisco-dcnm-rce.txt' ],
-            [ 'URL', 'https://seclists.org/fulldisclosure/2019/Jul/7' ]
-          ],
-        'DisclosureDate' => '2019-06-26'
+        'References' => [
+          [ 'CVE', '2019-1619' ],
+          [ 'CVE', '2019-1621' ],
+          [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190626-dcnm-bypass' ],
+          [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20190626-dcnm-file-dwnld' ],
+          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/Cisco/cisco-dcnm-rce.txt' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2019/Jul/7' ]
+        ],
+        'DisclosureDate' => '2019-06-26',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
       )
     )
 
@@ -64,13 +67,11 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res && res.code == 200
-      # get the JSESSIONID cookie
-      if res.get_cookies
-        res.get_cookies.split(';').each do |cok|
-          if cok.include?('JSESSIONID')
-            return cok
-          end
+    # get the JSESSIONID cookie
+    if res && res.code == 200 && res.get_cookies
+      res.get_cookies.split(';').each do |cok|
+        if cok.include?('JSESSIONID')
+          return cok
         end
       end
     end

--- a/modules/auxiliary/admin/networking/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_secure_acs_bypass.rb
@@ -21,17 +21,20 @@ class MetasploitModule < Msf::Auxiliary
           Instances of Secure ACS running version 5.1 with patches 3, 4, or 5 as well
           as version 5.2 with either no patches or patches 1 and 2 are vulnerable.
         },
-        'References' =>
-          [
-            ['BID', '47093'],
-            ['CVE', '2011-0951'],
-            ['URL', 'http://www.cisco.com/en/US/products/csa/cisco-sa-20110330-acs.html']
-          ],
-        'Author' =>
-          [
-            'Jason Kratzer <pyoor[at]flinkd.org>'
-          ],
-        'License' => MSF_LICENSE
+        'References' => [
+          ['BID', '47093'],
+          ['CVE', '2011-0951'],
+          ['URL', 'http://www.cisco.com/en/US/products/csa/cisco-sa-20110330-acs.html']
+        ],
+        'Author' => [
+          'Jason Kratzer <pyoor[at]flinkd.org>'
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
       )
     )
 
@@ -107,6 +110,5 @@ class MetasploitModule < Msf::Auxiliary
       print_error("#{rhost} - Failed! The webserver issued a #{res.code} response.")
       print_error('Please validate the TARGETURI option and try again.')
     end
-
   end
 end

--- a/modules/auxiliary/admin/networking/f5_config.rb
+++ b/modules/auxiliary/admin/networking/f5_config.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'Author' => ['h00die'],
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
         }

--- a/modules/auxiliary/admin/networking/juniper_config.rb
+++ b/modules/auxiliary/admin/networking/juniper_config.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DefaultAction' => 'JUNOS',
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
         }

--- a/modules/auxiliary/admin/networking/mikrotik_config.rb
+++ b/modules/auxiliary/admin/networking/mikrotik_config.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DefaultAction' => 'ROUTEROS',
         'Notes' => {
-          'Stability' => [],
+          'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
         }

--- a/modules/auxiliary/admin/networking/vyos_config.rb
+++ b/modules/auxiliary/admin/networking/vyos_config.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => [ 'h00die' ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [IOC_IN_LOGS],
+          'SideEffects' => [],
           'Reliability' => []
         }
       )


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

