### PR TITLE
Update nodejs cache sizes

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 2239
+  CachedSize = 940
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 3231
+  CachedSize = 1356
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS


### PR DESCRIPTION
Fix the nodejs payload cache sizes. Payloads were updated in ca2ac75e16430c5b73e8021f9b9d33c58f1295ce which used a regex to only encode certain characters instead of all of them, resulting in a much smaller payload.

## Verification

- [ ] See the tests pass