### PR TITLE
Fixes the script for updating cached payload sizes

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -172,6 +172,13 @@ class Payload < Msf::Module
   end
 
   #
+  # This method returns whether the payload has undefined CachedSize
+  #
+  def self.undefined_size?
+    csize = (const_defined?('CachedSize')) ? const_get('CachedSize') : nil
+    csize == :undefined
+  end
+  #
   # This method returns an optional cached size value
   #
   def cached_size
@@ -183,6 +190,13 @@ class Payload < Msf::Module
   #
   def dynamic_size?
       self.class.dynamic_size?
+  end
+
+  #
+  # This method returns whether the payload has undefined CachedSize
+  #
+  def undefined_size?
+      self.class.undefined_size?
   end
 
   #

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -125,9 +125,10 @@ class PayloadCachedSize
   # @param mod [Msf::Payload] The class of the payload module to update
   # @return [Boolean]
   def self.is_cached_size_accurate?(mod)
-    #return true if mod.dynamic_size? && is_dynamic?(mod)
     return true if mod.dynamic_size?
-    #return true if mod.dynamic_size? || is_dynamic?(mod)
+    
+    return true if mod.undefined_size?
+
     return false if mod.cached_size.nil?
 
     mod.cached_size == mod.generate_simple(module_options(mod)).size

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -114,8 +114,8 @@ class PayloadCachedSize
   # @return [Integer]
   def self.is_dynamic?(mod, generation_count=10)
     sha256 = OpenSSL::Digest.new('SHA256')
+    opts = module_options(mod)
     [*(1..generation_count)].map do |x|
-      opts = module_options(mod)
       sha256.digest(mod.generate_simple(opts))
     end.uniq.length != 1
   end

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -114,8 +114,9 @@ class PayloadCachedSize
   # @return [Integer]
   def self.is_dynamic?(mod, generation_count=5)
     opts = module_options(mod)
+    sha256 = OpenSSL::Digest.new('SHA256')
     [*(1..generation_count)].map do |x|
-      mod.generate_simple(opts).size
+      sha256.digest(mod.generate_simple(opts))
     end.uniq.length != 1
   end
 

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -114,9 +114,8 @@ class PayloadCachedSize
   # @return [Integer]
   def self.is_dynamic?(mod, generation_count=5)
     opts = module_options(mod)
-    sha256 = OpenSSL::Digest.new('SHA256')
     [*(1..generation_count)].map do |x|
-      sha256.digest(mod.generate_simple(opts))
+      mod.generate_simple(opts).size
     end.uniq.length != 1
   end
 

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -125,7 +125,7 @@ class PayloadCachedSize
   # @param mod [Msf::Payload] The class of the payload module to update
   # @return [Boolean]
   def self.is_cached_size_accurate?(mod)
-    return true if mod.dynamic_size? && is_dynamic?(mod)
+    return true if mod.dynamic_size? || is_dynamic?(mod)
     return false if mod.cached_size.nil?
 
     mod.cached_size == mod.generate_simple(module_options(mod)).size

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -125,8 +125,8 @@ class PayloadCachedSize
   # @param mod [Msf::Payload] The class of the payload module to update
   # @return [Boolean]
   def self.is_cached_size_accurate?(mod)
-    return true if mod.dynamic_size? && is_dynamic?(mod)
-    #return true if mod.dynamic_size?
+    #return true if mod.dynamic_size? && is_dynamic?(mod)
+    return true if mod.dynamic_size?
     #return true if mod.dynamic_size? || is_dynamic?(mod)
     return false if mod.cached_size.nil?
 

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -113,10 +113,9 @@ class PayloadCachedSize
   #   verify that the size is static.
   # @return [Integer]
   def self.is_dynamic?(mod, generation_count=10)
-    sha256 = OpenSSL::Digest.new('SHA256')
     opts = module_options(mod)
     [*(1..generation_count)].map do |x|
-      sha256.digest(mod.generate_simple(opts))
+      mod.generate_simple(opts).size
     end.uniq.length != 1
   end
 

--- a/modules/payloads/singles/php/exec.rb
+++ b/modules/payloads/singles/php/exec.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     # please do not copy me into new code, instead use the #php_exec_cmd method after including Msf::Payload::Php or
     # use the PHP adapter payload by selecting any php/unix/cmd/* payload
     vars = Rex::RandomIdentifier::Generator.new(language: :php)
-    shell <<-END_OF_PHP_CODE
+    shell = <<-END_OF_PHP_CODE
       #{php_preamble(vars_generator: vars)}
       #{php_system_block(vars_generator: vars, cmd: datastore['CMD'])}
     END_OF_PHP_CODE

--- a/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
@@ -4,7 +4,8 @@
 ##
 
 module MetasploitModule
-  CachedSize = 4000
+
+  CachedSize = :undefined
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
@@ -4,7 +4,8 @@
 ##
 
 module MetasploitModule
-  CachedSize = 2560
+
+  CachedSize = :undefined
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::EncryptedReverseTcp

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -23,6 +23,9 @@ gem 'rex-text'
 
 require 'rex'
 
+require 'pry'
+require 'pry-byebug'
+
 # Initialize the simplified framework instance.
 framework = Msf::Simple::Framework.create('DisableDatabase' => true)
 exceptions = []
@@ -32,6 +35,8 @@ framework.payloads.each_module do |name, mod|
     mod_inst = framework.payloads.create(name)
     #mod_inst.datastore.merge!(framework.datastore)
     next if mod_inst.is_a?(Msf::Payload::Adapter) || Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
+    binding.pry if name == "python/meterpreter/bind_tcp"
+    puts name
     $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
     Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
   rescue => e

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -25,13 +25,19 @@ require 'rex'
 
 # Initialize the simplified framework instance.
 exceptions = []
-framework = Msf::Simple::Framework.create({'DeferModuleLoads' => true})
+
+# Create dummy config file to avoid using locally saved options
+dummy_config = File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'spec', 'dummy','framework','config'))
+
+framework = Msf::Simple::Framework.create({'DeferModuleLoads' => true, 'ConfigDirectory' => dummy_config})
+module_set = framework.modules.module_set('payload')
+module_set.recalculate
 
 framework.payloads.each_module do |name, mod|
   begin
     next if name =~ /generic/
     next if name =~ /custom/
-    mod_inst = framework.payloads.create(name)
+    mod_inst = module_set.create(name)
     #mod_inst.datastore.merge!(framework.datastore)
     next if mod_inst.is_a?(Msf::Payload::Adapter) || Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
     $stdout.puts "[*] Updating the CacheSize for #{mod.file_path} in #{name}..."

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -26,7 +26,7 @@ require 'rex'
 # Initialize the simplified framework instance.
 exceptions = []
 
-# Create dummy config file to avoid using locally saved options
+# Use dummy config file to avoid using locally saved options
 dummy_config = File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'spec', 'dummy','framework','config'))
 
 framework = Msf::Simple::Framework.create({'DeferModuleLoads' => true, 'ConfigDirectory' => dummy_config})

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -25,21 +25,16 @@ require 'rex'
 
 # Initialize the simplified framework instance.
 exceptions = []
-framework = Msf::Simple::Framework.create({'DeferModuleLoads' => true,'DisableDatabase' => true})
-
-# ----------------------------------------
-#   mod_set = framework.modules.module_set('payload')
-#   mod_set.recalculate
-#   mod_inst = mod_set.create(name)
-# ----------------------------------------
+framework = Msf::Simple::Framework.create({'DeferModuleLoads' => true})
 
 framework.payloads.each_module do |name, mod|
   begin
     next if name =~ /generic/
+    next if name =~ /custom/
     mod_inst = framework.payloads.create(name)
     #mod_inst.datastore.merge!(framework.datastore)
     next if mod_inst.is_a?(Msf::Payload::Adapter) || Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
-    $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
+    $stdout.puts "[*] Updating the CacheSize for #{mod.file_path} in #{name}..."
     Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
   rescue => e
     $stderr.puts "[!] Caught Error while updating #{name}:\n#{e}\n#{e.backtrace.map { |line| "\t#{line}" }.join("\n")}"

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -23,20 +23,22 @@ gem 'rex-text'
 
 require 'rex'
 
-require 'pry'
-require 'pry-byebug'
-
 # Initialize the simplified framework instance.
-framework = Msf::Simple::Framework.create('DisableDatabase' => true)
 exceptions = []
+framework = Msf::Simple::Framework.create({'DeferModuleLoads' => true,'DisableDatabase' => true})
+
+# ----------------------------------------
+#   mod_set = framework.modules.module_set('payload')
+#   mod_set.recalculate
+#   mod_inst = mod_set.create(name)
+# ----------------------------------------
+
 framework.payloads.each_module do |name, mod|
   begin
     next if name =~ /generic/
     mod_inst = framework.payloads.create(name)
     #mod_inst.datastore.merge!(framework.datastore)
     next if mod_inst.is_a?(Msf::Payload::Adapter) || Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
-    binding.pry if name == "python/meterpreter/bind_tcp"
-    puts name
     $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
     Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
   rescue => e


### PR DESCRIPTION
Fixes #20864

This PR addresses issue with `update_payload_cached_sizes` script. There has been some issues and inconsistencies with the script, leading to behavior when developers had to manually update cached sizes of payload, when CI failed. This PR tries to address the issue by unifying the way framework instance is created in CI and in the script. Furthermore, it takes into account the `dynamic` cached sizes and tries to forbid overwriting cached sizes by multiple payloads (i.e. staggers). As a bonus, it fixes a bug in PHP exec payload. 

This is **work in progress**, the initial fix _seems_ to be working, further tests are necessary.

- [ ] Run the script with multiple modified payloads,  the script should updates `cached_sizes` accordingly
- [ ] Run the script in latest commit, the script should not update any cached sizes
- [ ] Make sure dynamic payloads stay dynamic