### PR TITLE
Fix ssh login crash for pro

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -68,7 +68,7 @@ module Metasploit
               :key_data      => credential.private,
             )
           end
-          opt_hash[:passphrase] = cred_details.password
+          opt_hash[:passphrase] = cred_details.password if cred_details.respond_to?(:password)
 
           result_options = {
             credential: credential


### PR DESCRIPTION
Fixes ssh login crash for pro:

```
LOGIN FAILED: {:private_data=>"vagrant", :private_type=>:password, :username=>"vagrant", :realm_key=>nil, :realm_value=>nil} - Unhandled error - scan may not produce correct results: undefined method `password' for an instance of Pro::BruteForce::AttemptQueue
```

Tracked down to the login scanner ssh module:

```
[2] pry(#<Metasploit::Framework::LoginScanner::SSH>)> cred_details
 => #<Pro::BruteForce::AttemptQueue:0x0000000145f7c808
  @attempts=
   [#<BruteForce::Reuse::Attempt:0x00000001416d7800
     id: 134,
     brute_force_run_id: 24,
     metasploit_credential_core_id: 1,
     service_id: 2,
     attempted_at: nil,
     created_at: "2025-10-23 13:58:23.077045000 +0000",
     updated_at: "2025-10-23 13:58:23.077045000 +0000",
     status: "Untried">]>
 [3] pry(#<Metasploit::Framework::LoginScanner::SSH>)> credential.password
 NoMethodError: undefined method `password' for an instance of Metasploit::Framework::Credential
 from (pry):6:in `attempt_login'
```

## Verification

Ensure the module no longer crashes if the cred_details doesn't respond to `password` 