### PR TITLE
Add parallel gem to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ PATH
       openvas-omp
       ostruct
       packetfu
+      parallel
       patch_finder
       pcaprub
       pdf-reader

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -262,6 +262,9 @@ Gem::Specification.new do |spec|
   # When Ruby ships with `gem --version` 3.6.0 or higher by default this can be removed
   spec.add_runtime_dependency 'stringio', '3.1.1'
 
+  # Needed for caching validation
+  spec.add_runtime_dependency 'parallel'
+
   # Standard libraries: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
   %w[
     abbrev


### PR DESCRIPTION
The parallel gem was added as a dependency here: https://github.com/rapid7/metasploit-framework/blob/ab45ae60f3470f2dee8f8197ec48980e4385e00c/lib/msf/core/modules/metadata/store.rb#L2

However it wasn't added as part of our gemspec (i.e. our gem code), it was only a transitive development dependency as part of the RuboCop gem:
https://github.com/rapid7/metasploit-framework/blob/ab45ae60f3470f2dee8f8197ec48980e4385e00c/Gemfile.lock#L557-L561

This pull request adds it correctly to the gemspec file so that codebases that depend on framework as a gem can pull in the parallel gem