### PR TITLE
Add the monkey patch for the TagBuilder that pro needs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -4,6 +4,26 @@ Fiddle.const_set(:VERSION, '0.0.0') unless Fiddle.const_defined?(:VERSION)
 require 'rails'
 require File.expand_path('../boot', __FILE__)
 
+require 'action_view'
+# Monkey patch https://github.com/rails/rails/blob/v7.2.2.1/actionview/lib/action_view/helpers/tag_helper.rb#L51
+# Might be fixed by 8.x https://github.com/rails/rails/blob/v8.0.2/actionview/lib/action_view/helpers/tag_helper.rb#L51C1-L52C1
+raise unless ActionView::VERSION::STRING == '7.2.2.1' # A developer will need to ensure this is still required when bumping rails
+module ActionView::Helpers::TagHelper
+  class TagBuilder
+    def self.define_element(name, code_generator:, method_name: name.to_s.underscore)
+      code_generator.define_cached_method(method_name, namespace: :tag_builder) do |batch|
+        # Fixing a bug introduced by Metasploit's global Kernel patch: https://github.com/rapid7/metasploit-framework/blob/ae1db09f32cd04c007dbf445cf16dc22c9fc2e53/lib/rex.rb#L74-L79
+        # which fails when using the below 'instance_methods.include?(method_name.to_sym)' check
+        batch.push(<<~RUBY) # unless instance_methods.include?(method_name.to_sym)
+              def #{method_name}(content = nil, escape: true, **options, &block)
+                tag_string("#{name}", content, options, escape: escape, &block)
+              end
+            RUBY
+      end
+    end
+  end
+end
+
 all_environments = [
     :development,
     :production,


### PR DESCRIPTION
Running the `msfconsole` command from a pro install was causing a crash 
```/Users/dwelch/.rvm/gems/ruby-3.3.8@pro/gems/activesupport-7.2.2.1/lib/active_support/code_generator.rb:35:in `instance_method': undefined method `select' for module `#<Module:0x000000012bb1ce58>' (NameError)

          owner.define_method(as, @cache.instance_method(canonical_name))
                                        ^^^^^^^^^^^^^^^^
	from /Users/dwelch/.rvm/gems/ruby-3.3.8@pro/gems/activesupport-7.2.2.1/lib/active_support/code_generator.rb:35:in `block in apply'
	from /Users/dwelch/.rvm/gems/ruby-3.3.8@pro/gems/activesupport-7.2.2.1/lib/active_support/code_generator.rb:34:in `each'
	from /Users/dwelch/.rvm/gems/ruby-3.3.8@pro/gems/activesupport-7.2.2.1/lib/active_support/code_generator.rb:34:in `apply'
	from /Users/dwelch/.rvm/gems/ruby-3.3.8@pro/gems/activesupport-7.2.2.1/lib/active_support/code_generator.rb:66:in `block in execute'
	from /Users/dwelch/.rvm/gems/ruby-3.3.8@pro/gems/activesupport-7.2.2.1/lib/active_support/code_generator.rb:65:in `each_value'
	from /Users/dwelch/.rvm/gems/ruby-3.3.8@pro/gems/activesupport-7.2.2.1/lib/active_support/code_generator.rb:65:in `execute'
```	
This patch to the `TagBuilder` already existed in pro but was missing from framework and will no longer be needed when we upgrade to Rails 8