### PR TITLE
Update the ldap_esc_vulnerable_cert_finder to check enrollment permissions

### DIFF
--- a/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
+++ b/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
@@ -244,6 +244,8 @@ if ($editFlags -band $EDITF_ATTRIBUTESUBJECTALTNAME2) {
 What templates to report (applies filtering to results).
 
 * **all** - Report all certificate templates.
+* **published** - Report certificate templates that are published by at least one CA server.
+* **enrollable** - Same as above, but omits templates that the user does not have permissions to enroll in.
 * **vulnerable** - Report certificate templates where at least one misconfiguration is appears to be present.
 * **vulnerable-and-published** - Same as above, but omits templates that are not published by at least one CA server.
 * **vulnerable-and-enrollable** - Same as above, but omits templates that the user does not have permissions to enroll in.

--- a/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
+++ b/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md
@@ -240,15 +240,13 @@ if ($editFlags -band $EDITF_ATTRIBUTESUBJECTALTNAME2) {
 
 ## Options
 
-### REPORT_NONENROLLABLE
-If set to `True` then report any certificate templates that are vulnerable but which are not known to be enrollable.
-If set to `False` then skip over these certificate templates and only report on certificate templates
-that are both vulnerable and enrollable.
+### REPORT
+What templates to report (applies filtering to results).
 
-### REPORT_PRIVENROLLABLE
-If set to `True` then report certificate templates that are only enrollable by the Domain and Enterprise Admins groups.
-If set to `False` then skip over these certificate templates and only report on certificate templates that are
-enrollable by at least one additional user or group.
+* **all** - Report all certificate templates.
+* **vulnerable** - Report certificate templates where at least one misconfiguration is appears to be present.
+* **vulnerable-and-published** - Same as above, but omits templates that are not published by at least one CA server.
+* **vulnerable-and-enrollable** - Same as above, but omits templates that the user does not have permissions to enroll in.
 
 ## Scenarios
 

--- a/lib/msf/core/exploit/remote/ldap/active_directory.rb
+++ b/lib/msf/core/exploit/remote/ldap/active_directory.rb
@@ -294,6 +294,8 @@ module Msf
           case ace.body.sid
           when Rex::Proto::Secauthz::WellKnownSids::SECURITY_WORLD_SID
             matcher.apply_ace!(ace)
+          when Rex::Proto::Secauthz::WellKnownSids::SECURITY_AUTHENTICATED_USER_SID
+            matcher.apply_ace!(ace)
           when Rex::Proto::Secauthz::WellKnownSids::SECURITY_PRINCIPAL_SELF_SID
             matcher.apply_ace!(ace) if self_sid == test_sid
           when Rex::Proto::Secauthz::WellKnownSids::SECURITY_CREATOR_OWNER_SID

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it']),
-      OptEnum.new('REPORT', [true, 'What templates to report (applies filtering to results)', 'all', %w[all vulnerable vulnerable-and-published vulnerable-and-enrollable]]),
+      OptEnum.new('REPORT', [true, 'What templates to report (applies filtering to results)', 'vulnerable-and-published', %w[all vulnerable vulnerable-and-published vulnerable-and-enrollable]]),
       OptBool.new('RUN_REGISTRY_CHECKS', [true, 'Authenticate to WinRM to query the registry values to enhance reporting for ESC9, ESC10 and ESC16. Must be a privileged user in order to query successfully', false]),
     ])
   end


### PR DESCRIPTION
This is a draft but the Tl;Dr is that the `ldap_esc_vulnerable_cert_finder` will now check for enrollment permissions on both the template and CA server. This means users can filter their results to only show templates that are vulnerable and that they have the necessary permissions to enroll in. See the `REPORT` datastore option's new documentation.

The new permissions allow us to detect when a particular user can enroll in a certificate and issue it, enabling us to call this out to the operator since it's actionable. Previously, operators would see templates that have a misconfiguration and are published but that they may or may not have permissions to issue. This is still the default behavior due to the default setting of `REPORT=vulnerable-and-published`.

The `REPORT` setting is divided up into levels of increasingly strict filtering which can be used based on what information the operator wants:

* **all** -- show all templates
* **vulnerable** -- show templates that have at least 1 misconfiguration technique flagged, whether or not you can issue it or if it's even published
* **vulnerable-and-published** - the above but the template is at least published by 1 CA that presumably *someone* can issue from, maybe not you but someone
* **vulnerable-and-enrollable** -- the above but meeting the requirements for you to exploit it which is generally that you can enroll in it with the exception of ESC9, ESC10 and ESC16 where it's if the user you can write to can enroll in it

## Verification

- [x] Run the module against a server with configured ESC vulnerabilities
- [x] Run with `REPORT=all` and see all certificate templates, regardless of whether or not they have a misconfiguration or are even published.
- [x] Run with `REPORT=vulnerable-and-enrollable` and *only* see certificate templates with vulnerabilities you can exploit. Templates that are "vulnerable" but that you don't have the permissions to should now be hidden.
- [x] Run with `REPORT=vulnerable-and-published` see pretty much the same results as the old behavior. The noteable changes are that we check for ESC16 and flag it as potentially vulnerable, and the permissions for the template object are displayed