### PR TITLE
Fix FileStat stat parsing on non-GNU systems

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -1157,24 +1157,34 @@ protected
     attr_accessor :stathash
 
     def initialize(filename, session)
-      data = session.shell_command_token("stat --format='%d,%i,%h,%u,%g,%t,%s,%B,%o,%X,%Y,%Z,%f' '#{filename}'").to_s.chomp
-      raise 'format argument of stat command not behaving as expected' unless data =~ /(\d+,){12}\w+/
+      data = session.shell_command_token(
+        "stat --format='%d,%i,%h,%u,%g,%t,%s,%B,%o,%X,%Y,%Z,%f' '#{filename}'"
+      ).to_s.chomp
+
+      unless data =~ /(\d+,){12}\w+/
+        data = session.shell_command_token(
+          "stat -f '%d,%i,%l,%u,%g,%r,%z,%k,%b,%a,%m,%c,%p' '#{filename}'"
+        ).to_s.chomp
+      end
+
+      raise "stat command returned an unexpected result: #{data}" unless data =~ /(\d+,){12}\w+/
 
       data = data.split(',')
-      @stathash = Hash.new
-      @stathash['st_dev'] = data[0].to_i
-      @stathash['st_ino'] = data[1].to_i
-      @stathash['st_nlink'] = data[2].to_i
-      @stathash['st_uid'] = data[3].to_i
-      @stathash['st_gid'] = data[4].to_i
-      @stathash['st_rdev'] = data[5].to_i
-      @stathash['st_size'] = data[6].to_i
+
+      @stathash = {}
+      @stathash['st_dev']     = data[0].to_i
+      @stathash['st_ino']     = data[1].to_i
+      @stathash['st_nlink']   = data[2].to_i
+      @stathash['st_uid']     = data[3].to_i
+      @stathash['st_gid']     = data[4].to_i
+      @stathash['st_rdev']    = data[5].to_i
+      @stathash['st_size']    = data[6].to_i
       @stathash['st_blksize'] = data[7].to_i
-      @stathash['st_blocks'] = data[8].to_i
-      @stathash['st_atime'] = data[9].to_i
-      @stathash['st_mtime'] = data[10].to_i
-      @stathash['st_ctime'] = data[11].to_i
-      @stathash['st_mode'] = data[12].to_i(16) # stat command returns hex value of mode"
+      @stathash['st_blocks']  = data[8].to_i
+      @stathash['st_atime']   = data[9].to_i
+      @stathash['st_mtime']   = data[10].to_i
+      @stathash['st_ctime']   = data[11].to_i
+      @stathash['st_mode']    = data[12].to_i(16)
     end
   end
 end


### PR DESCRIPTION
This PR fixes a portability issue in Msf::Post::File.stat where the implementation assumed GNU stat --format output.

On non-GNU systems (such as BSD variants), the existing code raised a runtime exception because the stat output did not match the expected format. This change preserves existing GNU/Linux behavior and adds a minimal, behavior-based fallback to a BSD-compatible stat -f format when the initial output does not match expectations.

No OS detection is introduced, and no external interfaces are changed.

Fixes #20030
