### PR TITLE
Fix msfdb init failures on NixOs

### DIFF
--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -46,7 +46,7 @@ module MsfdbHelpers
       begin
         file_name = File.join(path, 'msfdb_testfile')
         File.open(file_name, 'w') do |f|
-          f.puts "#!/bin/bash\necho exec"
+          f.puts "#!/bin/sh\necho exec"
         end
         File.chmod(0744, file_name)
 


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/19889

Fix msfdb init failures on NixOs

## Verification

Replication steps: https://github.com/rapid7/metasploit-framework/issues/19889#issuecomment-3252311853

Working: https://github.com/rapid7/metasploit-framework/issues/19889

Test steps: Ensure `msfdb init` continues to work on an ubuntu and osx box, and now also on nixos