### PR TITLE
Fix Kerberos Base Service Authenticator

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -712,9 +712,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       etype: etypes,
       options: ticket_options,
 
-      impersonate: options[:impersonate],
-      nonce: options[:nonce],
-
       # Specify nil to ensure the KDC uses the current time for the desired starttime of the requested ticket
       from: nil,
       till: expiry_time,
@@ -723,6 +720,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       # certificate time
       ctime: now
     }
+    tgs_body_options[:impersonate] = options[:impersonate] if options[:impersonate].present?
+    tgs_body_options[:nonce] = options[:nonce] if options[:nonce].present?
+
     if options[:additional_tickets].present?
       additional_tickets = options[:additional_tickets]
       additional_tickets = [additional_tickets] unless additional_tickets.is_a?(::Enumerable)
@@ -730,9 +730,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     end
 
     tgs_options = {
-      nonce: options[:nonce],
-      impersonate: options[:impersonate] ,
-      impersonate_type: options[:impersonate_type],
       session_key: session_key,
       subkey: nil,
       checksum: nil,
@@ -743,6 +740,11 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
 
       body: build_tgs_request_body(**tgs_body_options)
     }
+
+    tgs_options[:nonce] = tgs_options[:nonce] if options[:nonce].present?
+    tgs_options[:impersonate] = tgs_options[:impersonate] if options[:impersonate].present?
+    tgs_options[:impersonate_type] = tgs_options[:impersonate_type] if options[:impersonate_type].present?
+
     if options[:pa_data].present?
       pa_data = options[:pa_data].is_a?(::Enumerable) ? options[:pa_data] : [options[:pa_data]]
       tgs_options[:pa_data] = pa_data
@@ -854,7 +856,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def authenticate_via_krb5_ccache_credential_tgt(credential, options = {})
     realm = self.realm.upcase
     sname = options.fetch(:sname)
-    nonce = options.fetch(:nonce)
+    nonce = options.fetch(:nonce, nil)
     client_name = username
 
     now = Time.now.utc
@@ -869,9 +871,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     etypes = Set.new([credential.keyblock.enctype.value])
     tgs_options = {
       pa_data: [],
-      ticket_storage: ticket_storage,
-      nonce: nonce
+      ticket_storage: ticket_storage
     }
+    tgs_options[:nonce] = nonce if nonce
 
     tgs_ticket, tgs_auth, credential = request_service_ticket(
       session_key,


### PR DESCRIPTION
Multiple parameters were added to the `tgs_options` and `tgs_body_options` to facilitate authentication when impersonating a dMSA account. When those values were not set, the parameters were still being sent as a part of the request as `nil` values. This was cause the authentication attempt to fail. This fixes that issue by only sending the parameters if they set. 

## Verification
Run the `adcs.feature` cucumber test locally or verify that the excerpt from my local run looks correct. I couldn't include the full test output as it was too long, max body length is 65536 characters.
```
➜  ui git:(master) ✗ bundle exec cucumber features/adcs.feature
Using the default profile...
Feature: AD CS vulnerabilities
  Check if the certificate templates available on the AD CS server are vulnerable to the ESC's vulnerabilities
  and exploits the ESC1, ESC2, ESC3, ESC4, ESC9, ESC10, ESC13 and ESC16 vulnerabilities.
  It also check the Shadow Credentials vulnerablity.

  Background:                                              # features/adcs.feature:6
[database-cleaner] start
[database-cleaner] start finished
Capybara starting Puma...
* Version 6.6.1 , codename: Return to Forever
* Min threads: 0, max threads: 1
* Listening on http://127.0.0.1:57434
    Given I have a user "TestUser"                         # features/step_definitions/login_steps.rb:8
    And The "TestUser" has a workspace called "ADCS"       # features/step_definitions/workspace_steps.rb:8
    And I am logged in as a Metasploit Pro user "TestUser" # features/step_definitions/login_steps.rb:75

  @vulntarget
  Scenario: Starting an LDAP session with a pkcs12 certificate                                                     # features/adcs.feature:12
2026-01-16 12:35:04 -0800: The instance with ID 'i-03941b32f9f7ffe15' is 'running'.
2026-01-16 12:35:04 -0800: Pinging with command nc -v -z -w 2 10.140.10.208 22
2026-01-16 12:35:04 -0800: Connection to 10.140.10.208 port 22 [tcp/ssh] succeeded!
    Given I find the "windows_server_2022_domain_controller" vm target                                             # features/step_definitions/vsphere_steps.rb:25
      pre-discovery not needed for 10.140.10.208
    When I goto the "ADCS" project                                                                                 # features/step_definitions/workspace_steps.rb:34
    # issue icpr cert
    And I go to the module run page for "/auxiliary/admin/dcerpc/icpr_cert" in the "ADCS" workspace                # features/step_definitions/workspace_steps.rb:111
    When I fill in the "Target Addresses" field with the "windows_server_2022_domain_controller" vm target address # features/step_definitions/fill_in_steps.rb:167
    
    <redacted>
   
[database-cleaner] clean
[database-cleaner] cleaned

11 scenarios (11 passed)
356 steps (356 passed)
9m3.810s
```