### PR TITLE
Add autocheck report_vuln logic

### DIFF
--- a/lib/msf/core/exploit/remote/auto_check.rb
+++ b/lib/msf/core/exploit/remote/auto_check.rb
@@ -40,11 +40,35 @@ module Exploit::Remote::AutoCheck
 
     warning_msg = 'ForceExploit is enabled, proceeding with exploitation.'
     error_msg = '"set ForceExploit true" to override check result.'
-
     check_code = check
+
     case check_code
     when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears
       print_good(check_code.message)
+
+      if respond_to?(:report_vuln)
+        report_vuln_opts = {
+          name: fullname,
+          username: respond_to?(:owner) ? owner : nil,
+          refs: references,
+          info: description.strip
+        }
+
+        if respond_to?(:session) && session.respond_to?(:session_host)
+          report_vuln(
+            **report_vuln_opts,
+            host: session.session_host
+          )
+        elsif respond_to?(:rhost)
+          report_vuln(
+            **report_vuln_opts,
+            host: rhost,
+            port: respond_to?(:rport) ? rport : nil,
+            proto: Msf::DBManager::DEFAULT_SERVICE_PROTO
+          )
+        end
+      end
+
       return yield
     when Exploit::CheckCode::Detected
       print_warning(check_code.message)

--- a/spec/lib/msf/core/exploit/remote/auto_check_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/auto_check_spec.rb
@@ -68,16 +68,78 @@ RSpec.shared_examples "An AutoChecked method" do |opts|
     context 'when the check method returns vulnerable' do
       let(:check_result) { ::Msf::Exploit::CheckCode::Vulnerable }
 
-      before(:each) do
-        subject.send(opts[:method])
+      context 'when there is no session or rhost details' do
+        before(:each) do
+          subject.send(opts[:method])
+        end
+
+        it "calls the check method" do
+          expect(subject).to have_received(:check)
+        end
+
+        it "calls the original #{opts[:method]} method" do
+          expect(subject).to have_received(:"original_#{opts[:method]}_call")
+        end
       end
 
-      it "calls the check method" do
-        expect(subject).to have_received(:check)
+      context 'when a session is present' do
+        subject do
+          mock_module_with_session.new
+        end
+
+        before(:each) do
+          mock_session = instance_double(Msf::Sessions::Meterpreter_x64_Linux, session_host: '192.0.2.2')
+          allow(subject).to receive(:session).and_return(mock_session)
+          allow(subject).to receive(:report_vuln).and_call_original
+          subject.send(opts[:method])
+        end
+
+        it "calls the check method" do
+          expect(subject).to have_received(:check)
+        end
+
+        it "calls the original #{opts[:method]} method" do
+          expect(subject).to have_received(:"original_#{opts[:method]}_call")
+        end
+
+        it "registers the vulnerability" do
+          expect(subject).to have_received(:report_vuln).with(hash_including(
+            name: a_kind_of(String),
+            info: a_kind_of(String),
+            refs: a_kind_of(Array),
+            host: '192.0.2.2'
+          ))
+        end
       end
 
-      it "calls the original #{opts[:method]} method" do
-        expect(subject).to have_received(:"original_#{opts[:method]}_call")
+      context 'when rhost is present' do
+        subject do
+          mock_module_with_rhost.new
+        end
+
+        before(:each) do
+          allow(subject).to receive(:report_vuln).and_call_original
+          subject.send(opts[:method])
+        end
+
+        it "calls the check method" do
+          expect(subject).to have_received(:check)
+        end
+
+        it "calls the original #{opts[:method]} method" do
+          expect(subject).to have_received(:"original_#{opts[:method]}_call")
+        end
+
+        it "registers the vulnerability" do
+          expect(subject).to have_received(:report_vuln).with(hash_including(
+            name: a_kind_of(String),
+            info: a_kind_of(String),
+            refs: a_kind_of(Array),
+            host: '192.0.2.2',
+            port: 8080,
+            proto: 'tcp'
+          ))
+        end
       end
     end
 
@@ -121,7 +183,7 @@ RSpec.describe Msf::Exploit::Remote::AutoCheck do
       prepend context_described_class
 
       def check
-        # mocked
+        raise 'should be mocked'
       end
 
       def run
@@ -138,6 +200,32 @@ RSpec.describe Msf::Exploit::Remote::AutoCheck do
 
       def original_exploit_call
         # Helper for verifying the original exploit function was called
+      end
+
+      def report_vuln(opts)
+        original_report_vuln(opts)
+      end
+
+      def original_report_vuln(opts)
+        # Helper for verifying the original exploit function was called
+      end
+    end
+  end
+  let(:mock_module_with_session) do
+    Class.new(mock_module_with_prepend_autocheck) do
+      def session
+        raise 'should be mocked'
+      end
+    end
+  end
+  let(:mock_module_with_rhost) do
+    Class.new(mock_module_with_prepend_autocheck) do
+      def rhost
+        '192.0.2.2'
+      end
+
+      def rport
+        8080
       end
     end
   end


### PR DESCRIPTION
Modules that run a `check` before exploitation and are successful and identifying a vulnerability will now register a vulnerability with the identified host

## Verification

- Ensure CI passes
- The `vulns` and `vulns --verbose` command should output all details:
```
msf exploit(multi/http/react2shell_unauth_rce_cve_2025_55182) > vulns --verbose

Vulnerabilities
===============
  0. Vuln ID: 15
     Timestamp: 2025-12-22 14:24:28 UTC
     Host: 127.0.0.1
     Name: exploit/multi/http/react2shell_unauth_rce_cve_2025_55182
     References: CVE-2025-55182,CVE-2025-66478,URL-https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components,URL-https://gist.github.com/maple3142/48bc9393f45e068cf8c90ab865c0f5f3
     Information: A critical unauthenticated Remote Code Execution (RCE) vulnerability exists in React Server
            Components (RSC) Flight protocol. The vulnerability allows attackers to achieve prototype
            pollution during deserialization of RSC payloads by sending specially crafted multipart
            requests with "__proto__", "constructor", or "prototype" as module names.
     Vuln attempts:
     0. ID: 50
        Vuln ID: 15
        Timestamp: 2025-12-22 14:24:28 UTC
        Exploit: 
        Fail reason: Untried
        Username: user
        Module: exploit/multi/http/react2shell_unauth_rce_cve_2025_55182
        Session ID: nil
        Loot ID: nil
        Fail Detail: vulnerability identified
     1. ID: 51
        Vuln ID: 15
        Timestamp: 2025-12-22 14:24:55 UTC
        Exploit: false
        Fail reason: payload-failed
        Username: user
        Module: exploit/multi/http/react2shell_unauth_rce_cve_2025_55182
        Session ID: nil
        Loot ID: nil
        Fail Detail: No session created

```
- I also tested this in the context of Metasploit Pro by running the react2shell module against a vulnerable target which had an incorrect payload set:

<img width="1281" height="536" alt="image" src="https://github.com/user-attachments/assets/5cb0df01-7bd4-4cff-82b7-f2cab24738f6" />

Before this change; in an empty workspace - no vuln or vuln attempts would be registered. Note: This is an MVP implementation to bubble up the vulnerability reporting logic, we will still likely want an extra iteration to add the different metadata to the report_vuln logic to differentiate between between check methods and exploit methods to the user, as well as some of the more specific CheckCode metadata.