### PR TITLE
Unpin octokit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ PATH
       network_interface
       nexpose
       nokogiri
-      octokit (~> 4.0)
+      octokit
       openssl-ccm
       openvas-omp
       ostruct
@@ -393,7 +393,7 @@ GEM
       racc (~> 1.4)
     nori (2.7.1)
       bigdecimal
-    octokit (4.25.1)
+    octokit (10.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     openssl-ccm (1.2.3)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -100,8 +100,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'recog'
   # required for bitlocker fvek extraction
   spec.add_runtime_dependency 'openssl-ccm'
-  # Needed for documentation generation - locked unitl Ruby 2.6 support is dropped
-  spec.add_runtime_dependency 'octokit', '~> 4.0'
+  spec.add_runtime_dependency 'octokit'
   spec.add_runtime_dependency 'redcarpet'
   # Needed for Microsoft patch finding tool (msu_finder)
   spec.add_runtime_dependency 'patch_finder'


### PR DESCRIPTION
Unpin octokit

## Verification

Unpinned and verified that exporting a github oauth token allows retrieval of related pull requests still after running `info -d`

<img width="791" height="206" alt="image" src="https://github.com/user-attachments/assets/f37687a4-1ea0-45aa-84fb-2ce76073e9ca" />
