### PR TITLE
Fixes incorrect path parameter for `chmod` in `upload_and_compile`

### DIFF
--- a/lib/msf/core/post/linux/compile.rb
+++ b/lib/msf/core/post/linux/compile.rb
@@ -73,8 +73,9 @@ module Msf
 
           # only upload the file if a compiler exists
           write_file path.to_s, strip_comments(data)
-
-          compiler_cmd = "#{compiler} -o '#{path.sub(/\.c$/, '')}' '#{path}'"
+          
+          executable_path = path.sub(/\.c$/, '')
+          compiler_cmd = "#{compiler} -o '#{executable_path}' '#{path}'"
           if session.type == 'shell'
             compiler_cmd = "PATH=\"$PATH:/usr/bin/\" #{compiler_cmd}"
           end
@@ -95,7 +96,7 @@ module Msf
             fail_with Module::Failure::BadConfig, message
           end
 
-          chmod path
+          chmod executable_path
         end
 
         #

--- a/spec/lib/msf/core/post/linux/compile_spec.rb
+++ b/spec/lib/msf/core/post/linux/compile_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Msf::Post::Linux::Compile do
       expect(subject).to receive(:write_file).with(destination, origin)
       expect(subject).to receive(:cmd_exec).with("gcc -o '#{compiled}' '#{destination}' #{flags} && echo fixedStr").and_return('fixedStr')
       expect(subject).to receive(:rm_f).with(destination)
-      expect(subject).to receive(:chmod).with(destination)
+      expect(subject).to receive(:chmod).with(compiled)
 
       subject.upload_and_compile(compiled, origin, flags)
     end
@@ -105,7 +105,7 @@ RSpec.describe Msf::Post::Linux::Compile do
       expect(subject).to receive(:write_file).with(destination, origin)
       expect(subject).to receive(:cmd_exec).with("PATH=\"$PATH:/usr/bin/\" gcc -o '#{compiled}' '#{destination}' #{flags} && echo fixedStr").and_return('fixedStr')
       expect(subject).to receive(:rm_f).with(destination)
-      expect(subject).to receive(:chmod).with(destination)
+      expect(subject).to receive(:chmod).with(compiled)
 
       subject.upload_and_compile(compiled, origin, flags)
     end


### PR DESCRIPTION
This PR address #20405. Proposed change will separate the source file and executable file (`path` and `executable_path`, respectively). The `executable_path` will be used as parameter in `chmod`.