### PR TITLE
Rubocop: Lint/DetectMetadataTrailingLeadingWhitespace: Except BadChars

### DIFF
--- a/lib/rubocop/cop/lint/detect_metadata_trailing_leading_whitespace.rb
+++ b/lib/rubocop/cop/lint/detect_metadata_trailing_leading_whitespace.rb
@@ -20,7 +20,7 @@ module RuboCop
       class DetectMetadataTrailingLeadingWhitespace < Base
         extend AutoCorrector
         MSG = 'Metadata key or value has leading or trailing whitespace.'
-        EXEMPT_KEYS = %w[Description Payload].freeze
+        EXEMPT_KEYS = %w[Description Payload BadChars].freeze
 
         # Called for every method definition node
         # Only processes the initialize method


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/pull/20315#issuecomment-2993531643