### PR TITLE
Moves default payload into default options in Remote for Mac module

### DIFF
--- a/modules/exploits/osx/misc/remote_for_mac_udp_rce.rb
+++ b/modules/exploits/osx/misc/remote_for_mac_udp_rce.rb
@@ -37,9 +37,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_bash',
           'SSL' => true
         },
-        'DefaultPayload' => 'cmd/unix/reverse_bash',
         'DisclosureDate' => '2025-05-27',
         'Notes' => {
           'Stability' => [CRASH_SAFE],


### PR DESCRIPTION
This is the only entry which appears to be incorrect

```console
metasploit-framework/modules % grep -Ri 'DefaultPayload' .
./exploits/osx/misc/remote_for_mac_udp_rce.rb:        'DefaultPayload' => 'cmd/unix/reverse_bash',
metasploit-framework/modules %
```