### PR TITLE
Update reg checks when DC and CA are separate

### DIFF
--- a/lib/msf/core/exploit/remote/ldap/active_directory.rb
+++ b/lib/msf/core/exploit/remote/ldap/active_directory.rb
@@ -253,6 +253,34 @@ module Msf
         }
       end
 
+      # Query the LDAP server to retrieve all Certificate Authority (Enterprise CA) servers in the domain.
+      # @param [Net::LDAP::Connection] ldap The LDAP connection to use for querying.
+      # @return [Array<Hash>] An array of hashes, where each hash contains the `:name` and `:dNSHostName` of a CA server.
+      # @rtype [Array<Hash>]
+      def adds_get_ca_servers(ldap)
+        base_dn = "CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,#{@base_dn}"
+        filter = '(objectClass=pKIEnrollmentService)'
+        attributes = ['cn', 'dNSHostName']
+        ca_servers = []
+
+        ldap.search(base: base_dn, filter: filter, attributes: attributes) do |entry|
+          ca_servers << {
+            name: entry[:cn]&.first,
+            dNSHostName: entry[:dNSHostName]&.first
+          }
+        end
+
+        if ca_servers.empty?
+          print_warning('No Certificate Authority servers found in LDAP.')
+        else
+          ca_servers.each do |ca|
+            print_good("Found CA: #{ca[:name]} (#{ca[:dNSHostName]})")
+          end
+        end
+
+        ca_servers
+      end
+
       # Determine if a security descriptor will grant the permissions identified by *matcher* to the
       # *test_sid*.
       #

--- a/lib/msf/core/exploit/remote/ldap/active_directory.rb
+++ b/lib/msf/core/exploit/remote/ldap/active_directory.rb
@@ -270,14 +270,6 @@ module Msf
           }
         end
 
-        if ca_servers.empty?
-          print_warning('No Certificate Authority servers found in LDAP.')
-        else
-          ca_servers.each do |ca|
-            print_good("Found CA: #{ca[:name]} (#{ca[:dNSHostName]})")
-          end
-        end
-
         ca_servers
       end
 

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -423,6 +423,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     @registry_values
+  rescue StandardError => e
+    vprint_warning("Failed to query registry values: #{e.message}")
   end
 
   def resolve_group_memberships(user_dn)

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it']),
       OptEnum.new('REPORT', [true, 'What templates to report (applies filtering to results)', 'vulnerable-and-published', %w[all published enrollable vulnerable vulnerable-and-published vulnerable-and-enrollable]]),
       OptBool.new('RUN_REGISTRY_CHECKS', [true, 'Authenticate to WinRM to query the registry values to enhance reporting for ESC9, ESC10 and ESC16. Must be a privileged user in order to query successfully', false]),
-      OptString.new('CA', [true, 'The name of the Certificate Authority you wish to preform the registry checks on'], conditions: %w[RUN_REGISTRY_CHECKS == true]),
+      OptString.new('CA', [false, 'The name of the Certificate Authority you wish to preform the registry checks on'], conditions: %w[RUN_REGISTRY_CHECKS == true]),
       OptInt.new('TIMEOUT', [false, 'The WinRM timeout when running registry checks', 20], conditions: %w[RUN_REGISTRY_CHECKS == true]),
     ])
   end
@@ -386,7 +386,6 @@ class MetasploitModule < Msf::Auxiliary
     query_ca_reg_values(ca_ip_address, domain, user)
   end
 
-  # Query registry values directly from the CA
   def query_ca_reg_values(ca_ip_address, domain, user)
     conn = create_winrm_connection(ca_ip_address, domain, user, datastore['TIMEOUT'])
     conn.shell(:powershell) do |shell|
@@ -394,7 +393,6 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  # Enumerate registry values for the module
   def enum_registry_values
     @registry_values ||= {}
     domain = adds_get_domain_info(@ldap)[:dns_name]


### PR DESCRIPTION
Originally when the `RUN_REGISTRY_CHECKS` datastore option was added to the `ldap_esc_vulnerable_cert_finder` module, the module would only check the registry of the Domain Controller defined in the `rhost` value. This provides incorrect results in cases where the Certificate Authority is installed on a server separate from the Domain Controller. 

If the two systems are separated, the Domain Controller will hold:
- Certificate templates 
- `StrongCertificateBindingEnforcement` registry value
- `CertificateMappingMethods` registry value

And the Certificate Authority will hold:
- `DisableExtensionList` registry value
- `EditFlags` registry value

If the CA is installed on the DC then all the info needed resides on the DC. To solve the issue when they are separate the module now requires the user to define the datastore option `CA` ( just like the `icpr_cert` module) when `RUN_REGISTRY_CHECKS` is set to true.  The module  reaches out to the DC via LDAP and a new `adds_get_ca_servers` method which returns a list of containing the `name` and `dnshostname` of all the CA servers connected to the DC. Then the `dnshostname` of all the CA's  are resolved and then using the same credentials, a WMI connection is established and the registry keys are pulled from each CA.

## Verification

Installed on the same system:
- [ ] Snapshot your DC
- [ ] Setup a CA on the same machine as a DC. 
- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ldap_esc_vulnerable_cert_finder`
- [ ] `set RUN_REGISTRY_CHECKS true`
- [ ] `set CA msflab-DC-CA`
- [ ] **Verify** all the registry keys are collected as expected

Installed separately:
- [ ] Revert the snapshot
- [ ] Setup a separate Windows Server
- [ ] Join that server to the domain
- [ ] Setup an Enterprise Certificate Authority on the server (Stand Alone CA's need not be tested as they don't use certificate templates)
- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ldap_esc_vulnerable_cert_finder`
- [ ] `set RUN_REGISTRY_CHECKS true`
- [ ] `set CA msflab-CA-CA`
- [ ] **Verify** all the registry keys are collected as expected


Example output when testing a CA installed on a machine separate from the DC:
```
[+] Found CA: kerberos-CA-CA (CA.kerberos.issue)
[+] Registry values:
[+]   certificate_mapping_methods=4
[+]   strong_certificate_binding_enforcement=0
[+]   disable_extension_list={1.3.6.1.4.1.311.25.2}
[+]   edit_flags=1376590
```