### PR TITLE
Update named_pipes.txt

### DIFF
--- a/data/wordlists/named_pipes.txt
+++ b/data/wordlists/named_pipes.txt
@@ -24,3 +24,4 @@ wkssvc
 PIPE_EVENTROOT\CIMV2SCM EVENT PROVIDER
 db2remotecmd
 CxUIUSvcChannel
+cert


### PR DESCRIPTION
Added the cert pipe to the target pipe list for quick unauthenticated identification of likely Certificate Authority servers.

## Verification

List the steps needed to make sure this thing works:

[1 ] Start `msfconsole`
[ 2] `use auxiliary/scanner/smb/pipe_auditor`
[ 3] set rhosts <target ip> (needs to be pointed at a Certificate Authority server
[ 4] run

**Verify**

[1 ] Verify the \cert pipe is reported when targeting CA servers, and not present with other servers.

**Documentation**

Outlined in Microsoft's documentation (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-icpr/9f0b251b-c722-4851-9a45-4e912660b458), the \cert named pipe is used as part of the MS-ICPR protocol. This is commonly utilized during communications with Active Directory Certificate Services (ADCS) and Certificate Authority (CA) servers. 

From what we've seen during engagements, this pipe is only present on the CA servers. This pipe can also be enumerated with no domain authentication during recon to identify if the host is running ADCS services. High likelihood of the target being a CA server.
