### PR TITLE
Removing unhook extension autoload

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -184,7 +184,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
     # BEGIN: This should be removed on MSF 7
     # Unhook the process prior to loading stdapi to reduce logging/inspection by any AV/PSP (by default unhook is first, see meterpreter_options/windows.rb)
-    # The unhook extension is broken. reference: TODO
+    # The unhook extension is broken. reference: https://github.com/rapid7/metasploit-framework/pull/20514
 
     #extensions.push('unhook') if datastore['AutoUnhookProcess'] && session.platform == 'windows'
     extensions.push('stdapi') if datastore['AutoLoadStdapi']

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -184,7 +184,9 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
     # BEGIN: This should be removed on MSF 7
     # Unhook the process prior to loading stdapi to reduce logging/inspection by any AV/PSP (by default unhook is first, see meterpreter_options/windows.rb)
-    extensions.push('unhook') if datastore['AutoUnhookProcess'] && session.platform == 'windows'
+    # The unhook extension is broken. reference: TODO
+
+    #extensions.push('unhook') if datastore['AutoUnhookProcess'] && session.platform == 'windows'
     extensions.push('stdapi') if datastore['AutoLoadStdapi']
     extensions.push('priv') if datastore['AutoLoadStdapi'] && session.platform == 'windows'
     extensions.push('android') if session.platform == 'android'
@@ -197,7 +199,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     extensions.each do |extension|
       begin
         console.run_single("load #{extension}")
-        console.run_single('unhook_pe') if extension == 'unhook'
+        # console.run_single('unhook_pe') if extension == 'unhook'
         session.load_session_info if extension == 'stdapi' && datastore['AutoSystemInfo']
       rescue => e
         print_warning("Failed loading extension #{extension}")

--- a/lib/msf/base/sessions/meterpreter_options/windows.rb
+++ b/lib/msf/base/sessions/meterpreter_options/windows.rb
@@ -17,11 +17,7 @@ module Msf
             OptString.new(
               'AutoLoadExtensions',
               [true, "Automatically load extensions on bootstrap, comma separated.", 'priv,stdapi']
-            ),
-            OptBool.new(
-              'AutoUnhookProcess',
-              [true, "Automatically load the unhook extension and unhook the process", false]
-            ),
+            )
           ],
           self.class
         )

--- a/lib/msf/base/sessions/meterpreter_options/windows.rb
+++ b/lib/msf/base/sessions/meterpreter_options/windows.rb
@@ -16,7 +16,7 @@ module Msf
           [
             OptString.new(
               'AutoLoadExtensions',
-              [true, "Automatically load extensions on bootstrap, comma separated.", 'unhook,priv,stdapi']
+              [true, "Automatically load extensions on bootstrap, comma separated.", 'priv,stdapi']
             ),
             OptBool.new(
               'AutoUnhookProcess',


### PR DESCRIPTION
fix issue: https://github.com/rapid7/metasploit-framework/issues/20515

## Description

This is a regression I introduced on:
https://github.com/rapid7/metasploit-framework/pull/20012
while working on the break-up of the meterpreter options.
By default we weren't loading `unhook` and I wrongly follow the logic of adding it by default while keeping the `AutoLoadUnhook` as false. This PR reverts the standard loading logic withou having unhook by default. 

Some logs of the crash:

Last log item:

```
[1510] [REFRESH] Refreshing DLL: C:\Windows\SYSTEM32\MSASN1.dll
[1510] [REFRESH] Opening file: C:\Windows\SYSTEM32\MSASN1.dll
[1510] [REFRESH] Allocating memory for library
[1510] [REFRESH] Copying PE header into memory
[1510] [REFRESH] Copying PE sections into memory
[1510] [REFRESH] Calculating file relocations
[1510] [REFRESH] Resolving Import Address Table (IAT) 
[1510] [REFRESH] Loading library: ntdll.dll
[1510] [REFRESH] Searching for loaded module: ntdll.dll
[1510] [REFRESH] Loading library: api-ms-win-core-heap-l2-1-0.dll
[1510] [REFRESH] Redirected library: kernelbase.dll
[1510] [REFRESH] Searching for loaded module: kernelbase.dll
[1510] [REFRESH] Loading library: api-ms-win-core-libraryloader-l1-2-0.dll
[1510] [REFRESH] Redirected library: kernelbase.dll
[1510] [REFRESH] Searching for loaded module: kernelbase.dll
[1510] [REFRESH] Loading library: api-ms-win-core-registry-l1-1-0.dll
[1510] [REFRESH] Redirected library: kernelbase.dll
[1510] [REFRESH] Searching for loaded module: kernelbase.dll
[1510] [REFRESH] Loading library: api-ms-win-core-string-l1-1-0.dll
[1510] [REFRESH] Redirected library: kernelbase.dll
[1510] [REFRESH] Searching for loaded module: kernelbase.dll
[1510] [REFRESH] Loading library: api-ms-win-core-profile-l1-1-0.dll
[1510] [REFRESH] Redirected library: kernelbase.dll
[1510] [REFRESH] Searching for loaded module: kernelbase.dll
[1510] [REFRESH] Loading library: api-ms-win-core-processthreads-l1-1-0.dll
[1510] [REFRESH] Redirected library: kernel32.dll
[1510] [REFRESH] Searching for loaded module: kernel32.dll
[1510] [REFRESH] Loading library: api-ms-win-core-sysinfo-l1-1-0.dll
[1510] [REFRESH] Redirected library: kernelbase.dll
[1510] [REFRESH] Searching for loaded module: kernelbase.dll
[1510] [REFRESH] Loading library: api-ms-win-core-errorhandling-l1-1-0.dll
[1510] [REFRESH] Redirected library: kernelbase.dll
[1510] [REFRESH] Searching for loaded module: kernelbase.dll
[1510] [REFRESH] Loading library: api-ms-win-core-string-obsolete-l1-1-0.dll
[1510] [REFRESH] Redirected library: kernel32.dll
[1510] [REFRESH] Searching for loaded module: kernel32.dll
[1510] [REFRESH] Scanning module: MSASN1.dll

```

thanks to @jeffmcjunkin for spotting the issue

## Testing
Ensure the meterpreter session lods.