### PR TITLE
Add MITRE ATT&CK mappings for LDAP/AD CS modules

### DIFF
--- a/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
+++ b/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
@@ -43,7 +43,9 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
           [ 'URL', 'https://github.com/ly4k/Certipy' ],
           [ 'URL', 'https://medium.com/@offsecdeer/adcs-exploitation-series-part-2-certificate-mapping-esc15-6e19a6037760' ],
-          [ 'URL', 'https://www.thehacker.recipes/ad/movement/adcs/certificate-templates#esc16-a-compatibility-mode' ]
+          [ 'URL', 'https://www.thehacker.recipes/ad/movement/adcs/certificate-templates#esc16-a-compatibility-mode' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1484_001_GROUP_POLICY_MODIFICATION ]
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
+++ b/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://medium.com/@offsecdeer/adcs-exploitation-series-part-2-certificate-mapping-esc15-6e19a6037760' ],
           [ 'URL', 'https://www.thehacker.recipes/ad/movement/adcs/certificate-templates#esc16-a-compatibility-mode' ],
           [ 'ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION ],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1484_001_GROUP_POLICY_MODIFICATION ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES ]
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -34,7 +34,9 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
-          [ 'URL', 'https://github.com/ly4k/Certipy' ]
+          [ 'URL', 'https://github.com/ly4k/Certipy' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1552_004_PRIVATE_KEYS ]
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -35,8 +35,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
           [ 'URL', 'https://github.com/ly4k/Certipy' ],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES ],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1552_004_PRIVATE_KEYS ]
+          [ 'ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES ]
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -55,7 +55,8 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
-          [ 'URL', 'https://github.com/ly4k/Certipy' ]
+          [ 'URL', 'https://github.com/ly4k/Certipy' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES ]
         ],
         'License' => MSF_LICENSE,
         'Actions' => [

--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -55,8 +55,7 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
-          [ 'URL', 'https://github.com/ly4k/Certipy' ],
-          [ 'ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES ]
+          [ 'URL', 'https://github.com/ly4k/Certipy' ]
         ],
         'License' => MSF_LICENSE,
         'Actions' => [

--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -29,7 +29,9 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           ['URL', 'https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/resource-based-constrained-delegation-ad-computer-object-take-over-and-privilged-code-execution'],
           ['URL', 'https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'],
-          ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/3c6713e309cae871d685fa443d3e21b7026a2155/examples/rbcd.py']
+          ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/3c6713e309cae871d685fa443d3e21b7026a2155/examples/rbcd.py'],
+          ['ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION],
+          ['ATT&CK', Mitre::Attack::Technique::T1558_STEAL_OR_FORGE_KERBEROS_TICKETS]
         ],
         'License' => MSF_LICENSE,
         'Actions' => [

--- a/modules/auxiliary/admin/ldap/shadow_credentials.rb
+++ b/modules/auxiliary/admin/ldap/shadow_credentials.rb
@@ -29,8 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           ['URL', 'https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab'],
           ['URL', 'https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/shadow-credentials'],
-          ['ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION],
-          ['ATT&CK', Mitre::Attack::Technique::T1556_006_MULTI_FACTOR_AUTHENTICATION]
+          ['ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION]
         ],
         'License' => MSF_LICENSE,
         'Actions' => [

--- a/modules/auxiliary/admin/ldap/shadow_credentials.rb
+++ b/modules/auxiliary/admin/ldap/shadow_credentials.rb
@@ -28,7 +28,9 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab'],
-          ['URL', 'https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/shadow-credentials']
+          ['URL', 'https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/shadow-credentials'],
+          ['ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION],
+          ['ATT&CK', Mitre::Attack::Technique::T1556_006_MULTI_FACTOR_AUTHENTICATION]
         ],
         'License' => MSF_LICENSE,
         'Actions' => [

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -78,7 +78,9 @@ class MetasploitModule < Msf::Auxiliary
           'Spencer McIntyre', # ESC13 and ESC15 updates
           'jheysel-r7' # ESC4, ESC9 and ESC10 update
         ],
-        'References' => REFERENCES.values.flatten.map { |r| [ r.ctx_id, r.ctx_val ] }.uniq,
+        'References' => (REFERENCES.values.flatten.map { |r| [ r.ctx_id, r.ctx_val ] }.uniq + [
+          ['ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES]
+        ]).uniq,
         'DisclosureDate' => '2021-06-17',
         'License' => MSF_LICENSE,
         'DefaultOptions' => {


### PR DESCRIPTION
Ref: #20802 
This PR adds MITRE ATT&CK technique references to LDAP/AD CS related modules to support ATT&CK‑driven discovery. 


Module | ATT&CK IDs Added
-- | --
auxiliary/gather/ldap_esc_vulnerable_cert_finder | T1649
auxiliary/admin/dcerpc/icpr_cert | T1649, T1552.004
auxiliary/admin/dcerpc/esc_update_ldap_object | T1098, T1484.001
auxiliary/admin/ldap/shadow_credentials | T1098, T1556.006
auxiliary/admin/ldap/rbcd | T1098, T1558
auxiliary/admin/ldap/ad_cs_cert_template | T1649

