### PR TITLE
Remove warnings on bootup caused by psych 5.2.6

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -142,7 +142,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           working-directory: metasploit-framework
-          cache-version: 5
+          cache-version: 6
 
       - name: Acceptance
         env:
@@ -197,7 +197,7 @@ jobs:
           # use the default version from the .ruby-version file
           ruby-version: '.ruby-version'
           bundler-cache: true
-          cache-version: 4
+          cache-version: 6
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
           working-directory: docs
 
       - name: build

--- a/.github/workflows/ldap_acceptance.yml
+++ b/.github/workflows/ldap_acceptance.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
 
       - name: acceptance
         env:
@@ -141,7 +142,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
-          cache-version: 4
+          cache-version: 6
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
 
       - name: Run msftidy
         run: |

--- a/.github/workflows/mssql_acceptance.yml
+++ b/.github/workflows/mssql_acceptance.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
 
       - name: Extract runtime version
         run: |
@@ -156,7 +157,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
-          cache-version: 4
+          cache-version: 6
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/mysql_acceptance.yml
+++ b/.github/workflows/mysql_acceptance.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
 
       - name: Extract runtime version
         run: |
@@ -155,7 +156,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
-          cache-version: 4
+          cache-version: 6
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/postgres_acceptance.yml
+++ b/.github/workflows/postgres_acceptance.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
 
       - name: Extract runtime version
         run: |
@@ -159,7 +160,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
-          cache-version: 4
+          cache-version: 6
 
       - uses: actions/download-artifact@v4
         id: download

--- a/.github/workflows/shared_gem_verify.yml
+++ b/.github/workflows/shared_gem_verify.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: 6
 
       - name: Test
         run: ${{ inputs.test_commands }}

--- a/.github/workflows/shared_gem_verify_rails.yml
+++ b/.github/workflows/shared_gem_verify_rails.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: 6
 
       - name: Update Rails version
         run: |

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          cache-version: 5
+          cache-version: 6
           working-directory: metasploit-framework
 
       - name: Move mettle gem into framework
@@ -373,7 +373,7 @@ jobs:
         with:
           ruby-version: '3.3'
           bundler-cache: true
-          cache-version: 5
+          cache-version: 6
 
       - uses: actions/download-artifact@v4
         id: raw_report_data

--- a/.github/workflows/shared_smb_acceptance.yml
+++ b/.github/workflows/shared_smb_acceptance.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
           working-directory: 'metasploit-framework'
 
       - name: Copy ruby_smb gem into metasploit-framework
@@ -161,7 +162,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
-          cache-version: 4
+          cache-version: 6
           working-directory: metasploit-framework
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
 
       - name: Create database
         run: |

--- a/.github/workflows/weekly-data-and-external-tool-updater.yml
+++ b/.github/workflows/weekly-data-and-external-tool-updater.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ruby-version: '${{ matrix.ruby }}'
           bundler-cache: true
+          cache-version: 6
 
       - name: Run Ruby updater scripts
         run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ PATH
       pcaprub
       pdf-reader
       pg
+      psych (= 5.0.1)
       puma
       railties
       rasn1 (= 0.14.0)
@@ -412,8 +413,7 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    psych (5.2.6)
-      date
+    psych (5.0.1)
       stringio
     public_suffix (6.0.1)
     puma (6.6.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -254,6 +254,9 @@ Gem::Specification.new do |spec|
   # Needed to parse sections of ELF files in order to retrieve symbols
   spec.add_runtime_dependency 'elftools'
 
+  # Pinning Psych to 5.0.1 to avoid warnings on msfconsole bootup, can be removed when we move to Ruby 3.4
+  spec.add_runtime_dependency 'psych', '5.0.1'
+
   # Standard libraries: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
   %w[
     abbrev


### PR DESCRIPTION
Pin the psych version number to `5.0.1` to remove this warnign when booting up framework

```
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      stringio (>= 0)
      Available/installed versions of this gem:
      - 3.1.7
      - 3.0.4
```
Extra context: https://github.com/rubygems/rubygems/issues/7657#issuecomment-2521083323

# Testing
- [ ] Boot up framework
- [ ] The warning is no longer there
- [ ] If the warning persists run `gem uninstall psych` and try again
