### PR TITLE
Future proof peinject method override

### DIFF
--- a/lib/msf/core/payload/windows/pe_inject.rb
+++ b/lib/msf/core/payload/windows/pe_inject.rb
@@ -44,7 +44,7 @@ module Msf
       end
     end
 
-    def valid?(value, check_empty: nil, datastore: nil)
+    def valid?(value, **kwargs)
       return false unless super
       return false unless value && File.file?(File.expand_path(value)) # no memory: locations
 


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/20608

## Verification

Before

```
msf > generate
[-] Payload generation failed: unknown keyword: :datastore
```

After

```
msf-pro payload(windows/peinject/bind_named_pipe) > generate
[-] Payload generation failed: One or more options failed to validate: PE.
```