### PR TITLE
Fix trailing backslash in shell registry operations

### DIFF
--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -680,6 +680,9 @@ protected
   # Normalize the supplied full registry key string so the root key is sane.  For
   # instance, passing "HKLM\Software\Dog" will return 'HKEY_LOCAL_MACHINE\Software\Dog'
   #
+  # Any trailing backslash is stripped to prevent cmd.exe argument escaping
+  # issues when the normalized key is interpolated into a quoted shell command.
+  #
   def normalize_key(key)
     keys = split_key(key)
     if (keys[0] =~ /HKLM|HKEY_LOCAL_MACHINE/)
@@ -700,7 +703,7 @@ protected
       raise ArgumentError, "Cannot normalize unknown key: #{key}"
     end
     # print_status("Normalized #{key} to #{keys.join("\\")}")
-    return keys.compact.join("\\")
+    return keys.compact.join("\\").chomp("\\")
   end
 
   #

--- a/modules/exploits/windows/persistence/registry.rb
+++ b/modules/exploits/windows/persistence/registry.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft').include?('PowerShell')
 
     vprint_good('Powershell detected on system')
 

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft').include?('PowerShell')
 
     vprint_good('Powershell detected on system')
 

--- a/modules/exploits/windows/persistence/wsl/registry.rb
+++ b/modules/exploits/windows/persistence/wsl/registry.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # /tmp seems to persist on *some* Ubuntu WSL (wsl v1 it did, v2 it didnt)
     print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('/tmp')
-    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft\\').include?('PowerShell')
+    return Msf::Exploit::CheckCode::Safe('System does not have powershell') unless registry_enumkeys('HKLM\\SOFTWARE\\Microsoft').include?('PowerShell')
 
     vprint_good('Powershell detected on system')
 

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Post
   end
 
   def ntds_location
-    @ntds_location ||= registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\services\\NTDS\\Parameters\\', 'DSA Working Directory')
+    @ntds_location ||= registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\services\\NTDS\\Parameters', 'DSA Working Directory')
   end
 
   def ntdsutil_method

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -81,8 +81,8 @@ class MetasploitModule < Msf::Post
   def get_registry
     print_status('Looking in registry for stored login passwords by Picasa ...')
 
-    username = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa2\\Preferences\\', 'GaiaEmail') || ''
-    password = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa2\\Preferences\\', 'GaiaPass') || ''
+    username = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa2\\Preferences', 'GaiaEmail') || ''
+    password = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa2\\Preferences', 'GaiaPass') || ''
 
     credentials = Rex::Text::Table.new(
       'Header' => 'Picasa Credentials',
@@ -109,8 +109,8 @@ class MetasploitModule < Msf::Post
     end
 
     # For early versions of Picasa3
-    username = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences\\', 'GaiaEmail') || ''
-    password = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences\\', 'GaiaPass') || ''
+    username = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences', 'GaiaEmail') || ''
+    password = registry_getvaldata('HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences', 'GaiaPass') || ''
 
     if !username.empty? && !password.empty?
       passbin = [password].pack('H*')

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -378,14 +378,14 @@ class MetasploitModule < Msf::Post
   def get_domain_reg
     locations = []
     # Lots of redundancy but hey this is quick!
-    locations << ['HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\', 'Domain']
-    locations << ['HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\', 'DefaultDomainName']
-    locations << ['HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History\\', 'MachineDomain']
+    locations << ['HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters', 'Domain']
+    locations << ['HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon', 'DefaultDomainName']
+    locations << ['HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\History', 'MachineDomain']
 
     domains = []
 
     # Pulls cached domains from registry
-    domain_cache = registry_enumvals('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\DomainCache\\')
+    domain_cache = registry_enumvals('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\DomainCache')
     if domain_cache
       domain_cache.each { |ud| domains << ud }
     end

--- a/modules/post/windows/gather/credentials/idm.rb
+++ b/modules/post/windows/gather/credentials/idm.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Post
       print_status("Looking at Key #{k}")
 
       begin
-        subkeys = registry_enumkeys("HKU\\#{k}\\Software\\DownloadManager\\Passwords\\")
+        subkeys = registry_enumkeys("HKU\\#{k}\\Software\\DownloadManager\\Passwords")
 
         if subkeys.nil? || subkeys.empty?
           print_status('IDM not installed for this user.')

--- a/modules/post/windows/gather/credentials/imvu.rb
+++ b/modules/post/windows/gather/credentials/imvu.rb
@@ -52,13 +52,13 @@ class MetasploitModule < Msf::Post
       next if hive['HKU'].nil?
 
       vprint_status("Looking at Key #{hive['HKU']}")
-      subkeys = registry_enumkeys("#{hive['HKU']}\\Software\\IMVU\\")
+      subkeys = registry_enumkeys("#{hive['HKU']}\\Software\\IMVU")
       if subkeys.nil? || subkeys.empty?
         print_status('IMVU not installed for this user.')
         next
       end
-      user = registry_getvaldata("#{hive['HKU']}\\Software\\IMVU\\username\\", '')
-      hpass = registry_getvaldata("#{hive['HKU']}\\Software\\IMVU\\password\\", '')
+      user = registry_getvaldata("#{hive['HKU']}\\Software\\IMVU\\username", '')
+      hpass = registry_getvaldata("#{hive['HKU']}\\Software\\IMVU\\password", '')
       decpass = [ hpass.downcase.gsub(/'/, '').gsub(/\\?x([a-f0-9][a-f0-9])/, '\1') ].pack('H*')
       print_good("User=#{user}, Password=#{decpass}")
       creds << [user, decpass]

--- a/modules/post/windows/gather/credentials/nimbuzz.rb
+++ b/modules/post/windows/gather/credentials/nimbuzz.rb
@@ -48,15 +48,15 @@ class MetasploitModule < Msf::Post
       next if k.include?('_Classes')
 
       vprint_status("Looking at Key #{k}")
-      subkeys = registry_enumkeys("HKU\\#{k}\\Software\\Nimbuzz\\")
+      subkeys = registry_enumkeys("HKU\\#{k}\\Software\\Nimbuzz")
 
       if subkeys.nil? || (subkeys == '')
         print_status('Nimbuzz Instant Messenger not installed for this user.')
         next
       end
 
-      user = registry_getvaldata("HKU\\#{k}\\Software\\Nimbuzz\\PCClient\\Application\\", 'Username') || ''
-      hpass = registry_getvaldata("HKU\\#{k}\\Software\\Nimbuzz\\PCClient\\Application\\", 'Password')
+      user = registry_getvaldata("HKU\\#{k}\\Software\\Nimbuzz\\PCClient\\Application", 'Username') || ''
+      hpass = registry_getvaldata("HKU\\#{k}\\Software\\Nimbuzz\\PCClient\\Application", 'Password')
 
       next if hpass.nil? || (hpass == '')
 

--- a/modules/post/windows/gather/outlook.rb
+++ b/modules/post/windows/gather/outlook.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Post
 
   def outlook_installed?
     key_base = 'HKCU\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Windows Messaging Subsystem\\Profiles\\Outlook\\9375CFF0413111d3B88A00104B2A6676'
-    installed = registry_getvaldata("#{key_base}\\", 'NextAccountID')
+    installed = registry_getvaldata(key_base, 'NextAccountID')
 
     if installed.blank? || installed == 0
       return false

--- a/scripts/meterpreter/gettelnet.rb
+++ b/scripts/meterpreter/gettelnet.rb
@@ -33,7 +33,7 @@ def checkifinst()
   # This won't work on windows 2000 since there is no sc.exe
   print_status("Checking if Telnet is installed...")
   begin
-    registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\services\\TlntSvr\\","Start")
+    registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\services\\TlntSvr","Start")
     return true
   rescue
     return false

--- a/spec/lib/msf/core/post/windows/registry_spec.rb
+++ b/spec/lib/msf/core/post/windows/registry_spec.rb
@@ -1,0 +1,91 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Post::Windows::Registry do
+  subject do
+    context_described_class = described_class
+
+    klass = Class.new(Msf::Post) do
+      include context_described_class
+    end
+
+    klass.new
+  end
+
+  describe '#split_key' do
+    [
+      { input: 'HKLM\\SOFTWARE\\Microsoft', expected: ['HKLM', 'SOFTWARE\\Microsoft'] },
+      { input: 'HKLM\\SOFTWARE\\Microsoft\\', expected: ['HKLM', 'SOFTWARE\\Microsoft\\'] },
+      { input: 'HKLM', expected: ['HKLM', nil] },
+      { input: 'HKCU\\Environment', expected: ['HKCU', 'Environment'] },
+      { input: 'HKU\\S-1-5-21-1234', expected: ['HKU', 'S-1-5-21-1234'] },
+      { input: '', expected: ['', nil] },
+    ].each do |test_case|
+      it "splits #{test_case[:input].inspect} into #{test_case[:expected].inspect}" do
+        expect(subject.send(:split_key, test_case[:input])).to eq(test_case[:expected])
+      end
+    end
+  end
+
+  describe '#normalize_key' do
+    context 'with standard key paths' do
+      [
+        { input: 'HKLM\\SOFTWARE\\Microsoft', expected: 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft' },
+        { input: 'HKCU\\Environment', expected: 'HKEY_CURRENT_USER\\Environment' },
+        { input: 'HKU\\S-1-5-18', expected: 'HKEY_USERS\\S-1-5-18' },
+        { input: 'HKCR\\.exe', expected: 'HKEY_CLASSES_ROOT\\.exe' },
+        { input: 'HKCC\\System', expected: 'HKEY_CURRENT_CONFIG\\System' },
+        { input: 'HKPD', expected: 'HKEY_PERFORMANCE_DATA' },
+        { input: 'HKDD', expected: 'HKEY_DYN_DATA' },
+      ].each do |test_case|
+        it "normalizes #{test_case[:input].inspect} to #{test_case[:expected].inspect}" do
+          expect(subject.send(:normalize_key, test_case[:input])).to eq(test_case[:expected])
+        end
+      end
+    end
+
+    context 'with trailing backslash' do
+      it 'strips the trailing backslash from the normalized key' do
+        result = subject.send(:normalize_key, 'HKLM\\SOFTWARE\\Microsoft\\')
+        expect(result).to eq('HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft')
+        expect(result).not_to end_with('\\')
+      end
+
+      it 'produces the same result as a key without trailing backslash' do
+        with_slash = subject.send(:normalize_key, 'HKLM\\SOFTWARE\\Microsoft\\')
+        without_slash = subject.send(:normalize_key, 'HKLM\\SOFTWARE\\Microsoft')
+        expect(with_slash).to eq(without_slash)
+      end
+    end
+
+    context 'with root-only keys' do
+      it 'returns the expanded root key without a trailing backslash' do
+        result = subject.send(:normalize_key, 'HKLM')
+        expect(result).to eq('HKEY_LOCAL_MACHINE')
+        expect(result).not_to end_with('\\')
+      end
+    end
+
+    context 'with already fully expanded root keys' do
+      it 'returns the key unchanged' do
+        expect(subject.send(:normalize_key, 'HKEY_LOCAL_MACHINE\\SOFTWARE')).to eq('HKEY_LOCAL_MACHINE\\SOFTWARE')
+      end
+    end
+
+    context 'with an unknown root key' do
+      it 'raises ArgumentError' do
+        expect { subject.send(:normalize_key, 'BOGUS\\Key') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'idempotency' do
+      it 'returns the same result when called twice' do
+        key = 'HKLM\\SOFTWARE\\Microsoft\\'
+        first = subject.send(:normalize_key, key)
+        second = subject.send(:normalize_key, first)
+        expect(first).to eq(second)
+      end
+    end
+  end
+end


### PR DESCRIPTION

`registry_enumkeys` and other shell-based registry functions silently fail when the key path ends with a trailing backslash (`\`). This is because `normalize_key` preserves the trailing backslash, which then gets interpolated into a `cmd.exe` command like:

```
cmd.exe /c reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\"
```

The `\"` at the end is interpreted by `cmd.exe` as an escaped double-quote, producing a malformed command. Meterpreter sessions are unaffected because they use the Windows API directly, which tolerates trailing backslashes.

This caused `exploit/windows/persistence/registry` (and similar modules) to incorrectly report "System does not have powershell" on shell sessions while working correctly on meterpreter sessions.

**The fix:**
- Strip trailing backslash in `normalize_key` via `.chomp("\\")` — this protects all 10+ shell registry functions at the normalization layer
- Remove trailing backslashes from all affected module callers (defense in depth)
- Add RSpec tests for `normalize_key` and `split_key`

Fixes #20899

## Verification

- [x] Start msfconsole
- [x] Obtain a **shell session** on a Windows target (e.g., `windows/x64/shell/reverse_tcp`)
- [x] `use exploit/windows/persistence/registry`
- [x] `set SESSION <shell_session_id>`
- [x] `check`
- [x] **Verify** the output is `The target is vulnerable. Registry writable` (not `System does not have powershell`)
- [x] Obtain a **meterpreter session** on the same target
- [x] `set SESSION <meterpreter_session_id>`
- [x] `check`
- [x] **Verify** the output is still `The target is vulnerable. Registry writable` (no regression)
- [x] Run `bundle exec rspec spec/lib/msf/core/post/windows/registry_spec.rb`
- [x] **Verify** all 19 examples pass, 0 failures