### PR TITLE
Fix module cache generation

### DIFF
--- a/tools/automation/cache/build_new_cache.sh
+++ b/tools/automation/cache/build_new_cache.sh
@@ -1,10 +1,10 @@
 #!/bin/sh -ex
 bundle install
-rm db/modules_metadata_base.json
+rm -f db/modules_metadata_base.json
 git ls-files modules/ -z | xargs -0 -n1 -P `nproc` -I{} -- git log -1 --format="%ai {}" {} | while read -r udate utime utz ufile ; do
   touch -d "$udate $utime" $ufile
 done
-./msfconsole -qr tools/automation/cache/wait_for_cache.rc
+./msfconsole --no-defer-module-loads -qr tools/automation/cache/wait_for_cache.rc
 cp ~/.msf4/store/modules_metadata.json db/modules_metadata_base.json
 cp ~/.msf4/logs/framework.log .
 set +e

--- a/tools/automation/cache/wait_for_cache.rc
+++ b/tools/automation/cache/wait_for_cache.rc
@@ -1,9 +1,9 @@
 <ruby>
 require "msf/core/modules/metadata/store"
 
-UserMetaDataFile = Msf::Modules::Metadata::Store::UserMetaDataFile
+user_meta_data_file = Msf::Modules::Metadata::Store::UserMetaDataFile
 store_dir = File.join(Msf::Config.config_directory, "store")
-cache_file = File.join(store_dir, UserMetaDataFile)
+cache_file = File.join(store_dir, user_meta_data_file)
 framework.modules.refresh_cache_from_module_files
 while true do
 	break if File.exist?(cache_file)


### PR DESCRIPTION
Ensures that the module cache is generated correctly by forcing `--no-defer-module-loads` - as the current `defer-module-loads` behavior is missing cache invalidation logic improvements which should be fixed by https://github.com/rapid7/metasploit-framework/issues/20352

## Verification

- I ensured that it's possible to run `./tools/automation/cache/build_new_cache.sh` and that the `db/modules_metadata_base.json` file is regenerated correctly