### PR TITLE
Fixes deprecation message logic when no `data` object present

### DIFF
--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -144,7 +144,7 @@ module Msf::DBManager::Note
 
     ntype  = opts.delete(:type) || opts.delete(:ntype) || (raise RuntimeError, "A note :type or :ntype is required")
 
-    unless opts[:data].is_a?(Hash)
+    unless opts[:data].is_a?(Hash) || opts[:data].nil?
       stack_trace = caller.map { |line| "[-]   #{line}" }.join("\n")
       message = "\n[-] [DEPRECATION] Using #{__method__} with a non-hash data value is deprecated, please raise a Github issue with this output.\n[-] Call stack:\n#{stack_trace}"
       warn(message)

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -144,7 +144,8 @@ module Msf::DBManager::Note
 
     ntype  = opts.delete(:type) || opts.delete(:ntype) || (raise RuntimeError, "A note :type or :ntype is required")
 
-    unless opts[:data].is_a?(Hash) || opts[:data].nil?
+    has_valid_note_datatype = opts[:data].is_a?(Hash) || opts[:data].nil?
+    unless has_valid_note_datatype
       stack_trace = caller.map { |line| "[-]   #{line}" }.join("\n")
       message = "\n[-] [DEPRECATION] Using #{__method__} with a non-hash data value is deprecated, please raise a Github issue with this output.\n[-] Call stack:\n#{stack_trace}"
       warn(message)


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/20558.

With the previous implementation I added https://github.com/rapid7/metasploit-framework/pull/19939 if no `data` object was present in the `report_note` method it would incorrectly return the deprecation message. Now a `nil` check has been added, so if `data` is not present it will not return the depreciation message.

## Testing
Can be any target or module that make use of `report_note`. Below I will add what I used:

### Target
```
❯ docker run --platform linux/amd64 \
… ❯   -e "ACCEPT_EULA=Y" \
… ❯   -e "MSSQL_SA_PASSWORD=MyMSSQLServerPassword__<>" \
… ❯   -p 1433:1433 \
… ❯   mcr.microsoft.com/mssql/server:2022-latest
```

## Module 
```
admin/mssql/mssql_enum
```

Within the chosen module, comment out the `data` object from the `report_note` call:
```ruby
    report_note(
      host: mssql_client.peerhost,
      proto: 'TCP',
      port: mssql_client.peerport,
      type: 'MSSQL_ENUM',
      # data: { version: sqlversion }
    )
```

## Before
```
msf auxiliary(admin/mssql/mssql_enum) > run session=-1
[*] Running MS SQL Server Enumeration...
[*] Using existing session 1
[*] Version:
[*]	Microsoft SQL Server 2022 (RTM-CU18) (KB5050771) - 16.0.4185.3 (X64)
[*]		Feb 28 2025 18:24:49
[*]		Copyright (C) 2022 Microsoft Corporation
[*]		Developer Edition (64-bit) on Linux (Ubuntu 22.04.5 LTS) <X64>
[-] [DEPRECATION] Using report_note with a non-hash data value is deprecated, please raise a Github issue with this output.
[-] Call stack:
[-]   /Users/cgranleese/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/activerecord-7.2.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
[-]   /Users/cgranleese/code/metasploit-framework/lib/msf/core/db_manager/note.rb:81:in `report_note'
[-]   /Users/cgranleese/code/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:40:in `block in report_note'
[-]   /Users/cgranleese/code/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:164:in `data_service_operation'
[-]   /Users/cgranleese/code/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:38:in `report_note'
[-]   /Users/cgranleese/code/metasploit-framework/lib/msf/core/auxiliary/report.rb:185:in `report_note'
[-]   /Users/cgranleese/code/metasploit-framework/modules/auxiliary/admin/mssql/mssql_enum.rb:54:in `run'
[-]   /Users/cgranleese/code/metasploit-framework/lib/msf/base/simple/auxiliary.rb:180:in `job_run_proc'
[-]   /Users/cgranleese/code/metasploit-framework/lib/msf/base/simple/auxiliary.rb:87:in `run_simple'
[-]   /Users/cgranleese/code/metasploit-framework/lib/msf/base/simple/auxiliary.rb:98:in `run_simple'
[-]   /Users/cgranleese/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/auxiliary.rb:66:in `cmd_run'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:582:in `run_command'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:531:in `block in run_single'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `each'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_single'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/shell.rb:165:in `block in run'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/shell.rb:309:in `block in with_history_manager_context'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:35:in `with_context'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/shell.rb:306:in `with_history_manager_context'
[-]   /Users/cgranleese/code/metasploit-framework/lib/rex/ui/text/shell.rb:133:in `run'
[-]   /Users/cgranleese/code/metasploit-framework/lib/metasploit/framework/command/console.rb:54:in `start'
[-]   /Users/cgranleese/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
[-]   ./msfconsole:23:in `<main>'
[*] Configuration Parameters:
[*] 	C2 Audit Mode is Not Enabled
...
[*] Default Server Instance SQL Server Service is running under the privilege of:
[*] 	xp_regread might be disabled in this system
[*] Auxiliary module execution completed
```

## After
```
msf auxiliary(admin/mssql/mssql_enum) > run session=-1
[*] Running MS SQL Server Enumeration...
[*] Using existing session 1
[*] Version:
[*]	Microsoft SQL Server 2022 (RTM-CU18) (KB5050771) - 16.0.4185.3 (X64)
[*]		Feb 28 2025 18:24:49
[*]		Copyright (C) 2022 Microsoft Corporation
[*]		Developer Edition (64-bit) on Linux (Ubuntu 22.04.5 LTS) <X64>[*] Configuration Parameters:
[*] 	C2 Audit Mode is Not Enabled
...
[*] Default Server Instance SQL Server Service is running under the privilege of:
[*] 	xp_regread might be disabled in this system
[*] Auxiliary module execution completed
```


## Verification

- [ ] Follow testing steps again and confirm before and after
- [ ] Code change is sane
- [ ] CI goes green

