### PR TITLE
A few fixes and enhancement for API RPC

### DIFF
--- a/lib/msf/core/rpc/v10/constants.rb
+++ b/lib/msf/core/rpc/v10/constants.rb
@@ -6,16 +6,31 @@ API_VERSION = "1.0"
 
 
 class Exception < RuntimeError
-  attr_accessor :code, :message
+  attr_accessor :code, :message, :http_msg
 
   # Initializes Exception.
   #
   # @param [Integer] code An error code.
   # @param [String] message An error message.
   # @return [void]
-  def initialize(code, message)
+  def initialize(code, message, http_msg = nil)
     self.code    = code
     self.message = message
+    self.http_msg = http_msg
+    self.http_msg ||= case self.code
+                      when 400
+                        'Bad Request'
+                      when 401
+                        'Unauthorized'
+                      when 403
+                        'Forbidden'
+                      when 404
+                        'Not Found'
+                      when 500
+                        'Internal Server Error'
+                      else
+                        'Unknown Error'
+                      end
   end
 end
 

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -371,6 +371,10 @@ public
   #
   # @param [Hash] xopts Options:
   # @option xopts [String] :workspace Name of the workspace.
+  # @option xopts [String] :addresses Host addresses
+  # @option xopts [Boolean] :only_up If true, return hosts that are up.
+  # @option xopts [Integer] :limit Maximum number of hosts to return.
+  # @option xopts [Integer] :offset return the hosts starting at index `offset`.
   # @raise [Msf::RPC::ServerException] You might get one of these errors:
   #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
   #  * 500 Database not loaded. Try: rpc.call('console.create')
@@ -432,7 +436,7 @@ public
   # @option xopts [Integer] :limit Limit.
   # @option xopts [Integer] :offset Offset.
   # @option xopts [String] :proto Protocol.
-  # @option xopts [String] :address Address.
+  # @option xopts [String] :address Host address.
   # @option xopts [String] :ports Port range.
   # @option xopts [String] :names Names (Use ',' as the separator).
   # @raise [Msf::RPC::ServerException] You might get one of these errors:
@@ -494,6 +498,7 @@ public
   # @option xopts [String] :proto Protocol.
   # @option xopts [String] :address Address.
   # @option xopts [String] :ports Port range.
+  # @option xopts [String] :names Exploit that was used.
   # @raise [Msf::RPC::ServerException] You might get one of these errors:
   #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
   #  * 500 Database not loaded. Try: rpc.call('console.create')
@@ -517,7 +522,7 @@ public
     conditions = {}
     conditions["hosts.address"] = opts[:address] if opts[:address]
     conditions[:name] = opts[:names].strip().split(",") if opts[:names]
-    conditions["services.port"] = Rex::Socket.portspec_to_portlist(opts[:ports]) if opts[:port]
+    conditions["services.port"] = Rex::Socket.portspec_to_portlist(opts[:ports]) if opts[:ports]
     conditions["services.proto"] = opts[:proto] if opts[:proto]
 
     ret = {}
@@ -1113,7 +1118,6 @@ end
   # @param [Hash] xopts Filters for the search. See below:
   # @option xopts [String] :workspace Name of the workspace.
   # @option xopts [String] :address Host address.
-  # @option xopts [String] :names Names (separated by ',').
   # @option xopts [String] :ntype Note type.
   # @option xopts [String] :proto Protocol.
   # @option xopts [String] :ports Port change.
@@ -1139,7 +1143,6 @@ end
 
     conditions = {}
     conditions["hosts.address"] = opts[:address] if opts[:address]
-    conditions[:name] = opts[:names].strip().split(",") if opts[:names]
     conditions[:ntype] = opts[:ntype] if opts[:ntype]
     conditions["services.port"] = Rex::Socket.portspec_to_portlist(opts[:ports]) if opts[:ports]
     conditions["services.proto"] = opts[:proto] if opts[:proto]

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -221,7 +221,7 @@ class RPC_Module < RPC_Base
     res['license'] = m.license
     res['filepath'] = m.file_path
     res['arch'] = m.arch.map { |x| x.to_s }
-    res['platform'] = m.platform.platforms.map { |x| x.to_s }
+    res['platform'] = m.platform.platforms.map { |x| x.respond_to?(:realname) ? x.realname : x.to_s }
     res['authors'] = m.author.map { |a| a.to_s }
     res['privileged'] = m.privileged?
     res['check'] = m.has_check?
@@ -279,16 +279,17 @@ class RPC_Module < RPC_Base
     res
   end
 
-  def module_short_info(m)
-    res = {}
-    res['type'] = m.type
-    res['name'] = m.name
-    res['fullname'] = m.fullname
-    res['rank'] = RankingName[m.rank].to_s
-    res['disclosuredate'] = m.disclosure_date.nil? ? "" : m.disclosure_date.strftime("%Y-%m-%d")
-    res
-  end
-
+  # returns a list of module names that match the search string.
+  #
+  # @param match [string] the search string.
+  # @return [hash] a list of modules. it contains the following key:
+  #  * 'type' [string] The module type (exploit, auxiliary, post, payload, etc.)
+  #  * 'name' [string] The module name
+  #  * 'fullname' [string] The full module path
+  #  * 'rank' [string] The module rank (excellent, great, good, normal, etc.)
+  #  * 'disclosuredate' [string] The module disclosure date (YYYY-MM-DD)
+  # @example here's how you would use this from the client:
+  #  rpc.call('module.search', 'smb type:exploit')
   def rpc_search(match)
     matches = []
     self.framework.search(match).each do |m|
@@ -852,6 +853,17 @@ private
       error(500, "failed to generate: #{e.message}")
     end
   end
+
+  def module_short_info(m)
+    res = {}
+    res['type'] = m.type
+    res['name'] = m.name
+    res['fullname'] = m.fullname
+    res['rank'] = RankingName[m.rank].to_s
+    res['disclosuredate'] = m.disclosure_date.nil? ? "" : m.disclosure_date.strftime("%Y-%m-%d")
+    res
+  end
+
 
 
 end

--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -84,7 +84,7 @@ class Service
       res.body = process_exception(e).to_msgpack
       res.code = e.code
       res.message = e.http_msg
-    rescue ::Exception => e
+    rescue ::StandardError => e
       elog('Unknown Exception', error: e)
       res.body = process_exception(e).to_msgpack
       res.code = 500

--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -83,6 +83,12 @@ class Service
       elog('RPC Exception', error: e)
       res.body = process_exception(e).to_msgpack
       res.code = e.code
+      res.message = e.http_msg
+    rescue ::Exception => e
+      elog('Unknown Exception', error: e)
+      res.body = process_exception(e).to_msgpack
+      res.code = 500
+      res.message = 'Internal Server Error'
     end
     cli.send_response(res)
   end
@@ -145,9 +151,6 @@ class Service
         self.handlers[group].send(mname, *msg)
       end
 
-    rescue ::Exception => e
-      elog('RPC Exception', error: e)
-      process_exception(e)
     ensure
       Thread.current[:rpc_token] = nil
     end

--- a/msfrpcd
+++ b/msfrpcd
@@ -100,6 +100,15 @@ def start_rpc_service(opts, frameworkOpts, foreground)
   # Create an instance of the framework
   $framework = Msf::Simple::Framework.create(frameworkOpts)
 
+  if !$framework.db || !$framework.db.active
+    if $framework.db.error == "disabled"
+      $stderr.puts "Database support has been disabled"
+    else
+      error_msg = "#{$framework.db.error.class.is_a?(String) ? "#{$framework.db.error.class} " : nil}#{$framework.db.error}"
+      $stderr.puts "No database support: #{error_msg}"
+    end
+  end
+
   # Run the plugin instance in the foreground.
   begin
     $framework.plugins.load("#{RPC_TYPE.downcase}rpc", opts).run


### PR DESCRIPTION
This PR fixes and improves some minor issues I found will working with the API RPC:
- Add HTTP message in case of error (default to the standard message associated to the status code)
- Add and update a some method documentation
- Fix wrong hash key name in `rpc_vulns`
- Remove `names` for `rpc_notes` (doesn't exist in the data model)
- Add warning in case the DB is disabled
