### PR TITLE
Add the action file to add the PRs to the project

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,0 +1,19 @@
+name: Add pull request to the kanban board
+
+on:
+  pull_request:
+    types:
+       - opened
+       - reopened
+
+jobs:
+  add-to-project:
+    name: Add pull request to the kanban board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/rapid7/projects/17
+          # smcintyre/GITHUB_PROJECT_TOKEN (PAT), Expires on Wed, Jan 27 2027
+          github-token: ${{ secrets.GH_PROJECT_TOKEN }}
+

--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,7 +1,7 @@
 name: Add pull request to the kanban board
 
 on:
-  pull_request:
+  pull_request_target:
     types:
        - opened
        - reopened


### PR DESCRIPTION
Replaces #20904. It should run this time because the PR branch is coming from the same repo and not a fork. The intention is to add all opened and reopened PRs to the primary kanban board for tracking.