### PR TITLE
Modules: Convert Privileged property to Boolean in several modules

### DIFF
--- a/modules/exploits/multi/http/uptime_file_upload_2.rb
+++ b/modules/exploits/multi/http/uptime_file_upload_2.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
        'Platform'       => ['php'],
        'Arch'           => ARCH_PHP,
        'Targets'        => [['Automatic', {}]],
-       'Privileged'     => 'true',
+       'Privileged'     => true,
        'DefaultTarget'  => 0,
        # The post2file.php vuln was reported in 2013 by Denis Andzakovic. And then on Aug 2015,
        # it was discovered again by Ewerson 'Crash' Guimaraes.

--- a/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
+++ b/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'License'        => MSF_LICENSE,
         'Platform'       => 'php',
-        'Privileged'     => 'true',
+        'Privileged'     => true,
         'DefaultOptions' =>
           {
             'SSL'     => true,


### PR DESCRIPTION
As best I can tell, using a string literal does not result in unexpected behavior, so long as the author intended the value to be `true`. The default value is `false`.

The specified value is used verbatim without validation, but I don't think it will cause an issue as it is never used as anything other than a Boolean.

Regardless, we should be consistent with other modules.
