### PR TITLE
Improve login summary for ldap schannel scanner

### DIFF
--- a/modules/auxiliary/scanner/ldap/ldap_login.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_login.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     validate_connect_options!
-    results = super
+    results = super || {}
     logins = results.flat_map { |_k, v| v[:successful_logins] }
     sessions = results.flat_map { |_k, v| v[:successful_sessions] }
     print_status("Bruteforce completed, #{logins.size} #{logins.size == 1 ? 'credential was' : 'credentials were'} successful.")
@@ -169,6 +169,10 @@ class MetasploitModule < Msf::Auxiliary
         if opts[:ldap_auth] == Msf::Exploit::Remote::AuthOption::SCHANNEL
           # Schannel auth has no meaningful credential information to store in the DB
           msg = opts[:ldap_pkcs12].nil? ? 'Using stored certificate' : "Cert File #{opts[:ldap_pkcs12][:path]} (#{opts[:ldap_pkcs12][:value].certificate.subject})"
+          report_successful_login(
+            public: opts[:ldap_pkcs12][:value].certificate.subject.to_s,
+            private: opts[:ldap_pkcs12][:path]
+          )
           print_brute level: :good, ip: ip, msg: "Success: '#{msg}'"
         else
           create_credential_and_login(credential_data) if result.credential.private


### PR DESCRIPTION
Improves the login summary for LDAP login module when `LDAP::Auth=schannel` is set, as well as fixing an edge-case error when the module was canceled before completion.

## Verification

### Before

No report summary shown for schannel support:

<img width="1752" height="785" alt="image" src="https://github.com/user-attachments/assets/d95fd66c-521d-411a-b0ab-4cd1b37de54d" />

`flat_map` error when triggering ctrl+c before `@reports` is defined

```
msf-pro auxiliary(scanner/ldap/ldap_login) > rerun rhost=10.140.10.201 Ldap::Auth=schannel LDAP::CertFile=/tmp/21.pfx ssl=true
[*] Reloading module...
[*] The CreateSession option within this module can open an interactive session
^C[*] Caught interrupt from the console...
[*] Scan completed, 0 credentials were successful.
[*] 0 sessions were opened successfully.
[-] Auxiliary failed: NoMethodError undefined method `flat_map' for nil:NilClass
[-] Call stack:
[-]   /Users/adfoster/Documents/code/metasploit-framework/modules/auxiliary/scanner/ldap/ldap_login.rb:75:in `run'
```

### After

UX improved - report summary shown for schannel support:

<img width="1389" height="901" alt="image" src="https://github.com/user-attachments/assets/1c9d82c8-68f0-44eb-a46a-0bce5d023210" />

ctrl+c bug fixed

```
msf-pro auxiliary(scanner/ldap/ldap_login) > rerun rhost=10.140.10.201 Ldap::Auth=schannel LDAP::CertFile=/tmp/21.pfx ssl=true
[*] Reloading module...
[*] The CreateSession option within this module can open an interactive session
^C[*] Caught interrupt from the console...
[*] Scan completed, 0 credentials were successful.
[*] 0 sessions were opened successfully.
[*] Bruteforce completed, 0 credentials were successful.
[*] 0 LDAP sessions were opened successfully.
[*] Auxiliary module execution completed
```