### PR TITLE
Add HTTP Server Version Scanner Module

### DIFF
--- a/modules/auxiliary/scanner/http/http_version_scanner.rb
+++ b/modules/auxiliary/scanner/http/http_version_scanner.rb
@@ -1,0 +1,36 @@
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Scanner
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Simple TCP Banner Grabber',
+      'Description' => %q{
+        This module connects to a specified port and grabs the banner 
+        (the welcome message) sent by the service.
+      },
+      'Author'      => [ 'Apeksh Athrey' ],
+      'License'     => MSF_LICENSE
+    ))
+    register_options(
+      [
+        Opt::RPORT(80)
+      ])
+  end
+  def run_host(ip)
+    begin
+      connect
+      banner = sock.get_once(-1, 10)
+      if banner
+        print_good("#{ip}:#{rport} - BANNER FOUND: #{banner.strip}")
+
+        report_service(:host => ip, :port => rport, :name => "custom_banner", :info => banner)
+      else
+        print_status("#{ip}:#{rport} - Connected, but no banner received.")
+      end
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+
+    ensure
+      disconnect
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new auxiliary scanner module,auxiliary/scanner/http/http_version_scanner. It connects to target web servers, sends a standard HTTP GET request,and extracts the software version string from the HTTP Server response header.This allows for rapid fingerprinting of web services during the reconnaissance phase of a penetration test.

## Verification
1)Start a dummy web server for testing
2)Start 'msfconsole'.
3)Load the module:'use auxiliary/scanner/http/http_version_scanner'.
4)Set the target IP:'set RHOSTS 127.0.0.1'.
5)Set the target port:'set RPORT 8080'.
6)Run the scanner:'run'.

->Verify the module reports '[+] 127.0.0.1:8080 - VERSION DETECTED: SimpleHTTP/0.6 Python/3.x.x'(or similar stuff depending on the server you've chosen).
->Verify the service is correctly reported to the database using 'services'.

No specific hardware or complex software/coding environment is required.The module has been tested against a local python http server and standard apache/nginx instances.

