### PR TITLE
gem stringio version 3.1.2 is now default system gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ PATH
       sinatra
       sqlite3 (= 1.7.3)
       sshkey
-      stringio (= 3.1.1)
+      stringio (= 3.1.2)
       swagger-blocks
       syslog
       thin
@@ -602,7 +602,7 @@ GEM
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     sshkey (3.0.0)
-    stringio (3.1.1)
+    stringio (3.1.2)
     strptime (0.2.5)
     swagger-blocks (3.0.0)
     syslog (0.3.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -258,9 +258,8 @@ Gem::Specification.new do |spec|
   # Needed for generic in-memory cachine
   spec.add_runtime_dependency 'lru_redux'
 
-  # Pinned on 3.1.1 as it is the version supported by our Ruby 3.3.8 dependency to avoid this issue https://github.com/rubygems/rubygems/issues/7657#issuecomment-2521083323
-  # When Ruby ships with `gem --version` 3.6.0 or higher by default this can be removed
-  spec.add_runtime_dependency 'stringio', '3.1.1'
+  # gem version is now at 3.8.0, which has stringio version 3.1.2 as default system gem
+  spec.add_runtime_dependency 'stringio', '3.1.2'
 
   # Needed for caching validation
   spec.add_runtime_dependency 'parallel'


### PR DESCRIPTION
gem version is now at 3.8.0, which has stringio version 3.1.2 as default system gem