### PR TITLE
Check the path is set before checking the file exists

### DIFF
--- a/lib/msf/core/modules/metadata/store.rb
+++ b/lib/msf/core/modules/metadata/store.rb
@@ -56,7 +56,7 @@ module Msf::Modules::Metadata::Store
       retries +=1
 
       # Try to handle the scenario where the file is corrupted
-      if (retries < 2 && ::File.exist?(@path_to_user_metadata))
+      if retries < 2 && @path_to_user_metadata && ::File.exist?(@path_to_user_metadata)
         elog('Possible corrupt user metadata store, attempting restore')
         FileUtils.remove(@path_to_user_metadata)
         retry


### PR DESCRIPTION
This fixes an issue in the `#load_metadata` method where if `@path_to_user_metadata` was nil, the `::File.exists?` check would crash. This was causing an issue on Pro when the Framework was being initialized and for whatever reason the user metadata path wasn't set. It probably makes sense to set the metadata, but given that there's a code path where it's not, we should only be using it when it is. This will at least make sure the framework can be initialized, albeit possibly slower without the cache.

## Verification

- [ ] Start `msfconsole`
- [ ] See the framework loads
