### PR TITLE
Don't look up the local system SID

### DIFF
--- a/lib/msf/core/exploit/remote/ldap/active_directory.rb
+++ b/lib/msf/core/exploit/remote/ldap/active_directory.rb
@@ -302,6 +302,9 @@ module Msf
             matcher.apply_ace!(ace) if security_descriptor.group_sid == test_sid
           when test_sid
             matcher.apply_ace!(ace)
+          when Rex::Proto::Secauthz::WellKnownSids::SECURITY_LOCAL_SYSTEM_SID
+            # the SECURITY_LOCAL_SYSTEM_SID won't be found if looked up in the next block and if it's not the SID we're checking for, it doesn't apply anyways so just skip it
+            next
           else
             ldap_object = adds_get_object_by_sid(ldap, ace.body.sid)
             next unless ldap_object && ldap_object[:objectClass].include?('group')


### PR DESCRIPTION
This makes a small improvement to the new ActiveDirectory mixin when evaluating security descriptors. The local system SID `S-1-5-18` SID won't be in AD and because it wasn't matched as a special case until now, it would trigger multiple lookups in AD. The cache wasn't helping here because the object was never found in LDAP so it wouldn't be added to the cache, causing it to be looked up in a query each time.

This fixes the issue by adding the SID as a special case. It's placed after the SID we're testing for, so if the user wants to explicitly test for the SID they still can however if it's anything else, we know the ACE won't be applied so we just skip the lookup. This can be noticed when running the `ldap_esc_vulnerable_cert_finder` module with the `VERBOSE` option set to true. Without this change there'd be a bunch of lookups as seen by the `[*] Successfully queried (objectSID=S-1-5-18).` lines in the logs. Now, there are no queries for that particular SID.

# Testing
- [x] Run the `ldap_esc_vulnerable_cert_finder` with `VERBOSE=true` and see that there's not a bunch of unnecessary LDAP queries