### PR TITLE
Update display module action wording

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -909,7 +909,7 @@ module Msf
             end
 
             if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.respond_to?(:actions) && mod.actions.size > 1
-              print_status "Using action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
+              print_status "Setting default action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
             end
 
             mod.init_ui(driver.input, driver.output)


### PR DESCRIPTION
Updates the wording when using a module that supports module actions to be more clear

The rationale being: the module doesn't _use_ this action - it sets a default value, which can be set again by the user. The previous wording was confusing when using a non-interactive resource file, it gave the impression that the GET_TGT action was being used, but actually it was the GET_TGS action when the module was being used:

```
msf-pro auxiliary(admin/kerberos/get_ticket) > resource resource.rc
...
[*] Setting default action GET_TGT - view all 3 actions with the show actions command
    ^ The previous lexicon confused me
[*] Running module against 10.140.10.201
[*] Using cached credential for krbtgt/AD.PRO.LOCAL@AD.PRO.LOCAL Administrator@AD.PRO.LOCAL
[*] 10.140.10.201:88 - Getting TGS for Administrator@ad.pro.local (SPN: http/mspro-dc)
[+] 10.140.10.201:88 - Received a valid TGS-Response
...
```

## Verification


Use a module with an action:

```
msf-pro > use 4
[*] Setting default action GET_TGT - view all 3 actions with the show actions command
msf-pro auxiliary(admin/kerberos/get_ticket) > 
```