### PR TITLE
Remove the TDSENCRYPTION Guard Clause

### DIFF
--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -74,18 +74,6 @@ class MetasploitModule < Msf::Auxiliary
     @print_prefix = '' # remove the redundant prefix because #print_brute will add it
     print_brute level: :status, ip: ip, msg: 'MSSQL - Starting authentication scanner.'
 
-    if datastore['TDSENCRYPTION']
-      if create_session?
-        raise Msf::OptionValidateError.new(
-          {
-            'TDSENCRYPTION' => "Cannot create sessions when encryption is enabled. See https://github.com/rapid7/metasploit-framework/issues/18745 to vote for this feature."
-          }
-        )
-      else
-        print_brute level: :vstatus, ip: ip, msg: 'TDS Encryption enabled'
-      end
-    end
-
     cred_collection = build_credential_collection(
       realm: datastore['DOMAIN'],
       username: datastore['USERNAME'],


### PR DESCRIPTION
Now that #18745 is closed, this guard clause is no longer required. TDSENCRYPTION is compatible with sessions now, so we should allow users to configure it.

I should have included this change in #20677 but I didn't run into it because I was focused on the issue that'd occur when TDSENCRYPTION was false but the server required it.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/mssql/mssql_login`
- [x] Target a server that is configured with SSL, set `TDSENCRYPTION` and `CreateSession` to true
- [x] See that the options are compatible now and the session works just fine
