### PR TITLE
Add total number of currently defined aliases

### DIFF
--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -54,7 +54,9 @@ module Msf
             @aliases.each_pair do |key, val|
               tbl << ['alias', key, val]
             end
+            print_status("Total aliases: #{@aliases.length}")
             return print(tbl.to_s)
+
           end
         when 1 # display the alias if one matches this name (or help)
           return cmd_alias_help if (args[0] == '-h') || (args[0] == '--help')


### PR DESCRIPTION
## What this change does

This change enhances the `alias` command in the `alias` plugin by displaying the **total number of currently defined aliases** when listing them. This provides users with immediate feedback on how many aliases exist, improving overall usability and clarity during interactive sessions.

## Fixes

N/A – This is a minor usability enhancement and does not correspond to a specific GitHub issue.

## Verification

To verify this change:

- [ ] Start `msfconsole`
- [ ] Run the `alias` command without arguments
- [ ] **Verify** that existing aliases are listed correctly in a table format
- [ ] **Verify** that an additional line is printed showing the total number of defined aliases, e.g.:

[*] Total aliases: 3


## Demonstration

You can test this by adding a few aliases:

```bash
alias foo use exploit/windows/smb/ms08_067_netapi
alias bar sessions -i
alias
```

You should see a table of aliases followed by:
[*] Total aliases: 2
