### PR TITLE
fix : updated printing to prevent crash in auxiliary/scanner/sap/sap_soap_rfc_system_info or sap_icf_public_info.rb 

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_icf_public_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_icf_public_info.rb
@@ -149,6 +149,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # output table
-    print(@saptbl)
+    print_line(@saptbl.to_s)
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -184,6 +184,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # output table
-    print(@saptbl)
+    print_line(@saptbl.to_s)
   end
 end


### PR DESCRIPTION
Fixes issue #20915 in the same manner that Pull request  #20505 did

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/sap/sap_soap_rfc_system_info` (or `sap_icf_public_info.rb`)
- [ ] Run it against a target that should return some data
- [ ] No error should arise, and the following data should be returned :

[a.bmp](https://github.com/user-attachments/files/24971374/a.bmp)
