### PR TITLE
Add check method to ms17-010 scanner module

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -78,6 +78,10 @@ class MetasploitModule < Msf::Auxiliary
     s == 0 ? 'x86 (32-bit)' : 'x64 (64-bit)'
   end
 
+  def check_host(ip)
+    run_host(ip)
+  end
+
   def run_host(ip)
     checkcode = Exploit::CheckCode::Unknown
     details = {}


### PR DESCRIPTION
Adds a check method to ms17-010 scanner module to improve the metadata associated with automation workflows

## Verification

Ensure `check` and `run` now work for this module