### PR TITLE
Add a test login scanner and fix ANONYMOUS_LOGIN

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -59,6 +59,7 @@ module Auxiliary::AuthBrute
   # @return [Metasploit::Framework::CredentialCollection] the built CredentialCollection
   def build_credential_collection(opts)
     cred_collection = Metasploit::Framework::CredentialCollection.new({
+      anonymous_login: datastore['ANONYMOUS_LOGIN'],
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file: datastore['PASS_FILE'],
       user_file: datastore['USER_FILE'],

--- a/test/modules/auxiliary/test/login.rb
+++ b/test/modules/auxiliary/test/login.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+
+  def initialize
+    super(
+      'Name' => 'Test Login Scanner',
+      'Description' => %q{
+        Use this module to test how credentials are generated for login scanners.
+      },
+      'Author' => [
+        'Spencer McIntyre'
+      ],
+      'References' => [
+        [ 'CVE', '1999-0506'], # Weak password
+      ],
+      'DefaultOptions' => { 'RHOSTS' => '192.0.2.1' },
+      'License' => MSF_LICENSE
+    )
+  end
+
+  def run_host(ip)
+    print_brute(level: :vstatus, ip: ip, msg: 'Starting login bruteforce')
+
+    @scanner = TestLoginScanner.new(
+      host: ip,
+      port: 80,
+      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      proxies: datastore['Proxies'],
+      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+      framework: framework,
+      framework_module: self
+    )
+
+    cred_collection = build_credential_collection(
+      username: datastore['USERNAME'],
+      password: datastore['PASSWORD']
+    )
+    cred_collection = prepend_db_hashes(cred_collection)
+
+    @scanner.cred_details = cred_collection
+
+    @scanner.each_credential do |credential|
+      print_status("username: #{credential.public.inspect}, password: #{credential.private.inspect}")
+    end
+  end
+
+  class TestLoginScanner
+    include Metasploit::Framework::LoginScanner::Base
+
+    REALM_KEY = nil
+
+    def attempt_login(credential)
+     ::Metasploit::Framework::LoginScanner::Result.new(
+        host: host,
+        port: port,
+        protocol: 'tcp',
+        credential: credential,
+        status: Metasploit::Model::Login::Status::SUCCESSFUL
+      )
+    end
+  end
+end


### PR DESCRIPTION
This makes two changes, one in each commit.

## New Module: auxiliary/test/login
This is a new **testing** module that can be used to see how the datastore options adjust the login scanner behavior. It's effectively a dummy module. I forget why I originally wrote it but it came in handy again while testing #19653 so it seemed helpful to share it for future testing. The credential collection logic can be a bit complicated and this makes it easy to see exactly what's happening. Which leads to the second change...

## Fixed The ANONYMOUS_LOGIN option
The `ANONYMOUS_LOGIN` datastore option was not being passed to the credential collection from the `AuthBrute` mixin, meaning that users could set the option but then it wouldn't do anything. This bug has now been fixed and is a great use case for the new testing module because you can simply toggle it and see the differences.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Load the test modules with `loadpath test/modules`
- [ ] Use the new test module with `use auxiliary/test/login`
- [ ] Set the options to whatever, it never actually contacts a host that's online
- [ ] Set `ANONYMOUS_LOGIN` to true, see that it starts with an attempt to login with a blank username and password
- [ ] Set `ANONYMOUS_LOGIN` to false, see that it **does not** start with an attempt to login with a blank username and password

## Demo Output
```
msf auxiliary(test/login) > run
[*] 1.2.3.4: - Starting login bruteforce
[*] username: "test", password: "Password1"
[*] username: "test", password: "Password2"
[*] username: "test", password: "Password3"
[*] username: "alice", password: "Password1"
[*] username: "alice", password: "Password2"
[*] username: "alice", password: "Password3"
[*] username: "bob", password: "Password1"
[*] username: "bob", password: "Password2"
[*] username: "bob", password: "Password3"
[*] username: "charlie", password: "Password1"
[*] username: "charlie", password: "Password2"
[*] username: "charlie", password: "Password3"
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(test/login) > run ANONYMOUS_LOGIN=true
[*] 1.2.3.4: - Starting login bruteforce
[*] username: "", password: ""
[*] username: "test", password: "Password1"
[*] username: "test", password: "Password2"
[*] username: "test", password: "Password3"
[*] username: "alice", password: "Password1"
[*] username: "alice", password: "Password2"
[*] username: "alice", password: "Password3"
[*] username: "bob", password: "Password1"
[*] username: "bob", password: "Password2"
[*] username: "bob", password: "Password3"
[*] username: "charlie", password: "Password1"
[*] username: "charlie", password: "Password2"
[*] username: "charlie", password: "Password3"
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(test/login) > run ANONYMOUS_LOGIN=true PASSWORD_SPRAY=true
[*] 1.2.3.4: - Starting login bruteforce
[*] username: "", password: ""
[*] username: "test", password: "Password1"
[*] username: "alice", password: "Password1"
[*] username: "bob", password: "Password1"
[*] username: "charlie", password: "Password1"
[*] username: "test", password: "Password2"
[*] username: "alice", password: "Password2"
[*] username: "bob", password: "Password2"
[*] username: "charlie", password: "Password2"
[*] username: "test", password: "Password3"
[*] username: "alice", password: "Password3"
[*] username: "bob", password: "Password3"
[*] username: "charlie", password: "Password3"
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(test/login) > 
```
