### PR TITLE
Fixes smb_login crash 

### DIFF
--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -85,9 +85,11 @@ class SimpleClient
   
         dlog("SMB version(s) to negotiate: #{self.versions}")
         ok = self.client.negotiate
+        
+        # if SMB negotiation fails when selecting dialect, return false
         if ok.blank?
           dlog("Failed to negotiate SMB version")
-          return false
+          raise XCEPT::UnknownDialect
         end
         dlog("Negotiated SMB version: SMB#{negotiated_smb_version}")
 

--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -85,8 +85,12 @@ class SimpleClient
   
         dlog("SMB version(s) to negotiate: #{self.versions}")
         ok = self.client.negotiate
+        if ok.blank?
+          dlog("Failed to negotiate SMB version")
+          return false
+        end
         dlog("Negotiated SMB version: SMB#{negotiated_smb_version}")
-  
+
         if self.client.is_a?(RubySMB::Client)
           self.server_max_buffer_size = self.client.server_max_buffer_size
         else


### PR DESCRIPTION
This PR fixes #20183. The problematic code was present in `lib/rex/proto/smb/simple_client.rb` file, where SMB version negotiation is present:

```
[snipped]
        dlog("SMB version(s) to negotiate: #{self.versions}")
        ok = self.client.negotiate
        dlog("Negotiated SMB version: SMB#{negotiated_smb_version}")
  
        if self.client.is_a?(RubySMB::Client)
          self.server_max_buffer_size = self.client.server_max_buffer_size
        else
          self.server_max_buffer_size = ok['Payload'].v['MaxBuff']
        end
[snipped]
```
The `negotiate` returns `nil` when dialect selection fails and server uses unknown dialect. The fix takes this into account, when `negotiate` returns `nil` due to unknown dialect, the `login` function will throw exception `XCEPT::UnknownDialect`.