### PR TITLE
Add error handling for winrm login issues

### DIFF
--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def session_setup(shell, _rhost, _rport, _endpoint)
+  def session_setup(shell, rhost, _rport, _endpoint)
     # We use cmd rather than powershell because powershell v3 on 2012 (and maybe earlier)
     # do not seem to pass us stdout/stderr.
     begin
@@ -145,10 +145,10 @@ class MetasploitModule < Msf::Auxiliary
     rescue WinRM::WinRMWSManFault => e
       case e.fault_code
       when ::WindowsError::Win32::ERROR_ACCESS_DENIED.value.to_s
-        print_warning("Credentials were correct but access is denied for user: #{datastore['USERNAME']}")
+        print_brute(level: :warn, rhost: rhost, msg: "Credentials were correct but access is denied for user: #{shell.connection_opts[:user]}")
         wlog(e.fault_description)
       else
-        print_error(e.fault_description)
+        print_brute(level: :error, rhost: rhost, msg: e.fault_description)
         elog(e.full_message, error: e)
       end
       return


### PR DESCRIPTION
resolves #20588 

Ads error handling for winrm failures, specific handling in place for the error mentioned in the issue where a valid login is obtained but the users does not have the permissions required to create the session

# Verification Steps
- [ ] Start up `msfconsole`
- [ ] run `use winrm_login`
- [ ] Test it against our persistent environment `run pasword=vagrant domain=ad.pro.local rhosts=mspro-test-active_directory-w22std-0.mspro-test-active-directory-w22std-shared-persistent.ms.scanlab.r7ops.com winrm::auth=kerberos DomainControllerRhost=10.140.108.118 winrm::Rhostname=mspro-dc username=basic_user`
- [ ] verify output
```
msf auxiliary(scanner/winrm/winrm_login) > run pasword=vagrant domain=ad.pro.local rhosts=mspro-test-active_directory-w22std-0.mspro-test-active-directory-w22std-shared-persistent.ms.scanlab.r7ops.com winrm::auth=kerberos DomainControllerRhost=10.140.108.118 winrm::Rhostname=mspro-dc username=basic_user
[*] Using cached credential for http/mspro-dc@AD.PRO.LOCAL basic_user@AD.PRO.LOCAL
[+] 10.140.108.118:88 - Received AP-REQ. Extracting session key...
[+] 10.140.108.118:5985 - Login Successful: ad.pro.local\basic_user:vagrant
[!] Credentials were correct but access is denied for user: basic_user
[*] Scanned 1 of 1 hosts (100% complete)
[*] Scan completed, 1 credential was successful.

Successful logins
=================

    Host            Public      Private
    ----            ------      -------
    10.140.108.118  basic_user  vagrant


[*] 0 sessions were opened successfully.
[*] Auxiliary module execution completed
```
- [ ] switch the user to `web_admin` and verify they can still get a session