### PR TITLE
Fix a regression in Windows version fingerprinting

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -327,7 +327,7 @@ class MetasploitModule < Msf::Auxiliary
             port: rport,
             proto: 'tcp',
             ntype: 'fingerprint.match',
-            data: { :finger_print => nd_fingerprint_match }
+            data: nd_fingerprint_match
           )
         elsif smb1_fingerprint['native_os'] || smb1_fingerprint['native_lm']
           desc = "#{smb1_fingerprint['native_os']} (#{smb1_fingerprint['native_lm']})"
@@ -352,7 +352,7 @@ class MetasploitModule < Msf::Auxiliary
           port: rport,
           proto: 'tcp',
           ntype: 'smb.fingerprint',
-          data: { :finger_print => nd_smb_fingerprint }
+          data: nd_smb_fingerprint
         )
 
         disconnect


### PR DESCRIPTION
This fixes a regression in the Windows version fingerprinting offered by the `smb_version` module. The root of the issue was that `nd_smb_fingerprint` value was already a hash so it's not necessary to wrap it again.

In particular it impacted the normalization logic here:

https://github.com/rapid7/metasploit_data_models/blob/ac923620ef8df85c0b7b456dd907323b792fed65/lib/mdm/host/operating_system_normalization.rb

As the note had an extra hash present:

> #<Mdm::Note id: 17, created_at: "2025-06-10 23:18:57.286081000 +0000", ntype: "fingerprint.match", workspace_id: 7, service_id: 34, host_id: 3, updated_at: "2025-06-10 23:18:57.286081000 +0000", critical: nil, seen: nil, data: {:finger_print=>{"os.edition"=>"Standard", "os.version"=>"Service Pack 1", "os.build"=>"7601", "host.name"=>"METASPLOITABLE3"}}, vuln_id: nil>, #<Mdm::Note id: 18, created_at: "2025-06-10 23:18:57.355683000 +0000", ntype: "smb.fingerprint", workspace_id: 7, service_id: 34, host_id: 3, updated_at: "2025-06-10 23:18:57.355683000 +0000", critical: nil, seen: nil, data: {:finger_print=>{:native_os=>"Windows Server 2008 R2 Standard 7601 Service Pack 1", :native_lm=>"Windows Server 2008 R2 Standard 6.1", :os_edition=>"Standard", :os_sp=>"Service Pack 1", :os_build=>"7601", :SMBName=>"METASPLOITABLE3"}}, vuln_id: nil>]>

Which led to Mdm::Host instances not having their os set correctly:

> [+] #<Mdm::Host id: 3, created_at: "2025-06-10 23:18:08.123587000 +0000", address: #<IPAddr: IPv4:10.20.36.244/255.255.255.255>, mac: "00:50:56:94:b4:f0", comm: "", name: "METASPLOITABLE3", state: "alive", os_name: "Windows 7", os_flavor: nil, os_sp: "SP1", os_lang: nil, arch: "x86_64", workspace_id: 7, updated_at: "2025-06-10 23:19:18.120090000 +0000", purpose: "client", info: nil, comments: nil, scope: nil, virtual_host: "VMWare", note_count: 6, vuln_count: 2, service_count: 28, host_detail_count: 0, exploit_attempt_count: 4, cred_count: 0, history_count: 0, detected_arch: nil, os_family: "Windows">
