### PR TITLE
Remove encoding issue in source file

### DIFF
--- a/external/source/exploits/CVE-2023-21768/exploit.h
+++ b/external/source/exploits/CVE-2023-21768/exploit.h
@@ -177,7 +177,7 @@ typedef struct _KEVENT
 
 #define AFD_NOTIFYSOCK_IOCTL 0x12127
 
-// Good enough™ best guess on what this structure is.
+// Good enough best guess on what this structure is.
 typedef struct AFD_NOTIFYSOCK_DATA
 {
     HANDLE hCompletion;


### PR DESCRIPTION
Remove encoding issue in this source file which causes sonar qube to fail, and maybe other tooling

>  11:58:49.880 WARN  Invalid character encountered in file /home/jenkins/agent/workspace/ploit-framework-sonarqube_master/external/source/exploits/CVE-2023-21768/exploit.h at line 180 for encoding UTF-8. Please fix file content or configure the encoding to be used using property 'sonar.sourceEncoding'.

## Verification

Ensure CI passes