### PR TITLE
Bump rex-socket to 0.1.63

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,7 +515,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.62)
+    rex-socket (0.1.63)
       dnsruby
       rex-core
     rex-sslscan (0.1.13)

--- a/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
+++ b/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'readline'
 
 RSpec.describe Rex::Ui::Text::DispatcherShell do
-  let(:prompt) { '%undmsf6%clr' }
+  let(:prompt) { '%undmsf%clr' }
   let(:prompt_char) { '%clr>' }
   let(:subject) do
     dummy_class = Class.new

--- a/spec/support/acceptance/child_process.rb
+++ b/spec/support/acceptance/child_process.rb
@@ -541,7 +541,7 @@ module Acceptance
     end
 
     def self.prompt
-      /msf6.*>\s+/
+      /msf.*>\s+/
     end
 
     def reset


### PR DESCRIPTION
Bumps Rex-socket gem to pull in the following PR: https://github.com/rapid7/rex-socket/pull/78

## Verification

There's no changes to the code, so I believe passing CI would be the only verification we need. Rex-socket's tests all passed as well.

- [ ] Passing CI