### PR TITLE
Bump metasploit_data_models to 6.0.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,12 +353,15 @@ GEM
       mutex_m
       railties (~> 7.0)
     metasploit-payloads (2.0.240)
-    metasploit_data_models (6.0.9)
+    metasploit_data_models (6.0.12)
       activerecord (~> 7.0)
       activesupport (~> 7.0)
       arel-helpers
+      bigdecimal
+      drb
       metasploit-concern
-      metasploit-model (>= 3.1)
+      metasploit-model (~> 5.0.4)
+      mutex_m
       pg
       railties (~> 7.0)
       recog


### PR DESCRIPTION
Bumps metasploit_data_models to 6.0.12. This is needed to pull in changes required for https://github.com/rapid7/metasploit-framework/pull/20886.

> This PR adds a resource field to Mdm::Vuln and Mdm::Service. This field is stored as JSONB and is optional. It will be used to add specific resource information to a vulnerability or a service. This allows multiple instances of the same vulnerability or service type to be reported for different resources. A unique service is now defined by these fields: host, port, proto, name, and resource. Note that no validation is done on the resource field. It is a JSON object that can have arbitrary key/value pairs describing the vulnerability or service.
> 
> This also adds links between services to make layered services possible. A service can now have parent and child services. This design makes it possible to report vulnerabilities on specific service layers. For example, assuming we have these layered services:
> 
> Wordpress > HTTPS > SSL > TCP
> 
> A SQLi on resource /login?user= is reported on the Wordpress service.
> An SSL weak cipher vulnerability is reported on the SSL service.
> Each service has an optional resource field that can be used to distinguish one service from another on the same port. For example, it is possible to have two Wordpress services on the same port but with a different base URI:
> 
> Wordpress on port 80/TCP, resource: {uri: '/webapp1'}
> Wordpress on port 80/TCP, resource: {uri: '/webapp2'}
> Note that each service has port and proto fields to maintain compatibility with the older model. For example:
> 
> Wordpress (443/TCP) > HTTPS (443/TCP) > SSL (443/TCP) > TCP (443/TCP).
> 
> The drawback is that it duplicates the information. Also, no validation is done to check if a child service has the same port/proto as the parent service. I'm open to discussion on this.

## Verification
- [ ] CI passes