### PR TITLE
Pin StringIO version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ PATH
       sinatra
       sqlite3 (= 1.7.3)
       sshkey
+      stringio (= 3.1.1)
       swagger-blocks
       syslog
       thin
@@ -601,7 +602,7 @@ GEM
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     sshkey (3.0.0)
-    stringio (3.1.7)
+    stringio (3.1.1)
     strptime (0.2.5)
     swagger-blocks (3.0.0)
     syslog (0.3.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -261,6 +261,10 @@ Gem::Specification.new do |spec|
   # Needed for generic in-memory cachine
   spec.add_runtime_dependency 'lru_redux'
 
+  # Pinned on 3.1.1 as it is the version supported by our Ruby 3.3.8 dependency to avoid this issue https://github.com/rubygems/rubygems/issues/7657#issuecomment-2521083323
+  # When Ruby ships with `gem --version` 3.6.0 or higher by default this can be removed
+  spec.add_runtime_dependency 'stringio', '3.1.1'
+
   # Standard libraries: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
   %w[
     abbrev


### PR DESCRIPTION
Pin StringIO version to avoid this issue:

```
$ bundle exec ruby ./msfconsole  -q
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      stringio (>= 0)
      Available/installed versions of this gem:
      - 3.1.7
      - 3.1.1
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
```

As:
- [Ruby 3.3.8 ships with RubyGems 3.5.3](https://github.com/ruby/ruby/blob/v3_3_8/NEWS.md)
- [Ruby 3.4.4 ships with RubyGems 3.6.2](https://github.com/ruby/ruby/blob/v3_4_4/NEWS.md)

And i've chosen this version due to it being the default stringio gem for our ruby version on Ruby 3.3.3+:

```
$ docker run -it ruby:3.3.3-alpine /bin/sh -c 'ruby -r stringio -e "puts StringIO::VERSION"'
3.1.1

$ docker run -it ruby:3.3.2-alpine /bin/sh -c 'ruby -r stringio -e "puts StringIO::VERSION"'
3.1.0
```

And this issue is resolved in Ruby 3.6.0+ https://github.com/rubygems/rubygems/issues/7657#issuecomment-2521083323

## Verification

Ensure CI passes