### PR TITLE
Fix payload module reloading functionality

### DIFF
--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -61,7 +61,7 @@ module Msf::ModuleManager::Reloading
     reload_payload_set
 
     # Try to get the reloaded module class
-    reloaded_module_class = module_set_by_type[module_type][module_reference_name]
+    reloaded_module_class = module_set_by_type.dig(module_type,module_reference_name)
 
     if reloaded_module_class.blank?
       raise "Failed to reload payload module: #{metasploit_class.fullname} not found after reload"

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -86,9 +86,7 @@ module Msf::ModuleManager::Reloading
     module_type = 'payload'
 
     # Clear existing payload modules
-    if module_set_by_type[module_type]
-      module_set_by_type[module_type].clear
-    end
+      module_set_by_type.fetch(module_type,nil)&.clear
 
     # Reinitialize the payload module set
     init_module_set(module_type)

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -50,10 +50,7 @@ module Msf::ModuleManager::Reloading
     module_reference_name = metasploit_class.fullname.sub(%r{^payload/}, '')
 
     # Store original datastore if we have an instance
-    original_datastore = nil
-    if original_instance
-      original_datastore = original_instance.datastore.copy
-    end
+      original_datastore = original_instance&.datastore.copy
 
     # Clear the specific payload from the module set
     module_set = module_set_by_type[module_type]

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -61,7 +61,7 @@ module Msf::ModuleManager::Reloading
     reload_payload_set
 
     # Try to get the reloaded module class
-    reloaded_module_class = module_set_by_type.dig(module_type,module_reference_name)
+    reloaded_module_class = module_set_by_type[module_type][module_reference_name]
 
     if reloaded_module_class.blank?
       raise "Failed to reload payload module: #{metasploit_class.fullname} not found after reload"

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+
 # Concerns reloading modules
 module Msf::ModuleManager::Reloading
   # Reloads the module specified in mod.  This can either be an instance of a module or a module class.
@@ -6,40 +7,122 @@ module Msf::ModuleManager::Reloading
   # @param [Msf::Module, Class] mod either an instance of a module or a module class
   # @return (see Msf::Modules::Loader::Base#reload_module)
   def reload_module(mod)
-    # if it's can instance, then get its class
+    # if it's an instance, then get its class
     if mod.is_a? Msf::Module
       metasploit_class = mod.class
+      original_instance = mod
     else
       metasploit_class = mod
+      original_instance = nil
     end
 
-    if aliased_as = self.inv_aliases[metasploit_class.fullname]
+    # Handle aliases cleanup
+    if (aliased_as = inv_aliases[metasploit_class.fullname])
       aliased_as.each do |a|
-        self.aliases.delete a
+        aliases.delete a
       end
-      self.inv_aliases.delete metasploit_class.fullname
+      inv_aliases.delete metasploit_class.fullname
     end
 
+    # Special handling for payload modules
+    if metasploit_class.fullname.start_with?('payload/')
+      return reload_payload_module(metasploit_class, original_instance)
+    end
+
+    # Standard module reloading for non-payloads
     namespace_module = metasploit_class.module_parent
+
+    # Check if the namespace module has a loader
+    unless namespace_module.respond_to?(:loader)
+      raise "Module #{metasploit_class.fullname} namespace does not have a loader"
+    end
+
     loader = namespace_module.loader
-    loader.reload_module(mod)
+    return loader.reload_module(mod)
   end
+
+  private
+
+  # Reload payload modules by clearing and reloading the entire payload set
+  # This is necessary because payloads have complex interdependencies
+  def reload_payload_module(metasploit_class, original_instance = nil)
+    module_type = 'payload'
+    module_reference_name = metasploit_class.fullname.sub(%r{^payload/}, '')
+
+    # Store original datastore if we have an instance
+    original_datastore = nil
+    if original_instance
+      original_datastore = original_instance.datastore.copy
+    end
+
+    # Clear the specific payload from the module set
+    module_set = module_set_by_type[module_type]
+    if module_set
+      module_set.delete(module_reference_name)
+    end
+
+    # For payloads, we need to reload the entire payload ecosystem
+    # because of stage/stager dependencies
+    reload_payload_set
+
+    # Try to get the reloaded module class
+    reloaded_module_class = module_set_by_type[module_type][module_reference_name]
+
+    if reloaded_module_class.nil?
+      raise "Failed to reload payload module: #{metasploit_class.fullname} not found after reload"
+    end
+
+    # Create a new instance of the reloaded module
+    new_instance = reloaded_module_class.new
+
+    # Restore the original datastore if we had one
+    if original_datastore
+      new_instance.datastore.merge!(original_datastore)
+    end
+
+    return new_instance
+  rescue StandardError => e
+    elog("Failed to reload payload #{metasploit_class.fullname}: #{e.message}")
+    raise "Failed to reload payload: #{e.message}"
+  end
+
+  # Reload the entire payload module set
+  def reload_payload_set
+    module_type = 'payload'
+
+    # Clear existing payload modules
+    if module_set_by_type[module_type]
+      module_set_by_type[module_type].clear
+    end
+
+    # Reinitialize the payload module set
+    init_module_set(module_type)
+
+    # Reload payloads from all module paths
+    module_paths.each do |path|
+      # Load payloads with force flag to ensure reload
+      load_modules(path, type: [module_type], force: true)
+    rescue StandardError => e
+      wlog("Warning: Could not reload payloads from #{path}: #{e.message}")
+    end
+  end
+
+  public
 
   # Reloads modules from all module paths
   #
   # @return (see Msf::ModuleManager::Loading#load_modules)
   def reload_modules
-    self.enablement_by_type.each_key do |type|
+    enablement_by_type.each_key do |type|
       module_set_by_type[type].clear
       init_module_set(type)
     end
-    self.aliases.clear
-    self.inv_aliases.clear
+
+    aliases.clear
+    inv_aliases.clear
 
     # default the count to zero the first time a type is accessed
     count_by_type = Hash.new(0)
-
-    framework.init_module_paths unless framework.module_paths_inited
 
     module_paths.each do |path|
       path_count_by_type = load_modules(path, force: true)
@@ -51,7 +134,6 @@ module Msf::ModuleManager::Reloading
     end
 
     refresh_cache_from_module_files
-
     count_by_type
   end
 end

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -38,7 +38,7 @@ module Msf::ModuleManager::Reloading
     end
 
     loader = namespace_module.loader
-    return loader.reload_module(mod)
+    loader.reload_module(mod)
   end
 
   private

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -63,7 +63,7 @@ module Msf::ModuleManager::Reloading
     # Try to get the reloaded module class
     reloaded_module_class = module_set_by_type[module_type][module_reference_name]
 
-    if reloaded_module_class.nil?
+    if reloaded_module_class.blank?
       raise "Failed to reload payload module: #{metasploit_class.fullname} not found after reload"
     end
 

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 # Concerns reloading modules
-require 'pry'
-require 'pry-byebug'
+
 module Msf::ModuleManager::Reloading
   # Reloads the module specified in mod.  This can either be an instance of a module or a module class.
   #
@@ -9,7 +8,6 @@ module Msf::ModuleManager::Reloading
   # @return (see Msf::Modules::Loader::Base#reload_module)
   def reload_module(mod)
     # if it's an instance, then get its class
-    binding.pry
     if mod.is_a? Msf::Module
       metasploit_class = mod.class
     else
@@ -49,8 +47,6 @@ module Msf::ModuleManager::Reloading
       metasploit_class = mod
       original_instance = nil
     end 
-    binding.pry 
-
     if (module_set = self.module_set_by_type.fetch(metasploit_class.type, nil))
       module_set.delete(metasploit_class.refname)
     end

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
-
 # Concerns reloading modules
+require 'pry'
+require 'pry-byebug'
 module Msf::ModuleManager::Reloading
   # Reloads the module specified in mod.  This can either be an instance of a module or a module class.
   #
@@ -8,111 +9,107 @@ module Msf::ModuleManager::Reloading
   # @return (see Msf::Modules::Loader::Base#reload_module)
   def reload_module(mod)
     # if it's an instance, then get its class
+    binding.pry
+    if mod.is_a? Msf::Module
+      metasploit_class = mod.class
+    else
+      metasploit_class = mod
+    end
+
+    if aliased_as = self.inv_aliases[metasploit_class.fullname]
+      aliased_as.each do |a|
+        self.aliases.delete a
+      end
+      self.inv_aliases.delete metasploit_class.fullname
+    end
+
+    if mod.payload?
+      return reload_payload_module(mod)
+    end
+    
+    namespace_module = metasploit_class.module_parent
+    
+    # Check if the namespace module has a loader
+    unless namespace_module.respond_to?(:loader)
+      elog("Module does not have loader")
+      return mod
+    end
+
+    loader = namespace_module.loader
+    loader.reload_module(mod)
+  end
+  # Reload payload module, separately from other categories. This is due to complexity of payload module and due to the fact they don't follow class structure as rest of the modules. 
+  # @param [Msf::Module, Class] mod either an instance of a module or a module class
+  # @return (see Msf::Modules::Loader::Base#reload_module)
+  def reload_payload_module(mod)
     if mod.is_a? Msf::Module
       metasploit_class = mod.class
       original_instance = mod
     else
       metasploit_class = mod
       original_instance = nil
+    end 
+    binding.pry 
+
+    if (module_set = self.module_set_by_type.fetch(metasploit_class.type, nil))
+      module_set.delete(metasploit_class.refname)
     end
 
-    # Handle aliases cleanup
-    if (aliased_as = inv_aliases[metasploit_class.fullname])
-      aliased_as.each do |a|
-        aliases.delete a
-      end
-      inv_aliases.delete metasploit_class.fullname
-    end
-
-    # Special handling for payload modules
-    if mod&.payload?
-      return reload_payload_module(metasploit_class, original_instance)
-    end
-
-    # Standard module reloading for non-payloads
-    namespace_module = metasploit_class.module_parent
-
-    # Check if the namespace module has a loader
-    unless namespace_module.respond_to?(:loader)
-      raise "Module #{metasploit_class.fullname} namespace does not have a loader"
-    end
-
-    loader = namespace_module.loader
-    loader.reload_module(mod)
-  end
-
-  private
-
-  # Reloads a payload module. This must be done by reloading the entire parent
-  # directory to ensure the framework's complex payload "stitching" process
-  # (combining stages, stagers, and mixins) is correctly executed. This is slower
-  # but guarantees a fully-functional reloaded module.
-  def reload_payload_module(metasploit_class, original_instance = nil)
-    # Step 1: Get all necessary identifiers from the original module class.
-    fullname = metasploit_class.fullname
-    refname = metasploit_class.refname
-    type = metasploit_class.type
-    file_path = metasploit_class.file_path
-
-    # Get a reference to the original datastore now, but do not copy it yet.
-    original_datastore = original_instance&.datastore
-
-    # Step 2: Manually purge the old module from the framework's caches.
-    if (module_set = module_set_by_type.fetch(type, nil))
-      module_set.delete(refname)
-    end
-    if (aliases_for_fullname = inv_aliases[fullname])
-      aliases_for_fullname.each { |a| aliases.delete(a) }
-      inv_aliases.delete(fullname)
-    end
-
-    # Step 3: Get the module's parent directory path.
-    module_info = module_info_by_path[file_path]
+    module_info = self.module_info_by_path[metasploit_class.file_path]
     unless module_info && (parent_path = module_info[:parent_path])
-      raise Msf::LoadError, "Could not find cached module information for path: #{file_path}"
+      elog("Failed to get parent_path from module object")
+      return mod
     end
 
-    # Step 4: Use the core framework loader to reload the entire parent directory.
-    # This is the only way to reliably trigger the payload stitching logic.
-    load_modules(parent_path, force: true)
+    case original_instance&.payload_type
+      when Msf::Payload::Type::Single
+        prepend_path = 'singles'
+      when Msf::Payload::Type::Stager
+        prepend_path = 'stagers'
+      when Msf::Payload::Type::Stage
+        prepend_path = 'stages'
+      when Msf::Payload::Type::Adapter
+        prepend_path = 'adapters'
+    end
 
-    # Step 5: Now that the framework has completed its full reload process,
-    # use the public API to get a new instance of our reloaded module.
-    new_instance = framework.modules.create(fullname)
+    full_reference_name = File.join(prepend_path, module_info[:reference_name])
+    self.loaders.each { |loader| loader.load_module(parent_path,module_info[:type], full_reference_name, {:force => true}) }
+
+
+    # Get reloaded module
+    new_instance = framework.modules.create(metasploit_class.fullname)
 
     if new_instance.blank?
-      raise Msf::LoadError, "Failed to create a new instance of #{fullname} after reloading. The module file may be broken."
+      elog("Failed create new instance")
+      return mod
     end
 
-    # Step 6: Restore the datastore to the new, fully-functional instance.
-    # Now we perform the copy, which is a method on the new datastore's merge function.
-    if original_datastore
-      new_instance.datastore.merge!(original_datastore)
-    end
+    # Restore the datastore 
+    new_instance.datastore.merge!(original_instance.datastore)
+
 
     # Return the new instance, which the framework will make the active module.
     return new_instance
   rescue StandardError => e
-    elog("Failed to reload payload #{fullname}", error: e)
-    raise Msf::LoadError, e.message
+    elog("Failed to reload payload #{fullname}: #{e.message}")
+    return mod
   end
-
-  public
 
   # Reloads modules from all module paths
   #
   # @return (see Msf::ModuleManager::Loading#load_modules)
   def reload_modules
-    enablement_by_type.each_key do |type|
+    self.enablement_by_type.each_key do |type|
       module_set_by_type[type].clear
       init_module_set(type)
     end
-
-    aliases.clear
-    inv_aliases.clear
+    self.aliases.clear
+    self.inv_aliases.clear
 
     # default the count to zero the first time a type is accessed
     count_by_type = Hash.new(0)
+
+    framework.init_module_paths unless framework.module_paths_inited
 
     module_paths.each do |path|
       path_count_by_type = load_modules(path, force: true)
@@ -124,6 +121,7 @@ module Msf::ModuleManager::Reloading
     end
 
     refresh_cache_from_module_files
+
     count_by_type
   end
 end

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -53,7 +53,7 @@ module Msf::ModuleManager::Reloading
       original_datastore = original_instance&.datastore.copy
 
     # Clear the specific payload from the module set
-    module_set = module_set_by_type[module_type]
+    module_set = module_set_by_type.fetch(module_type,nil)
       module_set.delete(module_reference_name) if module_set
 
     # For payloads, we need to reload the entire payload ecosystem

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -1,7 +1,10 @@
 # -*- coding: binary -*-
 
-# Concerns reloading modules
-
+# Msf::ModuleManager::Reloading
+#
+# Provides methods for reloading Metasploit modules (including payloads,
+# stagers, adapters, stages, etc.), clearing out old aliases, and
+# refreshing the module cache.
 module Msf::ModuleManager::Reloading
   # Reloads the module specified in mod.  This can either be an instance of a module or a module class.
   #
@@ -15,7 +18,7 @@ module Msf::ModuleManager::Reloading
       metasploit_class = mod
     end
 
-    if aliased_as = inv_aliases[metasploit_class.fullname]
+    if (aliased_as = inv_aliases[metasploit_class.fullname])
       aliased_as.each do |a|
         aliases.delete a
       end
@@ -26,7 +29,7 @@ module Msf::ModuleManager::Reloading
       return reload_payload_module(mod)
     end
 
-    if aliased_as = inv_aliases[metasploit_class.fullname]
+    if (aliased_as = inv_aliases[metasploit_class.fullname])
       aliased_as.each do |a|
         aliases.delete a
       end

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -54,9 +54,7 @@ module Msf::ModuleManager::Reloading
 
     # Clear the specific payload from the module set
     module_set = module_set_by_type[module_type]
-    if module_set
-      module_set.delete(module_reference_name)
-    end
+      module_set.delete(module_reference_name) if module_set
 
     # For payloads, we need to reload the entire payload ecosystem
     # because of stage/stager dependencies

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -25,7 +25,7 @@ module Msf::ModuleManager::Reloading
     end
 
     # Special handling for payload modules
-    if metasploit_class.fullname.start_with?('payload/')
+    if mod&.payload?
       return reload_payload_module(metasploit_class, original_instance)
     end
 


### PR DESCRIPTION
## Summary

Fixes the issue where payload modules cannot be reloaded using the reload command in msfconsole.

## Problem

When attempting to reload payload modules, users encountered the error:

```
msf6 payload(windows/x64/exec) > reload
[*] Reloading module...
[-] Failed to reload: undefined method `loader' for Object:Class
```

This occurred because payload modules don't follow the same loader architecture as other module types (exploits, auxiliary, post, etc.). The existing `reload_module` method assumed all modules would have a `namespace_module.loader` available, which is not the case for payloads.

## Root Cause

Payload modules have interdependencies between stages and stagers, and don't maintain the same 1:1 file-to-module mapping that other module types have. The original implementation in `lib/msf/core/module_manager/reloading.rb` didn't account for this architectural difference.

## Background

This issue was discovered while developing Windows ARM64 (aarch64) payloads. The inability to reload payload modules during development was significantly hampering the iterative development process. Investigation led to the existing issue #16300 which had been open since March 2022 without resolution.

## Solution

- Payload Detection: Added logic to detect payload modules by checking if `fullname` starts with `payload/`
- Payload Reloading: Implemented `reload_payload_module` method that:
  - Preserves the original module's datastore configuration
  - Clears and reloads the entire payload module set (necessary due to stage/stager dependencies)
  - Returns a properly initialized module instance
- Backward Compatibility: Non-payload modules continue to use the existing loader-based approach

## Testing

Manual testing confirms both payload and non-payload module reloading works correctly:

### Payload Module Reloading:
```
msf6 payload(windows/x64/exec) > reload
[*] Reloading module...
msf6 payload(windows/x64/exec) >
```
### Exploit Module Reloading (unchanged behavior):
```
msf6 exploit(windows/smb/ms08_067_netapi) > reload
[*] Reloading module...
msf6 exploit(windows/smb/ms08_067_netapi) >
```
### Cross-module workflow:
```
msf6 payload(windows/x64/exec) > use exploit/windows/smb/ms08_067_netapi
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/smb/ms08_067_netapi) > reload
[*] Reloading module...
msf6 exploit(windows/smb/ms08_067_netapi) > use payload/windows/x64/exec
msf6 payload(windows/x64/exec) > reload
[*] Reloading module...
msf6 payload(windows/x64/exec) >
```