### PR TITLE
Remove ldap_esc_vulnerable_cert_finder acceptance test

### DIFF
--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -90,6 +90,25 @@ RSpec.describe 'LDAP modules' do
           }
         },
         {
+          name: 'auxiliary/gather/ldap_esc_vulnerable_cert_finder',
+          platforms: %i[linux osx windows],
+          targets: [:session, :rhost],
+          skipped: false,
+          lines: {
+            all: {
+              required: [
+                /Successfully queried/
+              ]
+            },
+            linux: {
+              known_failures: [
+                /Auxiliary aborted due to failure: not-found/,
+                /Auxiliary aborted due to failure: unknown: Net::LDAP::Error: 127.0.0.1:389 LDAP Error: Extended Operation\(1.3.6.1.4.1.4203.1.11.3\) not supported/
+              ]
+            }
+          }
+        },
+        {
           name: 'auxiliary/admin/ldap/rbcd',
           platforms: %i[linux osx windows],
           targets: [:session, :rhost],

--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -102,8 +102,7 @@ RSpec.describe 'LDAP modules' do
             },
             linux: {
               known_failures: [
-                /Auxiliary aborted due to failure: not-found/,
-                /Auxiliary aborted due to failure: unknown: Net::LDAP::Error: 127.0.0.1:389 LDAP Error: Extended Operation\(1.3.6.1.4.1.4203.1.11.3\) not supported/
+                /Auxiliary aborted due to failure: (not-found|unknown: Net::LDAP::Error: 127.0.0.1:389 LDAP Error: Extended Operation\(1.3.6.1.4.1.4203.1.11.3\) not supported)/,
               ]
             }
           }

--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -90,24 +90,6 @@ RSpec.describe 'LDAP modules' do
           }
         },
         {
-          name: 'auxiliary/gather/ldap_esc_vulnerable_cert_finder',
-          platforms: %i[linux osx windows],
-          targets: [:session, :rhost],
-          skipped: false,
-          lines: {
-            all: {
-              required: [
-                /Successfully queried/
-              ]
-            },
-            linux: {
-              known_failures: [
-                /Auxiliary aborted due to failure: not-found/
-              ]
-            }
-          }
-        },
-        {
           name: 'auxiliary/admin/ldap/rbcd',
           platforms: %i[linux osx windows],
           targets: [:session, :rhost],


### PR DESCRIPTION
The acceptance tests for our LDAP modules get run against a docker container running OpenLDAP which does not support the LDAP whoami extended operation OID: `1.3.6.1.4.1.4203.1.11.3`.  This is a problem because the `ldap_esc_vulnerable_cert_finder` is meant to be run against a Windows AD LDAP environment which does support this OID. This means, unfortunately, at the current time we are unable to support testing this module. 

```
            +[+] Successfully bound to the LDAP server via existing SESSION!
            +[*] Discovering base DN automatically
            +[-] Auxiliary aborted due to failure: unknown: Net::LDAP::Error: 127.0.0.1:389 LDAP Error: Extended Operation(1.3.6.1.4.1.4203.1.11.3) not supported
            +[*] Auxiliary module execution completed
```
## Verification

List the steps needed to make sure this thing works

- [ ] Ensure CI tests pass