### PR TITLE
Update post docs to use modern h3 for options instead of original spec (bold)

### DIFF
--- a/documentation/modules/post/android/capture/screen.md
+++ b/documentation/modules/post/android/capture/screen.md
@@ -14,11 +14,11 @@
 
 ## Options
 
-  **EXE_PATH**
+### EXE_PATH
 
   Path to the `screencap` executable on Android device. Default is `/system/bin/screencap`.
 
-  **TMP_PATH**
+### TMP_PATH
 
   Path to temp directory on Android device to save the screenshot to temporarily. Default is `/data/local/tmp/`.
 

--- a/documentation/modules/post/android/gather/wireless_ap.md
+++ b/documentation/modules/post/android/gather/wireless_ap.md
@@ -13,7 +13,9 @@
 
 ## Options
 
-  **SESSION** - The session to run the module on.
+### SESSION
+
+The session to run the module on.
 
 ## Extracted data
 

--- a/documentation/modules/post/bsd/gather/hashdump.md
+++ b/documentation/modules/post/bsd/gather/hashdump.md
@@ -10,7 +10,7 @@
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   Which session to use, which can be viewed with `sessions -l`
 

--- a/documentation/modules/post/hardware/automotive/can_flood.md
+++ b/documentation/modules/post/hardware/automotive/can_flood.md
@@ -27,16 +27,16 @@ Then do the thing:
 
 ## Options
 
-**CANBUS**
+### CANBUS
 Determines which CAN interface to use.
 
-**FRAMELIST**
+### FRAMELIST
 Path of the file that contains the list of frames. Default is "/usr/share/metasploit-framework/data/wordlists/can_flood_frames.txt".
 
-**ROUNDS**
+### ROUNDS
 Number of executed rounds. Default is 200.
 
-**SESSION**
+### SESSION
 The session to run this module on.
 
 ## Scenarios

--- a/documentation/modules/post/hardware/automotive/canprobe.md
+++ b/documentation/modules/post/hardware/automotive/canprobe.md
@@ -5,27 +5,27 @@ attempt to check for return packets.
 
 ## Options
 
-  **STARTID**
+### STARTID
 
   The CAN ID to start your scan from.
 
-  **STOPID**
+### STOPID
 
   The CAN ID to stop the CAN scan.  If no STOPID is specified it will only scan one ID (STARTID).
 
-  **FUZZ**
+### FUZZ
 
   If true the data segment will iterate through all possibilities (0-255).
 
-  **PROBEVALUE**
+### PROBEVALUE
 
   The value to put at each data segment.  The default is 0xFF.  When Fuzz is enabled this value is ignored.
 
-  **PADDING**
+### PADDING
 
   If you need to pad out the packet to be 8 packets for each request you can set this value to something between 0-255.
 
-  **CANBUS**
+### CANBUS
 
   The bus to scan.  See 'supported_buses' for a list of available buses.
 

--- a/documentation/modules/post/hardware/automotive/ecu_hard_reset.md
+++ b/documentation/modules/post/hardware/automotive/ecu_hard_reset.md
@@ -22,10 +22,10 @@ Launch msf:
 
 ## Options
 
-**ARBID**
+### ARBID
 CAN ID to perform ECU Hard Reset (Default: 0x7DF)
 
-**CANBUS**
+### CANBUS
 CAN Bus to perform scan on, defaults to connected bus
 
 ## Scenarios

--- a/documentation/modules/post/hardware/automotive/getvinfo.md
+++ b/documentation/modules/post/hardware/automotive/getvinfo.md
@@ -11,27 +11,27 @@ PIDs to ASCII.
 
 ## Options
 
-  **SRCID**
+### SRCID
 
   This is the SRC CAN ID for the ISO-TP connection.  Default is 0x7E0.
 
-  **DSTID**
+### DSTID
 
   This is the CAN ID of the expected response.  Default is 0x7E8.
 
-  **CANBUS**
+### CANBUS
 
   Determines which CAN bus to communicate on.  Type 'supported_buses' for valid options.
 
-  **CLEAR_DTCS**
+### CLEAR_DTCS
 
   If any Diagnostic Trouble Codes (DTCs) are present it will clear those and reset the MIL (Engine Light).
 
-  **PADDING**
+### PADDING
 
   Optional byte-value to use for padding all CAN bus packets to an 8-byte length.  Padding is disabled by default.
 
-  **FC**
+### FC
 
   Optional.  If true forces sending flow control packets on all multibyte ISO-TP requests
 

--- a/documentation/modules/post/hardware/automotive/identifymodules.md
+++ b/documentation/modules/post/hardware/automotive/identifymodules.md
@@ -4,15 +4,15 @@ with an error or an acknowldegment.  We use this information to map out modules 
 
 ## Options
 
-  **STARTID**
+### STARTID
 
   The CAN ID to start your scan from.
 
-  **ENDID**
+### ENDID
 
   The CAN ID to stop the CAN scan.
 
-  **CANBUS**
+### CANBUS
 
   The bus to scan.  See 'supported_buses' for a list of available buses
 

--- a/documentation/modules/post/hardware/automotive/mazda_ic_mover.md
+++ b/documentation/modules/post/hardware/automotive/mazda_ic_mover.md
@@ -26,7 +26,7 @@ Launch msf:
 
 ## Options
 
-**CANBUS**
+### CANBUS
 CAN Bus to perform scan on, defaults to connected bus
 
 ## Scenarios

--- a/documentation/modules/post/hardware/automotive/pdt.md
+++ b/documentation/modules/post/hardware/automotive/pdt.md
@@ -4,19 +4,19 @@ This module is based on research by Johannes Braun and Juergen Duerrwang, which 
 
 ## Options
 
-  **SRCID**
+### SRCID
 
   This is the SRC CAN ID for the PCU connection.  Default is 0x7F1.
 
-  **DSTID**
+### DSTID
 
   This is the CAN ID of the expected response.  Default is 0x7F9.
 
-  **CANBUS**
+### CANBUS
 
   Determines which CAN bus to communicate on.  Type 'supported_buses' for valid options.
 
-  **PADDING**
+### PADDING
 
   Optional byte-value to use for padding all CAN bus packets to an 8-byte length.  Padding is disabled by default.
 

--- a/documentation/modules/post/hardware/rftransceiver/rfpwnon.md
+++ b/documentation/modules/post/hardware/rftransceiver/rfpwnon.md
@@ -5,47 +5,47 @@ demonstrated to work against static key garage door openers.
 
 ## Options
 
-  **FREQ**
+### FREQ
 
   Frequency to brute force.
 
-  **BAUD**
+### BAUD
 
   Baud rate.  Default: 2000
 
-  **BINLENGTH**
+### BINLENGTH
 
   Binary bit-length for bruteforcing.  Default: 8
 
-  **REPEAT**
+### REPEAT
 
   How many times to repeat the sending of the packet.  Default: 5
 
-  **PPAD**
+### PPAD
 
   Binary data to append to packet.  (Example: "0101")  Default: None
 
-  **TPAD**
+### TPAD
 
   Binary data to add to end of packet.  (Example: "0101")  Default: None
 
-  **RAW**
+### RAW
 
   Do not do PWM encoding on packet.  Default: False
 
-  **TRI**
+### TRI
 
   Use trinary signals.  Default: False
 
-  **EXTRAVERBOSE**
+### EXTRAVERBOSE
 
   Adds some extra status messages.
 
-  **INDEX**
+### INDEX
 
   USB Index number.  Default: 0
 
-  **DELAY**
+### DELAY
 
   How many milliseconds to delay before transmission.  Too fast tends to lock up the device.  Default: 500 (0.5 seconds)
 

--- a/documentation/modules/post/hardware/rftransceiver/transmitter.md
+++ b/documentation/modules/post/hardware/rftransceiver/transmitter.md
@@ -8,23 +8,23 @@ given radio frequency.
 
 ## Options
 
-  **FREQ**
+### FREQ
 
   Frequency to brute force.
 
-  **BAUD**
+### BAUD
 
   Baud rate.  Default: 4800
 
-  **POWER**
+### POWER
 
   Power level to specify.  Default: 100
 
-  **SECONDS**
+### SECONDS
 
   How many seconds to transmit the signal.  Default: 4
 
-  **INDEX**
+### INDEX
 
   USB Index number.  Default: 0
 

--- a/documentation/modules/post/hardware/zigbee/zstumbler.md
+++ b/documentation/modules/post/hardware/zigbee/zstumbler.md
@@ -2,20 +2,20 @@ Actively scans the Zigbee channels by sending a beacon broadcast packet and list
 
 ## Options
 
-  **DEVICE**
+### DEVICE
 
   ZigBee Device ID.  Defaults to the target device that is specified via the target command or if
   one device is presented when running 'supported_devices' it will use that device.
 
-  **CHANNEL**
+### CHANNEL
 
   The channel to scan.  Setting this options will prevent the stumbler from changing channels.  Range is 11-26, inclusive.  Default: not set
 n
-  **LOOP**
+### LOOP
 
   How many times to loop over the channels.  Specifying a -1 will loop forever.  Default: 1
 
-  **DELAY**
+### DELAY
 
   The delay in seconds to listen to each channel.  Default: 2
 

--- a/documentation/modules/post/linux/gather/checkcontainer.md
+++ b/documentation/modules/post/linux/gather/checkcontainer.md
@@ -15,7 +15,7 @@
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   Which session to use, which can be viewed with `sessions -l`
 

--- a/documentation/modules/post/linux/gather/checkvm.md
+++ b/documentation/modules/post/linux/gather/checkvm.md
@@ -21,7 +21,7 @@ There are many locations that are checked for having evidence of being a virtual
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   Which session to use, which can be viewed with `sessions -l`
 

--- a/documentation/modules/post/linux/gather/enum_containers.md
+++ b/documentation/modules/post/linux/gather/enum_containers.md
@@ -17,11 +17,11 @@ This module looks for container platforms running on the target and then lists a
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   Which session to use, which can be viewed with `sessions -l`
  
-  **CMD**
+### CMD
 
   Optional shell command to run on each running container
 

--- a/documentation/modules/post/linux/gather/enum_nagios_xi.md
+++ b/documentation/modules/post/linux/gather/enum_nagios_xi.md
@@ -12,7 +12,7 @@ NagiosXI may store credentials of the hosts it monitors. This module extracts th
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   Which session to use, which can be viewed with `sessions -l`
 

--- a/documentation/modules/post/linux/manage/sshkey_persistence.md
+++ b/documentation/modules/post/linux/manage/sshkey_persistence.md
@@ -24,15 +24,15 @@ This module will add an SSH key to a specified user (or all), to allow remote lo
 
 ## Options
 
-  **SSHD_CONFIG**
+### SSHD_CONFIG
 
   Location of the sshd_config file on the remote system.  We use this to determine if the authorized_keys file location has changed on the system.  If it hasn't, we default to .ssh/authorized_keys
 
-  **USERNAME**
+### USERNAME
 
   If set, we only write our key to this user.  If not, we'll write to all users
 
-  **PUBKEY**
+### PUBKEY
 
   A public key to use.  If not provided, a pub/priv key pair is generated automatically
 

--- a/documentation/modules/post/multi/gather/chrome_cookies.md
+++ b/documentation/modules/post/multi/gather/chrome_cookies.md
@@ -28,17 +28,17 @@ Chrome does not need to be running on the target machine for this module to work
 
 ## Options
 
-  **CHROME_BINARY_PATH**
+### CHROME_BINARY_PATH
 
   The path to the user's Chrome binary. On Linux this defaults to searching for `google-chrome` in `$PATH`. On macOS, this defaults to `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'`. If the module doesn't find any cookies, it may be that a different Chrome binary to the one the user normally uses is being run. In that case, you can change the Chrome binary executed with this option.
 
-  **WRITABLE_DIR**
+### WRITABLE_DIR
 
   Directory used to write temporary files.
 
   Two files are written, with random 10-15 character alphanumeric filenames. One file contains an html file for Chrome and the other is where the cookies are saved. Both files are deleted during cleanup.
 
-  **REMOTE_DEBUGGING_PORT**
+### REMOTE_DEBUGGING_PORT
 
   Port to tell Chrome to expose Remote Debugging on. Default is the normal remote debugging port, `9222`.
 

--- a/documentation/modules/post/multi/gather/dbeaver.md
+++ b/documentation/modules/post/multi/gather/dbeaver.md
@@ -28,13 +28,13 @@
 
 ## Options
 
- **XML_FILE_PATH**
+### XML_FILE_PATH
 
 Specify an XML configuration file (eg.
 `C:\Users\FireEye\.dbeaver4\General\.dbeaver-data-sources.xml` or
 `C:\Users\FireEye\AppData\Roaming\DBeaverData\workspace6\General\.dbeaver-data-sources.xml`).
 
- **JSON_DIR_PATH**
+### JSON_DIR_PATH
 
 Specifies the config dir path for Dbeaver. Ensure that there are two files
 `credentials-config.json` and `data-sources.json` under the directory (eg.

--- a/documentation/modules/post/multi/gather/grub_creds.md
+++ b/documentation/modules/post/multi/gather/grub_creds.md
@@ -18,12 +18,12 @@ Any UNIX-like system with a `shell` or `meterpreter` session using GRUB.
 
 ## Options
 
-**FILENAME**
+### FILENAME
 
 A string that can be used to specify an additional file to check after the
 usual places.
 
-**VERBOSE**
+### VERBOSE
 
 A boolean that, when set, will provide more details on what is being checked.
 _(Note: this option is defined elsewhere in metasploit, but this module can make

--- a/documentation/modules/post/multi/gather/jenkins_gather.md
+++ b/documentation/modules/post/multi/gather/jenkins_gather.md
@@ -43,17 +43,17 @@ This module has been verified against:
 
 ## Options
 
-  **SEARCH_JOBS**
+### SEARCH_JOBS
 
   This option searches through the `jobs` folder for interesting
 keywords but obviously increases runtime on larger instances.
 
-  **STORE_LOOT**
+### STORE_LOOT
 
   This option saves interesting files and loot to disk. If set to
 false will simply output data to console.
 
-  **JENKINS_HOME**
+### JENKINS_HOME
   This option can be set if we want to specify where the Jenkins
 data resides.
 

--- a/documentation/modules/post/multi/gather/wlan_geolocate.md
+++ b/documentation/modules/post/multi/gather/wlan_geolocate.md
@@ -26,11 +26,11 @@
 
 ## Options
 
-  **geolocate**
+### geolocate
   
   A boolean on if wireless information should only be gathered, or the Google geolocate API should be used to geo the victim.  Defaults to `false`
   
-  **apikey**
+### apikey
 
   A string containing the Google provided geolocation api key. **REQUIRED** if `geolocate` is set to true. Defaults to empty string
 

--- a/documentation/modules/post/multi/manage/open.md
+++ b/documentation/modules/post/multi/manage/open.md
@@ -19,6 +19,6 @@ The following platforms are supported:
 
 ## Options
 
-**URI**
+### URI
 
 The URI that should be passed to the opening command, can be a website or a file.

--- a/documentation/modules/post/multi/manage/upload_exec.md
+++ b/documentation/modules/post/multi/manage/upload_exec.md
@@ -20,11 +20,11 @@ The following platforms are supported:
 
 ## Options
 
-**LFILE**
+### LFILE
 
 The file on your machine that you want to upload to the target machine.
 
-**RFILE**
+### RFILE
 
 The file path on the target machine. This defaults to LFILE.
 

--- a/documentation/modules/post/multi/recon/sudo_commands.md
+++ b/documentation/modules/post/multi/recon/sudo_commands.md
@@ -24,15 +24,15 @@
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   Which session to use, which can be viewed with `sessions`
 
-  **SUDO_PATH**
+### SUDO_PATH
 
   Path to sudo executable (default: `/usr/bin/sudo`)
 
-  **PASSWORD**
+### PASSWORD
 
   Password for the session user
 

--- a/documentation/modules/post/osx/admin/say.md
+++ b/documentation/modules/post/osx/admin/say.md
@@ -12,11 +12,11 @@ This module will speak whatever is in the 'TEXT' option on the victim machine.
 
 ## Options
 
-  **TEXT**
+### TEXT
 
   The text that should be read.  Default is `meta-sploit!`.
 
-  **VOICE**
+### VOICE
 
   The voice to use.  Default is `alex`.
   This can be obtained on the system by specifying `-v ?` (example from 10.14.4):

--- a/documentation/modules/post/osx/capture/screen.md
+++ b/documentation/modules/post/osx/capture/screen.md
@@ -13,19 +13,19 @@ This module takes screenshots of target desktop and automatically downloads them
 
 ## Options
 
-  **COUNT**
+### COUNT
   The number of screenshots to collect.  Default is `1`.
 
-  **DELAY**
+### DELAY
   Interval between screenshots in seconds. 0 for no delay.  Default is `10`.
 
-  **EXE_PATH**
+### EXE_PATH
   Path to remote screencapture executable.  Default is `/usr/sbin/screencapture`
 
-  **FILETYPE**
+### FILETYPE
   File format to use when saving a snapshot (Accepted: png, gif).  Default is `png`.
 
-  **TMP_PATH**
+### TMP_PATH
   Path to remote temp directory.  Default is `/tmp/<random>`
 
 ## Scenarios

--- a/documentation/modules/post/osx/gather/hashdump.md
+++ b/documentation/modules/post/osx/gather/hashdump.md
@@ -13,7 +13,7 @@ This module dumps SHA-1, LM, NT, and SHA-512 Hashes on OSX. Supports versions 10
 
 ## Options
 
-  **MATCHUSER**
+### MATCHUSER
   A regex to run against usernames.  Only matched usernames will have their hashes dumped.
 
 ## Scenarios

--- a/documentation/modules/post/osx/gather/password_prompt_spoof.md
+++ b/documentation/modules/post/osx/gather/password_prompt_spoof.md
@@ -14,16 +14,16 @@ allow permission for the prompt to be displayed.  See Scenarios for additional d
 
 ## Options
 
-   **BUNDLEPATH**
+### BUNDLEPATH
    Path to bundle containing icon.  Default is `/System/Library/CoreServices/CoreTypes.bundle`.
 
-   **ICONFILE**
+### ICONFILE
    Icon filename relative to bundle.  Default is `UserUnknownIcon.icns`
 
-   **TEXTCREDS**
+### TEXTCREDS
    Text displayed when asking for a password. Default is `Type your password to allow System Preferences to make changes`.
 
-   **TIMEOUT**
+### TIMEOUT
    Timeout for user to enter credentails.  Default is `60`.  Newer versions of OSX may require additional time due to user interaction.
 
 ## Scenarios

--- a/documentation/modules/post/osx/manage/sonic_pi.md
+++ b/documentation/modules/post/osx/manage/sonic_pi.md
@@ -23,30 +23,30 @@ Stop  Stop all jobs
 
 ## Options
 
-**OSC_HOST**
+### OSC_HOST
 
 This is the OSC server host, which is `127.0.0.1` by default.
 
-**OSC_PORT**
+### OSC_PORT
 
 This is the OSC server (UDP) port, which is `4557` by default.
 
-**START_SONIC_PI**
+### START_SONIC_PI
 
 Enable this to start Sonic Pi if it isn't running already. Note that
 this will start the GUI, which will be visible to the user.
 
-**FILE**
+### FILE
 
 This is the path to Sonic Pi code you want to run. It can be arbitrary
 Ruby.
 
-**SonicPiPath**
+### SonicPiPath
 
 This is the path to the Sonic Pi executable within its application
 bundle.
 
-**RubyPath**
+### RubyPath
 
 This is the path to a Ruby executable. Sonic Pi's vendored Ruby is the
 default.

--- a/documentation/modules/post/solaris/escalate/pfexec.md
+++ b/documentation/modules/post/solaris/escalate/pfexec.md
@@ -22,11 +22,11 @@
 
 ## Options
 
-  **PFEXEC_PATH**
+### PFEXEC_PATH
 
   Path to pfexec (default: `/usr/bin/pfexec`)
 
-  **SHELL_PATH**
+### SHELL_PATH
 
   Path to shell (default: `/bin/sh`)
 

--- a/documentation/modules/post/solaris/escalate/srsexec_readline.md
+++ b/documentation/modules/post/solaris/escalate/srsexec_readline.md
@@ -30,7 +30,7 @@
 
 ## Options
 
-  **File**
+### File
 
   The file that should have the first line read.  Default is `/etc/shadow` and root's hash will be databased.
 

--- a/documentation/modules/post/windows/gather/arp_scanner.md
+++ b/documentation/modules/post/windows/gather/arp_scanner.md
@@ -11,15 +11,15 @@ This Module will perform an ARP scan for a given IP range through a Meterpreter 
 
 ## Options
 
-  **RHOSTS**
+### RHOSTS
 
   The target address range or CIDR identifier.
 
-  **SESSION**
+### SESSION
 
   The session to run this module on.
 
-  **THREADS**
+### THREADS
 
   The number of concurrent threads.
 

--- a/documentation/modules/post/windows/gather/avast_memory_dump.md
+++ b/documentation/modules/post/windows/gather/avast_memory_dump.md
@@ -22,10 +22,10 @@ exists.
 
 ## Options
 
-**PID** 
+### PID 
 Specify the PID of the process you would like to dump.
 
-**DUMP_PATH** 
+### DUMP_PATH 
 Specify the location to write the memory dump to.
 
 ##  Scenarios  

--- a/documentation/modules/post/windows/gather/bitlocker_fvek.md
+++ b/documentation/modules/post/windows/gather/bitlocker_fvek.md
@@ -12,15 +12,15 @@ This module enumerates ways to decrypt a Bitlocker volume and if a recovery key 
 
 ## Options
 
-  **DRIVE_LETTER**
+### DRIVE_LETTER
 
   Dump information from the DRIVE_LETTER encrypted with Bitlocker.
 
-  **RECOVERY_KEY**
+### RECOVERY_KEY
 
   Use the recovery key provided to decrypt the Bitlocker master key (FVEK).
 
-  **SESSION**
+### SESSION
 
   The session to run this module on.
 

--- a/documentation/modules/post/windows/gather/bloodhound.md
+++ b/documentation/modules/post/windows/gather/bloodhound.md
@@ -23,9 +23,9 @@ This module can take several/many minutes to run due to the volume of data being
 Which method to use to get shaphound running.  Default is `download`.
 
   1. `download` requires the compromised host to have connectivity back to metasploit to download and execute the
-      payload.  Sharphound is not written to disk.
+payload.  Sharphound is not written to disk.
   2. `disk` requires admin privileges to bypass the execution policy (if it isn't open).  Writes the `sharphound.exe`
-     file to disk.  No connectivity is required but a disk write does happen which is likely to get caught by AV.
+file to disk.  No connectivity is required but a disk write does happen which is likely to get caught by AV.
 
 ### CollectionMethode
 

--- a/documentation/modules/post/windows/gather/cachedump.md
+++ b/documentation/modules/post/windows/gather/cachedump.md
@@ -11,7 +11,7 @@ This module uses the registry to extract the stored domain hashes that have been
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   The session to run this module on.
 

--- a/documentation/modules/post/windows/gather/credentials/mdaemon_cred_collector.md
+++ b/documentation/modules/post/windows/gather/credentials/mdaemon_cred_collector.md
@@ -20,7 +20,7 @@ You require a valid licence, but there's a demo for 30 days.
 
 ## Options
 
-  **RPATH**
+### RPATH
   The remote path of the MDaemon installation.
   If the machine runs on 64bits and the meterpreter is 32 bits, it won't be able to find the installation path in the registry, but it will search some default paths. If it is installed on a non-default path you can give the RPATH and it will work.
 

--- a/documentation/modules/post/windows/gather/credentials/moba_xterm.md
+++ b/documentation/modules/post/windows/gather/credentials/moba_xterm.md
@@ -18,11 +18,11 @@
 
 ## Options
 
- **MASTER_PASSWORD**
+### MASTER_PASSWORD
 
 - If you know the password, you can skip decrypting the master password. If not, it will be decrypted automatically
 
- **CONFIG_PATH**
+### CONFIG_PATH
 
 - Specifies the config file path for MobaXterm
 

--- a/documentation/modules/post/windows/gather/credentials/plsql_developer.md
+++ b/documentation/modules/post/windows/gather/credentials/plsql_developer.md
@@ -17,7 +17,7 @@ You can find its official website [here](https://www.allroundautomations.com/pro
 
 ## Options
 
- **PLSQL_PATH**
+### PLSQL_PATH
 
   - Specify the path of PL/SQL Developer
 

--- a/documentation/modules/post/windows/gather/credentials/purevpn_cred_collector.md
+++ b/documentation/modules/post/windows/gather/credentials/purevpn_cred_collector.md
@@ -12,7 +12,7 @@ Download links are provided for reference only and are not maintained by the pro
 
 ## Options
 
-**RPATH**
+### RPATH
 
 You may manually set the `RPATH` datastore option to allow the post module to find the installed
 directory of PureVPN.

--- a/documentation/modules/post/windows/gather/credentials/teamviewer_passwords.md
+++ b/documentation/modules/post/windows/gather/credentials/teamviewer_passwords.md
@@ -32,7 +32,7 @@
 
 ## Options
 
- **WINDOW_TITLE**
+### WINDOW_TITLE
 
 Specify a title for getting the window handle, e.g.:TeamViewer',Default is `TeamViewer`
 

--- a/documentation/modules/post/windows/gather/credentials/xshell_xftp_password.md
+++ b/documentation/modules/post/windows/gather/credentials/xshell_xftp_password.md
@@ -17,7 +17,7 @@ This module can decrypt the password of xshell and xftp, If the user chooses to 
 
 ## Options
 
- **MASTER_PASSWORD**
+### MASTER_PASSWORD
 
   - Specify user's master password, e.g.:123456'
 

--- a/documentation/modules/post/windows/gather/dumplinks.md
+++ b/documentation/modules/post/windows/gather/dumplinks.md
@@ -15,7 +15,7 @@
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   The session to run the module on.
 

--- a/documentation/modules/post/windows/gather/enum_applications.md
+++ b/documentation/modules/post/windows/gather/enum_applications.md
@@ -11,7 +11,7 @@ This module will enumerate all installed applications on a Windows system.
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   The session to run this module on.
 

--- a/documentation/modules/post/windows/gather/enum_av.md
+++ b/documentation/modules/post/windows/gather/enum_av.md
@@ -11,7 +11,7 @@ This module will enumerate all installed AntiVirus applications on the target Wi
 
 ## Options
 
-**SESSION**
+### SESSION
 
 The session to run this module on.
 

--- a/documentation/modules/post/windows/gather/enum_devices.md
+++ b/documentation/modules/post/windows/gather/enum_devices.md
@@ -15,7 +15,7 @@
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   The session to run the module on.
 

--- a/documentation/modules/post/windows/gather/get_bookmarks.md
+++ b/documentation/modules/post/windows/gather/get_bookmarks.md
@@ -12,7 +12,7 @@ This modules retrieves stored bookmarks for Google Chrome, Microsoft Edge and Op
 ## Options
 
 
-  **SESSION**
+### SESSION
 
   The session to run this module on.
 

--- a/documentation/modules/post/windows/gather/phish_windows_credentials.md
+++ b/documentation/modules/post/windows/gather/phish_windows_credentials.md
@@ -17,15 +17,15 @@
 
 ## Options
 
-  **DESCRIPTION**
+### DESCRIPTION
 
   Message shown in the login prompt.
 
-  **PROCESS**
+### PROCESS
 
   Prompt if a specific process is started by the target. (e.g. `calc.exe` or specify * for all processes.)
 
-  **SESSION**
+### SESSION
 
   The session to run this module on.
 

--- a/documentation/modules/post/windows/gather/tcpnetstat.md
+++ b/documentation/modules/post/windows/gather/tcpnetstat.md
@@ -12,7 +12,7 @@
 
 ## Options
 
-  **SESSION**
+### SESSION
 
   The session to run the module on.
 

--- a/documentation/modules/post/windows/manage/archmigrate.md
+++ b/documentation/modules/post/windows/manage/archmigrate.md
@@ -14,15 +14,15 @@ This module was not tested against, but may work against:
 
 ## Options
 
-**EXE**
+### EXE
 
 The executable to start and migrate into. Default: `C:\windows\sysnative\svchost.exe`
 
-**FALLBACK**
+### FALLBACK
 
 If the selected migration executable does not exist, fallback to a sysnative file. Default: `true`
 
-**IGNORE_SYSTEM**
+### IGNORE_SYSTEM
 
 Migrate even if you have SYSTEM privileges. Default: `true`
 

--- a/documentation/modules/post/windows/manage/install_python.md
+++ b/documentation/modules/post/windows/manage/install_python.md
@@ -26,20 +26,20 @@ This module has been tested against:
 
 
 ## Options
-  **PYTHON_VERSION**
+### PYTHON_VERSION
 
   Specifies the Python version you would like to download. Downloads Python version 3.8.2 by default.
 
-  **PYTHON_URL**
+### PYTHON_URL
 
   Specifies the URL used to download the Python embeddable zip file.
 
-  **FILE_PATH**
+### FILE_PATH
 
   Specifies the directory to place the Python embeddable zip file.
   Places Python zip file in the current working directory by default.
 
-  **CLEANUP**
+### CLEANUP
 
   If true, this option will delete the Python zip file as well as its extracted contents. It will also terminate running processes with name 'python', as you cannot delete the Python interpreter if it is actively running.
 

--- a/documentation/modules/post/windows/manage/sshkey_persistence.md
+++ b/documentation/modules/post/windows/manage/sshkey_persistence.md
@@ -19,29 +19,29 @@ This module will add an SSH key to a specified user (or all), to allow remote lo
 
 ## Options
 
-  **SSHD_CONFIG**
+### SSHD_CONFIG
 
   Location of the sshd_config file on the remote system.
   We use this to determine if the authorized_keys file location has changed on the system.
   If it hasn't, we default to .ssh/authorized_keys
 
-  **USERNAME**
+### USERNAME
 
   If set, we only write our key to this user.  If not, we'll write to all users
 
-  **PUBKEY**
+### PUBKEY
 
   A public key to use.  If not provided, a pub/priv key pair is generated automatically
 
-  **ADMIN_KEY_FILE**
+### ADMIN_KEY_FILE
 
   Location of public keys for Administrator level accounts
 
-  **ADMIN**
+### ADMIN
 
   Add public keys for gaining access to Administrator level accounts
 
-  **EDIT_CONFIG**
+### EDIT_CONFIG
 
   Allow the module to edit the sshd_config to enable public key authentication
 


### PR DESCRIPTION
A long while ago an r7 employee (forgot who, sorry, but she was awesome in helping spec out the original markdown doc format stuff!) decided we should use h3 (###) instead of bold (**) for Options. There were a lot of old docs, so this is an initial attempt to convert them all in post.