### PR TITLE
Handle SSH login success when shell creation fails

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -276,7 +276,12 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         if datastore['CreateSession']
-          session_setup(result, scanner, used_key: true)
+          begin
+            session_setup(result, scanner, used_key: true)
+          rescue StandardError => e
+            elog('Failed to setup the session', error: e)
+            print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
+          end
         end
         if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
           msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'


### PR DESCRIPTION
Fixes: #20854 
This change prevents auxiliary/scanner/ssh/ssh_login from treating a successful key authentication as a failure when a command shell cannot be created . The module now cleanly logs the session setup error without raising a stack trace so the successful login can still be recorded.

Local test setup:

1) Build a local SSH server that accepts keys but denies shell:

```bash
rm -rf /tmp/ssh-nosh
mkdir -p /tmp/ssh-nosh

ssh-keygen -t ed25519 -f /tmp/ssh-nosh/id_ed25519 -N ""
cat /tmp/ssh-nosh/id_ed25519.pub > /tmp/ssh-nosh/authorized_keys

cat <<'EOF' > /tmp/ssh-nosh/sshd_config
Port 2222
Protocol 2
PubkeyAuthentication yes
AuthorizedKeysFile .ssh/authorized_keys
PermitRootLogin no
PasswordAuthentication no
KbdInteractiveAuthentication no
ChallengeResponseAuthentication no
UsePAM no
AllowUsers git
ForceCommand /usr/bin/false
LogLevel VERBOSE
Subsystem sftp /usr/lib/openssh/sftp-server
EOF

cat <<'EOF' > /tmp/ssh-nosh/Dockerfile
FROM ubuntu:22.04
RUN apt-get update && apt-get install -y openssh-server && mkdir /var/run/sshd
RUN useradd -m -s /bin/bash git && passwd -d git && usermod -U git
RUN mkdir -p /home/git/.ssh
COPY authorized_keys /home/git/.ssh/authorized_keys
COPY sshd_config /etc/ssh/sshd_config
RUN chmod 700 /home/git/.ssh && chmod 600 /home/git/.ssh/authorized_keys && chown -R git:git /home/git/.ssh
EXPOSE 2222
CMD ["/usr/sbin/sshd","-D","-e"]
EOF

docker build -t ssh-nosh /tmp/ssh-nosh
docker run --rm -p 2222:2222 ssh-nosh
```
2. Verify auth succeeds but shell is denied:
```bash
ssh -i /tmp/ssh-nosh/id_ed25519 -p 2222 git@127.0.0.1 -vvv
```
3. Test in Metasploit:
```bash
use auxiliary/scanner/ssh/ssh_login
set RHOSTS 127.0.0.1
set RPORT 2222
set USERNAME git
set PRIVATE_KEY file:/tmp/ssh-nosh/id_ed25519
set CreateSession true
run
```
Expected: auth success is logged, session creation failure is handled cleanly with no stack trace.