### PR TITLE
Bump metasploit-credential 6.0.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ GEM
       mutex_m
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.19)
+    metasploit-credential (6.0.20)
       bigdecimal
       csv
       drb


### PR DESCRIPTION
Bumps metasploit-credential gem to 6.0.20. Pulls in changes from https://github.com/rapid7/metasploit-credential/pull/196

>This PR updates the service lookup in `#create_credential_service` to also include the service name. This change is needed since now the service name defines a unique service. Services with the same `host`, `port` and `proto` but with different names a now considered separate services. Note that this also applies to the new `resource` field. I haven't added the `resource` in the lookup since it doesn't seem to be necessary for now. Please, let me know if you think otherwise.

## Verification
- [ ] CI passes
