### PR TITLE
Modules: Resolve Rubocop Lint/Syntax violations

### DIFF
--- a/modules/auxiliary/scanner/dns/dns_amp.rb
+++ b/modules/auxiliary/scanner/dns/dns_amp.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
+++ b/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/linux/misc/zabbix_server_exec.rb
+++ b/modules/exploits/linux/misc/zabbix_server_exec.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
+++ b/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/post/windows/gather/enum_unattend.rb
+++ b/modules/post/windows/gather/enum_unattend.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Post
       "#{drive}\\",
       "#{drive}\\Windows\\System32\\sysprep\\",
       "#{drive}\\Windows\\panther\\",
-      "#{drive}\\Windows\\Panther\Unattend\\",
+      "#{drive}\\Windows\\Panther\\Unattend\\",
       "#{drive}\\Windows\\System32\\"
     ]
 


### PR DESCRIPTION
A few modules trigger `Lint/Syntax`:

<details>
<p>

```
# rubocop --only Lint/Syntax modules/
Inspecting 4805 files
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F...................................................................................................................................................................................................................................................................................................................................................................F...................................................................................................................................................................................................F................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F................................................................................................................F.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F................................................................................................................................................................................F...................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F........................................................................................                                             

Offenses:

modules/auxiliary/scanner/dns/dns_amp.rb:107:15: F: Lint/Syntax: invalid multibyte escape: /\x09\x8d(..)/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
    if data =~/\x09\x8d(..)/
              ^^^^^^^^^^^^^^
modules/auxiliary/scanner/dns/dns_amp.rb:107:29: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
    if data =~/\x09\x8d(..)/
                            
modules/auxiliary/scanner/dns/dns_amp.rb:141:1: F: Lint/Syntax: unexpected token kEND
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
end
^^^
modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb:92:14: F: Lint/Syntax: invalid multibyte escape: /[\x00\xff]([\x20-\x7f]{1,32})\x00+([\x20-\x7f]{1,32})\x00\x00([\x20-\x7f]{1,32})\x00/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
    buf.scan(/[\x00\xff]([\x20-\x7f]{1,32})\x00+([\x20-\x7f]{1,32})\x00\x00([\x20-\x7f]{1,32})\x00/m).each do |cred|
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb:92:100: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
    buf.scan(/[\x00\xff]([\x20-\x7f]{1,32})\x00+([\x20-\x7f]{1,32})\x00\x00([\x20-\x7f]{1,32})\x00/m).each do |cred|
                                                                                                   ^
modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:144:28: F: Lint/Syntax: invalid multibyte escape: /[\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xff]/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      next unless key.scan(/[\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xff]/).empty?
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:144:67: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      next unless key.scan(/[\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xff]/).empty?
                                                                  
modules/exploits/linux/misc/zabbix_server_exec.rb:132:25: F: Lint/Syntax: invalid multibyte escape: /\x30\xad/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      if res and res =~ /\x30\xad/
                        ^^^^^^^^^^
modules/exploits/linux/misc/zabbix_server_exec.rb:132:35: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      if res and res =~ /\x30\xad/
                                  
modules/exploits/linux/misc/zabbix_server_exec.rb:141:1: F: Lint/Syntax: unexpected token kEND
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
end
^^^
modules/exploits/multi/ftp/wuftpd_site_exec_format.rb:254:20: F: Lint/Syntax: invalid multibyte escape: /\xff/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      fmtbuf.gsub!(/\xff/, "\xff\xff")
                   ^^^^^^
modules/exploits/multi/ftp/wuftpd_site_exec_format.rb:254:26: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      fmtbuf.gsub!(/\xff/, "\xff\xff")
                         
modules/exploits/multi/ftp/wuftpd_site_exec_format.rb:270:18: F: Lint/Syntax: invalid multibyte escape: /\xff/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
    fmtbuf.gsub!(/\xff/, "\xff\xff")
                 ^^^^^^
modules/exploits/multi/ftp/wuftpd_site_exec_format.rb:270:24: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
    fmtbuf.gsub!(/\xff/, "\xff\xff")
                       
modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb:170:20: F: Lint/Syntax: invalid multibyte escape: /\xff\xe7/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      hunter.gsub!(/\xff\xe7/, hunter_suffix(my_payload.length))
                   ^^^^^^^^^^
modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb:170:30: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      hunter.gsub!(/\xff\xe7/, hunter_suffix(my_payload.length))
                             
modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb:170:64: F: Lint/Syntax: unexpected token tRPAREN
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      hunter.gsub!(/\xff\xe7/, hunter_suffix(my_payload.length))
                                                               ^
modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb:202:1: F: Lint/Syntax: unexpected token $end
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
modules/exploits/windows/ftp/servu_mdtm.rb:140:25: F: Lint/Syntax: invalid multibyte escape: /\xff/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
        shellcode.gsub!(/\xff/, "\xff\xff")
                        ^^^^^^
modules/exploits/windows/ftp/servu_mdtm.rb:140:31: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
        shellcode.gsub!(/\xff/, "\xff\xff")
                              
modules/exploits/windows/ftp/servu_mdtm.rb:143:7: F: Lint/Syntax: unexpected token kWHEN
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      when 2
      ^^^^
modules/exploits/windows/ftp/servu_mdtm.rb:146:27: F: Lint/Syntax: invalid multibyte escape: /\xff/
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
          shellcode.gsub!(/\xff/, "\xff\xff")
                          ^^^^^^
modules/exploits/windows/ftp/servu_mdtm.rb:146:33: F: Lint/Syntax: unexpected token tREGEXP_OPT
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
          shellcode.gsub!(/\xff/, "\xff\xff")
                                
modules/exploits/windows/ftp/servu_mdtm.rb:184:1: F: Lint/Syntax: unexpected token $end
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
modules/post/windows/gather/enum_unattend.rb:110:34: F: Lint/Syntax: invalid escape character syntax
(Using Ruby 3.3 parser; configure using TargetRubyVersion parameter, under AllCops)
      "#{drive}\\Windows\\Panther\Unattend\\",
                                 ^

4805 files inspected, 25 offenses detected
```

</p>
</details>

The `modules/post/windows/gather/enum_unattend.rb` module was simply missing a backslash.

The remaining 7 modules did not specify an encoding, causing an`invalid multibyte escape` error:

```ruby
data = "123\x09\x8d456"
flags = data.to_s.scan(/\x09\x8d(..)/).flatten.first
puts flags
```

```
# ruby asdf.rb 
asdf.rb: 
asdf.rb:2: invalid multibyte escape: /\x09\x8d(..)/ (SyntaxError)
```

This was resolved by specifying binary encoding:

```ruby
# encoding: binary
data = "123\x09\x8d456"
flags = data.to_s.scan(/\x09\x8d(..)/).flatten.first
puts flags
```

```
# ruby asdf.rb 
45
```

In practice, I don't think these will trigger bugs as we force load modules as binary. None the less, it is annoying to have these syntax errors raised by Rubocop and I want them to go away.
