### PR TITLE
Fixes typo in generating X64 PE file 

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -110,7 +110,7 @@ module Msf
         
         if plat.index(Msf::Module::Platform::Windows)
           return to_win32pe(framework, code, opts)  if arch.index(ARCH_X86)
-          return to_win64pe(framework, code, opts)  if arch.index(ARCH_X86)
+          return to_win64pe(framework, code, opts)  if arch.index(ARCH_X64)
         elsif plat.index(Msf::Module::Platform::Linux)
           return to_linux_armle_elf(framework, code, opts)     if arch.index(ARCH_ARMLE)
           return to_linux_armbe_elf(framework, code, opts)     if arch.index(ARCH_ARMBE)


### PR DESCRIPTION
This fixes a typo in `msf/util/exe.rb`:
```
def self.to_executable(framework, arch, plat, code = '', opts = {})
     [...]
      if plat.index(Msf::Module::Platform::Windows)
             return to_win32pe(framework, code, opts)  if arch.index(ARCH_X86)
             return to_win64pe(framework, code, opts)  if arch.index(ARCH_X86)
```
This bug was causing failure, when generating Windows x64 payloads.

