### PR TITLE
Add a missing keyword for option validation

### DIFF
--- a/lib/msf/core/opt_int_range.rb
+++ b/lib/msf/core/opt_int_range.rb
@@ -25,7 +25,7 @@ module Msf
       value.to_s.gsub(/\s/, '')
     end
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: true, datastore: nil)
       return false if check_empty && empty_required_value?(value)
 
       if value.present?


### PR DESCRIPTION
Add a missing keyword required for option validation. Fixes #20366.

## Before

```
msf6 auxiliary(scanner/ntp/timeroast) > show options 

Module options (auxiliary/scanner/ntp/timeroast):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   DELAY    20               yes       The delay in milliseconds between attempts.
   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RIDS                      yes       The RIDs to enumerate (e.g. 1000-2000).
   RPORT    123              yes       The target port (UDP)
   THREADS  1                yes       The number of concurrent threads (max one per host)
   TIMEOUT  5                yes       The timeout in seconds to wait at the end for replies.


View the full module info with the info, or info -d command.

msf6 auxiliary(scanner/ntp/timeroast) > set RHOSTS 192.168.159.10
RHOSTS => 192.168.159.10
msf6 auxiliary(scanner/ntp/timeroast) > set RIDS 2100-2105
RIDS => 2100-2105
msf6 auxiliary(scanner/ntp/timeroast) > run
[-] Auxiliary failed: ArgumentError unknown keyword: :datastore
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/opt_int_range.rb:28:in `valid?'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/option_container.rb:201:in `block in validate'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/option_container.rb:200:in `each_pair'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/option_container.rb:200:in `validate'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/module/options.rb:21:in `validate'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/scanner/ntp/timeroast.rb:47:in `validate'
msf6 auxiliary(scanner/ntp/timeroast) >
```

## After

```
msf6 auxiliary(scanner/ntp/timeroast) > run
[+] Hash for RID: 2103 - 2103:$sntp-ms$e1ad339bf37be380d1af3f353be0cbbf$1c0100e900000000000a3d3d4c4f434cec222c275be726140000000000000000ec227ce487ef24e6ec227ce487ef69af
[*] Waiting on 5 pending responses...
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ntp/timeroast) >
```

## Testing
- [x] Run the `timeroast` module, make sure it doesn't crash. Take setup steps from https://github.com/rapid7/metasploit-framework/pull/19748, though a valid target probably isn't necessary to reproduce the issue.