### PR TITLE
Mark additional flakey socket tests

### DIFF
--- a/spec/acceptance/meterpreter_spec.rb
+++ b/spec/acceptance/meterpreter_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe 'Meterpreter' do
   # Tests to ensure that Meterpreter is consistent across all implementations/operation systems
   METERPRETER_PAYLOADS = Acceptance::Session.with_session_name_merged(
     {
-      python: Acceptance::Session::PYTHON_METERPRETER,
-      php: Acceptance::Session::PHP_METERPRETER,
-      java: Acceptance::Session::JAVA_METERPRETER,
-      mettle: Acceptance::Session::METTLE_METERPRETER,
-      windows_meterpreter: Acceptance::Session::WINDOWS_METERPRETER
+      python: Acceptance::Session::Python::PYTHON_METERPRETER,
+      php: Acceptance::Session::Php::PHP_METERPRETER,
+      java: Acceptance::Session::Java::JAVA_METERPRETER,
+      mettle: Acceptance::Session::Mettle::METTLE_METERPRETER,
+      windows_meterpreter: Acceptance::Session::WindowsMeterpreter::WINDOWS_METERPRETER
     }
   )
 

--- a/spec/support/acceptance/session/java.rb
+++ b/spec/support/acceptance/session/java.rb
@@ -1,4 +1,6 @@
-module Acceptance::Session
+require_relative './shared'
+
+module Acceptance::Session::Java
   JAVA_METERPRETER = {
     payloads: [
       {
@@ -243,17 +245,20 @@ module Acceptance::Session
         lines: {
           linux: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }
         }

--- a/spec/support/acceptance/session/mettle.rb
+++ b/spec/support/acceptance/session/mettle.rb
@@ -1,4 +1,6 @@
-module Acceptance::Session
+require_relative './shared'
+
+module Acceptance::Session::Mettle
   METTLE_METERPRETER = {
     payloads: [
       {
@@ -325,17 +327,20 @@ module Acceptance::Session
         lines: {
           linux: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
               known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }
         }

--- a/spec/support/acceptance/session/php.rb
+++ b/spec/support/acceptance/session/php.rb
@@ -1,4 +1,6 @@
-module Acceptance::Session
+require_relative './shared'
+
+module Acceptance::Session::Php
   PHP_METERPRETER = {
     payloads: [
       {
@@ -264,7 +266,8 @@ module Acceptance::Session
               "[-] [[TCP-Server] Propagates close events to the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1",
               "[-] [[TCP-Server] Propagates close events from the peer] FAILED: [TCP-Server] Propagates close events from the peer",
               "[-] [[TCP-Server] Propagates close events from the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1",
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
@@ -285,7 +288,8 @@ module Acceptance::Session
               "[-] [[TCP-Server] Propagates close events to the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1",
               "[-] [[TCP-Server] Propagates close events from the peer] FAILED: [TCP-Server] Propagates close events from the peer",
               "[-] [[TCP-Server] Propagates close events from the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1",
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
@@ -307,7 +311,7 @@ module Acceptance::Session
               "[-] [[TCP-Server] Propagates close events from the peer] FAILED: [TCP-Server] Propagates close events from the peer",
               "[-] [[TCP-Server] Propagates close events from the peer] Exception: Rex::Post::Meterpreter::RequestError: core_channel_open: Operation failed: 1",
               "[-] FAILED: [UDP] Has the correct peer information",
-              ["[-] FAILED: [UDP] Receives data from the peer", { flaky: true }],
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }
         }

--- a/spec/support/acceptance/session/python.rb
+++ b/spec/support/acceptance/session/python.rb
@@ -1,4 +1,6 @@
-module Acceptance::Session
+require_relative './shared'
+
+module Acceptance::Session::Python
   PYTHON_METERPRETER = {
     payloads: [
       {
@@ -260,17 +262,20 @@ module Acceptance::Session
         lines: {
           linux: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }
         }

--- a/spec/support/acceptance/session/shared.rb
+++ b/spec/support/acceptance/session/shared.rb
@@ -1,0 +1,7 @@
+module Acceptance::Session::Shared
+    # TODO: Should be resolved
+    SOCKET_CHANNEL_FLAKES = [
+        ["[-] FAILED: [UDP] Receives data from the peer", { flaky: true }],
+        ["[-] FAILED: [TCP-Server] Propagates close events to the server", { flaky: true }]
+    ]
+end

--- a/spec/support/acceptance/session/windows_meterpreter.rb
+++ b/spec/support/acceptance/session/windows_meterpreter.rb
@@ -1,4 +1,6 @@
-module Acceptance::Session
+require_relative './shared'
+
+module Acceptance::Session::WindowsMeterpreter
   WINDOWS_METERPRETER = {
     payloads: [
       {
@@ -365,14 +367,19 @@ module Acceptance::Session
         skipped: false,
         lines: {
           linux: {
-            known_failures: []
+            known_failures: [
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
+            ]
           },
           osx: {
-            known_failures: []
+            known_failures: [
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
+            ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information"
+              "[-] FAILED: [UDP] Has the correct peer information",
+              *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }
         }


### PR DESCRIPTION

Ticket to resolve the underlying issue: https://github.com/rapid7/metasploit-framework/issues/20892 - I haven't dug deeper into these issues, I believe @zeroSteiner had planned to do this after the test suite is passing first

Mark additional flakey socket tests which are present in the other meterpreters (or test implementation) and centralize the configuration

```
  1) Meterpreter windows_meterpreter staged windows/x64/meterpreter/reverse_tcp windows post/test/socket_channels windows/windows_meterpreter meterpreter successfully opens a session for the "windows/x64/meterpreter/reverse_tcp" payload and passes the "post/test/socket_channels" tests
     Failure/Error: expect(test_line).to_not include('FAILED', '[-] FAILED', '[-] Exception', '[-] '), "Unexpected error: #{test_line}"
       Unexpected error: [-] FAILED: [TCP-Server] Propagates close events to the server
```


## Verification

Ensure CI passes