### PR TITLE
Fix undefined variable in Host.normalize_host causing session failures when DB is connected

### DIFF
--- a/lib/msf/util/host.rb
+++ b/lib/msf/util/host.rb
@@ -43,7 +43,7 @@ module Msf
             host.sock.respond_to?(:peerhost) &&
             host.sock.peerhost.to_s.length > 0
         )
-          norm_host = session.sock.peerhost
+          norm_host = host.sock.peerhost
         end
         # If We got here and still don't have a real host, there's nothing left
         # to try, just log it and return what we were given


### PR DESCRIPTION
# Bug Fix: shell_bind_aws_ssm Session Fails with Database Connected

## Issue Summary

The `payload/generic/shell_bind_aws_ssm` module failed to establish a session when a database was connected to Metasploit Framework, while working correctly without a database connection.

## Steps to Reproduce

1. Disconnect the database
2. Setup an SSM target
3. Set the `ACCESS_KEY_ID`, `EC2_ID`, `REGION` and `SECRET_ACCESS_KEY` datastore options
4. Run the module → Session establishes successfully
5. Connect a database and run the module → **No session established**

## Root Cause Analysis

The bug was located in `lib/msf/util/host.rb` at line 46.

### The Bug

```ruby
def self.normalize_host(host)
  # ... earlier code ...
  
  # If we got here and don't have a norm_host yet, it could be a
  # Msf::Session object with an empty or nil tunnel_host and tunnel_peer;
  # see if it has a socket and use its peerhost if so.
  if (
  norm_host.nil? &&
      host.respond_to?(:sock) &&
      host.sock.respond_to?(:peerhost) &&
      host.sock.peerhost.to_s.length > 0
  )
    norm_host = session.sock.peerhost  # BUG: 'session' is undefined!
  end
  
  # ... rest of code ...
end
```

The variable `session` does not exist in this method scope - it should be `host`.

### Why Database Connection Triggered the Bug

The execution flow when a database is connected:

1. Session is created and `on_session_open` event fires
2. `lib/msf/core/framework.rb` handles the event:
   ```ruby
   def on_session_open(session)
     opts = { :datastore => session.exploit_datastore.to_h, :critical => true }
     session_event('session_open', session, opts)
     framework.db.report_session(:session => session)  # Only called when DB is active!
   end
   ```
3. `report_session` calls `create_mdm_session_from_session` which calls:
   ```ruby
   host = Msf::Util::Host.normalize_host(session)
   ```
4. For AWS SSM sessions, `session_host` returns `nil` because host info is stored in `peer_info` hash, not in standard session attributes
5. Code falls through to the `sock.peerhost` fallback at lines 40-46
6. Line 46 references undefined `session` variable → `NameError` exception
7. Exception prevents session registration

**Without a database**, `framework.db.report_session` is never called, so the buggy code path is never executed.

## The Fix

**File:** `lib/msf/util/host.rb`  
**Line:** 46

### Before
```ruby
norm_host = session.sock.peerhost
```

### After
```ruby
norm_host = host.sock.peerhost
```

## Files Modified

- `lib/msf/util/host.rb` - Fixed typo on line 46

## Impact

This fix resolves session establishment issues for any session type where:
1. A database is connected
2. The session's `session_host` method returns `nil`
3. The session has a `sock` attribute with valid `peerhost` information

This primarily affects:
- `payload/generic/shell_bind_aws_ssm`
- Potentially other custom or edge-case session types with similar characteristics

## Testing Recommendations

1. Connect a PostgreSQL database to Metasploit
2. Configure and run `payload/generic/shell_bind_aws_ssm` against an SSM target
3. Verify session establishes successfully
4. Verify session is properly recorded in the database

## Date

December 12, 2025

Fixes: [#20675](https://github.com/rapid7/metasploit-framework/issues/20675)
