### PR TITLE
fix output of `sap_router_portscanner` that causes module crash

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
@@ -423,6 +423,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     print_warning('Warning: Service info could be inaccurate')
-    print(tbl)
+    print_line(tbl.to_s)
   end
 end


### PR DESCRIPTION
## Issue
```text
[*] Running module against 212.83.142.83
[*] 212.83.142.83:3299 - Scanning 172.16.13.37
[!] 212.83.142.83:3299 - Warning: Service info could be inaccurate
[-] 212.83.142.83:3299 - Auxiliary failed: NoMethodError undefined method 'gsub!' for an instance of Rex::Text::WrappedTable
[-] 212.83.142.83:3299 - Call stack:
[-] 212.83.142.83:3299 -   /opt/metasploit/vendor/bundle/ruby/3.4.0/gems/rex-text-0.2.61/lib/rex/text/color.rb:60:in 'Rex::Text::Color#substitute_colors'
[-] 212.83.142.83:3299 -   /opt/metasploit/lib/rex/ui/text/output.rb:68:in 'Rex::Ui::Text::Output#print'
[-] 212.83.142.83:3299 -   /opt/metasploit/lib/rex/ui/subscriber.rb:75:in 'Rex::Ui::Subscriber::Output#print'
[-] 212.83.142.83:3299 -   /opt/metasploit/modules/auxiliary/scanner/sap/sap_router_portscanner.rb:426:in 'Msf::Modules::Auxiliary__Scanner__Sap__Sap_router_portscanner::MetasploitModule#run_host'
[-] 212.83.142.83:3299 -   /opt/metasploit/modules/auxiliary/scanner/sap/sap_router_portscanner.rb:325:in 'block in Msf::Modules::Auxiliary__Scanner__Sap__Sap_router_portscanner::MetasploitModule#run'
[-] 212.83.142.83:3299 -   /opt/metasploit/vendor/bundle/ruby/3.4.0/gems/rex-socket-0.1.62/lib/rex/socket/range_walker.rb:223:in 'Rex::Socket::RangeWalker#each_ip'
[-] 212.83.142.83:3299 -   /opt/metasploit/modules/auxiliary/scanner/sap/sap_router_portscanner.rb:324:in 'Msf::Modules::Auxiliary__Scanner__Sap__Sap_router_portscanner::MetasploitModule#run'
[*] Auxiliary module execution completed
```

## Bugfix
update `print(tbl)` to `print_line(tbl.to_s)` to make sure output is provided as string