### PR TITLE
Pin setup ruby github action

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -134,9 +134,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Setup '${{ matrix.ruby }}' Ruby
-        env:
-          BUNDLE_FORCE_RUBY_PLATFORM: true
-        uses: ruby/setup-ruby@v1
+        # Skip for now to ensure CI passes on Windows server 2025 powershell tests
+        #env:
+        #  BUNDLE_FORCE_RUBY_PLATFORM: true
+        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -201,7 +201,8 @@ jobs:
           BUNDLE_FORCE_RUBY_PLATFORM: true
           # Required for macos13 pg gem compilation
           PKG_CONFIG_PATH: "/usr/local/opt/libpq/lib/pkgconfig"
-        uses: ruby/setup-ruby@v1
+        # Pinned to avoid Windows compilation failure with nokogiri
+        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -368,7 +369,7 @@ jobs:
         if: always()
         env:
           BUNDLE_FORCE_RUBY_PLATFORM: true
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c
         with:
           ruby-version: '3.3'
           bundler-cache: true


### PR DESCRIPTION
Pin setup ruby github action and he drop force ruby platform env var for now, as it's believed to be causing Windows compilation errors on CI:

```
In file included from ./loops.h:23,
                 from ./iconv.c:148:
./loop_wchar.h:39:17: error: conflicting types for 'mbrtowc'; have
'size_t(void)' {aka 'long long unsigned int(void)'}
   39 |   extern size_t mbrtowc ();
      |                 ^~~~~~~
In file included from ../include/iconv.h:118,
                 from ./iconv.c:20:
D:/a/_temp/msys64/ucrt64/include/wchar.h:1187:18: note: previous declaration of
'mbrtowc' with type 'size_t(wchar_t * restrict,  const char * restrict,  size_t,
mbstate_t * restrict)' {aka 'long long unsigned int(short unsigned int *
restrict,  const char * restrict,  long long unsigned int,  mbstate_t *
restrict)'}
1187 |   size_t __cdecl mbrtowc(wchar_t * __restrict__ _DstCh,const char *
__restrict__ _SrcCh,size_t _SizeInBytes,mbstate_t * __restrict__ _State);
      |                  ^~~~~~~
./loop_wchar.h: In function 'wchar_to_loop_convert':

```

The bug exists somewhere between this SHA and cb0fda56a307b8c78d38320cd40d9eb22a3bf04e - https://github.com/ruby/setup-ruby/commits/v1/

## Verification

- Ensure CI passes