### PR TITLE
Adds auto selection of cracker for password crackers

### DIFF
--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -300,24 +300,33 @@ module Metasploit
           if cracker_path && ::File.file?(cracker_path)
             return cracker_path
           else
+            # Look in the Environment PATH for the hashcat binary
+            if cracker == 'hashcat'
+              path = Rex::FileUtils.find_full_path('hashcat') ||
+                      Rex::FileUtils.find_full_path('hashcat.exe')
+            end
+
             # Look in the Environment PATH for the john binary
             if cracker == 'john'
               path = Rex::FileUtils.find_full_path('john') ||
-                     Rex::FileUtils.find_full_path('john.exe')
-            elsif cracker == 'hashcat'
-              path = Rex::FileUtils.find_full_path('hashcat') ||
-                     Rex::FileUtils.find_full_path('hashcat.exe')
-            else
-              raise PasswordCrackerNotFoundError, 'No suitable Cracker was selected, so a binary could not be found on the system'
+                      Rex::FileUtils.find_full_path('john.exe')
+            end
+            
+            # If neither john nor hashcat is found, raise an error
+            if path == ''
+              raise PasswordCrackerNotFoundError, 'No suitable Cracker was selected, so a binary could not be found on the system JOHN || HASHCAT'
             end
 
             if path && ::File.file?(path)
               return path
             end
 
-            raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
           end
+
+          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
+          
         end
+          
 
         # This method runs the command from {#crack_command} and yields each line of output.
         #

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -300,33 +300,21 @@ module Metasploit
           if cracker_path && ::File.file?(cracker_path)
             return cracker_path
           else
-            # Look in the Environment PATH for the hashcat binary
-            if cracker == 'hashcat'
-              path = Rex::FileUtils.find_full_path('hashcat') ||
-                      Rex::FileUtils.find_full_path('hashcat.exe')
-            end
-
-            # Look in the Environment PATH for the john binary
-            if cracker == 'john'
-              path = Rex::FileUtils.find_full_path('john') ||
-                      Rex::FileUtils.find_full_path('john.exe')
-            end
-            
-            # If neither john nor hashcat is found, raise an error
-            if path == ''
+            case cracker
+            when 'hashcat'
+              path = get_hashcat
+            when 'john'
+              path = get_john
+            when 'auto'
+              path = get_hashcat || get_john
+            else
               raise PasswordCrackerNotFoundError, 'No suitable Cracker was selected, so a binary could not be found on the system JOHN || HASHCAT'
             end
+            raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system' unless path && ::File.file?(path)
 
-            if path && ::File.file?(path)
-              return path
-            end
-
+            path
           end
-
-          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
-          
         end
-          
 
         # This method runs the command from {#crack_command} and yields each line of output.
         #
@@ -583,6 +571,18 @@ module Metasploit
             end
           end
           cmd << hash_path
+        end
+
+        def get_hashcat
+          # Look in the Environment PATH for the hashcat binary
+          Rex::FileUtils.find_full_path('hashcat') ||
+            Rex::FileUtils.find_full_path('hashcat.exe')
+        end
+
+        def get_john
+          # Look in the Environment PATH for the john binary
+          Rex::FileUtils.find_full_path('john') ||
+            Rex::FileUtils.find_full_path('john.exe')
         end
 
       end

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -119,6 +119,10 @@ module Metasploit
             public_send("#{attribute}=", value)
           end
         end
+        
+        def get_type
+          self.cracker
+        end
 
         # This method takes a {framework.db.cred.private.jtr_format} (string), and
         # returns the string number associated to the hashcat format
@@ -573,7 +577,7 @@ module Metasploit
           end
           cmd << hash_path
         end
-
+        
         def get_hashcat
           # Look in the Environment PATH for the hashcat binary
           self.cracker = 'hashcat'

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -310,7 +310,7 @@ module Metasploit
             when 'john'
               path = get_john
             when 'auto'
-              path = get_hashcat || get_john
+              path = get_john || get_hashcat
             else
               raise PasswordCrackerNotFoundError, 'No suitable Cracker was selected, so a binary could not be found on the system JOHN || HASHCAT'
             end

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -346,7 +346,6 @@ module Metasploit
             cmd = binary_path
             cmd << (' -V')
           end
-          puts cmd
           ::IO.popen(cmd, 'rb') do |fd|
             fd.each_line do |line|
               if cracker == 'john'

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -312,7 +312,7 @@ module Metasploit
             end
             raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system' unless path && ::File.file?(path)
 
-            path
+            return path
           end
         end
 
@@ -342,6 +342,7 @@ module Metasploit
             cmd = binary_path
             cmd << (' -V')
           end
+          puts cmd
           ::IO.popen(cmd, 'rb') do |fd|
             fd.each_line do |line|
               if cracker == 'john'
@@ -575,11 +576,13 @@ module Metasploit
 
         def get_hashcat
           # Look in the Environment PATH for the hashcat binary
+          self.cracker = 'hashcat'
           Rex::FileUtils.find_full_path('hashcat') ||
             Rex::FileUtils.find_full_path('hashcat.exe')
         end
 
         def get_john
+          self.cracker = 'john'
           # Look in the Environment PATH for the john binary
           Rex::FileUtils.find_full_path('john') ||
             Rex::FileUtils.find_full_path('john.exe')

--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -88,6 +88,9 @@ module Msf
       rescue Metasploit::Framework::PasswordCracker::PasswordCrackerNotFoundError => e
         fail_with(Msf::Module::Failure::BadConfig, e.message)
       end
+
+      # redefine cracker is action is auto
+
       # throw this to a local variable since it causes a shell out to pull the version
       cracker_version = cracker.cracker_version
       if cracker.cracker == 'john' && (cracker_version.nil? || !cracker_version.include?('jumbo'))

--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -88,7 +88,6 @@ module Msf
       rescue Metasploit::Framework::PasswordCracker::PasswordCrackerNotFoundError => e
         fail_with(Msf::Module::Failure::BadConfig, e.message)
       end
-
       # throw this to a local variable since it causes a shell out to pull the version
       cracker_version = cracker.cracker_version
       if cracker.cracker == 'john' && (cracker_version.nil? || !cracker_version.include?('jumbo'))

--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -89,8 +89,6 @@ module Msf
         fail_with(Msf::Module::Failure::BadConfig, e.message)
       end
 
-      # redefine cracker is action is auto
-
       # throw this to a local variable since it causes a shell out to pull the version
       cracker_version = cracker.cracker_version
       if cracker.cracker == 'john' && (cracker_version.nil? || !cracker_version.include?('jumbo'))

--- a/modules/auxiliary/analyze/crack_aix.rb
+++ b/modules/auxiliary/analyze/crack_aix.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
-        ['auto', { 'Description' => 'Auto-selection of cracker' ]}
+        ['auto', { 'Description' => 'Auto-selection of cracker' }]
       ],
       'DefaultAction' => 'auto',
       'Notes' => {

--- a/modules/auxiliary/analyze/crack_aix.rb
+++ b/modules/auxiliary/analyze/crack_aix.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_aix.rb
+++ b/modules/auxiliary/analyze/crack_aix.rb
@@ -25,8 +25,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Auto-selection of cracker' ]}
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -45,9 +46,9 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    if @cracker_type == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif @cracker_type == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
@@ -63,12 +64,12 @@ class MetasploitModule < Msf::Auxiliary
       next unless fields.count >= 3
 
       cred = { 'hash_type' => hash_type, 'method' => method }
-      if action.name == 'john'
+      if @cracker_type == 'john'
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         4.times { fields.pop } # Get rid of extra :
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif @cracker_type == 'hashcat'
         cred['core_id'] = fields.shift
         cred['hash'] = fields.shift
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
@@ -86,13 +87,19 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     tbl = tbl = cracker_results_table
+    cracker = new_password_cracker(action.name)
+    if action.name == 'auto'
+      @cracker_type = cracker.get_type
+    else
+      @cracker_type = action.name
+    end
 
     hash_types_to_crack = ['descrypt']
     jobs_to_do = []
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, @cracker_type)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -109,8 +116,6 @@ class MetasploitModule < Msf::Auxiliary
     # array of arrays for cracked passwords.
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
-
-    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.  max length of DES is 8
     wordlist = wordlist_file(8)
@@ -136,7 +141,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance = cracker.dup
       cracker_instance.format = format
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -147,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -189,7 +194,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status "Cracking #{format} hashes in wordlist mode..."
       cracker_instance.mode_wordlist(wordlist.path)
       # Turn on KoreLogic rules if the user asked for it
-      if action.name == 'john' && datastore['KORELOGIC']
+      if @cracker_type == 'john' && datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status 'Applying KoreLogic ruleset...'
       end

--- a/modules/auxiliary/analyze/crack_aix.rb
+++ b/modules/auxiliary/analyze/crack_aix.rb
@@ -25,9 +25,8 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
-        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'auto',
+      'DefaultAction' => 'john',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -45,21 +44,16 @@ class MetasploitModule < Msf::Auxiliary
 
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
-    
-    newaction = getaction()
 
-    if newaction == 'john'
+    if action.name == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif newaction == 'hashcat'
+    elsif action.name == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
-
-    newaction = getaction()
-
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -69,12 +63,12 @@ class MetasploitModule < Msf::Auxiliary
       next unless fields.count >= 3
 
       cred = { 'hash_type' => hash_type, 'method' => method }
-      if newaction == 'john'
+      if action.name == 'john'
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         4.times { fields.pop } # Get rid of extra :
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif newaction == 'hashcat'
+      elsif action.name == 'hashcat'
         cred['core_id'] = fields.shift
         cred['hash'] = fields.shift
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
@@ -91,9 +85,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-
-    newaction = getaction()
-
     tbl = tbl = cracker_results_table
 
     hash_types_to_crack = ['descrypt']
@@ -101,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, newaction)
+      job = hash_job(hash_type, action.name)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -119,7 +110,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(newaction)
+    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.  max length of DES is 8
     wordlist = wordlist_file(8)
@@ -145,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance = cracker.dup
       cracker_instance.format = format
 
-      if newaction == 'john'
+      if action.name == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -156,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if newaction == 'john'
+      if action.name == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -198,7 +189,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status "Cracking #{format} hashes in wordlist mode..."
       cracker_instance.mode_wordlist(wordlist.path)
       # Turn on KoreLogic rules if the user asked for it
-      if newaction == 'john' && datastore['KORELOGIC']
+      if action.name == 'john' && datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status 'Applying KoreLogic ruleset...'
       end
@@ -221,25 +212,5 @@ class MetasploitModule < Msf::Auxiliary
         File.delete(f)
       end
     end
-  end
-
-  def getaction
-    newaction = action.name
-    if action.name == 'auto'
-      path = Rex::FileUtils.find_full_path('hashcat') ||
-      Rex::FileUtils.find_full_path('hashcat.exe')
-      if path
-        newaction = 'hashcat'
-      else
-        path = Rex::FileUtils.find_full_path('john') ||
-        Rex::FileUtils.find_full_path('john.exe')
-        if path
-          newaction = 'john'
-        else
-          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
-        end
-      end
-    end
-    return newaction
   end
 end

--- a/modules/auxiliary/analyze/crack_aix.rb
+++ b/modules/auxiliary/analyze/crack_aix.rb
@@ -25,8 +25,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -44,16 +45,21 @@ class MetasploitModule < Msf::Auxiliary
 
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
+    
+    newaction = getaction()
 
-    if action.name == 'john'
+    if newaction == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif newaction == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
+
+    newaction = getaction()
+
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -63,12 +69,12 @@ class MetasploitModule < Msf::Auxiliary
       next unless fields.count >= 3
 
       cred = { 'hash_type' => hash_type, 'method' => method }
-      if action.name == 'john'
+      if newaction == 'john'
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         4.times { fields.pop } # Get rid of extra :
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif newaction == 'hashcat'
         cred['core_id'] = fields.shift
         cred['hash'] = fields.shift
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
@@ -85,6 +91,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+
+    newaction = getaction()
+
     tbl = tbl = cracker_results_table
 
     hash_types_to_crack = ['descrypt']
@@ -92,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, newaction)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -110,7 +119,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(action.name)
+    cracker = new_password_cracker(newaction)
 
     # generate our wordlist and close the file handle.  max length of DES is 8
     wordlist = wordlist_file(8)
@@ -136,7 +145,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance = cracker.dup
       cracker_instance.format = format
 
-      if action.name == 'john'
+      if newaction == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -147,7 +156,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if newaction == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -189,7 +198,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status "Cracking #{format} hashes in wordlist mode..."
       cracker_instance.mode_wordlist(wordlist.path)
       # Turn on KoreLogic rules if the user asked for it
-      if action.name == 'john' && datastore['KORELOGIC']
+      if newaction == 'john' && datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status 'Applying KoreLogic ruleset...'
       end
@@ -212,5 +221,25 @@ class MetasploitModule < Msf::Auxiliary
         File.delete(f)
       end
     end
+  end
+
+  def getaction
+    newaction = action.name
+    if action.name == 'auto'
+      path = Rex::FileUtils.find_full_path('hashcat') ||
+      Rex::FileUtils.find_full_path('hashcat.exe')
+      if path
+        newaction = 'hashcat'
+      else
+        path = Rex::FileUtils.find_full_path('john') ||
+        Rex::FileUtils.find_full_path('john.exe')
+        if path
+          newaction = 'john'
+        else
+          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
+        end
+      end
+    end
+    return newaction
   end
 end

--- a/modules/auxiliary/analyze/crack_databases.rb
+++ b/modules/auxiliary/analyze/crack_databases.rb
@@ -34,8 +34,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -58,15 +59,20 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    newaction = getaction()
+
+    if newaction == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif newaction == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
+
+    newaction = getaction()
+
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -74,13 +80,13 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
 
-      if action.name == 'john'
+      if newaction == 'john'
         next unless fields.count >= 3
 
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif newaction == 'hashcat'
         next unless fields.count >= 2
 
         cred['core_id'] = fields.shift
@@ -109,6 +115,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    
+    newaction = getaction()
+
     tbl = tbl = cracker_results_table
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex
@@ -128,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
 
       # hashcat requires a format we dont have all the data for
       # in the current dumper, so this is disabled in module and lib
-      if action.name == 'john'
+      if newaction == 'john'
         hash_types_to_crack << 'oracle'
         hash_types_to_crack << 'dynamic_1506'
       end
@@ -143,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, newaction)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -161,7 +170,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(action.name)
+    cracker = new_password_cracker(newaction)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -187,7 +196,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance = cracker.dup
       cracker_instance.format = format
 
-      if action.name == 'john'
+      if newaction == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -198,7 +207,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if newaction == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -239,7 +248,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if action.name == 'john' && datastore['KORELOGIC']
+        if newaction == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end
@@ -263,4 +272,25 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   end
+
+  def getaction
+    newaction = action.name
+    if action.name == 'auto'
+      path = Rex::FileUtils.find_full_path('hashcat') ||
+      Rex::FileUtils.find_full_path('hashcat.exe')
+      if path
+        newaction = 'hashcat'
+      else
+        path = Rex::FileUtils.find_full_path('john') ||
+        Rex::FileUtils.find_full_path('john.exe')
+        if path
+          newaction = 'john'
+        else
+          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
+        end
+      end
+    end
+    return newaction
+  end
+
 end

--- a/modules/auxiliary/analyze/crack_databases.rb
+++ b/modules/auxiliary/analyze/crack_databases.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_databases.rb
+++ b/modules/auxiliary/analyze/crack_databases.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = cracker_results_table
+    tbl = tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_databases.rb
+++ b/modules/auxiliary/analyze/crack_databases.rb
@@ -34,9 +34,8 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
-        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'auto',
+      'DefaultAction' => 'john',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -59,20 +58,15 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    newaction = getaction()
-
-    if newaction == 'john'
+    if action.name == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif newaction == 'hashcat'
+    elsif action.name == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
-
-    newaction = getaction()
-
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -80,13 +74,13 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
 
-      if newaction == 'john'
+      if action.name == 'john'
         next unless fields.count >= 3
 
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif newaction == 'hashcat'
+      elsif action.name == 'hashcat'
         next unless fields.count >= 2
 
         cred['core_id'] = fields.shift
@@ -115,9 +109,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    
-    newaction = getaction()
-
     tbl = tbl = cracker_results_table
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex
@@ -137,7 +128,7 @@ class MetasploitModule < Msf::Auxiliary
 
       # hashcat requires a format we dont have all the data for
       # in the current dumper, so this is disabled in module and lib
-      if newaction == 'john'
+      if action.name == 'john'
         hash_types_to_crack << 'oracle'
         hash_types_to_crack << 'dynamic_1506'
       end
@@ -152,7 +143,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, newaction)
+      job = hash_job(hash_type, action.name)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -170,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(newaction)
+    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -196,7 +187,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance = cracker.dup
       cracker_instance.format = format
 
-      if newaction == 'john'
+      if action.name == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -207,7 +198,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if newaction == 'john'
+      if action.name == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -248,7 +239,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if newaction == 'john' && datastore['KORELOGIC']
+        if action.name == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end
@@ -272,25 +263,4 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   end
-
-  def getaction
-    newaction = action.name
-    if action.name == 'auto'
-      path = Rex::FileUtils.find_full_path('hashcat') ||
-      Rex::FileUtils.find_full_path('hashcat.exe')
-      if path
-        newaction = 'hashcat'
-      else
-        path = Rex::FileUtils.find_full_path('john') ||
-        Rex::FileUtils.find_full_path('john.exe')
-        if path
-          newaction = 'john'
-        else
-          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
-        end
-      end
-    end
-    return newaction
-  end
-
 end

--- a/modules/auxiliary/analyze/crack_linux.rb
+++ b/modules/auxiliary/analyze/crack_linux.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_linux.rb
+++ b/modules/auxiliary/analyze/crack_linux.rb
@@ -32,8 +32,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Auto-selection of cracker' }]
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -58,9 +59,9 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    if @cracker_type == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif @cracker_type == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
@@ -74,14 +75,14 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         next unless fields.count >= 3 # If we don't have an expected minimum number of fields, this is probably not a hash line
 
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         4.times { fields.pop } # Get rid of extra :
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif @cracker_type == 'hashcat'
         next unless fields.count >= 2 # If we don't have an expected minimum number of fields, this is probably not a hash line
 
         cred['core_id'] = fields.shift
@@ -100,7 +101,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
+    cracker = new_password_cracker(action.name)
+    if action.name == 'auto'
+      @cracker_type = cracker.get_type
+    else
+      @cracker_type = action.name
+    end
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex
     hash_types_to_crack = []
@@ -115,7 +122,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, @cracker_type)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -132,8 +139,6 @@ class MetasploitModule < Msf::Auxiliary
     # array of arrays for cracked passwords.
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
-
-    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -158,7 +163,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance = cracker.dup
       cracker_instance.format = format
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -169,7 +174,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -211,7 +216,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status "Cracking #{format} hashes in wordlist mode..."
       cracker_instance.mode_wordlist(wordlist.path)
       # Turn on KoreLogic rules if the user asked for it
-      if action.name == 'john' && datastore['KORELOGIC']
+      if @cracker_type == 'john' && datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status 'Applying KoreLogic ruleset...'
       end

--- a/modules/auxiliary/analyze/crack_linux.rb
+++ b/modules/auxiliary/analyze/crack_linux.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = cracker_results_table
+    tbl = tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_linux.rb
+++ b/modules/auxiliary/analyze/crack_linux.rb
@@ -32,8 +32,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -58,15 +59,20 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    newaction = getaction()
+
+    if newaction == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif newaction == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
+
+    newaction = getaction()
+
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -74,14 +80,14 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
 
-      if action.name == 'john'
+      if newaction == 'john'
         next unless fields.count >= 3 # If we don't have an expected minimum number of fields, this is probably not a hash line
 
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         4.times { fields.pop } # Get rid of extra :
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif newaction == 'hashcat'
         next unless fields.count >= 2 # If we don't have an expected minimum number of fields, this is probably not a hash line
 
         cred['core_id'] = fields.shift
@@ -100,6 +106,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+
+    newaction = getaction()
+
     tbl = tbl = cracker_results_table
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex
@@ -115,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, newaction)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -133,7 +142,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(action.name)
+    cracker = new_password_cracker(newaction)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -158,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
       cracker_instance = cracker.dup
       cracker_instance.format = format
 
-      if action.name == 'john'
+      if newaction == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -169,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if newaction == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -211,7 +220,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status "Cracking #{format} hashes in wordlist mode..."
       cracker_instance.mode_wordlist(wordlist.path)
       # Turn on KoreLogic rules if the user asked for it
-      if action.name == 'john' && datastore['KORELOGIC']
+      if newaction == 'john' && datastore['KORELOGIC']
         cracker_instance.rules = 'KoreLogicRules'
         print_status 'Applying KoreLogic ruleset...'
       end
@@ -234,5 +243,25 @@ class MetasploitModule < Msf::Auxiliary
         File.delete(f)
       end
     end
+  end
+
+  def getaction
+    newaction = action.name
+    if action.name == 'auto'
+      path = Rex::FileUtils.find_full_path('hashcat') ||
+      Rex::FileUtils.find_full_path('hashcat.exe')
+      if path
+        newaction = 'hashcat'
+      else
+        path = Rex::FileUtils.find_full_path('john') ||
+        Rex::FileUtils.find_full_path('john.exe')
+        if path
+          newaction = 'john'
+        else
+          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
+        end
+      end
+    end
+    return newaction
   end
 end

--- a/modules/auxiliary/analyze/crack_osx.rb
+++ b/modules/auxiliary/analyze/crack_osx.rb
@@ -24,8 +24,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -47,15 +48,20 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    newaction = getaction()
+
+    if newaction == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif newaction == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
+
+    newaction = getaction()
+
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -63,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
       # If we don't have an expected minimum number of fields, this is probably not a hash line
-      if action.name == 'john'
+      if newaction == 'john'
         next unless fields.count >= 3
 
         cred['username'] = fields.shift
@@ -72,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
           4.times { fields.pop } # Get rid of extra :
         end
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif newaction == 'hashcat'
         next unless fields.count >= 3
 
         cred['core_id'] = fields.shift
@@ -91,6 +97,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+
+    newaction = getaction()
+
     tbl = tbl = cracker_results_table
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex
@@ -102,7 +111,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, newaction)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -120,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(action.name)
+    cracker = new_password_cracker(newaction)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -144,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
       # dupe our original cracker so we can safely change options between each run
       cracker_instance = cracker.dup
       cracker_instance.format = format
-      if action.name == 'john'
+      if newaction == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -153,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
       results = check_results(cracker_instance.each_cracked_password, results, format, 'Already Cracked/POT')
       vprint_good(append_results(tbl, results)) unless results.empty?
 
-      if action.name == 'john'
+      if newaction == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -194,7 +203,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if action.name == 'john' && datastore['KORELOGIC']
+        if newaction == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end
@@ -217,5 +226,25 @@ class MetasploitModule < Msf::Auxiliary
         File.delete(f)
       end
     end
+  end
+
+  def getaction
+    newaction = action.name
+    if action.name == 'auto'
+      path = Rex::FileUtils.find_full_path('hashcat') ||
+      Rex::FileUtils.find_full_path('hashcat.exe')
+      if path
+        newaction = 'hashcat'
+      else
+        path = Rex::FileUtils.find_full_path('john') ||
+        Rex::FileUtils.find_full_path('john.exe')
+        if path
+          newaction = 'john'
+        else
+          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
+        end
+      end
+    end
+    return newaction
   end
 end

--- a/modules/auxiliary/analyze/crack_osx.rb
+++ b/modules/auxiliary/analyze/crack_osx.rb
@@ -24,8 +24,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Auto-selection of cracker' }]
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -47,9 +48,9 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    if @cracker_type == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif @cracker_type == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
@@ -63,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
       # If we don't have an expected minimum number of fields, this is probably not a hash line
-      if action.name == 'john'
+      if @cracker_type == 'john'
         next unless fields.count >= 3
 
         cred['username'] = fields.shift
@@ -72,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
           4.times { fields.pop } # Get rid of extra :
         end
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif @cracker_type == 'hashcat'
         next unless fields.count >= 3
 
         cred['core_id'] = fields.shift
@@ -91,7 +92,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
+    cracker = new_password_cracker(action.name)
+    if action.name == 'auto'
+      @cracker_type = cracker.get_type
+    else
+      @cracker_type = action.name
+    end
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex
     hash_types_to_crack = []
@@ -102,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, @cracker_type)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -119,8 +126,6 @@ class MetasploitModule < Msf::Auxiliary
     # array of arrays for cracked passwords.
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
-
-    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -144,7 +149,7 @@ class MetasploitModule < Msf::Auxiliary
       # dupe our original cracker so we can safely change options between each run
       cracker_instance = cracker.dup
       cracker_instance.format = format
-      if action.name == 'john'
+      if @cracker_type == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -153,7 +158,7 @@ class MetasploitModule < Msf::Auxiliary
       results = check_results(cracker_instance.each_cracked_password, results, format, 'Already Cracked/POT')
       vprint_good(append_results(tbl, results)) unless results.empty?
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -194,7 +199,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if action.name == 'john' && datastore['KORELOGIC']
+        if @cracker_type == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end

--- a/modules/auxiliary/analyze/crack_osx.rb
+++ b/modules/auxiliary/analyze/crack_osx.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_osx.rb
+++ b/modules/auxiliary/analyze/crack_osx.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = cracker_results_table
+    tbl = tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -24,8 +24,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -48,15 +49,20 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    newaction = getaction()
+
+    if newaction == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif newaction == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
+
+    newaction = getaction()
+    
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -64,13 +70,13 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
       # If we don't have an expected minimum number of fields, this is probably not a hash line
-      if action.name == 'john'
+      if newaction == 'john'
         next unless fields.count >= 3
 
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif newaction == 'hashcat'
         next unless fields.count >= 2
 
         cred['core_id'] = fields.shift
@@ -89,6 +95,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+
+    newaction = getaction()
+
     tbl = tbl = cracker_results_table
 
     hash_types_to_crack = []
@@ -100,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, newaction)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -118,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(action.name)
+    cracker = new_password_cracker(newaction)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -142,7 +151,7 @@ class MetasploitModule < Msf::Auxiliary
       # dupe our original cracker so we can safely change options between each run
       cracker_instance = cracker.dup
       cracker_instance.format = format
-      if action.name == 'john'
+      if newaction == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -153,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if newaction == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -194,7 +203,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if action.name == 'john' && datastore['KORELOGIC']
+        if newaction == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end
@@ -218,4 +227,25 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   end
+
+  def getaction
+    newaction = action.name
+    if action.name == 'auto'
+      path = Rex::FileUtils.find_full_path('hashcat') ||
+      Rex::FileUtils.find_full_path('hashcat.exe')
+      if path
+        newaction = 'hashcat'
+      else
+        path = Rex::FileUtils.find_full_path('john') ||
+        Rex::FileUtils.find_full_path('john.exe')
+        if path
+          newaction = 'john'
+        else
+          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
+        end
+      end
+    end
+    return newaction
+  end
+
 end

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -24,8 +24,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Auto-selection of cracker' }]
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -48,9 +49,9 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    if @cracker_type == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif @cracker_type == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
@@ -64,13 +65,13 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
       # If we don't have an expected minimum number of fields, this is probably not a hash line
-      if action.name == 'john'
+      if @cracker_type == 'john'
         next unless fields.count >= 3
 
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif action.name == 'hashcat'
+      elsif @cracker_type == 'hashcat'
         next unless fields.count >= 2
 
         cred['core_id'] = fields.shift
@@ -89,7 +90,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
+    cracker = new_password_cracker(action.name)
+    if action.name == 'auto'
+      @cracker_type = cracker.get_type
+    else
+      @cracker_type = action.name
+    end
 
     hash_types_to_crack = []
     hash_types_to_crack << 'PBKDF2-HMAC-SHA1' if datastore['ATLASSIAN']
@@ -100,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, @cracker_type)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -117,8 +124,6 @@ class MetasploitModule < Msf::Auxiliary
     # array of arrays for cracked passwords.
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
-
-    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -142,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
       # dupe our original cracker so we can safely change options between each run
       cracker_instance = cracker.dup
       cracker_instance.format = format
-      if action.name == 'john'
+      if @cracker_type == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -153,7 +158,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -194,7 +199,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if action.name == 'john' && datastore['KORELOGIC']
+        if @cracker_type == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = cracker_results_table
+    tbl = tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -247,5 +247,4 @@ class MetasploitModule < Msf::Auxiliary
     end
     return newaction
   end
-
 end

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -24,9 +24,8 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
-        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'auto',
+      'DefaultAction' => 'john',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -49,20 +48,15 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    newaction = getaction()
-
-    if newaction == 'john'
+    if action.name == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif newaction == 'hashcat'
+    elsif action.name == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
   end
 
   def check_results(passwords, results, hash_type, method)
-
-    newaction = getaction()
-    
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
@@ -70,13 +64,13 @@ class MetasploitModule < Msf::Auxiliary
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
       # If we don't have an expected minimum number of fields, this is probably not a hash line
-      if newaction == 'john'
+      if action.name == 'john'
         next unless fields.count >= 3
 
         cred['username'] = fields.shift
         cred['core_id'] = fields.pop
         cred['password'] = fields.join(':') # Anything left must be the password. This accounts for passwords with semi-colons in it
-      elsif newaction == 'hashcat'
+      elsif action.name == 'hashcat'
         next unless fields.count >= 2
 
         cred['core_id'] = fields.shift
@@ -95,9 +89,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-
-    newaction = getaction()
-
     tbl = tbl = cracker_results_table
 
     hash_types_to_crack = []
@@ -109,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, newaction)
+      job = hash_job(hash_type, action.name)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -127,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(newaction)
+    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -151,7 +142,7 @@ class MetasploitModule < Msf::Auxiliary
       # dupe our original cracker so we can safely change options between each run
       cracker_instance = cracker.dup
       cracker_instance.format = format
-      if newaction == 'john'
+      if action.name == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -162,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if newaction == 'john'
+      if action.name == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -203,7 +194,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if newaction == 'john' && datastore['KORELOGIC']
+        if action.name == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end
@@ -226,25 +217,5 @@ class MetasploitModule < Msf::Auxiliary
         File.delete(f)
       end
     end
-  end
-
-  def getaction
-    newaction = action.name
-    if action.name == 'auto'
-      path = Rex::FileUtils.find_full_path('hashcat') ||
-      Rex::FileUtils.find_full_path('hashcat.exe')
-      if path
-        newaction = 'hashcat'
-      else
-        path = Rex::FileUtils.find_full_path('john') ||
-        Rex::FileUtils.find_full_path('john.exe')
-        if path
-          newaction = 'john'
-        else
-          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
-        end
-      end
-    end
-    return newaction
   end
 end

--- a/modules/auxiliary/analyze/crack_windows.rb
+++ b/modules/auxiliary/analyze/crack_windows.rb
@@ -30,8 +30,9 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
+        ['auto', { 'Description' => 'Auto-selection of cracker' }]
       ],
-      'DefaultAction' => 'john',
+      'DefaultAction' => 'auto',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -62,9 +63,9 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    if action.name == 'john'
+    if @cracker_type == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif action.name == 'hashcat'
+    elsif @cracker_type == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
@@ -102,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
 
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
-      if action.name == 'john'
+      if @cracker_type == 'john'
         # If we don't have an expected minimum number of fields, this is probably not a hash line
         next unless fields.count > 2
 
@@ -136,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
           cred['password'] = john_lm_upper_to_ntlm(password, nt_hash)
         end
         next if cred['password'].nil?
-      elsif action.name == 'hashcat'
+      elsif @cracker_type == 'hashcat'
         next unless fields.count >= 2
 
         cred['core_id'] = fields.shift
@@ -164,7 +165,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     tbl = cracker_results_table
-
+    cracker = new_password_cracker(action.name)
+    if action.name == 'auto'
+      @cracker_type = cracker.get_type
+    else
+      @cracker_type = action.name
+    end
     # array of hashes in jtr_format in the db, converted to an OR combined regex
     hash_types_to_crack = []
     hash_types_to_crack << 'lm' if datastore['LANMAN']
@@ -178,7 +184,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, action.name)
+      job = hash_job(hash_type, @cracker_type)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -195,8 +201,6 @@ class MetasploitModule < Msf::Auxiliary
     # array of arrays for cracked passwords.
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
-
-    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -220,7 +224,7 @@ class MetasploitModule < Msf::Auxiliary
       # dupe our original cracker so we can safely change options between each run
       cracker_instance = cracker.dup
       cracker_instance.format = format
-      if action.name == 'john'
+      if @cracker_type == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -231,7 +235,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if action.name == 'john'
+      if @cracker_type == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -274,7 +278,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if action.name == 'john' && datastore['KORELOGIC']
+        if @cracker_type == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end

--- a/modules/auxiliary/analyze/crack_windows.rb
+++ b/modules/auxiliary/analyze/crack_windows.rb
@@ -30,9 +30,8 @@ class MetasploitModule < Msf::Auxiliary
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],
         ['hashcat', { 'Description' => 'Use Hashcat' }],
-        ['auto', { 'Description' => 'Use either John the Ripper or Hashcat, if both are present, use Hashcat' }] 
       ],
-      'DefaultAction' => 'auto',
+      'DefaultAction' => 'john',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],
@@ -63,11 +62,9 @@ class MetasploitModule < Msf::Auxiliary
   def show_command(cracker_instance)
     return unless datastore['ShowCommand']
 
-    newaction = getaction()
-
-    if newaction == 'john'
+    if action.name == 'john'
       cmd = cracker_instance.john_crack_command
-    elsif newaction == 'hashcat'
+    elsif action.name == 'hashcat'
       cmd = cracker_instance.hashcat_crack_command
     end
     print_status("   Cracking Command: #{cmd.join(' ')}")
@@ -99,16 +96,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check_results(passwords, results, hash_type, method)
-
-    newaction = getaction()
-
     passwords.each do |password_line|
       password_line.chomp!
       next if password_line.blank?
 
       fields = password_line.split(':')
       cred = { 'hash_type' => hash_type, 'method' => method }
-      if newaction == 'john'
+      if action.name == 'john'
         # If we don't have an expected minimum number of fields, this is probably not a hash line
         next unless fields.count > 2
 
@@ -142,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
           cred['password'] = john_lm_upper_to_ntlm(password, nt_hash)
         end
         next if cred['password'].nil?
-      elsif newaction == 'hashcat'
+      elsif action.name == 'hashcat'
         next unless fields.count >= 2
 
         cred['core_id'] = fields.shift
@@ -169,9 +163,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-
-    newaction = getaction()
-
     tbl = cracker_results_table
 
     # array of hashes in jtr_format in the db, converted to an OR combined regex
@@ -187,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # build our job list
     hash_types_to_crack.each do |hash_type|
-      job = hash_job(hash_type, newaction)
+      job = hash_job(hash_type, action.name)
       if job.nil?
         print_status("No #{hash_type} found to crack")
       else
@@ -205,7 +196,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker(newaction)
+    cracker = new_password_cracker(action.name)
 
     # generate our wordlist and close the file handle.
     wordlist = wordlist_file
@@ -229,7 +220,7 @@ class MetasploitModule < Msf::Auxiliary
       # dupe our original cracker so we can safely change options between each run
       cracker_instance = cracker.dup
       cracker_instance.format = format
-      if newaction == 'john'
+      if action.name == 'john'
         cracker_instance.fork = datastore['FORK']
       end
 
@@ -240,7 +231,7 @@ class MetasploitModule < Msf::Auxiliary
       job['cred_ids_left_to_crack'] = job['cred_ids_left_to_crack'] - results.map { |i| i[0].to_i } # remove cracked hashes from the hash list
       next if job['cred_ids_left_to_crack'].empty?
 
-      if newaction == 'john'
+      if action.name == 'john'
         print_status "Cracking #{format} hashes in single mode..."
         cracker_instance.mode_single(wordlist.path)
         show_command cracker_instance
@@ -283,7 +274,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status "Cracking #{format} hashes in wordlist mode..."
         cracker_instance.mode_wordlist(wordlist.path)
         # Turn on KoreLogic rules if the user asked for it
-        if newaction == 'john' && datastore['KORELOGIC']
+        if action.name == 'john' && datastore['KORELOGIC']
           cracker_instance.rules = 'KoreLogicRules'
           print_status 'Applying KoreLogic ruleset...'
         end
@@ -307,25 +298,5 @@ class MetasploitModule < Msf::Auxiliary
         File.delete(f)
       end
     end
-  end
- 
-  def getaction
-    newaction = action.name
-    if action.name == 'auto'
-      path = Rex::FileUtils.find_full_path('hashcat') ||
-      Rex::FileUtils.find_full_path('hashcat.exe')
-      if path
-        newaction = 'hashcat'
-      else
-        path = Rex::FileUtils.find_full_path('john') ||
-        Rex::FileUtils.find_full_path('john.exe')
-        if path
-          newaction = 'john'
-        else
-          raise PasswordCrackerNotFoundError, 'No suitable john/hashcat binary was found on the system'
-        end
-      end
-    end
-    return newaction
   end
 end

--- a/modules/auxiliary/analyze/crack_windows.rb
+++ b/modules/auxiliary/analyze/crack_windows.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = tbl = cracker_results_table
+    tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type

--- a/modules/auxiliary/analyze/crack_windows.rb
+++ b/modules/auxiliary/analyze/crack_windows.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    tbl = cracker_results_table
+    tbl = tbl = cracker_results_table
     cracker = new_password_cracker(action.name)
     if action.name == 'auto'
       @cracker_type = cracker.get_type


### PR DESCRIPTION
# Description
The changes satisfy the requests made in issue number #20396.

The first change was made in the file _“lib/metasploit/framework/password_crackers/cracker.rb”_
to the _“binary_path”_ function. In the issue, the user reported that if **John The Ripper** was not detected by **Metasploit**, it would not check if **Hashcat** was installed, so I modified the function so that there are four concatenated if statements rather than an if-elsif-else statement.

The second change is in _“modules/auxiliary/analyze/”_ in the files:

- crack_aix.rb
- crack_databases.rb
- crack_linux.rb
- crack_osx.rb
- crack_webapps.rb
- crack_windows.rb

They received the same change with the same implementation. I added an action, “**auto**.” If this action is used, the module will see if either **Hashcat** or **John The Ripper** is installed and will choose one of the two, preferring **Hashcat**.

# Verification
- [ ] Start `msfconsole`
- [ ] `use auxiliary/analyze/crack_databases`
- [ ] `set action auto`
- [ ] **Insert something to crack**(example: `creds add user:test_user postgres:md55d41402abc4b2a76b9719d911017c592`
- [ ] `run`
