### PR TITLE
Fix HTTP-based login scanners when using SSL with custom port

### DIFF
--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -304,6 +304,7 @@ module Exploit::Remote::HttpClient
         evade_uri_fake_params_start:   datastore['HTTP::uri_fake_params_start'],
         evade_header_folding:          datastore['HTTP::header_folding'],
         ntlm_domain:                   datastore['DOMAIN'],
+        ssl:                           datastore['SSL'],
         digest_auth_iis:               datastore['DigestAuthIIS'],
       }.merge(conf)
     )

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -171,6 +171,7 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        ssl: datastore['SSL'],
         http_success_codes: success_codes,
         connection_timeout: 5
       )


### PR DESCRIPTION
This PR corrects a bug (#20481) that ends scanner http_login with error "No authentication required" when using SSL with a custom port (different from 443).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use scanner/http/http_login`
- [x] `set RHOST 172.16.1.100`
- [x] `set SSL true`
- [x] `set RPORT 444`
- [x] `run`
- [x] **Verify** that the scan works like expected
- [x] **Verify** that the scan does not stops with error "No authentication required"
