### PR TITLE
Fix errant space in CVE number

### DIFF
--- a/modules/auxiliary/admin/networking/thinmanager_traversal_upload.rb
+++ b/modules/auxiliary/admin/networking/thinmanager_traversal_upload.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'License' => MSF_LICENSE,
         'References' => [
-          ['CVE', '2023-27855 '],
+          ['CVE', '2023-27855'],
           ['URL', 'https://www.tenable.com/security/research/tra-2023-13'],
           ['URL', 'https://rockwellautomation.custhelp.com/app/answers/answer_view/a_id/1138640']
         ],


### PR DESCRIPTION
Fixes an errant space that crept into a the CVE number for `thinmanager_traversal_upload`