### PR TITLE
Drop the ldap_esc_vulnerable_cert_finder tests

### DIFF
--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -90,24 +90,6 @@ RSpec.describe 'LDAP modules' do
           }
         },
         {
-          name: 'auxiliary/gather/ldap_esc_vulnerable_cert_finder',
-          platforms: %i[linux osx windows],
-          targets: [:session, :rhost],
-          skipped: false,
-          lines: {
-            all: {
-              required: [
-                /Successfully queried/
-              ]
-            },
-            linux: {
-              known_failures: [
-                /Auxiliary aborted due to failure: (not-found|unknown: Net::LDAP::Error: 127.0.0.1:389 LDAP Error: Extended Operation\(1.3.6.1.4.1.4203.1.11.3\) not supported)/,
-              ]
-            }
-          }
-        },
-        {
           name: 'auxiliary/admin/ldap/rbcd',
           platforms: %i[linux osx windows],
           targets: [:session, :rhost],


### PR DESCRIPTION
Related to #20681 but we're still having issues with the LDAP acceptance tests and the ESC vulnerable cert finder module.

## Verification

- [ ] See the tests pass


