### PR TITLE
Adds sentinel notes to modules that are missing stability, reliability or side effects

### DIFF
--- a/modules/auxiliary/gather/pimcore_creds_sqli.rb
+++ b/modules/auxiliary/gather/pimcore_creds_sqli.rb
@@ -35,7 +35,9 @@ class MetasploitModule < Msf::Auxiliary
           [ 'EDB', '45208' ]
         ],
         'Notes' => {
-          'SideEffects' => [ IOC_IN_LOGS ]
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY
         },
         'DisclosureDate' => '2018-08-13'
       )

--- a/modules/auxiliary/gather/rails_doubletap_file_read.rb
+++ b/modules/auxiliary/gather/rails_doubletap_file_read.rb
@@ -29,7 +29,10 @@ class MetasploitModule < Msf::Auxiliary
           [ 'EDB', '46585' ]
         ],
         'Notes' => {
-          'AKA' => ['DoubleTap']
+          'AKA' => ['DoubleTap'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -42,7 +42,12 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DisclosureDate' => '2014-09-24',
         'License' => MSF_LICENSE,
-        'Notes' => { 'AKA' => ['Shellshock'] }
+        'Notes' => {
+          'AKA' => ['Shellshock'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+        }
       )
     )
 

--- a/modules/auxiliary/scanner/http/apache_optionsbleed.rb
+++ b/modules/auxiliary/scanner/http/apache_optionsbleed.rb
@@ -31,7 +31,10 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2017-09-18',
         'License' => MSF_LICENSE,
         'Notes' => {
-          'AKA' => ['Optionsbleed']
+          'AKA' => ['Optionsbleed'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
+++ b/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
@@ -33,7 +33,10 @@ class MetasploitModule < Msf::Auxiliary
         'DisclosureDate' => '2019-12-17',
         'License' => MSF_LICENSE,
         'Notes' => {
-          'AKA' => ['Shitrix']
+          'AKA' => ['Shitrix'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/auxiliary/scanner/ike/cisco_ike_benigncertain.rb
+++ b/modules/auxiliary/scanner/ike/cisco_ike_benigncertain.rb
@@ -36,7 +36,10 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://musalbas.com/2016/08/18/equation-group-benigncertain.html' ]
         ],
         'Notes' => {
-          'AKA' => ['BENIGNCERTAIN']
+          'AKA' => ['BENIGNCERTAIN'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DisclosureDate' => '2016-09-29'
       )

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -39,7 +39,9 @@ class MetasploitModule < Msf::Auxiliary
         'DefaultAction' => 'Scan',
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],
-          'AKA' => ['BlueKeep']
+          'AKA' => ['BlueKeep'],
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -50,7 +50,10 @@ class MetasploitModule < Msf::Auxiliary
           'AKA' => [
             'DOUBLEPULSAR',
             'ETERNALBLUE'
-          ]
+          ],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/auxiliary/scanner/vxworks/urgent11_check.rb
+++ b/modules/auxiliary/scanner/vxworks/urgent11_check.rb
@@ -29,7 +29,11 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DisclosureDate' => '2019-08-09', # NVD entry publication
         'License' => MSF_LICENSE,
-        'Notes' => { 'Stability' => [CRASH_SAFE] }
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+        }
       )
     )
 

--- a/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
+++ b/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
@@ -266,6 +266,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_DOWN, ],
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         },
         'Compat' => {
           'Meterpreter' => {

--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -70,7 +70,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'AKA' => ['chocobo_root.c'],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_OS_DOWN ]
+          'Stability' => [ CRASH_OS_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -70,6 +70,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_OS_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -64,7 +64,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'AKA' => ['unsanitary.sh'],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0,
         'Compat' => {

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -69,7 +69,10 @@ class MetasploitModule < Msf::Exploit::Local
                    [
                      'double-fdput',
                      'doubleput.c'
-                   ]
+                   ],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 1,
         'Compat' => {

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -87,7 +87,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'AKA' => ['get-rekt-linux-hardened.c', 'upstream44.c'],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_OS_DOWN ]
+          'Stability' => [ CRASH_OS_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
+++ b/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
@@ -40,7 +40,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' => [['Auto', {}]],
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -57,7 +57,10 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultTarget' => 0,
         'Notes' => {
-          'AKA' => ['RationalLove.c']
+          'AKA' => ['RationalLove.c'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'Compat' => {
           'Meterpreter' => {

--- a/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
@@ -65,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -73,7 +73,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'AKA' => ['subuid_shell.c'],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0,
         'Compat' => {

--- a/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
+++ b/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
@@ -55,6 +55,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'Reliability' => [ UNRELIABLE_SESSION ],
           'Stability' => [ CRASH_OS_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -58,7 +58,8 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DisclosureDate' => '2019-07-04'
       )

--- a/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
@@ -72,6 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_OS_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
+++ b/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
@@ -41,7 +41,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' => [['Auto', {}]],
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -67,7 +67,8 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0,
         'Compat' => {

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -69,6 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_OS_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         },
         'DefaultTarget' => 0
       )

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged' => true,
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 1
       )

--- a/modules/exploits/linux/smtp/exim_gethostbyname_bof.rb
+++ b/modules/exploits/linux/smtp/exim_gethostbyname_bof.rb
@@ -41,7 +41,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops' => true,
           'ActiveTimeout' => 24 * 60 * 60 # we may need more than 150 s to execute our bind-shell
         },
-        'Notes' => { 'AKA' => ['ghost'] },
+        'Notes' => {
+          'AKA' => ['ghost'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+        },
         'Targets' => [['Automatic', {}]],
         'DefaultTarget' => 0
       )

--- a/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
@@ -91,7 +91,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2015-07-06',
         'DefaultTarget' => 0,
         'Notes' => {
-          'AKA' => ['0DayFlush']
+          'AKA' => ['0DayFlush'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/exploits/multi/http/rails_double_tap.rb
+++ b/modules/exploits/multi/http/rails_double_tap.rb
@@ -46,7 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'AKA' => [ 'doubletap' ],
           'Stability' => [ CRASH_SAFE ],
-          'SideEffects' => [ IOC_IN_LOGS ]
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => UNKNOWN_RELIABILITY
         },
         'Privileged' => false,
         'DisclosureDate' => '2019-03-13',

--- a/modules/exploits/osx/local/vmware_bash_function_root.rb
+++ b/modules/exploits/osx/local/vmware_bash_function_root.rb
@@ -49,7 +49,10 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget' => 0,
         'DisclosureDate' => '2014-09-24',
         'Notes' => {
-          'AKA' => ['Shellshock']
+          'AKA' => ['Shellshock'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/exploits/osx/samba/trans2open.rb
+++ b/modules/exploits/osx/samba/trans2open.rb
@@ -35,7 +35,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'osx',
         'Arch' => ARCH_PPC,
         'Notes' => {
-          'AKA' => ['ECHOWRECKER']
+          'AKA' => ['ECHOWRECKER'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'Targets' => [
           [

--- a/modules/exploits/unix/http/lifesize_room.rb
+++ b/modules/exploits/unix/http/lifesize_room.rb
@@ -46,6 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
           'Reliability' => [ REPEATABLE_SESSION, ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         }
       )
     )

--- a/modules/exploits/windows/fileformat/blazedvd_plf.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_plf.rb
@@ -70,6 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_DOWN, ],
           'SideEffects' => [ SCREEN_EFFECTS, ],
+          'Reliability' => UNKNOWN_RELIABILITY,
         }
       )
     )

--- a/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
+++ b/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
@@ -61,6 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2017-06-13',
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_RESTARTS, ],
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         }
       )
     )

--- a/modules/exploits/windows/fileformat/ms14_017_rtf.rb
+++ b/modules/exploits/windows/fileformat/ms14_017_rtf.rb
@@ -52,6 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_DOWN, ],
           'SideEffects' => [ SCREEN_EFFECTS, ],
+          'Reliability' => UNKNOWN_RELIABILITY,
         }
       )
     )

--- a/modules/exploits/windows/ftp/sami_ftpd_user.rb
+++ b/modules/exploits/windows/ftp/sami_ftpd_user.rb
@@ -74,7 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Sami FTP Server version 2.0.2', { 'Ret' => 0x10022ADE }], # p/p/r tmp01.dll
         ],
         'Notes' => {
-          'Stability' => [ CRASH_SERVICE_DOWN ]
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DisclosureDate' => '2006-01-24'
       )

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -70,7 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'AKA' => ['EXPLODINGCAN'],
           'Stability' => [CRASH_SERVICE_DOWN],
           'Reliability' => [REPEATABLE_SESSION],
-          'Side Effects' => []
+          'Side Effects' => [],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/exploits/windows/local/alpc_taskscheduler.rb
+++ b/modules/exploits/windows/local/alpc_taskscheduler.rb
@@ -50,7 +50,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           # Exploit overwrites PrintConfig.dll, which makes it unusable.
           'Stability' => [ OS_RESOURCE_LOSS ],
-          'Reliability' => [ REPEATABLE_SESSION ]
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DisclosureDate' => '2018-08-27',
         'DefaultTarget' => 0

--- a/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
@@ -38,7 +38,9 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'DisclosureDate' => '2019-08-22',
         'Notes' => {
-          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY
         },
         'References' => [
           ['URL', 'https://heynowyouseeme.blogspot.com/2019/08/windows-10-lpe-uac-bypass-in-windows.html'],

--- a/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
@@ -38,7 +38,9 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'DisclosureDate' => '2019-02-19',
         'Notes' => {
-          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+          'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY
         },
         'References' => [
           ['URL', 'https://www.activecyber.us/activelabs/windows-uac-bypass'],

--- a/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
+++ b/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_RESTARTS, ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'Reliability' => UNKNOWN_RELIABILITY,
         },
         'Compat' => {
           'Meterpreter' => {

--- a/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
+++ b/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
@@ -55,7 +55,8 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'Notes' => {
           'SideEffects' => [ARTIFACTS_ON_DISK, SCREEN_EFFECTS],
-          'Stability' => [CRASH_OS_RESTARTS]
+          'Stability' => [CRASH_OS_RESTARTS],
+          'Reliability' => UNKNOWN_RELIABILITY
         },
         'DisclosureDate' => '2018-10-09',
         'DefaultTarget' => 0,

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -53,7 +53,9 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => '2014-07-22',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Stability' => [ CRASH_OS_RESTARTS, ]
+          'Stability' => [ CRASH_OS_RESTARTS, ],
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'Compat' => {
           'Meterpreter' => {

--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -55,7 +55,9 @@ class MetasploitModule < Msf::Exploit::Local
           'DisclosureDate' => '2013-10-08',
           'DefaultTarget' => 0,
           'Notes' => {
-            'Stability' => [ CRASH_OS_RESTARTS, ]
+            'Stability' => [ CRASH_OS_RESTARTS, ],
+            'Reliability' => UNKNOWN_RELIABILITY,
+            'SideEffects' => UNKNOWN_SIDE_EFFECTS
           }
         }
       )

--- a/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
@@ -65,7 +65,9 @@ class MetasploitModule < Msf::Exploit::Local
           'DisclosureDate' => '2014-10-14',
           'DefaultTarget' => 0,
           'Notes' => {
-            'Stability' => [ CRASH_OS_RESTARTS, ]
+            'Stability' => [ CRASH_OS_RESTARTS, ],
+            'Reliability' => UNKNOWN_RELIABILITY,
+            'SideEffects' => UNKNOWN_SIDE_EFFECTS
           }
         }
       )

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -54,7 +54,9 @@ class MetasploitModule < Msf::Exploit::Local
           'DisclosureDate' => '2015-05-12',
           'DefaultTarget' => 0,
           'Notes' => {
-            'Stability' => [ CRASH_OS_RESTARTS, ]
+            'Stability' => [ CRASH_OS_RESTARTS, ],
+            'Reliability' => UNKNOWN_RELIABILITY,
+            'SideEffects' => UNKNOWN_SIDE_EFFECTS
           }
         }
       )

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -45,7 +45,8 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0,
         'Compat' => {

--- a/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
+++ b/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
@@ -48,7 +48,8 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SAFE ]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DefaultTarget' => 0,
         'Compat' => {

--- a/modules/exploits/windows/misc/hta_server.rb
+++ b/modules/exploits/windows/misc/hta_server.rb
@@ -35,6 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'SideEffects' => [ SCREEN_EFFECTS ],
           'Stability' => [ CRASH_SAFE ],
+          'Reliability' => UNKNOWN_RELIABILITY,
         }
       )
     )

--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -42,6 +42,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2013-05-22',
         'Notes' => {
           'Stability' => [ CRASH_SERVICE_RESTARTS ],
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS,
         }
       )
     )

--- a/modules/exploits/windows/misc/tiny_identd_overflow.rb
+++ b/modules/exploits/windows/misc/tiny_identd_overflow.rb
@@ -45,7 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SERVICE_DOWN ]
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'Privileged' => false,
         'DisclosureDate' => '2007-05-14'

--- a/modules/exploits/windows/nuuo/nuuo_cms_sqli.rb
+++ b/modules/exploits/windows/nuuo/nuuo_cms_sqli.rb
@@ -42,7 +42,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Nuuo Central Management Server <= v2.10.0', {} ],
         ],
         'Notes' => {
-          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY
         },
         'Privileged' => false, # we run as NETWORK_SERVICE
         'DisclosureDate' => '2018-10-11',

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -195,7 +195,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DisclosureDate' => '2019-05-14',
         'Notes' => {
-          'AKA' => ['Bluekeep']
+          'AKA' => ['Bluekeep'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/exploits/windows/smb/group_policy_startup.rb
+++ b/modules/exploits/windows/smb/group_policy_startup.rb
@@ -47,7 +47,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DisclosureDate' => '2015-01-26',
         'Notes' => {
-          'AKA' => ['badsamba']
+          'AKA' => ['badsamba'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )

--- a/modules/exploits/windows/smb/ms04_007_killbill.rb
+++ b/modules/exploits/windows/smb/ms04_007_killbill.rb
@@ -63,7 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'AKA' => [ 'kill-bill' ],
           'Reliability' => [ UNRELIABLE_SESSION ],
-          'Stability' => [ CRASH_OS_RESTARTS, CRASH_SERVICE_DOWN ]
+          'Stability' => [ CRASH_OS_RESTARTS, CRASH_SERVICE_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DisclosureDate' => '2004-02-10',
         'DefaultTarget' => 0

--- a/modules/exploits/windows/smb/ms06_040_netapi.rb
+++ b/modules/exploits/windows/smb/ms06_040_netapi.rb
@@ -88,7 +88,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Notes' => {
           'Reliability' => [ UNRELIABLE_SESSION ],
-          'Stability' => [ CRASH_OS_RESTARTS, CRASH_SERVICE_DOWN ]
+          'Stability' => [ CRASH_OS_RESTARTS, CRASH_SERVICE_DOWN ],
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DisclosureDate' => '2006-08-08'
       )

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -32,7 +32,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'License' => MSF_LICENSE,
         'Notes' => {
-          'AKA' => ['ECLIPSEDWING']
+          'AKA' => ['ECLIPSEDWING'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'References' => [
           %w(CVE 2008-4250),

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -35,7 +35,10 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Privileged' => true,
         'Notes' => {
-          'AKA' => ['EDUCATEDSCHOLAR']
+          'AKA' => ['EDUCATEDSCHOLAR'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'Payload' => {
           'Space' => 1024,

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -146,7 +146,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'Notes' => {
-          'AKA' => ['ETERNALBLUE']
+          'AKA' => ['ETERNALBLUE'],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'DisclosureDate' => '2017-03-14'
       )

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -80,7 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
             'ETERNALROMANCE',
             'ETERNALCHAMPION',
             'ETERNALBLUE' # does not use any CVE from Blue, but Search should show this, it is preferred
-          ]
+          ],
+          'Stability' => UNKNOWN_STABILITY,
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
         }
       )
     )


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/issues/17582

This PR is a continuation of https://github.com/rapid7/metasploit-framework/pull/20343. This time we are adding notes to any modules that already contain a notes section but are missing stability, reliability or side effects. Again the notes will be set to sentinel values.

Any notes added will contain sentinel values that mark the values as `UNKNOWN_*`.
## Example
```
      'Notes' => {
         'SideEffects' => [ IOC_IN_LOGS ],
         'Stability' => UNKNOWN_STABILITY,
         'Reliability' => UNKNOWN_RELIABILITY
      }
```

## Verification

- [ ] Code changes are sane
- [ ] Test `info -d` 