### PR TITLE
Bump metasploit-credential to version using rubyzip 3.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
+gem 'metasploit-credential', git: 'https://github.com/philtownes-r7/metasploit-credential.git', branch: 'bump-ruby-zip-to-3_1_1'
+
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests


### PR DESCRIPTION
Bumps metasploit-credential to a version that uses rubyzip 3.1.1

RubyZip 3.1.1 supports Zip64, which is needed to handle large files in zip archives - particularly in Pro.
