### PR TITLE
Encoders: Fix assemble method Metasm CPU definition

### DIFF
--- a/modules/encoders/x64/zutto_dekiru.rb
+++ b/modules/encoders/x64/zutto_dekiru.rb
@@ -23,10 +23,10 @@ class MetasploitModule < Msf::Encoder::Xor
         'KeyPack' => 'Q<'
       }
     )
+    @cpu64 = Metasm::X86_64.new
   end
 
-  @cpu64 = Metasm::X86_64.new
-  def assemble(src, cpu = @cpu64)
+  def assemble(src, cpu: @cpu64)
     Metasm::Shellcode.assemble(cpu, src).encode_string
   end
 

--- a/modules/encoders/x86/service.rb
+++ b/modules/encoders/x86/service.rb
@@ -18,11 +18,11 @@ class MetasploitModule < Msf::Encoder
       'Arch' => ARCH_X86,
       'License' => MSF_LICENSE,
       'EncoderType' => Msf::Encoder::Type::Raw
-        )
+    )
+    @cpu32 = Metasm::Ia32.new
   end
 
-  @cpu32 = Metasm::Ia32.new
-  def assemble(src, cpu = @cpu32)
+  def assemble(src, cpu: @cpu32)
     Metasm::Shellcode.assemble(cpu, src).encode_string
   end
 


### PR DESCRIPTION
Fixes #20245.

# Before

```
# ./msfvenom --arch x64 --platform windows -p windows/x64/meterpreter/reverse_tcp_rc4 -e x64/zutto_dekiru EXITFUNC=thread RC4PASSWORD=12345678123456781234567812345678 LHOST=127.0.0.1 LPORT=80 --format raw -o /tmp/zutto_dekiru.raw 
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x64/zutto_dekiru
Error: undefined local variable or method `cpu_from_headers' for an instance of Metasm::Shellcode
```

# After

```
# ./msfvenom --arch x64 --platform windows -p windows/x64/meterpreter/reverse_tcp_rc4 -e x64/zutto_dekiru EXITFUNC=thread RC4PASSWORD=12345678123456781234567812345678 LHOST=127.0.0.1 LPORT=80 --format raw -o /tmp/zutto_dekiru.raw 
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x64/zutto_dekiru
x64/zutto_dekiru succeeded with size 703 (iteration=0)
x64/zutto_dekiru chosen with final size 703
Payload size: 703 bytes
Saved as: /tmp/zutto_dekiru.raw
```
