### PR TITLE
Bump rex-random_identifier to version 0.1.21

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
       rex-random_identifier
       rex-text
       ruby-rc4
-    rex-random_identifier (0.1.20)
+    rex-random_identifier (0.1.21)
       bigdecimal
       rex-text
     rex-registry (0.1.6)


### PR DESCRIPTION
Bumps rex-random_identifier to version 0.1.21, based on adfoster's comment on [PR](https://github.com/rapid7/rex-random_identifier/pull/21#issuecomment-3361553810)

I didn't touch bigdecimal since it's version was already `bigdecimal (3.2.3)`
