### PR TITLE
Bump rubocop from 1.75.6 to 1.75.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rspec-rerun'
   # Required during CI as well local development
-  gem 'rubocop', '1.75.6'
+  gem 'rubocop', '1.75.7'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -523,7 +523,7 @@ GEM
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
     rspec-support (3.13.2)
-    rubocop (1.75.6)
+    rubocop (1.75.7)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -633,7 +633,7 @@ DEPENDENCIES
   redcarpet
   rspec-rails
   rspec-rerun
-  rubocop (= 1.75.6)
+  rubocop (= 1.75.7)
   ruby-prof
   simplecov (= 0.18.2)
   test-prof


### PR DESCRIPTION
The latest version of Rubocop fixes a bug in `Layout/SpaceBeforeBrackets`.

We bumped Rubocop from 1.67.0 to 1.75.6 without issues last week (#20196), so I don't expect a minor update from 1.75.6 to 1.75.7 to cause any issues.
