### PR TITLE
Revert "Ensure thinkphp rce runs on metasploit pro"

### DIFF
--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -88,12 +88,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  # The CmdStager mixin implicitly includes the HttpServer mixin which opts this module out of auto-exploitation
-  # https://github.com/rapid7/metasploit-framework/blob/72ae91e4bc763da378bbd5be104f642f9d7eebc1/lib/msf/core/exploit/remote/http_server.rb#L53-L58
-  def autofilter
-    true
-  end
-
   # PoC version check using the first <span> from the ThinkPHP copyright:
   #
   #   wvu@kharak:~$ curl -vs "http://127.0.0.1:8080/index.php?s=$((RANDOM))" | xmllint --html --xpath 'substring-after(//div[@class = "copyright"]/span[1]/text(), "V")' -


### PR DESCRIPTION
Reverts rapid7/metasploit-framework#20194

This needs some more QA and investigation cycles to see what other modules are excluded - and we don't quite have the right time for that right now, so reverting for now.