### PR TITLE
Enable defer module loads by default

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -59,8 +59,8 @@ module Msf
         name: DEFER_MODULE_LOADS,
         description: 'When enabled will not eagerly load all modules',
         requires_restart: true,
-        default_value: false,
-        developer_notes: 'Needs a final round of testing. Can be enabled after 6.4.0 is released.'
+        default_value: true,
+        developer_notes: 'Enabled in Metasploit 6.4.x'
       }.freeze,
       {
         name: SMB_SESSION_TYPE,


### PR DESCRIPTION
Enables the defer module loads feature by default

# Testing steps
- [ ] Boot up msfconsole
- [ ] run `features`
- [ ] You should see `4   defer_module_loads           true     When enabled will not eagerly load all modules` indicating the feature is enabled
