### PR TITLE
Allow toggling the SACL in LDAP queries

### DIFF
--- a/documentation/modules/auxiliary/gather/ldap_query.md
+++ b/documentation/modules/auxiliary/gather/ldap_query.md
@@ -78,6 +78,12 @@ Used only when the `RUN_SINGLE_QUERY` action is used. Should be a comma separate
 of attributes to display from the full result set for each entry that was returned by the
 target LDAP server. Used to filter the results down to manageable sets of data.
 
+### LDAP::QuerySacl
+Query the SACL on security descriptors. If the authenticated user does not have permission
+to view the SACL, the entire security descriptor will be omitted by the server. Setting
+this to false enables the other fields of the security descriptor to be viewed when those
+permissions are not present. Only applicable for Active Directory LDAP servers.
+
 ## Scenarios
 
 ### RUN_SINGLE_QUERY with Table Output

--- a/lib/msf/core/exploit/remote/ldap/queries.rb
+++ b/lib/msf/core/exploit/remote/ldap/queries.rb
@@ -81,7 +81,7 @@ module Msf
         results
       end
 
-      def perform_ldap_query_streaming(ldap, filter, attributes, base, schema_dn, scope: nil)
+      def perform_ldap_query_streaming(ldap, filter, attributes, base, schema_dn, scope: nil, controls: [])
         if attributes.nil? || schema_dn.nil?
           attribute_properties = {}
         else
@@ -96,7 +96,7 @@ module Msf
 
         scope ||= Net::LDAP::SearchScope_WholeSubtree
         result_count = 0
-        ldap.search(base: base, filter: filter, attributes: attributes, scope: scope, return_result: false) do |result|
+        ldap.search(base: base, filter: filter, attributes: attributes, scope: scope, controls: controls, return_result: false) do |result|
           result_count += 1
           yield result, attribute_properties if block_given?
         end

--- a/lib/msf/ui/tip.rb
+++ b/lib/msf/ui/tip.rb
@@ -51,7 +51,8 @@ module Msf
         "Execute a command across all sessions with #{highlight('sessions -C <command>')}",
         "Use #{highlight('post/multi/manage/autoroute')} to automatically add pivot routes",
         "Use #{highlight('check')} before #{highlight('run')} to confirm if a target is vulnerable",
-        "Bind your reverse shell to a tunnel with #{highlight('set ReverseListenerBindAddress <tunnel_address>')} and #{highlight('set ReverseListenerBindPort <tunnel_port>')} (e.g., ngrok)"
+        "Bind your reverse shell to a tunnel with #{highlight('set ReverseListenerBindAddress <tunnel_address>')} and #{highlight('set ReverseListenerBindPort <tunnel_port>')} (e.g., ngrok)",
+        "Use #{highlight('set LDAP::QuerySacl false')} to view security descriptors with the ldap_query module from non-privileged accounts"
       ].freeze
       private_constant :COMMON_TIPS
 

--- a/modules/auxiliary/gather/ldap_query.rb
+++ b/modules/auxiliary/gather/ldap_query.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     register_advanced_options([
-      OptBool.new('LDAP::QuerySacl', [true, 'Query the SACL field from security descriptors (requires privileges)', true])
+      OptBool.new('LDAP::QuerySacl', [true, 'Query the SACL field from security descriptors (requires privileges)', false])
     ])
   end
 


### PR DESCRIPTION
The SACL field within security descriptors typically requires elevated privileges to be read. This means that by default if a user queries a security descriptor and does not have the privileges to read the SACL, the entire field is omitted. Microsoft provides a control that can be applied to the query to toggle this, allowing the rest of the security descriptor to be returned where otherwise it'd be omitted. This PR exposes Metasploit's existing control construction as a datastore option so that users may turn this on and off at while. This means that underpriviliged users can not query for security descriptors and get the majority of the data in the field.

## Verification

List the steps needed to make sure this thing works

- [ ] Put this updated/hacked version of the `ENUM_ACCOUNTS` query into the local query file at `~/.msf4/ldap_queries.yaml`, it includes the `nTSecurityDescriptor` field.
- [ ] Start msfconsole and load the `ldap_query` module
- [ ] Run the `HACKED_ENUM_ACCOUNTS` action with a normal user account and `LDAP::QuerySacl=false`, see the security descriptor field is present
- [ ] Toggle `LDAP::QuerySacl` back to true and run it again, see no security descriptor field (this is the old behavior where the SACL is included by default)

```
---
queries:
  - action: HACKED_ENUM_ACCOUNTS
    description: 'Dump info about all known user accounts in the domain.'
    filter: '(|(objectClass=organizationalPerson)(sAMAccountType=805306368)(objectcategory=user)(objectClass=user))'
    attributes:
      - dn
      - name
      - nTSecurityDescriptor
      - description
      - displayName
      - sAMAccountName
      - objectSID
      - userPrincipalName
      - userAccountControl
      - homeDirectory
      - homeDrive
      - profilePath
      - memberof
      - lastLogoff
      - lastLogon
      - lastLogonDate
      - logonCount
      - badPwdCount
      - pwdLastSet
      - SmartcardLogonRequired
      - LastBadPasswordAttempt
      - PasswordLastSet
      - PaswordNeverExpires
    references:
      - http://www.ldapexplorer.com/en/manual/109050000-famous-filters.htm
      - https://adsecurity.org/wp-content/uploads/2016/08/DEFCON24-2016-Metcalf-BeyondTheMCSE-RedTeamingActiveDirectory.pdf
```