### PR TITLE
Register VulnAttempts for both Exploit and Auxiliary modules

### DIFF
--- a/lib/msf/core/auxiliary.rb
+++ b/lib/msf/core/auxiliary.rb
@@ -46,6 +46,7 @@ class Auxiliary < Msf::Module
 
     self.sockets = Array.new
     self.queue   = Array.new
+    self.fail_reason = Msf::Module::Failure::None
   end
 
   #
@@ -159,8 +160,26 @@ class Auxiliary < Msf::Module
 
   # Override Msf::Module#fail_with for Msf::Simple::Auxiliary::job_run_proc
   def fail_with(reason, msg = nil)
-    raise Msf::Auxiliary::Failed, "#{reason.to_s}: #{msg}"
+    allowed_values = Msf::Module::Failure.constants.collect {|e| Msf::Module::Failure.const_get(e)}
+    if allowed_values.include?(reason)
+      self.fail_reason = reason
+    else
+      self.fail_reason = Msf::Module::Failure::Unknown
+    end
+
+    self.fail_detail = msg
+    raise Msf::Auxiliary::Failed, "#{reason.to_s}: #{(msg || "No failure message given")}"
   end
+
+  #
+  # The reason why the module was not successful (one of the constant defined above)
+  #
+  attr_accessor  :fail_reason
+
+  #
+  # Detailed exception string indicating why the module was not successful
+  #
+  attr_accessor  :fail_detail
 
   attr_accessor :queue
 

--- a/lib/msf/core/db_manager/exploit_attempt.rb
+++ b/lib/msf/core/db_manager/exploit_attempt.rb
@@ -79,13 +79,9 @@ module Msf::DBManager::ExploitAttempt
 
     vuln = nil
     if rids.present?
-      if svc
-        # Try to find an existing vulnerability with the same service & references
-        vuln = find_vuln_by_refs(rids, host, svc, false)
-      else
-        # Try to find an existing vulnerability with the same host & references
-        vuln = find_vuln_by_refs(rids, host, nil, false)
-      end
+      # Try to find an existing vulnerability with the same service & references
+      # or, if svc is nil, with the same host & references
+      vuln = find_vuln_by_refs(rids, host, svc, false)
     end
 
     opts[:service] = svc

--- a/lib/msf/core/db_manager/exploit_attempt.rb
+++ b/lib/msf/core/db_manager/exploit_attempt.rb
@@ -33,16 +33,31 @@ module Msf::DBManager::ExploitAttempt
   # @option (see #do_report_failure_or_success)
   # @return (see #do_report_failure_or_success)
   def report_exploit_failure(opts)
-    return unless opts.has_key?(:refs) && !opts[:refs].blank?
-    host   = opts[:host] || return
+    return unless opts[:refs].present? && opts[:host].present?
 
+    host = opts[:host]
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
-    port   = opts[:port]
-    proto   = opts[:proto] || Msf::DBManager::DEFAULT_SERVICE_PROTO
-    svc    = opts[:service]
+    opts = opts.clone()
+    port = opts[:port]
+    proto = opts[:proto] || Msf::DBManager::DEFAULT_SERVICE_PROTO
+    svc = opts[:service]
+    rids = opts.delete(:ref_ids) || []
+
+    opts[:refs].each do |ref|
+      if ref.instance_of?(Mdm::Module::Ref)
+        str = ref.name
+      elsif (ref.respond_to?(:ctx_id)) && (ref.respond_to?(:ctx_val))
+        str = "#{ref.ctx_id}-#{ref.ctx_val}"
+      elsif (ref.is_a?(Hash) && ref[:ctx_id] && ref[:ctx_val])
+        str = "#{ref[:ctx_id]}-#{ref[:ctx_val]}"
+      elsif ref.is_a?(String)
+        str = ref
+      end
+      rids << find_or_create_ref(name: str) unless str.nil?
+    end
 
     # Look up the service as appropriate
-    if port and svc.nil?
+    if port && svc.nil?
       # only one result can be returned, as the +port+ field restricts potential results to a single service
       svc = services(:workspace => wspace,
                      :hosts => {address: host},
@@ -52,7 +67,7 @@ module Msf::DBManager::ExploitAttempt
 
     # Look up the host as appropriate
     if !host || !host.kind_of?(::Mdm::Host)
-      if svc.kind_of? ::Mdm::Service
+      if svc&.kind_of? ::Mdm::Service
         host = svc.host
       else
         host = get_host(workspace: wspace, address: host)
@@ -60,11 +75,22 @@ module Msf::DBManager::ExploitAttempt
     end
 
     # Bail if we dont have a host object
-    return if not host
+    return unless host
 
-    opts = opts.clone()
+    vuln = nil
+    if rids.present?
+      if svc
+        # Try to find an existing vulnerability with the same service & references
+        vuln = find_vuln_by_refs(rids, host, svc, false)
+      else
+        # Try to find an existing vulnerability with the same host & references
+        vuln = find_vuln_by_refs(rids, host, nil, false)
+      end
+    end
+
     opts[:service] = svc
     opts[:host] = host
+    opts[:vuln] = vuln if vuln
 
     do_report_failure_or_success(opts)
   end
@@ -137,7 +163,7 @@ module Msf::DBManager::ExploitAttempt
         ref_objs = ::Mdm::Ref.where(name: ref_names)
 
         # Try find a matching vulnerability
-        vuln = find_vuln_by_refs(ref_objs, host, svc)
+        vuln = find_vuln_by_refs(ref_objs, host, svc, false)
       end
 
       attempt_info = {

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -44,8 +44,8 @@ module Msf::DBManager::Vuln
     other_vulns.empty? ? nil : other_vulns.first
   end
 
-  def find_vuln_by_refs(refs, host, service=nil)
-    ref_ids = refs.find_all { |ref| ref.name.starts_with? 'CVE-'}
+  def find_vuln_by_refs(refs, host, service = nil, cve_only = true)
+    ref_ids = cve_only ? refs.find_all { |ref| ref.name.starts_with? 'CVE-'} : refs
     relation = host.vulns.joins(:refs)
     if !service.try(:id).nil?
       return relation.where(service_id: service.try(:id), refs: { id: ref_ids}).first

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1460,34 +1460,6 @@ class Exploit < Msf::Module
     return self.fail_reason
   end
 
-  def report_failure
-    return unless framework.db and framework.db.active
-
-    info = {
-      :timestamp   => Time.now.utc,
-      :workspace   => framework.db.find_workspace(self.workspace),
-      :module      => self.fullname,
-      :fail_reason => self.fail_reason,
-      :fail_detail => self.fail_detail,
-      :target_name => self.target.name,
-      :username    => self.owner,
-      :refs        => self.references,
-      :run_id      => self.datastore['RUN_ID']
-    }
-
-    if self.datastore['RHOST'] && (self.options['RHOST'] || self.options['RHOSTS'])
-      info[:host] = self.datastore['RHOST']
-    end
-
-    if self.datastore['RPORT'] and self.options['RPORT']
-      info[:port] = self.datastore['RPORT']
-      if self.class.ancestors.include?(Msf::Exploit::Remote::Tcp)
-        info[:proto] = 'tcp'
-      end
-    end
-
-    framework.db.report_exploit_failure(info)
-  end
 
   ##
   #

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -48,6 +48,7 @@ module Msf
     include Msf::Module::Author
     include Msf::Module::Compatibility
     include Msf::Module::DataStore
+    include Msf::Module::Failure
     include Msf::Module::FullName
     include Msf::Module::ModuleInfo
     include Msf::Module::ModuleStore

--- a/spec/support/shared/examples/msf/db_manager/exploit_attempt.rb
+++ b/spec/support/shared/examples/msf/db_manager/exploit_attempt.rb
@@ -43,7 +43,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
     end
 
     let(:refs) do
-      [ FactoryBot.create(:mdm_ref) ]
+      [ FactoryBot.create(:mdm_module_ref) ]
     end
 
     context "with a run" do
@@ -58,7 +58,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
       end
 
       context 'with a vuln' do
-        specify do
+        it "should create a vuln attempt" do
           expect {
             report_exploit_failure
           }.to change(Mdm::VulnAttempt,:count).by(1)
@@ -81,7 +81,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
           ).to exist
         end
 
-        context "calling report_exploit_success" do
+        context "calling report_exploit_failure" do
           after(:example) do
             report_exploit_failure
           end
@@ -106,7 +106,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
 
         let(:match) {nil}
 
-        specify do
+        it "should not create a vuln attempt" do
           expect {
             report_exploit_failure
           }.not_to change(Mdm::VulnAttempt, :count)
@@ -118,7 +118,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
           }.to change(MetasploitDataModels::AutomaticExploitation::MatchResult,:count).by(0)
         end
 
-        context "calling report_exploit_success" do
+        context "calling report_exploit_failure" do
           after(:example) do
             report_exploit_failure
           end
@@ -154,7 +154,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
       end
 
       context 'with a vuln' do
-        specify do
+        it "should create a vuln attempt" do
           expect {
             report_exploit_failure
           }.to change(Mdm::VulnAttempt,:count).by(1)
@@ -166,7 +166,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
           }.to change(MetasploitDataModels::AutomaticExploitation::MatchResult,:count).by(0)
         end
 
-        context "calling report_exploit_success" do
+        context "calling report_exploit_failure" do
           after(:example) do
             report_exploit_failure
           end
@@ -189,7 +189,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
       context 'without a vuln' do
         let(:vuln) { nil }
 
-        specify do
+        it "should not create a vuln attempt" do
           expect {
             report_exploit_failure
           }.not_to change(Mdm::VulnAttempt, :count)
@@ -201,7 +201,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
           }.to change(MetasploitDataModels::AutomaticExploitation::MatchResult,:count).by(0)
         end
 
-        context "calling report_exploit_success" do
+        context "calling report_exploit_failure" do
           after(:example) do
             report_exploit_failure
           end
@@ -219,6 +219,36 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
           end
         end
 
+      end
+    end
+
+    context 'with a vuln but providing the related refs only' do
+      let(:vuln) { FactoryBot.create(:mdm_vuln, host: host) }
+      let(:opts) do
+        {
+          workspace: workspace,
+          refs: refs,
+          host: host
+        }
+      end
+
+      before :example do
+        refs.each do |module_ref|
+          ref = FactoryBot.create(:mdm_ref, name: module_ref.name)
+          FactoryBot.create(:mdm_vuln_ref, ref_id: ref.id, vuln_id: vuln.id)
+        end
+      end
+
+      it "should create a vuln attempt" do
+        expect {
+          report_exploit_failure
+        }.to change(Mdm::VulnAttempt,:count).by(1)
+      end
+
+      it 'creates the expected vuln attempt' do
+        report_exploit_failure
+        vuln_attempt = Mdm::VulnAttempt.last
+        expect(vuln_attempt.vuln).to eq(vuln)
       end
     end
   end
@@ -279,7 +309,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
       end
 
       context 'with a vuln' do
-        specify do
+        it "should create a vuln attempt" do
           expect {
             report_exploit_success
           }.to change(Mdm::VulnAttempt,:count).by(1)
@@ -326,7 +356,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
 
         let(:match) {nil}
 
-        specify do
+        it "should not create a vuln attempt" do
           expect {
             report_exploit_success
           }.not_to change(Mdm::VulnAttempt, :count)
@@ -374,7 +404,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
       end
 
       context 'with a vuln' do
-        specify do
+        it "should create a vuln attempt" do
           expect {
             report_exploit_success
           }.to change(Mdm::VulnAttempt,:count).by(1)
@@ -409,7 +439,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
       context 'without a vuln' do
         let(:vuln) { nil }
 
-        specify do
+        it "should not create a vuln attempt" do
           expect {
             report_exploit_success
           }.not_to change(Mdm::VulnAttempt, :count)


### PR DESCRIPTION
In continuation to the `ExploitAttempt` [PR](https://github.com/rapid7/metasploit-framework/pull/20111), this one enables auxiliary modules to properly register as a `VulnAttempt`. Due to the nature of auxiliary modules, it is not guaranteed the module properly reports a failure or a success. In fact, most of the auxiliary modules don’t call `fail_with`, but just return `nil`. Also, scanner/gather modules that get no results also won’t report this attempt as a failure. For all of these reasons, the resulting `VulnAttempt` for auxiliary modules will have a `fail_reason` with the value `none` when the actual result is unknown.

## Verification

### Register a vulnerability using an exploit and an auxiliary modules
This will require a Windows target and admin credentials.

- [ ] Start `msfconsole`
- [ ] create a new workspace: `workspace -a vuln_attempt_test`
- [ ] Make sure no vulnerabilities and no hosts are registered with `vulns` and `hosts` commands
- [ ] `use exploit/windows/smb/psexec`
- [ ] `run verbose=true rhosts=<remote host> smbuser=<username> smbpass=<password>`
- [ ] Make sure you get a session
- [ ] Back to the console, verify a vulnerability and host are registered with `vulns` and `hosts` commands
- [ ] Enter Pry with the `pry` command
- [ ] Get the vulnerability ID with this command: `Mdm::Host.where(workspace: Mdm::Workspace.where(name: 'vuln_attempt_test').first).first.vulns.first.id`
- [ ] Check the vuln attempts querying the `Mdm::VulnAttempt` data model with this command: `Mdm::VulnAttempt.where(vuln_id: <vuln ID>)`
- [ ] Verify the vuln attempt is correctly registered
- [ ] Repeat with a failing attempt (e.g. wrong password or wrong IP address) and verify the failed vuln attempt is also registered.
- [ ] Repeat with an auxiliary module that is related to the same vulnerability (`use auxiliary/admin/smb/psexec_ntdsgrab`).
- [ ] Verify the vuln attempts are correctly registered

## Scenarios
```
msf6 > workspace -a vuln_attempt_test
[*] Added workspace: vuln_attempt_test
[*] Workspace: vuln_attempt_test
msf6 > vulns

Vulnerabilities
===============

Timestamp  Host  Name  References
---------  ----  ----  ----------

msf6 > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

msf6 > use exploit/windows/smb/psexec
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf6 exploit(windows/smb/psexec) > set payload windows/meterpreter/bind_tcp
payload => windows/meterpreter/bind_tcp
msf6 exploit(windows/smb/psexec) > run verbose=true rhosts=10.210.23.21 smbuser=msfuser smbpass=msfuser
[*] 10.210.23.21:445 - Connecting to the server...
[*] 10.210.23.21:445 - Authenticating to 10.210.23.21:445 as user 'msfuser'...
[*] 10.210.23.21:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 10.210.23.21:445 - PowerShell found
[*] 10.210.23.21:445 - Selecting PowerShell target
[*] 10.210.23.21:445 - Powershell command length: 4279
[*] 10.210.23.21:445 - Executing the payload...
[*] 10.210.23.21:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.210.23.21[\svcctl] ...
[*] 10.210.23.21:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.210.23.21[\svcctl] ...
[*] 10.210.23.21:445 - Obtaining a service manager handle...
[*] 10.210.23.21:445 - Creating the service...
[+] 10.210.23.21:445 - Successfully created the service
[*] 10.210.23.21:445 - Starting the service...
[+] 10.210.23.21:445 - Service start timed out, OK if running a command or non-service executable...
[*] 10.210.23.21:445 - Removing the service...
[+] 10.210.23.21:445 - Successfully removed the service
[*] 10.210.23.21:445 - Closing service handle...
[*] Started bind TCP handler against 10.210.23.21:4444
[*] Sending stage (177734 bytes) to 10.210.23.21
[*] Meterpreter session 1 opened (192.168.144.3:43871 -> 10.210.23.21:4444) at 2025-05-28 19:06:37 +0200

meterpreter > [*] Shutting down session: 1

[*] 10.210.23.21 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(windows/smb/psexec) > vulns

Vulnerabilities
===============

Timestamp                Host          Name                                                 References
---------                ----          ----                                                 ----------
2025-05-28 17:06:37 UTC  10.210.23.21  Microsoft Windows Authenticated User Code Execution  CVE-1999-0504,OSVDB-3106,URL-http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx,URL-https://www.optiv.com/blog/owning-computers-without-shell-access,URL-http://sourcef
                                                                                            orge.net/projects/smbexec/

msf6 exploit(windows/smb/psexec) > hosts

Hosts
=====

address       mac  name            os_name       os_flavor  os_sp  purpose  info  comments
-------       ---  ----            -------       ---------  -----  -------  ----  --------
10.210.23.21       msfuser-2008R2  Windows 2008             SP1    server

msf6 exploit(windows/smb/psexec) > pry
[*] Starting Pry shell...
[*] You are in the "exploit/windows/smb/psexec" module object

...[SNIP]...

[1] pry(#<Msf::Ui::Console::CommandDispatcher::Developer>)> Mdm::Host.where(workspace: Mdm::Workspace.where(name: 'vuln_attempt_test').first).first.vulns.first.id
=> 20
[2] pry(#<Msf::Ui::Console::CommandDispatcher::Developer>)> Mdm::VulnAttempt.where(vuln_id: 20)
=> [#<Mdm::VulnAttempt:0x0000726bae6f1198 id: 41, vuln_id: 20, attempted_at: 2025-05-28 17:06:37.162081 UTC, exploited: true, fail_reason: nil, username: "n00tmeg", module: "exploit/windows/smb/psexec", session_id: 36, loot_id: nil, fail_detail: nil>]
[3] pry(#<Msf::Ui::Console::CommandDispatcher::Developer>)>
msf6 exploit(windows/smb/psexec) > run verbose=true rhosts=10.210.23.21 smbuser=msfuser smbpass=wrong
[*] 10.210.23.21:445 - Connecting to the server...
[*] 10.210.23.21:445 - Authenticating to 10.210.23.21:445 as user 'msfuser'...
[-] 10.210.23.21:445 - Exploit failed [no-access]: Rex::Proto::SMB::Exceptions::LoginError Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.
[*] Exploit completed, but no session was created.
msf6 exploit(windows/smb/psexec) > pry
[*] Starting Pry shell...
[*] You are in the "exploit/windows/smb/psexec" module object

...[SNIP]...

[1] pry(#<Msf::Ui::Console::CommandDispatcher::Developer>)> Mdm::VulnAttempt.where(vuln_id: 20)
=> [#<Mdm::VulnAttempt:0x0000726bae731040 id: 41, vuln_id: 20, attempted_at: 2025-05-28 17:06:37.162081 UTC, exploited: true, fail_reason: nil, username: "n00tmeg", module: "exploit/windows/smb/psexec", session_id: 36, loot_id: nil, fail_detail: nil>,
 #<Mdm::VulnAttempt:0x0000726bae730280
  id: 42,
  vuln_id: 20,
  attempted_at: 2025-05-28 17:07:07.516117 UTC,
  exploited: false,
  fail_reason: "no-access",
  username: "n00tmeg",
  module: "exploit/windows/smb/psexec",
  session_id: nil,
  loot_id: nil,
  fail_detail: "Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.">]
[2] pry(#<Msf::Ui::Console::CommandDispatcher::Developer>)>
msf6 exploit(windows/smb/psexec) >
msf6 exploit(windows/smb/psexec) >
msf6 exploit(windows/smb/psexec) > use auxiliary/admin/smb/psexec_ntdsgrab
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf6 auxiliary(admin/smb/psexec_ntdsgrab) > run verbose=true rhosts=10.210.23.21 smbuser=msfuser smbpass=wrong
[*] Running module against 10.210.23.21
[-] 10.210.23.21:445 - Unable to authenticate with given credentials: Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/smb/psexec_ntdsgrab) > pry
[*] Starting Pry shell...
[*] You are in the "auxiliary/admin/smb/psexec_ntdsgrab" module object

...[SNIP]...

[1] pry(#<Msf::Ui::Console::CommandDispatcher::Developer>)> Mdm::VulnAttempt.where(vuln_id: 20)
=> [#<Mdm::VulnAttempt:0x0000726bae731f40 id: 41, vuln_id: 20, attempted_at: 2025-05-28 17:06:37.162081 UTC, exploited: true, fail_reason: nil, username: "n00tmeg", module: "exploit/windows/smb/psexec", session_id: 36, loot_id: nil, fail_detail: nil>,
 #<Mdm::VulnAttempt:0x0000726bae731cc0
  id: 42,
  vuln_id: 20,
  attempted_at: 2025-05-28 17:07:07.516117 UTC,
  exploited: false,
  fail_reason: "no-access",
  username: "n00tmeg",
  module: "exploit/windows/smb/psexec",
  session_id: nil,
  loot_id: nil,
  fail_detail: "Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.">,
 #<Mdm::VulnAttempt:0x0000726bae731a40 id: 43, vuln_id: 20, attempted_at: 2025-05-28 17:08:26.621116 UTC, exploited: false, fail_reason: "none", username: "n00tmeg", module: "auxiliary/admin/smb/psexec_ntdsgrab", session_id: nil, loot_id: nil, fail_detail: nil>]
```