### PR TITLE
fix: WebLogic server detection regex

### DIFF
--- a/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Failed to obtain response from service') unless res
 
-    /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
+    /WebLogic\s+Server[ -]+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
     return CheckCode::Unknown('Failed to detect WebLogic') unless version
 
     @version_no = Rex::Version.new(version)

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Failed to obtain response from service') unless res
 
-    /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
+    /WebLogic\s+Server[ -]+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
     return CheckCode::Unknown('Failed to detect WebLogic') unless version
 
     @version_no = Rex::Version.new(version)


### PR DESCRIPTION
Some WebLogic server versions reports their version with a dash between 'Server' and 'Version', like
`<p id="footerVersion">WebLogic Server-Version: 12.2.1.3.0</p>`

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use multi/misc/weblogic_deserialize_badattrval`
- [x] `set RHOSTS x.x.x.x`
- [x]  `check`
- [x] Version gets detected correctly: `[*] x.x.x.x:7001 - WebLogic version detected: 12.2.1.3.0`