### PR TITLE
Move LINQPad module into windows/persistence category

### DIFF
--- a/modules/exploits/windows/persistence/linqpad_deserialization_persistence.rb
+++ b/modules/exploits/windows/persistence/linqpad_deserialization_persistence.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        'Name' => 'LINQPad Deserialization Exploit',
+        'Name' => 'LINQPad Deserialization Persistence',
         'Description' => %q{
           This module exploits a bug in LIQPad up to version 5.48.00. The bug is only exploitable in paid version of software. The core of a bug is cache file containing deserialized data, which attacker can overwrite with malicious payload. The data gets deserialized every time the app restarts.
         },


### PR DESCRIPTION
Relocates the LINQPad deserialization module into the windows/persistence category so users can find it under persistence. No functional changes; only path and display name updated.

Resolves #20576 