### PR TITLE
Fix msfdb startup

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -1005,7 +1005,7 @@ def should_delete
   ask_yn("Would you like to delete your existing data and configurations?")
 end
 
-if $PROGRAM_NAME == __FILE__
+if File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
   # Bomb out if we're root
   if !Gem.win_platform? && Process.uid.zero?
     puts "Please run #{@script_name} as a non-root user"


### PR DESCRIPTION
`msfdb` wasn't starting when using `bundle exec`. This was due to this line:
```ruby
if $PROGRAM_NAME == __FILE__
```

One possible fix is to check the file's absolute path against the absolute path of the program name:
```ruby
if File.expand_path($PROGRAM_NAME) == File.expand_path(__FILE__)
```

## Testing
Running `bundle exec ./msfdb` does nothing without the fix. It correctly runs with this fix.
