### PR TITLE
Add missing references for AD CS modules

### DIFF
--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -32,6 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           'Spencer McIntyre'
         ],
         'References' => [
+          [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
           [ 'URL', 'https://github.com/ly4k/Certipy' ]
         ],

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -60,6 +60,7 @@ class MetasploitModule < Msf::Auxiliary
           'Spencer McIntyre'
         ],
         'References' => [
+          [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
           [ 'URL', 'https://github.com/ly4k/Certipy' ]
         ],


### PR DESCRIPTION
This adds some missing references to a couple of AD CS related modules. This allows them to be correlated as related modules based on the URL of the initial research.