### PR TITLE
Fixes disclosure date in exploit/linux/http/pandora_fms_auth_netflow_rce.rb

### DIFF
--- a/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_netflow_rce.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'DisclosureDate' => '2025-12-30',
+        'DisclosureDate' => '2025-06-27',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'RPORT' => 80,


### PR DESCRIPTION
This PR fixes error in `disclosure date` of `pandora_fms_auth_netflow_rce` module.