### PR TITLE
Fix non-printable non-ascii chars in module description and name

### DIFF
--- a/modules/auxiliary/admin/http/wp_gdpr_compliance_privesc.rb
+++ b/modules/auxiliary/admin/http/wp_gdpr_compliance_privesc.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
           The Wordpress GDPR Compliance plugin <= v1.4.2 allows unauthenticated users to set
           wordpress administration options by overwriting values within the database.
 
-          The vulnerability is present in WordPress’s admin-ajax.php, which allows unauthorized
+          The vulnerability is present in WordPress's admin-ajax.php, which allows unauthorized
           users to trigger handlers and make configuration changes because of a failure to do
           capability checks when executing the 'save_setting' internal action.
 

--- a/modules/auxiliary/scanner/http/apache_normalize_path.rb
+++ b/modules/auxiliary/scanner/http/apache_normalize_path.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'Apache 2.4.49/2.4.50 Traversal RCE scanner',
         'Description' => %q{
           This module scans for an unauthenticated RCE vulnerability which exists in Apache version 2.4.49 (CVE-2021-41773).
-          If files outside of the document root are not protected by ‘require all denied’ and CGI has been explicitly enabled,
+          If files outside of the document root are not protected by 'require all denied' and CGI has been explicitly enabled,
           it can be used to execute arbitrary commands (Remote Command Execution).
           This vulnerability has been reintroduced in Apache 2.4.50 fix (CVE-2021-42013).
         },

--- a/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'Dolibarr 16 pre-auth contact database dump',
         'Description' => %q{
           Dolibarr version 16 < 16.0.5 is vulnerable to a pre-authentication contact database dump.
-          An unauthenticated attacker may retrieve a company’s entire customer file, prospects, suppliers,
+          An unauthenticated attacker may retrieve a company's entire customer file, prospects, suppliers,
           and potentially employee information if a contact file exists.
           Both public and private notes are also included in the dump.
         },

--- a/modules/auxiliary/scanner/http/jira_user_enum.rb
+++ b/modules/auxiliary/scanner/http/jira_user_enum.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           This module exploits an information disclosure vulnerability that allows an
           unauthenticated user to enumerate users in the /ViewUserHover.jspa endpoint.
-          This only affects Jira versions < 7.13.16, 8.0.0 ≤ version < 8.5.7, 8.6.0 ≤ version < 8.11.1
+          This only affects Jira versions < 7.13.16, 8.0.0 <= version < 8.5.7, 8.6.0 <= version < 8.11.1
           Discovered by Mikhail Klyuchnikov @__mn1__
           This module has been tested on versions 8.4.1, 8.5.6, 8.10.1, 8.11.0
         },

--- a/modules/encoders/php/minify.rb
+++ b/modules/encoders/php/minify.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Encoder
       'Name' => 'PHP Minify Encoder',
       'Description' => %q{
         This encoder minifies a PHP payload by removing leasing spaces, trailing
-        new lines, comments, …
+        new lines, comments, ...
       },
       'Author' => 'Julien Voisin',
       'License' => BSD_LICENSE,

--- a/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
+++ b/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           QuTS hero. QTS is a core part of the firmware for numerous QNAP entry and mid-level Network Attached Storage
           (NAS) devices, and QuTS hero is a core part of the firmware for numerous QNAP high-end and enterprise NAS devices.
 
-          The vulnerable endpoint is the quick.cgi component, exposed by the device’s web based administration feature.
+          The vulnerable endpoint is the quick.cgi component, exposed by the device's web based administration feature.
           The quick.cgi component is present in an uninitialized QNAP NAS device. This component is intended to be used
           during either manual or cloud based provisioning of a QNAP NAS device. Once a device has been successfully
           initialized, the quick.cgi component is disabled on the system.

--- a/modules/exploits/linux/http/solarview_unauth_rce_cve_2023_23333.rb
+++ b/modules/exploits/linux/http/solarview_unauth_rce_cve_2023_23333.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'SolarView Compact unauthenticated remote command execution vulnerability.',
         'Description' => %q{
-          CONTEC's SolarView™ Series enables you to monitor and visualize solar power and is only available in Japan.
+          CONTEC's SolarView Series enables you to monitor and visualize solar power and is only available in Japan.
           This module exploits a command injection vulnerability on the SolarView Compact `v6.00` web application
           via vulnerable endpoint `downloader.php`.
           After exploitation, an attacker will have full access with the same user privileges under

--- a/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Local
           This exploit targets the Linux kernel bug in OverlayFS.
 
           A flaw was found in the Linux kernel, where unauthorized access to the execution of the setuid file with capabilities
-          was found in the Linux kernel’s OverlayFS subsystem in how a user copies a capable file from a nosuid mount into another mount.
+          was found in the Linux kernel's OverlayFS subsystem in how a user copies a capable file from a nosuid mount into another mount.
           This uid mapping bug allows a local user to escalate their privileges on the system.
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/multi/http/apache_commons_text4shell.rb
+++ b/modules/exploits/multi/http/apache_commons_text4shell.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This exploit takes advantage of the StringSubstitutor interpolator class,
           which is included in the Commons Text library. A default interpolator
           allows for string lookups that can lead to Remote Code Execution. This
-          is due to a logic flaw that makes the “script”, “dns” and “url” lookup
+          is due to a logic flaw that makes the "script", "dns" and "url" lookup
           keys interpolated by default, as opposed to what it should be, according
           to the documentation of the StringLookupFactory class. Those keys allow
           an attacker to execute arbitrary code via lookups primarily using the

--- a/modules/exploits/multi/http/apache_normalize_path_rce.rb
+++ b/modules/exploits/multi/http/apache_normalize_path_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Apache 2.4.49/2.4.50 Traversal RCE',
         'Description' => %q{
           This module exploit an unauthenticated RCE vulnerability which exists in Apache version 2.4.49 (CVE-2021-41773).
-          If files outside of the document root are not protected by ‘require all denied’ and CGI has been explicitly enabled,
+          If files outside of the document root are not protected by 'require all denied' and CGI has been explicitly enabled,
           it can be used to execute arbitrary commands (Remote Command Execution).
           This vulnerability has been reintroduced in Apache 2.4.50 fix (CVE-2021-42013).
         },

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'ForgeRock / OpenAM Jato Java Deserialization',
         'Description' => %q{
           This module leverages a pre-authentication remote code execution vulnerability in the OpenAM identity and
-          access management solution. The vulnerability arises from a Java deserialization flaw in OpenAM’s
+          access management solution. The vulnerability arises from a Java deserialization flaw in OpenAM's
           implementation of the Jato framework and can be triggered by a simple one-line GET or POST request to a
           vulnerable endpoint. Successful exploitation yields code execution on the target system as the service user.
 

--- a/modules/exploits/multi/http/invision_customcss_rce.rb
+++ b/modules/exploits/multi/http/invision_customcss_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           Invision Community up to and including version 5.0.6 contains a remote code
           execution vulnerability in the theme editor's customCss endpoint. By crafting
-          a specially formatted `content` parameter with a `{expression="…"}`
+          a specially formatted `content` parameter with a `{expression="..."}`
           construct, arbitrary PHP can be evaluated. This module leverages that flaw
           to execute payloads or system commands as the webserver user.
         },

--- a/modules/exploits/multi/http/roundcube_auth_rce_cve_2025_49113.rb
+++ b/modules/exploits/multi/http/roundcube_auth_rce_cve_2025_49113.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Roundcube ≤ 1.6.10 Post-Auth RCE via PHP Object Deserialization',
+        'Name' => 'Roundcube Post-Auth RCE via PHP Object Deserialization',
         'Description' => %q{
           Roundcube Webmail before 1.5.10 and 1.6.x before 1.6.11 allows remote code execution
           by authenticated users because the _from parameter in a URL is not validated

--- a/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
+++ b/modules/exploits/multi/http/spip_porte_plume_previsu_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'SPIP Unauthenticated RCE via porte_plume Plugin',
         'Description' => %q{
           This module exploits a Remote Code Execution vulnerability in SPIP versions up to and including 4.2.12.
-          The vulnerability occurs in SPIP’s templating system where it incorrectly handles user-supplied input,
+          The vulnerability occurs in SPIP's templating system where it incorrectly handles user-supplied input,
           allowing an attacker to inject and execute arbitrary PHP code. This can be achieved by crafting a
           payload manipulating the templating data processed by the `echappe_retour()` function, invoking
           `traitements_previsu_php_modeles_eval()`, which contains an `eval()` call.

--- a/modules/exploits/multi/http/wp_hash_form_rce.rb
+++ b/modules/exploits/multi/http/wp_hash_form_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'WordPress Hash Form Plugin RCE',
         'Description' => %q{
-          The Hash Form – Drag & Drop Form Builder plugin for WordPress suffers from a critical vulnerability
+          The Hash Form - Drag & Drop Form Builder plugin for WordPress suffers from a critical vulnerability
           due to missing file type validation in the file_upload_action function. This vulnerability exists
           in all versions up to and including 1.1.0. Unauthenticated attackers can exploit this flaw to upload arbitrary
           files, including PHP scripts, to the server, potentially allowing for remote code execution on the affected

--- a/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
+++ b/modules/exploits/multi/veritas/beagent_sha_auth_rce.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Veritas Backup Exec Agent Remote Code Execution',
         'Description' => %q{
           Veritas Backup Exec Agent supports multiple authentication schemes and SHA authentication is one of them.
-          This authentication scheme is no longer used within Backup Exec versions, but hadn’t yet been disabled.
+          This authentication scheme is no longer used within Backup Exec versions, but hadn't yet been disabled.
           An attacker could remotely exploit the SHA authentication scheme to gain unauthorized access to
           the BE Agent and execute an arbitrary OS command on the host with NT AUTHORITY\SYSTEM or root privileges
           depending on the platform.

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'pfSense plugin pfBlockerNG unauthenticated RCE as root',
         'Description' => %q{
-          pfBlockerNG is a popular pfSense plugin that is not installed by default. It’s generally used to
+          pfBlockerNG is a popular pfSense plugin that is not installed by default. It's generally used to
           block inbound connections from whole countries or IP ranges. Versions 2.1.4_26 and below are affected
           by an unauthenticated RCE vulnerability that results in root access. Note that version 3.x is unaffected.
         },

--- a/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits an arbitrary file upload in the WordPress wpDiscuz plugin
           versions >= `7.0.0` and <= `7.0.4`. This flaw gave unauthenticated attackers the ability
           to upload arbitrary files, including PHP files, and achieve remote code execution on a
-          vulnerable site’s server.
+          vulnerable site's server.
         },
         'Author' => [
           'Chloe Chamberland', # Vulnerability Discovery, initial msf module

--- a/modules/exploits/windows/http/git_lfs_rce.rb
+++ b/modules/exploits/windows/http/git_lfs_rce.rb
@@ -22,10 +22,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           A critical vulnerability (CVE-2020-27955) in Git Large File Storage (Git LFS), an open source Git extension for
           versioning large files, allows attackers to achieve remote code execution if the Windows-using victim is tricked
-          into cloning the attacker’s malicious repository using a vulnerable Git version control tool
+          into cloning the attacker's malicious repository using a vulnerable Git version control tool
         },
         'Author' => [
-          'Dawid Golunski ', # Discovery
+          'Dawid Golunski', # Discovery
           'space-r7',        # Guidance, git mixins
           'jheysel-r7'       # Metasploit module
         ],

--- a/modules/exploits/windows/http/moveit_cve_2023_34362.rb
+++ b/modules/exploits/windows/http/moveit_cve_2023_34362.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'MOVEit SQL Injection vulnerability',
         'Description' => %q{
           This module exploits an SQL injection vulnerability in the MOVEit Transfer web application
-          that allows an unauthenticated attacker to gain access to MOVEit Transfer’s database.
+          that allows an unauthenticated attacker to gain access to MOVEit Transfer's database.
           Depending on the database engine being used (MySQL, Microsoft SQL Server, or Azure SQL), an
           attacker can leverage an information leak be able to upload a .NET deserialization payload.
         },

--- a/spec/module_validation_spec.rb
+++ b/spec/module_validation_spec.rb
@@ -184,6 +184,16 @@ RSpec.describe ModuleValidation::Validator do
       end
     end
 
+    context 'when the name has non-printable ascii characters' do
+      let(:mod_options) do
+        super().merge(name: 'Testing human-readable printable ascii characters ≤')
+      end
+
+      it 'has errors' do
+        expect(subject.errors.full_messages).to eq ['Name must only contain human-readable printable ascii characters']
+      end
+    end
+
     context 'when the module file path is not snake case' do
       let(:mod_options) do
         super().merge(file_path: 'modules/exploits/windows/smb/CVE_2020_0796_smbghost.rb')
@@ -201,6 +211,16 @@ RSpec.describe ModuleValidation::Validator do
 
       it 'has errors' do
         expect(subject.errors.full_messages).to eq ["Description can't be blank"]
+      end
+    end
+
+    context 'when the description has non-printable ascii characters' do
+      let(:mod_options) do
+        super().merge(description: "Testing human-readable printable ascii characters ≤\n\tand newlines/tabs")
+      end
+
+      it 'has errors' do
+        expect(subject.errors.full_messages).to eq ['Description must only contain human-readable printable ascii characters, including newlines and tabs']
       end
     end
 

--- a/spec/support/lib/module_validation.rb
+++ b/spec/support/lib/module_validation.rb
@@ -28,6 +28,8 @@ module ModuleValidation
     validate :validate_reference_ctx_id
     validate :validate_author_bad_chars
     validate :validate_target_platforms
+    validate :validate_description_does_not_contain_non_printable_chars
+    validate :validate_name_does_not_contain_non_printable_chars
 
     attr_reader :mod
 
@@ -151,6 +153,22 @@ module ModuleValidation
 
     def has_notes?
       !notes.empty?
+    end
+
+    def validate_description_does_not_contain_non_printable_chars
+      unless description&.match?(/\A[ -~\t\n]*\z/)
+        # Blank descriptions are validated elsewhere, so we will return early to not also add this error
+        # and cause unnecessary confusion.
+        return if description.nil?
+
+        errors.add :description, 'must only contain human-readable printable ascii characters, including newlines and tabs'
+      end
+    end
+
+    def validate_name_does_not_contain_non_printable_chars
+      unless name&.match?(/\A[ -~]+\z/)
+        errors.add :name, 'must only contain human-readable printable ascii characters'
+      end
     end
 
     validates :mod, presence: true


### PR DESCRIPTION
This PR updates the module validation to now only accept printable characters. The reason for this change was due to some non-printable chars in both module descriptions and names causing issues.

Now Ci will fail if the name or description contains any non-printable characters.

Tests were also added for the new validation.

I also updated any modules that currently failed on CI with this extra validation in place.

## Verification

- [ ] Code changes are sane
- [ ] CI passes
- [ ] Fixed modules descriptions and name altered appropriately
