### PR TITLE
Fixes database name stripping

### DIFF
--- a/lib/msf/core/db_connector.rb
+++ b/lib/msf/core/db_connector.rb
@@ -247,6 +247,7 @@ module DbConnector
       targ,name = dest.split('/')
       (name = targ and targ = nil) if not name
       res[:host],res[:port] = targ.split(':') if targ
+      name = name&.split('?')&.first
     end
     res[:name] = name || 'metasploit3'
     res


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/19945

I was able to replicate the issue locally:
```
2025-08-28 10:25:45.367 UTC [63] FATAL:  database "msf_dev?pool=200&timeout=5" does not exist
db-1  | 2025-08-28 10:25:45.374 UTC [64] FATAL:  database "msf_dev?pool=200&timeout=5" does not exist
ms-1  | [-] Error while running command db_connect: We could not find your database: msf_dev?pool=200&timeout=5. Available database configurations can be found in config/database.yml.
ms-1  |
ms-1  | To resolve this error:
ms-1  |
ms-1  | - Did you not create the database, or did you delete it? To create the database, run:
ms-1  |
ms-1  |     bin/rails db:create
ms-1  |
ms-1  | - Has the database name changed? Verify that config/database.yml contains the correct database name.
```

I believe this was due to to query parameters not being stripped correctly here: https://github.com/rapid7/metasploit-framework/blob/6043d0ffbacf265f806dc6180778eb5551b498a1/lib/msf/core/db_connector.rb#L247


## Explanation
I believe this was due to the database name not being stripped and therefore the database could not be found correctly.
Was getting `database "msf_dev?pool=200&timeout=5" does not exist` but expected `msf_dev` as the database name.

## Replication steps I used
```
# 1. Clean up
docker compose -f docker-compose.yml -f docker-compose.override.yml down -v

# 2. Rebuild the Docker container with our fix (no cache to ensure fresh build)
docker compose -f docker-compose.yml -f docker-compose.override.yml build --no-cache

# 3. Start the database container first
docker compose -f docker-compose.yml -f docker-compose.override.yml up -d db

# 4. Create the database
docker compose -f docker-compose.yml -f docker-compose.override.yml exec db createdb -U postgres msf_dev

# 5. Bring up
docker compose -f docker-compose.yml -f docker-compose.override.yml up
```

## Verification
- [ ] Code changes are sane
- [ ] Verify issue on master using the above replication steps
- [ ] Verify the issue is not present on this branch