### PR TITLE
Add syslog to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ PATH
       sqlite3 (= 1.7.3)
       sshkey
       swagger-blocks
+      syslog
       thin
       tzinfo
       tzinfo-data
@@ -572,6 +573,8 @@ GEM
     sshkey (3.0.0)
     strptime (0.2.5)
     swagger-blocks (3.0.0)
+    syslog (0.3.0)
+      logger
     test-prof (1.4.4)
     thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -271,6 +271,7 @@ Gem::Specification.new do |spec|
     mutex_m
     ostruct
     rinda
+    syslog
   ].each do |library|
     spec.add_runtime_dependency library
   end


### PR DESCRIPTION
Add syslog to gemspec

## Verification

In preparation for the Ruby 3.3 upgrade we'll add `syslog` to our gemspec to avoid this error:

```
C:/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/logging-2.4.0/lib/logging.rb:10: warning: syslog was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add syslog to your Gemfile or gemspec to silence this warning.
Also please contact the author of logging-2.4.0 to request adding syslog into its gemspec.
```