### PR TITLE
Updates macos runners

### DIFF
--- a/.github/workflows/shared_gem_verify.yml
+++ b/.github/workflows/shared_gem_verify.yml
@@ -31,7 +31,7 @@ jobs:
           - ubuntu-latest
           - windows-2022
           - windows-2025
-          - macos-13
+          - macos-15-intel
 
     env:
       RAILS_ENV: test

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
           - windows-2022
           - ubuntu-latest
         ruby:
@@ -92,7 +92,7 @@ jobs:
           # - { meterpreter: { name: windows_meterpreter }, ruby: '3.4', os: windows-2025 }
 
           # Mettle
-          - { meterpreter: { name: mettle }, os: macos-13 }
+          - { meterpreter: { name: mettle }, os: macos-15-intel }
           - { meterpreter: { name: mettle }, os: ubuntu-latest }
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR updates the macOS runners that are now retired, see https://github.com/actions/runner-images/issues/13046.

## Verification

- [ ] Code changes are sane
- [ ] CI goes green