### PR TITLE
Add Specs for mkdir post API to behave consistently across session types

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -117,43 +117,13 @@ module Msf::Post::File
 
   alias ls dir
 
-def meterpreter_mkdir_p(path)
-  return nil if directory?(path)
-
-  separator = session.fs.file.separator
-  normalized = path.tr('\\/', separator)
-  directories = normalized.split(separator)
-  current_path = ''
-
-  if normalized.match?(/\A[a-zA-Z]:#{Regexp.escape(separator)}?/)
-    current_path = "#{directories.shift}#{separator}"
-  elsif normalized.start_with?(separator)
-    current_path = separator
-  end
-
-  directories.each do |dir|
-    next if dir.empty?
-
-    current_path =
-      if current_path.end_with?(separator) || current_path.empty?
-        "#{current_path}#{dir}"
-      else
-        "#{current_path}#{separator}#{dir}"
-      end
-
-    session.fs.dir.mkdir(current_path) unless directory?(current_path)
-  end
-
-  nil
-end
-
   # create and mark directory for cleanup
   def mkdir(path)
     result = nil
     vprint_status("Creating directory #{path}")
     if session.type == 'meterpreter'
       # behave like mkdir -p and don't throw an error if the directory exists
-      result = meterpreter_mkdir_p(path)
+      result = session.fs.dir.mkdir(path) unless directory?(path)
     elsif session.type == 'powershell'
       result = cmd_exec("New-Item \"#{path}\" -itemtype directory")
     elsif session.platform == 'windows'

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -117,37 +117,35 @@ module Msf::Post::File
 
   alias ls dir
 
-  def meterpreter_parent_directory(path)
-    separator = session.fs.file.separator
-    normalized_path = path.tr('\\', '/')
-    parent_path = ::File.dirname(normalized_path)
+def meterpreter_mkdir_p(path)
+  return nil if directory?(path)
 
-    return nil if parent_path == '.'
+  separator = session.fs.file.separator
+  normalized = path.tr('\\/', separator)
+  directories = normalized.split(separator)
+  current_path = ''
 
-    if parent_path.match?(/^[a-zA-Z]:$/)
-      return "#{parent_path}#{separator}"
-    end
-
-    parent_path.tr('/', separator)
+  if normalized.match?(/\A[a-zA-Z]:#{Regexp.escape(separator)}?/)
+    current_path = "#{directories.shift}#{separator}"
+  elsif normalized.start_with?(separator)
+    current_path = separator
   end
 
-  def meterpreter_mkdir_p(path)
-    return nil if directory?(path)
+  directories.each do |dir|
+    next if dir.empty?
 
-    begin
-      return session.fs.dir.mkdir(path)
-    rescue StandardError
-      parent_path = meterpreter_parent_directory(path)
-
-      if parent_path && parent_path != path && !directory?(parent_path)
-        meterpreter_mkdir_p(parent_path)
+    current_path =
+      if current_path.end_with?(separator) || current_path.empty?
+        "#{current_path}#{dir}"
+      else
+        "#{current_path}#{separator}#{dir}"
       end
 
-      return session.fs.dir.mkdir(path) unless directory?(path)
-    end
-
-    nil
+    session.fs.dir.mkdir(current_path) unless directory?(current_path)
   end
+
+  nil
+end
 
   # create and mark directory for cleanup
   def mkdir(path)

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -117,13 +117,45 @@ module Msf::Post::File
 
   alias ls dir
 
+  def meterpreter_parent_directory(path)
+    separator = session.fs.file.separator
+    normalized_path = path.tr('\\', '/')
+    parent_path = ::File.dirname(normalized_path)
+
+    return nil if parent_path == '.'
+
+    if parent_path.match?(/^[a-zA-Z]:$/)
+      return "#{parent_path}#{separator}"
+    end
+
+    parent_path.tr('/', separator)
+  end
+
+  def meterpreter_mkdir_p(path)
+    return nil if directory?(path)
+
+    begin
+      return session.fs.dir.mkdir(path)
+    rescue StandardError
+      parent_path = meterpreter_parent_directory(path)
+
+      if parent_path && parent_path != path && !directory?(parent_path)
+        meterpreter_mkdir_p(parent_path)
+      end
+
+      return session.fs.dir.mkdir(path) unless directory?(path)
+    end
+
+    nil
+  end
+
   # create and mark directory for cleanup
   def mkdir(path)
     result = nil
     vprint_status("Creating directory #{path}")
     if session.type == 'meterpreter'
       # behave like mkdir -p and don't throw an error if the directory exists
-      result = session.fs.dir.mkdir(path) unless directory?(path)
+      result = meterpreter_mkdir_p(path)
     elsif session.type == 'powershell'
       result = cmd_exec("New-Item \"#{path}\" -itemtype directory")
     elsif session.platform == 'windows'

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -117,37 +117,35 @@ module Msf::Post::File
 
   alias ls dir
 
-  def meterpreter_parent_directory(path)
-    separator = session.fs.file.separator
-    normalized_path = path.tr('\\', '/')
-    parent_path = ::File.dirname(normalized_path)
+def meterpreter_mkdir_p(path)
+  return nil if directory?(path)
 
-    return nil if parent_path == '.'
+  separator = session.fs.file.separator
+  normalized = path.tr('\\/', separator)
+  directories = normalized.split(separator)
+  current_path = ''
 
-    if parent_path.match?(/^[a-zA-Z]:$/)
-      return "#{parent_path}#{separator}"
-    end
-
-    parent_path.tr('/', separator)
+  if normalized.match?(/\A[a-zA-Z]:#{Regexp.escape(separator)}?/)
+    current_path = "#{directories.shift}#{separator}"
+  elsif normalized.start_with?(separator)
+    current_path = separator
   end
 
-  def meterpreter_mkdir_p(path)
-    return nil if directory?(path)
+  directories.each do |dir|
+    next if dir.empty?
 
-    begin
-      return session.fs.dir.mkdir(path)
-    rescue StandardError
-      parent_path = meterpreter_parent_directory(path)
-
-      if parent_path && parent_path != path && !directory?(parent_path)
-        meterpreter_mkdir_p(parent_path)
+    current_path =
+      if current_path.end_with?(separator) || current_path.empty?
+        "#{current_path}#{dir}"
+      else
+        "#{current_path}#{separator}#{dir}"
       end
 
-      return session.fs.dir.mkdir(path) unless directory?(path)
-    end
-
-    nil
+    session.fs.dir.mkdir(current_path) unless directory?(current_path)
   end
+
+  nil
+end
 
   # create and mark directory for cleanup
   def mkdir(path, cleanup: true)

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -117,43 +117,13 @@ module Msf::Post::File
 
   alias ls dir
 
-def meterpreter_mkdir_p(path)
-  return nil if directory?(path)
-
-  separator = session.fs.file.separator
-  normalized = path.tr('\\/', separator)
-  directories = normalized.split(separator)
-  current_path = ''
-
-  if normalized.match?(/\A[a-zA-Z]:#{Regexp.escape(separator)}?/)
-    current_path = "#{directories.shift}#{separator}"
-  elsif normalized.start_with?(separator)
-    current_path = separator
-  end
-
-  directories.each do |dir|
-    next if dir.empty?
-
-    current_path =
-      if current_path.end_with?(separator) || current_path.empty?
-        "#{current_path}#{dir}"
-      else
-        "#{current_path}#{separator}#{dir}"
-      end
-
-    session.fs.dir.mkdir(current_path) unless directory?(current_path)
-  end
-
-  nil
-end
-
   # create and mark directory for cleanup
   def mkdir(path, cleanup: true)
     result = nil
     vprint_status("Creating directory #{path}")
     if session.type == 'meterpreter'
       # behave like mkdir -p and don't throw an error if the directory exists
-      result = meterpreter_mkdir_p(path)
+      result = session.fs.dir.mkdir(path) unless directory?(path)
     elsif session.type == 'powershell'
       result = cmd_exec("New-Item \"#{path}\" -itemtype directory")
     elsif session.platform == 'windows'

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -117,13 +117,45 @@ module Msf::Post::File
 
   alias ls dir
 
+  def meterpreter_parent_directory(path)
+    separator = session.fs.file.separator
+    normalized_path = path.tr('\\', '/')
+    parent_path = ::File.dirname(normalized_path)
+
+    return nil if parent_path == '.'
+
+    if parent_path.match?(/^[a-zA-Z]:$/)
+      return "#{parent_path}#{separator}"
+    end
+
+    parent_path.tr('/', separator)
+  end
+
+  def meterpreter_mkdir_p(path)
+    return nil if directory?(path)
+
+    begin
+      return session.fs.dir.mkdir(path)
+    rescue StandardError
+      parent_path = meterpreter_parent_directory(path)
+
+      if parent_path && parent_path != path && !directory?(parent_path)
+        meterpreter_mkdir_p(parent_path)
+      end
+
+      return session.fs.dir.mkdir(path) unless directory?(path)
+    end
+
+    nil
+  end
+
   # create and mark directory for cleanup
   def mkdir(path, cleanup: true)
     result = nil
     vprint_status("Creating directory #{path}")
     if session.type == 'meterpreter'
       # behave like mkdir -p and don't throw an error if the directory exists
-      result = session.fs.dir.mkdir(path) unless directory?(path)
+      result = meterpreter_mkdir_p(path)
     elsif session.type == 'powershell'
       result = cmd_exec("New-Item \"#{path}\" -itemtype directory")
     elsif session.platform == 'windows'

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -67,6 +67,13 @@ class MetasploitModule < Msf::Post
       ret
     end
 
+    it 'should create intermediary directories' do
+      nested_path = [datastore['BaseDirectoryName'], 'parent', 'child'].join(fs_sep)
+      mkdir(nested_path)
+
+      directory?(nested_path)
+    end
+    
     it 'should list the directory we just made' do
       dents = dir(datastore['BaseDirectoryName'])
       dents.include?('file') && dents.include?('directory')

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Post
 
       directory?(nested_path)
     end
-    
+
     it 'should list the directory we just made' do
       dents = dir(datastore['BaseDirectoryName'])
       dents.include?('file') && dents.include?('directory')
@@ -84,13 +84,11 @@ class MetasploitModule < Msf::Post
       !directory?(datastore['BaseDirectoryName'])
     end
 
-    unless (session.platform == 'windows') || (session.platform != 'windows' && command_exists?('ln'))
-      print_warning('skipping link related checks because the target is incompatible')
-    else
+    if (session.platform == 'windows') || (session.platform != 'windows' && command_exists?('ln'))
       it 'should delete a symbolic link target' do
         # TODO: Fix this functionality
         if session.platform.eql?('windows') && session.type.eql?('shell')
-          vprint_status("test skipped for Windows CMD - functionality not correct")
+          vprint_status('test skipped for Windows CMD - functionality not correct')
           next true
         end
         mkdir(datastore['BaseDirectoryName'])
@@ -123,6 +121,8 @@ class MetasploitModule < Msf::Post
         rm_rf("#{datastore['BaseDirectoryName']}.1")
         ret
       end
+    else
+      print_warning('skipping link related checks because the target is incompatible')
     end
   end
 
@@ -223,7 +223,7 @@ class MetasploitModule < Msf::Post
     # binary_data = ::File.read("/bin/ls")
     # binary_data = ::File.read('/bin/echo')
     # binary_data = "\xff\x00\xff\xfe\xff\`$(echo blha)\`"
-    binary_data = ((0..255).to_a * 500).shuffle.pack("c*")
+    binary_data = ((0..255).to_a * 500).shuffle.pack('c*')
     it 'should write binary data' do
       vprint_status "Writing #{binary_data.length} bytes"
       t = Time.now
@@ -300,13 +300,12 @@ class MetasploitModule < Msf::Post
 
   def make_symlink(target, symlink)
     if session.platform == 'windows'
-      cmd_exec("cmd.exe", "/c mklink #{directory?(target) ? '/D ' : ''}#{symlink} #{target}")
+      cmd_exec('cmd.exe', "/c mklink #{directory?(target) ? '/D ' : ''}#{symlink} #{target}")
     else
       cmd_exec("ln -s $(pwd)/#{target} $(pwd)/#{symlink}")
     end
   end
 
-  def register_dir_for_cleanup(path)
-  end
+  def register_dir_for_cleanup(path); end
 
 end


### PR DESCRIPTION
## Summary

This PR fixes [#20697](https://github.com/rapid7/metasploit-framework/issues/20697)
Currently, `powershell`, Windows shell, and Unix (`mkdir -p`) automatically create intermediate directories. However, Windows Meterpreter relies on `CreateDirectoryW`, which fails if parent directories do not exist. This leads to inconsistent behavior depending on the session type.


## Change

This PR introduces a recursive helper method `meterpreter_mkdir_p` and `meterpreter_parent_directory`  to emulate `mkdir -p` behavior for Meterpreter sessions.

The implementation:

* Checks whether the target directory already exists.
* Attempts to create the directory.
* If creation fails due to a missing parent, it recursively creates the parent directory first.
* Retries directory creation after ensuring the parent exists.
* Normalizes path separators for cross-platform compatibility.
* Handles Windows drive roots correctly (e.g., `C:\`).
