### PR TITLE
Expose encoder options

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -563,7 +563,7 @@ class Payload < Msf::Module
       return configure_encoder.call(encoder)
     end
 
-    nil
+    return compatible_encoders&.first
   end
 
   #

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -537,7 +537,7 @@ class Payload < Msf::Module
         payload_defaults = { 'ENCODER' => encoder }
          mod.datastore.import_defaults_from_hash(payload_defaults, imported_by: 'choose_encoder')
       else
-        payload.datastore['ENCODER'] = encoder
+        mod.datastore['ENCODER'] = encoder
       end
 
       encoder

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -535,7 +535,7 @@ class Payload < Msf::Module
     configure_encoder = lambda do |encoder|
       if payload.datastore.is_a?(Msf::DataStore)
         payload_defaults = { 'ENCODER' => encoder }
-        payload.datastore.import_defaults_from_hash(payload_defaults, imported_by: 'choose_encoder')
+         mod.datastore.import_defaults_from_hash(payload_defaults, imported_by: 'choose_encoder')
       else
         payload.datastore['ENCODER'] = encoder
       end

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -121,6 +121,22 @@ module Common
       end
     end
 
+    if ((mod.exploit? or mod.evasion? or mod.payload?) and mod.datastore['ENCODER'])
+      e = framework.encoders.create(mod.datastore['ENCODER'])
+
+      if (!e)
+        print_error("Invalid encoder defined: #{mod.datastore['ENCODER']}\n")
+        return
+      end
+
+      e.share_datastore(mod.datastore)
+
+      if (e)
+        e_opt = Serializer::ReadableText.dump_options(e, '   ')
+        print("\nEncoder options (#{mod.datastore['ENCODER']}):\n\n#{e_opt}\n") if (e_opt and e_opt.length > 0)
+      end
+    end
+
     # Print the selected target
     if (mod.exploit? and mod.target)
       mod_targ = Serializer::ReadableText.dump_exploit_target(mod, '   ')

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2190,6 +2190,25 @@ class Core
       end
     end
 
+    # Set ENCODER
+    if name.upcase == 'ENCODER' && active_module && active_module.exploit? && !clear
+      value = trim_path(value, 'encoder')
+
+      payload = active_module.framework.payloads.create(datastore['PAYLOAD'])
+      
+      unless payload
+        print_error("Please set a valid PAYLOAD before setting the ENCODER.")
+        return false
+      end
+
+      index_from_list(payload.compatible_encoders, value) do |mod|
+        return false unless mod && mod.respond_to?(:first)
+        # [name, class] from compatible_encoders
+        value = mod.first
+      end
+    end
+
+
     unless global || valid_options.any? { |vo| vo.casecmp?(name) }
       message = "Unknown datastore option: #{name}."
       suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -288,6 +288,10 @@ class Exploit
     Msf::Payload.choose_payload(mod)
   end
 
+  def self.choose_encoder(mod)
+    Msf::Payload.choose_encoder(mod)
+  end
+
 end
 
 end end end end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1673,19 +1673,19 @@ module Msf
               end
             end
 
-            if (mod.exploit? and mod.datastore['ENCODER'])
-              p = framework.encoders.create(mod.datastore['ENCODER'])
+            if ((mod.exploit? or mod.evasion? or mod.payload?) and mod.datastore['ENCODER'])
+              e = framework.encoders.create(mod.datastore['ENCODER'])
 
-              if (!p)
+              if (!e)
                 print_error("Invalid encoder defined: #{mod.datastore['ENCODER']}\n")
                 return
               end
 
-              p.share_datastore(mod.datastore)
+              e.share_datastore(mod.datastore)
 
-              if (p)
-                p_opt = Serializer::ReadableText.dump_advanced_options(p, '   ')
-                print("\nEncoder advanced options (#{mod.datastore['ENCODER']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
+              if (e)
+                e_opt = Serializer::ReadableText.dump_advanced_options(e, '   ')
+                print("\nEncoder advanced options (#{mod.datastore['ENCODER']}):\n\n#{e_opt}\n") if (e_opt and e_opt.length > 0)
               end
             end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1672,6 +1672,24 @@ module Msf
                 print("\nPayload advanced options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
               end
             end
+
+            if (mod.exploit? and mod.datastore['ENCODER'])
+              p = framework.encoders.create(mod.datastore['ENCODER'])
+
+              if (!p)
+                print_error("Invalid encoder defined: #{mod.datastore['ENCODER']}\n")
+                return
+              end
+
+              p.share_datastore(mod.datastore)
+
+              if (p)
+                p_opt = Serializer::ReadableText.dump_advanced_options(p, '   ')
+                print("\nEncoder advanced options (#{mod.datastore['ENCODER']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
+              end
+            end
+
+
             print("\nView the full module info with the #{Msf::Ui::Tip.highlight('info')}, or #{Msf::Ui::Tip.highlight('info -d')} command.\n\n")
           end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -908,6 +908,14 @@ module Msf
               print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
+            # Choose a default encoder when the module is used, not run
+            if mod.datastore['ENCODER']
+              print_status("Using configured encoder #{mod.datastore['ENCODER']}")
+            elsif dispatcher.respond_to?(:choose_encoder)
+              chosen_encoder = dispatcher.choose_encoder(mod) 
+              print_status("No encoder configured, defaulting to #{chosen_encoder}") if chosen_encoder
+            end
+
             if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.respond_to?(:actions) && mod.actions.size > 1
               print_status "Setting default action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
             end

--- a/modules/encoders/cmd/base64.rb
+++ b/modules/encoders/cmd/base64.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder
 
     register_advanced_options(
       [
-        OptString.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', '', %w[base64 base64-long base64-short openssl] ])
+        OptEnum.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', '', %w[base64 base64-long base64-short openssl] ])
       ]
     )
   end


### PR DESCRIPTION
This exposes encoder options.

- [x] Exposed in exploit modules
- [x] Exposed in payload modules

## WHY

```
msf exploit(multi/http/vbulletin_replace_ad_template_rce) >  set ENCODER cmd/base64
msf exploit(multi/http/vbulletin_replace_ad_template_rce) >  show advanced

...
Encoder advanced options (cmd/base64):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   Base64Decoder                   no        The binary to use for base64 decoding
   VERBOSE        false            no        Enable detailed status messages
   WORKSPACE                       no        Specify the workspace for this module


View the full module info with the info, or info -d command.

msf exploit(multi/http/vbulletin_replace_ad_template_rce) > 
```