### PR TITLE
auxiliary(scanner/http/redoc_exposed): detect exposed ReDoc API docs UI

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
+++ b/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
@@ -2,13 +2,11 @@
 
 Detects publicly exposed ReDoc API documentation pages by looking for known DOM elements and script names. The module is read-only and sends safe `GET` requests.
 
-### Module Options
 
-- **RHOSTS** (required): Target address range or CIDR identifier.
-- **RPORT**: Default `80` (from `DefaultOptions`).
-- **SSL**: Enable to negotiate HTTPS to the target.
-- **REDOC_PATHS** (required): Comma-separated paths to probe. **Default**:  
-  `/redoc,/redoc/,/docs,/api/docs,/openapi`
+#### REDOC_PATHS
+Comma-separated custom paths to probe. If unset, defaults to:
+/redoc,/redoc/,/docs,/api/docs,/openapi
+
 
 ### How It Works
 

--- a/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
+++ b/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
@@ -1,39 +1,34 @@
-## Summary
-This module detects publicly exposed **ReDoc** API documentation pages.  
-It performs safe, read-only HTTP GET requests and reports likely ReDoc instances based on common HTML markers.
+## ReDoc API Docs UI Exposed
 
-## Module name
-`auxiliary/scanner/http/redoc_exposed`
+Detects publicly exposed ReDoc API documentation pages by looking for known DOM elements, script names, and titles. The module is read-only and makes safe GET requests.
 
-## Options
-* **RPORT** – Target TCP port (default: 80)  
-* **SSL** – Enable TLS (default: false)  
-* **REDOC_PATHS** – Optional comma-separated list of paths to probe. When unset, the module probes: `/redoc, /redoc/, /docs, /api/docs, /openapi`.
+### Module Options
 
-## Verification steps
-1. Start `msfconsole`  
-2. `use auxiliary/scanner/http/redoc_exposed`  
-3. `set RHOSTS <target or file:/path/to/targets.txt>`  
-4. (Optional) `set REDOC_PATHS /redoc,/docs`  
-5. (Optional) `set RPORT <port>` and/or `set SSL true`  
+* **RHOSTS** (required): Target address range or CIDR identifier.
+* **RPORT**: Default `80` (overridable via `DefaultOptions` or at runtime).
+* **SSL**: HTTPS support is registered by default (set if needed).
+* **REDOC_PATHS**: Comma-separated custom paths to probe. If unset, defaults to:
+  `/redoc,/redoc/,/docs,/api/docs,/openapi`.
+
+### Verification Steps
+
+1. Start `msfconsole`.
+2. `use auxiliary/scanner/http/redoc_exposed`
+3. `set RHOSTS <target-or-range>`
+4. (Optional) `set REDOC_PATHS /redoc,/docs`
+5. (Optional) `set SSL true`
 6. `run`
 
-### Expected
+### Scenarios
+```text
+msf6 > use auxiliary/scanner/http/redoc_exposed
+msf6 auxiliary(scanner/http/redoc_exposed) > set RHOSTS 192.0.2.0/24
+msf6 auxiliary(scanner/http/redoc_exposed) > run
+[+] 192.0.2.15 - ReDoc likely exposed at /docs
+[*] 192.0.2.23 - no ReDoc found
+```
+### Notes
 
-`[+] <ip> - ReDoc likely exposed at <path>`
-
-### Scanning notes
-- DOM-driven checks via `get_html_document`:
-  - `<redoc>` / `redoc-` custom elements
-  - `#redoc` container
-  - `<script src="...redoc(.standalone).js">`
-- Falls back to body/title heuristics if DOM parsing is unavailable.
-- No intrusive actions; **read-only** HTTP GET requests only.
-
-### Example session
-
-use auxiliary/scanner/http/redoc_exposed
-set RHOSTS 127.0.0.1
-set RPORT 8001
-set SSL false
-run
+* **Stability**: `CRASH_SAFE` (GET requests only).
+* **Reliability**: No session creation.
+* **SideEffects**: Requests may appear in server logs (`IOC_IN_LOGS` if applicable).

--- a/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
+++ b/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
@@ -1,25 +1,32 @@
 ## ReDoc API Docs UI Exposed
 
-Detects publicly exposed ReDoc API documentation pages by looking for known DOM elements, script names, and titles. The module is read-only and makes safe GET requests.
+Detects publicly exposed ReDoc API documentation pages by looking for known DOM elements and script names. The module is read-only and sends safe `GET` requests.
 
 ### Module Options
 
-* **RHOSTS** (required): Target address range or CIDR identifier.
-* **RPORT**: Default `80` (overridable via `DefaultOptions` or at runtime).
-* **SSL**: HTTPS support is registered by default (set if needed).
-* **REDOC_PATHS**: Comma-separated custom paths to probe. If unset, defaults to:
-  `/redoc,/redoc/,/docs,/api/docs,/openapi`.
+- **RHOSTS** (required): Target address range or CIDR identifier.
+- **RPORT**: Default `80` (from `DefaultOptions`).
+- **SSL**: Enable to negotiate HTTPS to the target.
+- **REDOC_PATHS** (required): Comma-separated paths to probe. **Default**:  
+  `/redoc,/redoc/,/docs,/api/docs,/openapi`
+
+### How It Works
+
+- Prefers DOM checks (`<redoc>`, `#redoc`, or scripts containing `redoc` / `redoc.standalone`).
+- Falls back to title/body heuristics for “redoc”.
+- Considers only **2xx** and **403** responses (avoids noisy redirects).
 
 ### Verification Steps
 
 1. Start `msfconsole`.
 2. `use auxiliary/scanner/http/redoc_exposed`
 3. `set RHOSTS <target-or-range>`
-4. (Optional) `set REDOC_PATHS /redoc,/docs`
-5. (Optional) `set SSL true`
+4. (Optional) `set SSL true`
+5. (Optional) `set REDOC_PATHS /redoc,/docs`
 6. `run`
 
 ### Scenarios
+
 ```text
 msf6 > use auxiliary/scanner/http/redoc_exposed
 msf6 auxiliary(scanner/http/redoc_exposed) > set RHOSTS 192.0.2.0/24
@@ -31,4 +38,5 @@ msf6 auxiliary(scanner/http/redoc_exposed) > run
 
 * **Stability**: `CRASH_SAFE` (GET requests only).
 * **Reliability**: No session creation.
-* **SideEffects**: Requests may appear in server logs (`IOC_IN_LOGS` if applicable).
+* **SideEffects**: Requests may appear in server logs (`IOC_IN_LOGS`).
+

--- a/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
+++ b/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
@@ -1,39 +1,91 @@
-## Summary
-This module detects publicly exposed **ReDoc** API documentation pages.  
-It performs safe, read-only HTTP GET requests and reports likely ReDoc instances based on common HTML markers.
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
 
-## Module name
-`auxiliary/scanner/http/redoc_exposed`
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
 
-## Options
-* **RPORT** – Target TCP port (default: 80)  
-* **SSL** – Enable TLS (default: false)  
-* **REDOC_PATHS** – Optional comma-separated list of paths to probe. When unset, the module probes: `/redoc, /redoc/, /docs, /api/docs, /openapi`.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ReDoc API Docs UI Exposed',
+        'Description' => %q{
+          Detects publicly exposed ReDoc API documentation pages.
+          The module performs safe, read-only GET requests and reports likely
+          ReDoc instances based on HTML markers.
+        },
+        'Author' => [
+          'Hamza Sahin (@hamzasahin61)'
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],  # GET requests only; should not crash or disrupt the target service
+          'Reliability' => [],          # Does not establish sessions; leaving this empty is acceptable
+          'SideEffects' => []           # Add IOC_IN_LOGS if server logs may record these requests
+        }
+      )
+    )
 
-## Verification steps
-1. Start `msfconsole`  
-2. `use auxiliary/scanner/http/redoc_exposed`  
-3. `set RHOSTS <target or file:/path/to/targets.txt>`  
-4. (Optional) `set REDOC_PATHS /redoc,/docs`  
-5. (Optional) `set RPORT <port>` and/or `set SSL true`  
-6. `run`
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptBool.new('SSL', [true, 'Negotiate SSL/TLS for outgoing connections', false]),
+        OptString.new('REDOC_PATHS', [
+          false,
+          'Comma-separated list of paths to probe (overrides defaults)',
+          nil
+        ])
+      ]
+    )
+  end
 
-### Expected
+  # returns true if the response looks like a ReDoc page
+  def redoc_like?(res)
+    return false unless res && res.code.between?(200, 403)
 
-`[+] <ip> - ReDoc likely exposed at <path>`
+    # Prefer DOM checks
+    doc = res.get_html_document
+    if doc
+      return true if doc.at_css('redoc, redoc-, #redoc')
+      return true if doc.css('script[src*="redoc"]').any?
+      return true if doc.css('script[src*="redoc.standalone"]').any?
+    end
 
-### Scanning notes
-- DOM-driven checks via `get_html_document`:
-  - `<redoc>` / `redoc-` custom elements
-  - `#redoc` container
-  - `<script src="...redoc(.standalone).js">`
-- Falls back to body/title heuristics if DOM parsing is unavailable.
-- No intrusive actions; **read-only** HTTP GET requests only.
+    # Fallback to body/title heuristics
+    title = res.get_html_title.to_s
+    body = res.body.to_s
 
-### Example session
+    return true if title =~ /redoc/i
+    return true if body =~ /<redoc-?/i
+    return true if body =~ /redoc(\.standalone)?\.js/i
 
-use auxiliary/scanner/http/redoc_exposed
-set RHOSTS 127.0.0.1
-set RPORT 8001
-set SSL false
-run
+    false
+  end
+
+  def check_path(path)
+    res = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(path) })
+    redoc_like?(res)
+  end
+
+  def run_host(ip)
+    vprint_status("#{ip} - scanning for ReDoc")
+
+    paths =
+      if (ds = datastore['REDOC_PATHS']) && !ds.empty?
+        ds.split(',').map(&:strip)
+      else
+        ['/redoc', '/redoc/', '/docs', '/api/docs', '/openapi']
+      end
+
+    hit = paths.find { |p| check_path(p) }
+    if hit
+      print_good("#{ip} - ReDoc likely exposed at #{hit}")
+      report_service(host: ip, port: rport, proto: 'tcp', name: 'http')
+    else
+      vprint_status("#{ip} - no ReDoc found")
+    end
+  end
+end

--- a/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
+++ b/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
@@ -21,12 +21,6 @@ is read-only and sends safe `GET` requests.
 ### REDOC_PATHS
 Comma-separated custom paths to probe. If unset, defaults to `/redoc,/redoc/,/docs,/api/docs,/openapi`
 
-## How It Works
-
-- Prefers DOM checks (`<redoc>`, `#redoc`, or scripts containing `redoc` / `redoc.standalone`).
-- Falls back to title/body heuristics for “redoc”.
-- Considers only **2xx** and **403** responses (avoids noisy redirects).
-- 
 ## Scenarios
 
 ```text

--- a/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
+++ b/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
@@ -1,0 +1,39 @@
+## Summary
+This module detects publicly exposed **ReDoc** API documentation pages.  
+It performs safe, read-only HTTP GET requests and reports likely ReDoc instances based on common HTML markers.
+
+## Module name
+`auxiliary/scanner/http/redoc_exposed`
+
+## Options
+* **RPORT** – Target TCP port (default: 80)  
+* **SSL** – Enable TLS (default: false)  
+* **REDOC_PATHS** – Optional comma-separated list of paths to probe. When unset, the module probes: `/redoc, /redoc/, /docs, /api/docs, /openapi`.
+
+## Verification steps
+1. Start `msfconsole`  
+2. `use auxiliary/scanner/http/redoc_exposed`  
+3. `set RHOSTS <target or file:/path/to/targets.txt>`  
+4. (Optional) `set REDOC_PATHS /redoc,/docs`  
+5. (Optional) `set RPORT <port>` and/or `set SSL true`  
+6. `run`
+
+### Expected
+
+`[+] <ip> - ReDoc likely exposed at <path>`
+
+### Scanning notes
+- DOM-driven checks via `get_html_document`:
+  - `<redoc>` / `redoc-` custom elements
+  - `#redoc` container
+  - `<script src="...redoc(.standalone).js">`
+- Falls back to body/title heuristics if DOM parsing is unavailable.
+- No intrusive actions; **read-only** HTTP GET requests only.
+
+### Example session
+
+use auxiliary/scanner/http/redoc_exposed
+set RHOSTS 127.0.0.1
+set RPORT 8001
+set SSL false
+run

--- a/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
+++ b/documentation/modules/auxiliary/scanner/http/redoc_exposed.md
@@ -1,20 +1,14 @@
-## ReDoc API Docs UI Exposed
+## Vulnerable Application
 
-Detects publicly exposed ReDoc API documentation pages by looking for known DOM elements and script names. The module is read-only and sends safe `GET` requests.
-
-
-#### REDOC_PATHS
-Comma-separated custom paths to probe. If unset, defaults to:
-/redoc,/redoc/,/docs,/api/docs,/openapi
-
+Detects publicly exposed ReDoc API documentation pages by looking for known DOM elements and script names. The module
+is read-only and sends safe `GET` requests.
 
 ### How It Works
-
 - Prefers DOM checks (`<redoc>`, `#redoc`, or scripts containing `redoc` / `redoc.standalone`).
 - Falls back to title/body heuristics for “redoc”.
 - Considers only **2xx** and **403** responses (avoids noisy redirects).
-
-### Verification Steps
+  
+## Verification Steps
 
 1. Start `msfconsole`.
 2. `use auxiliary/scanner/http/redoc_exposed`
@@ -22,8 +16,18 @@ Comma-separated custom paths to probe. If unset, defaults to:
 4. (Optional) `set SSL true`
 5. (Optional) `set REDOC_PATHS /redoc,/docs`
 6. `run`
+   
+## Options
+### REDOC_PATHS
+Comma-separated custom paths to probe. If unset, defaults to `/redoc,/redoc/,/docs,/api/docs,/openapi`
 
-### Scenarios
+## How It Works
+
+- Prefers DOM checks (`<redoc>`, `#redoc`, or scripts containing `redoc` / `redoc.standalone`).
+- Falls back to title/body heuristics for “redoc”.
+- Considers only **2xx** and **403** responses (avoids noisy redirects).
+- 
+## Scenarios
 
 ```text
 msf6 > use auxiliary/scanner/http/redoc_exposed
@@ -32,9 +36,8 @@ msf6 auxiliary(scanner/http/redoc_exposed) > run
 [+] 192.0.2.15 - ReDoc likely exposed at /docs
 [*] 192.0.2.23 - no ReDoc found
 ```
-### Notes
+## Notes
 
 * **Stability**: `CRASH_SAFE` (GET requests only).
 * **Reliability**: No session creation.
 * **SideEffects**: Requests may appear in server logs (`IOC_IN_LOGS`).
-

--- a/modules/auxiliary/scanner/http/redoc_exposed.rb
+++ b/modules/auxiliary/scanner/http/redoc_exposed.rb
@@ -1,0 +1,76 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ReDoc API Docs UI Exposed',
+        'Description' => %q{
+          Detects publicly exposed ReDoc API documentation pages which may reveal API surface,
+          endpoints, request/response models, and other implementation details useful to attackers.
+        },
+        'Author' => [
+          'Hamza Sahin <hmzshn61@gmail.com>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'URL', 'https://redocly.com/docs/redoc/' ]
+        ],
+        'Actions' => [ [ 'Scan', { 'Description' => 'Scan for exposed ReDoc UI' } ] ],
+        'DefaultAction' => 'Scan'
+      )
+    )
+
+    register_advanced_options([
+      OptString.new('REDOC_PATHS', [ true, 'Comma-separated paths to probe', '/redoc,/docs,/api/docs,/openapi,/redoc/' ])
+    ])
+  end
+
+  # Returns :yes if the path looks like a ReDoc page, else :no
+  def check_path(path)
+    res = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(path) }, 10)
+    return :no if res.nil?
+
+    code_ok = res.code && res.code.between?(200, 403)
+    body = res.body.to_s
+
+    title_hit = body =~ /<\s*title[^>]*>[^<]*redoc[^<]*<\/\s*title\s*>/i
+    redoc_hit = body =~ /(redoc(?:\.standalone)?\.js|<\s*redoc-?)/i
+
+    return :yes if code_ok && (title_hit || redoc_hit)
+    :no
+  end
+
+  def run_host(ip)
+    vprint_status("#{ip} - scanning for ReDoc")
+
+    paths = (datastore['REDOC_PATHS'] || '').split(',').map(&:strip)
+    paths = ['/redoc', '/docs', '/api/docs', '/openapi', '/redoc/'] if paths.empty?
+
+    hit = paths.find { |p| check_path(p) == :yes }
+
+    if hit
+      print_good("#{ip} - ReDoc likely exposed at #{hit}")
+      report_service(
+        host: ip,
+        port: rport,
+        proto: 'tcp',
+        name: (ssl ? 'https' : 'http')
+      )
+      report_note(
+        host: ip,
+        port: rport,
+        proto: 'tcp',
+        type: 'http.redoc.exposed',
+        data: { path: hit }
+      )
+    else
+      vprint_status("#{ip} - no ReDoc found")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/redoc_exposed.rb
+++ b/modules/auxiliary/scanner/http/redoc_exposed.rb
@@ -20,7 +20,12 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => [
           'Hamza Sahin (@hamzasahin61)'
         ],
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],  # GET requests only; should not crash or disrupt the target service
+          'Reliability' => [],          # Does not establish sessions; leaving this empty is acceptable
+          'SideEffects' => []           # Add IOC_IN_LOGS if server logs may record these requests
+        }
       )
     )
 
@@ -51,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Fallback to body/title heuristics
     title = res.get_html_title.to_s
-    body  = res.body.to_s
+    body = res.body.to_s
 
     return true if title =~ /redoc/i
     return true if body =~ /<redoc-?/i


### PR DESCRIPTION
## Summary
This module detects publicly exposed **ReDoc** API documentation pages.  
It performs safe, read-only HTTP GET requests and reports likely ReDoc instances based on common HTML markers.

## Module name
`auxiliary/scanner/http/redoc_exposed`

## Options
* **RPORT** – Target TCP port (default: 80)  
* **SSL** – Enable TLS (default: false)  
* **REDOC_PATHS** – Optional comma-separated list of paths to probe. When unset, the module probes: `/redoc, /redoc/, /docs, /api/docs, /openapi`.

## Verification steps
1. Start `msfconsole`  
2. `use auxiliary/scanner/http/redoc_exposed`  
3. `set RHOSTS <target or file:/path/to/targets.txt>`  
4. (Optional) `set REDOC_PATHS /redoc,/docs`  
5. (Optional) `set RPORT <port>` and/or `set SSL true`  
6. `run`

### Expected

`[+] <ip> - ReDoc likely exposed at <path>`

### Scanning notes
- DOM-driven checks via `get_html_document`:
  - `<redoc>` / `redoc-` custom elements
  - `#redoc` container
  - `<script src="...redoc(.standalone).js">`
- Falls back to body/title heuristics if DOM parsing is unavailable.
- No intrusive actions; **read-only** HTTP GET requests only.

### Example session

use auxiliary/scanner/http/redoc_exposed
set RHOSTS 127.0.0.1
set RPORT 8001
set SSL false
run
