### PR TITLE
adjustments to the persistence lib and landed modules

### DIFF
--- a/lib/msf/core/exploit/local/persistence.rb
+++ b/lib/msf/core/exploit/local/persistence.rb
@@ -3,8 +3,8 @@
 module Msf
   module Exploit::Local::Persistence
     def initialize(info = {})
-      @persistence_service = Rex::Sync::Event.new(auto_reset=false)
-      @clean_up_rc = nil
+      @persistence_service = Rex::Sync::Event.new(auto_reset = false)
+      @clean_up_rc = ''
       super(
         update_info(
           info,
@@ -36,6 +36,23 @@ module Msf
       @persistence_service.wait if run_as_background
     end
 
+    def writable_dir
+      # base the WritableDir default off of the persistence module path to avoid
+      # needing to probe the target directly, or deal with one offs like ssh sessions
+      return datastore['WritableDir'] unless datastore['WritableDir'].empty?
+
+      mod_path = self.class.file_path.downcase.tr('\\', '/')
+
+      if mod_path.include?('/windows/')
+        '%TEMP%'
+      elsif mod_path.include?('/multi/')
+        print_warning('Please set the WritableDir datastore option or the module is likely to fail')
+        ''
+      else
+        '/tmp/'
+      end
+    end
+
     def install_persistence
       # to be overloaded by the module
     end
@@ -52,7 +69,7 @@ module Msf
       clean_rc = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + '.rc'
       file_local_write(clean_rc, @clean_up_rc)
 
-      print_status("Meterpreter-compatible Cleaup RC file: #{clean_rc}")
+      print_status("Meterpreter-compatible Cleanup RC file: #{clean_rc}")
 
       report_note(host: host,
                   type: 'host.persistance.cleanup',

--- a/modules/exploits/example_linux_persistence.rb
+++ b/modules/exploits/example_linux_persistence.rb
@@ -91,9 +91,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     # Check a example app is installed
-    print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if datastore['WritableDir'].start_with?('/tmp')
-    return CheckCode::Safe("#{datastore['WritableDir']} doesnt exist") unless exists?(datastore['WritableDir'])
-    return CheckCode::Safe("#{datastore['WritableDir']} isnt writable") unless writable?(datastore['WritableDir'])
+    print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe('example app is required') unless command_exists?('example')
 
     CheckCode::Detected('example app is installed')

--- a/modules/exploits/linux/persistence/bash_profile.rb
+++ b/modules/exploits/linux/persistence/bash_profile.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('/tmp')
+    print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if writable_dir.start_with?('/tmp')
     ppath = profile_path
 
     # check that target Bash profile file exists
@@ -100,6 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def install_persistence
+    super
     # create Bash profile backup on local system before persistence is added
     ppath = profile_path
     backup_profile = read_file(ppath)
@@ -113,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Local
       exec_payload_string = "#{pload} > /dev/null 2>&1 & \n" # send stdin,out,err to /dev/null
     else
       # upload persistent payload to target and make executable (chmod 700)
-      payload_path = datastore['WritableDir']
+      payload_path = writable_dir
       payload_path = payload_path.end_with?('/') ? payload_path : "#{payload_path}/"
       payload_name = datastore['BACKDOOR_NAME'] || rand_text_alphanumeric(5..10)
       payload_path << payload_name
@@ -126,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status('Created Bash profile persistence')
     print_good('Payload will be triggered when target opens a Bash terminal')
 
-    @clean_up_rc = "rm #{payload_path}\n"
+    @clean_up_rc << "rm #{payload_path}\n"
     @clean_up_rc << "upload #{backup_profile_path} #{ppath}"
   end
 end


### PR DESCRIPTION
Per discussion with @dledda-r7 , adjusting a few things with the persistence library to fix:
1. A typo
2. `@clean_up_rc` should not be `nil`, since its always a string, and modules append to it. https://github.com/rapid7/metasploit-framework/pull/20381#discussion_r2213414606
3. Creates `writable_dir` so that if the datastore option is blank, we attempt to guess the correct tmp directory without target interaction based on module path, or give a warning if unknown. This solves the problem of the option being `''` by default and modules generally not working without it being set, or having to overwrite it often. https://github.com/rapid7/metasploit-framework/pull/19815#discussion_r1927105189