### PR TITLE
Rubocop: Disable Layout/LineContinuationLeadingSpace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -158,6 +158,12 @@ Style/RedundantAssignment:
 Style/SwapValues:
   Enabled: false
 
+Layout/LineContinuationLeadingSpace:
+  Description: >-
+    Disabled as it sometimes improves the readability of code having leading spaces
+    for indented code strings.
+  Enabled: false
+
 Layout/ModuleHashOnNewLine:
   Enabled: true
 


### PR DESCRIPTION
We current have `NewCops` disabled. Once enabled, the [Layout/LineContinuationLeadingSpace](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/LineContinuationLeadingSpace) rule will be enabled.

This PR disables this rule.

This rule supports enforcing either leading spaces or trailing spaces, but we don't want to mandate use of one over the other.

Sometimes leading whitespace is useful. For example, code such as the following:

```ruby
      "<SOAP-ENV:Envelope\r\n" \
      " SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"\r\n" \
      " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\"\r\n" \
      " xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"\r\n" \
      ">\r\n" \
```

This code would result in the following violations:

```
modules/exploits/linux/upnp/miniupnpd_soap_bof.rb:154:8: C: [Correctable] Layout/LineContinuationLeadingSpace: Move leading spaces to the end of the previous line.
      " SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"\r\n" \
       ^
modules/exploits/linux/upnp/miniupnpd_soap_bof.rb:155:8: C: [Correctable] Layout/LineContinuationLeadingSpace: Move leading spaces to the end of the previous line.
      " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\"\r\n" \
       ^
modules/exploits/linux/upnp/miniupnpd_soap_bof.rb:156:8: C: [Correctable] Layout/LineContinuationLeadingSpace: Move leading spaces to the end of the previous line.
      " xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"\r\n" \
       ^
modules/exploits/linux/upnp/miniupnpd_soap_bof.rb:208:8: C: [Correctable] Layout/LineContinuationLeadingSpace: Move leading spaces to the end of the previous line.
      " SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"\r\n" \
       ^
modules/exploits/linux/upnp/miniupnpd_soap_bof.rb:209:8: C: [Correctable] Layout/LineContinuationLeadingSpace: Move leading spaces to the end of the previous line.
      " xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org/soap/encoding/\"\r\n" \
       ^
modules/exploits/linux/upnp/miniupnpd_soap_bof.rb:210:8: C: [Correctable] Layout/LineContinuationLeadingSpace: Move leading spaces to the end of the previous line.
      " xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"\r\n" \
       ^
```
