### PR TITLE
Remove the version from the default prompt

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -17,7 +17,7 @@ class Driver < Msf::Ui::Driver
   ConfigCore  = "framework/core"
   ConfigGroup = "framework/ui/console"
 
-  DefaultPrompt     = "%undmsf#{Metasploit::Framework::Version::MAJOR}%clr"
+  DefaultPrompt     = "%undmsf%clr"
   DefaultPromptChar = "%clr>"
 
   #


### PR DESCRIPTION
Fixes #20355

This removes the major version from the default prompt.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Don't see the major version in the prompt any more
