### PR TITLE
Adds `lib/msf/base/sessions` path to Meterpreter acceptance workflow paths

### DIFF
--- a/.github/workflows/meterpreter_acceptance.yml
+++ b/.github/workflows/meterpreter_acceptance.yml
@@ -44,6 +44,7 @@ on:
       - 'Gemfile.lock'
       - 'data/templates/**'
       - 'modules/payloads/**'
+      - 'lib/msf/base/sessions/**'
       - 'lib/msf/core/payload/**'
       - 'lib/msf/core/**'
       - 'test/modules/**'


### PR DESCRIPTION
This PR adds `lib/msf/base/sessions` path to Meterpreter acceptance workflow paths. This means if any changes are made to file under that path the `.github/workflows/meterpreter_acceptance.yml` job will now run. Spotted as part of https://github.com/rapid7/metasploit-framework/pull/20514 when the Meterpreter tests didn't run on CI.

## Verification

- [ ] Code changes are sane