### PR TITLE
Fix the flakey UDP channel tests

### DIFF
--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -82,7 +82,6 @@ jobs:
           - { name: java, runtime_version: 21 }
 
           # PHP
-          - { name: php, runtime_version: 5.3 }
           - { name: php, runtime_version: 7.4 }
           - { name: php, runtime_version: 8.3 }
         include:

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -112,11 +112,12 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
 
-      - uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+      - uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
         if: ${{ matrix.meterpreter.name == 'php' }}
         with:
           php-version: ${{ matrix.meterpreter.runtime_version }}
           tools: none
+          extensions: sockets
 
       - name: Set up Python
         if: ${{ matrix.meterpreter.name == 'python' }}
@@ -192,7 +193,7 @@ jobs:
           ref: ${{ inputs.metasploit_framework_commit }}
 
       # https://github.com/orgs/community/discussions/26952
-      - name: Support longpaths
+      - name: Support longpaths when running on Windows
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.239)
+      metasploit-payloads (= 2.0.240)
       metasploit_data_models (>= 6.0.7)
       metasploit_payloads-mettle (= 1.0.45)
       mqtt
@@ -352,7 +352,7 @@ GEM
       drb
       mutex_m
       railties (~> 7.0)
-    metasploit-payloads (2.0.239)
+    metasploit-payloads (2.0.240)
     metasploit_data_models (6.0.9)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -138,7 +138,7 @@ class Library
     when ARCH_X86
       native = 'V'
     else
-      raise NotImplementedError, 'Unsupported architecture (must be ARCH_X86 or ARCH_X64)'
+      raise NotImplementedError, 'Unsupported architecture for railgun (must be ARCH_X86 or ARCH_X64)'
     end
 
     # We transmit the immediate stack and three heap-buffers:
@@ -285,7 +285,7 @@ class Library
     when ARCH_X86
       native = 'V'
     else
-      raise NotImplementedError, 'Unsupported architecture (must be ARCH_X86 or ARCH_X64)'
+      raise NotImplementedError, 'Unsupported architecture for railgun (must be ARCH_X86 or ARCH_X64)'
     end
 
     rec_inout_buffers = packet.get_tlv_value(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_INOUT)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.239'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.240'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.45'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 36399
+  CachedSize = 36978
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
Should fix most of the Meterpreter acceptance tests. This whole things was a giant exercise in CI whack a mole where almost all of the issues were related to the runners and not actually in Meterpreter.

Requires https://github.com/rapid7/metasploit-payloads/pull/787 for the one issue that was due to Meterpreter.

* Drops PHP 5 from the test suite, for whatever reason it's not working on Windows despite working locally
* Updates the mac runners from 13 to 15 to fix PHP
    * Drops the railgun tests on the mac runners because they're ARM now and railgun doesn't support ARM
* Drops Java 8, Java 8 isn't installing on the new mac runners
* Adds Java 11 as an older version for testing