### PR TITLE
Add MITRE ATT&CK mappings for Kerberos roasting modules

### DIFF
--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -30,7 +30,8 @@ class MetasploitModule < Msf::Auxiliary
           'smashery', # MSF Module
         ],
         'References' => [
-          ['URL', 'https://github.com/CoreSecurity/impacket/blob/master/examples/GetUserSPNs.py']
+          ['URL', 'https://github.com/CoreSecurity/impacket/blob/master/examples/GetUserSPNs.py'],
+          ['ATT&CK', Mitre::Attack::Technique::T1558_003_KERBEROASTING]
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],

--- a/modules/auxiliary/scanner/ntp/timeroast.rb
+++ b/modules/auxiliary/scanner/ntp/timeroast.rb
@@ -26,8 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'References' => [
           ['URL', 'https://github.com/SecuraBV/Timeroast/'],
-          ['URL', 'https://www.secura.com/uploads/whitepapers/Secura-WP-Timeroasting-v3.pdf'],
-          ['ATT&CK', Mitre::Attack::Technique::T1558_003_KERBEROASTING]
+          ['URL', 'https://www.secura.com/uploads/whitepapers/Secura-WP-Timeroasting-v3.pdf']
         ],
         'Notes' => {
           'Stability' => [],

--- a/modules/auxiliary/scanner/ntp/timeroast.rb
+++ b/modules/auxiliary/scanner/ntp/timeroast.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'References' => [
           ['URL', 'https://github.com/SecuraBV/Timeroast/'],
-          ['URL', 'https://www.secura.com/uploads/whitepapers/Secura-WP-Timeroasting-v3.pdf']
+          ['URL', 'https://www.secura.com/uploads/whitepapers/Secura-WP-Timeroasting-v3.pdf'],
+          ['ATT&CK', Mitre::Attack::Technique::T1558_003_KERBEROASTING]
         ],
         'Notes' => {
           'Stability' => [],


### PR DESCRIPTION
Refs: #20802 

This PR adds MITRE ATT&CK technique references to Kerberos roasting modules to support ATT&CK‑driven discovery. 


Module | ATT&CK IDs Added
-- | --
auxiliary/gather/kerberoast | T1558.003
auxiliary/scanner/ntp/timeroast | T1558.003

