### PR TITLE
Fix deprecated "run post/" command usage in documentation

### DIFF
--- a/documentation/modules/post/windows/manage/install_python.md
+++ b/documentation/modules/post/windows/manage/install_python.md
@@ -57,7 +57,9 @@ Get initial access: Create a Meterpreter exe using msfvenom, then transfer it to
 
 Use the post module to install Python on the target filesystem
 
-    msf > use post/windows/manage/install_python
+    msf > use post/windows/<same-module-path>
+    run
+
     msf post(windows/manage/install_python) > set SESSION 1
     SESSION => 1
     msf post(windows/manage/install_python) > exploit


### PR DESCRIPTION
This PR updates outdated Metasploit command examples found in the documentation.
Older examples used the deprecated syntax:

- run post/<module>

These have been replaced with the modern usage:

- use <module>
- run

This brings the documentation in line with current Metasploit practices.
