### PR TITLE
Pin date dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ PATH
       bson
       chunky_png
       csv
+      date (= 3.4.1)
       dnsruby
       drb
       ed25519

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -153,6 +153,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bcrypt_pbkdf'
   spec.add_runtime_dependency 'ruby_smb', '~> 3.3.15'
   spec.add_runtime_dependency 'net-imap' # Used in Postgres auth for its SASL stringprep implementation
+  spec.add_runtime_dependency 'date', '3.4.1' # Temporarily pinned until 3.5 can be tested
   spec.add_runtime_dependency 'net-ldap'
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'net-sftp'


### PR DESCRIPTION
Pin date dependency; as it looks like 3.5.0 might be causing issues:

```
$ ./msfconsole
[*] Bundler failed to load and returned this error:

   'You have already activated date 3.5.0, but your Gemfile requires date 3.4.1. Prepending `bundle exec` to your command may solve this.'

[*] You may need to uninstall or upgrade bundler
```

But this will require additional cycles to verify, so pinning for now

## Verification

Ensure CI passes