### PR TITLE
Fix show options crash

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -581,7 +581,13 @@ class ReadableText
 
     option_tables = []
 
-    options_grouped_by_conditions.sort.each do |conditions, options|
+    sort_by_empty_then_lexicographical = proc do |(conditions_a, _options_a), (conditions_b, _options_b)|
+      next -1 if conditions_a.empty?
+      next 1 if conditions_b.empty?
+      conditions_a.to_s <=> conditions_b.to_s
+    end
+
+    options_grouped_by_conditions.sort(&sort_by_empty_then_lexicographical).each do |conditions, options|
       tbl = options_table(missing, mod, options, indent)
 
       next if tbl.rows.empty?


### PR DESCRIPTION
Fixes a crash when running the show options command on some modules

Caused by modules empty conditions

```
msf-pro auxiliary(pro/single) > show options
[-] Error while running command show: comparison of Array with Array failed

Call stack:
/Users/user/.rvm/gems/ruby-3.3.8@pro/gems/metasploit-framework-6.4.78/lib/msf/base/serializer/readable_text.rb:584:in `sort'
/Users/user/.rvm/gems/ruby-3.3.8@pro/gems/metasploit-framework-6.4.78/lib/msf/base/serializer/readable_text.rb:584:in `dump_options'
/Users/user/.rvm/gems/ruby-3.3.8@pro/gems/metasploit-framework-6.4.78/lib/msf/ui/console/command_dispatcher/common.rb:102:in `show_options'
/Users/user/.rvm/gems/ruby-3.3.8@pro/gems/metasploit-framework-6.4.78/lib/msf/ui/console/command_dispatcher/modules.rb:692:in `block in cmd_show'
/Users/user/.rvm/gems/ruby-3.3.8@pro/gems/metasploit-framework-6.4.78/lib/msf/ui/console/command_dispatcher/modules.rb:662:in `each'
/Users/user/.rvm/gems/ruby-3.3.8@pro/gems/metasploit-framework-6.4.78/lib/msf/ui/console/command_dispatcher/modules.rb:662:in `cmd_show'
```

## Verification

- Ensure CI passes