### PR TITLE
Remove a CVE that was mistakenly added

### DIFF
--- a/modules/exploits/unix/webapp/fusionpbx_exec_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/fusionpbx_exec_cmd_exec.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => ['bcoles'],
         'References' => [
-          ['CVE', '2019-11409'],
           ['URL', 'https://docs.fusionpbx.com/en/latest/advanced/command.html']
         ],
         'Platform' => %w[php linux unix],


### PR DESCRIPTION
This removes a CVE reference that was added in PR #20595 that should not have been added per @bcoles's comment [here](https://github.com/rapid7/metasploit-framework/pull/20595#discussion_r2412149831).