### PR TITLE
Add MITRE ATT&CK mappings for exploit and privilege escalation modules

### DIFF
--- a/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
@@ -50,7 +50,9 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2020-1472' ],
           [ 'URL', 'https://www.secura.com/blog/zero-logon' ],
           [ 'URL', 'https://github.com/SecuraBV/CVE-2020-1472/blob/master/zerologon_tester.py' ],
-          [ 'URL', 'https://github.com/dirkjanm/CVE-2020-1472/blob/master/restorepassword.py' ]
+          [ 'URL', 'https://github.com/dirkjanm/CVE-2020-1472/blob/master/restorepassword.py' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1068_EXPLOITATION_FOR_PRIVILEGE_ESCALATION ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1078_VALID_ACCOUNTS ]
         ]
       )
     )

--- a/modules/exploits/multi/http/atlassian_confluence_rce_cve_2023_22527.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_rce_cve_2023_22527.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2023-22527'],
           ['URL', 'https://confluence.atlassian.com/security/cve-2023-22527-rce-remote-code-execution-vulnerability-in-confluence-data-center-and-confluence-server-1333990257.html'],
-          ['URL', 'https://blog.projectdiscovery.io/atlassian-confluence-ssti-remote-code-execution/']
+          ['URL', 'https://blog.projectdiscovery.io/atlassian-confluence-ssti-remote-code-execution/'],
+          ['ATT&CK', Mitre::Attack::Technique::T1190_EXPLOIT_PUBLIC_FACING_APPLICATION]
         ],
         'DisclosureDate' => '2024-01-16', # Atlassian advisory released
         'License' => MSF_LICENSE,

--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -19,6 +19,10 @@ class MetasploitModule < Msf::Post
         },
         'License' => MSF_LICENSE,
         'Author' => 'hdm',
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1068_EXPLOITATION_FOR_PRIVILEGE_ESCALATION],
+          ['ATT&CK', Mitre::Attack::Technique::T1548_002_BYPASS_USER_ACCOUNT_CONTROL]
+        ],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
         'Compat' => {


### PR DESCRIPTION
Ref : #20802 
This PR adds MITRE ATT&CK technique references to exploit and privilege‑escalation modules to support ATT&CK‑driven discovery. 

Module | ATT&CK IDs Added
-- | --
post/windows/escalate/getsystem | T1068, T1548.002
auxiliary/admin/dcerpc/cve_2020_1472_zerologon | T1068, T1078
exploit/multi/http/atlassian_confluence_rce_cve_2023_22527 | T1190

