### PR TITLE
modules/auxiliary/scanner/afp: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -13,37 +13,45 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Exploit::Remote::AFP
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'         => 'Apple Filing Protocol Login Utility',
-      'Description'  => %q{
-        This module attempts to bruteforce authentication credentials for AFP.
-      },
-      'References'     =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apple Filing Protocol Login Utility',
+        'Description' => %q{
+          This module attempts to bruteforce authentication credentials for AFP.
+        },
+        'References' => [
           [ 'URL', 'https://web.archive.org/web/20130309051753/https://developer.apple.com/library/mac/#documentation/Networking/Reference/AFP_Reference/Reference/reference.html' ],
           [ 'URL', 'https://developer.apple.com/library/mac/documentation/networking/conceptual/afp/AFPSecurity/AFPSecurity.html' ]
 
         ],
-      'Author'       => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
-      'License'      => MSF_LICENSE
-    ))
+        'Author' => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ACCOUNT_LOCKOUTS],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::Proxies,
-        OptInt.new('LoginTimeOut', [ true, "Timeout on login", 23 ]),
-        OptBool.new('RECORD_GUEST', [ false, "Record guest login to the database", false]),
-        OptBool.new('CHECK_GUEST', [ false, "Check for guest login", true])
-      ], self)
+        OptInt.new('LoginTimeOut', [ true, 'Timeout on login', 23 ]),
+        OptBool.new('RECORD_GUEST', [ false, 'Record guest login to the database', false]),
+        OptBool.new('CHECK_GUEST', [ false, 'Check for guest login', true])
+      ]
+    )
   end
 
   def run_host(ip)
-    print_status("Scanning IP: #{ip.to_s}")
+    print_status("Scanning IP: #{ip}")
 
     cred_collection = build_credential_collection(
-        username: datastore['USERNAME'],
-        password: datastore['PASSWORD'],
+      username: datastore['USERNAME'],
+      password: datastore['PASSWORD']
     )
 
     scanner = Metasploit::Framework::LoginScanner::AFP.new(
@@ -71,8 +79,8 @@ class MetasploitModule < Msf::Auxiliary
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
-          module_fullname: self.fullname,
-          workspace_id: myworkspace_id
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
       )
       if result.success?
         credential_core = create_credential(credential_data)
@@ -86,6 +94,4 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   end
-
-
 end

--- a/modules/auxiliary/scanner/afp/afp_server_info.rb
+++ b/modules/auxiliary/scanner/afp/afp_server_info.rb
@@ -3,58 +3,65 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'English'
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::AFP
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'         => 'Apple Filing Protocol Info Enumerator',
-      'Description'  => %q{
-        This module fetches AFP server information, including server name,
-        network address, supported AFP versions, signature, machine type,
-        and server flags.
-      },
-      'References'     =>
-        [
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apple Filing Protocol Info Enumerator',
+        'Description' => %q{
+          This module fetches AFP server information, including server name,
+          network address, supported AFP versions, signature, machine type,
+          and server flags.
+        },
+        'References' => [
           [ 'URL', 'https://web.archive.org/web/20130309051753/https://developer.apple.com/library/mac/#documentation/Networking/Reference/AFP_Reference/Reference/reference.html' ]
         ],
-      'Author'       => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
-      'License'      => MSF_LICENSE
-    ))
+        'Author' => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
   end
 
   def run_host(ip)
     print_status("AFP #{ip} Scanning...")
-    begin
-      connect
-      response = get_info
-      report(response)
-    rescue ::Timeout::Error
-    rescue ::Interrupt
-      raise $!
-    rescue ::Rex::ConnectionError, ::IOError, ::Errno::ECONNRESET, ::Errno::ENOPROTOOPT
-    rescue ::Exception
-      raise $!
-      print_error("AFP #{rhost}:#{rport} #{$!.class} #{$!}")
-    ensure
-      disconnect
-    end
+    connect
+    response = get_info
+    report(response)
+  rescue ::Timeout::Error => e
+    vprint_error(e.message)
+  rescue ::Rex::ConnectionError, ::IOError, ::Errno::ECONNRESET, ::Errno::ENOPROTOOPT => e
+    vprint_error(e.message)
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  rescue StandardError
+    print_error("AFP #{rhost}:#{rport} #{$ERROR_INFO.class} #{$ERROR_INFO}")
+    raise $ERROR_INFO
+  ensure
+    disconnect
   end
 
   def report(response)
-    report_info = "AFP #{rhost}:#{rport} Server Name: #{response[:server_name]} \n" +
-    "AFP #{rhost}:#{rport}  Server Flags: \n" +
-    format_flags_report(response[:server_flags]) +
-    "AFP #{rhost}:#{rport}  Machine Type: #{response[:machine_type]} \n" +
-    "AFP #{rhost}:#{rport}  AFP Versions: #{response[:versions].join(', ')} \n" +
-    "AFP #{rhost}:#{rport}  UAMs: #{response[:uams].join(', ')}\n" +
-    "AFP #{rhost}:#{rport}  Server Signature: #{response[:signature]}\n" +
-    "AFP #{rhost}:#{rport}  Server Network Address: \n" +
-    format_addresses_report(response[:network_addresses]) +
-    "AFP #{rhost}:#{rport}   UTF8 Server Name: #{response[:utf8_server_name]}"
-
+    report_info = "AFP #{rhost}:#{rport} Server Name: #{response[:server_name]} \n" \
+                  "AFP #{rhost}:#{rport}  Server Flags: \n" +
+                  format_flags_report(response[:server_flags]) +
+                  "AFP #{rhost}:#{rport}  Machine Type: #{response[:machine_type]} \n" \
+                  "AFP #{rhost}:#{rport}  AFP Versions: #{response[:versions].join(', ')} \n" \
+                  "AFP #{rhost}:#{rport}  UAMs: #{response[:uams].join(', ')}\n" \
+                  "AFP #{rhost}:#{rport}  Server Signature: #{response[:signature]}\n" \
+                  "AFP #{rhost}:#{rport}  Server Network Address: \n" +
+                  format_addresses_report(response[:network_addresses]) +
+                  "AFP #{rhost}:#{rport}   UTF8 Server Name: #{response[:utf8_server_name]}"
 
     lines = "AFP #{rhost}:#{rport}:#{rport} AFP:\n#{report_info}"
 
@@ -62,26 +69,27 @@ class MetasploitModule < Msf::Auxiliary
       print_status(line)
     end
 
-    report_note(:host => datastore['RHOST'],
-      :proto => 'tcp',
-      :port => datastore['RPORT'],
-      :type => 'afp_server_info',
-      :data => { :server_info => response })
+    report_note(
+      host: datastore['RHOST'],
+      proto: 'tcp',
+      port: datastore['RPORT'],
+      type: 'afp_server_info',
+      data: { server_info: response }
+    )
 
-      report_service(
-        :host => datastore['RHOST'],
-        :port => datastore['RPORT'],
-        :proto => 'tcp',
-        :name => "afp",
-        :info => "AFP name: #{response[:utf8_server_name]}, Versions: #{response[:versions].join(', ')}"
-      )
-
+    report_service(
+      host: datastore['RHOST'],
+      port: datastore['RPORT'],
+      proto: 'tcp',
+      name: 'afp',
+      info: "AFP name: #{response[:utf8_server_name]}, Versions: #{response[:versions].join(', ')}"
+    )
   end
 
   def format_flags_report(parsed_flags)
     report = ''
     parsed_flags.each do |flag, val|
-      report << "AFP #{rhost}:#{rport}     *  #{flag}: #{val.to_s} \n"
+      report << "AFP #{rhost}:#{rport}     *  #{flag}: #{val} \n"
     end
     return report
   end
@@ -89,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
   def format_addresses_report(parsed_network_addresses)
     report = ''
     parsed_network_addresses.each do |val|
-      report << "AFP #{rhost}:#{rport}     *  #{val.to_s} \n"
+      report << "AFP #{rhost}:#{rport}     *  #{val} \n"
     end
     return report
   end


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

