### PR TITLE
Added SNI support for the ssl_version scanner

### DIFF
--- a/modules/auxiliary/scanner/ssl/ssl_version.rb
+++ b/modules/auxiliary/scanner/ssl/ssl_version.rb
@@ -74,6 +74,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
+        OptString.new('SSLServerNameIndication', [ false, 'SSL/TLS Server Name Indication (SNI)', nil]),
         OptEnum.new('SSLVersion', [ true, 'SSL version to test', 'All', ['All'] + Array.new(OpenSSL::SSL::SSLContext.new.ciphers.length) { |i| (OpenSSL::SSL::SSLContext.new.ciphers[i][1]).to_s }.uniq.reverse]),
         OptEnum.new('SSLCipher', [ true, 'SSL cipher to test', 'All', ['All'] + Array.new(OpenSSL::SSL::SSLContext.new.ciphers.length) { |i| (OpenSSL::SSL::SSLContext.new.ciphers[i][0]).to_s }.uniq]),
       ]
@@ -471,8 +472,11 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       ctx = { 'Msf' => framework, 'MsfExploit' => self }
+      tls_server_name_indication = nil
+      tls_server_name_indication = datastore['SSLServerNameIndication'] if datastore['SSLServerNameIndication'].present?
+      tls_server_name_indication = datastore['RHOSTNAME'] if tls_server_name_indication.nil? && datastore['RHOSTNAME'].present?
       # Initialize rex-sslscan scanner
-      scanner = Rex::SSLScan::Scanner.new(ip, rport, ctx)
+      scanner = Rex::SSLScan::Scanner.new(ip, rport, ctx, tls_server_name_indication: tls_server_name_indication)
 
       # Perform the scan
       scan_result = scanner.scan


### PR DESCRIPTION
This PR fixes missing SNI support for the ssl_version scanner.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssl/ssl_version`
- [x] `set rhosts localhost` - target server with weak certificates and ciphers enabled, default port is 443. Use hostname
- [x] `set SSLServerNameIndication localhost`
- [x] `run`
- [x] Verify Certificate Information
- [x] Verify that certificate is saved to loot
- [x] Verify that information about public key size is visible
- [x] Verify that each enabled protocol version has a list of all accepted ciphers
- [x] Verify that detailed scan results are saved to loot
#
- [x] `set rhosts 127.0.0.1` - target server with weak certificates and ciphers enabled, default port is 443. Use server's IP address
- [x] `set SSLServerNameIndication 127.0.0.1`
- [x] `run`
- [x] Verify Certificate Information
- [x] Verify that certificate is saved to loot
- [x] Verify that information about public key size is visible
- [x] Verify that each enabled protocol version has a list of all accepted ciphers
- [x] Verify that detailed scan results are saved to loot
#
- [x] `set rhosts 127.0.0.1` - target server with weak certificates and ciphers enabled, default port is 443. Use server's IP address
- [x] `set SSLServerNameIndication localhost`
- [x] `run`
- [x] Verify Certificate Information
- [x] Verify that certificate is saved to loot
- [x] Verify that information about public key size is visible
- [x] Verify that each enabled protocol version has a list of all accepted ciphers
- [x] Verify that detailed scan results are saved to loot
