### PR TITLE
Process and propagate KERB-SUPERSEDED-BY-USER error details

### DIFF
--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -87,8 +87,11 @@ module Metasploit
             # It doesn't appear to be documented anywhere, but Microsoft gives us a bit
             # of extra information in the e-data section
             begin
-              pa_data_entry = krb_err.res.e_data_as_pa_data_entry
-              if pa_data_entry && pa_data_entry.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_PW_SALT
+              pa_data_entry = krb_err.res.e_data_as_pa_data.find do |pa_data|
+                pa_data.type == Rex::Proto::Kerberos::Model::PreAuthType::PA_PW_SALT
+              end
+
+              if pa_data_entry
                 pw_salt = pa_data_entry.decoded_value
                 if pw_salt.nt_status
                   case pw_salt.nt_status.value
@@ -107,7 +110,7 @@ module Metasploit
                   Metasploit::Model::Login::Status::DISABLED
                 end
               else
-                  Metasploit::Model::Login::Status::DISABLED
+                Metasploit::Model::Login::Status::DISABLED
               end
             rescue Rex::Proto::Kerberos::Model::Error::KerberosDecodingError
               # Could be a non-MS implementation?

--- a/lib/rex/proto/kerberos/model.rb
+++ b/lib/rex/proto/kerberos/model.rb
@@ -51,7 +51,9 @@ module Rex
           NT_UID = 5
         end
 
-        # From padata - https://www.iana.org/assignments/kerberos-parameters/kerberos-parameters.xhtml
+        # See:
+        # * https://www.iana.org/assignments/kerberos-parameters/kerberos-parameters.xhtml#pre-authentication
+        # * https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/ae60c948-fda8-45c2-b1d1-a71b484dd1f7
 
         module PreAuthType
           PA_TGS_REQ = 1
@@ -65,6 +67,7 @@ module Rex
           PA_FOR_USER = 129
           PA_SUPPORTED_ETYPES = 165
           PA_PAC_OPTIONS = 167
+          KERB_SUPERSEDED_BY_USER = 170
         end
 
         module AuthorizationDataType

--- a/lib/rex/proto/kerberos/model/error.rb
+++ b/lib/rex/proto/kerberos/model/error.rb
@@ -176,9 +176,12 @@ module Rex
                   pa_datas = res.e_data_as_pa_data
                 rescue OpenSSL::ASN1::ASN1Error
                 else
-                  superseded_pa_data = pa_datas.find { |pa_data| pa_data.type == Rex::Proto::Kerberos::Model::PreAuthType::KERB_SUPERSEDED_BY_USER }
-                  if superseded_pa_data
-                    error_code = "#{error_code}. This account has been superseded by #{superseded_pa_data.decoded_value}."
+                  pa_data_entry = pa_datas.find do |pa_data|
+                    pa_data.type == Rex::Proto::Kerberos::Model::PreAuthType::KERB_SUPERSEDED_BY_USER
+                  end
+
+                  if pa_data_entry
+                    error_code = "#{error_code}. This account has been superseded by #{pa_data_entry.decoded_value}."
                   end
                 end
               end

--- a/lib/rex/proto/kerberos/model/kerb_superseded_by_user.rb
+++ b/lib/rex/proto/kerberos/model/kerb_superseded_by_user.rb
@@ -1,0 +1,81 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of a Kerberos KERB-SUPERSEDED-BY-USER
+        # message as defined in [MS-KILE 2.2.13](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/79170b21-ad15-4a1b-99c4-84b3992d9e70).
+        class KerbSupersededByUser < Element
+
+          attr_accessor :principal_name
+
+          attr_accessor :realm
+
+          def ==(other)
+            realm == other.realm && principal_name == other.principal_name
+          end
+
+          def decode(input)
+            case input
+            when String
+              decode_string(input)
+            when OpenSSL::ASN1::Sequence
+              decode_asn1(input)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode KerbSupersededByUser, invalid input'
+            end
+
+            self
+          end
+
+          def encode
+            principal_name_asn1 = OpenSSL::ASN1::ASN1Data.new([encode_principal_name], 1, :CONTEXT_SPECIFIC)
+            realm_asn1 = OpenSSL::ASN1::ASN1Data.new([encode_realm], 2, :CONTEXT_SPECIFIC)
+            seq = OpenSSL::ASN1::Sequence.new([principal_name_asn1, realm_asn1])
+
+            seq.to_der
+          end
+
+          private
+
+          def decode_string(input)
+            asn1 = OpenSSL::ASN1.decode(input)
+
+            decode_asn1(asn1)
+          end
+
+          # Decodes a Rex::Proto::Kerberos::Model::KerbSupersededByUser from an
+          # OpenSSL::ASN1::Sequence
+          #
+          # @param input [OpenSSL::ASN1::Sequence] the input to decode from
+          def decode_asn1(input)
+            seq_values = input.value
+            self.principal_name = decode_principal_name(seq_values[0])
+            self.realm = decode_realm(seq_values[1])
+          end
+
+         def decode_principal_name(input)
+           PrincipalName.decode(input.value[0])
+          end
+
+          # Decodes the realm from an OpenSSL::ASN1::ASN1Data
+          #
+          # @param input [OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [Array<String>]
+          def decode_realm(input)
+            input.value[0].value
+          end
+
+          def encode_principal_name
+            self.principal_name.encode
+          end
+
+          def encode_realm
+            OpenSSL::ASN1::OctetString.new(self.realm)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/kerb_superseded_by_user.rb
+++ b/lib/rex/proto/kerberos/model/kerb_superseded_by_user.rb
@@ -16,6 +16,10 @@ module Rex
             realm == other.realm && principal_name == other.principal_name
           end
 
+          def to_s
+            "#{principal_name}@#{realm}"
+          end
+
           def decode(input)
             case input
             when String

--- a/lib/rex/proto/kerberos/model/krb_error.rb
+++ b/lib/rex/proto/kerberos/model/krb_error.rb
@@ -72,30 +72,24 @@ module Rex
             raise ::NotImplementedError, 'KrbError encoding not supported'
           end
 
-          # Decodes the e_data field as an Array<PreAuthDataEntry>
+          # Decodes the e_data field as an Array<PreAuthDataEntry>.
           #
           # @return [Array<Rex::Proto::Kerberos::Model::PreAuthDataEntry>]
           def e_data_as_pa_data
+            return [] unless self.e_data
+
             pre_auth = []
             decoded = OpenSSL::ASN1.decode(self.e_data)
-            decoded.each do |pre_auth_data|
-              pre_auth << Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(pre_auth_data)
+
+            if decoded.first.tag_class == :UNIVERSAL && decoded.first.tag == 16
+              decoded.each do |pre_auth_data|
+                pre_auth << Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(pre_auth_data)
+              end
+            else
+              pre_auth << Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(decoded)
             end
 
             pre_auth
-          end
-
-          # Decodes the e_data field as a PreAuthData
-          #
-          # @return [Rex::Proto::Kerberos::Model::PreAuthData]
-          def e_data_as_pa_data_entry
-            if self.e_data
-              decoded = OpenSSL::ASN1.decode(self.e_data)
-              Rex::Proto::Kerberos::Model::PreAuthDataEntry.decode(decoded)
-            else
-              # This is implementation-defined, so may be different in some cases
-              nil
-            end
           end
 
           private

--- a/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
@@ -76,6 +76,9 @@ module Rex
             when Rex::Proto::Kerberos::Model::PreAuthType::PA_FOR_USER
               decoded = OpenSSL::ASN1.decode(self.value)
               PreAuthForUser.decode(decoded)
+            when Rex::Proto::Kerberos::Model::PreAuthType::KERB_SUPERSEDED_BY_USER
+              decoded = OpenSSL::ASN1.decode(self.value)
+              KerbSupersededByUser.decode(decoded)
             else
               # Unknown type - just ignore for now
             end


### PR DESCRIPTION
While starting to look into the BadSuccessor attack it became apparent that Metasploit could benefit from processing the KERB-SUPERSEDED-BY-USER structure included in Kerberos error messages. This would be the case after an account has completed the migration process. FWIW, the error details also appear to be included even if the password is invalid so an attacker can identify an account has been migrated without knowing it's password.

Related to but does not complete #20217

## Verification

- [ ] Set up a Server 2025 DC (for the full attack, 2025 is required)
- [ ] Use the this powershell code to create a new key and setup accounts to do the migration, updated `msflab.local` / `DC=msflab,DC=local` to the desired domain

```powershell
Add-KdsRootKey –EffectiveTime ((get-date).addhours(-10))
New-ADUser -Name "svc_sql" -SamAccountName "svc_sql" -UserPrincipalName "svc_sql@msflab.local" -AccountPassword (ConvertTo-SecureString "Password1!" -AsPlainText -Force) -Enabled $true -PasswordNeverExpires $true

$params = @{
 Name = "dMSA"
 DNSHostName = "DMSA"
 CreateDelegatedServiceAccount = $true
 KerberosEncryptionType = "AES256"
}
New-ADServiceAccount @params

$params = @{
 Identity = "dMSA"
 Properties = "msDS-DelegatedMSAState"
}
Get-ADServiceAccount @params

$params = @{
 Identity = "dMSA"
 SupersededAccount = "CN=svc_sql,CN=Users,DC=msflab,DC=local"
}
Start-ADServiceAccountMigration @params -Verbose

$params = @{
 Identity = "dMSA"
 SupersededAccount = "CN=svc_sql,CN=Users,DC=msflab,DC=local"
}
Complete-ADServiceAccountMigration @params
```

- [ ] Run the `auxiliary/admin/kerberos/get_ticket` module
  - [ ] Set the user to the `svc_sql` account and use the `GET_TGT` action
  - [ ] See that the account was superseded in the error response

## Demo

```
msf6 auxiliary(admin/kerberos/get_ticket) > show options 

Module options (auxiliary/admin/kerberos/get_ticket):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   AES_KEY                         no        The AES key to use for Kerberos authentication in hex string. Supported keys: 128 or 256 bits
   CERT_FILE                       no        The PKCS12 (.pfx) certificate file to authenticate with
   CERT_PASSWORD                   no        The certificate file's password
   DOMAIN         msflab.local     no        The Fully Qualified Domain Name (FQDN). Ex: mydomain.local
   NTHASH                          no        The NT hash in hex string. Server must support RC4
   PASSWORD       Password1!       no        The domain user's password
   RHOSTS         192.168.159.10   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT          88               yes       The target port
   Timeout        10               yes       The TCP timeout to establish Kerberos connection and read data
   USERNAME       svc_sql          no        The domain user


   When ACTION is GET_TGS:

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   IMPERSONATE                   no        The user on whose behalf a TGS is requested (it will use S4U2Self/S4U2Proxy to request the ticket)
   Krb5Ccname                    no        The Kerberos TGT to use when requesting the service ticket. If unset, the database will be checked
   SPN                           no        The Service Principal Name, format is service_name/FQDN. Ex: cifs/dc01.mydomain.local


Auxiliary action:

   Name     Description
   ----     -----------
   GET_TGT  Request a Ticket-Granting-Ticket (TGT)



View the full module info with the info, or info -d command.

msf6 auxiliary(admin/kerberos/get_ticket) > run
[*] Running module against 192.168.159.10
[*] 192.168.159.10:88 - Getting TGT for svc_sql@msflab.local
[-] Auxiliary aborted due to failure: unknown: Kerberos Error - KDC_ERR_CLIENT_REVOKED (18) - Clients credentials have been revoked. This account has been superseded by dMSA$@MSFLAB.LOCAL.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) > run PASSWORD=roofasd
[*] Running module against 192.168.159.10
[*] 192.168.159.10:88 - Getting TGT for svc_sql@msflab.local
[-] Auxiliary aborted due to failure: unknown: Kerberos Error - KDC_ERR_CLIENT_REVOKED (18) - Clients credentials have been revoked. This account has been superseded by dMSA$@MSFLAB.LOCAL.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/kerberos/get_ticket) >
```
