### PR TITLE
Bump mqtt dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,8 @@ GEM
     mime-types-data (3.2025.0924)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
-    mqtt (0.6.0)
+    mqtt (0.7.0)
+      logger
     msgpack (1.6.1)
     multi_json (1.15.0)
     mustermann (3.0.3)


### PR DESCRIPTION
Bump mqtt dependency

## Verification

- Ensure CI passes
- Module tested:

```
docker run -i -p 1883:1883  toke/mosquitto
```

```
msf auxiliary(scanner/mqtt/connect) > run rhost=127.0.0.1
[*] 127.0.0.1:1883        - 127.0.0.1:1883 - Testing without credentials
[+] 127.0.0.1:1883        - Does not require authentication
[*] 127.0.0.1:1883        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```