### PR TITLE
Fix false positives on lg simple editor check methods

### DIFF
--- a/modules/exploits/windows/http/lg_simple_editor_rce.rb
+++ b/modules/exploits/windows/http/lg_simple_editor_rce.rb
@@ -68,8 +68,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
 
-    version = Rex::Version.new(res.get_html_document.xpath('//h2')[0]&.text&.gsub('v', ''))
-    return Exploit::CheckCode::Unknown if version.nil? || version == 'Unknown'
+    version_text = res.get_html_document.xpath('//h2')[0]&.text&.gsub('v', '')
+    return Exploit::CheckCode::Unknown if version_text.blank? || version_text == 'Unknown'
+
+    version = Rex::Version.new(version_text)
+    return Exploit::CheckCode::Unknown if version == Rex::Version.new('0')
     return Exploit::CheckCode::Appears("Version: #{version}") if version <= Rex::Version.new('3.21.0')
 
     Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
+++ b/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
@@ -67,8 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
 
-    version = Rex::Version.new(res.get_html_document.xpath('//h2')[0]&.text&.gsub('v', ''))
-    return Exploit::CheckCode::Unknown if version.nil? || version == 'Unknown'
+    version_text = res.get_html_document.xpath('//h2')[0]&.text&.gsub('v', '')
+    return Exploit::CheckCode::Unknown if version_text.blank? || version_text == 'Unknown'
+
+    version = Rex::Version.new(version_text)
+    return Exploit::CheckCode::Unknown if version == Rex::Version.new('0')
     return Exploit::CheckCode::Appears("Version: #{version}") if version <= Rex::Version.new('3.21.0')
 
     Exploit::CheckCode::Safe


### PR DESCRIPTION
Fix false positives on lg simple editor check methods

## Verification

Before false positives:

```
msf exploit(windows/http/lg_simple_editor_rce) > recheck http://127.0.0.1:8080/ httptrace=true
[*] Reloading module...
####################
# Request:
####################
GET /simpleeditor/common/commonReleaseNotes.do HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36


####################
# Response:
####################
HTTP/1.1 404 Not Found
Date: Fri, 13 Feb 2026 22:49:43 GMT
Server: Apache/2.4.66 (Debian)
Content-Length: 313
Content-Type: text/html; charset=iso-8859-1

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.66 (Debian) Server at 127.0.0.1 Port 8080</address>
</body></html>

[*] 127.0.0.1:8080 - The target appears to be vulnerable. Version: 0
msf exploit(windows/http/lg_simple_editor_rce) > 
```

After no false positives:

```
msf exploit(windows/http/lg_simple_editor_rce) > check http://127.0.0.1:8080/ httptrace=true
####################
# Request:
####################
GET /simpleeditor/common/commonReleaseNotes.do HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36


####################
# Response:
####################
HTTP/1.1 404 Not Found
Date: Fri, 13 Feb 2026 22:49:26 GMT
Server: Apache/2.4.66 (Debian)
Content-Length: 313
Content-Type: text/html; charset=iso-8859-1

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.66 (Debian) Server at 127.0.0.1 Port 8080</address>
</body></html>

[*] 127.0.0.1:8080 - Cannot reliably check exploitability.
msf exploit(windows/http/lg_simple_editor_rce) > 

```