### PR TITLE
Update the ldap/change_password module

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/change_password.md
+++ b/documentation/modules/auxiliary/admin/ldap/change_password.md
@@ -7,7 +7,7 @@ Allows changing or resetting users' passwords over the LDAP protocol (particular
 
 Note that users can typically not reset their own passwords (unless they have very high privileges), but can usually change their password as long as they know the existing one.
 
-This module works with existing sessions (or relaying), especially for Resetting, wherein the target's password is not required.
+This module works with existing sessions (or relaying), especially for resetting, wherein the target's password is not required.
 
 ## Actions
 
@@ -19,14 +19,14 @@ This module works with existing sessions (or relaying), especially for Resetting
 The required options are based on the action being performed:
 
 - When resetting a password, you must specify the `TARGET_USER`
-- When changing a password, you must specify the `USERNAME` and `PASSWORD`, even if using an existing session (since the API requires both of these to be specified, even for open LDAP sessions)
+- When changing a password, you must specify the `LDAPUsername` and `LDAPPassword`, even if using an existing session (since the API requires both of these to be specified, even for open LDAP sessions)
 - The `NEW_PASSWORD` option must always be provided
 
-**USERNAME**
+**LDAPUsername**
 
 The username to use to authenticate to the server. Required for changing a password, even if using an existing session.
 
-**PASSWORD**
+**LDAPPassword**
 
 The password to use to authenticate to the server, prior to performing the password modification. Required for changing a password, even if using an existing session (since the server requires proof that you know the existing password).
 

--- a/modules/auxiliary/admin/ldap/change_password.rb
+++ b/modules/auxiliary/admin/ldap/change_password.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
         extra_error = ' or incorrect current password'
       end
 
-      error = "The password changed failed, likely due to a password policy violation (e.g. not sufficiently complex, matching previous password, or changing the password too often)#{extra_error}"
+      error = "The password change failed, likely due to a password policy violation (e.g. not sufficiently complex, matching previous password, or changing the password too often)#{extra_error}"
       fail_with(Failure::NotFound, error)
     else
       validate_query_result!(ldap_result)
@@ -82,12 +82,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if action.name == 'CHANGE'
-      fail_with(Failure::BadConfig, 'Must set USERNAME when changing password') if datastore['USERNAME'].blank?
-      fail_with(Failure::BadConfig, 'Must set PASSWORD when changing password') if datastore['PASSWORD'].blank?
+      fail_with(Failure::BadConfig, 'Must set LDAPUsername when changing password') if datastore['LDAPUsername'].blank?
+      fail_with(Failure::BadConfig, 'Must set LDAPPassword when changing password') if datastore['LDAPPassword'].blank?
     elsif action.name == 'RESET'
       fail_with(Failure::BadConfig, 'Must set TARGET_USER when resetting password') if datastore['TARGET_USER'].blank?
     end
-    if session.blank? && datastore['USERNAME'].blank? && datastore['LDAP::Auth'] != Msf::Exploit::Remote::AuthOption::SCHANNEL
+    if session.blank? && datastore['LDAPUsername'].blank? && datastore['LDAP::Auth'] != Msf::Exploit::Remote::AuthOption::SCHANNEL
       print_warning('Connecting with an anonymous bind')
     end
     ldap_connect do |ldap|
@@ -143,13 +143,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_change
-    obj = get_user_obj(datastore['USERNAME'])
+    obj = get_user_obj(datastore['LDAPUsername'])
 
     new_pass = "\"#{datastore['NEW_PASSWORD']}\"".encode('utf-16le').bytes.pack('c*')
-    old_pass = "\"#{datastore['PASSWORD']}\"".encode('utf-16le').bytes.pack('c*')
+    old_pass = "\"#{datastore['LDAPPassword']}\"".encode('utf-16le').bytes.pack('c*')
     unless @ldap.modify(dn: obj['dn'], operations: [[:delete, ATTRIBUTE, old_pass], [:add, ATTRIBUTE, new_pass]])
-      fail_with_ldap_error("Failed to reset the password for #{datastore['USERNAME']}.")
+      fail_with_ldap_error("Failed to change the password for #{datastore['LDAPUsername']}.")
     end
-    print_good("Successfully changed password for #{datastore['USERNAME']}.")
+    print_good("Successfully changed password for #{datastore['LDAPUsername']}.")
   end
 end


### PR DESCRIPTION
This updates the `auxiliary/admin/ldap/change_password` module to use the new LDAP datastore options. This means when users set the new options, the outputs are all correct now. Fixes #20252

This also fixes some minor typos.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/ldap/change_password`
- [ ] Set the new `LDAP`-prefixed datastore options
- [ ] Change a user's password given knowledge of the existing value
- [ ] Reset a user's password with a privileged account
- [ ] See the correct messages in the outputs