### PR TITLE
Modules: Convert DisableNops property to Boolean in several modules

### DIFF
--- a/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
+++ b/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x09\x0a\x0b\x0c\x0d\x20",
           'StackAdjustment' => -3500,
           'PrependEncoder' => "\x83\xec\x7f",
-          'DisableNops' => 'True'
+          'DisableNops' => true
         },
         'Platform' => 'bsd',
         'Arch' => ARCH_X86,

--- a/modules/exploits/mainframe/ftp/ftp_jcl_creds.rb
+++ b/modules/exploits/mainframe/ftp/ftp_jcl_creds.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false,
         'Targets' => [['Automatic', {}]],
         'DisclosureDate' => '2013-05-12',
-        'DisableNops' => 'true',
+        'DisableNops' => true,
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/exploits/multi/browser/msfd_rce_browser.rb
+++ b/modules/exploits/multi/browser/msfd_rce_browser.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space' => 8192,  # Arbitrary limit
-          'DisableNops' =>  'True',
+          'DisableNops' => true,
           'BadChars' => "\x22\x0a"
         },
       'DisclosureDate' => '2018-04-11',  # Vendor notification

--- a/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
+++ b/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 256,
           # NOTE: \xff's need to be doubled (per ftp/telnet stuff)
           'BadChars' => "\x00\x09\x0a\x0d\x20\x25\x2f",
-          'DisableNops'	=>  'True',
+          'DisableNops'	=> true,
           'StackAdjustment' 	=> -1500
         },
       'Platform'       => [ 'linux' ],

--- a/modules/exploits/windows/browser/orbit_connecting.rb
+++ b/modules/exploits/windows/browser/orbit_connecting.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'StackAdjustment' => -3500,
           'PrependEncoder'  => "\x81\xc4\x54\xf2\xff\xff",
           'EncoderType'   => Msf::Encoder::Type::AlphanumMixed,
-          'DisableNops'  =>  'True',
+          'DisableNops'  => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/acdsee_xpm.rb
+++ b/modules/exploits/windows/fileformat/acdsee_xpm.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'   =>  'True',
+          'DisableNops'   => true,
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/apple_quicktime_pnsize.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_pnsize.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'          => 750,
           'BadChars'       => "",  #Memcpy
           'EncoderType'    => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'    =>  'True',
+          'DisableNops'    => true,
           'PrependEncoder' => "\xeb\x03\x59\xeb\x05\xe8\xf8\xff\xff\xff",
           'EncoderOptions' =>
             {

--- a/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
+++ b/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'   =>  'True',
+          'DisableNops'   => true,
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Space' => 0x1000,
           'BadChars' => "\x00\x0d\x0a\x1a\x2c\x2e\x3a\x5c", # \x00\r\n\x1a,.:\\
-          'DisableNops' => 'True',
+          'DisableNops' => true,
           'StackAdjustment' => -3500,
         },
       'Platform'		=> 'win',

--- a/modules/exploits/windows/fileformat/csound_getnum_bof.rb
+++ b/modules/exploits/windows/fileformat/csound_getnum_bof.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space' => 650,
           'BadChars' => "\x00\x0a\x1a\x2c\xff",
           'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff", # Stack adjustment # add esp, -3500
-          'DisableNops' => 'True'
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets' =>

--- a/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
+++ b/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Space' => 4720,
           'BadChars' => "\x00\x20\x0a\x0d",
-          'DisableNops' => 'True',
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets' =>

--- a/modules/exploits/windows/fileformat/fdm_torrent.rb
+++ b/modules/exploits/windows/fileformat/fdm_torrent.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'    => 1024,
-          'DisableNops'   =>  'True',
+          'DisableNops' => true,
           'BadChars' => "\x00\x2c\x5c",
           'StackAdjustment' => -3500,
         },

--- a/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
+++ b/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'BadChars' => "\x00\x0a\x0d\x20",
           'StackAdjustment' => -3500,
-          'DisableNops' => 'True',
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/ht_mp3player_ht3_bof.rb
+++ b/modules/exploits/windows/fileformat/ht_mp3player_ht3_bof.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'    => 4108,
-          'DisableNops'   	=>  'True',
+          'DisableNops' => true,
           # input restriction: UTF-8!
           'BadChars' 			=> [0,0x0a,0x0d,*(0x80..0xcf)].pack("C*"),
           'EncoderType' 		=> Msf::Encoder::Type::AlphanumMixed,

--- a/modules/exploits/windows/fileformat/magix_musikmaker_16_mmm.rb
+++ b/modules/exploits/windows/fileformat/magix_musikmaker_16_mmm.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'       => 8000,  #could be more, but this is enough
-          'DisableNops' =>  'True',
+          'DisableNops' => true,
           'BadChars'    => "\x00\x0a\x0d",
         },
       'Platform' => 'win',

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Space' => 1500,
           'BadChars' => "\x00\x09\x0a",
-          'DisableNops' => 'True',
+          'DisableNops' => true,
           'StackAdjustment' => -3500,
           'PrependEncoder' => "\xeb\x03\x59\xeb\x05\xe8\xf8\xff\xff\xff",
           'EncoderType' => Msf::Encoder::Type::AlphanumUpper,

--- a/modules/exploits/windows/fileformat/mjm_coreplayer2011_s3m.rb
+++ b/modules/exploits/windows/fileformat/mjm_coreplayer2011_s3m.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'       => 2339,  #about 0x900 bytes
-          'DisableNops' => 'True',
+          'DisableNops' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/mjm_quickplayer_s3m.rb
+++ b/modules/exploits/windows/fileformat/mjm_quickplayer_s3m.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'       => 2339,  #about 0x900 bytes
-          'DisableNops' => 'True',
+          'DisableNops' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
+++ b/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 650,
           'BadChars' => "\x00\x0a\x0d\x20",
           'StackAdjustment' => -3500,
-          'DisableNops'   =>  'True',
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
+++ b/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'StackAdjustment' => -3500,
           'PrependEncoder' => "\x81\xc4\xff\xef\xff\xff\x44",
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'   =>  'True',
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/videospirit_visprj.rb
+++ b/modules/exploits/windows/fileformat/videospirit_visprj.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Space'        => 800,  #0x320 bytes - avoid marking wrong page as RWX
           'BadChars'     => "\x00\x0a\x0b\x0c\x0d\x0e\x0f\x1a\x1b\x1c\x1d\x1e\x1f\x21\x22\x26\x27\x2f\x3c\x3e",
-          'DisableNops'  => 'True',
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets'  =>

--- a/modules/exploits/windows/fileformat/vuplayer_cue.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_cue.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 750,
           'BadChars' => "\x00",
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'  =>  'True',
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/vuplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_m3u.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 750,
           'BadChars' => "\x00",
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'  =>  'True',
+          'DisableNops' => true
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
+++ b/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'BadChars'    => "\xff",
           'Space'       => 600,
-          'DisableNops' => 'True',
+          'DisableNops' => true,
           'PrependEncoder' => "\x81\xec\xc8\x00\x00\x00" # sub esp,200
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'       => 936,
-          'DisableNops' => 'True',
+          'DisableNops' => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
+++ b/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'            => 1000,
           'BadChars'         => "\x00\x0a\x0d",
           'StackAdjustment'  => -3500,
-          'DisableNops'      => 'True'
+          'DisableNops'      => true
         },
       'Targets'       =>
         [

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           # format string max length
           'Space'    => 1024,
           'BadChars' => "\x00\x0a\x0d\x25",
-          'DisableNops'	=>  'True',
+          'DisableNops'	=> true,
           'StackAdjustment' 	=> -1500
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/ftp/seagull_list_reply.rb
+++ b/modules/exploits/windows/ftp/seagull_list_reply.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'BadChars' => "\x00",
           'StackAdjustment' => -1500,
-          'DisableNops' => 'True',
+          'DisableNops' => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
           # format string max length
           'Space'    => 1024,
           'BadChars' => "\x00\x08\x0a\x0d\x2c\xff",
-          'DisableNops'	=>  'True'
+          'DisableNops'	=> true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
+++ b/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
           #'Space'			=> 600,
           'BadChars' 		=> "\x00\x0a\x0d\x20%=?\x2f\x5c\x3a\x3d\@;!$",
           'EncoderType'		=> Msf::Encoder::Type::AlphanumMixed,
-          'DisableNops'  		=>  'True',
+          'DisableNops'  		=> true,
           'StackAdjustment' 	=> -3500,
         },
       'Platform' => ['win'],

--- a/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
+++ b/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x0d\x20",
           'EncoderType' => Msf::Encoder::Type::AlphanumUpper,
           'StackAdjustment' => -3500,
-          'DisableNops'  =>  'True',
+          'DisableNops'  => true,
         },
       'Targets'        =>
         [

--- a/modules/exploits/windows/http/badblue_passthru.rb
+++ b/modules/exploits/windows/http/badblue_passthru.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x0b\x0d\x20\x23\x25\x26\x2b\x2f\x3a\x3c\x3d\x3f\x5c",
           'StackAdjustment' => -3500,
           #'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'	=>  'True',
+          'DisableNops'	=> true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/belkin_bulldog.rb
+++ b/modules/exploits/windows/http/belkin_bulldog.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'  =>  'True',
+          'DisableNops'  => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 750,
           'BadChars' => "\x00",
           'PrependEncoder' => "\xeb\x03\x59\xeb\x05\xe8\xf8\xff\xff\xff",
-          'DisableNops' => 'True',
+          'DisableNops' => true,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
           'EncoderOptions' =>
             {

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 750,
           'BadChars' => "\x00",
           'PrependEncoder' => "\xeb\x03\x59\xeb\x05\xe8\xf8\xff\xff\xff",
-          'DisableNops' => 'True',
+          'DisableNops' => true,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
           'EncoderOptions' =>
             {

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 750,
           'BadChars' => "\x00",
           'PrependEncoder' => "\xeb\x03\x59\xeb\x05\xe8\xf8\xff\xff\xff",
-          'DisableNops' => 'True',
+          'DisableNops' => true,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
           'EncoderOptions' =>
             {

--- a/modules/exploits/windows/http/httpdx_handlepeer.rb
+++ b/modules/exploits/windows/http/httpdx_handlepeer.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
           # other characters get mangled, but only in a temporary buffer
           'BadChars' => "\x00\x0a\x0d\x20\x25\x2e\x2f\x3f\x5c",
           'StackAdjustment' => -3500,
-          # 'DisableNops'	=>  'True'
+          # 'DisableNops'	=> true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/http/httpdx_tolog_format.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           # format string max length
           'Space'    => 1024,
           'BadChars' => "\x00\x0a\x0d\x25\x2f\x3f\x5c",
-          'DisableNops'	=>  'True',
+          'DisableNops'	=> true,
           'StackAdjustment' 	=> -1500
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/http/steamcast_useragent.rb
+++ b/modules/exploits/windows/http/steamcast_useragent.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
           'StackAdjustment' => -3500,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'  =>  'True',
+          'DisableNops'  => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'          => 2000,
           'BadChars'       => "\x00",
           'EncoderType'    => Msf::Encoder::Type::AlphanumUnicodeMixed,
-          'DisableNops'    =>  'True',
+          'DisableNops'    => true,
           'EncoderOptions' =>
             {
               'BufferRegister' => 'ESI',

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Payload' => {
         'Space' => 4500,
-        'DisableNops' => 'True',
+        'DisableNops' => true,
       },
       'Platform' => 'win',
       'DisclosureDate' => 'Aug 05 2011',

--- a/modules/exploits/windows/misc/bigant_server.rb
+++ b/modules/exploits/windows/misc/bigant_server.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x20\x0a\x0d",
           'StackAdjustment' => -3500,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'  =>  'True',
+          'DisableNops' => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/bigant_server_250.rb
+++ b/modules/exploits/windows/misc/bigant_server_250.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x20\x0a\x0d",
           'StackAdjustment' => -3500,
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'  =>  'True',
+          'DisableNops'  => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/nettransport.rb
+++ b/modules/exploits/windows/misc/nettransport.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space'    => 5000,
           'BadChars' => "\x00\x20\x0a\x0d",
           'StackAdjustment' => -3500,
-          'DisableNops'     =>  'True'
+          'DisableNops'     => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/poppeeper_date.rb
+++ b/modules/exploits/windows/misc/poppeeper_date.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x20\x0d",
           'StackAdjustment'  => -3500,
           'EncoderType' => Msf::Encoder::Type::AlphanumMixed,
-          'DisableNops' => 'True',
+          'DisableNops' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/poppeeper_uidl.rb
+++ b/modules/exploits/windows/misc/poppeeper_uidl.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x20\x0d",
           'StackAdjustment'  => -3500,
           'EncoderType' => Msf::Encoder::Type::AlphanumMixed,
-          'DisableNops' => 'True',
+          'DisableNops' => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/talkative_response.rb
+++ b/modules/exploits/windows/misc/talkative_response.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x20\x0d",
           'StackAdjustment'  => -3500,
           'EncoderType' => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops' => 'True',
+          'DisableNops' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'       => 936,
-          'DisableNops' => 'True',
+          'DisableNops' => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/novell/groupwisemessenger_client.rb
+++ b/modules/exploits/windows/novell/groupwisemessenger_client.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Space'    => 750,
           'BadChars' => "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
-          'DisableNops'   =>  'True',
+          'DisableNops' => true,
           'StackAdjustment' => -3500,
           'PrependEncoder' => "\x81\xc4\xff\xef\xff\xff\x44",
           'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,

--- a/modules/exploits/windows/scada/sunway_force_control_netdbsrv.rb
+++ b/modules/exploits/windows/scada/sunway_force_control_netdbsrv.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'Payload'        =>
         {
-          'DisableNops' => 'true',
+          'DisableNops' => true,
           'BadChars' => "\x0a\x0d\xae",
         },
       'Platform'       => 'win',


### PR DESCRIPTION
As best I can tell, using a string literal does not result in unexpected behavior, so long as the author intended the value to be `true`. The default value is `false`.

The specified value is used verbatim without validation, but I don't think it will cause an issue as it is never used as anything other than a Boolean.

Regardless, we should be consistent with other modules.