### PR TITLE
fix(console): prevent RHOSTS temp file deletion after services -R

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -84,15 +84,11 @@ module Common
     if rhosts.length > 5
       # Lots of hosts makes 'show options' wrap which is difficult to
       # read, store to a temp file
-      rhosts_file = Rex::Quickfile.new("msf-db-rhosts-")
+      rhosts_file = Rex::Quickfile.create("msf-db-rhosts-")
       mydatastore['RHOSTS'] = 'file:'+rhosts_file.path
       # create the output file and assign it to the RHOSTS variable
       rhosts_file.write(rhosts.join("\n")+"\n")
       rhosts_file.close
-      # Keep a reference so Ruby's GC doesn't finalize and unlink the temp file
-      # before a module has a chance to read it.
-      @persisted_rhosts_files ||= []
-      @persisted_rhosts_files << rhosts_file
     else
       # For short lists, just set it directly
       mydatastore['RHOSTS'] = rhosts.join(" ")

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -89,6 +89,10 @@ module Common
       # create the output file and assign it to the RHOSTS variable
       rhosts_file.write(rhosts.join("\n")+"\n")
       rhosts_file.close
+      # Keep a reference so Ruby's GC doesn't finalize and unlink the temp file
+      # before a module has a chance to read it.
+      @persisted_rhosts_files ||= []
+      @persisted_rhosts_files << rhosts_file
     else
       # For short lists, just set it directly
       mydatastore['RHOSTS'] = rhosts.join(" ")


### PR DESCRIPTION
## Fix: RHOSTS temp file deleted before module run when using `services ... -R`

### Summary
Using `services -p <ports> -u -R`  could set `RHOSTS` to a `file:/tmp/msf-db-rhosts-*` path that vanished immediately upon running a module. This resulted in modules starting with an empty or ineffective target list. The root cause was that the temporary file was created via `Rex::Quickfile` in `set_rhosts_from_addrs` and the only Ruby reference to the object went out of scope. Under recent Ruby / Rex behavior, the file was unlinked when the object was garbage collected (often triggered right as a module initialized and allocated additional objects).

### Root Cause
`set_rhosts_from_addrs` wrote the host list to a `Rex::Quickfile`, closed it, and returned without retaining a reference. If `Rex::Quickfile` (or an underlying implementation analogous to `Tempfile`) registers a finalizer that unlinks the file, the OS file disappeared as soon as GC (garbage collector) finalized the object. GC frequently occurred when a module was launched due to new allocations, making the deletion appear to be caused by the module itself.

### Fix Implemented
We now retain references to created `Rex::Quickfile` instances in an instance variable `@persisted_rhosts_files`, preventing garbage collection (and therefore unlink) for the lifetime of the console process. For small host lists (≤5 hosts), behavior is unchanged: the list is stored inline in the `RHOSTS` datastore.

### Test Coverage
#### Note on Reproduction via `db_import`
The issue is most easily observed after importing a larger host/service set from an Nmap XML file using `db_import <scan.xml>`. Imported scans commonly contain more than five hosts, causing `set_rhosts_from_addrs` to choose the temp file path variant (`file:/tmp/msf-db-rhosts-*`). More you have larger host/service more you have chance to trigger the garbage collector at the run.

1. Import large number of data
From namp scan:
```
db_import nmap_scan.xml
```
Or create many fake hosts/services ( > 60 ):
On bash:
```
echo "workspace -a Demo" > add_rdps.rc
for i in $(seq 1 60); do
  echo "hosts -a 192.168.0.$i"
  echo "services -a -p 3389 -r tcp -s rdp 192.168.0.$i"
done >> add_rdps.rc
```
```
msfconsole -r add_rdps.rc
```

2. Select and run a module:

```
use auxiliary/scanner/rdp/rdp_scanner
services -p 3389 -u -R
ls /tmp/msf-db-rhosts-XXXXXXXXX
run
ls /tmp/msf-db-rhosts-XXXXXXXXX
```
Note the displayed file path (e.g. `file:/tmp/msf-db-rhosts-...`).

The file has been removed and the module didn't scan the targets. Because the garbage collector clean the file.

<img width="1190" height="628" alt="image" src="https://github.com/user-attachments/assets/e44eb336-0c5f-4304-aa73-583245080e73" />


Apply the fix and rerun the step 1 and 2 above you will see that the scan run properly and the file is not clean by the GC.

<img width="1019" height="846" alt="image" src="https://github.com/user-attachments/assets/0775e290-8e59-453e-b1b7-16a4e091c57b" />

