### PR TITLE
Rubocop: Disable Style/FormatStringToken

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,6 +113,12 @@ Style/DocumentDynamicEvalDefinition:
 Style/EndlessMethod:
   Enabled: true
 
+Style/FormatStringToken:
+  Enabled: true
+  Exclude:
+  # We aren't ready to enable this for modules yet
+    - 'modules/**/*'
+
 Style/HashExcept:
   Enabled: true
 


### PR DESCRIPTION
This PR disables the [Style/FormatStringToken](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FormatStringToken) rule.

This rule is used to enforce annotated strings used with `format()` (or `sprintf()`).

`format()` (and `sprintf()`) are used when the format of the string is important for readability (or when the author was not familiar with Ruby's string interpolation), or to cast data to a specific format (ie, Integer to hex).

In practice, once annotated, the strings become more difficult to read than the original (and often more difficult to read than an interpolated string). For example:

```ruby
value = 123

# Before (violation)
puts format("Value: %d", value)

# After (fixed)
puts format("Value: %<value>d", value: value)

# Alternatively using interpolation without format():
puts "Value: #{value}"
```

But more importantly, *`Style/FormatStringToken` violations cannot be autocorrected*. Attempting to manually resolve these violations is error-prone and burdens both the person fixing the violations and the PR reviewer.

In the long term, we should turn this back on and replace many of these violations with string interpolation.
