### PR TITLE
Fix logging error in kerberos authenticator

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -89,6 +89,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def_delegators :@framework_module,
                 :print_status,
                 :print_good,
+                :print_error,
                 :vprint_error,
                 :vprint_status,
                 :workspace


### PR DESCRIPTION
Fixes a logging bug when handling Kerberos authentication errors

## Verification

Bug caused by: https://github.com/rapid7/metasploit-framework/blob/571e25dc8e4b1820b1d507722ce9bcf2829dc6c4/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb#L332


Example:
```
diff --git a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
index 7cad02f524f..3a4d3a498a7 100644
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -89,7 +89,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def_delegators :@framework_module,
                 :print_status,
                 :print_good,
-                :print_error,
+                # :print_error,
                 :vprint_error,
                 :vprint_status,
                 :workspace
@@ -193,6 +193,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   end
 
   def connect(options = {})
+    print_error("example error")
     unless options[:rhost]
       unless (host = @host)
         vprint_status("Using DNS to lookup the KDC for #{realm}...")
```

Before

```
msf-pro auxiliary(admin/kerberos/get_ticket) > rerun action=GET_TGT rhost=10.140.10.201 cert_file=/tmp/21.pfx
[*] Reloading module...
[*] Running module against 10.140.10.201
[*] 10.140.10.201:88 - Getting TGT for administrator@ad.pro.local
[DEPRECATION] The global method :print_error is deprecated, please raise a Github issue with this output. Called from: ["/Users/user/Documents/code/metasploit-framework/lib/msfenv.rb:73:in `print_error'", "/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb:196:in `connect'", "/Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/kerberos/client.rb:130:in `send_request_as'"]
example error
[+] 10.140.10.201:88 - Received a valid TGT-Response
[*] 10.140.10.201:88 - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20250811165223_default_10.140.10.201_mit.kerberos.cca_509968.bin
[*] Auxiliary module execution completed

```

After:

```
msf-pro auxiliary(admin/kerberos/get_ticket) > rerun action=GET_TGT rhost=10.140.10.201 cert_file=/tmp/21.pfx
[*] Reloading module...
[*] Running module against 10.140.10.201
[*] 10.140.10.201:88 - Getting TGT for administrator@ad.pro.local
[-] example error
[+] 10.140.10.201:88 - Received a valid TGT-Response
[*] 10.140.10.201:88 - TGT MIT Credential Cache ticket saved to /Users/user/.msf4/loot/20250811165304_default_10.140.10.201_mit.kerberos.cca_644399.bin
[*] Auxiliary module execution completed
msf-pro auxiliary(admin/kerberos/get_ticket) > 
```