### PR TITLE
Fix a Kerberos Error Edge Case When Logging In

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Msf::Exploit::Failure::BadConfig, 'The SMBDomain option is required when using Kerberos authentication.') if datastore['SMBDomain'].blank?
       fail_with(Msf::Exploit::Failure::BadConfig, 'The DomainControllerRhost is required when using Kerberos authentication.') if datastore['DomainControllerRhost'].blank?
 
-      if !datastore['PASSWORD']
+      if datastore['SMBPass'].blank?
         # In case no password has been provided, we assume the user wants to use Kerberos tickets stored in cache
         # Write mode is still enable in case new TGS tickets are retrieved.
         ticket_storage = kerberos_ticket_storage({ read: true, write: true })
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
       realm: domain,
       username: datastore['SMBUser'],
       password: datastore['SMBPass'],
-      nil_passwords: datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS && !datastore['PASSWORD']
+      nil_passwords: datastore['SMB::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS && datastore['SMBPass'].blank?
     )
     cred_collection = prepend_db_hashes(cred_collection)
 


### PR DESCRIPTION
It turns out that when logging in with Kerberos to a Server 2019 DC that it will return KDC_ERR_KEY_EXPIRED when the password is both marked as needs to be changed as well as expired. In the case where it's marked as needs to be changed, the authentication has succeeded, so we mark that successful. The server will however reply with the same error code for an account where the password has expired and in this case, there's no guarantee that the password provided to it is the correct value. This change updates the error logic to mark the attempt as a failure in this case.

This also updates faulty logic in the `smb_login.rb` module, where `!datastore['PASSWORD']` was incorrectly evaluated when `datastore['SMBPass']` was a blank string. This was causing failures and for empty passwords to be used when they shouldn't be. The `PASSWORD` datastore option is actually deregistered and I believe these cases were left over from some previous refactoring work.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] Use kerberos authentication to target an account that has an expired password, make sure it's marked as a failure
- [x] Repeat the process with the correct password and see it's successful
