### PR TITLE
Add MITRE ATT&CK mappings for SMB/SAMR account operations

### DIFF
--- a/modules/auxiliary/admin/dcerpc/samr_account.rb
+++ b/modules/auxiliary/admin/dcerpc/samr_account.rb
@@ -34,8 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/addcomputer.py'],
-          ['ATT&CK', Mitre::Attack::Technique::T1136_002_DOMAIN_ACCOUNT],
-          ['ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION]
+          ['ATT&CK', Mitre::Attack::Technique::T1136_002_DOMAIN_ACCOUNT]
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/admin/dcerpc/samr_account.rb
+++ b/modules/auxiliary/admin/dcerpc/samr_account.rb
@@ -34,6 +34,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['URL', 'https://github.com/SecureAuthCorp/impacket/blob/master/examples/addcomputer.py'],
+          ['ATT&CK', Mitre::Attack::Technique::T1136_002_DOMAIN_ACCOUNT],
+          ['ATT&CK', Mitre::Attack::Technique::T1098_ACCOUNT_MANIPULATION]
         ],
         'Notes' => {
           'Reliability' => [],

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -16,6 +16,9 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Determine what users exist via the SAM RPC service',
       'Author' => 'hdm',
       'License' => MSF_LICENSE,
+      'References' => [
+        [ 'ATT&CK', Mitre::Attack::Technique::T1087_ACCOUNT_DISCOVERY ]
+      ],
       'DefaultOptions' => {
         'DCERPC::fake_bind_multi' => false
       },

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -44,6 +44,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' => [
         [ 'CVE', '1999-0506'], # Weak password
         [ 'ATT&CK', Mitre::Attack::Technique::T1021_002_SMB_WINDOWS_ADMIN_SHARES ],
+        [ 'ATT&CK', Mitre::Attack::Technique::T1110_BRUTE_FORCE ],
       ],
       'License' => MSF_LICENSE,
       'DefaultOptions' => {


### PR DESCRIPTION
Refs: #20802

This PR adds MITRE ATT&CK technique references to SMB and SAMR account operation modules to support ATT&CK‑driven discovery. 


Module | ATT&CK IDs Added
-- | --
auxiliary/admin/dcerpc/samr_account | T1136.002, T1098
auxiliary/scanner/smb/smb_enumusers | T1087
auxiliary/scanner/smb/smb_login | T1110

