### PR TITLE
Revert "Report more vulns when importing acunetix XML file"

### DIFF
--- a/lib/rex/parser/acunetix_document.rb
+++ b/lib/rex/parser/acunetix_document.rb
@@ -214,6 +214,7 @@ module Rex
       return unless in_tag("ReportItem")
       return unless @state[:report_item][:name]
       return unless @state[:report_item][:severity]
+      return unless @state[:report_item][:severity].downcase == "high"
 
       @state[:vuln_info] = {}
       @state[:vuln_info][:name] = @state[:report_item][:name]


### PR DESCRIPTION
Reverts rapid7/metasploit-framework#20969

Removing this line caused some issues when importing the acunetix.xml file from our QA repo;
The import failed in our tests over in Pro, when parsing a ReportItem with an empty request/response field.

It also feels like there is some fundamental issues in the Acunetix parser; some vulnerabilities could get reported under the wrong name/path.