### PR TITLE
Adds safe navigator in ldap_esc_vulnerable_cert_finder

### DIFF
--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -401,7 +401,7 @@ class MetasploitModule < Msf::Auxiliary
     ca_servers = adds_get_ca_servers(@ldap)
     if ca_servers.empty?
       print_warning('No Certificate Authority servers found in LDAP.')
-      return
+      return {}
     end
 
     ca_servers.each do |ca_server|

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -401,7 +401,7 @@ class MetasploitModule < Msf::Auxiliary
     ca_servers = adds_get_ca_servers(@ldap)
     if ca_servers.empty?
       print_warning('No Certificate Authority servers found in LDAP.')
-      return {}
+      return
     end
 
     ca_servers.each do |ca_server|
@@ -1057,7 +1057,7 @@ class MetasploitModule < Msf::Auxiliary
 
       registry_values = enum_registry_values if datastore['RUN_REGISTRY_CHECKS']
 
-      if registry_values.any?
+      if registry_values&.any?
         registry_values.each do |key, value|
           vprint_good("#{key}: #{value.inspect}")
         end


### PR DESCRIPTION
Fixes mismatch between guard clause and return value in `ldap_esc_vulnerable_cert_finder`. Previously, the return value from `enum_registry_values` was checked against `any?` guard clause, resulting in failure in case `enum_registry_values` returns `nil`. ~~To keep the existing logic of guard clause, this PR returns `{}` instead of `nil`.~~ This has been fixed by adding safe navigation operator when using `.any?`.