### PR TITLE
Fixes samba share iteration in linux/samba/is_known_pipename

### DIFF
--- a/modules/exploits/linux/samba/is_known_pipename.rb
+++ b/modules/exploits/linux/samba/is_known_pipename.rb
@@ -209,7 +209,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     share_info.each do |share|
-      next if share&.first&.upcase == 'IPC$'
+      next if share.blank?
+      next if share.first.blank?
+      next if share.first.upcase == 'IPC$'
 
       found = find_writeable_path(share.first)
       next unless found

--- a/modules/exploits/linux/samba/is_known_pipename.rb
+++ b/modules/exploits/linux/samba/is_known_pipename.rb
@@ -209,7 +209,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     share_info.each do |share|
-      next if share.first.upcase == 'IPC$'
+      next if share&.first&.upcase == 'IPC$'
 
       found = find_writeable_path(share.first)
       next unless found


### PR DESCRIPTION
This PR fixes #20544 by adding a logic to check if the value is nil.