### PR TITLE
Fix references to LDAP Datastore Options

### DIFF
--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -6,7 +6,7 @@ This module uses an anonymous-bind LDAP connection to dump data from
 the vmdir service in VMware vCenter Server version 6.7 prior to the
 6.7U3f update, only if upgraded from a previous release line, such as
 6.0 or 6.5.
-If the bind username and password are provided (BIND_DN and BIND_PW
+If the bind username and password are provided (BIND_DN and LDAPPassword
 options), these credentials will be used instead of attempting an
 anonymous bind.
 

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -36,18 +36,33 @@ If you already have the LDAP base DN, you may set it in this option.
 ### VMware vCenter Server 6.7 virtual appliance on ESXi
 
 ```
-msf5 > use auxiliary/gather/vmware_vcenter_vmdir_ldap
-msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > options
+msf6 auxiliary(gather/vmware_vcenter_vmdir_ldap) > show options
 
-   Name      Current Setting  Required  Description
-   ----      ---------------  --------  -----------
-   BASE_DN                    no        LDAP base DN if you already have it
-   DOMAIN                     no        The domain to authenticate to
-   PASSWORD                   no        The password to authenticate with
-   RHOSTS                     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT     636              yes       The target port
-   SSL       true             no        Enable SSL on the LDAP connection
-   USERNAME                   no        The username to authenticate with
+Module options (auxiliary/gather/vmware_vcenter_vmdir_ldap):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   BASE_DN                   no        LDAP base DN if you already have it
+   SSL      true             no        Enable SSL on the LDAP connection
+
+
+   Used when connecting via an existing SESSION:
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION                   no        The session to run this module on
+
+
+   Used when making a new connection via RHOSTS:
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   LDAPDomain                     no        The domain to authenticate to
+   LDAPPassword                   no        The password to authenticate with
+   LDAPUsername                   no        The username to authenticate with
+   RHOSTS                         no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-
+                                            metasploit.html
+   RPORT         636              no        The target port
 
 
 Auxiliary action:
@@ -57,6 +72,8 @@ Auxiliary action:
    Dump  Dump all LDAP data
 
 
+
+View the full module info with the info, or info -d command.
 msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > set rhosts [redacted]
 rhosts => [redacted]
 msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > run

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
           the vmdir service in VMware vCenter Server version 6.7 prior to the
           6.7U3f update, only if upgraded from a previous release line, such as
           6.0 or 6.5.
-          If the bind username and password are provided (BIND_DN and BLDAPPassword
+          If the bind username and password are provided (BIND_DN and LDAPPassword
           options), these credentials will be used instead of attempting an
           anonymous bind.
         },

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -102,9 +102,16 @@ class MetasploitModule < Msf::Auxiliary
       # HACK: Stash discovered base DN in CheckCode reason
       Exploit::CheckCode::Vulnerable(base_dn)
     end
+  rescue Errno::ECONNRESET
+    fail_with(Failure::Disconnected, 'The connection was reset.')
+  rescue Rex::ConnectionError => e
+    fail_with(Failure::Unreachable, e.message)
+  rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
+    fail_with(Failure::NoAccess, e.message)
+  rescue Rex::Proto::LDAP::LdapException => e
+    fail_with(Failure::NoAccess, e.message)
   rescue Net::LDAP::Error => e
-    print_error("#{e.class}: #{e.message}")
-    Exploit::CheckCode::Unknown
+    fail_with(Failure::Unknown, "#{e.class}: #{e.message}")
   end
 
   def pillage(entries)

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
           the vmdir service in VMware vCenter Server version 6.7 prior to the
           6.7U3f update, only if upgraded from a previous release line, such as
           6.0 or 6.5.
-          If the bind username and password are provided (BIND_DN and BIND_PW
+          If the bind username and password are provided (BIND_DN and BLDAPPassword
           options), these credentials will be used instead of attempting an
           anonymous bind.
         },

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -91,12 +91,12 @@ class MetasploitModule < Msf::Auxiliary
 
       # Look for an entry with a non-empty vmwSTSPrivateKey attribute
       unless entries&.find { |entry| entry[:vmwstsprivatekey].any? }
-        print_error("#{ldap.peerinfo} is NOT vulnerable to CVE-2020-3952") unless datastore['BIND_PW'].present?
+        print_error("#{ldap.peerinfo} is NOT vulnerable to CVE-2020-3952") unless datastore['LDAPPassword'].present?
         print_error('Dump failed')
         return Exploit::CheckCode::Safe
       end
 
-      print_good("#{ldap.peerinfo} is vulnerable to CVE-2020-3952") unless datastore['BIND_PW'].present?
+      print_good("#{ldap.peerinfo} is vulnerable to CVE-2020-3952") unless datastore['LDAPPassword'].present?
       pillage(entries)
 
       # HACK: Stash discovered base DN in CheckCode reason


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/20259
Replaces old datastore options with new datastore options.