### PR TITLE
Adds PPC reverse payloads to fetch adapters

### DIFF
--- a/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
@@ -19,7 +19,7 @@ module MetasploitModule
         'Author' => 'Ramon de C Valle',
         'License' => MSF_LICENSE,
         'Platform' => 'linux',
-        'Arch' => [ ARCH_PPC, ARCH_CBEA ],
+        'Arch' => ARCH_PPC,
         'Handler' => Msf::Handler::BindTcp,
         'Session' => Msf::Sessions::CommandShellUnix,
         'Payload' => {

--- a/modules/payloads/singles/linux/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc/shell_find_port.rb
@@ -19,7 +19,7 @@ module MetasploitModule
         'Author' => 'Ramon de C Valle',
         'License' => MSF_LICENSE,
         'Platform' => 'linux',
-        'Arch' =>  ARCH_PPC,
+        'Arch' => ARCH_PPC,
         'Handler' => Msf::Handler::FindPort,
         'Session' => Msf::Sessions::CommandShellUnix,
         'Payload' => {

--- a/modules/payloads/singles/linux/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc/shell_find_port.rb
@@ -19,7 +19,7 @@ module MetasploitModule
         'Author' => 'Ramon de C Valle',
         'License' => MSF_LICENSE,
         'Platform' => 'linux',
-        'Arch' => [ ARCH_PPC, ARCH_CBEA ],
+        'Arch' =>  ARCH_PPC,
         'Handler' => Msf::Handler::FindPort,
         'Session' => Msf::Sessions::CommandShellUnix,
         'Payload' => {

--- a/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
@@ -19,7 +19,7 @@ module MetasploitModule
         'Author' => 'Ramon de C Valle',
         'License' => MSF_LICENSE,
         'Platform' => 'linux',
-        'Arch' => [ ARCH_PPC, ARCH_CBEA ],
+        'Arch' => ARCH_PPC,
         'Handler' => Msf::Handler::ReverseTcp,
         'Session' => Msf::Sessions::CommandShellUnix,
         'Payload' => {


### PR DESCRIPTION
The fetch payloads for PPC are limited to Meterpreter payloads - which ~never work~ sometimes don't work. Therefore, if user wants to use fetch payloads for PPC, they are strictly limited. This PR expands that by adding shell payloads to available fetch payloads for PPC. However, this should be merged before  #19799 because that PR fixes a bug, which causes payload generation for PPC unavailable.