### PR TITLE
Pin rexml to avoid winrm warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ PATH
       rex-struct2
       rex-text
       rex-zip
+      rexml (= 3.4.1)
       rinda
       ruby-macho
       ruby-mysql
@@ -529,7 +530,7 @@ GEM
       bigdecimal
     rex-zip (0.1.6)
       rex-text
-    rexml (3.4.4)
+    rexml (3.4.1)
     rinda (0.2.0)
       drb
       forwardable

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -157,6 +157,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'net-sftp'
   spec.add_runtime_dependency 'winrm'
+  # Pinned to avoid WinRM warnings: https://github.com/WinRb/WinRM/issues/355 - if bumping verify windows/winrm/winrm_script_exec works against metasploitable with vagrant/vagrant creds 
+  spec.add_runtime_dependency 'rexml', '3.4.1'
   spec.add_runtime_dependency 'ffi', '< 1.17.0'
 
   #


### PR DESCRIPTION
Pin rexml to avoid winrm warnings

Spotted as part of https://github.com/rapid7/metasploit-framework/issues/20588

```
[+] 10.10.11.78:88 - Received a valid TGT-Response
[*] 10.10.11.78:5985      - TGT MIT Credential Cache ticket saved to /home/silver/.msf4/loot/20251005213427_default_10.10.11.78_mit.kerberos.cca_296558.bin
[+] 10.10.11.78:88 - Received a valid TGS-Response
[*] 10.10.11.78:5985      - TGS MIT Credential Cache ticket saved to /home/silver/.msf4/loot/20251005213429_default_10.10.11.78_mit.kerberos.cca_040298.bin
[+] 10.10.11.78:88 - Received a valid delegation TGS-Response
[+] 10.10.11.78:88 - Received AP-REQ. Extracting session key...
[!] No active DB -- Credential data will not be saved!
[+] 10.10.11.78:5985 - Login Successful: test.corp\john:p@ass
/opt/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/rexml-3.4.4/lib/rexml/xpath.rb:67: warning: REXML::XPath.each, REXML::XPath.first, REXML::XPath.match dropped support for nodeset...
/opt/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/rexml-3.4.4/lib/rexml/xpath.rb:67: warning: REXML::XPath.each, REXML::XPath.first, REXML::XPath.match dropped support for nodeset...
/opt/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/rexml-3.4.4/lib/rexml/xpath.rb:67: warning: REXML::XPath.each, REXML::XPath.first, REXML::XPath.match dropped support for nodeset...
[!] 10.10.11.78:5985      - LOGIN FAILED: {private_data: "p@ss", private_type: :password, username: "john", realm_key: "Active Directory Domain", realm_value: "test.corp"} - Unhandled error - scan may not produce correct results: [WSMAN ERROR CODE: 5]: <f:WSManFault Code='5' Machine='10.10.11.78' xmlns:f='http://schemas.microsoft.com/wbem/wsman/1/wsmanfault'><f:Message>Access is denied. </f:Message></f:WSManFault> - [...]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

Ensure the warnings no longer appear when running winrm against metasploitablee so these warnings no longer appear:

```
bundle && bundle exec ruby ./msfconsole --no-defer-module-loads -qx 'use windows/winrm/winrm_script_exec; run username=vagrant password=vagrant rhost=10.140.10.33 payload=windows/x64/meterpreter/bind_tcp'
...
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
[*] Checking for Powershell 2.0
[*] Grabbing %TEMP%
[*] Uploading powershell script to C:\Users\vagrant\AppData\Local\Temp\nyGypQDR.ps1 (This may take a few minutes)...
[*] Attempting to execute script...
[*] Started bind TCP handler against 10.140.10.33:4444
[-] The connection was refused by the remote host (10.140.10.33:4444).
[*] Sending stage (230982 bytes) to 10.140.10.33
/Users/user/.rvm/gems/ruby-3.3.0@metasploit-framework/gems/rexml-3.4.4/lib/rexml/xpath.rb:67: warning: REXML::XPath.each, REXML::XPath.first, REXML::XPath.match dropped support for nodeset...
/Users/user/.rvm/gems/ruby-3.3.0@metasploit-framework/gems/rexml-3.4.4/lib/rexml/xpath.rb:67: warning: REXML::XPath.each, REXML::XPath.first, REXML::XPath.match dropped support for nodeset...
/Users/user/.rvm/gems/ruby-3.3.0@metasploit-framework/gems/rexml-3.4.4/lib/rexml/xpath.rb:67: warning: REXML::XPath.each, REXML::XPath.first, REXML::XPath.match dropped support for nodeset...
```