### PR TITLE
Fix krb5_ccache_presenter specs

### DIFF
--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -124,10 +124,10 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
-            Start time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
-            End time: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
-            Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
+            Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
+            Start time: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
+            End time: #{Time.parse('2032-11-25 15:51:29 +0000').localtime}
+            Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').localtime}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -157,10 +157,10 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
           Addresses: 0
           Authdatas: 0
           Times:
-            Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
-            Start time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
-            End time: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
-            Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
+            Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
+            Start time: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
+            End time: #{Time.parse('2032-11-25 15:51:29 +0000').localtime}
+            Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').localtime}
           Ticket:
             Ticket Version Number: 5
             Realm: WINDOMAIN.LOCAL
@@ -170,10 +170,10 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
               Key Version Number: 2
               Decrypted (with key: 4b912be0366a6f37f4a7d571bee18b1173d93195ef76f8d1e3e81ef6172ab326):
                 Times:
-                  Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
-                  Start time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
-                  End time: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
-                  Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').to_time}
+                  Auth time: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
+                  Start time: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
+                  End time: #{Time.parse('2032-11-25 15:51:29 +0000').localtime}
+                  Renew Till: #{Time.parse('2032-11-25 15:51:29 +0000').localtime}
                 Client Addresses: 0
                 Transited: tr_type: 0, Contents: ""
                 Client Name: 'Administrator'
@@ -183,7 +183,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                 Flags: 0x50e00000 (FORWARDABLE, PROXIABLE, RENEWABLE, INITIAL, PRE_AUTHENT)
                 PAC:
                   Validation Info:
-                    Logon Time: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+                    Logon Time: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
                     Logoff Time: Never Expires (inf)
                     Kick Off Time: Never Expires (inf)
                     Password Last Set: No Time Set (0)
@@ -284,7 +284,7 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
                     Logon Domain Name: 'WINDOMAIN.LOCAL'
                   Client Info:
                     Name: 'Administrator'
-                    Client ID: #{Time.parse('2022-11-28 15:51:29 +0000').to_time}
+                    Client ID: #{Time.parse('2022-11-28 15:51:29 +0000').localtime}
                   Pac Server Checksum:
                     Signature: 5eb9400bcab42babcd598210
                   Pac Privilege Server Checksum:


### PR DESCRIPTION
Specs for `krb5_ccache_presenter` are failing when local time zone is not UTC.

## Verification
Set the time zone to something different than UTC and run:
```
bundle exec rspec spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
```
or use the `TZ` environment variable:
```
TZ='America/New_York' bundle exec rspec spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
```
or use `tzselect` before running rspec.

## Without this fix
```
> bundle exec rspec spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
...[SNIP]...
  1) Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter#present when decryption key is not provided returns a string not containing pac info
     Failure/Error: expect(subject.present).to eq(no_decryption_example)

       expected: "Primary Principal: Administrator@WINDOMAIN.LOCAL\nCcache version: 4\n\nCreds: 1\n  Credential[0]:\n ...rnaKCi0awaZQrvXPMnqvVqBYM3SsZRXOgDrcq/T79qR9cCvmQT2hhsmrh4c15ldVpIpmeR2YS/msnk7iVVhPqec/jkVTvpB7/E="
            got: "Primary Principal: Administrator@WINDOMAIN.LOCAL\nCcache version: 4\n\nCreds: 1\n  Credential[0]:\n ...rnaKCi0awaZQrvXPMnqvVqBYM3SsZRXOgDrcq/T79qR9cCvmQT2hhsmrh4c15ldVpIpmeR2YS/msnk7iVVhPqec/jkVTvpB7/E="

       (compared using ==)

       Diff:
       @@ -13,10 +13,10 @@
            Addresses: 0
            Authdatas: 0
            Times:
       -      Auth time: 2022-11-28 15:51:29 +0000
       -      Start time: 2022-11-28 15:51:29 +0000
       -      End time: 2032-11-25 15:51:29 +0000
       -      Renew Till: 2032-11-25 15:51:29 +0000
       +      Auth time: 2022-11-28 16:51:29 +0100
       +      Start time: 2022-11-28 16:51:29 +0100
       +      End time: 2032-11-25 16:51:29 +0100
       +      Renew Till: 2032-11-25 16:51:29 +0100
            Ticket:
              Ticket Version Number: 5
              Realm: WINDOMAIN.LOCAL
...[SNIP]...
```

## With this fix
```
...[SNIP]...
Finished in 0.33922 seconds (files took 6.44 seconds to load)
17 examples, 0 failures
...[SNIP]...
```