### PR TITLE
Update Wordpress Mixin to log services

### DIFF
--- a/lib/msf/core/exploit/remote/http/wordpress.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress.rb
@@ -38,6 +38,16 @@ module Msf
           def wp_content_dir
             datastore['WPCONTENTDIR']
           end
+          
+          def report_wordpress_service
+            report_service(
+              host: rhost,
+              port: rport,
+              proto: 'tcp',
+              name: ssl ? 'https' : 'http',
+              info: 'WordPress'
+            )
+          end
         end
       end
     end

--- a/lib/msf/core/exploit/remote/http/wordpress.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress.rb
@@ -38,14 +38,27 @@ module Msf
           def wp_content_dir
             datastore['WPCONTENTDIR']
           end
-          
+
           def report_wordpress_service
             report_service(
               host: rhost,
               port: rport,
               proto: 'tcp',
               name: ssl ? 'https' : 'http',
-              info: 'WordPress'
+              name: 'WordPress',
+              parents: {
+                name: ssl ? 'https' : 'http',
+                host: rhost,
+                port: rport,
+                proto: 'tcp',
+                parents: {
+                  name: 'tcp',
+                  host: rhost,
+                  port: rport,
+                  proto: 'tcp',
+                  parents: nil
+                }
+              }
             )
           end
         end

--- a/lib/msf/core/exploit/remote/http/wordpress.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress.rb
@@ -44,7 +44,6 @@ module Msf
               host: rhost,
               port: rport,
               proto: 'tcp',
-              name: ssl ? 'https' : 'http',
               name: 'WordPress',
               parents: {
                 name: ssl ? 'https' : 'http',

--- a/lib/msf/core/exploit/remote/http/wordpress/base.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/base.rb
@@ -29,7 +29,11 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Base
       )
     end
 
-    return res if res && res.code == 200 && res.body && wordpress_detect_regexes.any? { |r| res.body =~ r }
+    if res && res.code == 200 && res.body && wordpress_detect_regexes.any? { |r| res.body =~ r }
+      report_wordpress_service
+      return res
+    end
+    
     return nil
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
     print_error("Error connecting to #{target_uri}: #{e}")

--- a/lib/msf/core/exploit/remote/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/version.rb
@@ -152,6 +152,8 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       return check_theme_version_from_style(name, fixed_version, vuln_introduced_version) if type == :theme
     end
 
+    report_wordpress_service
+    
     version_res = extract_and_check_version(res.body.to_s, :readme, type, fixed_version, vuln_introduced_version)
     if version_res == Msf::Exploit::CheckCode::Detected && type == :theme
       # If no version could be found in readme.txt for a theme, try style.css

--- a/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Base do
                                                                          proto: 'tcp',
                                                                          name: 'WordPress',
                                                                          parents: {
-                                                                           name: 'https',
+                                                                           name: 'http',
                                                                            host: nil,
                                                                            port:
                                                                              80,

--- a/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
@@ -54,7 +54,26 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Base do
       let(:wp_body) { '<a href="http://domain.com/wp-content/themes/a/style.css">' }
 
       it 'reports the WordPress service over HTTP' do
-        expect(subject).to receive(:report_service).with(hash_including(name: 'http', info: 'WordPress'))
+        expect(subject).to receive(:report_service).with(hash_including({host: nil,
+                                                                         port: 80,
+                                                                         proto: 'tcp',
+                                                                         name: 'WordPress',
+                                                                         parents: {
+                                                                           name: 'https',
+                                                                           host: nil,
+                                                                           port:
+                                                                             80,
+                                                                           proto: 'tcp',
+                                                                           parents: {
+                                                                             name: 'tcp',
+                                                                             host:
+                                                                               nil,
+                                                                             port:
+                                                                               80,
+                                                                             proto: 'tcp',
+                                                                             parents: nil
+                                                                           }
+                                                                         }}))
         subject.wordpress_and_online?
       end
     end

--- a/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Base do
 
   describe '#wordpress_and_online?' do
     before :example do
+      allow(subject).to receive(:report_service)
       allow(subject).to receive(:send_request_cgi) do
         res = Rex::Proto::Http::Response.new
         res.code = wp_code
@@ -48,6 +49,24 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Base do
       it { expect(subject.wordpress_and_online?).to be_nil }
     end
 
+    
+    context 'when WordPress is detected' do
+      let(:wp_body) { '<a href="http://domain.com/wp-content/themes/a/style.css">' }
+
+      it 'reports the WordPress service over HTTP' do
+        expect(subject).to receive(:report_service).with(hash_including(name: 'http', info: 'WordPress'))
+        subject.wordpress_and_online?
+      end
+    end
+
+    context 'when WordPress is not detected' do
+      let(:wp_body) { 'Invalid body' }
+
+      it 'does not report the WordPress service' do
+        expect(subject).not_to receive(:report_service)
+        subject.wordpress_and_online?
+      end
+    end
   end
 
 end

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
                                                                           proto: 'tcp',
                                                                           name: 'WordPress',
                                                                           parents: {
-                                                                            name: 'https',
+                                                                            name: 'http',
                                                                             host: nil,
                                                                             port: 80,
                                                                             proto: 'tcp',

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -189,22 +189,24 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
       it 'reports the WordPress service over HTTP' do
         expect(subject).to receive(:report_service).with(hash_including({host: nil,
-port: 80,
-proto: 'tcp',
-name: 'WordPress',
-parents: {
-  name: 'https',
-  host: nil,
-  port: 80,
-  proto: 'tcp',
-  parents: {
-    name: 'tcp',
-    host: nil,
-    port: 80,
-    proto: 'tcp',
-    parents: nil
-  }
-}}))
+                                                                          port: 80,
+                                                                          proto: 'tcp',
+                                                                          name: 'WordPress',
+                                                                          parents: {
+                                                                            name: 'https',
+                                                                            host: nil,
+                                                                            port: 80,
+                                                                            proto: 'tcp',
+                                                                            parents: {
+                                                                              name: 'tcp',
+                                                                              host:
+                                                                                nil,
+                                                                              port: 80,
+                                                                              proto: 'tcp',
+                                                                              parents:
+                                                                                nil
+                                                                            }
+                                                                          }}))
         subject.send(:check_version_from_readme, :plugin, 'name')
       end
     end

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -188,7 +188,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_body) { 'stable tag: 1.0.0' }
 
       it 'reports the WordPress service over HTTP' do
-        expect(subject).to receive(:report_service).with(hash_including(name: 'http', info: 'WordPress'))
+        expect(subject).to receive(:report_service).with(hash_including({host: nil,
+port: 80,
+proto: 'tcp',
+name: 'WordPress',
+parents: {
+  name: 'https',
+  host: nil,
+  port: 80,
+  proto: 'tcp',
+  parents: {
+    name: 'tcp',
+    host: nil,
+    port: 80,
+    proto: 'tcp',
+    parents: nil
+  }
+}}))
         subject.send(:check_version_from_readme, :plugin, 'name')
       end
     end

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
   describe '#check_version_from_readme' do
     before :example do
+      allow(subject).to receive(:report_service)
       allow(subject).to receive(:send_request_cgi) do |opts|
         res = Rex::Proto::Http::Response.new
         res.code = wp_code
@@ -179,6 +180,25 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
         ret = subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)
         expect(ret).to eq(expected_checkcode)
         expect(ret.reason).to eq(expected_checkcode.reason)
+      end
+    end
+    
+    context 'when a readme is found' do
+      let(:wp_code) { 200 }
+      let(:wp_body) { 'stable tag: 1.0.0' }
+
+      it 'reports the WordPress service over HTTP' do
+        expect(subject).to receive(:report_service).with(hash_including(name: 'http', info: 'WordPress'))
+        subject.send(:check_version_from_readme, :plugin, 'name')
+      end
+    end
+
+    context 'when no readme is found for a plugin' do
+      let(:wp_code) { 404 }
+
+      it 'does not report the WordPress service' do
+        expect(subject).not_to receive(:report_service)
+        subject.send(:check_version_from_readme, :plugin, 'name')
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR fixes [#20958](https://github.com/rapid7/metasploit-framework/issues/20958)
This improves how reporting detected WordPress services from the shared HTTP mixin.
When WordPress is confirmed,  report the service as http or https (based on SSL) with WordPress as service info, so module output and host/service data are more accurate and consistent across the framework. 

### What this change does
Adds a reusable helper (`report_wordpress_service`) in the WordPress HTTP mixin for consistent service reporting. 

Updates `wordpress_and_online?` to report the WordPress service whenever detection succeeds. 

Updates `check_version_from_readme` to report the service when a WordPress plugin/theme readme is successfully retrieved and processed, which improves downstream reporting for modules that rely on this shared check path. 
