### PR TITLE
Add validation for arch values

### DIFF
--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'http://web.archive.org/web/20211209044023/https://theyhack.me/SuiteCRM-RCE-2/'] # This exploit
         ],
         'Platform' => %w[linux unix],
-        'Arch' => %w[ARCH_X64 ARCH_CMD ARCH_X86],
+        'Arch' => [ARCH_X64, ARCH_CMD, ARCH_X86],
         'Targets' => [
           [
             'Linux (x64)', {

--- a/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
+++ b/modules/exploits/multi/http/spip_bigup_unauth_rce.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-3-2-SPIP-4-2-16-SPIP-4-1-18.html']
         ],
         'Platform' => %w[php unix linux win],
-        'Arch' => %w[ARCH_PHP ARCH_CMD],
+        'Arch' => [ARCH_PHP, ARCH_CMD],
         'Targets' => [
           [
             'PHP In-Memory', {

--- a/modules/exploits/unix/webapp/byob_unauth_rce.rb
+++ b/modules/exploits/unix/webapp/byob_unauth_rce.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://blog.chebuya.com/posts/unauthenticated-remote-command-execution-on-byob/']
         ],
         'Platform' => %w[unix linux],
-        'Arch' => %w[ARCH_CMD],
+        'Arch' => [ARCH_CMD],
         'Targets' => [
           [
             'Unix/Linux Command Shell', {

--- a/modules/exploits/unix/webapp/vicidial_agent_authenticated_rce.rb
+++ b/modules/exploits/unix/webapp/vicidial_agent_authenticated_rce.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2024-09-10',
         'Platform' => %w[unix linux],
-        'Arch' => %w[ARCH_CMD],
+        'Arch' => [ARCH_CMD],
         'Targets' => [
           [
             'Unix/Linux Command Shell', {

--- a/spec/module_validation_spec.rb
+++ b/spec/module_validation_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ModuleValidation::Validator do
       file_path: 'modules/exploits/windows/smb/cve_2020_0796_smbghost.rb',
       type: 'exploit',
       platform: Msf::Module::PlatformList.new(Msf::Module::Platform::Windows),
+      arch: [Rex::Arch::ARCH_X86],
       targets: [Msf::Module::Target.new('Windows 10 v1903-1909 x64', { 'Platform' => 'win', 'Arch' => ['x64'] })],
       description: %q{
           A vulnerability exists within the Microsoft Server Message Block 3.1.1 (SMBv3) protocol that can be leveraged to
@@ -234,6 +235,22 @@ RSpec.describe ModuleValidation::Validator do
       end
     end
 
+    context 'when the arch array contains a valid value' do
+      it 'has no errors' do
+        expect(subject.errors.full_messages).to be_empty
+      end
+    end
+
+    context 'when the arch array contains an invalid value' do
+      let(:mod_options) do
+        super().merge(arch: ["Rex::Arch::ARCH_X86"])
+      end
+
+      it 'has errors' do
+        expect(subject.errors.full_messages).to eq ["Arch contains invalid values [\"Rex::Arch::ARCH_X86\"] - only [\"x86\", \"x86_64\", \"x64\", \"mips\", \"mipsle\", \"mipsbe\", \"mips64\", \"mips64le\", \"ppc\", \"ppce500v2\", \"ppc64\", \"ppc64le\", \"cbea\", \"cbea64\", \"sparc\", \"sparc64\", \"armle\", \"armbe\", \"aarch64\", \"cmd\", \"php\", \"tty\", \"java\", \"ruby\", \"dalvik\", \"python\", \"nodejs\", \"firefox\", \"zarch\", \"r\", \"riscv32be\", \"riscv32le\", \"riscv64be\", \"riscv64le\", \"loongarch64\"] is allowed"]
+      end
+    end
+
     context 'when the platform is missing and targets does not contain platform values' do
       let(:mod_options) do
         super().merge(platform: nil, targets: [Msf::Module::Target.new('Windows 10 v1903-1909 x64', { 'Arch' => ['x64'] })])
@@ -279,7 +296,7 @@ RSpec.describe ModuleValidation::Validator do
         super().merge(new_module_options, rank: Msf::GreatRanking, rank_to_s: 'great')
       end
 
-      it 'has no errors' do
+      it 'has errors' do
         expect(subject.errors.full_messages).to eq [
           "Stability contains invalid values [[\"unknown-stability\"]] - only [\"crash-safe\", \"crash-service-restarts\", \"crash-service-down\", \"crash-os-restarts\", \"crash-os-down\", \"service-resource-loss\", \"os-resource-loss\"] is allowed",
           "Side effects contains invalid values [[\"unknown-side-effects\"]] - only [\"artifacts-on-disk\", \"config-changes\", \"ioc-in-logs\", \"account-lockouts\", \"account-logout\", \"screen-effects\", \"audio-effects\", \"physical-effects\"] is allowed",

--- a/spec/support/lib/module_validation.rb
+++ b/spec/support/lib/module_validation.rb
@@ -9,6 +9,10 @@ module ModuleValidation
         return
       end
 
+      # Special cases for modules/exploits/bsd/finger/morris_fingerd_bof.rb which has a one-off architecture defined in
+      # the module itself, and that value is not included in the valid list of architectures.
+      # https://github.com/rapid7/metasploit-framework/blob/389d84cbf0d7c58727846466d9a9f6a468f32c61/modules/exploits/bsd/finger/morris_fingerd_bof.rb#L11
+      return if attribute == :arch && value == ["vax"] && record.fullname == "exploit/bsd/finger/morris_fingerd_bof"
       return if value == options[:sentinel_value]
 
       invalid_options = value - options[:in]
@@ -186,6 +190,9 @@ module ModuleValidation
       mod.validates :reliability,
                     'module_validation/array_inclusion': { in: VALID_RELIABILITY_VALUES, sentinel_value: Msf::UNKNOWN_RELIABILITY }
     end
+
+    validates :arch,
+              'module_validation/array_inclusion': { in: Rex::Arch::ARCH_TYPES }
 
     validates :license,
               presence: true,


### PR DESCRIPTION
This PR updates the module validation to now only accept valid arch values. 

Now CI will fail if the name or description contains any non-printable characters.

Tests were also added for the new validation.

I also updated any modules that currently failed on CI with this extra validation in place.

## Verification
- [ ] Code changes are sane
- [ ] CI passes
- [ ] Fixed modules arch values appropriately