### PR TITLE
Fix SSH command shells dying on cmd_exec with trailing newline

### DIFF
--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -145,7 +145,7 @@ module SingleCommandShell
 
     # Send the command to the session's stdin.
     delimiter = "echo #{token}"
-    if cmd.strip.end_with?(command_separator)
+    if cmd.match?(/\r?\n\z/) || cmd.strip.end_with?(command_separator)
       # This command already ends with a delimiter - don't need to add another one
       shell_data = cmd + "#{delimiter}#{command_termination}"
     else

--- a/spec/lib/msf/core/session/provider/single_command_shell_spec.rb
+++ b/spec/lib/msf/core/session/provider/single_command_shell_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Session::Provider::SingleCommandShell do
+  class DummySingleCommandShell
+    include Msf::Session::Provider::SingleCommandShell
+
+    attr_reader :writes
+
+    def initialize
+      @writes = []
+    end
+
+    def platform
+      'linux'
+    end
+
+    def shell_init
+      true
+    end
+
+    def shell_read(*)
+      nil
+    end
+
+    def shell_write(buf)
+      @writes << buf
+    end
+
+    def shell_close
+      true
+    end
+
+    def shell_read_until_token(_token, _wanted_idx = 0, _timeout = 10)
+      ''
+    end
+  end
+
+  describe '#shell_command_token_base' do
+    it 'does not inject a separator after a trailing newline' do
+      shell = DummySingleCommandShell.new
+
+      shell.shell_command_token_base("id\n", 1, ';')
+
+      expect(shell.writes.last).not_to match(/\n;/)
+    end
+  end
+end


### PR DESCRIPTION
Fixes: #20642 

## Summary
- Treat a trailing newline as an explicit command terminator in SingleCommandShell token execution.
- Prevents SSH command shells from injecting a separator after a newline, which could terminate non‑PTY sessions.
- Adds a small spec for the newline case.

Local Test Setup
1) Build a minimal SSH server:
```bash
   rm -rf /tmp/ssh-nosh
   mkdir -p /tmp/ssh-nosh

   ssh-keygen -t ed25519 -f /tmp/ssh-nosh/id_ed25519 -N ""
   cat /tmp/ssh-nosh/id_ed25519.pub > /tmp/ssh-nosh/authorized_keys

   cat <<'EOF' > /tmp/ssh-nosh/sshd_config
   Port 2222
   Protocol 2
   PubkeyAuthentication yes
   AuthorizedKeysFile .ssh/authorized_keys
   PermitRootLogin no
   PasswordAuthentication no
   KbdInteractiveAuthentication no
   ChallengeResponseAuthentication no
   UsePAM no
   AllowUsers git
   LogLevel VERBOSE
   Subsystem sftp /usr/lib/openssh/sftp-server
   EOF

   cat <<'EOF' > /tmp/ssh-nosh/Dockerfile
   FROM ubuntu:22.04
   RUN apt-get update && apt-get install -y openssh-server && mkdir /var/run/sshd
   RUN useradd -m -s /bin/bash git && passwd -d git && usermod -U git
   RUN mkdir -p /home/git/.ssh
   COPY authorized_keys /home/git/.ssh/authorized_keys
   COPY sshd_config /etc/ssh/sshd_config
   RUN chmod 700 /home/git/.ssh && chmod 600 /home/git/.ssh/authorized_keys && chown -R git:git /home/git/.ssh
   EXPOSE 2222
   CMD ["/usr/sbin/sshd","-D","-e"]
   EOF

   docker build -t ssh-nosh /tmp/ssh-nosh
   docker run --rm -p 2222:2222 ssh-nosh
```

2) In msfconsole:
```bash
   use auxiliary/scanner/ssh/ssh_login
   set RHOSTS 127.0.0.1
   set RPORT 2222
   set USERNAME git
   set PRIVATE_KEY file:/tmp/ssh-nosh/id_ed25519
   set CreateSession true
   run
   sessions -i <id>
   irb
   self.shell_command_token("id\n")
```

## Expected behavior
- The command runs and the SSH session remains alive.
- Prior to this change, the trailing newline could terminate the session.
