### PR TITLE
Resolve method undefined issue

### DIFF
--- a/spec/support/acceptance/session.rb
+++ b/spec/support/acceptance/session.rb
@@ -104,11 +104,11 @@ module Acceptance::Session
 
       case operator.to_sym
       when :==
-        evaluate_predicate(left_operand, environment) == evaluate_predicate(right_operand, environment)
+        self.eval_predicate(left_operand, environment) == self.eval_predicate(right_operand, environment)
       when :!=
-        evaluate_predicate(left_operand, environment) != evaluate_predicate(right_operand, environment)
+        self.eval_predicate(left_operand, environment) != self.eval_predicate(right_operand, environment)
       when :or
-        evaluate_predicate(left_operand, environment) || evaluate_predicate(right_operand, environment)
+        self.eval_predicate(left_operand, environment) || self.eval_predicate(right_operand, environment)
       else
         raise "unexpected operator #{operator.inspect}"
       end


### PR DESCRIPTION
Resolve method undefined issue - this method is recursive, but the method got renamed. It supports this capability in the acceptance tests layer, but it wasn't needed in the end as it was entirely flakey across all payloads

```diff
-              ["[-] FAILED: [UDP] Receives data from the peer", { if: [:meterpreter_runtime_version, :==, "php5.3"] }],
+              ["[-] FAILED: [UDP] Receives data from the peer", { flaky: true }],
```

## Verification

Ensure CI passes