### PR TITLE
ensured: MsTdsLogin7 UTF-18 fields use RubySMB String16

### DIFF
--- a/lib/msf/core/post/windows/file_system.rb
+++ b/lib/msf/core/post/windows/file_system.rb
@@ -28,16 +28,6 @@ module Msf
           )
         end
 
-        class String16 < BinData::String
-          def assign(val)
-            super(val.encode('utf-16le'))
-          end
-
-          def snapshot
-            super.force_encoding('utf-16le')
-          end
-        end
-
         class UnicodeString < BinData::Record
           endian :little
 


### PR DESCRIPTION
Fixes: #20874 

This change ensures MsTdsLogin7 UTF‑16 buffer fields are represented as RubySMB::Field::String16 objects rather than raw strings. It updates buffer field handling to use the RubySMB String16 class for UTF‑16 fields and makes the buffer parsing logic work with both registered symbols and class types.


All Tests Pass
```bash
bundle exec rspec --seed 10152 spec/lib/rex/proto/ms_tds/ms_tds_login7_spec.rb spec/api/json_rpc_spec.rb 
```

Output
```bash
Overriding user environment variable 'OPENSSL_CONF' to enable legacy functions.
Run options:
  include {:focus=>true}
  exclude {:acceptance=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 10152
Metasploit's json-rpc ...............
Rex::Proto::MsTds::MsTdsLogin7 .......................................

Top 10 slowest examples (57.83 seconds, 98.1% of total time):
  Metasploit's json-rpc analyze when there are modules available with no options returns the list of known modules associated with a reported host
    30.1 seconds ./spec/api/json_rpc_spec.rb:456
  Metasploit's json-rpc analyze when there are modules available when payloads requirements are specified returns the list of known modules associated with a reported host
    24.08 seconds ./spec/api/json_rpc_spec.rb:516
  Metasploit's json-rpc health status when using the REST health check functionality passes the health check
    1.11 seconds ./spec/api/json_rpc_spec.rb:129
  Metasploit's json-rpc Running a check job and verifying results when the module returns check code safe returns successful job results
    0.69375 seconds ./spec/api/json_rpc_spec.rb:209
  Metasploit's json-rpc Running a check job and verifying results when the check command raises a known msf error returns the error results
    0.67201 seconds ./spec/api/json_rpc_spec.rb:268
  Metasploit's json-rpc Running a check job and verifying results when the check command has an unexpected error returns the error results
    0.67008 seconds ./spec/api/json_rpc_spec.rb:301
  Metasploit's json-rpc analyze when there are no modules found returns an empty list of modules
    0.32274 seconds ./spec/api/json_rpc_spec.rb:588
  Metasploit's json-rpc health status when using the RPC health check functionality when there is an issue fails the health check
    0.06814 seconds ./spec/api/json_rpc_spec.rb:183
  Metasploit's json-rpc health status when using the RPC health check functionality when the service is healthy passes the health check
    0.0567 seconds ./spec/api/json_rpc_spec.rb:163
  Metasploit's json-rpc Running a check job and verifying results when the module does not support a check method returns successful job results
    0.05419 seconds ./spec/api/json_rpc_spec.rb:244

Top 2 slowest example groups:
  Metasploit's json-rpc
    3.9 seconds average (58.49 seconds / 15 examples) ./spec/api/json_rpc_spec.rb:10
  Rex::Proto::MsTds::MsTdsLogin7
    0.01151 seconds average (0.44904 seconds / 39 examples) ./spec/lib/rex/proto/ms_tds/ms_tds_login7_spec.rb:1

Finished in 58.95 seconds (files took 10.7 seconds to load)
54 examples, 0 failures

Randomized with seed 10152
Coverage report generated for RSpec to /Users/apple/Desktop/metasploit-framework/coverage.
Line Coverage: 34.52% (29563 / 85647)
```