### PR TITLE
Add validate_options check for IMPERSONATE and IMPERSONATE_TYPE in get_ticket

### DIFF
--- a/modules/auxiliary/admin/kerberos/get_ticket.rb
+++ b/modules/auxiliary/admin/kerberos/get_ticket.rb
@@ -134,6 +134,10 @@ class MetasploitModule < Msf::Auxiliary
     if datastore['SPN'].present? && !datastore['SPN'].match(%r{.+/.+})
       fail_with(Failure::BadConfig, 'SPN format must be service_name/FQDN (ex: cifs/dc01.mydomain.local)')
     end
+
+    if datastore['IMPERSONATE'].present? && datastore['IMPERSONATE_TYPE'] == 'none'
+      fail_with(Failure::BadConfig, 'IMPERSONATE_TYPE must be set to "generic", "dmsa" or "auto" when IMPERSONATE is provided')
+    end
   end
 
   def run


### PR DESCRIPTION
This PR adds a check to the `validate_config` method of the `get_ticket` module. If the `IMPERSONATE` datastore option is present, ensure that the `IMPERSONATE_TYPE` datastore option is not set to `none`
