### PR TITLE
GSoC 2026 Wiki Updates

### DIFF
--- a/docs/metasploit-framework.wiki/GSoC-2026-Project-Ideas.md
+++ b/docs/metasploit-framework.wiki/GSoC-2026-Project-Ideas.md
@@ -1,0 +1,57 @@
+GSoC Project Ideas in no particular order. When you've picked one, take a look at [[How-to-Apply-to-GSoC]] for how to make a proposal.
+
+Mentors: [@jheysel-r7](https://github.com/jheysel-r7)
+Co-mentors: [@zeroSteiner](https://github.com/zeroSteiner) [@h00die](https://github.com/h00die)
+
+Slack Contacts: @jheysel-r7, @zeroSteiner and @h00die on [Metasploit Slack](https://metasploit.slack.com/)
+
+
+For any questions about these projects reach out on the Metasploit Slack in the `#gsoc` channel or DM one of the mentors
+using the Slack contacts listed above. Note that mentors may be busy so please don't expect an immediate response,
+however we will endeavor to respond as soon as possible. If you'd prefer not to join Slack, you can also email
+`msfdev [@] metasploit [dot] com` and we will respond to your questions there if email is preferable.
+
+## Enhance Metasploit Framework
+### CertificateTrace and KerberosTicketTrace Support
+
+Kerberos and certificate-based authentication mechanisms are becoming increasingly prevalent across modern environments,
+particularly in Active Directory and enterprise deployments. As a result, Metasploit modules that interact with these
+authentication flows often require operators and developers to inspect Kerberos tickets or certificate material in order
+to understand behavior, troubleshoot failures, or validate exploitation techniques. Today, this inspection typically
+requires switching to separate auxiliary modules or exporting artifacts (such as .pfx files) for analysis with external
+tooling, which interrupts the normal workflow.
+
+This project would introduce CertificateTrace and KerberosTicketTrace functionality to Metasploit, allowing relevant
+authentication artifacts to be captured and inspected as part of module execution. Similar in concept to the existing
+HttpTrace capability, these traces would focus specifically on certificate and Kerberos-based authentication, decoding
+and presenting useful metadata in a consistent, operator-friendly format. The value of these traces is expected to grow
+alongside continued adoption of Kerberos and certificate-based authentication.
+
+
+Size: Medium–Large
+Difficulty: 4/5
+
+### Automated Vulnerable Environment Provisioning (build_vuln)
+
+Many Metasploit modules—particularly those targeting web applications or open source software—include documentation
+describing how to build a vulnerable test environment, and some provide vulnerable container images to simplify this
+process. However, this information is typically maintained in module documentation and requires users to manually build
+and start the environment outside of Metasploit, making module verification more time-consuming and inconsistent.
+
+This project proposes a new Metasploit command (for example, build_vuln) that automates launching a vulnerable
+environment for a given exploit module. Vulnerable environments would be defined using Open Container Initiative
+(OCI)–compliant configurations and designed to work with both Podman and Docker, with rootless execution.
+
+The goal of this project is to automate setup steps that are already documented today, making it easier for users to
+test exploits locally and for contributors and Rapid7 engineers to verify module behavior in a repeatable,
+well-defined environment. This project would include refactoring existing modules to leverage the new functionality
+where possible (docker-compose files already exist), as well as creating new vulnerable environment definitions for
+popular modules that lack them today.
+
+
+Size: Medium–Large
+Difficulty: 4/5
+
+## Submit your own
+
+If you want to suggest your own idea, please discuss it with us first on [Slack](https://metasploit.com/slack) in the `#gsoc` channel to make sure it is a reasonable amount of work for a summer and that it fits the goals of the project.

--- a/docs/metasploit-framework.wiki/GSoC-2026-Project-Ideas.md
+++ b/docs/metasploit-framework.wiki/GSoC-2026-Project-Ideas.md
@@ -24,12 +24,15 @@ tooling, which interrupts the normal workflow.
 This project would introduce CertificateTrace and KerberosTicketTrace functionality to Metasploit, allowing relevant
 authentication artifacts to be captured and inspected as part of module execution. Similar in concept to the existing
 HttpTrace capability, these traces would focus specifically on certificate and Kerberos-based authentication, decoding
-and presenting useful metadata in a consistent, operator-friendly format. The value of these traces is expected to grow
-alongside continued adoption of Kerberos and certificate-based authentication.
+and presenting useful metadata in a consistent, operator-friendly format. Similar to HttpTrace and HttpTraceHeadersOnly,
+we would expect there to be support for different levels of logging, ex: print only the Certificate Signing Request (CSR).
 
 
-Size: Medium–Large
-Difficulty: 4/5
+Mentors: @jheysel-r7, @zeroSteiner
+Size: 175 hrs
+Difficulty: Medium
+Required Skills: Understanding of how Kerberos and certificate-based authentication work; ability to write and deliver Ruby code.
+Preferred Skills: Experience working with or using Kerberos and/or certificate-based authentication.
 
 ### Automated Vulnerable Environment Provisioning (build_vuln)
 
@@ -49,9 +52,13 @@ where possible (docker-compose files already exist), as well as creating new vul
 popular modules that lack them today.
 
 
-Size: Medium–Large
-Difficulty: 4/5
+Mentors: @jheysel-r7, @h00die
+Size: 360 hrs
+Difficulty: Medium
+Required Skills: Understanding of how containers work in the context of the Open Container Initiative; ability to write and deliver Ruby code.
+Preferred Skills: Experience using containers; understanding of container definitions and best practices.
 
 ## Submit your own
 
-If you want to suggest your own idea, please discuss it with us first on [Slack](https://metasploit.com/slack) in the `#gsoc` channel to make sure it is a reasonable amount of work for a summer and that it fits the goals of the project.
+If you want to suggest your own idea, please discuss it with us first on [Slack](https://metasploit.com/slack) in the
+`#gsoc` channel to make sure it is a reasonable amount of work for a summer and that it fits the goals of the project.

--- a/docs/metasploit-framework.wiki/GSoC-2026-Project-Ideas.md
+++ b/docs/metasploit-framework.wiki/GSoC-2026-Project-Ideas.md
@@ -3,7 +3,7 @@ GSoC Project Ideas in no particular order. When you've picked one, take a look a
 Mentors: [@jheysel-r7](https://github.com/jheysel-r7)
 Co-mentors: [@zeroSteiner](https://github.com/zeroSteiner) [@h00die](https://github.com/h00die)
 
-Slack Contacts: @jheysel-r7, @zeroSteiner and @h00die on [Metasploit Slack](https://metasploit.slack.com/)
+Slack Contacts: @jheysel, @zeroSteiner and @h00die on [Metasploit Slack](https://metasploit.slack.com/)
 
 
 For any questions about these projects reach out on the Metasploit Slack in the `#gsoc` channel or DM one of the mentors

--- a/docs/metasploit-framework.wiki/How-to-Apply-to-GSoC.md
+++ b/docs/metasploit-framework.wiki/How-to-Apply-to-GSoC.md
@@ -1,24 +1,19 @@
-**Note:** this is currently outdated will be updated shortly, check back on Jan 29 2026
-
 **Note:** Final project proposals must be submitted through to Google through the GSoC Program Website, as stated in the [rules](https://summerofcode.withgoogle.com/rules/).
 
 Before submitting to the GSoC website, it is also helpful to solicit proposal feedback. This can be done by reaching out to us on our Slack at <https://metasploit.com/slack> via the `#gsoc` channel, or via sending an email to `msfdev [@] metasploit [dot]  com`. If you don't hear back right away on a proposal, don't give up! Contributors may be busy, or you may need to try again to get someone's attention (but don't spam).
 
-# 2022 Timeline
+# 2026 Timeline
 An updated list of the application timeline can be found at https://developers.google.com/open-source/gsoc/timeline. Please refer to this link for any updates that Google may make, as they have been known to change the timeline for certain dates in the past.
 
 ## Important Dates
 
-- GSoC Applications Open: April 4th at 1800 UTC
-- GSoC Applications Close: April 19th at 1800 UTC for 2022 GSoC applications. **No late submissions will be accepted, period.**
-- Accepted applications announced: May 20th at 1800 UTC
-- Programming Starts: June 13th.
+- GSoC Applications Open: March 16th at 18:00 UTC
+- GSoC Applications Close: March 31th at 1800 UTC for 2026 GSoC applications
+- Accepted GSoC contributor projects announced: April 30th at 1800 UTC
+- Programming Starts: May 25th.
 
-## Important Changes for 2022
-- All submissions (including both draft submissions and final submissions) must be in PDF format when being submitted to GSoC's website. If you would like us to review your submission prior to the final deadline, please submit a Google Drive link to your DOC formatted proposal to msfdev [AT] metasploit [DOT] com and make sure that you have enabled commenting so that potential mentors can provide feedback.
-
-# 2022 Idea List
-You can find the current list of GSoC ideas at [[GSoC-2022-Project-Ideas]]. Please see the note at the bottom of this page if you are interested in submitting your own idea, as this will require approval.
+# 2026 Idea List
+You can find the current list of GSoC ideas at [[GSoC-2026-Project-Ideas]]. Please see the note at the bottom of this page if you are interested in submitting your own idea, as this will require approval.
 
 # Getting started
 Students interesting in GSoC, can start by reading Google's official guides.

--- a/docs/metasploit-framework.wiki/How-to-Apply-to-GSoC.md
+++ b/docs/metasploit-framework.wiki/How-to-Apply-to-GSoC.md
@@ -1,3 +1,5 @@
+**Note:** this is currently outdated will be updated shortly, check back on Jan 29 2026
+
 **Note:** Final project proposals must be submitted through to Google through the GSoC Program Website, as stated in the [rules](https://summerofcode.withgoogle.com/rules/).
 
 Before submitting to the GSoC website, it is also helpful to solicit proposal feedback. This can be done by reaching out to us on our Slack at <https://metasploit.com/slack> via the `#gsoc` channel, or via sending an email to `msfdev [@] metasploit [dot]  com`. If you don't hear back right away on a proposal, don't give up! Contributors may be busy, or you may need to try again to get someone's attention (but don't spam).

--- a/docs/navigation.rb
+++ b/docs/navigation.rb
@@ -911,6 +911,10 @@ NAVIGATION_CONFIG = [
             path: 'GSoC-2023-Project-Ideas.md',
             title: without_prefix('GSoC')
           },
+          {
+            path: 'GSoC-2026-Project-Ideas.md',
+            title: without_prefix('GSoC')
+          },
         ]
       },
       {


### PR DESCRIPTION
This PR adds a new docs file GSoC-2026-Project-Ideas.md, which as the title suggests, outlines the Metasploit Framework project ideas for GSoC 2026. It also updates the GSoC-How-To-Apply page with relevant dates and information. 