### PR TITLE
exploit/multi/local/periodic_script_persistence: Unset DefaultTarget

### DIFF
--- a/modules/exploits/multi/local/periodic_script_persistence.rb
+++ b/modules/exploits/multi/local/periodic_script_persistence.rb
@@ -43,7 +43,6 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'DisablePayloadHandler' => true
         },
-        'DefaultTarget' => 4,
         'SessionTypes' => [ 'shell', 'meterpreter' ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],


### PR DESCRIPTION
The `exploit/multi/local/periodic_script_persistence` module sets an invalid target index within the `DefaultTarget` option.

https://github.com/rapid7/metasploit-framework/blob/55bb27711d84dfe296d151af20ba7e89c0f0780f/modules/exploits/multi/local/periodic_script_persistence.rb#L37-L46

Targets are zero-indexed. As such, `4` is an invalid target index.

This caused issues with the Local Exploit Suggester (#20609).

I'm not sure why `4` (presumably `3`) was chosen as the default target. This target does not perform automatic targeting and is not a safe default target for all platforms.

This PR removes the default `DefaultTarget` value, forcing the operator to knowingly and intentionally chose a `target`.
