### PR TITLE
Fixes MsfVenom not running outside framework dir

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # -*- coding: binary -*-
 
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('Gemfile', __dir__)
+require 'bundler/setup'
+
 class MsfVenomError < StandardError; end
 class HelpError < StandardError; end
 class UsageError < MsfVenomError; end


### PR DESCRIPTION
GitHub Issue #19384 

Resolve `msfvenom` unable to run outside of `metasploit-framework` directory.

The update allows the `msfvenom` ruby process to find and use the GemFile from the `metasploit-framework` directory without having to run the process from inside the directory.

## Verification

List the steps needed to make sure this thing works

- [ ] Run `msfvenom` from anywhere outside of the `metasploit-framework` git repository


