### PR TITLE
Clean up 2 aux docs

### DIFF
--- a/documentation/modules/auxiliary/dos/http/metasploit_httphandler_dos.md
+++ b/documentation/modules/auxiliary/dos/http/metasploit_httphandler_dos.md
@@ -14,14 +14,20 @@
 
 ### DOSTYPE
 
-	GENTLE: *Current sessions will continue to work, but not future ones*
-	  A lack of input sanitation permits an attacker to submit a request that will be added to the resources and will be used as regex rule it is possible then to make a valid regex rule that captures all the new handler requests. The sessions that were established previously will continue to work.
+#### GENTLE
 
-	SOFT: *No past or future sessions will work*
-      A lack of input sanitation and lack of exception handling causes Metasploit to behave abnormally when looking an appropriate resource for the request, by submitting an invalid regex as a resource. This means that no request, current or future will get served an answer.
+*Current sessions will continue to work, but not future ones*
+A lack of input sanitation permits an attacker to submit a request that will be added to the resources and will be used as regex rule it is possible then to make a valid regex rule that captures all the new handler requests. The sessions that were established previously will continue to work.
 
-	HARD: *ReDOS or Catastrophic Regex Backtracking*
-	  A lack of input sanitization on paths added as resources allows an attacker to execute a catastrophic regex backtracking operation causing a Denial of Service by CPU consumption.
+#### SOFT
+
+*No past or future sessions will work*
+A lack of input sanitation and lack of exception handling causes Metasploit to behave abnormally when looking an appropriate resource for the request, by submitting an invalid regex as a resource. This means that no request, current or future will get served an answer.
+
+#### HARD
+
+*ReDOS or Catastrophic Regex Backtracking*
+A lack of input sanitization on paths added as resources allows an attacker to execute a catastrophic regex backtracking operation causing a Denial of Service by CPU consumption.
 
 ## Scenarios
 

--- a/documentation/modules/auxiliary/gather/office365userenum.md
+++ b/documentation/modules/auxiliary/gather/office365userenum.md
@@ -28,17 +28,39 @@ Office365's implementation of ActiveSync is vulnerable.
 
 ## Options
 
-  LOGFILE  =   Output file to use for verbose logging.
-  OUTPUT   =   Output file for results.
-  PASSWORD =   Password to use during enumeration. Note this must exist
-               but does not necessarily need to be valid. If it is
-               found to be valid for an account it will be reported.
-  THREADS  =   Number of concurrent requests to use during enumeration.
-  TIMEOUT  =   HTTP request timeout to use during enumeration.
-  URL      =   URL of Office365 ActiveSync service.
-  USERS    =   Input fie containing candidate usernames, one per line.
-  VERBOSE  =   Enable/Disable DEBUG logging
+### LOGFILE
 
+Output file to use for verbose logging.
+
+### OUTPUT
+
+Output file for results.
+
+### PASSWORD
+
+Password to use during enumeration. Note this must exist
+but does not necessarily need to be valid. If it is
+found to be valid for an account it will be reported.
+
+### THREADS
+
+Number of concurrent requests to use during enumeration.
+
+### TIMEOUT
+
+HTTP request timeout to use during enumeration.
+
+### URL
+
+URL of Office365 ActiveSync service.
+
+### USERS
+
+Input fie containing candidate usernames, one per line.
+
+### VERBOSE
+
+Enable/Disable DEBUG logging
 
 ## Scenarios
 


### PR DESCRIPTION
While looking for https://github.com/rapid7/metasploit-framework/pull/20625#pullrequestreview-3345883145 I didn't find any in Aux, however I found 2 docs that were not well formatted and fixed their options up.