### PR TITLE
Fix issue when scanning via Nexpose plugin when Site has Credential

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ PATH
       recog
       redcarpet
       reline
+      rest-client
       rex-arch
       rex-bin_tools
       rex-core
@@ -285,6 +286,7 @@ GEM
     hrr_rb_ssh-ed25519 (0.4.2)
       ed25519 (~> 1.2)
       hrr_rb_ssh (>= 0.4)
+    http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     http_parser.rb (0.8.0)
@@ -388,6 +390,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     net-ssh (7.3.0)
+    netrc (0.11.0)
     network_interface (0.0.4)
     nexpose (7.3.0)
     nio4r (2.7.4)
@@ -478,6 +481,11 @@ GEM
     reline (0.6.2)
       io-console (~> 0.5)
     require_all (3.0.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rex-arch (0.1.18)
       rex-text
     rex-bin_tools (0.1.10)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -157,8 +157,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ldap'
   spec.add_runtime_dependency 'net-smtp'
   spec.add_runtime_dependency 'net-sftp'
+  spec.add_runtime_dependency 'rest-client'
   spec.add_runtime_dependency 'winrm'
-  # Pinned to avoid WinRM warnings: https://github.com/WinRb/WinRM/issues/355 - if bumping verify windows/winrm/winrm_script_exec works against metasploitable with vagrant/vagrant creds 
+  # Pinned to avoid WinRM warnings: https://github.com/WinRb/WinRM/issues/355 - if bumping verify windows/winrm/winrm_script_exec works against metasploitable with vagrant/vagrant creds
   spec.add_runtime_dependency 'rexml', '3.4.1'
   spec.add_runtime_dependency 'ffi', '< 1.17.0'
 


### PR DESCRIPTION
This PR fixes an error that occurs when running a Nexpose scan. The error occurs if the Nexpose Site has a Credential or a Shared Credential applies to the site.
The issue has been fixed by using the Nexpose v3 api in place of failing API calls.

n.b. This PR adds `rest-client` as a runtime dependency

## Verification
In Nexpose, create a Shared Credential and in Site Assignment, set the credential to: 'Assign these credentials to all current and future sites'.

```
./msfconsole
load nexpose
nexpose_connect <username>:<password>@<nexpose-ip>:<nexpose-port> ok
nexpose_scan <ip-to-scan>
```

On master, there will be an error e.g:
```
[-] Error while running command nexpose_scan: NexposeAPI: GET request to /api/2.1/site_configurations/<id> failed. response body: The credential with id:<id> cannot be mapped to a know credential type.
```

This is fixed on this branch:
```
[*] Creating a new scan using template pentest-audit and 32 concurrent IPs against <ip-to-scan>
[*] Scanning 1 addresses with template pentest-audit in sets of 32
[*] Scanning <ip-to-scan>-<ip-to-scan>...
[*]  >> Created temporary site #57
[*]  >> Created site credential #3:
[*]  >> Created temporary report configuration #33
[*]  >> Scan has been launched with ID #32
[*]  >> Found 0 devices and 0 unresponsive
[*]  >> Scan has been completed with ID #32
[*]  >> Waiting on the report to generate...
[*]  >> Downloading the report data from Nexpose...
[*] Completed the scan of 1 addresses
```