### PR TITLE
Modules: Convert SSL default option to Boolean in several modules

### DIFF
--- a/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
+++ b/modules/auxiliary/admin/http/cisco_ssm_onprem_account.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2024-07-20',
         'DefaultOptions' => {
           'RPORT' => 8443,
-          'SSL' => 'True'
+          'SSL' => true
         },
         'License' => MSF_LICENSE,
         'Notes' => {

--- a/modules/auxiliary/admin/http/idsecure_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/idsecure_auth_bypass.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2023-11-27',
         'DefaultOptions' => {
           'RPORT' => 30443,
-          'SSL' => 'True'
+          'SSL' => true
         },
         'License' => MSF_LICENSE,
         'Notes' => {

--- a/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
+++ b/modules/auxiliary/admin/http/ivanti_vtm_admin.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2024-08-05',
         'DefaultOptions' => {
           'RPORT' => 9090,
-          'SSL' => 'True'
+          'SSL' => true
         },
         'License' => MSF_LICENSE,
         'Notes' => {

--- a/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
+++ b/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2024-08-29',
         'DefaultOptions' => {
           'RPORT' => 443,
-          'SSL' => 'True'
+          'SSL' => true
         },
         'License' => MSF_LICENSE,
         'Notes' => {

--- a/modules/auxiliary/admin/networking/thinmanager_traversal_delete.rb
+++ b/modules/auxiliary/admin/networking/thinmanager_traversal_delete.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2023-08-17',
         'DefaultOptions' => {
           'RPORT' => 2031,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/admin/networking/thinmanager_traversal_upload.rb
+++ b/modules/auxiliary/admin/networking/thinmanager_traversal_upload.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2023-04-05',
         'DefaultOptions' => {
           'RPORT' => 2031,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/admin/networking/thinmanager_traversal_upload2.rb
+++ b/modules/auxiliary/admin/networking/thinmanager_traversal_upload2.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2023-08-17',
         'DefaultOptions' => {
           'RPORT' => 2031,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/admin/scada/mypro_mgr_creds.rb
+++ b/modules/auxiliary/admin/scada/mypro_mgr_creds.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2025-02-13',
         'DefaultOptions' => {
           'RPORT' => 34022,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Platform' => 'win',
         'Arch' => [ ARCH_CMD ],

--- a/modules/auxiliary/gather/pacsserver_traversal.rb
+++ b/modules/auxiliary/gather/pacsserver_traversal.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2025-03-13',
         'DefaultOptions' => {
           'RPORT' => 3000,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2024-08-22',
         'DefaultOptions' => {
           'RPORT' => 8443,
-          'SSL' => 'True'
+          'SSL' => true
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/gather/thinmanager_traversal_download.rb
+++ b/modules/auxiliary/gather/thinmanager_traversal_download.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2023-04-05',
         'DefaultOptions' => {
           'RPORT' => 2031,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/gather/upsmon_traversal.rb
+++ b/modules/auxiliary/gather/upsmon_traversal.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2022-11-10',
         'DefaultOptions' => {
           'RPORT' => 8000,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/linux/http/cisco_firepower_useradd.rb
+++ b/modules/exploits/linux/http/cisco_firepower_useradd.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2016-10-10',
         'CmdStagerFlavor' => %w{echo},
         'DefaultOptions' => {
-          'SSL' => 'true',
+          'SSL' => true,
           'SSLVersion' => 'Auto',
           'RPORT' => 443
         },

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2024-10-09',
         'DefaultOptions' => {
           'RPORT' => 443,
-          'SSL' => 'True',
+          'SSL' => true,
           'FETCH_FILENAME' => Rex::Text.rand_text_alpha(1..3),
           'FETCH_WRITABLE_DIR' => '/tmp'
         },

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'RPORT' => '9191',
-          'SSL' => 'false'
+          'SSL' => false
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/windows/http/magicinfo_traversal.rb
+++ b/modules/exploits/windows/http/magicinfo_traversal.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2025-04-30',
         'DefaultOptions' => {
           'RPORT' => 7002,
-          'SSL' => 'True'
+          'SSL' => true
         },
         'Platform' => [ 'windows' ],
         'Arch' => [ ARCH_CMD ],

--- a/modules/exploits/windows/scada/mypro_mgr_cmd.rb
+++ b/modules/exploits/windows/scada/mypro_mgr_cmd.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2024-11-21',
         'DefaultOptions' => {
           'RPORT' => 34022,
-          'SSL' => 'False'
+          'SSL' => false
         },
         'Platform' => 'win',
         'Arch' => [ ARCH_CMD ],


### PR DESCRIPTION

A quick search through the library code reveals several instances (before I stopped looking) where using a string literal may result in unexpected behavior, as a value of `'False'` or `'false'` evaluates to `true`. I'm not sure if these code paths would be hit by the affected modules (because I didn't look); regardless, we should be consistent with other modules.

https://github.com/rapid7/metasploit-framework/blob/b6ed7f0970fc88d9e85ac48d0aec58c3f0321076/lib/msf/core/exploit/format/webarchive.rb#L331

https://github.com/rapid7/metasploit-framework/blob/b6ed7f0970fc88d9e85ac48d0aec58c3f0321076/lib/msf/core/exploit/remote/browser_autopwn2.rb#L554

https://github.com/rapid7/metasploit-framework/blob/b6ed7f0970fc88d9e85ac48d0aec58c3f0321076/lib/msf/core/exploit/remote/winrm.rb#L62-L63

```
irb(main):001> 'False' ? true : false
(irb):1: warning: string literal in condition
=> true
```

https://github.com/rapid7/metasploit-framework/blob/b6ed7f0970fc88d9e85ac48d0aec58c3f0321076/lib/msf/core/exploit/remote/http_server.rb#L440-L441

```
irb(main):001> !!'False'
=> true
```
