### PR TITLE
Fix a regression in smb_login

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
       realm: domain,
       username: datastore['SMBUser'],
       password: datastore['SMBPass'],
-      ignore_private: datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS && !datastore['PASSWORD']
+      nil_passwords: datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS && !datastore['PASSWORD']
     )
     cred_collection = prepend_db_hashes(cred_collection)
 

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    options_to_deregister = %w[USERNAME PASSWORD CommandShellCleanupCommand AutoVerifySession]
+    options_to_deregister = %w[USERNAME PASSWORD CommandShellCleanupCommand AutoVerifySession KrbCacheMode]
 
     if framework.features.enabled?(Msf::FeatureManager::SMB_SESSION_TYPE)
       add_info('New in Metasploit 6.4 - The %grnCreateSession%clr option within this module can open an interactive session')


### PR DESCRIPTION
This fixes a bug that was introduced when #19653 was landed. I forgot that the change to `ignore_private` needed to be propagated to this module as well. The result is that currently `smb_login` won't run.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Run the `smb_login` module to make sure it works, use it with a username and password like normal
- [x] Run the `smb_login` module with *no password* leveraging Kerberos authentication, make sure to `set SMB::Auth kerberos` and the other relvant options. Run it the first time with a password to cache a ticket before removing the password to ensure that the fix for #19843 is still in place.

## Demos

Current stack trace from the old and broken version:

```
msf auxiliary(scanner/smb/smb_login) > run
[*] 192.168.159.10:445    - 192.168.159.10:445 - Starting SMB login bruteforce
[-] 192.168.159.10:445    - Auxiliary failed: NoMethodError undefined method `ignore_private=' for an instance of Metasploit::Framework::CredentialCollection
[-] 192.168.159.10:445    - Call stack:
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/credential_collection.rb:59:in `public_send'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/credential_collection.rb:59:in `block in initialize'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/credential_collection.rb:58:in `each'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/credential_collection.rb:58:in `initialize'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/credential_collection.rb:224:in `initialize'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:61:in `new'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:61:in `build_credential_collection'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/scanner/smb/smb_login.rb:177:in `run_host'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:116:in `block (2 levels) in run'
[-] 192.168.159.10:445    -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_login) >
```

New and not broken, notice the password is blank and the logs state that a cached credential is used.

```
msf auxiliary(scanner/smb/smb_login) > set SMBPASS ""
SMBPASS => 
msf auxiliary(scanner/smb/smb_login) > run
msf auxiliary(scanner/smb/smb_login) > run
[*] 192.168.159.10:445    - 192.168.159.10:445 - Starting SMB login bruteforce
[*] 192.168.159.10:445    - Using cached credential for cifs/dc.msflab.local@MSFLAB.LOCAL smcintyre@MSFLAB.LOCAL
[+] 192.168.159.10:445    - 192.168.159.10:445 - Success: 'msflab.local\smcintyre:' Administrator
[*] 192.168.159.10:445    - Scanned 1 of 1 hosts (100% complete)
[*] 192.168.159.10:445    - Bruteforce completed, 1 credential was successful.
[*] 192.168.159.10:445    - You can open an SMB session with these credentials and CreateSession set to true
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_login) >
```