### PR TITLE
azure_ad_login: add context to error message

### DIFF
--- a/modules/auxiliary/scanner/http/azure_ad_login.rb
+++ b/modules/auxiliary/scanner/http/azure_ad_login.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("#{domain}\\#{username} exists but is disabled; it will not be reported")
       :next_user
     else # Unknown error code
-      print_error("Received unknown response with error code: #{auth_details}")
+      print_error("Received unknown response for #{domain}\\#{username}:#{password} with error code: #{auth_details}")
     end
   end
 


### PR DESCRIPTION
Include domain and username in the default/catch-all error message, so that this information is not lost.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/azure_ad_login`
- [x] set appropriate options (user/pass/domain)
- [x] **Verify** the thing does what it should: it prints an error message *with* context showing the corresponding username.
- [x] **Verify** the thing does not do what it should not: it doesn't omit the username information from the message.
- [ ] ~~**Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md)):~~ This is not necessary for a change this small.