### PR TITLE
modules/auxiliary/scanner/dect: Resolve RuboCop violations

### DIFF
--- a/modules/auxiliary/scanner/dect/call_scanner.rb
+++ b/modules/auxiliary/scanner/dect/call_scanner.rb
@@ -8,20 +8,24 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'DECT Call Scanner',
-      'Description'    => 'This module scans for active DECT calls',
-      'Author'         => [ 'DK <privilegedmode[at]gmail.com>' ],
-      'License'        => MSF_LICENSE
+      'Name' => 'DECT Call Scanner',
+      'Description' => 'This module scans for active DECT calls.',
+      'Author' => [ 'DK <privilegedmode[at]gmail.com>' ],
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
   end
 
   def print_results
     print_line("Time\t\t\t\tRFPI\t\tChannel")
-    @calls.each do |rfpi, data|
+    @calls.each_value do |data|
       print_line("#{data['time']}\t#{data['rfpi']}\t#{data['channel']}")
     end
   end
-
 
 =begin
   def record_call(data)
@@ -43,14 +47,13 @@ class MetasploitModule < Msf::Auxiliary
     open_coa
 
     begin
-
-      print_status("Changing to call scan mode.")
+      print_status('Changing to call scan mode.')
       call_scan_mode
-      print_status("Scanning...")
+      print_status('Scanning...')
 
-      while (true)
-        data = poll_coa()
-        if (data)
+      loop do
+        data = poll_coa
+        if data
           parsed_data = parse_call(data)
           parsed_data['time'] = Time.now
           print_good("Found active call on: #{parsed_data['rfpi']}")
@@ -60,12 +63,12 @@ class MetasploitModule < Msf::Auxiliary
         next_channel
 
         vprint_status("Switching to channel: #{channel}")
-        select(nil,nil,nil,1)
+        select(nil, nil, nil, 1)
       end
     ensure
-      print_status("Closing interface")
-      stop_coa()
-      close_coa()
+      print_status('Closing interface')
+      stop_coa
+      close_coa
     end
 
     print_results

--- a/modules/auxiliary/scanner/dect/station_scanner.rb
+++ b/modules/auxiliary/scanner/dect/station_scanner.rb
@@ -8,18 +8,21 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'DECT Base Station Scanner',
-      'Description'    => 'This module scans for DECT base stations',
-      'Author'         => [ 'DK <privilegedmode[at]gmail.com>' ],
-      'License'        => MSF_LICENSE
+      'Name' => 'DECT Base Station Scanner',
+      'Description' => 'This module scans for DECT base stations.',
+      'Author' => [ 'DK <privilegedmode[at]gmail.com>' ],
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [],
+        'Reliability' => []
+      }
     )
-
   end
-
 
   def print_results
     print_line("RFPI\t\tChannel")
-    @base_stations.each do |rfpi, data|
+    @base_stations.each_value do |data|
       print_line("#{data['rfpi']}\t#{data['channel']}")
     end
   end
@@ -33,17 +36,16 @@ class MetasploitModule < Msf::Auxiliary
     open_coa
 
     begin
-
-      print_status("Changing to fp scan mode.")
+      print_status('Changing to fp scan mode.')
       fp_scan_mode
-      print_status("Scanning...")
+      print_status('Scanning...')
 
-      while(true)
-        data = poll_coa()
+      loop do
+        data = poll_coa
 
-        if (data)
+        if data
           parsed_data = parse_station(data)
-          if (not @base_stations.key?(parsed_data['rfpi']))
+          if !@base_stations.key?(parsed_data['rfpi'])
             print_good("Found New RFPI: #{parsed_data['rfpi']}")
             @base_stations[parsed_data['rfpi']] = parsed_data
           end
@@ -52,12 +54,12 @@ class MetasploitModule < Msf::Auxiliary
         next_channel
 
         vprint_status("Switching to channel: #{channel}")
-        select(nil,nil,nil,1)
+        select(nil, nil, nil, 1)
       end
     ensure
-      print_status("Closing interface")
-      stop_coa()
-      close_coa()
+      print_status('Closing interface')
+      stop_coa
+      close_coa
     end
 
     print_results


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

