### PR TITLE
Rubocop: Enable Style/RedundantRegexpArgument

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -152,6 +152,12 @@ Style/RedundantAssignment:
     and return expression
   Enabled: false
 
+Style/RedundantRegexpArgument:
+  Enabled: true
+  Exclude:
+  # We aren't ready to enable this for modules yet
+    - 'modules/**/*'
+
 Style/SwapValues:
   Enabled: false
 

--- a/lib/metasploit/framework/ntds/account.rb
+++ b/lib/metasploit/framework/ntds/account.rb
@@ -128,7 +128,7 @@ module Metasploit
         def get_hash_history(data)
           raw_history = data.slice!(0,HASH_HISTORY_SIZE)
           split_history = raw_history.scan(/.{1,33}/)
-          split_history.map!{ |hash| hash.gsub(/\x00/,'')}
+          split_history.map!{ |hash| hash.gsub("\x00",'')}
           split_history.reject!{ |hash| hash.blank? }
         end
 
@@ -137,7 +137,7 @@ module Metasploit
         end
 
         def get_string(data,length)
-          data.slice!(0,length).force_encoding("UTF-8").gsub(/\x00/,'')
+          data.slice!(0,length).force_encoding("UTF-8").gsub("\x00",'')
         end
 
         def uac_string

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -166,7 +166,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     # always make sure that the new session has a new guid if it's not already known
     guid = session.session_guid
     if guid == "\x00" * 16
-      guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*')
+      guid = [SecureRandom.uuid.gsub('-', '')].pack('H*')
       session.core.set_session_guid(guid)
       session.session_guid = guid
       # TODO: New stageless session, do some account in the DB so we can track it later.

--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -40,7 +40,7 @@ module Msf
       end
 
       def generate_uri_option(opts, opt)
-        opts[opt] ? "--#{opt} '#{opts[opt].gsub(/'/, "\\'")}' " : ''
+        opts[opt] ? "--#{opt} '#{opts[opt].gsub('\'', "\\'")}' " : ''
       end
 
       def generate_http_uri(opts)
@@ -101,7 +101,7 @@ module Msf
         opts[:uuid] = Base64.encode64(opts[:uuid].to_raw).strip
         guid = "\x00" * 16
         unless opts[:stageless] == true
-          guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*')
+          guid = [SecureRandom.uuid.gsub('-', '')].pack('H*')
         end
         opts[:session_guid] = Base64.encode64(guid).strip
 

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -606,7 +606,7 @@ module Auxiliary::AuthBrute
       rescue
         return []
       end
-      upfile_contents.split(/\n/).each do |line|
+      upfile_contents.split("\n").each do |line|
         user,pass = line.split(/\s+/,2).map { |x| x.strip }
         creds << [user.to_s, pass.to_s]
       end

--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -209,7 +209,7 @@ def nmap_validate_arg(str)
     return false
   end
   # Check for quote balance
-  if !(str.scan(/'/).size % 2).zero? or !(str.scan(/"/).size % 2).zero?
+  if !(str.scan('\'').size % 2).zero? or !(str.scan('"').size % 2).zero?
     print_error "Unbalanced quotes in nmap argument: #{str}"
     return false
   end

--- a/lib/msf/core/auxiliary/rocketmq.rb
+++ b/lib/msf/core/auxiliary/rocketmq.rb
@@ -68,7 +68,7 @@ module Msf
     # @return [Hash] Hash including RocketMQ versions info and Broker info if found
     def parse_rocketmq_data(res)
       # remove a response header so we have json-ish data
-      res = res.split(/\x00_/)[1]
+      res = res.split("\x00_")[1]
       unless res.starts_with?("{")
         print_error("Failed to successfully remove the response header and now cannot parse the response.")
         return nil

--- a/lib/msf/core/cert_provider.rb
+++ b/lib/msf/core/cert_provider.rb
@@ -11,7 +11,7 @@ module Ssl
       opts[:loc] ||= Faker::Address.city
       opts[:org] ||= Faker::Company.name
       opts[:ou] ||= Faker::Hacker.send(%w{noun verb adjective}.sample.to_sym).gsub(/\W+/,'.')
-      opts[:cn] ||= opts[:org].downcase.gsub(/and/,'').gsub(/\W+/,'.') + '.' +  Faker::Internet.domain_suffix
+      opts[:cn] ||= opts[:org].downcase.gsub('and','').gsub(/\W+/,'.') + '.' +  Faker::Internet.domain_suffix
       opts[:email] ||= "#{opts[:ou]}@#{opts[:cn]}"
       opts
     end

--- a/lib/msf/core/db_manager/import/ip360/v3.rb
+++ b/lib/msf/core/db_manager/import/ip360/v3.rb
@@ -55,7 +55,7 @@ module Msf::DBManager::Import::IP360::V3
 
     # nCircle has some quotes escaped which causes the parser to break
     # we don't need these lines so just replace \" with "
-    data.gsub!(/\\"/,'"')
+    data.gsub!('\"','"')
 
     # parse nCircle Scan Output
     parser = Rex::Parser::IP360XMLStreamParser.new
@@ -158,11 +158,11 @@ module Msf::DBManager::Import::IP360::V3
 
     refs = []
 
-    cves.split(/,/).each do |cve|
+    cves.split(',').each do |cve|
       refs.push(cve.to_s)
     end if cves
 
-    bids.split(/,/).each do |bid|
+    bids.split(',').each do |bid|
       refs.push('BID-' + bid.to_s)
     end if bids
 

--- a/lib/msf/core/db_manager/import/libpcap.rb
+++ b/lib/msf/core/db_manager/import/libpcap.rb
@@ -171,7 +171,7 @@ module Msf::DBManager::Import::Libpcap
         # he thinks the server is HTTP and he just made an authentication attempt. At
         # this point, we'll just believe everything the packet says -- validation ought
         # to come later.
-        user,pass = b64_cred.unpack("m*").first.split(/:/,2)
+        user,pass = b64_cred.unpack("m*").first.split(':',2)
         msf_import_service(
             :workspace => wspace,
             :host      => pkt.ip_daddr,

--- a/lib/msf/core/exploit/local/sap_smd_agent_unencrypted_property.rb
+++ b/lib/msf/core/exploit/local/sap_smd_agent_unencrypted_property.rb
@@ -13,7 +13,7 @@ module Msf
         property_value = property[:value].strip
         if property_name =~ %r{(smd/agent/|sld/usr|sld/pwd)}i
           # BASE64 decode and parse property value
-          string_type, string_len, string_val = Rex::Text.decode_base64(property[:value].sub('\\=', '=')).split(/\|/)
+          string_type, string_len, string_val = Rex::Text.decode_base64(property[:value].sub('\\=', '=')).split('|')
           if string_len.to_i > 0 && string_type == 'java.lang.String'
             property_value = string_val.first(string_len.to_i)
           else

--- a/lib/msf/core/exploit/php_exe.rb
+++ b/lib/msf/core/exploit/php_exe.rb
@@ -76,7 +76,7 @@ module Exploit::PhpEXE
 
     php.gsub!(/#.*$/, '')
     php.gsub!(/[\t ]+/, ' ')
-    php.gsub!(/\n/, ' ')
+    php.gsub!("\n", ' ')
     return "<?php #{php} ?>"
   end
 

--- a/lib/msf/core/exploit/remote/http/joomla/version.rb
+++ b/lib/msf/core/exploit/remote/http/joomla/version.rb
@@ -57,7 +57,7 @@ module Msf::Exploit::Remote::HTTP::Joomla::Version
       /MooTools.More\=\{version\:\"1\.4\.0\.1\"/
       version = '2.5'
     when /<meta name=\"Keywords\" content=\"(.*)\">\s+<meta name/
-      version = $1.split(/,/)[0]
+      version = $1.split(',')[0]
     when /(Copyright \(C\) 2005 \- 200(6|7))/,
       /47 2005\-09\-15 02\:55\:27Z rhuk/,
       /423 2005\-10\-09 18\:23\:50Z stingrey/,

--- a/lib/msf/core/exploit/remote/http/sccm.rb
+++ b/lib/msf/core/exploit/remote/http/sccm.rb
@@ -359,7 +359,7 @@ module Msf
               workspace_id: myworkspace_id
             }
 
-            domain, account = user.split(/\\/)
+            domain, account = user.split("\\")
             credential_data = {
               origin_type: :service,
               module_fullname: fullname,

--- a/lib/msf/core/exploit/remote/mssql_sqli.rb
+++ b/lib/msf/core/exploit/remote/mssql_sqli.rb
@@ -73,8 +73,8 @@ module Exploit::Remote::MSSQL_SQLI
     print_status("Warning: This module will leave #{var_payload}.exe in the SQL Server %TEMP% directory")
     print_status("Writing the debug.com loader to the disk...")
     h2b = File.read(datastore['HEX2BINARY'], File.size(datastore['HEX2BINARY']))
-    h2b.gsub!(/KemneE3N/, "%TEMP%\\#{var_bypass}")
-    h2b.split(/\n/).each do |line|
+    h2b.gsub!('KemneE3N', "%TEMP%\\#{var_bypass}")
+    h2b.split("\n").each do |line|
       mssql_xpcmdshell("#{line}", false)
     end
 

--- a/lib/msf/core/exploit/sqli/mssqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mssqli/common.rb
@@ -125,7 +125,7 @@ module Msf::Exploit::SQLi::Mssqli
 
       columns = columns.map do |col|
         col = "cast(isnull(#{col},'#{@null_replacement}') as varchar(max))"
-        @encoder ? @encoder[:encode].sub(/\^DATA\^/, col) : col
+        @encoder ? @encoder[:encode].sub('^DATA^', col) : col
       end.join("+'#{@second_concat_separator}'+")
       unless condition.empty?
         condition = ' where ' + condition
@@ -137,7 +137,7 @@ module Msf::Exploit::SQLi::Mssqli
       if @safe
         # no group_concat, leak one row at a time
         count_item = 'cast(count(1) as varchar(max))'
-        count_item = @encoder ? @encoder[:encode].sub(/\^DATA\^/, count_item) : count_item
+        count_item = @encoder ? @encoder[:encode].sub('^DATA^', count_item) : count_item
         row_count = run_sql("select #{count_item} from #{table}#{condition}")
         row_count = @encoder ? @encoder[:decode].call(row_count).to_i : row_count.to_i
         num_limit = row_count if num_limit == 0 || row_count < num_limit
@@ -183,7 +183,7 @@ module Msf::Exploit::SQLi::Mssqli
       random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
       random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
       query_string = "'#{random_string}'"
-      query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
+      query_string = @encoder[:encode].sub('^DATA^', query_string) if @encoder
       output = run_sql("select #{query_string}")
       return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
@@ -203,7 +203,7 @@ module Msf::Exploit::SQLi::Mssqli
     #
     def read_from_file(fpath, binary=false)
       alias1 = Rex::Text.rand_text_alpha(1) + Rex::Text.rand_text_alphanumeric(5..11)
-      expr = @encoder ? @encoder[:encode].sub(/\^DATA\^/, 'BulkColumn') : 'BulkColumn'
+      expr = @encoder ? @encoder[:encode].sub('^DATA^', 'BulkColumn') : 'BulkColumn'
       output = if @truncation_length
         truncated_query("select substring(#{expr},^OFFSET^,#{@truncation_length}) " \
         "from openrowset(bulk N'#{fpath}',SINGLE_CLOB) as #{alias1}")
@@ -225,7 +225,7 @@ module Msf::Exploit::SQLi::Mssqli
       result = [ ]
       offset = 1
       loop do
-        slice = run_sql(query.sub(/\^OFFSET\^/, offset.to_s))
+        slice = run_sql(query.sub('^OFFSET^', offset.to_s))
         offset += @truncation_length # should be same as @truncation_length for most cases
         result << slice
         vprint_status "{SQLi} Truncated output: #{slice} of size #{slice.size}"
@@ -247,7 +247,7 @@ module Msf::Exploit::SQLi::Mssqli
     end
 
     def call_function(function)
-      function = @encoder[:encode].sub(/\^DATA\^/, function) if @encoder
+      function = @encoder[:encode].sub('^DATA^', function) if @encoder
       output = nil
       if @truncation_length
         output = truncated_query("select substring(#{function},^OFFSET^,#{@truncation_length})")

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -134,11 +134,11 @@ module Msf::Exploit::SQLi::MySQLi
       one_column = columns.length == 1
       if one_column
         columns = "ifnull(#{columns.first},'#{@null_replacement}')"
-        columns = @encoder[:encode].sub(/\^DATA\^/, columns) if @encoder
+        columns = @encoder[:encode].sub('^DATA^', columns) if @encoder
       else
         columns = "concat_ws('#{@second_concat_separator}'," + columns.map do |col|
           col = "ifnull(#{col},'#{@null_replacement}')"
-          @encoder ? @encoder[:encode].sub(/\^DATA\^/, col) : col
+          @encoder ? @encoder[:encode].sub('^DATA^', col) : col
         end.join(',') + ')'
       end
       unless condition.empty?
@@ -198,7 +198,7 @@ module Msf::Exploit::SQLi::MySQLi
       random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
       random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
       query_string = "'#{random_string}'"
-      query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
+      query_string = @encoder[:encode].sub('^DATA^', query_string) if @encoder
       output = run_sql("select #{query_string}")
       return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
@@ -235,7 +235,7 @@ module Msf::Exploit::SQLi::MySQLi
       result = [ ]
       offset = 1
       loop do
-        slice = run_sql(query.sub(/\^OFFSET\^/, offset.to_s))
+        slice = run_sql(query.sub('^OFFSET^', offset.to_s))
         offset += @truncation_length # should be same as @truncation_length for most cases
         result << slice
         vprint_status "{SQLi} Truncated output: #{slice} of size #{slice.size}"
@@ -262,7 +262,7 @@ module Msf::Exploit::SQLi::MySQLi
     # @return [String] What the function call returns
     #
     def call_function(function)
-      function = @encoder[:encode].sub(/\^DATA\^/, function) if @encoder
+      function = @encoder[:encode].sub('^DATA^', function) if @encoder
       output = nil
       if @truncation_length
         output = truncated_query("select mid(#{function},^OFFSET^,#{@truncation_length})")

--- a/lib/msf/core/exploit/sqli/postgresqli/common.rb
+++ b/lib/msf/core/exploit/sqli/postgresqli/common.rb
@@ -126,11 +126,11 @@ module Msf::Exploit::SQLi::PostgreSQLi
       one_column = columns.length == 1
       if one_column
         columns = "coalesce(#{columns.first}::text,'#{@null_replacement}')"
-        columns = @encoder[:encode].sub(/\^DATA\^/, columns) if @encoder
+        columns = @encoder[:encode].sub('^DATA^', columns) if @encoder
       else
         columns = "concat_ws('#{@second_concat_separator}'," + columns.map do |col|
           col = "coalesce(#{col}::text,'#{@null_replacement}')"
-          @encoder ? @encoder[:encode].sub(/\^DATA\^/, col) : col
+          @encoder ? @encoder[:encode].sub('^DATA^', col) : col
         end.join(',') + ')'
       end
       unless condition.empty?
@@ -190,7 +190,7 @@ module Msf::Exploit::SQLi::PostgreSQLi
       random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
       random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
       query_string = "'#{random_string}'"
-      query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
+      query_string = @encoder[:encode].sub('^DATA^', query_string) if @encoder
       output = run_sql("select #{query_string}")
       return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
@@ -233,7 +233,7 @@ module Msf::Exploit::SQLi::PostgreSQLi
       result = [ ]
       offset = 1
       loop do
-        slice = run_sql(query.sub(/\^OFFSET\^/, offset.to_s))
+        slice = run_sql(query.sub('^OFFSET^', offset.to_s))
         offset += @truncation_length # should be same as @truncation_length for most cases
         result << slice
         vprint_status "{SQLi} Truncated output: #{slice} of size #{slice.size}"
@@ -261,7 +261,7 @@ module Msf::Exploit::SQLi::PostgreSQLi
     # @return [String] What the function call returns
     #
     def call_function(function)
-      function = @encoder[:encode].sub(/\^DATA\^/, function) if @encoder
+      function = @encoder[:encode].sub('^DATA^', function) if @encoder
       output = nil
       if @truncation_length
         output = truncated_query("select substr(#{function},^OFFSET^,#{@truncation_length})")

--- a/lib/msf/core/exploit/sqli/sqlitei/common.rb
+++ b/lib/msf/core/exploit/sqli/sqlitei/common.rb
@@ -80,11 +80,11 @@ module Msf::Exploit::SQLi::SQLitei
       one_column = columns.length == 1
       if one_column
         columns = "ifnull(#{columns.first},'#{@null_replacement}')"
-        columns = @encoder[:encode].sub(/\^DATA\^/, columns) if @encoder
+        columns = @encoder[:encode].sub('^DATA^', columns) if @encoder
       else
         columns = columns.map do |col|
           col = "ifnull(#{col},'#{@null_replacement}')"
-          @encoder ? @encoder[:encode].sub(/\^DATA\^/, col) : col
+          @encoder ? @encoder[:encode].sub('^DATA^', col) : col
         end.join("||'#{@second_concat_separator}'||")
       end
       unless condition.empty?
@@ -144,7 +144,7 @@ module Msf::Exploit::SQLi::SQLitei
       random_string_len = @truncation_length ? [rand(2..10), @truncation_length].min : rand(2..10)
       random_string = Rex::Text.rand_text_alphanumeric(random_string_len)
       query_string = "'#{random_string}'"
-      query_string = @encoder[:encode].sub(/\^DATA\^/, query_string) if @encoder
+      query_string = @encoder[:encode].sub('^DATA^', query_string) if @encoder
       output = run_sql("select #{query_string}")
       return false if output.nil?
       (@encoder ? @encoder[:decode].call(output) : output) == random_string
@@ -162,7 +162,7 @@ module Msf::Exploit::SQLi::SQLitei
       result = [ ]
       offset = 1
       loop do
-        slice = run_sql(query.sub(/\^OFFSET\^/, offset.to_s))
+        slice = run_sql(query.sub('^OFFSET^', offset.to_s))
         offset += @truncation_length # should be same as @truncation_length for most cases
         result << slice
         vprint_status "{SQLi} Truncated output: #{slice} of size #{slice.size}"
@@ -178,7 +178,7 @@ module Msf::Exploit::SQLi::SQLitei
     #   @return [String] the output of the function
     #
     def call_function(function)
-      function = @encoder[:encode].sub(/\^DATA\^/, function) if @encoder
+      function = @encoder[:encode].sub('^DATA^', function) if @encoder
       output = nil
       if @truncation_length
         output = truncated_query("select substr(#{function},^OFFSET^,#{@truncation_length})")

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -69,7 +69,7 @@ module Msf::Modules::Metadata::Search
     search_string += ' '
 
     # Split search terms by space, but allow quoted strings
-    terms = search_string.split(/\"/).collect{|term| term.strip==term ? term : term.split(' ')}.flatten
+    terms = search_string.split('"').collect{|term| term.strip==term ? term : term.split(' ')}.flatten
     terms.delete('')
 
     # All terms are either included or excluded

--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -333,7 +333,7 @@ class Msf::Payload::Apk
     classes['Payload'] = Rex::Text::rand_text_alpha_lower(5).capitalize
     classes['MainService'] = Rex::Text::rand_text_alpha_lower(5).capitalize
     classes['MainBroadcastReceiver'] = Rex::Text::rand_text_alpha_lower(5).capitalize
-    package_slash = package.gsub(/\./, "/")
+    package_slash = package.gsub('.', "/")
 
     print_status "Adding payload as package #{package}\n"
     payload_files = Dir.glob("#{tempdir}/payload/smali/com/metasploit/stage/*.smali")
@@ -350,7 +350,7 @@ class Msf::Payload::Apk
         end
         smali.gsub!(/com\/metasploit\/stage\/#{oldclass}/, package_slash + "/" + newclass)
       end
-      smali.gsub!(/com\/metasploit\/stage/, package_slash)
+      smali.gsub!('com/metasploit/stage', package_slash)
       newfilename = "#{payload_dir}#{smali_class}"
       File.open(newfilename, "wb") {|file| file.puts smali }
     end

--- a/lib/msf/core/payload/java.rb
+++ b/lib/msf/core/payload/java.rb
@@ -100,7 +100,7 @@ module Msf::Payload::Java
 }
     app_name = opts[:app_name] || Rex::Text.rand_text_alpha_lower(rand(8)+8)
 
-    web_xml.gsub!(/NAME/, app_name)
+    web_xml.gsub!('NAME', app_name)
 
     paths = [
       [ "metasploit", "Payload.class" ],

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -96,7 +96,7 @@ module Payload::Python::MeterpreterLoader
     if opts[:stageless] == true
       session_guid = '00' * 16
     else
-      session_guid = SecureRandom.uuid.gsub(/-/, '')
+      session_guid = SecureRandom.uuid.gsub('-', '')
     end
     met.sub!("SESSION_GUID = \'\'", "SESSION_GUID = \'#{session_guid}\'")
 

--- a/lib/msf/core/payload/ruby.rb
+++ b/lib/msf/core/payload/ruby.rb
@@ -29,7 +29,7 @@ module Msf::Payload::Ruby
             eval(code) rescue nil
           end
         end
-      ^.strip.split(/\n/).map{|line| line.strip}.join("\n")
+      ^.strip.split("\n").map{|line| line.strip}.join("\n")
     end
 
     buf

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -375,7 +375,7 @@ module Msf::Post::File
       return unless data
 
       chksum = data.scan(/^([A-F0-9-]+)$/).flatten.first
-      return chksum&.gsub(/-/, '')&.downcase
+      return chksum&.gsub('-', '')&.downcase
     end
 
     case util
@@ -423,7 +423,7 @@ module Msf::Post::File
       data = cmd_exec("$sha1 = New-Object -TypeName System.Security.Cryptography.SHA1CryptoServiceProvider; [System.BitConverter]::ToString($sha1.ComputeHash([System.IO.File]::ReadAllBytes('#{file_name}')))")
       return unless data
       chksum = data.scan(/^([A-F0-9-]+)$/).flatten.first
-      return chksum&.gsub(/-/, '')&.downcase
+      return chksum&.gsub('-', '')&.downcase
     end
 
     case util

--- a/lib/msf/core/post/linux/f5_mcp.rb
+++ b/lib/msf/core/post/linux/f5_mcp.rb
@@ -44,7 +44,7 @@ module Msf
 
           @tags_by_id =
             objects
-            .split(/\n/)
+            .split("\n")
             .reject { |o| o.start_with?('#') }
             .map(&:strip)
             .map do |o|

--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -81,7 +81,7 @@ module Msf::Post::Unix
     passwd = '/etc/passwd'
     if file_exist?(passwd)
       read_file(passwd).each_line do |passwd_line|
-        user_dirs << passwd_line.split(/:/)[5]
+        user_dirs << passwd_line.split(':')[5]
       end
     end
 

--- a/lib/msf/core/post/webrtc.rb
+++ b/lib/msf/core/post/webrtc.rb
@@ -10,10 +10,10 @@ module Msf::Post::WebRTC
   #
   def connect_video_chat(server, channel, offerer_id)
     interface = load_interface('answerer.html')
-    interface.gsub!(/\=SERVER\=/, server)
-    interface.gsub!(/\=RHOST\=/, rhost)
-    interface.gsub!(/\=CHANNEL\=/, channel)
-    interface.gsub!(/\=OFFERERID\=/, offerer_id)
+    interface.gsub!('=SERVER=', server)
+    interface.gsub!('=RHOST=', rhost)
+    interface.gsub!('=CHANNEL=', channel)
+    interface.gsub!('=OFFERERID=', offerer_id)
 
     tmp_interface = Tempfile.new(['answerer', '.html'])
     tmp_interface.binmode
@@ -37,7 +37,7 @@ module Msf::Post::WebRTC
     interface_path = ::File.join(Msf::Config.data_directory, 'webcam', html_name)
     interface_code = ''
     ::File.open(interface_path) { |f| interface_code = f.read }
-    interface_code.gsub!(/\=WEBRTCAPIJS\=/, load_api_code)
+    interface_code.gsub!('=WEBRTCAPIJS=', load_api_code)
     interface_code
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1009,7 +1009,7 @@ class Core
 
     # Parse any extra options that should be passed to the plugin
     args.each { |opt|
-      k, v = opt.split(/\=/)
+      k, v = opt.split('=')
 
       opts[k] = v if (k and v)
     }
@@ -1082,7 +1082,7 @@ class Core
       tabs += tab_complete_filenames(str,words)
     end
 
-    return tabs.map{|e| e.sub(/\.rb/, '')} - framework.plugins.map(&:name)
+    return tabs.map{|e| e.sub('.rb', '')} - framework.plugins.map(&:name)
   end
 
   def cmd_route_help
@@ -1235,7 +1235,7 @@ class Core
           if (route.comm.kind_of?(Msf::Session))
             gw = "Session #{route.comm.sid}"
           else
-            gw = route.comm.name.split(/::/)[-1]
+            gw = route.comm.name.split('::')[-1]
           end
 
           tbl_ipv4 << [ route.subnet, route.netmask, gw ] if Rex::Socket.is_ipv4?(route.netmask)

--- a/lib/msf/util/document_generator/document_normalizer.rb
+++ b/lib/msf/util/document_generator/document_normalizer.rb
@@ -15,7 +15,7 @@ module Redcarpet
 
 
       def list(content, list_type)
-        if list_type == :unordered && content.scan(/<li>/).flatten.length > 15
+        if list_type == :unordered && content.scan('<li>').flatten.length > 15
           %Q|<p><div id=\"long_list\"><ul>#{content}<ul></div></p>|
         elsif list_type == :unordered
           %Q|<ul>#{content}</ul>|

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1717,8 +1717,8 @@ require 'digest/sha1'
 </servlet>
 </web-app>
 }
-    web_xml.gsub!(/NAME/, app_name)
-    web_xml.gsub!(/PAYLOAD/, jsp_name)
+    web_xml.gsub!('NAME', app_name)
+    web_xml.gsub!('PAYLOAD', jsp_name)
 
     zip = Rex::Zip::Archive.new
     zip.add_file('META-INF/', '', meta_inf)

--- a/lib/msf/util/windows_registry/remote_registry.rb
+++ b/lib/msf/util/windows_registry/remote_registry.rb
@@ -144,7 +144,7 @@ module WindowsRegistry
 
     def get_value(key, value_name = nil)
       sd_backup = change_dacl(key, Rex::Proto::Secauthz::WellKnownSids::DOMAIN_ALIAS_SID_ADMINS) if @inline
-      root_key, sub_key = key.gsub(/\//, '\\').split('\\', 2)
+      root_key, sub_key = key.gsub('/', '\\').split('\\', 2)
       root_key_handle = @winreg.open_root_key(root_key)
       subkey_handle = @winreg.open_key(root_key_handle, sub_key)
       begin

--- a/lib/postgres/postgres-pr/typeconv/array.rb
+++ b/lib/postgres/postgres-pr/typeconv/array.rb
@@ -20,7 +20,7 @@ module Postgres::Conversion
     raise ConversionError, "'{' expected" unless buf.get_byte == '{'
 
     elems = []
-    unless buf.scan(/\}/) # array is not empty
+    unless buf.scan('}') # array is not empty
       loop do
         # skip whitespace
         buf.skip(/\s+/)   
@@ -33,7 +33,7 @@ module Postgres::Conversion
           if conv_proc then conv_proc.call(e) else e end
         end
 
-        break if buf.scan(/\}/)
+        break if buf.scan('}')
         break unless buf.scan(/#{ delim }/)
       end
     end

--- a/lib/rbmysql/error.rb
+++ b/lib/rbmysql/error.rb
@@ -11,7 +11,7 @@ class RbMysql
         errname = errname.to_s
         next unless errname =~ prefix_re
         errno = self.const_get errname
-        excname = errname.sub(prefix_re,'').gsub(/(\A.|_.)([A-Z]+)/){$1+$2.downcase}.gsub(/_/,'')
+        excname = errname.sub(prefix_re,'').gsub(/(\A.|_.)([A-Z]+)/){$1+$2.downcase}.gsub('_','')
         klass = Class.new self
         klass.const_set 'ERRNO', errno
         self.const_set excname, klass
@@ -908,7 +908,7 @@ class RbMysql
   end
 
   ServerError.define_error_class(/\AER_/)
-  ServerError::ERROR_MAP.values.each{|v| RbMysql.const_set v.name.split(/::/).last, v} # for compatibility
+  ServerError::ERROR_MAP.values.each{|v| RbMysql.const_set v.name.split('::').last, v} # for compatibility
 
   # client side error
   class ClientError < Error

--- a/lib/rex/parser/acunetix_document.rb
+++ b/lib/rex/parser/acunetix_document.rb
@@ -416,7 +416,7 @@ module Rex
       verb,req = headers.cmd_string.split(/\s+/)
       return unless verb
       return unless req
-      path,query_string = req.split(/\?/)[0,2]
+      path,query_string = req.split('?')[0,2]
       return verb,path,query_string
     end
 

--- a/lib/rex/parser/appscan_document.rb
+++ b/lib/rex/parser/appscan_document.rb
@@ -130,7 +130,7 @@ module Rex
 
     def parse_params(request_body)
       return unless request_body
-      pairs = request_body.split(/&/)
+      pairs = request_body.split('&')
       params = []
       pairs.each do |pair|
         param,value = pair.split("=",2)
@@ -189,7 +189,7 @@ module Rex
       return unless(in_issue && has_text)
       return unless @state[:web_site].present?
       really_original_traffic = unindent_and_crlf(@text)
-      request_headers, request_body, response_headers, response_body = really_original_traffic.split(/\r\n\r\n/)
+      request_headers, request_body, response_headers, response_body = really_original_traffic.split("\r\n\r\n")
       return unless(request_headers && response_headers)
       req_header = Rex::Proto::Http::Packet::Header.new
       res_header = Rex::Proto::Http::Packet::Header.new

--- a/lib/rex/parser/nexpose_raw_document.rb
+++ b/lib/rex/parser/nexpose_raw_document.rb
@@ -680,7 +680,7 @@ module Rex
     end
 
     def clean_formatted_text(txt)
-      txt.split(/\n/).map{ |t|
+      txt.split("\n").map{ |t|
         t.sub(/^\s+$/, '').
           sub(/^(\s{6,20})/, '      ')
       }.join("\n").gsub(/\n{4,10}/, "\n\n\n")

--- a/lib/rex/parser/openvas_document.rb
+++ b/lib/rex/parser/openvas_document.rb
@@ -119,8 +119,8 @@ module Parser
             @state[:port] = p_num
             @state[:proto] = p_proto
           elsif @text.index('(')
-            @state[:proto] = @text.split('(')[1].split('/')[1].gsub(/\)/, '')
-            @state[:port] = @text.split('(')[1].split('/')[0].gsub(/\)/, '')
+            @state[:proto] = @text.split('(')[1].split('/')[1].gsub(')', '')
+            @state[:port] = @text.split('(')[1].split('/')[0].gsub(')', '')
           elsif @text.index('/')
             @state[:proto] = @text.split('/')[1].strip
             @state[:port] = @text.split('/')[0].strip

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -58,7 +58,7 @@ private
     if opts[:stageless] == true || opts[:null_session_guid] == true
       session_guid = "\x00" * 16
     else
-      session_guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*')
+      session_guid = [SecureRandom.uuid.gsub('-', '')].pack('H*')
     end
     session_data = [
       0,                  # comms socket, patched in by the stager

--- a/lib/rex/post/meterpreter/extensions/priv/passwd.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/passwd.rb
@@ -19,7 +19,7 @@ class SamUser
   # Administrator:500:aad3b435b51404eeaadfb435b51404ee:31d6cfe0d16de931b73c59d7e0c089c0:::
   #
   def initialize(hash_str)
-    self.user_name, self.user_id, self.lanman, self.ntlm = hash_str.split(/:/)
+    self.user_name, self.user_id, self.lanman, self.ntlm = hash_str.split(':')
 
     self.hash_string = hash_str
   end

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -121,7 +121,7 @@ class Priv < Extension
     # This can take a long long time for large domain controls, bump the timeout to one hour
     response = client.send_request(Packet.create_request(COMMAND_ID_PRIV_PASSWD_GET_SAM_HASHES), 3600)
 
-    response.get_tlv_value(TLV_TYPE_SAM_HASHES).split(/\n/).map { |hash|
+    response.get_tlv_value(TLV_TYPE_SAM_HASHES).split("\n").map { |hash|
       SamUser.new(hash)
     }
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -147,9 +147,9 @@ class Webcam
     interface = load_interface('offerer.html')
     api       = load_api_code
 
-    interface = interface.gsub(/\=SERVER\=/, server)
-    interface = interface.gsub(/\=CHANNEL\=/, channel)
-    interface = interface.gsub(/\=OFFERERID\=/, offerer_id)
+    interface = interface.gsub('=SERVER=', server)
+    interface = interface.gsub('=CHANNEL=', channel)
+    interface = interface.gsub('=OFFERERID=', offerer_id)
 
     tmp_dir = session.sys.config.getenv("TEMP")
 

--- a/lib/rex/post/meterpreter/pivot.rb
+++ b/lib/rex/post/meterpreter/pivot.rb
@@ -17,7 +17,7 @@ class PivotListener
   attr_accessor :stage
 
   def initialize(session_class, url, stage)
-    self.id = [SecureRandom.uuid.gsub(/-/, '')].pack('H*')
+    self.id = [SecureRandom.uuid.gsub('-', '')].pack('H*')
     self.session_class = session_class
     self.url = url
     self.stage = stage

--- a/lib/rex/proto/http/request.rb
+++ b/lib/rex/proto/http/request.rb
@@ -118,7 +118,7 @@ class Request < Packet
 
     # /././././
     if self.junk_self_referring_directories
-      str.gsub!(/\//) {
+      str.gsub!('/') {
         '/.' * (rand(3) + 1) + '/'
       }
     end
@@ -126,12 +126,12 @@ class Request < Packet
     # /%3faaa=bbbbb
     # which could possibly decode to "/?aaa=bbbbb", which if the IDS normalizes first, then splits the URI on ?, then it can be bypassed
     if self.junk_param_start
-      str.sub!(/\//, '/%3f' + Rex::Text.rand_text_alpha(rand(5) + 1) + '=' + Rex::Text.rand_text_alpha(rand(10) + 1) + '/../')
+      str.sub!('/', '/%3f' + Rex::Text.rand_text_alpha(rand(5) + 1) + '=' + Rex::Text.rand_text_alpha(rand(10) + 1) + '/../')
     end
 
     # /RAND/../RAND../
     if self.junk_directories
-      str.gsub!(/\//) {
+      str.gsub!('/') {
         dirs = ''
         (rand(5)+5).times {
           dirs << '/' + Rex::Text.rand_text_alpha(rand(5) + 1) + '/..'
@@ -144,7 +144,7 @@ class Request < Packet
     #
     # NOTE: this must be done after all other odd directory junk, since they would cancel this out, except junk_end_of_uri, since that a specific slash in a specific place
     if self.junk_slashes
-      str.gsub!(/\//) {
+      str.gsub!('/') {
         '/' * (rand(3) + 2)
       }
       str.sub!(/^[\/]+/, '/') # only one beginning slash!

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -196,7 +196,7 @@ class Response < Packet
   #
   def update_cmd_parts(str)
     if (md = str.match(/HTTP\/(.+?)\s+(\d+)\s?(.+?)\r?\n?$/))
-      self.message = md[3].gsub(/\r/, '')
+      self.message = md[3].gsub("\r", '')
       self.code    = md[2].to_i
       self.proto   = md[1]
     else

--- a/lib/rex/proto/ldap/auth.rb
+++ b/lib/rex/proto/ldap/auth.rb
@@ -274,7 +274,7 @@ module Rex
             hash = [
               lm_hash || '0' * 48,
               nt_hash || '0' * 48
-            ].join(':').gsub(/\n/, '\\n')
+            ].join(':').gsub("\n", '\\n')
             arg[:private] = hash
           when NTLM_CONST::NTLM_V2_RESPONSE
             if NTLM_CRYPT.is_hash_from_empty_pwd?({
@@ -308,7 +308,7 @@ module Rex
             hash = [
               lm_hash || '0' * 32,
               nt_hash || '0' * 32
-            ].join(':').gsub(/\n/, '\\n')
+            ].join(':').gsub("\n", '\\n')
             arg[:private] = hash
           when NTLM_CONST::NTLM_2_SESSION_RESPONSE
             if NTLM_CRYPT.is_hash_from_empty_pwd?({
@@ -325,7 +325,7 @@ module Rex
             hash = [
               lm_hash || '0' * 48,
               nt_hash || '0' * 48
-            ].join(':').gsub(/\n/, '\\n')
+            ].join(':').gsub("\n", '\\n')
             arg[:private] = hash
           else
             return

--- a/lib/rex/proto/mms/model/message.rb
+++ b/lib/rex/proto/mms/model/message.rb
@@ -97,7 +97,7 @@ module Rex
             mms << "Subject: #{self.subject}\n"
             mms << "Content-Type: multipart/mixed; boundary=#{body.bound}\n"
             mms << "\n"
-            mms << body.to_s.gsub(/\-\-\r\n\r\n\-\-_/, "--\n--_")
+            mms << body.to_s.gsub("--\r\n\r\n--_", "--\n--_")
 
             mms
           end

--- a/lib/rex/proto/mssql/client.rb
+++ b/lib/rex/proto/mssql/client.rb
@@ -577,8 +577,8 @@ module Rex
           print_status("Warning: This module will leave #{var_payload}.exe in the SQL Server %TEMP% directory")
           print_status("Writing the debug.com loader to the disk...")
           h2b = File.read(@hex2binary, File.size(@hex2binary))
-          h2b.gsub!(/KemneE3N/, "%TEMP%\\#{var_bypass}")
-          h2b.split(/\n/).each do |line|
+          h2b.gsub!('KemneE3N', "%TEMP%\\#{var_bypass}")
+          h2b.split("\n").each do |line|
             mssql_xpcmdshell("#{line}", false)
           end
 

--- a/lib/rex/proto/sip/response.rb
+++ b/lib/rex/proto/sip/response.rb
@@ -45,7 +45,7 @@ module Rex
         def self.parse(data)
           response = Response.new
           # do some basic sanity checking on this response to ensure that it is SIP
-          response.status_line = data.split(/\r\n/)[0]
+          response.status_line = data.split("\r\n")[0]
           unless response.status_line && response.status_line =~ SIP_STATUS_REGEX
             fail(ArgumentError, "Invalid SIP status line: #{response.status_line}")
           end

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -218,7 +218,7 @@ class MsftidyDoc
     @lines.each do |ln|
       idx += 1
 
-      tback = ln.scan(/```/)
+      tback = ln.scan('```')
       if tback.length > 0
         if tback.length.even?
           warn("Should use single backquotes (`) for single line literals instead of triple backquotes (```)", idx)

--- a/tools/exploit/find_badchars.rb
+++ b/tools/exploit/find_badchars.rb
@@ -120,7 +120,7 @@ case fmt
   when "gdb"
     translated = ''
     from_dbg.each_line do |ln|
-      translated << ln.chomp.split(':')[1].gsub!(/0x/, '\x').gsub!(/ /, '')
+      translated << ln.chomp.split(':')[1].gsub!('0x', '\x').gsub!(/ /, '')
     end
     from_dbg = Rex::Text.hex_to_raw(translated)
 

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -173,7 +173,7 @@ puts [
 
 shell.run { |l|
   l.gsub!(/(\r|\n)/, '')
-  l.gsub!(/\\n/, "\n")
+  l.gsub!("\\n", "\n")
   l.gsub!(';', "\n")
 
   break if %w[quit exit].include? l.chomp

--- a/tools/exploit/nasm_shell.rb
+++ b/tools/exploit/nasm_shell.rb
@@ -46,7 +46,7 @@ shell.history_manager = Rex::Ui::Text::Shell::HistoryManager.new
 
 shell.run { |line|
   line.gsub!(/(\r|\n)/, '')
-  line.gsub!(/\\n/, "\n")
+  line.gsub!("\\n", "\n")
 
   break if (line =~ /^(exit|quit)/i)
 

--- a/tools/hardware/elm327_relay.rb
+++ b/tools/hardware/elm327_relay.rb
@@ -200,7 +200,7 @@ module ELM327HWBridgeRelay
       stats["packet_stats"] = @packets_sent
       stats["last_request"] = @last_sent
       volt = send_cmd("ATRV")
-      stats["voltage"] = volt.gsub(/V/,'')
+      stats["voltage"] = volt.gsub('V','')
       stats
     end
 
@@ -282,7 +282,7 @@ module ELM327HWBridgeRelay
         return result
       end
       result["Packets"] = []
-      resp.split(/\r/).each do |line|
+      resp.split("\r").each do |line|
         pkt = {}
         if line=~/^(\w+) (.+)/
           pkt["ID"] = $1

--- a/tools/modules/missing_payload_tests.rb
+++ b/tools/modules/missing_payload_tests.rb
@@ -34,7 +34,7 @@ framework.payloads.each_module { |reference_name, payload_class|
   }
   ancestor_reference_names = module_ancestors.map { |module_ancestor|
     unpacked_module_ancestor_full_name = module_ancestor.name.sub(/^Msf::Modules::Mod/, '')
-                                                             .sub(/::MetasploitModule/, '')
+                                                             .sub('::MetasploitModule', '')
     module_ancestor_full_name = [unpacked_module_ancestor_full_name].pack("H*")
     module_ancestor_full_name.sub(%r{^payload/}, '')
   }


### PR DESCRIPTION
We currently have `NewCops` disabled. Once enabled, the [Style/RedundantRegexpArgument](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantRegexpArgument) rule will be enabled.

This PR resolves existing `Style/RedundantRegexpArgument` violations and enables this rule - except for `modules/**/*`. I would liked to have enabled this for modules, but there are far too many existing violations in the modules (that are well outside the scope of this PR) to resolve within this PR.

All changes were applied automatically with:

```
rubocop -a --only Style/RedundantRegexpArgument lib/ tools/
```
