### PR TITLE
fix: ensure USERPASS_FILE credentials store password (set private_type)

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -313,7 +313,7 @@ module Metasploit::Framework
       end
 
       each_user_pass_from_userpass_file do |user, pass|
-        yield Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm)
+        yield Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm, private_type: private_type(pass))
       end
 
       additional_privates.each do |add_private|
@@ -374,7 +374,7 @@ module Metasploit::Framework
       end
 
       each_user_pass_from_userpass_file do |user, pass|
-        yield Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm)
+        yield Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm, private_type: private_type(pass))
       end
 
       additional_publics.each do |add_public|


### PR DESCRIPTION
## Summary:
Fix a bug where credentials sourced from USERPASS_FILE were not reliably persisted with their passwords in the Metasploit credential database.

The yielded credentials from each_user_pass_from_userpass_file did not set private_type, so the framework didn’t persist the password as a Metasploit::Credential::Password.
This PR makes ensures private_type is always set for USERPASS_FILE credentials.


## Reproduction 
### Behavior Before Fix

Create a file:

```
postgres password
```

Run an AuthBrute-based module, (postgres_login, mssql_login ...):
```
use auxiliary/scanner/postgres/postgres_login
set RHOSTS <target>
set USERPASS_FILE /path/to/file
run
```
After a successful attempt, run:
```
creds
```
**Password is missing (blank / not stored).**

<img width="1274" height="137" alt="image" src="https://github.com/user-attachments/assets/3aa98da3-ffff-4d1a-9c0d-df266f096485" />


### Behavior After Fix
The same steps now show password under the private column in creds output:

```
creds
```
**Password is present and stored.**

<img width="1293" height="137" alt="image" src="https://github.com/user-attachments/assets/f5cd7b46-5155-4b36-a482-7c0975856a7b" />

