### PR TITLE
Set the ticket storage so KrbCacheMode is used

### DIFF
--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -151,7 +151,8 @@ class MetasploitModule < Msf::Auxiliary
       username: username,
       password: password,
       framework: framework,
-      framework_module: framework_module
+      framework_module: framework_module,
+      ticket_storage: kerberos_ticket_storage
     )
 
     # Get a TGT - allow getting from cache


### PR DESCRIPTION
This is a quick fix for the new `auxiliary/gather/kerberoast` module to ensure that the `KrbCacheMode` datastore option is used. The underlying issue was that the `ticket_storage` kwarg wasn't being set, so regardless of what the user had set `KrbCacheMode` too, the default read-write cache would be used.

## Testing
- [ ] Use `auxiliary/gather/kerberoast`
- [ ] Set the necessary targeting options
- [ ] Run the module with a `KrbCacheMode` of none, see that it obtains tickets
- [ ] Run the module with a `KrbCacheMode` of read-write, see that it reuses the TGT from the previous run

## Old Demo

This shows that despite `KrbCacheMode` being `none`, it's reusing a cached ticket

```
msf6 auxiliary(gather/kerberoast) > run KrbCacheMode=none
[*] Running module against 192.168.159.10

[*] Using cached credential for krbtgt/MSFLAB.LOCAL@MSFLAB.LOCAL smcintyre@MSFLAB.LOCAL
[+] 192.168.159.10:88 - Received a valid TGS-Response
[*] 192.168.159.10:389 - TGS MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20250519142417_default_192.168.159.10_mit.kerberos.cca_931017.bin
[+] Query returned 1 result.
[+] Success: 
$krb5tgs$18$roastme$MSFLAB.LOCAL$*HTTP/testserver.msflab.local*$7dd063985d658c796fa85b56$08eacc3686dfd4a7d7ceff9a0449e2f46b12848b2c863b99ae3645ea9ab00910b9b85e7694e07a88cbd621c9105f04a72bd5fae95d8ed9ed39e88f150d6ca6f96f3045f110bc657d224f87e845b46ae6cfbafa65dbc2fb69a76ecc49939df7ec4f50079996fd3e97b39eff08bac46be58968ee09091566cf51f9d95becd9f6992385e9e55a5d96c21ff73fd7e332330e589810a300025bf4741f07dcee4acb658365f28c89a14f76ed3da2f8d5fd41ae5e95fb0d2f540e1b1e1dff534d446e2f95d4c011dfa8ee1c175bb15671658a565b1e98ecfedd22549c8087419af022e9b42577d3714920de2dfecd5a3cf38889d468ca1eec58ccd8c828936ad8d5f8843a20a5eee96bb50fecbb735af53e13790c39c12c08c8463ac4235ae7fbc402dcf9ead751b56c381e55e3edec81e35c512073e414cfcf9963c3ea5e1aeb4e1989631693f8e2a1bfc9c9c7bc87707e4af76dc0e325fce0cfc417e60a22754adbd1f995710cd8b1f5d9ecf62d7996f1b7f8f3aa6a4610cf446400d89f786d16a0f72005920383183c7c7ed03a546d81ea01686d6295779eea838508a5f335d4d9c9cf40568c325804b0026a7c8184b016356868a383d7e3e44dc286ee86e20007556ecfcbf8abea64a6747404f4ba1d8685722129692cdaf2f52f4b18e24d0fb5fd50bef1a9e19edd2c8b3ee244b421d0d98a9a3df3453ef2293a88e66e49a96ea3e75b755f6f9a25485e76abb84ef3c5921947882a6150eb85b2819ec4c3bb80e4a1fa24767512ea92d6ed1ef138f755b8f0c3cc91c340a4aa0b8ae1d35d6e40b041a1f70809242f3d9c945d23ec32ecab0341a7572b2941ae740658e8d6a200a518beea188c8f6dbbc828e687af45b19147b43b335d758b8d632ab27185d2c4a0f0720bf70d6194ceb5b04d9a1c37aecc47eaea99f8b11617e469095d62ccf2c4f6f9f6ae7b3ba9a9b5718b86819c742fac9591b48ae868091e64082ec727eb2b7a35744a1d97e4cec1d6672d3023e3211e676c17384e47f9a84940773c3ff758dd2e98674362fe5b11e5726b3512f067f69defd8e0b421ad562e3d76a1ef822a421fba01a7f3018d38de25f15473cac5c789de9da4d238668ed3031d752d50fb376691bed9c2b2cae2200b5a3594164e14094c71a0e8216b5f34855960375bab326c07aa8845bc8f82cb67b94a1541d2fa49a6bcfbd97a80bc858c7b63a2f3f8cbcec51f52f1b5d803b896c102dd4a5541560477187c431880bbac877c08e22983cf0d65e9b2292c26c885465feff0cebea69073d63cf0d7f45d84d29771ae4c1d40001ca785a8e4dc23e6e906d726682b9b913e596ec0b4049219fc71ba6742ba8b75c0bde47ff3151e4b95700e21ac63fffcc98995a25775fd2df70bffd545233c5e1bb2c07adefcf54f905c6a350145b47bc3d64f5af99e7403277e481eafc506ec253dae1578f92d689ac33660c3920f92102e91c0ea46080d308f25de633c7ef1d1363614bcf67c727591904cdbba57da14560977dab490071a4f8870b075560d61b1d9ddf58234839cdcbebc12d18b71ab28d221515d6cd94723d6
[*] Auxiliary module execution completed
msf6 auxiliary(gather/kerberoast) >
```