### PR TITLE
Add MITRE ATT&CK mappings for relay and SCCM credential modules

### DIFF
--- a/modules/auxiliary/admin/sccm/get_naa_credentials.rb
+++ b/modules/auxiliary/admin/sccm/get_naa_credentials.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://blog.xpnsec.com/unobfuscating-network-access-accounts/'],
           ['URL', 'https://github.com/subat0mik/Misconfiguration-Manager/blob/main/attack-techniques/CRED/CRED-2/cred-2_description.md'],
           ['URL', 'https://github.com/Mayyhem/SharpSCCM'],
-          ['URL', 'https://github.com/garrettfoster13/sccmhunter']
+          ['URL', 'https://github.com/garrettfoster13/sccmhunter'],
+          ['ATT&CK', Mitre::Attack::Technique::T1552_001_CREDENTIALS_IN_FILES]
         ],
         'License' => MSF_LICENSE,
         'Notes' => {

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -21,6 +21,10 @@ class MetasploitModule < Msf::Auxiliary
         'jhicks-r7', # query for available certs
         'Spencer McIntyre'
       ],
+      'References' => [
+        ['ATT&CK', Mitre::Attack::Technique::T1557_ADVERSARY_IN_THE_MIDDLE],
+        ['ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES]
+      ],
       'License' => MSF_LICENSE,
       'Actions' => [[ 'Relay', { 'Description' => 'Run SMB ESC8 relay server' } ]],
       'PassiveActions' => [ 'Relay' ],

--- a/modules/auxiliary/server/relay/relay_get_naa_credentials.rb
+++ b/modules/auxiliary/server/relay/relay_get_naa_credentials.rb
@@ -30,7 +30,9 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://blog.xpnsec.com/unobfuscating-network-access-accounts/'],
         ['URL', 'https://github.com/subat0mik/Misconfiguration-Manager/blob/main/attack-techniques/CRED/CRED-2/cred-2_description.md'],
         ['URL', 'https://github.com/Mayyhem/SharpSCCM'],
-        ['URL', 'https://github.com/garrettfoster13/sccmhunter']
+        ['URL', 'https://github.com/garrettfoster13/sccmhunter'],
+        ['ATT&CK', Mitre::Attack::Technique::T1557_ADVERSARY_IN_THE_MIDDLE],
+        ['ATT&CK', Mitre::Attack::Technique::T1552_UNSECURED_CREDENTIALS]
       ],
       'DefaultOptions' => {
         'RPORT' => 80

--- a/modules/auxiliary/server/relay/relay_get_naa_credentials.rb
+++ b/modules/auxiliary/server/relay/relay_get_naa_credentials.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://github.com/Mayyhem/SharpSCCM'],
         ['URL', 'https://github.com/garrettfoster13/sccmhunter'],
         ['ATT&CK', Mitre::Attack::Technique::T1557_ADVERSARY_IN_THE_MIDDLE],
-        ['ATT&CK', Mitre::Attack::Technique::T1552_UNSECURED_CREDENTIALS]
+        ['ATT&CK', Mitre::Attack::Technique::T1552_001_CREDENTIALS_IN_FILES]
       ],
       'DefaultOptions' => {
         'RPORT' => 80


### PR DESCRIPTION
Ref: #20802 

This PR adds MITRE ATT&CK technique references to relay and SCCM credential modules to support ATT&CK‑driven discovery.


Module | ATT&CK IDs Added
-- | --
auxiliary/server/relay/relay_get_naa_credentials | T1557, T1552
auxiliary/server/relay/esc8 | T1557, T1649
auxiliary/admin/sccm/get_naa_credentials | T1552.001

