### PR TITLE
Rubocop: Add Lint/ModuleInvalidDefaultTarget

### DIFF
--- a/lib/rubocop/cop/lint/module_invalid_default_target.rb
+++ b/lib/rubocop/cop/lint/module_invalid_default_target.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      class ModuleInvalidDefaultTarget < Base
+        extend AutoCorrector
+        include Alignment
+
+        MSG = 'Module DefaultTarget is out of range. Must specify a valid target index between 0 and %<targets>s'
+
+        def_node_matcher :find_update_info_node, <<~PATTERN
+          (def :initialize _args (begin (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...))) ...))
+        PATTERN
+
+        def_node_matcher :find_nested_update_info_node, <<~PATTERN
+          (def :initialize _args (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...)) ...))
+        PATTERN
+
+        def on_def(node)
+          update_info_node = find_update_info_node(node) || find_nested_update_info_node(node)
+          return if update_info_node.nil?
+
+          hash = update_info_node.arguments.find { |argument| hash_arg?(argument) }
+
+          targets = 0
+          hash.each_pair do |key, value|
+            next unless key.value == 'Targets'
+
+            if value.array_type?
+              targets = value.values.size
+            end
+
+            break
+          end
+
+          hash.each_pair do |key, value|
+            next unless key.value == 'DefaultTarget'
+            next if value.value < targets
+            next if value.value == 0
+
+            add_offense(
+              value,
+              message: format(MSG, targets: (targets - 1).to_s),
+              &autocorrector(value)
+            )
+
+            break
+          end
+        end
+
+        private
+
+        def autocorrector(value_node)
+          lambda do |corrector|
+            corrector.replace(value_node.loc.expression, '0')
+          end
+        end
+
+        def hash_arg?(node)
+          node.type == :hash
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
FIxes #20612.

```
# rubocop --only Lint/ModuleInvalidDefaultTarget modules/exploits/
Inspecting 2590 files
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................W....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................                                                                                                                                                         

Offenses:

modules/exploits/multi/local/periodic_script_persistence.rb:46:28: W: [Correctable] Lint/ModuleInvalidDefaultTarget: Module DefaultTarget is out of range. Must specify a valid target index between 0 and 3
        'DefaultTarget' => 4,
                           ^

2590 files inspected, 1 offense detected, 1 offense autocorrectable
```

```
# rubocop --only Lint/ModuleInvalidDefaultTarget modules/exploits/multi/local/periodic_script_persistence.rb  -d -a
For /root/Desktop/metasploit-framework: configuration from /root/Desktop/metasploit-framework/.rubocop.yml
Default configuration from /var/lib/gems/3.3.0/gems/rubocop-1.75.7/config/default.yml
Use parallel by default.
Skipping parallel inspection: only a single file needs inspection
Inspecting 1 file
Scanning /root/Desktop/metasploit-framework/modules/exploits/multi/local/periodic_script_persistence.rb
Loading cache from /root/.cache/rubocop_cache/9201f3b08a9241101940210e4146f7fdb796baa1/328a82a0abc902e560a44c835a1a67943bd7257b/317d21ae17bacab79be1031b4b1900ff8a0b0745
W

Offenses:

modules/exploits/multi/local/periodic_script_persistence.rb:46:28: W: [Corrected] Lint/ModuleInvalidDefaultTarget: Module DefaultTarget is out of range. Must specify a valid target index between 0 and 3
        'DefaultTarget' => 4,
                           ^

1 file inspected, 1 offense detected, 1 offense corrected
Finished in 0.39817420599865727 seconds
```
