### PR TITLE
Add MITRE ATT&CK mapping for Windows password cracking

### DIFF
--- a/modules/auxiliary/analyze/crack_windows.rb
+++ b/modules/auxiliary/analyze/crack_windows.rb
@@ -26,6 +26,9 @@ class MetasploitModule < Msf::Auxiliary
         'hdm',
         'h00die' # hashcat integration
       ],
+      'References' => [
+        [ 'ATT&CK', Mitre::Attack::Technique::T1110_002_PASSWORD_CRACKING ]
+      ],
       'License' => MSF_LICENSE, # JtR itself is GPLv2, but this wrapper is MSF (BSD)
       'Actions' => [
         ['john', { 'Description' => 'Use John the Ripper' }],


### PR DESCRIPTION
Ref: #20802 
This PR adds a MITRE ATT&CK technique reference to the Windows password cracking module to support ATT&CK‑driven discovery.


Module | ATT&CK IDs Added
-- | --
auxiliary/analyze/crack_windows | T1110.002


(auxiliary/gather/windows_secrets_dump already had ATT&CK references and was not changed.)