### PR TITLE
Fix the UPDATE Action in the ad_cs_cert_template Module

### DIFF
--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -509,7 +509,8 @@ class MetasploitModule < Msf::Auxiliary
     new_configuration = load_local_template
 
     operations = []
-    obj.each do |attribute, value|
+    obj.each do |symbol, value|
+      attribute = symbol.to_s
       next if IGNORED_ATTRIBUTES.any? { |word| word.casecmp?(attribute) }
 
       if new_configuration.keys.any? { |word| word.casecmp?(attribute) }
@@ -526,7 +527,7 @@ class MetasploitModule < Msf::Auxiliary
 
     new_configuration.each_key do |attribute|
       next if IGNORED_ATTRIBUTES.any? { |word| word.casecmp?(attribute) }
-      next if obj.attribute_names.any? { |i| i.casecmp?(attribute) }
+      next if obj.attribute_names.any? { |i| i.to_s.casecmp?(attribute) }
 
       operations << [:add, attribute, new_configuration[attribute]]
     end


### PR DESCRIPTION
This issue was brought to our attention via a failing cucumber test. It seems as though https://github.com/rapid7/metasploit-framework/pull/20345/files introduced a regression when calling `get_certificate_template`. The method used to return a hash (previously the result of  `ldap_get(...)`, now the result of `@ldap.search(...)`) where all the keys were strings. Now in the hash returned all the keys are symbols. When the `action_update` method was parsing the newly formatted hash it was causing issues. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use admin/ldap/ad_cs_cert_template`
- [ ] `set action UPDATE`
- [ ] `set cert_template ESC4`
- [ ] `set LDAPUsername, LDAPPassword`
- [ ] **Verify** you see `The operation completed successfully!`
- [ ] **Verify** the module does not crash saying `The LDAP operation failed because the referenced attribute does not exist`

## Testing
Update action
```
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > set action update
action => update
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > set cert_template ESC4_Group_Ancestry_Check
cert_template => ESC4_Group_Ancestry_Check
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > rexploit
[*] Reloading module...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[+] Read certificate template data for: CN=ESC4_Group_Ancestry_Check,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=kerberos,DC=issue
[*] Certificate template data written to: /Users/jheysel/.msf4/loot/20250715171440_default_172.16.199.200_windows.ad.cs.te_747298.json
[+] The operation completed successfully!
[*] Auxiliary module execution completed
```

Ensuring the other actions still work (although not affected by this PR)

Read
```
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > set action read
action => read
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > run
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[+] Read certificate template data for: CN=ESC4_Group_Ancestry_Check,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=kerberos,DC=issue
[*] Certificate template data written to: /Users/jheysel/.msf4/loot/20250715173539_default_172.16.199.200_windows.ad.cs.te_951549.json
[*] Certificate Template:
[*]   distinguishedName:    CN=ESC4_Group_Ancestry_Check,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=kerberos,DC=issue
[*]   displayName:          ESC4_Group_Ancestry_Check
[*]   objectGUID:           abee4cb2-e3a6-4068-8841-bd82cda15a23
[*]   nTSecurityDescriptor: D:PAI(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;AU)
[*]     * Permissions applied for administrator@kerberos.issue: READ
[*]   flags: 0x00000000
[*]   msPKI-Certificate-Name-Flag: 0x00000001
[*]     * CT_FLAG_ENROLLEE_SUPPLIES_SUBJECT
[*]   msPKI-Enrollment-Flag: 0x00000000
[*]   msPKI-Private-Key-Flag: 0x00000010
[*]     * CT_FLAG_EXPORTABLE_KEY
[*]   msPKI-RA-Signature: 0x00000000
[*]   msPKI-Template-Schema-Version: 2
[*]   pKIKeyUsage: 0x00000000
[*]   pKIMaxIssuingDepth: -1
[*]   showInAdvancedViewOnly: TRUE
[+] The operation completed successfully!
[*] Auxiliary module execution completed
```
Create
```
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > set action create
action => create
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > run
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] Creating: CN=testingtesting,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=kerberos,DC=issue
[+] The operation completed successfully!
[*] Auxiliary module execution completed
```
Delete
```
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > set action delete
action => delete
msf6 auxiliary(admin/ldap/ad_cs_cert_template) > run
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[+] Read certificate template data for: CN=testingtesting,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=kerberos,DC=issue
[*] Certificate template data written to: /Users/jheysel/.msf4/loot/20250715171152_default_172.16.199.200_windows.ad.cs.te_529284.json
[+] The operation completed successfully!
[*] Auxiliary module execution completed
```





