### PR TITLE
Fixes an error in `report_note` deprecation message

### DIFF
--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -145,9 +145,10 @@ module Msf::DBManager::Note
     ntype  = opts.delete(:type) || opts.delete(:ntype) || (raise RuntimeError, "A note :type or :ntype is required")
 
     unless opts[:data].is_a?(Hash)
-      message = "[DEPRECATION] Using #{method.inspect} with a non-hash data value is deprecated, please raise a Github issue with this output. Called from: #{caller(1, stack_size).to_a}"
-      print_warning message
-      # Additionally write to ~/.msf4/logs/framework.log - as this gets attached to Github issues etc
+      stack_trace = caller.map { |line| "[-]   #{line}" }.join("\n")
+      message = "\n[-] [DEPRECATION] Using #{__method__} with a non-hash data value is deprecated, please raise a Github issue with this output.\n[-] Call stack:\n#{stack_trace}"
+      warn(message)
+      # Additionally write to ~/.msf4/logs/framework.log - as this gets attached to GitHub issues etc
       elog(message)
     end
 


### PR DESCRIPTION
Fixes an issue in https://github.com/rapid7/metasploit-framework/pull/19939 where the `report_note` deprecation message for using non-hash values. It was previous failing due to attempting to call `method.inspect`. This has been updated to now make use off `__method__`. I also added a stack trace to make it easier to identify what module the call is coming from.

## Example
![image](https://github.com/user-attachments/assets/b74b1d86-b354-4c1e-ace3-422952be0495)

## Verification

- [ ] Start `msfconsole`
- [ ] Get an MSSQL target
- [ ] Get a MSSQL session
- [ ] run `use mssql_enum`
- [ ] run `use 0`
- [ ] run `run session=-1`
- [ ] Verify the module works as expected
- [ ] Change a report note hash to a string
- [ ] Verify the module calls out the deprecation warning
