### PR TITLE
add x64 acceptance tests, and use single, release payload

### DIFF
--- a/spec/support/acceptance/session/windows_meterpreter.rb
+++ b/spec/support/acceptance/session/windows_meterpreter.rb
@@ -18,6 +18,24 @@ module Acceptance::Session
             MeterpreterDebugBuild: true
           }
         }
+      },
+      {
+        name: "windows/x64/meterpreter/reverse_tcp",
+        extension: ".exe",
+        platforms: [:windows],
+        execute_cmd: ["${payload_path}"],
+        executable: true,
+        generate_options: {
+          '-f': "exe"
+        },
+        datastore: {
+          global: {},
+          module: {
+            # Not supported by Windows Meterpreter
+            # MeterpreterTryToFork: false,
+            MeterpreterDebugBuild: false
+          }
+        }
       }
     ],
     module_tests: [


### PR DESCRIPTION
Cleaned up version of https://github.com/rapid7/metasploit-framework/pull/20543
Only adding one more payload, but it is x64, single and not a debug build.

We should probably add more, but this is trivial and a minor addition.

We'll need to find why http[s] stuff is not working.

# Verification steps:
In the acceptance tests for this PR below, go to the build/windows_meterpreter windows-2022 tests and verify that both x64 and x86 Meterpreters are run in the acceptance test.