### PR TITLE
Fix the cve_2022_26923_certifried module after the datastore option changes

### DIFF
--- a/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
       )
     ])
 
-    deregister_options('CERT_TEMPLATE', 'ALT_DNS', 'ALT_UPN', 'PFX', 'ON_BEHALF_OF', 'SMBUser', 'SMBPass', 'SMBDomain')
+    deregister_options('CERT_TEMPLATE', 'ALT_DNS', 'ALT_UPN', 'PFX', 'ON_BEHALF_OF', 'SMBUser', 'SMBPass', 'SMBDomain', 'LDAPUsername', 'LDAPPassword', 'LDAPDomain')
   end
 
   def run
@@ -170,10 +170,10 @@ class MetasploitModule < Msf::Auxiliary
       end
       opts = {
         tree: tree,
-        computer_name: computer_info&.name
+        account_name: computer_info&.name
       }
       begin
-        delete_account(opts) if opts[:tree] && opts[:computer_name]
+        delete_account(opts) if opts[:tree] && opts[:account_name]
       rescue MsSamrUnknownError => e
         print_warning("Unable to delete the computer account, this will have to be done manually with an Administrator account (#{e.message})")
       end


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/20249.

The `cve_2022_26923_certifried` module needed to be updated to account for the datastore option name created in https://github.com/rapid7/metasploit-framework/pull/19606. The fix simply deregisters the new option names, which keeps the original behavior for this module and maintains consistency between the documentation and the datastore options.

Users can still use the `USERNAME`, `PASSWORD`, and `DOMAIN` options, which will be used for both SMB and LDAP authentication. This is possible because these options are declared as fallbacks for both protocols.

This also fixes an option key value when calling `#delete_account`, which is now different after the changes mentioned above.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use admin/dcerpc/cve_2022_26923_certifried`
- [x] `show options`
- [x] **verify** the `LDAPUsername`, `LDAPPassword` and `LDAPDomain` options are not there.
- [x] `run verbose=true rhosts=<remote host> username=<username> password=<password> domain=<domain> dc_name=<DC hostname> ca=<CA name>`
- [x] **Verify** it works as expected.
