### PR TITLE
Update metasploit-payloads gem to 2.0.221

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.191)
+      metasploit-payloads (= 2.0.221)
       metasploit_data_models (>= 6.0.7)
       metasploit_payloads-mettle (= 1.0.35)
       mqtt
@@ -328,7 +328,7 @@ GEM
       activemodel (~> 7.0)
       activesupport (~> 7.0)
       railties (~> 7.0)
-    metasploit-payloads (2.0.191)
+    metasploit-payloads (2.0.221)
     metasploit_data_models (6.0.9)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -95,7 +95,7 @@ metasploit-concern, 5.0.4, "New BSD"
 metasploit-credential, 6.0.16, "New BSD"
 metasploit-framework, 6.4.66, "New BSD"
 metasploit-model, 5.0.3, "New BSD"
-metasploit-payloads, 2.0.191, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.221, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.9, "New BSD"
 metasploit_payloads-mettle, 1.0.35, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.191'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.221'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.35'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Includes changes from:
* rapid7/metasploit-payloads#738
* rapid7/metasploit-payloads#756
* rapid7/metasploit-payloads#711
* rapid7/metasploit-payloads#747

