### PR TITLE
Fix ldap schannel superclass method call

### DIFF
--- a/lib/msf/core/auxiliary/report_summary.rb
+++ b/lib/msf/core/auxiliary/report_summary.rb
@@ -78,7 +78,7 @@ module Msf
       end
 
       def report_successful_login(public:, private:)
-        return super unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins'] && @report
+        return unless framework.features.enabled?(Msf::FeatureManager::SHOW_SUCCESSFUL_LOGINS) && datastore['ShowSuccessfulLogins'] && @report
 
         @report[rhost] ||= {}
         @report[rhost][:successful_logins] ||= []
@@ -86,6 +86,8 @@ module Msf
           public: public,
           private_data: private
         }
+
+        nil
       end
 
       # Creates a credential and adds to to the DB if one is present, then calls create_credential_login to


### PR DESCRIPTION
Fix LDAP schannel superclass method call

```
LOGIN FAILED: {:private_data=>nil, :private_type=>nil, :username=>nil, :realm_key=>nil, :realm_value=>nil} - Unhandled error - scan may not produce correct results: super: no superclass method `report_successful_login' for
```

## Verification

Script:

```
<ruby>

rhost = "10.140.99.152"

def cert_file(core)
  path = "/tmp/#{core.id}.pfx"
  File.binwrite(path, Base64.decode64(core.private.data))

  path
end

def krb5ccname(value)
  #"#{value.path}"
   "id:#{value.id}"
end

# ICPR cert
run_single("use auxiliary/admin/dcerpc/icpr_cert")
run_single("run rhost=#{rhost} smbuser=sandy smbpass=vagrant smbdomain=ad.pro.local ca=mspro-dc-ad-pro-local-CA cert_template=esc1 alt_upn=administrator@ad.pro.local")

cert = framework.db.creds({ type: 'Metasploit::Credential::Pkcs12' }).last
puts "Stored pkcs12: id=#{cert.id} public=#{cert.public} cert=#{cert.private['metadata'].inspect}"

# Ldap login
run_single("use auxiliary/scanner/ldap/ldap_login")
run_single("run showSuccessfulLogins=false rhost=#{rhost} ssl=true Ldap::Auth=schannel LDAP::CertFile=#{cert_file(cert)}")
</ldap>
```

### Before

Crash when `showSuccessfulLogins` is false

```
[!] 10.140.98.105:389 - LOGIN FAILED: {:private_data=>nil, :private_type=>nil, :username=>nil, :realm_key=>nil, :realm_value=>nil} - Unhandled error - scan may not produce correct results: super: no superclass method `report_successful_login' for
```

### After

No crash:

```
[+] 10.140.98.105:389 - Success: 'Cert File /tmp/41.pfx (/CN=sandy)'
[*] LDAP session 1 opened (10.4.225.254:50018 -> 10.140.98.105:389) at 2025-08-21 11:40:15 +0100
[*] Scanned 1 of 1 hosts (100% complete)
```