### PR TITLE
Ensure temp rhost files are cleaned up

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -82,9 +82,18 @@ module Common
     end
 
     if rhosts.length > 5
+      @rhosts_file_cleanup_proc ||= at_exit do
+        @temp_rhosts_files.each do |path|
+          File.delete(path)
+        rescue => e
+          elog(e)
+        end
+      end
       # Lots of hosts makes 'show options' wrap which is difficult to
       # read, store to a temp file
       rhosts_file = Rex::Quickfile.create("msf-db-rhosts-")
+      @temp_rhosts_files ||= []
+      @temp_rhosts_files << rhosts_file.path
       mydatastore['RHOSTS'] = 'file:'+rhosts_file.path
       # create the output file and assign it to the RHOSTS variable
       rhosts_file.write(rhosts.join("\n")+"\n")


### PR DESCRIPTION
Ensure temp rhost files are cleaned up

Continuation of #20599

## Verification

Replication steps from: #20599 - verify the files created are cleaned up from the disk after msfconsole exits