### PR TITLE
Fix SSH Socket Channels

### DIFF
--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -73,7 +73,7 @@ module Msf::Sessions
 
         ssh_channel.on_eof do |_ch|
           dlog('ssh_channel#on_eof shutting down the socket')
-          rsock.shutdown(Socket::SHUT_WR)
+          lsock.shutdown(Socket::SHUT_WR)
         end
 
         lsock.extend(SocketInterface)
@@ -313,7 +313,7 @@ module Msf::Sessions
           if success
             if timed_out
               # We're not using the port; clean it up
-              elog("Remote forwarding on #{Rex::Socket.to_authority(params.localhost, params.localport)} succeeded after timeout. Stopping channel to clean up dangling port")
+              elog("Remote forwarding on #{Rex::Socket.to_authority(params.localhost, params.localport)} succeeded after timeout, stopping channel to clean up dangling port")
               stop_server_channel(params.localhost, params.localport)
             else
               dlog("Remote forwarding from #{params.localhost} established on port #{params.localport}")

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -141,14 +141,15 @@ module Msf::Sessions
     # Represents an SSH reverse port forward.
     # Will receive connection messages back from the SSH server,
     # whereupon a TcpClientChannel will be opened
+
     class TcpServerChannel
       include Rex::IO::StreamServer
 
-      def initialize(params, client, host, port)
+      attr_reader :params
+
+      def initialize(params, client)
         @params = params
         @client = client
-        @host = host
-        @port = port
         @channels = []
         @closed = false
         @mutex = Mutex.new
@@ -181,7 +182,7 @@ module Msf::Sessions
 
       def close
         if !closed?
-          @closed = @client.stop_server_channel(@host, @port)
+          @closed = @client.stop_server_channel(@params.localhost, @params.localport)
         end
       end
 
@@ -305,21 +306,23 @@ module Msf::Sessions
       timed_out = false
       @ssh_connection.send_global_request('tcpip-forward', :string, params.localhost, :long, params.localport) do |success, response|
         mutex.synchronize {
-          remote_port = params.localport
-          remote_port = response.read_long if remote_port == 0
+          if params.localport == 0
+            params.localport = response.read_long
+          end
+
           if success
             if timed_out
               # We're not using the port; clean it up
-              elog("Remote forwarding on #{params.localhost}:#{params.localport} succeeded after timeout. Stopping channel to clean up dangling port")
-              stop_server_channel(params.localhost, remote_port)
+              elog("Remote forwarding on #{Rex::Socket.to_authority(params.localhost, params.localport)} succeeded after timeout. Stopping channel to clean up dangling port")
+              stop_server_channel(params.localhost, params.localport)
             else
-              dlog("Remote forwarding from #{params.localhost} established on port #{remote_port}")
-              key = [params.localhost, remote_port]
-              msf_channel = TcpServerChannel.new(params, self, params.localhost, remote_port)
+              dlog("Remote forwarding from #{params.localhost} established on port #{params.localport}")
+              key = [params.localhost, params.localport]
+              msf_channel = TcpServerChannel.new(params, self)
               @server_channels[key] = msf_channel
             end
           else
-              elog("Remote forwarding failed on #{params.localhost}:#{params.localport}")
+            elog("Remote forwarding failed on #{Rex::Socket.to_authority(params.localhost, params.localport)}")
           end
           condition.signal
         }
@@ -364,7 +367,7 @@ module Msf::Sessions
       condition = ConditionVariable.new
       opened = false
       ssh_channel = @ssh_connection.open_channel('direct-tcpip', :string, params.peerhost, :long, params.peerport, :string, params.localhost, :long, params.localport) do |_|
-        dlog("new direct-tcpip channel opened to #{Rex::Socket.is_ipv6?(params.peerhost) ? '[' + params.peerhost + ']' : params.peerhost}:#{params.peerport}")
+        dlog("new direct-tcpip channel opened to #{Rex::Socket.to_authority(params.peerhost, params.peerport)}")
         opened = true
         mutex.synchronize do
           condition.signal


### PR DESCRIPTION
This fixes a couple of errors in the `post/test/socket_channels` tests (added in #20689 for context). UDP tests are skipped because the SSH RFC doesn't support UDP channels. One TCP client test is failing, the one where binding to port 0 should allow the target to specify the port and return the value. RFC 4254 section 7.2 doesn't make any note of how the originator IP and port should be handled in this context. The way [Rex::Parameters#localport is written](https://github.com/rapid7/rex-socket/blob/146bc6b2f9ee195625dfb73285f91864c29ab3ab/lib/rex/socket/parameters.rb#L341) prevents checking if port 0 was explicitly set or not. If it was explicitly set and that could be detected, an error should be thrown but that doesn't seem possible.

At this point, all the tests that should pass, are passing for SSH sessions.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login` to open an SSH session, make sure CreateSession is true **and the target server permits the necessary forwarding options in the OpenSSH config**
- [ ] Load the test modules with `loadpath test/modules`
- [ ] Run `post/test/socket_channels`
- [ ] Only see the one failure "[-] FAILED: [TCP-Client] Allows binding to port 0"

## Old and Broken
```
msf auxiliary(scanner/ssh/ssh_login) > set AutoRunScript 
AutoRunScript => post/test/socket_channels
msf auxiliary(scanner/ssh/ssh_login) > run
[*] 127.0.0.1:22          - Starting bruteforce
[*] 127.0.0.1:22 SSH - Testing User/Pass combinations
[+] 127.0.0.1:22          - Success: 'smcintyre:Password1!' 'uid=1000(smcintyre) gid=1000(smcintyre) groups=1000(smcintyre),10(wheel),967(wireshark) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 Linux fedora 6.18.8-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Jan 30 20:23:28 UTC 2026 x86_64 GNU/Linux '
[*] Session ID 1 (?? -> ??) processing AutoRunScript 'post/test/socket_channels'
[*] Running against session 1
[*] Session type is shell and platform is linux
[*] Running TCP client channel tests...
[-] FAILED: [TCP-Client] Allows binding to port 0
[+] [TCP-Client] Has the correct peer information
[+] [TCP-Client] Receives data from the peer
[+] [TCP-Client] Sends data to the peer
[+] [TCP-Client] Propagates close events to the peer
[-] FAILED: [TCP-Client] Propagates close events from the peer
[!] UDP channels are not supported by SSH sessions.
[*] Running TCP server channel tests...
[-] [[TCP-Server] Allows binding to port 0] FAILED: [TCP-Server] Allows binding to port 0
[-] [[TCP-Server] Allows binding to port 0] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] [[TCP-Server] Accepts a connection] FAILED: [TCP-Server] Accepts a connection
[-] [[TCP-Server] Accepts a connection] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] [[TCP-Server] Has the correct peer information] FAILED: [TCP-Server] Has the correct peer information
[-] [[TCP-Server] Has the correct peer information] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] [[TCP-Server] Receives data from the peer] FAILED: [TCP-Server] Receives data from the peer
[-] [[TCP-Server] Receives data from the peer] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] [[TCP-Server] Sends data to the peer] FAILED: [TCP-Server] Sends data to the peer
[-] [[TCP-Server] Sends data to the peer] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] [[TCP-Server] Propagates close events to the server] FAILED: [TCP-Server] Propagates close events to the server
[-] [[TCP-Server] Propagates close events to the server] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] [[TCP-Server] Propagates close events to the peer] FAILED: [TCP-Server] Propagates close events to the peer
[-] [[TCP-Server] Propagates close events to the peer] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] [[TCP-Server] Propagates close events from the peer] FAILED: [TCP-Server] Propagates close events from the peer
[-] [[TCP-Server] Propagates close events from the peer] Exception: NoMethodError: undefined method `params' for an instance of Msf::Sessions::SshCommandShellBind::TcpServerChannel
[-] Passed: 4; Failed: 10; Skipped: 0
[*] SSH session 1 opened (127.0.0.1:34873 -> 127.0.0.1:22) at 2026-02-10 17:06:01 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) >
```

## New and Fixed
```
msf auxiliary(scanner/ssh/ssh_login) > run
[*] 127.0.0.1:22          - Starting bruteforce
[*] 127.0.0.1:22 SSH - Testing User/Pass combinations
[+] 127.0.0.1:22          - Success: 'smcintyre:Password1!' 'uid=1000(smcintyre) gid=1000(smcintyre) groups=1000(smcintyre),10(wheel),967(wireshark) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 Linux fedora 6.18.8-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Jan 30 20:23:28 UTC 2026 x86_64 GNU/Linux '
[*] Session ID 1 (?? -> ??) processing AutoRunScript 'post/test/socket_channels'
[*] Running against session 1
[*] Session type is shell and platform is linux
[*] Running TCP client channel tests...
[-] FAILED: [TCP-Client] Allows binding to port 0
[+] [TCP-Client] Has the correct peer information
[+] [TCP-Client] Receives data from the peer
[+] [TCP-Client] Sends data to the peer
[+] [TCP-Client] Propagates close events to the peer
[+] [TCP-Client] Propagates close events from the peer
[!] UDP channels are not supported by SSH sessions.
[*] Running TCP server channel tests...
[+] [TCP-Server] Allows binding to port 0
[+] [TCP-Server] Accepts a connection
[+] [TCP-Server] Has the correct peer information
[+] [TCP-Server] Receives data from the peer
[+] [TCP-Server] Sends data to the peer
[+] [TCP-Server] Propagates close events to the server
[+] [TCP-Server] Propagates close events to the peer
[+] [TCP-Server] Propagates close events from the peer
[-] Passed: 13; Failed: 1; Skipped: 0
[*] SSH session 1 opened (127.0.0.1:41345 -> 127.0.0.1:22) at 2026-02-10 16:51:25 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
