### PR TITLE
Report more vulns when importing acunetix XML file

### DIFF
--- a/lib/rex/parser/acunetix_document.rb
+++ b/lib/rex/parser/acunetix_document.rb
@@ -214,7 +214,6 @@ module Rex
       return unless in_tag("ReportItem")
       return unless @state[:report_item][:name]
       return unless @state[:report_item][:severity]
-      return unless @state[:report_item][:severity].downcase == "high"
 
       @state[:vuln_info] = {}
       @state[:vuln_info][:name] = @state[:report_item][:name]


### PR DESCRIPTION
This PR removes the `high` severity requirement needing to be met before a vulnerability gets reported when `db_import`'ing an Acunetix XML report file.

As an example XML file, you can use the file provided by bcoles here: https://github.com/rapid7/metasploit-framework/issues/17932

## Verification

- [ ] Start `msfconsole`
- [ ] `db_import FILE_HERE.xml`
- [ ] `vulns`
- [ ] Verify you have many vulnerabilities reported

## Before
```
msf > vulns

Vulnerabilities
===============

Timestamp                Host             Name                                                              References
---------                ----             ----                                                              ----------
2026-02-12 17:32:45 UTC  192.168.200.142  PHP-CGI remote code execution
```

## After
```
msf > vulns

Vulnerabilities
===============

Timestamp                Host             Name                                                              References
---------                ----             ----                                                              ----------
2026-02-12 17:32:45 UTC  192.168.200.142  PHP-CGI remote code execution
2026-02-13 14:28:31 UTC  192.168.200.142  Apache 2.x version older than 2.2.9
2026-02-13 14:28:31 UTC  192.168.200.142  Apache httpd remote denial of service
2026-02-13 14:28:31 UTC  192.168.200.142  Apache httpOnly cookie disclosure
2026-02-13 14:28:31 UTC  192.168.200.142  Apache JServ protocol service
2026-02-13 14:28:31 UTC  192.168.200.142  HTML form without CSRF protection
2026-02-13 14:28:31 UTC  192.168.200.142  Password field submitted using GET method
2026-02-13 14:28:31 UTC  192.168.200.142  PHP hangs on parsing particular strings as floating point number
2026-02-13 14:28:31 UTC  192.168.200.142  User credentials are sent in clear text
2026-02-13 14:28:31 UTC  192.168.200.142  Apache 2.x version older than 2.2.10
2026-02-13 14:28:31 UTC  192.168.200.142  Apache mod_negotiation filename bruteforcing
2026-02-13 14:28:31 UTC  192.168.200.142  Clickjacking: X-Frame-Options header missing
2026-02-13 14:28:31 UTC  192.168.200.142  File upload
2026-02-13 14:28:31 UTC  192.168.200.142  Sensitive page could be cached
2026-02-13 14:28:31 UTC  192.168.200.142  Session token in URL
2026-02-13 14:28:31 UTC  192.168.200.142  TRACE method is enabled
2026-02-13 14:28:31 UTC  192.168.200.142  Broken links
2026-02-13 14:28:31 UTC  192.168.200.142  Error page web server version disclosure
2026-02-13 14:28:31 UTC  192.168.200.142  Password type input with auto-complete enabled
```