### PR TITLE
HWBridge: support sessions -c execution and preserve non-200 JSON errors

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1640,6 +1640,12 @@ class Core
               print_line(output) if output
             when 'mssql', 'postgresql', 'mysql'
               session.run_cmd(cmd, driver.output)
+            when 'hwbridge'
+              if session.respond_to?(:console) && session.console
+                session.console.run_single(cmd)
+              else
+                print_error("Session #{s} has no hwbridge console; skipping...")
+              end
             end
           ensure
             # Restore timeout for each session

--- a/modules/auxiliary/client/hwbridge/connect.rb
+++ b/modules/auxiliary/client/hwbridge/connect.rb
@@ -69,12 +69,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    parsed = nil
-    begin
-      parsed = JSON.parse(res.body)
-    rescue JSON::ParserError
-      parsed = nil
-    end
+    parsed = res.get_json_document
 
     if res.code == 200
       print_status res.body if datastore['DEBUGJSON'] == true

--- a/modules/auxiliary/client/hwbridge/connect.rb
+++ b/modules/auxiliary/client/hwbridge/connect.rb
@@ -69,12 +69,27 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    if res.code == 200
-      print_status res.body if datastore['DEBUGJSON'] == true
-      return JSON.parse(res.body)
+    parsed = nil
+    begin
+      parsed = JSON.parse(res.body)
+    rescue JSON::ParserError
+      parsed = nil
     end
 
-    return
+    if res.code == 200
+      print_status res.body if datastore['DEBUGJSON'] == true
+      return parsed || {}
+    end
+
+    # Preserve non-200 JSON bodies so callers can surface adapter error codes
+    if parsed.is_a?(Hash)
+      parsed['_http_status'] = res.code
+      print_error("HTTP #{res.code}: #{parsed}") if datastore['DEBUGJSON'] == true
+      return parsed
+    end
+
+    print_error("HTTP #{res.code}: #{res.body}") if datastore['DEBUGJSON'] == true
+    return({ 'status' => 'error', 'error' => { 'code' => 'HTTP_ERROR', 'message' => "HTTP #{res.code}" } })
   rescue OpenSSL::SSL::SSLError
     vprint_error('SSL error')
     return


### PR DESCRIPTION
## Summary
This PR improves non-interactive HWBridge workflows in two focused ways:

1. `sessions -c` now executes commands for `hwbridge` sessions.
2. `auxiliary/client/hwbridge/connect` now preserves parsed JSON error bodies for non-200 HTTP responses (instead of returning `nil`).

## Motivation
In resource-script automation, interactive `sessions -i` for HWBridge can fail in non-TTY contexts (readline/TTY errors).  
The intended alternative is `sessions -c`, but `cmd_sessions` did not execute commands for `hwbridge` session type.

Additionally, when adapter calls returned non-200 (for example `RATE_LIMITED`), `fetch_json` dropped the response body, making diagnosis difficult.

## Changes
### 1) `cmd_sessions` support for `hwbridge` in `-c` path
**File:** `lib/msf/ui/console/command_dispatcher/core.rb`

- In `when 'cmd'` handling, add `when 'hwbridge'` branch.
- Execute command via `session.console.run_single(cmd)`.

Result:
- `sessions -i <id> -c "<hwbridge command>"` now runs HWBridge console commands non-interactively.

### 2) Preserve non-200 JSON in HWBridge connector
**File:** `modules/auxiliary/client/hwbridge/connect.rb`

- `fetch_json` now parses JSON response bodies for non-200 statuses.
- Returns structured error hashes (including `_http_status`) instead of returning `nil`.
- 200-path behavior remains unchanged.

Result:
- Adapter errors like `RATE_LIMITED` are surfaced in logs/callers.

## Behavioral Impact
- No behavior change for non-HWBridge session types.
- No behavior change for successful HTTP 200 JSON responses.
- Improved observability for HWBridge non-200 responses.

## Verification Steps
1. Start a compliant HWBridge adapter endpoint.
2. In `msfconsole`:
   - `use auxiliary/client/hwbridge/connect`
   - set `RHOST/RPORT/TARGETURI`
   - `set DEBUGJSON true`
   - `run`
3. Verify non-interactive command execution:
   - `sessions -i 1 -c "load_custom_methods"`
   - `sessions -i 1 -c "send_frame ..."`
4. Trigger adapter-side throttling (or any non-200 error) and verify output includes structured JSON error details with `_http_status`.

## Example Evidence (from validation logs)
- `sessions -c` now executes HWBridge commands and returns command JSON:
  - `{"status":"ok","value":{"tx_id":"...","squarepeg":{"message_id":9401,...}}}`
- Non-200 adapter errors are now visible:
  - `HTTP 400: {"status"=>"error","error"=>{"code"=>"RATE_LIMITED",...},"_http_status"=>400}`

## Checklist
- [x] `sessions -c` executes HWBridge commands for `hwbridge` sessions
- [x] Non-200 adapter errors are surfaced as parsed JSON
- [x] No intended behavior change for `meterpreter/shell/sql` command execution paths
- [x] Console output included for verification