### PR TITLE
Align login scanner APIs

### DIFF
--- a/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
+++ b/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
@@ -10,6 +10,11 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
+        # Checks if the target is Advantech WebAccess
+        #
+        # @return [false] Indicates there were no errors
+        # @return [String] a human-readable error message describing why
+        #   this scanner can't run
         def check_setup
           uri = normalize_uri("#{uri}broadWeb/bwRoot.asp")
 
@@ -19,10 +24,10 @@ module Metasploit
           })
 
           if res && res.body =~ /Welcome to Advantech WebAccess/i
-            return true
+            return false
           end
 
-          false
+          'Unable to locate "Welcome to Advantech WebAccess" in body. (Is this really Advantech WebAccess?)'
         end
 
         def do_login(user, pass)

--- a/lib/metasploit/framework/login_scanner/caidao.rb
+++ b/lib/metasploit/framework/login_scanner/caidao.rb
@@ -11,9 +11,11 @@ module Metasploit
         PRIVATE_TYPES      = [ :password ]
         LOGIN_STATUS       = Metasploit::Model::Login::Status # Shorter name
 
-        # Checks if the target is Caidao Backdoor. The login module should call this.
+        # Checks if the target is correct
         #
-        # @return [Boolean] TrueClass if target is Caidao, otherwise FalseClass
+        # @return [false] Indicates there were no errors
+        # @return [String] a human-readable error message describing why
+        #   this scanner can't run
         def check_setup
           @flag ||= Rex::Text.rand_text_alphanumeric(4)
           @lmark ||= Rex::Text.rand_text_alphanumeric(4)
@@ -22,7 +24,7 @@ module Metasploit
           case uri
           when /php$/mi
             @payload = "$_=\"#{@flag}\";echo \"#{@lmark}\".$_.\"#{@rmark}\";"
-            return true
+            return false
           when /asp$/mi
             @payload = 'execute("response.write(""'
             @payload << "#{@lmark}"
@@ -31,14 +33,14 @@ module Metasploit
             @payload << '""):response.write(""'
             @payload << "#{@rmark}"
             @payload << '""):response.end")'
-            return true
+            return false
           when /aspx$/mi
             @payload = "Response.Write(\"#{@lmark}\");"
             @payload << "Response.Write(\"#{@flag}\");"
             @payload << "Response.Write(\"#{@rmark}\")"
-            return true
+            return false
           end
-          false
+          "Unable to locate target extension in uri. (Is this really caidao?)"
         end
 
         def set_sane_defaults

--- a/lib/metasploit/framework/login_scanner/cisco_firepower.rb
+++ b/lib/metasploit/framework/login_scanner/cisco_firepower.rb
@@ -18,10 +18,10 @@ module Metasploit
           })
 
           if res && res.code == 200 && res.body.include?('/img/favicon.png?v=6.0.1-1213')
-            return true
+            return false
           end
 
-          false
+          'Unable to locate favicon in body. (Is this really CiscoFirepower?)'
         end
 
         def do_login(cred)

--- a/lib/metasploit/framework/login_scanner/directadmin.rb
+++ b/lib/metasploit/framework/login_scanner/directadmin.rb
@@ -10,18 +10,20 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
 
 
-        # Checks if the target is Direct Admin Web Control Panel. The login module should call this.
+        # Checks if the target is correct
         #
-        # @return [Boolean] TrueClass if target is DAWCP, otherwise FalseClass
+        # @return [false] Indicates there were no errors
+        # @return [String] a human-readable error message describing why
+        #   this scanner can't run
         def check_setup
           login_uri = normalize_uri("#{uri}/CMD_LOGIN")
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('DirectAdmin Login')
-            return true
+            return false
           end
 
-          false
+          'Unable to locate "DirectAdmin Login" in body. (Is this really DirectAdmin?)'
         end
 
 

--- a/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
+++ b/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
@@ -14,18 +14,20 @@ module Metasploit
 
         # Checks if the target is ManageEngine Desktop Central.
         #
-        # @return [Boolean] TrueClass if target is MSP, otherwise FalseClass
+        # @return [false] Indicates there were no errors
+        # @return [String] a human-readable error message describing why
+        #   this scanner can't run
         def check_setup
           login_uri = normalize_uri("#{uri}/configurations.do")
           res = send_request({'uri' => login_uri})
 
-          if res && res.body.include?('ManageEngine Desktop Central')
-            return true
+          fingerprint = 'ManageEngine Desktop Central'
+          if res && res.body.include?(fingerprint)
+            return false
           end
 
-          false
+          "Unable to locate \"#{fingerprint}\" in body. (Is this really ManageEngine Desktop Central?)"
         end
-
 
         # Returns the latest sid from MSP
         #

--- a/lib/metasploit/framework/login_scanner/nessus.rb
+++ b/lib/metasploit/framework/login_scanner/nessus.rb
@@ -13,17 +13,19 @@ module Metasploit
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
 
-        # Checks if the target is a Tenable Nessus server.
+        # Checks if the target is correct
         #
-        # @return [Boolean] TrueClass if target is Nessus server, otherwise FalseClass
+        # @return [false] Indicates there were no errors
+        # @return [String] a human-readable error message describing why
+        #   this scanner can't run
         def check_setup
           login_uri = "/server/properties"
           res = send_request({'uri'=> login_uri})
           if res && res.body.include?('Nessus')
-            return true
+            return false
           end
 
-          false
+          'Unable to locate "Nessus" in body. (Is this really Nessus?)'
         end
 
         # Actually doing the login. Called by #attempt_login

--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -9,17 +9,17 @@ module Metasploit
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
         def check_setup
-          version = "Not Detected"
           res = send_request({ 'uri' => uri })
 
-          if res && res.body.include?('phpMyAdmin')
-            if res.body =~ /PMA_VERSION:"(\d+\.\d+\.\d+)"/
-              version = Rex::Version.new($1)
+          if res && res.body.include?('phpMyAdmin') && res.body =~ /PMA_VERSION:"(\d+\.\d+\.\d+)"/
+            version = Rex::Version.new($1).to_s
+            if version.present?
+              framework_module.print_status("PhpMyAdmin Version: #{version}") if framework_module
+              return false
             end
-            return version.to_s
           end
 
-          false
+          'Unable to locate "phpMyAdmin" and "PMA_VERSION" in body. (Is this really PhpMyAdmin?)'
         end
 
         def get_session_info

--- a/lib/metasploit/framework/login_scanner/softing_sis.rb
+++ b/lib/metasploit/framework/login_scanner/softing_sis.rb
@@ -25,7 +25,7 @@ module Metasploit
             # if we successfully get the version
             if res_json['version']
               # report the version
-              print_brute(level: :good, ip: ip, msg: "Softing Secure Integration Server #{res_json['version']}")
+              framework_module.print_brute(level: :good, ip: ip, msg: "Softing Secure Integration Server #{res_json['version']}") if framework_module
               return false
             end
           end

--- a/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
+++ b/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
@@ -12,18 +12,20 @@ module Metasploit
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
 
-        # Checks if the target is Symantec Web Gateway. The login module should call this.
+        # Checks if the target is correct
         #
-        # @return [Boolean] TrueClass if target is SWG, otherwise FalseClass
+        # @return [false] Indicates there were no errors
+        # @return [String] a human-readable error message describing why
+        #   this scanner can't run
         def check_setup
           login_uri = normalize_uri("#{uri}/spywall/login.php")
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('Symantec Web Gateway')
-            return true
+            return false
           end
 
-          false
+          'Unable to locate "Symantec Web Gateway" in body. (Is this really Symantec Web Gateway?)'
         end
 
 

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -10,18 +10,20 @@ module Metasploit
         PRIVATE_TYPES = [ :password ].freeze
         LOGIN_STATUS = Metasploit::Model::Login::Status # Shorter name
 
-        # Checks if the target is Syncovery File Sync & Backup Software. The login module should call this.
+        # Checks if the target is correct
         #
-        # @return [Boolean] TrueClass if target is Syncovery, otherwise FalseClass
+        # @return [false] Indicates there were no errors
+        # @return [String] a human-readable error message describing why
+        #   this scanner can't run
         def check_setup
           login_uri = normalize_uri("#{uri}/")
           res = send_request({ 'uri' => login_uri })
 
           if res && res.code == 200 && res.body.include?('Syncovery')
-            return true
+            return false
           end
 
-          false
+          'Unable to locate "Syncovery" in body. (Is this really Syncovery?)'
         end
 
         # Gets the Syncovery version.

--- a/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
+++ b/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
@@ -15,7 +15,7 @@ module Metasploit
         def check_setup
           res = send_request({ 'uri' => normalize_uri('/enginemanager/login.htm') })
 
-          if res && res.body.include?('Wowza Streaming Engine Manager')
+          if res && res.code == 200 && res.body.include?('Wowza Streaming Engine Manager')
             return false
           end
 

--- a/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
+++ b/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
@@ -15,10 +15,11 @@ module Metasploit
         def check_setup
           res = send_request({ 'uri' => normalize_uri('/enginemanager/login.htm') })
 
-          return false unless res
-          return false unless res.code == 200
+          if res && res.body.include?('Wowza Streaming Engine Manager')
+            return false
+          end
 
-          res.body.include?('Wowza Streaming Engine Manager')
+          'Unable to locate "Wowza Streaming Engine Manager" in body. (Is this really Wowza Streaming Engine Manager?)'
         end
 
         #

--- a/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
+++ b/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if datastore['TRYDEFAULT']
-        print_status("Default credential admin:[empty] added to the credential queue for testing.")
+        print_status('Default credential admin:[empty] added to the credential queue for testing.')
         cred_collection.add_public('admin')
         cred_collection.add_private('')
       end
@@ -80,11 +80,11 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: :password,
-      username: result.credential.public,
+      username: result.credential.public
     }.merge(service_data)
 
     login_data = {
@@ -115,13 +115,13 @@ class MetasploitModule < Msf::Auxiliary
     scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
         report_good_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         report_bad_cred(ip, rport, result)
       end
     end
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     msg = scanner(ip).check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "Target is not Advantech WebAccess - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "Target is not Advantech WebAccess - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
+++ b/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
@@ -128,8 +128,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    unless scanner(ip).check_setup
-      print_brute(:level => :error, :ip => ip, :msg => 'Target is not Advantech WebAccess')
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "Target is not Advantech WebAccess - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
-      private_type: :password,
+      private_type: :password
     }.merge(service_data)
 
     login_data = {
@@ -119,13 +119,13 @@ class MetasploitModule < Msf::Auxiliary
     scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential.private}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential.private}'")
         report_good_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential.private}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential.private}'")
         report_bad_cred(ip, rport, result)
       end
     end
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     msg = scanner(ip).check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "Target is not caidao - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "Target is not Caidao or backdoor type is not supported - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -132,8 +132,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    unless scanner(ip).check_setup
-      print_brute(:level => :error, :ip => ip, :msg => 'Backdoor type is not support')
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "Target is not caidao - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/cisco_firepower_login.rb
+++ b/modules/auxiliary/scanner/http/cisco_firepower_login.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if datastore['TRYDEFAULT']
-        print_status("Default credential admin:Admin123 added to the credential queue for testing.")
+        print_status('Default credential admin:Admin123 added to the credential queue for testing.')
         cred_collection.add_public('admin')
         cred_collection.add_private('Admin123')
       end
@@ -83,11 +83,11 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: :password,
-      username: result.credential.public,
+      username: result.credential.public
     }.merge(service_data)
 
     login_data = {
@@ -118,13 +118,13 @@ class MetasploitModule < Msf::Auxiliary
     scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
         report_good_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         report_bad_cred(ip, rport, result)
       end
     end
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     msg = scanner(ip).check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "Target is not Cisco Firepower Management console - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "Target is not Cisco Firepower Management console - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/cisco_firepower_login.rb
+++ b/modules/auxiliary/scanner/http/cisco_firepower_login.rb
@@ -131,8 +131,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    unless scanner(ip).check_setup
-      print_brute(:level => :error, :ip => ip, :msg => 'Target is not Cisco Firepower Management console.')
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "Target is not Cisco Firepower Management console - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/directadmin_login.rb
+++ b/modules/auxiliary/scanner/http/directadmin_login.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'DefaultOptions' => {
           'RPORT' => 2222,
-          'SSL' => true,
+          'SSL' => true
         },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
@@ -69,17 +69,17 @@ class MetasploitModule < Msf::Auxiliary
     scanner(ip).scan! do |result|
       credential_data = result.to_h.merge({
         workspace_id: myworkspace_id,
-        module_fullname: self.fullname,
+        module_fullname: fullname
       })
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
         create_credential_and_login(credential_data)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         invalidate_login(credential_data)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         invalidate_login(credential_data)
       end
     end
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
-     msg = scanner(ip).check_setup
-     if msg
-       print_brute(:level => :error, :ip => ip, :msg => "Target is not DirectAdmin Web Control Panel - #{msg}")
-       return
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(level: :error, ip: ip, msg: "Target is not DirectAdmin Web Control Panel - #{msg}")
+      return
     end
 
     bruteforce(ip)

--- a/modules/auxiliary/scanner/http/directadmin_login.rb
+++ b/modules/auxiliary/scanner/http/directadmin_login.rb
@@ -87,9 +87,10 @@ class MetasploitModule < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
-    unless scanner(ip).check_setup
-      print_brute(:level => :error, :ip => ip, :msg => 'Target is not DirectAdmin Web Control Panel')
-      return
+     msg = scanner(ip).check_setup
+     if msg
+       print_brute(:level => :error, :ip => ip, :msg => "Target is not DirectAdmin Web Control Panel - #{msg}")
+       return
     end
 
     bruteforce(ip)

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -64,11 +64,11 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: :password,
-      username: result.credential.public,
+      username: result.credential.public
     }.merge(service_data)
 
     login_data = {
@@ -86,10 +86,10 @@ class MetasploitModule < Msf::Auxiliary
     @scanner.scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
         do_report(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         invalidate_login(
           address: ip,
           port: rport,
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Auxiliary
           proof: result.proof
         )
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         invalidate_login(
           address: ip,
           port: rport,
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
     init(ip)
     msg = @scanner.check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "Target is not ManageEngine Desktop Central - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "Target is not ManageEngine Desktop Central - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -121,8 +121,9 @@ class MetasploitModule < Msf::Auxiliary
   # Start here
   def run_host(ip)
     init(ip)
-    unless @scanner.check_setup
-      print_brute(:level => :error, :ip => ip, :msg => 'Target is not ManageEngine Desktop Central')
+    msg = @scanner.check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "Target is not ManageEngine Desktop Central - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/phpmyadmin_login.rb
+++ b/modules/auxiliary/scanner/http/phpmyadmin_login.rb
@@ -82,14 +82,14 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     msg = scanner(ip).check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "PhpMyAdmin is not available - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "PhpMyAdmin is not available - #{msg}")
       return
     end
 
     scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
         store_valid_credential(
           user: result.credential.public,
           private: result.credential.private,
@@ -104,10 +104,10 @@ class MetasploitModule < Msf::Auxiliary
           }
         )
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         report_bad_cred(ip, rport, result)
       end
     end

--- a/modules/auxiliary/scanner/http/phpmyadmin_login.rb
+++ b/modules/auxiliary/scanner/http/phpmyadmin_login.rb
@@ -80,13 +80,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    phpmyadmin_res = scanner(ip).check_setup
-    unless phpmyadmin_res
-      print_brute(:level => :error, :ip => ip, :msg => "PhpMyAdmin is not available")
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "PhpMyAdmin is not available - #{msg}")
       return
     end
-
-    print_status("PhpMyAdmin Version: #{phpmyadmin_res}")
 
     scanner(ip).scan! do |result|
       case result.status

--- a/modules/auxiliary/scanner/http/softing_sis_login.rb
+++ b/modules/auxiliary/scanner/http/softing_sis_login.rb
@@ -107,15 +107,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    softing_ver = scanner(ip).check_setup
-    # if we get "false", throw the error
-    unless softing_ver
-      print_brute(level: :error, ip: ip, msg: 'Target is not Softing Secure Integration Server')
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(level: :error, ip: ip, msg: "Target is not Softing Secure Integration Server - #{msg}")
       return
     end
 
-    # otherwise, report the version
-    print_brute(level: :good, ip: ip, msg: "Softing Secure Integration Server #{softing_ver}")
     bruteforce(ip)
   end
 

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'DefaultOptions' => {
           'RPORT' => 443,
-          'SSL' => true,
+          'SSL' => true
         },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
@@ -74,11 +74,11 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: :password,
-      username: result.credential.public,
+      username: result.credential.public
     }.merge(service_data)
 
     login_data = {
@@ -110,13 +110,13 @@ class MetasploitModule < Msf::Auxiliary
     scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        print_brute(level: :good, ip: ip, msg: "Success: '#{result.credential}'")
         report_good_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        vprint_brute(level: :verror, ip: ip, msg: result.proof)
         report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        vprint_brute(level: :verror, ip: ip, msg: "Failed: '#{result.credential}'")
         report_bad_cred(ip, rport, result)
       end
     end
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     msg = scanner(ip).check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "Target is not Symantec Web Gateway - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "Target is not Symantec Web Gateway - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -124,8 +124,9 @@ class MetasploitModule < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
-    unless scanner(ip).check_setup
-      print_brute(:level => :error, :ip => ip, :msg => 'Target is not Symantec Web Gateway')
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "Target is not Symantec Web Gateway - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/http/syncovery_linux_login.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_login.rb
@@ -128,11 +128,12 @@ class MetasploitModule < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
-    if scanner(ip).check_setup
-      vprint_brute(level: :good, ip: ip, msg: 'Syncovery File Sync & Backup Software confirmed')
-    else
-      print_brute(level: :error, ip: ip, msg: 'Target is not Syncovery File Sync & Backup Software')
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(level: :error, ip: ip, msg: "Target is not Syncovery File Sync & Backup Software - #{msg}")
       return
+    else
+      vprint_brute(level: :good, ip: ip, msg: 'Syncovery File Sync & Backup Software confirmed')
     end
 
     version = scanner(ip).get_version

--- a/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.rb
+++ b/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     msg = scanner(ip).check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "TWowza Streaming Engine Manager not found - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "TWowza Streaming Engine Manager not found - #{msg}")
     else
       vprint_brute(level: :good, ip: ip, msg: 'Found Wowza Streaming Engine Manager')
       return

--- a/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.rb
+++ b/modules/auxiliary/scanner/http/wowza_streaming_engine_manager_login.rb
@@ -122,10 +122,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    if scanner(ip).check_setup
-      vprint_brute(level: :good, ip: ip, msg: 'Found Wowza Streaming Engine Manager')
+    msg = scanner(ip).check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "TWowza Streaming Engine Manager not found - #{msg}")
     else
-      print_brute(level: :error, ip: ip, msg: 'Wowza Streaming Engine Manager not found')
+      vprint_brute(level: :good, ip: ip, msg: 'Found Wowza Streaming Engine Manager')
       return
     end
 

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => [ 'void_in' ],
         'License' => MSF_LICENSE,
         'DefaultOptions' => {
-          'SSL' => true,
+          'SSL' => true
         },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
@@ -76,11 +76,11 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       private_data: result.credential.private,
       private_type: :password,
-      username: result.credential.public,
+      username: result.credential.public
     }.merge(service_data)
 
     login_data = {
@@ -98,10 +98,10 @@ class MetasploitModule < Msf::Auxiliary
     @scanner.scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}'"
+        print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}'"
         do_report(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute :level => :verror, :ip => ip, :msg => result.proof
+        vprint_brute level: :verror, ip: ip, msg: result.proof
         invalidate_login(
           address: ip,
           port: rport,
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
           proof: result.proof
         )
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
+        vprint_brute level: :verror, ip: ip, msg: "Failed: '#{result.credential}'"
         invalidate_login(
           address: ip,
           port: rport,
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
 
     msg = @scanner.check_setup
     if msg
-      print_brute(:level => :error, :ip => ip, :msg => "Target is not a Tenable Nessus server - #{msg}")
+      print_brute(level: :error, ip: ip, msg: "Target is not a Tenable Nessus server - #{msg}")
       return
     end
 

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -133,8 +133,10 @@ class MetasploitModule < Msf::Auxiliary
   # Start here
   def run_host(ip)
     init(ip)
-    unless @scanner.check_setup
-      print_brute :level => :error, :ip => ip, :msg => 'Target is not a Tenable Nessus server'
+
+    msg = @scanner.check_setup
+    if msg
+      print_brute(:level => :error, :ip => ip, :msg => "Target is not a Tenable Nessus server - #{msg}")
       return
     end
 

--- a/spec/lib/metasploit/framework/login_scanner/caidao_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/caidao_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
           allow(subject).to receive(:uri).and_return('asp')
         end
 
-        it 'returns true' do
+        it 'returns false' do
           expect(subject.check_setup).to be(false)
         end
 
@@ -46,7 +46,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
           allow(subject).to receive(:uri).and_return('aspx')
         end
 
-        it 'returns true' do
+        it 'returns false' do
           expect(subject.check_setup).to be(false)
         end
 
@@ -61,7 +61,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
           allow(subject).to receive(:uri).and_return('html')
         end
 
-        it 'returns false' do
+        it 'returns failure details' do
           expect(subject.check_setup).to eq("Unable to locate target extension in uri. (Is this really caidao?)")
         end
 

--- a/spec/lib/metasploit/framework/login_scanner/caidao_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/caidao_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
           allow(subject).to receive(:uri).and_return('php')
         end
 
-        it 'returns true' do
-          expect(subject.check_setup).to be_truthy
+        it 'returns false' do
+          expect(subject.check_setup).to be(false)
         end
 
         it 'creates a php payload' do
@@ -32,7 +32,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
         end
 
         it 'returns true' do
-          expect(subject.check_setup).to be_truthy
+          expect(subject.check_setup).to be(false)
         end
 
         it 'creates an asp payload' do
@@ -47,7 +47,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
         end
 
         it 'returns true' do
-          expect(subject.check_setup).to be_truthy
+          expect(subject.check_setup).to be(false)
         end
 
         it 'creates an aspx payload' do
@@ -62,7 +62,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
         end
 
         it 'returns false' do
-          expect(subject.check_setup).to be_falsy
+          expect(subject.check_setup).to eq("Unable to locate target extension in uri. (Is this really caidao?)")
         end
 
         it 'creates no payload' do

--- a/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe Metasploit::Framework::LoginScanner::ManageEngineDesktopCentral d
           res.body = 'ManageEngine Desktop Central'
           res
         end
-        it 'returns true' do
-          expect(subject.check_setup).to be_truthy
+        it 'returns false' do
+          expect(subject.check_setup).to be(false)
         end
       end
 
       context 'when target is not ManageEngine Desktop Central' do
-        it 'returns false' do
-          expect(subject.check_setup).to be_falsey
+        it 'returns failure details' do
+          expect(subject.check_setup).to eq("Unable to locate \"ManageEngine Desktop Central\" in body. (Is this really ManageEngine Desktop Central?)")
         end
       end
     end

--- a/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe Metasploit::Framework::LoginScanner::Nessus do
 
       context 'when target is Nessus' do
         let(:response) { msp_html_response }
-        it 'returns true' do
+        it 'returns false' do
           expect(http_scanner.check_setup).to be(false)
         end
       end
 
       context 'when target is not Nessus' do
-        it 'returns false' do
+        it 'returns failure details' do
           expect(http_scanner.check_setup).to eq("Unable to locate \"Nessus\" in body. (Is this really Nessus?)")
         end
       end

--- a/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe Metasploit::Framework::LoginScanner::Nessus do
       context 'when target is Nessus' do
         let(:response) { msp_html_response }
         it 'returns true' do
-          expect(http_scanner.check_setup).to be_truthy
+          expect(http_scanner.check_setup).to be(false)
         end
       end
 
       context 'when target is not Nessus' do
         it 'returns false' do
-          expect(http_scanner.check_setup).to be_falsey
+          expect(http_scanner.check_setup).to eq("Unable to locate \"Nessus\" in body. (Is this really Nessus?)")
         end
       end
     end

--- a/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe Metasploit::Framework::LoginScanner::PhpMyAdmin do
   let(:successful_res) do
     res = Rex::Proto::Http::Response.new(302, 'OK')
     res.headers['Location'] = 'index.php'
-    res.headers['Set-Cookie'] = 'phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; pma_lang=en; phpMyAdmin=7e1hg9scaugr23p8c6ki8gotbd;' 
+    res.headers['Set-Cookie'] = 'phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; pma_lang=en; phpMyAdmin=7e1hg9scaugr23p8c6ki8gotbd;'
     res.body = "phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; name=\"token\" value=\"4_0'xIB=m@&z%m%#\""
     res
   end
 
   let(:failed_res) do
     res = Rex::Proto::Http::Response.new(200, 'OK')
-    res.headers['Set-Cookie'] = 'phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; pma_lang=en; phpMyAdmin=7e1hg9scaugr23p8c6ki8gotbd;' 
+    res.headers['Set-Cookie'] = 'phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; pma_lang=en; phpMyAdmin=7e1hg9scaugr23p8c6ki8gotbd;'
     res.body = "phpMyAdmin=e6d3qlut3i67uuab10m1n6sj4b; name=\"token\" value=\"4_0'xIB=m@&z%m%#\""
     res
   end
@@ -62,30 +62,30 @@ RSpec.describe Metasploit::Framework::LoginScanner::PhpMyAdmin do
     end
 
     context 'when the target is not PhpMyAdmin' do
-      it 'should return false' do
-        expect(subject.check_setup).to eql(false)
+      it 'should return a string' do
+        expect(subject.check_setup).to eql("Unable to locate \"phpMyAdmin\" and \"PMA_VERSION\" in body. (Is this really PhpMyAdmin?)")
       end
     end
 
     context 'when the version of PhpMyAdmin is detected' do
       let(:response) { phpMyAdmin_res }
-      it 'should return the version' do
-        expect(subject.check_setup).to eql("4.8.2")
+      it 'should return false' do
+        expect(subject.check_setup).to eql(false)
       end
     end
 
     context 'when the version of PhpMyAdmin is not detected' do
       let(:response) { phpMyAdmin_no_vers }
-      it 'should return "Not Detected"' do
-        expect(subject.check_setup).to eql("Not Detected")
+      it 'returns failure details' do
+        expect(subject.check_setup).to eql("Unable to locate \"phpMyAdmin\" and \"PMA_VERSION\" in body. (Is this really PhpMyAdmin?)")
       end
     end
   end
 
   describe '#get_session_info' do
     context 'when session info cannot be obtained' do
-      it 'should return an unable to connect status' do
-        expect(subject.get_session_info).to eql({ status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Cannot retrieve session info' })
+      it 'returns failure details' do
+        expect(subject.check_setup).to eql("Unable to locate \"phpMyAdmin\" and \"PMA_VERSION\" in body. (Is this really PhpMyAdmin?)")
       end
     end
 

--- a/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
@@ -60,14 +60,14 @@ RSpec.describe Metasploit::Framework::LoginScanner::SymantecWebGateway do
 
       context 'when target is Symantec Web Gateway' do
         let(:response) { swg_html_response }
-        it 'returns true' do
-          expect(subject.check_setup).to be_truthy
+        it 'returns false' do
+          expect(subject.check_setup).to be(false)
         end
       end
 
       context 'when target is not Symantec Web Gateway' do
-        it 'returns false' do
-          expect(subject.check_setup).to be_falsey
+        it 'returns failure details' do
+          expect(subject.check_setup).to eq("Unable to locate \"Symantec Web Gateway\" in body. (Is this really Symantec Web Gateway?)")
         end
       end
     end


### PR DESCRIPTION
Fixes a bug in Metasploit Pro that reported false positives for HTTP bruteforcing

Context: Our login scanners implement a pre-scan check for "Is this actually the software I think it is?"

There's two different APIs that people have been followed:

```ruby
# False => I found it
# String => Custom error message
def check_setup
   if i_found_the_thing
     return false
   end
   "Thing not found"
end
```

And:

```ruby
# True => I found it
# False => I did not find it
def check_setup
   if i_found_the_thing
     return true
   end
   false
end
```

We've got 10 or so modules that implement pattern two out of 34 modules, and the rest implement pattern 1

This pull request aligns with pattern 1 and enforces this API with automated tests, which will make it easier to update in the future if we decide to update this API.

It also adds automated tests to ensure there's no more regressions in the API.

## Verification

- Static code review
- Ensure CI passes
- Ensure Metasploit Pro no longer reports false positives on successfully bruteforcing manage engine:
<img width="979" height="434" alt="image" src="https://github.com/user-attachments/assets/417ce06e-8c8e-40a6-8de2-9fa0d6bab226" />
- Ensure Metasploit Pro no longer attempts to brutefore services incorrectly
 
before:
```
...
[*] [2026.01.28-14:48:38] 192.168.123.1:8000 (LoginScanner::AdvantechWebAccess) INCORRECT - foo:bar
[*] [2026.01.28-14:48:40] 192.168.123.1:8000 (LoginScanner::Caidao) INCORRECT - foo:bar
[*] [2026.01.28-14:48:41] 192.168.123.1:8000 (LoginScanner::CiscoFirepower) INCORRECT - foo:bar
[*] [2026.01.28-14:48:48] 192.168.123.1:8000 (LoginScanner::DirectAdmin) INCORRECT - foo:bar
[*] [2026.01.28-14:48:53] 192.168.123.1:8000 (LoginScanner::WowzaStreamingEngineManager) INCORRECT - foo:bar
[*] [2026.01.28-14:48:57] 192.168.123.1:8000 (LoginScanner::Nessus) INCORRECT - foo:bar
...
```

afer:
```
...
[-] [2026.01.28-15:50:24] 192.168.123.1:8000 (LoginScanner::CiscoFirepower) - Unable to locate favicon in body. (Is this really CiscoFirepower?)
[-] [2026.01.28-15:50:24] 192.168.123.1:8000 (LoginScanner::SyncoveryFileSyncBackup) - Unable to locate "Syncovery" in body. (Is this really Syncovery?)
[-] [2026.01.28-15:50:25] 192.168.123.1:8000 (LoginScanner::WowzaStreamingEngineManager) - Unable to locate "Wowza Streaming Engine Manager" in body. (Is this really Wowza Streaming Engine Manager?)
[-] [2026.01.28-15:50:25] 192.168.123.1:8000 (LoginScanner::Caidao) - Unable to locate target extension in uri. (Is this really caidao?)
...
```

