### PR TITLE
Update bad successor description

### DIFF
--- a/modules/auxiliary/admin/ldap/bad_successor.rb
+++ b/modules/auxiliary/admin/ldap/bad_successor.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
           Accounts OU, but if a normal user has write access to any other OU they can then create a dMSA account in
           said OU. After creating the account the user can edit LDAP attributes of the account to indicate that this
           account should inherit privileges from the Administrator user. Once this is complete we can request kerberos
-          tickets on behalf of the dMSA account and voilà, you're admin.
+          tickets on behalf of the dMSA account and voila, you're admin.
 
           The module has two actions, one for creating the dMSA account and setting it up to impersonate a high
           privilege user, and another action for requesting the kerberos tickets needed to use the dMSA account for privilege


### PR DESCRIPTION
Update bad successor description

## Verification

Ensure tests pass:

```
  1) modules it should behave like all modules with module type can be instantiated auxiliary admin/ldap/bad_successor behaves like a module with valid metadata verifies modules metadata
     Failure/Error: expect(validator.errors.full_messages).to be_empty
       expected `["Description must only contain human-readable printable ascii characters, including newlines and tabs"].empty?` to be truthy, got false
     Shared Example Group: "a module with valid metadata" called from ./spec/support/shared/examples/all_modules_with_module_type_can_be_instantiated.rb:35
     Shared Example Group: "all modules with module type can be instantiated" called from ./spec/modules_spec.rb:6

```