### PR TITLE
Fix label check bug

### DIFF
--- a/.github/workflows/extended_tests.yml
+++ b/.github/workflows/extended_tests.yml
@@ -40,7 +40,7 @@ jobs:
             //
             // This script has intentionally been inlined instead of using third-party Github actions for both
             // security and performance reasons.
-            const currentLabelNames = github.event.pull_request.labels.map(label => label.name);
+            const currentLabelNames = context.payload.pull_request.labels.map(label => label.name);
             const newLabelName = "additional-testing-required";
             const comment = `
               Thanks for your pull request! As part of our landing process, we manually verify that all modules work as expected.


### PR DESCRIPTION
Fix label check bug

```
TypeError: Cannot read properties of undefined (reading 'pull_request')
```

Context: We're using github script so the syntax is different in this context

## Verification
Code review