### PR TITLE
This adds the `HTTP::Auth` Option to HTTP Modules

### DIFF
--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -15,6 +15,7 @@ module Exploit::Remote::HttpClient
 
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::LoginScanner
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
 
   #
   # Initializes an exploit module that exploits a vulnerability in an HTTP
@@ -155,6 +156,25 @@ module Exploit::Remote::HttpClient
 
     http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: self)
 
+    if datastore['HTTP::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+      kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
+        host: datastore['DomainControllerRhost'],
+        hostname: datastore['HTTP::Rhostname'],
+        proxies: datastore['Proxies'],
+        realm: datastore['DOMAIN'],
+        username: datastore['HttpUsername'],
+        password: datastore['HttpPassword'],
+        timeout: 20, # datastore['timeout']
+        framework: framework,
+        framework_module: self,
+        cache_file: datastore['HTTP::Krb5Ccname'].blank? ? nil : datastore['HTTP::Krb5Ccname'],
+        mutual_auth: true,
+        use_gss_checksum: true,
+        ticket_storage: kerberos_ticket_storage,
+        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['HTTP::KrbOfferedEncryptionTypes'])
+      )
+    end
+
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,
       (opts['rport'] || rport).to_i,
@@ -167,6 +187,7 @@ module Exploit::Remote::HttpClient
       proxies,
       client_username,
       client_password,
+      kerberos_authenticator: kerberos_authenticator,
       comm: opts['comm'],
       subscriber: http_logger_subscriber,
       sslkeylogfile: sslkeylogfile
@@ -373,6 +394,22 @@ module Exploit::Remote::HttpClient
       actual_timeout = datastore['HttpClientTimeout']
     else
       actual_timeout = opts[:timeout] || timeout
+    end
+
+    unless opts.key?('preferred_auth')
+      case datastore['HTTP::Auth']
+      when Msf::Exploit::Remote::AuthOption::AUTO
+        opts['preferred_auth'] = nil
+      when Msf::Exploit::Remote::AuthOption::KERBEROS
+        opts['preferred_auth'] = 'Kerberos'
+      when Msf::Exploit::Remote::AuthOption::NTLM
+        opts['preferred_auth'] = 'NTLM'
+      when Msf::Exploit::Remote::AuthOption::PLAINTEXT
+        # Basic auth might as well be plaintext right?
+        opts['preferred_auth'] = 'Basic'
+      when Msf::Exploit::Remote::AuthOption::NONE
+        opts['preferred_auth'] = 'None'
+      end
     end
 
     c = opts['client'] || connect(opts)

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -159,22 +159,29 @@ module Exploit::Remote::HttpClient
 
     http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: self)
 
-    kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
-      host: datastore['DomainControllerRhost'],
-      hostname: datastore['HTTP::Rhostname'],
-      proxies: datastore['Proxies'],
-      realm: datastore['DOMAIN'],
-      username: datastore['HttpUsername'],
-      password: datastore['HttpPassword'],
-      timeout: 20, # datastore['timeout']
-      framework: framework,
-      framework_module: self,
-      cache_file: datastore['HTTP::Krb5Ccname'].blank? ? nil : datastore['HTTP::Krb5Ccname'],
-      mutual_auth: true,
-      use_gss_checksum: true,
-      ticket_storage: kerberos_ticket_storage,
-      offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['HTTP::KrbOfferedEncryptionTypes'])
-    )
+    kerberos_authenticator = nil
+    if datastore['HTTP::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The HTTP::Rhostname option is required when using Kerberos authentication.') if datastore['HTTP::Rhostname'].blank?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'The DOMAIN option is required when using Kerberos authentication.') if datastore['DOMAIN'].blank?
+      offered_etypes = Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['HTTP::KrbOfferedEncryptionTypes'])
+      fail_with(Msf::Exploit::Failure::BadConfig, 'At least one encryption type is required when using Kerberos authentication.') if offered_etypes.empty?
+
+      kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
+        host: datastore['DomainControllerRhost'],
+        hostname: datastore['HTTP::Rhostname'],
+        proxies: datastore['Proxies'],
+        realm: datastore['DOMAIN'],
+        username: datastore['HttpUsername'],
+        password: datastore['HttpPassword'],
+        framework: framework,
+        framework_module: self,
+        cache_file: datastore['HTTP::Krb5Ccname'].blank? ? nil : datastore['HTTP::Krb5Ccname'],
+        mutual_auth: true,
+        use_gss_checksum: true,
+        ticket_storage: kerberos_ticket_storage,
+        offered_etypes: offered_etypes
+      )
+    end
 
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -16,6 +16,7 @@ module Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::LoginScanner
   include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   #
   # Initializes an exploit module that exploits a vulnerability in an HTTP
@@ -36,6 +37,8 @@ module Exploit::Remote::HttpClient
 
     register_advanced_options(
       [
+        *kerberos_storage_options(protocol: 'HTTP'),
+        *kerberos_auth_options(protocol: 'HTTP', auth_methods: Msf::Exploit::Remote::AuthOption::HTTP_OPTIONS),
         OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests',
           Rex::UserAgent.session_agent
           ]),
@@ -156,24 +159,22 @@ module Exploit::Remote::HttpClient
 
     http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: self)
 
-    if datastore['HTTP::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
-      kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
-        host: datastore['DomainControllerRhost'],
-        hostname: datastore['HTTP::Rhostname'],
-        proxies: datastore['Proxies'],
-        realm: datastore['DOMAIN'],
-        username: datastore['HttpUsername'],
-        password: datastore['HttpPassword'],
-        timeout: 20, # datastore['timeout']
-        framework: framework,
-        framework_module: self,
-        cache_file: datastore['HTTP::Krb5Ccname'].blank? ? nil : datastore['HTTP::Krb5Ccname'],
-        mutual_auth: true,
-        use_gss_checksum: true,
-        ticket_storage: kerberos_ticket_storage,
-        offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['HTTP::KrbOfferedEncryptionTypes'])
-      )
-    end
+    kerberos_authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
+      host: datastore['DomainControllerRhost'],
+      hostname: datastore['HTTP::Rhostname'],
+      proxies: datastore['Proxies'],
+      realm: datastore['DOMAIN'],
+      username: datastore['HttpUsername'],
+      password: datastore['HttpPassword'],
+      timeout: 20, # datastore['timeout']
+      framework: framework,
+      framework_module: self,
+      cache_file: datastore['HTTP::Krb5Ccname'].blank? ? nil : datastore['HTTP::Krb5Ccname'],
+      mutual_auth: true,
+      use_gss_checksum: true,
+      ticket_storage: kerberos_ticket_storage,
+      offered_etypes: Msf::Exploit::Remote::AuthOption.as_default_offered_etypes(datastore['HTTP::KrbOfferedEncryptionTypes'])
+    )
 
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -323,7 +323,7 @@ module Rex
             return res
           elsif supported_auths.include?('Negotiate') && (preferred_auth.nil? || preferred_auth == 'Kerberos')
             opts['provider'] = 'Negotiate'
-            temp_response = kerberos_auth(opts)
+            temp_response = kerberos_auth(opts, mechanism: Rex::Proto::Gss::Mechanism::SPNEGO)
             if temp_response.is_a? Rex::Proto::Http::Response
               res = temp_response
             end
@@ -411,16 +411,21 @@ module Rex
           end
         end
 
-        def kerberos_auth(opts = {})
+        def kerberos_auth(opts = {}, mechanism: Rex::Proto::Gss::Mechanism::KERBEROS)
           to = opts['timeout'] || 20
-          auth_result = kerberos_authenticator.authenticate(mechanism: Rex::Proto::Gss::Mechanism::KERBEROS)
+          auth_result = kerberos_authenticator.authenticate(mechanism: mechanism)
           gss_data = auth_result[:security_blob]
           gss_data_b64 = Rex::Text.encode_base64(gss_data)
 
           # Separate options for the auth requests
           auth_opts = opts.clone
           auth_opts['headers'] = opts['headers'].clone
-          auth_opts['headers']['Authorization'] = "Kerberos #{gss_data_b64}"
+          case mechanism
+          when Rex::Proto::Gss::Mechanism::KERBEROS
+            auth_opts['headers']['Authorization'] = "Kerberos #{gss_data_b64}"
+          when Rex::Proto::Gss::Mechanism::SPNEGO
+            auth_opts['headers']['Authorization'] = "Negotiate #{gss_data_b64}"
+          end
 
           if auth_opts['no_body_for_auth']
             auth_opts.delete('data')

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -314,6 +314,13 @@ module Rex
               res = temp_response
             end
             return res
+          elsif supported_auths.include?('Kerberos') && (preferred_auth.nil? || preferred_auth == 'Kerberos') && kerberos_authenticator
+            opts['provider'] = 'Kerberos'
+            temp_response = kerberos_auth(opts, mechanism: Rex::Proto::Gss::Mechanism::KERBEROS)
+            if temp_response.is_a? Rex::Proto::Http::Response
+              res = temp_response
+            end
+            return res
           elsif supported_auths.include?('Negotiate') && (preferred_auth.nil? || preferred_auth == 'Negotiate')
             opts['provider'] = 'Negotiate'
             temp_response = negotiate_auth(opts)
@@ -321,7 +328,7 @@ module Rex
               res = temp_response
             end
             return res
-          elsif supported_auths.include?('Negotiate') && (preferred_auth.nil? || preferred_auth == 'Kerberos')
+          elsif supported_auths.include?('Negotiate') && (preferred_auth.nil? || preferred_auth == 'Kerberos') && kerberos_authenticator
             opts['provider'] = 'Negotiate'
             temp_response = kerberos_auth(opts, mechanism: Rex::Proto::Gss::Mechanism::SPNEGO)
             if temp_response.is_a? Rex::Proto::Http::Response

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -8,6 +8,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   # Scanner mixin should be near last
   include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
+  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   def initialize
     super(
@@ -31,6 +33,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
+        *kerberos_storage_options(protocol: 'HTTP'),
+        *kerberos_auth_options(protocol: 'HTTP', auth_methods: Msf::Exploit::Remote::AuthOption::HTTP_OPTIONS),
         OptString.new('HttpQueryString', [ false, 'The HTTP query string', nil ]),
         OptBool.new('FollowRedirect', [ false, 'Follow a HTTP redirect', false ]),
         OptInt.new('FollowRedirectDepth', [false, 'Follow HTTP redirect depth', 1]),

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -8,8 +8,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   # Scanner mixin should be near last
   include Msf::Auxiliary::Scanner
-  include Msf::Exploit::Remote::Kerberos::Ticket::Storage
-  include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
   def initialize
     super(
@@ -33,8 +31,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        *kerberos_storage_options(protocol: 'HTTP'),
-        *kerberos_auth_options(protocol: 'HTTP', auth_methods: Msf::Exploit::Remote::AuthOption::HTTP_OPTIONS),
         OptString.new('HttpQueryString', [ false, 'The HTTP query string', nil ]),
         OptBool.new('FollowRedirect', [ false, 'Follow a HTTP redirect', false ]),
         OptInt.new('FollowRedirectDepth', [false, 'Follow HTTP redirect depth', 1]),


### PR DESCRIPTION
This adds the `HTTP::Auth` option to HTTP modules, which most notably enables Kerberos authentication. Prior to this, Metasploit's HTTP client stack had a partial implementation that was used by WinRM but the necessary code to enable general HTTP modules to authenticate with Kerberos was absent. This corrects that, so future modules such as those planned in #20467 and #20465 will get Kerberos authentication "for free".

## Verification

- [x] Set up an ESC8 target with web enrollment services, see https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.md#setting-up-a-esc8-vulnerable-host
- [x] Run the `auxiliary/scanner/http/title` module with different authentication options (set `HTTP::Auth`), NTLM, Kerberos and Auto should all work
- [x] Optionally use wireshark / HttpTrace to validate the authenticate method is correct
- [x] See the correct HTML title when authentication succeeds
- [x] **Test a WinRM module to ensure that they still work**

## Demo
```
msf auxiliary(scanner/http/title) > run HTTP::Auth=none
[+] [192.168.159.10:443] [C:401] [R:] [S:Microsoft-IIS/10.0] 401 - Unauthorized: Access is denied due to invalid credentials.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/title) > run HTTP::Auth=plaintext
[+] [192.168.159.10:443] [C:401] [R:] [S:Microsoft-IIS/10.0] 401 - Unauthorized: Access is denied due to invalid credentials.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/title) > run HTTP::Auth=ntlm
[+] [192.168.159.10:443] [C:200] [R:] [S:Microsoft-IIS/10.0] Microsoft Active Directory Certificate Services
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/title) > run HTTP::Auth=kerberos
[*] Using KDC dc.msflab.local for realm msflab.local
[+] dc.msflab.local:88 - Received a valid TGT-Response
[*] 192.168.159.10:443    - TGT MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20250822155419_default_192.168.159.10_mit.kerberos.cca_965310.bin
[+] dc.msflab.local:88 - Received a valid TGS-Response
[*] 192.168.159.10:443    - TGS MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20250822155419_default_192.168.159.10_mit.kerberos.cca_631324.bin
[+] dc.msflab.local:88 - Received a valid delegation TGS-Response
[+] [192.168.159.10:443] [C:200] [R:] [S:Microsoft-IIS/10.0] Microsoft Active Directory Certificate Services
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/title) > run krbcachemode=none 
[*] Using KDC dc.msflab.local for realm msflab.local
[+] dc.msflab.local:88 - Received a valid TGT-Response
[+] dc.msflab.local:88 - Received a valid TGS-Response
[+] dc.msflab.local:88 - Received a valid delegation TGS-Response
[+] [192.168.159.10:443] [C:200] [R:] [S:Microsoft-IIS/10.0] Microsoft Active Directory Certificate Services
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/title) > run krbcachemode=read-write
[*] Using cached credential for http/dc.msflab.local@MSFLAB.LOCAL smcintyre@MSFLAB.LOCAL
[+] [192.168.159.10:443] [C:200] [R:] [S:Microsoft-IIS/10.0] Microsoft Active Directory Certificate Services
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/title) >
```