### PR TITLE
lib/msf/base/sessions/meterpreter.rb: Use &. across the entire chain when handling datastore['AutoLoadExtensions']

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -206,7 +206,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
     load_embedded_extensions
 
-    extensions = datastore['AutoLoadExtensions']&.delete(' ').split(',') || []
+    extensions = datastore['AutoLoadExtensions']&.delete(' ')&.split(',') || []
 
     # BEGIN: This should be removed on MSF 7
     # Unhook the process prior to loading stdapi to reduce logging/inspection by any AV/PSP (by default unhook is first, see meterpreter_options/windows.rb)


### PR DESCRIPTION
As it currently stands, the pivot payload is broken, because, in that case, `datastore['AutoLoadExtensions']` is nil.

https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/post/meterpreter/pivot.rb#L151