### PR TITLE
Fix modules\auxiliary\scanner\redis\redis_server 

### DIFF
--- a/modules/auxiliary/scanner/redis/redis_server.rb
+++ b/modules/auxiliary/scanner/redis/redis_server.rb
@@ -43,9 +43,9 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Contacting redis")
     begin
       connect
-      # Split the input command into parts using space as the delimiter 
+      # Split the input command into parts using space as the delimiter
       command_parts=command.split(' ')
-      # Execute the Redis command using the split parts 
+      # Execute the Redis command using the split parts
       return unless (data = redis_command(*command_parts))
 
       report_service(host: rhost, port: rport, name: "redis server", info: "#{command} response: #{data}")

--- a/modules/auxiliary/scanner/redis/redis_server.rb
+++ b/modules/auxiliary/scanner/redis/redis_server.rb
@@ -43,7 +43,10 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Contacting redis")
     begin
       connect
-      return unless (data = redis_command(command))
+      # Split the input command into parts using space as the delimiter 
+      command_parts=command.split(' ')
+      # Execute the Redis command using the split parts 
+      return unless (data = redis_command(*command_parts))
 
       report_service(host: rhost, port: rport, name: "redis server", info: "#{command} response: #{data}")
       print_good("Found redis with #{command} command: #{Rex::Text.to_hex_ascii(data)}")


### PR DESCRIPTION
This change updates the redis_server module to correctly parse Redis commands that contain multiple words (e.g., CONFIG SET dir /tmp). Previously, the module would incorrectly split command arguments, potentially leading to execution failures or unexpected behavior.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/redis/redis_server`
- [ ] `set RHOSTS <IP>` (target a Redis server with **unauthorized access enabled**, i.e., no password)
- [ ] `set redis.command "MODULE LIST"` or any multi-word Redis command (e.g., `"CONFIG SET dir /tmp"`)
- [ ] **Verify** the command is parsed and executed correctly
- [ ] **Verify** no syntax errors or parsing issues occur

Before and after the modification, the module can correctly execute single-argument commands, such as INFO.
![INFO_before_modify](https://github.com/user-attachments/assets/ca90ccd2-cc0e-4456-b3aa-342362573b4b)
![INFO_after_modify](https://github.com/user-attachments/assets/0ab03d01-e7d3-4afa-95f3-ca7a319c0dfb)
However, before the fix, the module was unable to properly handle multi-argument commands like MODULE LIST or MODULE LOAD ./exp.so.
![MODULE_LOAD_exp_before_modify](https://github.com/user-attachments/assets/3598295f-d4c2-49de-9367-7abf18968581)
After the fix, these multi-argument commands can now be executed successfully.
<img width="653" height="101" alt="MODULE_LOAD_exp_after_modify" src="https://github.com/user-attachments/assets/f469f5f5-c8c5-4f6d-b16b-2f67d0365630" />

This issue was fundamentally caused by incorrect string splitting logic in the original implementation. The module treated multi-word strings as a single command word, which led to command parsing failures and prevented the correct command from being recognized.



