### PR TITLE
Add T1003 "OS credential dumping" MITRE technique reference

### DIFF
--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -34,7 +34,8 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'References' => [
           [ 'URL', 'http://sourceforge.net/projects/smbexec' ],
-          [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ]
+          [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'URL', 'http://sourceforge.net/projects/smbexec' ],
           [ 'URL', 'https://www.optiv.com/blog/owning-computers-without-shell-access' ],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_003_NTDS ]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
+++ b/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://www.rapid7.com/blog/post/2024/05/30/etr-cve-2024-24919-check-point-security-gateway-information-disclosure/' ],
           # Publication of first proof-of-concept exploit
           [ 'URL', 'https://labs.watchtowr.com/check-point-wrong-check-point-cve-2024-24919/' ],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW ]
         ]
       )
     )

--- a/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
+++ b/modules/auxiliary/gather/checkpoint_gateway_fileread_cve_2024_24919.rb
@@ -34,7 +34,8 @@ class MetasploitModule < Msf::Auxiliary
           # Rapid7 ETR advisory for CVE-2024-24919
           [ 'URL', 'https://www.rapid7.com/blog/post/2024/05/30/etr-cve-2024-24919-check-point-security-gateway-information-disclosure/' ],
           # Publication of first proof-of-concept exploit
-          [ 'URL', 'https://labs.watchtowr.com/check-point-wrong-check-point-cve-2024-24919/' ]
+          [ 'URL', 'https://labs.watchtowr.com/check-point-wrong-check-point-cve-2024-24919/' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
         ]
       )
     )

--- a/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
+++ b/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://www.fortiguard.com/psirt/FG-IR-18-384'],
           ['URL', 'https://i.blackhat.com/USA-19/Wednesday/us-19-Tsai-Infiltrating-Corporate-Intranet-Like-NSA.pdf'],
           ['URL', 'https://devco.re/blog/2019/08/09/attacking-ssl-vpn-part-2-breaking-the-Fortigate-ssl-vpn/'],
-          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
+          ['ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW]
         ],
         'Author' => [
           'Meh Chang', # discovery and PoC

--- a/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
+++ b/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Auxiliary
           %w[EDB 47288],
           ['URL', 'https://www.fortiguard.com/psirt/FG-IR-18-384'],
           ['URL', 'https://i.blackhat.com/USA-19/Wednesday/us-19-Tsai-Infiltrating-Corporate-Intranet-Like-NSA.pdf'],
-          ['URL', 'https://devco.re/blog/2019/08/09/attacking-ssl-vpn-part-2-breaking-the-Fortigate-ssl-vpn/']
+          ['URL', 'https://devco.re/blog/2019/08/09/attacking-ssl-vpn-part-2-breaking-the-Fortigate-ssl-vpn/'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'Author' => [
           'Meh Chang', # discovery and PoC

--- a/modules/auxiliary/gather/ldap_passwords.rb
+++ b/modules/auxiliary/gather/ldap_passwords.rb
@@ -40,7 +40,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://blog.xpnsec.com/lapsv2-internals/'],
-          ['URL', 'https://github.com/fortra/impacket/blob/master/examples/GetLAPSPassword.py']
+          ['URL', 'https://github.com/fortra/impacket/blob/master/examples/GetLAPSPassword.py'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'DisclosureDate' => '2020-07-23',
         'License' => MSF_LICENSE,

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://seclists.org/fulldisclosure/2017/Feb/2'],
-          ['URL', 'https://en.wikipedia.org/wiki/Binary_search_algorithm']
+          ['URL', 'https://en.wikipedia.org/wiki/Binary_search_algorithm'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'DisclosureDate' => '2017-01-31',
         'License' => MSF_LICENSE,

--- a/modules/auxiliary/gather/qnap_lfi.rb
+++ b/modules/auxiliary/gather/qnap_lfi.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://infosecwriteups.com/qnap-pre-auth-root-rce-affecting-450k-devices-on-the-internet-d55488d28a05'],
           ['URL', 'https://www.qnap.com/en-us/security-advisory/nas-201911-25'],
           ['URL', 'https://github.com/Imanfeng/QNAP-NAS-RCE'],
-          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
+          ['ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW]
         ],
         'DisclosureDate' => '2019-11-25', # Vendor advisory
         'Actions' => [

--- a/modules/auxiliary/gather/qnap_lfi.rb
+++ b/modules/auxiliary/gather/qnap_lfi.rb
@@ -36,7 +36,8 @@ class MetasploitModule < Msf::Auxiliary
           ['EDB', '48531'],
           ['URL', 'https://infosecwriteups.com/qnap-pre-auth-root-rce-affecting-450k-devices-on-the-internet-d55488d28a05'],
           ['URL', 'https://www.qnap.com/en-us/security-advisory/nas-201911-25'],
-          ['URL', 'https://github.com/Imanfeng/QNAP-NAS-RCE']
+          ['URL', 'https://github.com/Imanfeng/QNAP-NAS-RCE'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'DisclosureDate' => '2019-11-25', # Vendor advisory
         'Actions' => [

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['CVE', '2020-3952'],
-          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0006.html']
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0006.html'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'DisclosureDate' => '2020-04-09', # Vendor advisory
         'License' => MSF_LICENSE,

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -68,6 +68,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING],
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -68,7 +68,10 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py'],
-          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_002_SECURITY_ACCOUNT_MANAGER],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_004_LSA_SECRETS],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_005_CACHED_DOMAIN_CREDENTIALS],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_006_DCSYNC]
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/scanner/http/epmp1000_dump_hashes.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_dump_hashes.rb
@@ -19,7 +19,8 @@ class MetasploitModule < Msf::Auxiliary
         },
         'References' => [
           ['URL', 'http://ipositivesecurity.com/2015/11/28/cambium-epmp-1000-multiple-vulnerabilities/'],
-          ['URL', 'https://support.cambiumnetworks.com/file/476262a0256fdd8be0e595e51f5112e0f9700f83']
+          ['URL', 'https://support.cambiumnetworks.com/file/476262a0256fdd8be0e595e51f5112e0f9700f83'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'Author' => [
           'Karn Ganeshen <KarnGaneshen[at]gmail.com>'

--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
           'SideEffects' => UNKNOWN_SIDE_EFFECTS
         },
         'References' => [
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW ]
         ]
       )
     )

--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -32,7 +32,10 @@ class MetasploitModule < Msf::Auxiliary
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,
           'SideEffects' => UNKNOWN_SIDE_EFFECTS
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
 

--- a/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
+++ b/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2022-24989'],
           ['URL', 'https://octagon.net/blog/2022/03/07/cve-2022-24990-terrmaster-tos-unauthenticated-remote-command-execution-via-php-object-instantiation/'],
           ['URL', 'https://github.com/0xf4n9x/CVE-2022-24990'],
-          ['URL', 'https://attackerkb.com/topics/h8YKVKx21t/cve-2022-24990']
+          ['URL', 'https://attackerkb.com/topics/h8YKVKx21t/cve-2022-24990'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'DisclosureDate' => '2022-03-07',
         'Platform' => ['unix', 'linux'],

--- a/modules/post/aix/hashdump.rb
+++ b/modules/post/aix/hashdump.rb
@@ -21,7 +21,10 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
   end

--- a/modules/post/aix/hashdump.rb
+++ b/modules/post/aix/hashdump.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Post
           'Reliability' => []
         },
         'References' => [
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW ]
         ]
       )
     )

--- a/modules/post/android/gather/hashdump.rb
+++ b/modules/post/android/gather/hashdump.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Post
         'References' => [
           ['URL', 'https://www.pentestpartners.com/security-blog/cracking-android-passwords-a-how-to/'],
           ['URL', 'https://hashcat.net/forum/thread-2202.html'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING],
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/post/bsd/gather/hashdump.rb
+++ b/modules/post/bsd/gather/hashdump.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Post
           'Reliability' => []
         },
         'References' => [
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW ]
         ]
       )
     )

--- a/modules/post/bsd/gather/hashdump.rb
+++ b/modules/post/bsd/gather/hashdump.rb
@@ -22,7 +22,10 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
   end

--- a/modules/post/linux/gather/f5_loot_mcp.rb
+++ b/modules/post/linux/gather/f5_loot_mcp.rb
@@ -28,6 +28,7 @@ class MetasploitModule < Msf::Post
           ['URL', 'https://github.com/rbowes-r7/refreshing-mcp-tool'], # Original PoC
           ['URL', 'https://www.rapid7.com/blog/post/2022/11/16/cve-2022-41622-and-cve-2022-41800-fixed-f5-big-ip-and-icontrol-rest-vulnerabilities-and-exposures/'],
           ['URL', 'https://support.f5.com/csp/article/K97843387'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING],
         ],
         'DisclosureDate' => '2022-11-16',
         'Notes' => {

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -21,7 +21,10 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
   end

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Post
           'Reliability' => []
         },
         'References' => [
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW ]
         ]
       )
     )

--- a/modules/post/linux/gather/manageengine_password_manager_creds.rb
+++ b/modules/post/linux/gather/manageengine_password_manager_creds.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Post
         ],
         'References' => [
           [ 'URL', 'https://www.trustedsec.com/blog/the-curious-case-of-the-password-database/' ],
-          [ 'URL', 'https://github.com/trustedsec/Zoinks/blob/main/zoinks.py' ]
+          [ 'URL', 'https://github.com/trustedsec/Zoinks/blob/main/zoinks.py' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
         ],
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],

--- a/modules/post/linux/gather/mimipenguin.rb
+++ b/modules/post/linux/gather/mimipenguin.rb
@@ -37,7 +37,8 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://github.com/huntergregal/mimipenguin' ],
           [ 'URL', 'https://bugs.launchpad.net/ubuntu/+source/gnome-keyring/+bug/1772919' ],
           [ 'URL', 'https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/1717490' ],
-          [ 'CVE', '2018-20781' ]
+          [ 'CVE', '2018-20781' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
         ],
         'DisclosureDate' => '2018-05-23',
         'DefaultTarget' => 0,

--- a/modules/post/linux/gather/mimipenguin.rb
+++ b/modules/post/linux/gather/mimipenguin.rb
@@ -38,7 +38,8 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://bugs.launchpad.net/ubuntu/+source/gnome-keyring/+bug/1772919' ],
           [ 'URL', 'https://bugs.launchpad.net/ubuntu/+source/lightdm/+bug/1717490' ],
           [ 'CVE', '2018-20781' ],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_007_PROC_FILESYSTEM ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW ]
         ],
         'DisclosureDate' => '2018-05-23',
         'DefaultTarget' => 0,

--- a/modules/post/linux/gather/openvpn_credentials.rb
+++ b/modules/post/linux/gather/openvpn_credentials.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['shell', 'meterpreter'],
         'References' => [
           ['URL', 'https://gist.github.com/rvrsh3ll/cc93a0e05e4f7145c9eb#file-openvpnscraper-sh'],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_007_PROC_FILESYSTEM ]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/post/linux/gather/openvpn_credentials.rb
+++ b/modules/post/linux/gather/openvpn_credentials.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Post
         'Platform' => ['linux'],
         'SessionTypes' => ['shell', 'meterpreter'],
         'References' => [
-          ['URL', 'https://gist.github.com/rvrsh3ll/cc93a0e05e4f7145c9eb#file-openvpnscraper-sh']
+          ['URL', 'https://gist.github.com/rvrsh3ll/cc93a0e05e4f7145c9eb#file-openvpnscraper-sh'],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/post/linux/gather/vcenter_secrets_dump.rb
+++ b/modules/post/linux/gather/vcenter_secrets_dump.rb
@@ -57,7 +57,8 @@ class MetasploitModule < Msf::Post
           [ 'URL', 'https://github.com/shmilylty/vhost_password_decrypt' ],
           [ 'CVE', '2022-22948' ],
           [ 'URL', 'https://pentera.io/blog/information-disclosure-in-vmware-vcenter/' ],
-          [ 'URL', 'https://github.com/ErikWynter/metasploit-framework/blob/vcenter_gather_postgresql/modules/post/multi/gather/vmware_vcenter_gather_postgresql.rb' ]
+          [ 'URL', 'https://github.com/ErikWynter/metasploit-framework/blob/vcenter_gather_postgresql/modules/post/multi/gather/vmware_vcenter_gather_postgresql.rb' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
         ],
         'Notes' => {
           'Stability' => [ CRASH_SAFE ],

--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -35,7 +35,10 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
     register_options([

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -23,7 +23,10 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
   end

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Post
           'Reliability' => []
         },
         'References' => [
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_008_ETC_PASSWD_AND_ETC_SHADOW ]
         ]
       )
     )

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'References' => [
           ['URL', 'https://web.archive.org/web/20220407023137/https://lab.mediaservice.net/code/cachedump.rb'],
-          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
+          ['ATT&CK', Mitre::Attack::Technique::T1003_005_CACHED_DOMAIN_CREDENTIALS]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Post
         'Platform' => ['win'],
         'SessionTypes' => ['meterpreter'],
         'References' => [
-          ['URL', 'https://web.archive.org/web/20220407023137/https://lab.mediaservice.net/code/cachedump.rb']
+          ['URL', 'https://web.archive.org/web/20220407023137/https://lab.mediaservice.net/code/cachedump.rb'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/post/windows/gather/credentials/credential_collector.rb
+++ b/modules/post/windows/gather/credentials/credential_collector.rb
@@ -30,7 +30,10 @@ class MetasploitModule < Msf::Post
               priv_passwd_get_sam_hashes
             ]
           }
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
   end

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
           }
         },
         'References' => [
-          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_003_NTDS ]
         ]
       )
     )

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -40,7 +40,10 @@ class MetasploitModule < Msf::Post
               stdapi_fs_stat
             ]
           }
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
     deregister_options('SMBUser', 'SMBPass', 'SMBDomain')

--- a/modules/post/windows/gather/credentials/enum_cred_store.rb
+++ b/modules/post/windows/gather/credentials/enum_cred_store.rb
@@ -37,7 +37,10 @@ class MetasploitModule < Msf::Post
               stdapi_sys_process_memory_write
             ]
           }
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
   end

--- a/modules/post/windows/gather/credentials/enum_laps.rb
+++ b/modules/post/windows/gather/credentials/enum_laps.rb
@@ -42,7 +42,10 @@ class MetasploitModule < Msf::Post
               stdapi_net_resolve_hosts
             ]
           }
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
+        ]
       )
     )
 

--- a/modules/post/windows/gather/credentials/sso.rb
+++ b/modules/post/windows/gather/credentials/sso.rb
@@ -34,7 +34,10 @@ class MetasploitModule < Msf::Post
               kiwi_exec_cmd
             ]
           }
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_001_LSASS_MEMORY ]
+        ]
       )
     )
   end

--- a/modules/post/windows/gather/credentials/windows_autologin.rb
+++ b/modules/post/windows/gather/credentials/windows_autologin.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'meterpreter' ],
         'References' => [
           [ 'URL', 'http://support.microsoft.com/kb/315231' ],
-          [ 'URL', 'http://core.yehg.net/lab/#tools.exploits' ]
+          [ 'URL', 'http://core.yehg.net/lab/#tools.exploits' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_OS_CREDENTIAL_DUMPING ]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
+++ b/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Post
           ['CVE', '2021-36934'],
           ['URL', 'https://github.com/GossiTheDog/HiveNightmare'],
           ['URL', 'https://isc.sans.edu/diary/Summer+of+SAM+-+incorrect+permissions+on+Windows+1011+hives/27652'],
-          ['URL', 'https://github.com/romarroca/SeriousSam']
+          ['URL', 'https://github.com/romarroca/SeriousSam'],
+          ['ATT&CK', Mitre::Attack::Technique::T1003_002_SECURITY_ACCOUNT_MANAGER]
         ],
         'DisclosureDate' => '2021-07-20',
         'Platform' => [ 'win' ],

--- a/modules/post/windows/gather/file_from_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_from_raw_ntfs.rb
@@ -24,7 +24,8 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => ['meterpreter'],
         'Author' => ['Danil Bazin <danil.bazin[at]hsc.fr>'], # @danilbaz
         'References' => [
-          [ 'URL', 'http://www.amazon.com/System-Forensic-Analysis-Brian-Carrier/dp/0321268172/' ]
+          [ 'URL', 'http://www.amazon.com/System-Forensic-Analysis-Brian-Carrier/dp/0321268172/' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_003_NTDS ]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/post/windows/gather/hashdump.rb
+++ b/modules/post/windows/gather/hashdump.rb
@@ -30,7 +30,10 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [],
           'Reliability' => []
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_002_SECURITY_ACCOUNT_MANAGER ]
+        ]
       )
     )
 

--- a/modules/post/windows/gather/lsa_secrets.rb
+++ b/modules/post/windows/gather/lsa_secrets.rb
@@ -26,7 +26,10 @@ class MetasploitModule < Msf::Post
           'Reliability' => [],
           'SideEffects' => []
         },
-        'Author' => ['Rob Bathurst <rob.bathurst[at]foundstone.com>']
+        'Author' => ['Rob Bathurst <rob.bathurst[at]foundstone.com>'],
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_004_LSA_SECRETS ]
+        ]
       )
     )
     register_options([

--- a/modules/post/windows/gather/memory_dump.rb
+++ b/modules/post/windows/gather/memory_dump.rb
@@ -45,7 +45,10 @@ class MetasploitModule < Msf::Post
               stdapi_sys_process_getpid
             ]
           }
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_001_LSASS_MEMORY ]
+        ]
       )
     )
     register_options([

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -21,7 +21,9 @@ class MetasploitModule < Msf::Post
         },
         'License' => MSF_LICENSE,
         'Author' => ['Koen Riepe (koen.riepe@fox-it.com)'],
-        'References' => [''],
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_003_NTDS ]
+        ],
         'Platform' => [ 'win' ],
         'Arch' => [ 'x86', 'x64' ],
         'SessionTypes' => [ 'meterpreter' ],

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -40,7 +40,10 @@ class MetasploitModule < Msf::Post
               stdapi_sys_process_getpid
             ]
           }
-        }
+        },
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_002_SECURITY_ACCOUNT_MANAGER ]
+        ]
       )
     )
     register_options(

--- a/modules/post/windows/manage/kerberos_tickets.rb
+++ b/modules/post/windows/manage/kerberos_tickets.rb
@@ -50,7 +50,8 @@ class MetasploitModule < Msf::Post
         ],
         'References' => [
           [ 'URL', 'https://github.com/GhostPack/Rubeus' ],
-          [ 'URL', 'https://github.com/wavvs/nanorobeus' ]
+          [ 'URL', 'https://github.com/wavvs/nanorobeus' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1003_004_LSA_SECRETS ]
         ],
         'Platform' => ['win'],
         'SessionTypes' => %w[meterpreter],


### PR DESCRIPTION
This adds the reference to MITRE ATT&CK technique T1003 "OS credential dumping". (see https://attack.mitre.org/techniques/T1003/ for details).

This has been mainly done with the help of AI and local scripts. The process was as follows:
1. Use both the source code and the documentation for each module in Metasploit.
2. Filter according to keywords related to the MITRE technique.
3. Process each module from the filtered list of modules using AI with a specific crafted prompt, the source code and the documentation.
4. Final manual review.