### PR TITLE
Update payload docs to use modern h3 for options instead of original spec (bold)

### DIFF
--- a/documentation/modules/payload/cmd/unix/bind_busybox_telnetd.md
+++ b/documentation/modules/payload/cmd/unix/bind_busybox_telnetd.md
@@ -8,17 +8,17 @@ with BusyBox telnetd installed.
 
 ## Options
 
-  **LOGIN_CMD**
+### LOGIN_CMD
 
   The command telnetd will execute on connect. The default value is `/bin/sh`
   in order to provide a command shell.
 
-  **TelnetdPath**
+### TelnetdPath
   The path to the telnetd executable on disk. The default value is `telnetd`.
 
 ### Advanced
 
-  **CommandShellCleanupCommand**
+### CommandShellCleanupCommand
 
   The command to run before the session is closed. The default value is
   `pkill telnetd` and is used to avoid leaving a persistent command shell


### PR DESCRIPTION
A long while ago an r7 employee (forgot who, sorry, but she was awesome in helping spec out the original markdown doc format stuff!) decided we should use h3 (###) instead of bold (**) for Options. There were a lot of old docs, so this is an initial attempt to convert them all in payload.