### PR TITLE
Use the smaller base64 encoder

### DIFF
--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -51,6 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'php',
               'Arch' => ARCH_PHP,
               'Payload' => {
+                'Encoder' => 'php/base64',
                 'PrependEncoder' => 'php -r "',
                 'AppendEncoder' => '"'
               }
@@ -310,7 +311,7 @@ class MetasploitModule < Msf::Exploit::Remote
       allow_retry: false
     )
     Rex.sleep(1)
-    return session_created? ? true : nil
+    return session_created? || nil
   end
 
   def send_backdoor_cleanup


### PR DESCRIPTION
This fixes the php_fpm_rce module which stopped working against the docker target from the original PR (#12863) when #19420 was landed. #19420 added a new encoder that increases the size of the payload more than the older base64 one. Now the `php_fpm_rce` module can't exactly have a spare requirement because it depends on the target, so in this case it makes more sense to just prefer the older encoder that yields smaller payloads.

Fixes #20310, supersedes #20311.

## Testing

- [ ] Setup the docker target (see #12863, the steps still work)
- [ ] Run the exploit and see it work, previously it would fail with a QSL size error