### PR TITLE
bump rex-exploitation gem from 0.1.41 to 0.1.44

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     bindata (2.4.15)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -487,9 +487,11 @@ GEM
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.41)
+    rex-exploitation (0.1.44)
+      bigdecimal
       jsobfu
       metasm
+      racc
       rex-arch
       rex-encoder
       rex-text
@@ -526,7 +528,7 @@ GEM
       bigdecimal
     rex-zip (0.1.6)
       rex-text
-    rexml (3.4.1)
+    rexml (3.4.4)
     rinda (0.2.0)
       drb
       forwardable


### PR DESCRIPTION
Bump `rex-exploitation` (which also bumps a few other libraries):

```
[2025-09-25 00:57:03] root@kali:~/Desktop/metasploit-framework# bundle update rex-exploitation
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Resolving dependencies...
Using bigdecimal 3.2.3 (was 3.2.2)
Using rexml 3.4.4 (was 3.4.1)
Using rex-exploitation 0.1.44 (was 0.1.41)
Bundle updated!
1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details
[2025-09-25 00:57:57] root@kali:~/Desktop/metasploit-framework# gitd Gemfile.lock 
diff --git a/Gemfile.lock b/Gemfile.lock
index ecce02373b..7ebb9076ac 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     bindata (2.4.15)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -487,9 +487,11 @@ GEM
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.41)
+    rex-exploitation (0.1.44)
+      bigdecimal
       jsobfu
       metasm
+      racc
       rex-arch
       rex-encoder
       rex-text
@@ -526,7 +528,7 @@ GEM
       bigdecimal
     rex-zip (0.1.6)
       rex-text
-    rexml (3.4.1)
+    rexml (3.4.4)
     rinda (0.2.0)
       drb
       forwardable
```
