### PR TITLE
Bump rex-arch gem from 0.1.18 to 0.1.19

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,7 +486,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rex-arch (0.1.18)
+    rex-arch (0.1.19)
       rex-text
     rex-bin_tools (0.1.10)
       metasm


### PR DESCRIPTION
~~`rex-arch` version 0.1.19 does not exist yet.~~

This allows us to use register constants for multiple architectures introduced in https://github.com/rapid7/rex-arch/pull/12.
