### PR TITLE
Fix legacy method override in torchserver_cve_2023_43654

### DIFF
--- a/modules/exploits/multi/http/torchserver_cve_2023_43654.rb
+++ b/modules/exploits/multi/http/torchserver_cve_2023_43654.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ::File.binread(::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2022-1471', "#{class_name}.class"))
   end
 
-  def on_request_uri(cli, request)
+  def java_class_loader_on_request_uri(cli, request)
     if request.relative_resource.end_with?("#{@model_name}.mar")
       print_good('Sending model archive')
       send_response(cli, generate_mar, { 'Content-Type' => 'application/octet-stream' })


### PR DESCRIPTION
I think `Msf::Exploit::Remote::Java::HTTP::ClassLoader` module had `on_request_uri` method, that was later renamed to `java_class_loader_on_request_uri`.

Verified the fix as well 👍 
