### PR TITLE
Adds Rubocop rule to detect calls to old cmd_exec API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ require:
   - ./lib/rubocop/cop/lint/module_enforce_notes.rb
   - ./lib/rubocop/cop/lint/detect_invalid_pack_directives.rb
   - ./lib/rubocop/cop/lint/detect_metadata_trailing_leading_whitespace.rb
+  - ./lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
 
 Layout/SpaceBeforeBrackets:
   Enabled: true
@@ -675,4 +676,10 @@ Style/UnpackFirst:
   Enabled: false
 
 Lint/DetectMetadataTrailingLeadingWhitespace:
+  Enabled: true
+
+Lint/DetectOutdatedCmdExecApi:
+  Description: >-
+    Detects outdated usage of cmd_exec with separate arguments.
+    Use `create_process(executable, args: [], time_out: 15, opts: {})` API with an args array instead.
   Enabled: true

--- a/docs/metasploit-framework.wiki/Post-Mixins.md
+++ b/docs/metasploit-framework.wiki/Post-Mixins.md
@@ -1,0 +1,192 @@
+# Post Exploitation Mixins
+
+Post exploitation mixins provide a consistent API for interacting with compromised systems across different session types (Meterpreter, shell, PowerShell). Located in `lib/msf/core/post/`, these mixins abstract platform and session type differences.
+
+## Msf::Post::Common
+
+Core utilities for command execution and session interaction.
+
+```ruby
+include Msf::Post::Common
+
+# Modern API - use create_process for commands with arguments
+output = create_process('grep', args: ['-r', pattern, '/var/log'], time_out: 30, opts: { 'Hidden' => true })
+
+# Legacy API - cmd_exec only for static command strings
+hostname = cmd_exec('hostname')
+
+# Environment variables
+env_vars = get_envs('HOME', 'USER', 'PATH')  # Returns hash of env vars
+home = get_env('HOME')                        # Single variable
+
+# Check command availability
+if command_exists?('python3')
+  version = create_process('python3', args: ['--version'])
+end
+
+# Session information
+target = "#{rhost}:#{rport}"  # Or use: peer
+```
+
+## Msf::Post::File
+
+Cross-platform file system operations.
+
+```ruby
+include Msf::Post::File
+
+# Navigation and listing
+current = pwd
+cd('/tmp')
+files = dir('/etc')  # or ls('/etc')
+
+# File checks
+if file?('/etc/passwd') && readable?('/etc/passwd')
+  content = read_file('/etc/passwd')
+  store_loot('passwd', 'text/plain', session, content)
+end
+
+if directory?('/var/www') && writable?('/var/www')
+  write_file('/var/www/shell.php', payload)
+end
+
+# File operations
+mkdir('/tmp/staging')              # Auto-registered for cleanup
+data = read_file('/etc/shadow')
+write_file('/tmp/output.txt', data)
+hash = file_remote_digestmd5('/bin/bash')
+
+# Path expansion
+expanded = expand_path('$HOME/.ssh/id_rsa')  # Unix
+expanded = expand_path('%APPDATA%\\data')     # Windows
+```
+
+## Msf::Post::Process
+
+Process enumeration and manipulation.
+
+```ruby
+include Msf::Post::Process
+
+# Enumerate processes
+processes = get_processes
+processes.each { |p| print_line("#{p['pid']}: #{p['name']}") }
+
+# Find specific processes
+nginx_pids = pidof('nginx')
+if nginx_pids.any?
+  print_good("Found nginx: #{nginx_pids.join(', ')}")
+  nginx_pids.each { |pid| kill_process(pid) }
+end
+
+# Check process existence
+if has_pid?(1234)
+  print_good("Process 1234 is running")
+end
+```
+
+## Msf::Post::Unix
+
+Unix/Linux-specific utilities.
+
+```ruby
+include Msf::Post::Unix
+
+# Privilege checking
+if is_root?
+  print_good("Running as root")
+else
+  print_warning("Running as #{whoami}")
+end
+
+# User enumeration
+users = get_users
+users.each do |u|
+  print_line("#{u['name']} (UID: #{u['uid']}, Shell: #{u['shell']})")
+end
+admin_users = users.select { |u| u['uid'].to_i == 0 }
+
+# Group enumeration
+groups = get_groups
+sudo_group = groups.find { |g| g['name'] =~ /sudo|wheel/ }
+print_good("Sudo users: #{sudo_group['users']}") if sudo_group
+
+# Find SSH keys and interesting files
+ssh_keys = enum_user_directories
+ssh_keys.each do |key|
+  content = read_file(key)
+  store_loot('ssh.key', 'text/plain', session, content, key)
+end
+```
+
+## Platform-Specific Mixins
+
+### Msf::Post::Windows
+Windows-specific operations including registry manipulation, service management, and Windows API access. See Windows-specific documentation.
+
+### Msf::Post::Linux
+Linux-specific system information gathering and kernel utilities.
+
+### Msf::Post::OSX
+macOS-specific utilities and system interaction methods.
+
+### Msf::Post::Android
+Android device interaction and data collection methods.
+
+### Msf::Post::Hardware
+Hardware interaction utilities (e.g., USB devices, serial ports).
+
+## Example Module
+
+```ruby
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Linux Credential Harvester',
+      'Description' => 'Collects credentials from Linux system',
+      'License' => MSF_LICENSE,
+      'Author' => ['Your Name'],
+      'Platform' => ['linux'],
+      'SessionTypes' => ['meterpreter', 'shell']
+    ))
+  end
+
+  def run
+    print_status("Harvesting credentials on #{peer}")
+    
+    if is_root?
+      # Root access - collect shadow file
+      if readable?('/etc/shadow')
+        shadow = read_file('/etc/shadow')
+        store_loot('shadow', 'text/plain', session, shadow, '/etc/shadow')
+      end
+    end
+    
+    # Collect SSH keys
+    ssh_keys = enum_user_directories
+    ssh_keys.each do |key_path|
+      key = read_file(key_path)
+      store_loot('ssh.key', 'text/plain', session, key, key_path)
+    end
+    
+    # Check for interesting processes
+    if pidof('sshd').any?
+      print_good("SSH daemon running")
+    end
+  end
+end
+```
+
+## Best Practices
+
+- **Use `create_process`** for commands with arguments: `create_process('ls', args: ['-la', path])`
+- **Use `cmd_exec`** only for static strings: `cmd_exec('hostname')`
+- **Check before acting**: Use `file?()`, `readable?()`, `writable?()` before file operations
+- **Handle errors**: Wrap operations in `begin/rescue` blocks
+- **Register cleanup**: Files created with `write_file()` are auto-registered; use `register_file_for_cleanup()` for others
+- **Store loot properly**: Use `store_loot()` to save collected data
+- **Check session type**: Some operations behave differently on Meterpreter vs shell sessions
+

--- a/docs/navigation.rb
+++ b/docs/navigation.rb
@@ -598,6 +598,10 @@ NAVIGATION_CONFIG = [
                 ]
               },
               {
+                path: 'Post-Mixins.md',
+                title: 'PostMixins'
+              },
+              {
                 path: 'How-to-log-in-Metasploit.md',
                 title: 'Logging'
               },

--- a/lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
+++ b/lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Detects outdated usage of the `cmd_exec` API where arguments are passed as a second parameter.
+      # The modern API is `create_process(executable, args: [])` which properly handles argument arrays.
+      #
+      # `cmd_exec` should only be used with a single static command string. When you need to pass
+      # arguments or construct commands dynamically, use `create_process` instead.
+      #
+      # @example
+      #   # bad - outdated API with args parameter
+      #   cmd_exec('cmd.exe', '/c echo hello')
+      #   cmd_exec(binary, args, timeout)
+      #   cmd_exec("ls", "-la /tmp")
+      #
+      #   # good - static command strings
+      #   cmd_exec('id -u')
+      #   cmd_exec('hostname')
+      #   cmd_exec("echo $PPID")
+      #
+      #   # good - modern API with args array
+      #   create_process('cmd.exe', args: ['/c', 'echo', 'hello'])
+      #   create_process(binary, args: args_array, time_out: timeout)
+      class DetectOutdatedCmdExecApi < Base
+        MSG = 'Do not use cmd_exec with separate arguments. ' \
+              "Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`"
+
+        # Called for every method in the code
+        # Checks if it's a cmd_exec call with separate arguments and registers an offense if so
+        # @param node [RuboCop::AST::SendNode] The method call node being checked
+        def on_send(node)
+          return unless cmd_exec_with_args?(node)
+
+          add_offense(node, message: MSG)
+        end
+
+        private
+
+        # Check if this is a cmd_exec call with a second argument (args parameter)
+        # @param node [RuboCop::AST::SendNode]
+        # @return [Boolean]
+        def cmd_exec_with_args?(node)
+          return false unless node.method_name == :cmd_exec
+
+          # cmd_exec with 2 or more arguments (cmd, args, ...) is outdated
+          # cmd_exec with 1 argument (just the command) is acceptable
+          node.arguments.length >= 2 && !nil_second_arg?(node)
+        end
+
+        # Check if the second argument is explicitly nil
+        # cmd_exec(cmd, nil, timeout) might be used to skip args but set timeout
+        # @param node [RuboCop::AST::SendNode]
+        # @return [Boolean]
+        def nil_second_arg?(node)
+          return false if node.arguments.length < 2
+
+          second_arg = node.arguments[1]
+          # Use nil_type? to check if the node represents a nil literal in the code (e.g., `nil`)
+          second_arg.nil_type?
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
+++ b/lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
@@ -25,7 +25,7 @@ module RuboCop
       #   create_process(binary, args: args_array, time_out: timeout)
       class DetectOutdatedCmdExecApi < Base
         MSG = 'Do not use cmd_exec with separate arguments. ' \
-              "Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`"
+              "Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html#msfpostcommon"
 
         # Called for every method in the code
         # Checks if it's a cmd_exec call with separate arguments and registers an offense if so

--- a/spec/rubocop/cop/lint/detect_outdated_cmd_exec_api_spec.rb
+++ b/spec/rubocop/cop/lint/detect_outdated_cmd_exec_api_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rubocop/cop/lint/detect_outdated_cmd_exec_api'
+require 'rubocop/rspec/support'
+
+RSpec.describe RuboCop::Cop::Lint::DetectOutdatedCmdExecApi, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when cmd_exec is called with separate arguments' do
+    expect_offense(<<~RUBY)
+      cmd_exec('cmd.exe', '/c echo hello')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+    RUBY
+  end
+
+  it 'registers an offense when cmd_exec is called with variable arguments' do
+    expect_offense(<<~RUBY)
+      cmd_exec(binary, args, timeout)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+    RUBY
+  end
+
+  it 'registers an offense when cmd_exec is called with command and args string' do
+    expect_offense(<<~RUBY)
+      cmd_exec("ls", "-la /tmp")
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+    RUBY
+  end
+
+  it 'registers an offense when cmd_exec is called with command and timeout without explicit nil' do
+    expect_offense(<<~RUBY)
+      cmd_exec('cmd.exe', "/c \#{rasdial_cmd}", 60)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+    RUBY
+  end
+
+  it 'does not register an offense when cmd_exec is called with a single static command' do
+    expect_no_offenses(<<~RUBY)
+      cmd_exec('id -u')
+    RUBY
+  end
+
+  it 'does not register an offense when cmd_exec is called with a single command string' do
+    expect_no_offenses(<<~RUBY)
+      cmd_exec('hostname')
+    RUBY
+  end
+
+  it 'does not register an offense when cmd_exec is called with a single interpolated command' do
+    expect_no_offenses(<<~RUBY)
+      cmd_exec("echo $PPID")
+    RUBY
+  end
+
+  it 'does not register an offense when cmd_exec is called with nil as second argument' do
+    expect_no_offenses(<<~RUBY)
+      cmd_exec(cmd, nil, timeout)
+    RUBY
+  end
+
+  it 'does not register an offense when cmd_exec is called with explicit nil args and timeout' do
+    expect_no_offenses(<<~RUBY)
+      cmd_exec("./\#{exploit_name} \#{arg}", nil, timeout)
+    RUBY
+  end
+
+  it 'does not register an offense for create_process calls' do
+    expect_no_offenses(<<~RUBY)
+      create_process('cmd.exe', args: ['/c', 'echo', 'hello'])
+    RUBY
+  end
+
+  it 'does not register an offense for create_process with variable args' do
+    expect_no_offenses(<<~RUBY)
+      create_process(binary, args: args_array, time_out: timeout)
+    RUBY
+  end
+end
+

--- a/spec/rubocop/cop/lint/detect_outdated_cmd_exec_api_spec.rb
+++ b/spec/rubocop/cop/lint/detect_outdated_cmd_exec_api_spec.rb
@@ -11,28 +11,28 @@ RSpec.describe RuboCop::Cop::Lint::DetectOutdatedCmdExecApi, :config do
   it 'registers an offense when cmd_exec is called with separate arguments' do
     expect_offense(<<~RUBY)
       cmd_exec('cmd.exe', '/c echo hello')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
     RUBY
   end
 
   it 'registers an offense when cmd_exec is called with variable arguments' do
     expect_offense(<<~RUBY)
       cmd_exec(binary, args, timeout)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
     RUBY
   end
 
   it 'registers an offense when cmd_exec is called with command and args string' do
     expect_offense(<<~RUBY)
       cmd_exec("ls", "-la /tmp")
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
     RUBY
   end
 
   it 'registers an offense when cmd_exec is called with command and timeout without explicit nil' do
     expect_offense(<<~RUBY)
       cmd_exec('cmd.exe', "/c \#{rasdial_cmd}", 60)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead use: `create_process(executable, args: [], time_out: 15, opts: {})`
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
     RUBY
   end
 

--- a/spec/rubocop/cop/lint/detect_outdated_cmd_exec_api_spec.rb
+++ b/spec/rubocop/cop/lint/detect_outdated_cmd_exec_api_spec.rb
@@ -11,28 +11,28 @@ RSpec.describe RuboCop::Cop::Lint::DetectOutdatedCmdExecApi, :config do
   it 'registers an offense when cmd_exec is called with separate arguments' do
     expect_offense(<<~RUBY)
       cmd_exec('cmd.exe', '/c echo hello')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html#msfpostcommon
     RUBY
   end
 
   it 'registers an offense when cmd_exec is called with variable arguments' do
     expect_offense(<<~RUBY)
       cmd_exec(binary, args, timeout)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html#msfpostcommon
     RUBY
   end
 
   it 'registers an offense when cmd_exec is called with command and args string' do
     expect_offense(<<~RUBY)
       cmd_exec("ls", "-la /tmp")
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html#msfpostcommon
     RUBY
   end
 
   it 'registers an offense when cmd_exec is called with command and timeout without explicit nil' do
     expect_offense(<<~RUBY)
       cmd_exec('cmd.exe', "/c \#{rasdial_cmd}", 60)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/DetectOutdatedCmdExecApi: Do not use cmd_exec with separate arguments. Use create_process with an args array instead, see https://docs.metasploit.com/docs/development/developing-modules/libraries/post-mixins.html#msfpostcommon
     RUBY
   end
 


### PR DESCRIPTION
This PR adds a Rubocop rule to detect calls to the old `cmd_exec` API and raise an offense  for those so it is caught as part of CI.

The offense message will also call out that the user should now make use of the `create_process` API. The cop message will contain an example of the new API to make it easier for users to identify what the new pattern is.

<img width="1966" height="770" alt="image" src="https://github.com/user-attachments/assets/2b2552f4-3d2e-4e4b-9e63-cb78e7506c4b" />

## Expectations
### bad - `cmd_exec` with args parameter
```
cmd_exec('cmd.exe', '/c echo hello')
cmd_exec(binary, args, timeout)
cmd_exec("ls", "-la /tmp")
```
### good - `cmd_exec` with static command strings
```
cmd_exec('id -u')
cmd_exec('hostname')
cmd_exec("echo $PPID")
```
### good - `create_process` API with args array
```
create_process('cmd.exe', args: ['/c', 'echo', 'hello'])
create_process(binary, args: args_array, time_out: timeout)
```

## Docs update
As part of this I added some docs for our post mixins. The reasoning was I wanted to have something that the cop would point to in oder to see how the `create_process` should be used when called out by the cop.
<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/29ed180e-6909-4257-9ad1-1d0fd31a1d1b" />


## Verification

- [ ] Code changes are sane
- [ ] Run the cop against a file that should raise offenses: `rubocop --only Lint/DetectOutdatedCmdExecApi -A lib/msf/core/post/common.rb`
- [ ] Verify we are happy with the cop message when an offense is raised
