### PR TITLE
Linqpad cleanup

### DIFF
--- a/documentation/modules/exploit/windows/local/linqpad_deserialization_persistence.md
+++ b/documentation/modules/exploit/windows/local/linqpad_deserialization_persistence.md
@@ -7,7 +7,7 @@ LINQPad is a scratchpad for .NET programming. Versions prior to 5.52.01 contain 
 1. Install the application
 2. Start msfconsole
 3. Get Meterpreter/cmd shell
-4. Run: `use windows/local/linqpad_deserialization_persistence_persistence`
+4. Run: `use windows/local/linqpad_deserialization_persistence`
 5. Set payload - for example `set payload cmd/windows/generic` - and corresponding parameters
 6. Set parameters `session`, `cache_path`, `linqpad_path`, `cleanup`
 7. Run exploit

--- a/documentation/modules/exploit/windows/local/linqpad_deserialization_persistence.md
+++ b/documentation/modules/exploit/windows/local/linqpad_deserialization_persistence.md
@@ -1,24 +1,22 @@
-## LINQPad 5.48 Deserialization
+## Vulnerable Application
 
-LINQPad is a scratchpad for .NET programming. Versions prior to 5.52 contain a deserialization vulnerability in processing cache file when program is starting. Application can be downloaded from [here](https://www.linqpad.net/).
+LINQPad is a scratchpad for .NET programming. Versions prior to 5.52.01 contain a deserialization vulnerability in processing cache file when program is starting. Application can be downloaded from [here](https://www.linqpad.net/LINQPad5.aspx).
 
 ## Verification Steps
-Steps:
 
 1. Install the application
 2. Start msfconsole
 3. Get Meterpreter/cmd shell
-4. Run: `use windows/local/linqpad_deserialization`
+4. Run: `use windows/local/linqpad_deserialization_persistence_persistence`
 5. Set payload - for example `set payload cmd/windows/generic` - and corresponding parameters
-5. Set parameters `session`, `cache_path`, `linqpad_path`, `cleanup`
-6. Run exploit
+6. Set parameters `session`, `cache_path`, `linqpad_path`, `cleanup`
+7. Run exploit
 
 ## Options
 
 ### cleanup
 
 Enable cleanup of malicious file. The module will replace cache filewith malicious content. If `cleanup` is enabled, after successful execution, the module will remove malicious cache file. The original file will be restored upon re-execution of Linqpad.
-
 
 ### cache\_path
 
@@ -28,7 +26,7 @@ The parameter sets path for folder, where vulnerable cache file is present. This
 
 Final part of exploit runs the LINQPad to trigger deserialization procedure. The `linpad_path` parameter sets the path to LINQPad binary, which is ran at the end of exploit.
 
-Example:
+## Scenarios
 
 ```
 msf > use exploit/multi/handler
@@ -41,13 +39,13 @@ msf exploit(multi/handler) > run
 
 meterpreter > background
 [*] Backgrounding session 1...
-msf exploit(multi/handler) > use windows/local/linqpad_deserialization
-msf exploit(windows/local/linqpad_deserialization) > set LINQPAD_FILE C:/ProgramData/LINQPad/Updates50.AnyCPU/552/LINQPad.exe
-msf exploit(windows/local/linqpad_deserialization) > set payload windows/exec/cmd
-msf exploit(windows/local/linqpad_deserialization) > set cache_path C:/Users/ms/AppData/Local/LINQPad
-msf exploit(windows/local/linqpad_deserialization) > set CMD calc.exe
-msf exploit(windows/local/linqpad_deserialization) > set session 1
-msf exploit(windows/local/linqpad_deserialization) > exploit
+msf exploit(multi/handler) > use windows/local/linqpad_deserialization_persistence
+msf exploit(windows/local/linqpad_deserialization_persistence) > set LINQPAD_FILE C:/ProgramData/LINQPad/Updates50.AnyCPU/552/LINQPad.exe
+msf exploit(windows/local/linqpad_deserialization_persistence) > set payload windows/exec/cmd
+msf exploit(windows/local/linqpad_deserialization_persistence) > set cache_path C:/Users/ms/AppData/Local/LINQPad
+msf exploit(windows/local/linqpad_deserialization_persistence) > set CMD calc.exe
+msf exploit(windows/local/linqpad_deserialization_persistence) > set session 1
+msf exploit(windows/local/linqpad_deserialization_persistence) > exploit
 [*] Exploit completed, but no session was created.
 ```
 

--- a/modules/exploits/windows/local/linqpad_deserialization_persistence.rb
+++ b/modules/exploits/windows/local/linqpad_deserialization_persistence.rb
@@ -60,9 +60,9 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Unknown('Cannot find cache file')
     elsif file?(datastore['CACHE_PATH'] + '/autorefcache46.2.dat')
       return Exploit::CheckCode::Safe('Contains not vulnerable version of LINQPad')
-    else
-      return Exploit::CheckCode::Vulnerable('LINPad and vulnerable cache file present, target possibly exploitable')
     end
+
+    Exploit::CheckCode::Vulnerable('LINPad and vulnerable cache file present, target possibly exploitable')
   end
 
   def exploit

--- a/modules/exploits/windows/local/linqpad_deserialization_persistence.rb
+++ b/modules/exploits/windows/local/linqpad_deserialization_persistence.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'LINQPad Deserialization Exploit',
         'Description' => %q{
-          This module exploits a bug in LIQPad up to version 5.48.00. The bug is only exploitable in paid version of software. The core of a bug is cache file containing deserialized data, which attacker can overwrite with malicious payload. The data gets deserialized every time the app restarts.
+          This module exploits a bug in LINQPad up to version 5.52.00. The bug is only exploitable in paid version of software. The core of a bug is cache file containing deserialized data, which attacker can overwrite with malicious payload. The data gets deserialized every time the app restarts.
         },
         'License' => MSF_LICENSE,
         'Author' => [


### PR DESCRIPTION
A few prep things for linqpad deserialization persistence before moving it to a mixin.

Fixes:

1. doc header standardization
2. move doc to correct name for module
3. fix consistence in module naming
4. fix version number consistence (original writeup tested against 48, but 52 was the fix release)

@msutovsky-r7 ping since you wrote the original module