### PR TITLE
Update module counter

### DIFF
--- a/tools/modules/module_commits.rb
+++ b/tools/modules/module_commits.rb
@@ -21,9 +21,11 @@ class CommitHistory < Struct.new(:fname, :total, :authors)
 end
 
 msfbase = __FILE__
+
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
+msfbase = File.expand_path(File.join(File.dirname(msfbase), '..', '..'))
 
 dir = ARGV[0] || File.join(msfbase, "modules", "exploits")
 raise ArgumentError, "Need a filename or directory" unless (dir and File.readable? dir)

--- a/tools/modules/module_commits.rb
+++ b/tools/modules/module_commits.rb
@@ -59,7 +59,8 @@ end
 @module_stats = []
 
 Find.find(dir) do |fname|
-  next unless fname =~ /rb$/
+  next unless fname =~ /\.(rb|py)$/ # be either ruby or python
+  next unless File.file?(fname) && File.readable?(fname)
   @module_stats << check_commit_history(fname)
 end
 


### PR DESCRIPTION
This slightly udpates the module commit counter. It's still slow as heck but now:

* Is slightly more comprehensive because now it checks for those heretical python modules
* Picks a default directory that actually works

## Verification

- [ ] Start a shell whereever you have Metasploit Framework
- [ ] `cd tools/modules`
- [ ] `ruby module_commits.rb | tee msf_count.txt`
- [ ]  Get a healthy snack
- [ ] **Verify** that the module counter eventually finishes and tells you that psexec is wildly popular among the Metasploit development community with 150 commits, followed by MS17-010, followed by MS08-067. Very insightful.
- [ ] **Write** a blog post about the stunning insights you've uncovered about how popular these particular modules are. (optional)

## Behold

```text
➜  modules git:(update-module-counter) ✗ ruby module_commits.rb | tee msf-counts.txt                  
Commits for /Users/todbeardsley/git/metasploit-framework/modules/exploits/aix/local/ibstat_path.rb 21
------------------------------------------------------------------------
Sagi Shahar                 6
g0tmi1k                     3
bcook-r7                    3
William Vu                  2
FireFart                    2
mercd                       1
Tab Assassin                1
wchen-r7                    1
adfoster-r7                 1
bcoles                      1
Commits for /Users/todbeardsley/git/metasploit-framework/modules/exploits/aix/local/invscout_rpm_priv_esc.rb 2
------------------------------------------------------------------------
bcoles                      1
cgranleese-r7               1
Commits for /Users/todbeardsley/git/metasploit-framework/modules/exploits/aix/local/xorg_x11_server.rb 11
------------------------------------------------------------------------
Zack Flack                  5
dzflack                     2
bwatters-r7                 1
adfoster-r7                 1
dwelch-r7                   1
bcoles                      1
Commits for /Users/todbeardsley/git/metasploit-framework/modules/exploits/aix/rpc_cmsd_opcode21.rb 37
------------------------------------------------------------------------
jduck                      11
hdm                         5
bcook-r7                    4
FireFart                    4
Tab Assassin                2
g0tmi1k                     2
todb-r7                     2
William Vu                  1
dm-ct                       1
adfoster-r7                 1
juanvazquez                 1
bcoles                      1
wchen-r7                    1
jhart-r7                    1
```

etc. Eventually you get a final count at the end. It takes... a while.
