### PR TITLE
fix(post/windows/manage/remove_host): handle whitespace parsing robustly

### DIFF
--- a/modules/post/windows/manage/remove_host.rb
+++ b/modules/post/windows/manage/remove_host.rb
@@ -61,11 +61,16 @@ class MetasploitModule < Msf::Post
     fdray.each do |line|
       main_part = line.split('#', 2).first.to_s.strip
       parts = main_part.split(/\s+/)
-      unless parts[1..-1].to_a.include?(hosttoremove)
+      if parts[1..-1].to_a.include?(hosttoremove)
+        parts.delete_if { |p| p.casecmp(hosttoremove).zero? }
+        next if parts.size < 2
+        rebuilt = parts.join(' ')
+        rebuilt += " " + line.split('#', 2).last if line.include?('#')
+        newfile += "#{rebuilt}\r\n"
+      else
         newfile += "#{line}\r\n"
       end
     end
-
 
     fd.close
 

--- a/modules/post/windows/manage/remove_host.rb
+++ b/modules/post/windows/manage/remove_host.rb
@@ -59,10 +59,13 @@ class MetasploitModule < Msf::Post
     fdray = fd.read.split("\r\n")
 
     fdray.each do |line|
-      unless line.match("\t#{hosttoremove}$")
+      main_part = line.split('#', 2).first.to_s.strip
+      parts = main_part.split(/\s+/)
+      unless parts[1..-1].to_a.include?(hosttoremove)
         newfile += "#{line}\r\n"
       end
     end
+
 
     fd.close
 


### PR DESCRIPTION
See #20157

This PR fixes a bug in the `post/windows/manage/remove_host` module that caused it to incorrectly assume hosts file entries use only tab-separated fields. In reality, Windows hosts files can use **any type of whitespace** (spaces, tabs, or mixed) and may include trailing whitespace or inline comments.

The original logic only matched tab-separated entries, ignoring entries with spaces or trailing whitespace, and did not handle inline comments correctly. Additionally, because it used regex matching, it could (in rare cases) remove unintended entries if the specified domain contained regex-like characters (e.g., `.`, `*`).

This fix updates the parsing logic to:

- Correctly detect and split hosts file entries based on **any whitespace** (spaces, tabs, or mixed)
- Ignore inline comments when checking for matching host names
- Remove only exact matches for the specified host name, regardless of leading/trailing whitespace
- Avoid unintended removal of entries with partial or regex-like matches

## Example hosts file

Below is an example hosts file with various edge cases that this PR correctly handles:


```
127.0.0.1 example.com
127.0.0.1 asdf
127.0.0.1   asdf
127.0.0.1 asdfnot
127.0.0.1 notasdf
127.0.0.1 asdf # with comment
127.0.0.1 foo asdf bar
127.0.0.1 shop.ebay.com
127.0.0.1 shop4ebay.com
127.0.0.1 google.com
#just a comment

10.0.0.1 asdf
```


If you run the module with:

`set DOMAIN asdf`


it will remove **only** these lines:

```
127.0.0.1 asdf
127.0.0.1   asdf
127.0.0.1 asdf # with comment
127.0.0.1 foo asdf bar
10.0.0.1 asdf

```

while leaving **all other lines untouched**, including:

```

127.0.0.1 shop.ebay.com
127.0.0.1 shop4ebay.com
127.0.0.1 google.com
#just a comment

```
If you run the module with:

`set DOMAIN shop.ebay.com`


it will remove **only** this line:

```
127.0.0.1 shop.ebay.com

```

while leaving **all other lines untouched**, including:

```

127.0.0.1 asdf
127.0.0.1   asdf
127.0.0.1 asdf # with comment
127.0.0.1 foo asdf bar
10.0.0.1 asdf
127.0.0.1 shop4ebay.com
127.0.0.1 google.com
#just a comment

```

## Verification

To test the fix:

- [ ] Start `msfconsole`
- [ ] Obtain a Meterpreter session on a Windows target
- [ ] Create a hosts file on the target with entries like those shown above, using **both tabs and spaces** for separation
- [ ] `use post/windows/manage/remove_host`
- [ ] `set DOMAIN <target host name>`
- [ ] `set SESSION <session ID>`
- [ ] `run`
- [ ] Verify that only exact matches for the specified host name are removed, regardless of whitespace (tabs or spaces)
- [ ] Verify that similar entries (like `shop4ebay.com` vs. `shop.ebay.com`), comments, and unrelated entries remain untouched

##  Screenshots:
![image](https://github.com/user-attachments/assets/b33eccf6-a8cc-43d8-879d-69ebd976c218)
*Before*

![image2](https://github.com/user-attachments/assets/e83f3315-3c19-4b01-9ef3-de81bc30488a)
*Afterwards*



Thanks for reviewing!