### PR TITLE
Fix broken module metadata

### DIFF
--- a/modules/payloads/singles/linux/riscv32le/chmod.rb
+++ b/modules/payloads/singles/linux/riscv32le/chmod.rb
@@ -31,7 +31,7 @@ module MetasploitModule
   end
 
   # @return [String] the full path of the file to be modified
-  def file_path
+  def chmod_file_path
     datastore['FILE'] || ''
   end
 
@@ -63,7 +63,7 @@ module MetasploitModule
       0x05d00893,  # li a7,93 # __NR_exit
       0x00000073,  # ecall
     ].pack('V*')
-    shellcode += file_path + "\x00"
+    shellcode += chmod_file_path + "\x00"
 
     # align our shellcode to 4 bytes
     shellcode += "\x00" while shellcode.bytesize % 4 != 0

--- a/modules/payloads/singles/linux/riscv64le/chmod.rb
+++ b/modules/payloads/singles/linux/riscv64le/chmod.rb
@@ -31,7 +31,7 @@ module MetasploitModule
   end
 
   # @return [String] the full path of the file to be modified
-  def file_path
+  def chmod_file_path
     datastore['FILE'] || ''
   end
 
@@ -63,7 +63,7 @@ module MetasploitModule
       0x05d00893,  # li a7,93 # __NR_exit
       0x00000073,  # ecall
     ].pack('V*')
-    shellcode += file_path + "\x00"
+    shellcode += chmod_file_path + "\x00"
 
     # align our shellcode to 4 bytes
     shellcode += "\x00" while shellcode.bytesize % 4 != 0


### PR DESCRIPTION
Fix the broken module metadata introduced by https://github.com/rapid7/metasploit-framework/pull/20703

```
cat ./db/modules_metadata_base.json | grep is_install_path | sort | uniq -c
   2     "is_install_path": null,
6080     "is_install_path": true,
```

Cause by `file_path` being overriden in the module:

```
   "path": "/etc/shadow",
    "is_install_path": null,
    "ref_name": "linux/riscv32le/chmod",
```

Which invalidates this logic:

https://github.com/rapid7/metasploit-framework/blob/7325d2a265761f4bbbd7aa518d879976c11c510c/lib/msf/core/modules/metadata/obj.rb#L122-L126

## Verification

Before

```
msf payload(linux/riscv32le/chmod) > irb
[*] Starting IRB shell...
[*] You are in payload/linux/riscv32le/chmod

>> file_path
=> "/etc/shadow"
```

After

```
msf payload(linux/riscv32le/chmod) > irb
[*] Starting IRB shell...
[*] You are in payload/linux/riscv32le/chmod

>> file_path
=> "/Users/dev/metasploit-framework/modules/payloads/singles/linux/riscv32le/chmod.rb"
```