### PR TITLE
Improve canonicalize method in msfcrawler.rb

### DIFF
--- a/modules/auxiliary/crawler/msfcrawler.rb
+++ b/modules/auxiliary/crawler/msfcrawler.rb
@@ -390,27 +390,27 @@ class MetasploitModule < Msf::Auxiliary
     return hashreq
   end
 
-  # Taken from https://www.ruby-forum.com/t/creating-a-canonicalized-url/127036/6 by Rob Biedenharn
-  # TODO: This method should be rewritten
-  # rubocop:disable Style/PerlBackrefs
-  # rubocop:disable Style/WhileUntilDo
-  # rubocop:disable Style/BlockDelimiters
   def canonicalize(uri)
-    u = uri.is_a?(URI) ? uri : URI.parse(uri.to_s)
-    u.normalize!
-    newpath = u.path
-    while newpath.gsub!(%r{([^/]+)/\.\./?}) { |match|
-      $1 == '..' ? match : ''
-    } do end
-    newpath = newpath.gsub(%r{/\./}, '/').sub(%r{/\.\z}, '/')
-    u.path = newpath
-    # Ugly fix
-    u.path = u.path.gsub("\/..\/", "\/")
-    u.to_s
+    uri = URI(uri) unless uri.is_a?(URI)
+    uri.normalize!
+
+    path = uri.path.dup
+    segments = path.split('/')
+    resolved = []
+
+    segments.each do |segment|
+      next if segment == '.' || segment.empty?
+
+      if segment == '..'
+        resolved.pop unless resolved.empty?
+      else
+        resolved << segment
+      end
+    end
+
+    uri.path = '/' + resolved.join('/')
+    uri.to_s
   end
-  # rubocop:enable Style/PerlBackrefs
-  # rubocop:enable Style/WhileUntilDo
-  # rubocop:enable Style/BlockDelimiters
 
   def hashsig(hashreq)
     hashreq.to_s


### PR DESCRIPTION
During the recent Rubocop improvements the need to update the `canonicalize` method inside msfcrawler.rb was brought to my attention. This updates the method such that the  `rubocop:disable` `Style/PerlBackrefs`, `Style/WhileUntilDo` and `Style/BlockDelimiters` are no longer needed. 

This also fixes a bug in the old implementation when attempting to canonicalize the URL `http://example.com/a/./b/../../c/`. It would incorrectly return `http://example.com/a/c/` when it should have been returning `http://example.com/c/` due to the way the URL was parsed in the old method.

## Verification

Review the new method. Ensure everything looks good. Run this small test script which compares the output of the old and new method:

<details>
<summary>canonicalize_test.rb</summary>

<p> 

```ruby
require 'minitest/autorun'
require 'uri'

# Original implementation
def canonicalize_v1(uri)
  u = uri.is_a?(URI) ? uri : URI.parse(uri.to_s)
  u.normalize!
  newpath = u.path
  while newpath.gsub!(%r{([^/]+)/\.\./?}) { |match|
    $1 == '..' ? match : ''
  } do end
  newpath = newpath.gsub(%r{/\./}, '/').sub(%r{/\.\z}, '/')
  u.path = newpath
  u.path = u.path.gsub("/../", "/")
  u.to_s
end

# Cleaner implementation
def canonicalize_v2(uri)
  uri = URI(uri) unless uri.is_a?(URI)
  uri.normalize!

  path = uri.path.dup
  segments = path.split('/')
  resolved = []

  segments.each do |segment|
    next if segment == '.' || segment.empty?

    if segment == '..'
      resolved.pop unless resolved.empty?
    else
      resolved << segment
    end
  end

  uri.path = '/' + resolved.join('/')
  uri.to_s
end


class CanonicalizeTest < Minitest::Test
  TEST_CASES = {
    'http://example.com/a/b/../c/./d.html'     => 'http://example.com/a/c/d.html',
    'http://example.com/a/./b/../../c/'        => 'http://example.com/c/',
    'http://example.com/a/b/../../../../c'     => 'http://example.com/c',
    'http://example.com/a//b///c/../'          => 'http://example.com/a/b/',
    'http://example.com/'                      => 'http://example.com/',
    'http://example.com/./'                    => 'http://example.com/',
    'http://example.com/../'                   => 'http://example.com/',
    'http://example.com/foo/./bar/../baz'      => 'http://example.com/foo/baz',
    'http://example.com/foo/bar/../../baz'     => 'http://example.com/baz',
    'http://example.com/foo/bar/./././../baz/' => 'http://example.com/foo/baz/',
    'http://example.com/foo/bar/./.././baz//'  => 'http://example.com/foo/baz/',
    'http://example.com/foo//bar///baz/.././qux' => 'http://example.com/foo/bar/qux',
    'http://example.com/a/b/c/../../../'       => 'http://example.com/',
    'http://example.com/a/./b/././c/'          => 'http://example.com/a/b/c/',
    'http://example.com/a/../../b'             => 'http://example.com/b',
    'http://example.com/a/../../../b'          => 'http://example.com/b'
  }

  def test_canonicalize_outputs_match_expected
    TEST_CASES.each do |input, expected|
      actual_v1 = canonicalize_v1(input)
      actual_v2 = canonicalize_v2(input)

      assert_equal expected, actual_v1, "v1 failed for: #{input}\nExpected: #{expected}\nGot: #{actual_v1}"
      assert_equal expected, actual_v2, "v2 failed for: #{input}\nExpected: #{expected}\nGot: #{actual_v2}"
    end
  end
end
```

</p>

</details>





