### PR TITLE
opentsdb_key_cmd_injection: Set Arch to ARCH_CMD

### DIFF
--- a/modules/exploits/linux/http/opentsdb_key_cmd_injection.rb
+++ b/modules/exploits/linux/http/opentsdb_key_cmd_injection.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2023-25826'] # CVE that seems to be a dupe of CVE-2023-36812 since it describes the same issue and references the PR that introduces the commits that are referenced in CVE-2023-36812
         ],
         'Platform' => 'linux',
-        'Arch' => 'ARCH_CMD',
+        'Arch' => ARCH_CMD,
         'DefaultOptions' => {
           'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
           'RPORT' => 4242,


### PR DESCRIPTION
Specify the correct architecture `ARCH_CMD` in `exploit/linux/http/opentsdb_key_cmd_injection`. This fixes a bug where users were unable to specify a `payload` when using this module.
