### PR TITLE
post/windows/manage/remove_host: resolve hosts-file path dynamically instead of hard-coded C:\Windows

### DIFF
--- a/modules/post/windows/manage/remove_host.rb
+++ b/modules/post/windows/manage/remove_host.rb
@@ -44,10 +44,17 @@ class MetasploitModule < Msf::Post
     )
   end
 
+  def hosts_path
+    root = client.sys.config.getenv('SystemRoot') ||
+           client.sys.config.getenv('windir')     ||
+           'C:\\Windows'
+    "#{root}\\System32\\drivers\\etc\\hosts"
+  end
+
   def run
     hosttoremove = datastore['DOMAIN']
-    # remove hostname from hosts file
-    fd = client.fs.file.new('C:\\WINDOWS\\System32\\drivers\\etc\\hosts', 'r+b')
+    path = hosts_path
+    fd = client.fs.file.new(path, 'r+b')
 
     # Get a temporary file path
     meterp_temp = Tempfile.new('meterp')
@@ -77,7 +84,7 @@ class MetasploitModule < Msf::Post
     meterp_temp.write(newfile)
     meterp_temp.close
 
-    client.fs.file.upload_file('C:\\WINDOWS\\System32\\drivers\\etc\\hosts', meterp_temp)
+    client.fs.file.upload_file(path, meterp_temp)
     print_good('Done!')
   end
 end


### PR DESCRIPTION

### What this change does

* **Fixes** see #20280 – `post/windows/manage/remove_host` no longer relies on the
  hard-coded path `C:\WINDOWS\System32\drivers\etc\hosts`.  
  A helper now builds the path from `%SystemRoot%` / `%windir%`, so the module
  works on systems installed on **any** drive.

## Verification

- [x] Start `msfconsole`.
- [x] Get a Meterpreter session on any Windows host.<br>
      *(To simulate a non-C: install you can temporarily run  
      `meterpreter > setenv SystemRoot D:\Windows`)*
- [x] Run:  
  ```text
  use post/windows/manage/remove_host
  set SESSION 1
  set DOMAIN asdf
  run
    ```

- [x] **Verify** the entry `asdf` is removed from
  `%SystemRoot%\System32\drivers\etc\hosts`.
- [x] **Verify** other hosts-file lines and comments remain unchanged.


