### PR TITLE
Fix enum_user_directories Duplicate Directories

### DIFF
--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -89,9 +89,9 @@ module Msf::Post::Unix
     # the users aren't in /etc/passwd (LDAP, for example)
     case session.platform
     when 'osx'
-      user_dirs << cmd_exec('ls /Users').each_line.map { |l| "/Users/#{l}" }
+      user_dirs << cmd_exec('ls /Users').each_line.map { |l| "/Users/#{l.chomp}" }
     else
-      user_dirs << cmd_exec('ls /home').each_line.map { |l| "/home/#{l}" }
+      user_dirs << cmd_exec('ls /home').each_line.map { |l| "/home/#{l.chomp}" }
     end
 
     user_dirs.flatten!


### PR DESCRIPTION
This first part of #enum_user_directories parses `/etc/passwd` and adds for example `/home/msfuser` to the `user_dirs` array. 
```
    passwd = '/etc/passwd'
    if file_exist?(passwd)
      read_file(passwd).each_line do |passwd_line|
        user_dirs << passwd_line.split(':')[5]
      end
    end
```

The second part #enum_user_directories runs the `cmd_exec` command below and adds for example`/home/msfuser\n` to the `user_dirs` array. Every directory contains a new line at the end of the string except for the last entry, which is why we've added `.chomp` so that the duplicate entries will now get removed by the `.uniq` call at the end of the method. 
```
user_dirs << cmd_exec('ls /home').each_line.map { |l| "/home/#{l.chomp}" }
```


## Verification

Test this in isolation or run a post module such as the new `ssh_key` persistence module which calls #enum_user_directories to see how it was evaluating some home directories twice before this fix.  Note this wasn't causing issues but figured it should be corrected. 