### PR TITLE
Update the payload preferences

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -502,6 +502,9 @@ class Payload < Msf::Module
     # XXX: This approach is subpar, and payloads should really be ranked!
     preferred_payloads = [
       # These payloads are generally reliable and common enough in practice
+      'windows/meterpreter/reverse_tcp',  # all 64-bit versions of Windows will also support x86 but the same isn't true
+      'x64/meterpreter/reverse_tcp',      # for Linux so if a 32-bit Windows Meterpreter isn't an option, select any x64
+      'x86/meterpreter/reverse_tcp',      # Meterpreter
       '/meterpreter/reverse_tcp',
       '/shell/reverse_tcp',
       'cmd/unix/reverse_bash',


### PR DESCRIPTION
This makes a change to the preferred list of payloads inspired by the exploit added in https://github.com/rapid7/metasploit-framework/pull/20747. In that PR it was noticed that the payload was defaulting to AARCH64 when it wasn't specified and that's not as common of an architecture as x86 / x64. The changes in this PR will prioritize the 32-bit Windows meterpreter when it's compatible. 64-bit version of Windows always support 32-bit code execution AFAIK. The same isn't true for Linux though, so in cases where the 32-bit version of the Windows Meterpreter isn't compatible, we'll default to an x64 meterpreter for any platform.

# Testing
- [ ] Use a couple of exploits and see that the automatically selected payload is reasonable. For advanced testing, you could make a mock module and toggle the different platform and architecture options to see how they affect the automatic selection.