### PR TITLE
Add more specific error messages

### DIFF
--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -192,7 +192,7 @@ jobs:
           ref: ${{ inputs.metasploit_framework_commit }}
 
       # https://github.com/orgs/community/discussions/26952
-      - name: Support longpaths
+      - name: Support longpaths when running on Windows
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -138,7 +138,7 @@ class Library
     when ARCH_X86
       native = 'V'
     else
-      raise NotImplementedError, 'Unsupported architecture (must be ARCH_X86 or ARCH_X64)'
+      raise NotImplementedError, 'Unsupported architecture for railgun (must be ARCH_X86 or ARCH_X64)'
     end
 
     # We transmit the immediate stack and three heap-buffers:
@@ -285,7 +285,7 @@ class Library
     when ARCH_X86
       native = 'V'
     else
-      raise NotImplementedError, 'Unsupported architecture (must be ARCH_X86 or ARCH_X64)'
+      raise NotImplementedError, 'Unsupported architecture for railgun (must be ARCH_X86 or ARCH_X64)'
     end
 
     rec_inout_buffers = packet.get_tlv_value(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_INOUT)


### PR DESCRIPTION
This preserves a couple of small changes from #20729 that updates some messages to be a little more clear. No functional changes. Since I force pushed to this branch to drop the now irrelevant commits, GitHub won't let the original PR be opened. This is also significantly different from the original intention, so here it is in a new PR.