### PR TITLE
Fixes bug in auxiliary/scanner/sap/sap_router_info_request

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_router_info_request.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_info_request.rb
@@ -67,6 +67,7 @@ class MetasploitModule < Msf::Auxiliary
         info << data
       end
     end
+    fail_with(Failure::UnexpectedReply, 'Received unexpected response')
   end
 
   def run_host(ip)


### PR DESCRIPTION
This PR address [20269](https://github.com/rapid7/metasploit-framework/issues/20269). The fix is pretty simple, just adds exception when parsing of received data fails and avoids returning `nil`.