### PR TITLE
Updates metasploit-payloads to 2.0.242

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.240)
+      metasploit-payloads (= 2.0.242)
       metasploit_data_models (>= 6.0.15)
       metasploit_payloads-mettle (= 1.0.46)
       mqtt
@@ -352,7 +352,7 @@ GEM
       drb
       mutex_m
       railties (~> 7.0)
-    metasploit-payloads (2.0.240)
+    metasploit-payloads (2.0.242)
     metasploit_data_models (6.0.15)
       activerecord (~> 7.0)
       activesupport (~> 7.0)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -99,7 +99,7 @@ metasploit-concern, 5.0.5, "New BSD"
 metasploit-credential, 6.0.20, "New BSD"
 metasploit-framework, 6.4.123, "New BSD"
 metasploit-model, 5.0.4, "New BSD"
-metasploit-payloads, 2.0.240, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.242, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.15, "New BSD"
 metasploit_payloads-mettle, 1.0.46, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.240'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.243'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.46'
   # Needed by msfgui and other rpc components

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.243'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.242'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.46'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 36978
+  CachedSize = 36994
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 36994
+  CachedSize = 36978
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 4416
+  CachedSize = 4656
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 273486
+  CachedSize = 196678
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 190534
+  CachedSize = 273486
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 273486
+  CachedSize = 196678
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 190534
+  CachedSize = 273486
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 274532
+  CachedSize = 197724
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 191580
+  CachedSize = 274532
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 274532
+  CachedSize = 197724
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 191580
+  CachedSize = 274532
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 273486
+  CachedSize = 196678
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 190534
+  CachedSize = 273486
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 273486
+  CachedSize = 196678
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 190534
+  CachedSize = 273486
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/encrypted_shell_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 4608
+  CachedSize = 4176
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 320078
+  CachedSize = 244806
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 232006
+  CachedSize = 320078
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 320078
+  CachedSize = 244806
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 232006
+  CachedSize = 320078
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 233052
+  CachedSize = 321124
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 321124
+  CachedSize = 245852
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 233052
+  CachedSize = 321124
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 321124
+  CachedSize = 245852
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 320078
+  CachedSize = 244806
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 232006
+  CachedSize = 320078
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 320078
+  CachedSize = 244806
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 232006
+  CachedSize = 320078
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/encrypted_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 2880
+  CachedSize = 2992
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::EncryptedReverseTcp

--- a/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/encrypted_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 3072
+  CachedSize = 2688
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::EncryptedReverseTcp


### PR DESCRIPTION
Includes changes from:
* rapid7/metasploit-payloads#790
