### PR TITLE
Add kernel_rex_version for kernel parsing

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -29,28 +29,24 @@ module Msf
           uname('-r')
         end
         
-        # Returns the kernel release as a Rex::Version object.
+        # Returns the kernel release information as a hashable object
         #
-        # @param release [String, nil] Pre-fetched kernel release string.
-        # @return [Rex::Version] the upstream kernel version
-        # @return [nil] if the release could not be determined or parsed
         #
         def kernel_rex_release
           release = kernel_release
 
           # regex for parsing kernel release
-          # (5.15.0)-(25)-(generic) 
-          # consists of three groups - the "main version" (xx.zz.yy), the patched version and the type of kernel
-          # this regex should make it easier to create Rex::Version of out it 
-
-          parsed_kernel_release = release.scan(/(\d+\.\d+\.?\d*)-?(\d+\.\d+|\w+\d+|\d+)?-?(\w+)?/)
+          # (5.15.0)-(25-generic) 
+          # consists of two groups - the kernel upstream version (xx.zz.yy) and distro-specific information
+          # this regex should make it easier to parse it
           
-          return nil if parsed_kernel_release.blank?
+          return nil unless release =~ /(\d+\.\d+\.?\d*\.?\d*)[-.]?(.+)/
+          
+          { 
+            :upstream => Rex::Version.new(Regexp.last_match(1)),
+            :distro_suffix => Regexp.last_match(2)
+          }
 
-          Rex::Version.new(parsed_kernel_release.first.join('-'))
-        end
-
-        def kernel_rex_release_major
         end
 
         #

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -30,6 +30,25 @@ module Msf
         end
 
         #
+        # Returns the kernel release as a Rex::Version object.
+        #
+        # @param release [String, nil] Pre-fetched kernel release string.
+        # @return [Rex::Version] the upstream kernel version
+        # @return [nil] if the release could not be determined or parsed
+        #
+        def kernel_rex_version(release = nil)
+          release ||= kernel_release
+          return nil if release.blank?
+
+          version_string = release.split('-').first
+          return nil if version_string.blank?
+
+          Rex::Version.new(version_string)
+        rescue ArgumentError, RuntimeError
+          nil
+        end
+
+        #
         # Returns the kernel version
         #
         # @return [String]

--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -28,24 +28,29 @@ module Msf
         def kernel_release
           uname('-r')
         end
-
-        #
+        
         # Returns the kernel release as a Rex::Version object.
         #
         # @param release [String, nil] Pre-fetched kernel release string.
         # @return [Rex::Version] the upstream kernel version
         # @return [nil] if the release could not be determined or parsed
         #
-        def kernel_rex_version(release = nil)
-          release ||= kernel_release
-          return nil if release.blank?
+        def kernel_rex_release
+          release = kernel_release
 
-          version_string = release.split('-').first
-          return nil if version_string.blank?
+          # regex for parsing kernel release
+          # (5.15.0)-(25)-(generic) 
+          # consists of three groups - the "main version" (xx.zz.yy), the patched version and the type of kernel
+          # this regex should make it easier to create Rex::Version of out it 
 
-          Rex::Version.new(version_string)
-        rescue ArgumentError, RuntimeError
-          nil
+          parsed_kernel_release = release.scan(/(\d+\.\d+\.?\d*)-?(\d+\.\d+|\w+\d+|\d+)?-?(\w+)?/)
+          
+          return nil if parsed_kernel_release.blank?
+
+          Rex::Version.new(parsed_kernel_release.first.join('-'))
+        end
+
+        def kernel_rex_release_major
         end
 
         #

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -97,15 +97,13 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     # Check the kernel version to see if its in a vulnerable range
-    release = kernel_release
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    release = kernel_rex_release
+
+    if release[:upstream] > Rex::Version.new('4.14.11') || release[:upstream] < Rex::Version.new('4.0')
+      return CheckCode::Safe("Kernel version #{release[:upstream]} is not vulnerable")
     end
-    if v > Rex::Version.new('4.14.11') || v < Rex::Version.new('4.0')
-      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
-    end
-    vprint_good "Kernel version #{release} appears to be vulnerable"
+
+    vprint_good "Kernel version #{release[:upstream]} appears to be vulnerable"
 
     # Check the app is installed and the version, debian based example
     package = cmd_exec('dpkg -l example | grep \'^ii\'')

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -97,15 +97,13 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     # Check the kernel version to see if its in a vulnerable range
-    # we guard this because some distros have funky kernel versions https://github.com/rapid7/metasploit-framework/issues/19812
     release = kernel_release
-    begin
-      if Rex::Version.new(release.split('-').first) > Rex::Version.new('4.14.11') ||
-         Rex::Version.new(release.split('-').first) < Rex::Version.new('4.0')
-        return CheckCode::Safe("Kernel version #{release} is not vulnerable")
-      end
-    rescue ArgumentError => e
-      return CheckCode::Safe("Error determining or processing kernel release (#{release}) into known format: #{e}")
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
+    if v > Rex::Version.new('4.14.11') || v < Rex::Version.new('4.0')
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
     vprint_good "Kernel version #{release} appears to be vulnerable"
 

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -98,6 +98,8 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_rex_release
+    
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
 
     if release[:upstream] > Rex::Version.new('4.14.11') || release[:upstream] < Rex::Version.new('4.0')
       return CheckCode::Safe("Kernel version #{release[:upstream]} is not vulnerable")

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -98,8 +98,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_rex_release
-    
-    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+    return CheckCode::Unknown('Could not determine kernel release') if release.nil?
 
     if release[:upstream] > Rex::Version.new('4.14.11') || release[:upstream] < Rex::Version.new('4.0')
       return CheckCode::Safe("Kernel version #{release[:upstream]} is not vulnerable")

--- a/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
+++ b/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
@@ -91,10 +91,9 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
-    kernel_version = kernel_rex_version
-    if kernel_version.nil?
-      return CheckCode::Unknown('Could not determine kernel version')
-    end
+    kernel_version = kernel_rex_version[:upstream]
+
+    return CheckCode::Unknown('Could not determine kernel version') if kernel_version.nil?
 
     if kernel_version < Rex::Version.new('3.12')
       vprint_error "Linux kernel version #{kernel_version} is not vulnerable"

--- a/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
+++ b/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
@@ -91,7 +91,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
-    kernel_version = Rex::Version.new kernel_release.split('-').first
+    kernel_version = kernel_rex_version
+    if kernel_version.nil?
+      return CheckCode::Unknown('Could not determine kernel version')
+    end
 
     if kernel_version < Rex::Version.new('3.12')
       vprint_error "Linux kernel version #{kernel_version} is not vulnerable"

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -186,21 +186,17 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_release
     version = kernel_version
 
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
-    end
-    if v < Rex::Version.new('4.4') ||
-       v > Rex::Version.new('4.5.5')
-      vprint_error "Kernel version #{release} #{version} is not vulnerable"
-      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
+    if release[:upstream] < Rex::Version.new('4.4') ||
+       release[:upstream] > Rex::Version.new('4.5.5')
+      vprint_error "Kernel version #{release[:upstream]} #{version} is not vulnerable"
+      return CheckCode::Safe
     end
 
-    if version.downcase.include?('ubuntu') && release =~ /^4\.4\.0-(\d+)-/ && (::Regexp.last_match(1).to_i > 21)
-      vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
+    if version.downcase.include?('ubuntu') && release[:distro_suffix] =~ /^(\d+)-/ && (::Regexp.last_match(1).to_i > 21)
+      vprint_error "Kernel version #{release[:upstream]} is not vulnerable"
+      return CheckCode::Safe
     end
-    vprint_good "Kernel version #{release} #{version} appears to be vulnerable"
+    vprint_good "Kernel version #{release[:upstream]} #{version} appears to be vulnerable"
 
     lib = cmd_exec('dpkg --get-selections | grep ^fuse').to_s
     unless lib.include?('install')

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -186,8 +186,12 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_release
     version = kernel_version
 
-    if Rex::Version.new(release.split('-').first) < Rex::Version.new('4.4') ||
-       Rex::Version.new(release.split('-').first) > Rex::Version.new('4.5.5')
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
+    if v < Rex::Version.new('4.4') ||
+       v > Rex::Version.new('4.5.5')
       vprint_error "Kernel version #{release} #{version} is not vulnerable"
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -186,6 +186,8 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_release
     version = kernel_version
 
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+
     if release[:upstream] < Rex::Version.new('4.4') ||
        release[:upstream] > Rex::Version.new('4.5.5')
       vprint_error "Kernel version #{release[:upstream]} #{version} is not vulnerable"

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -113,6 +113,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     release = kernel_release
 
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+
     if release[:upstream] > Rex::Version.new('4.14.11') || release[:upstream] < Rex::Version.new('4.0')
       return CheckCode::Safe("Kernel version #{release[:upstream]} is not vulnerable")
     end

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -112,15 +112,12 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good("System architecture #{arch} is supported")
 
     release = kernel_release
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
-    end
-    if v > Rex::Version.new('4.14.11') || v < Rex::Version.new('4.0')
-      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
+
+    if release[:upstream] > Rex::Version.new('4.14.11') || release[:upstream] < Rex::Version.new('4.0')
+      return CheckCode::Safe("Kernel version #{release[:upstream]} is not vulnerable")
     end
 
-    vprint_good("Kernel version #{release} appears to be vulnerable")
+    vprint_good("Kernel version #{release[:upstream]} appears to be vulnerable")
 
     if unprivileged_bpf_disabled?
       return CheckCode::Safe('Unprivileged BPF loading is not permitted')

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -112,8 +112,11 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good("System architecture #{arch} is supported")
 
     release = kernel_release
-    if Rex::Version.new(release.split('-').first) > Rex::Version.new('4.14.11') ||
-       Rex::Version.new(release.split('-').first) < Rex::Version.new('4.0')
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
+    if v > Rex::Version.new('4.14.11') || v < Rex::Version.new('4.0')
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
 

--- a/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
+++ b/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
@@ -3,9 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'pry'
-require 'pry-byebug'
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 

--- a/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
+++ b/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
@@ -3,6 +3,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'pry'
+require 'pry-byebug'
+
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
@@ -99,56 +102,37 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good('Unprivileged BPF loading is permitted')
 
-    release = kernel_release
+    release = kernel_rex_release
     version = kernel_version
-
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
-    end
 
     # If the target is Ubuntu...
     if version =~ /[uU]buntu/
-      version_array = release.split('-')
-      if version_array.length < 2
-        fail_with(Failure::UnexpectedReply, 'The target Ubuntu server does not have the expected kernel version format!')
-      end
-      major_version = version_array[0]
-      minor_version = version_array[1]
 
       # First check if we are past the 5.11.x kernel releases and into at the time of
       # writing beta versions of Ubuntu. If so,the target isn't vuln.
-      if v >= Rex::Version.new('5.12.0')
-        return CheckCode::Safe("Target Ubuntu kernel version is #{major_version}-#{minor_version} which is not vulnerable!")
-      elsif (v == Rex::Version.new('5.11.0')) && (Rex::Version.new(minor_version) >= Rex::Version.new('17.18'))
+      if release[:upstream] >= Rex::Version.new('5.12.0')
+        return CheckCode::Safe("Target Ubuntu kernel version is #{release[:upstream]}-#{release[:distro_suffix]} which is not vulnerable!")
+      elsif (release[:upstream] == Rex::Version.new('5.11.0')) && (Rex::Version.new(release[:distro_suffix]) >= Rex::Version.new('17.18'))
         return CheckCode::Safe('Target Ubuntu kernel version is running a 5.11.x build however it has updated to a patched version!')
-      elsif (v == Rex::Version.new('5.8.0')) && (Rex::Version.new(minor_version) >= Rex::Version.new('53.60'))
+      elsif (release[:upstream] == Rex::Version.new('5.8.0')) && (Rex::Version.new(release[:distro_suffix]) >= Rex::Version.new('53.60'))
         return CheckCode::Safe('Target Ubuntu kernel version is running a 5.8.x build however it has updated to a patched version!')
-      elsif (v != Rex::Version.new('5.8.0')) && (v != Rex::Version.new('5.11.0')) # Only Ubuntu 20.04.02, Groovy, and Hirsuite are affected, other releases used a kernel either too old or which was patched.
+      elsif (release[:upstream] != Rex::Version.new('5.8.0')) && (release[:upstream] != Rex::Version.new('5.11.0')) # Only Ubuntu 20.04.02, Groovy, and Hirsuite are affected, other releases used a kernel either too old or which was patched.
         return CheckCode::Unknown('Unknown target kernel version, recommend manually checking if target kernel is vulnerable.')
       end
-    elsif release =~ /\.fc3[2,3,4]\./
-      version_array = release.split('-')
-      if version_array.length < 2
-        fail_with(Failure::UnexpectedReply, 'The target Fedora server does not have the expected kernel version format!')
-      end
-      major_version = version_array[0]
-      if version_array[1].split('.').length != 3
-        fail_with(Failure::UnexpectedReply, 'The target Fedora server does not have the expected minor kernel version format!')
-      end
-      minor_version = version_array[1].split('.')[0]
-      if v > Rex::Version.new('5.11.20')
-        return CheckCode::Safe("Target Fedora kernel version is #{major_version}-#{minor_version} which is not vulnerable!")
-      elsif v == Rex::Version.new('5.11.20') && Rex::Version.new(minor_version) >= Rex::Version.new('300')
+    elsif release[:distro_suffix] =~ /(\d+)\.fc3[2,3,4]\./
+
+      if release[:upstream] > Rex::Version.new('5.11.20')
+        return CheckCode::Safe("Target Fedora kernel version is #{release[:upstream]}-#{release[:distro_suffix]} which is not vulnerable!")
+      elsif release[:upstream] == Rex::Version.new('5.11.20') && Rex::Version.new(Regexp.last_match(1)) >= Rex::Version.new('300')
         return CheckCode::Safe('Target Fedora system is running a 5.11.20 kernel however it has been patched!')
-      elsif v <= Rex::Version.new('5.7')
+      elsif release[:upstream] <= Rex::Version.new('5.7')
         return CheckCode::Safe('Running a Fedora system with a kernel before kernel version 5.7 where the vulnerability was introduced')
       end
     else
       return CheckCode::Unknown("Target is not a known target, so we can't check if the target is vulnerable or not!")
     end
 
-    vprint_good("Kernel version #{release} appears to be vulnerable")
+    vprint_good("Kernel version #{release[:upstream]} appears to be vulnerable")
 
     config = kernel_config
 

--- a/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
+++ b/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_rex_release
     version = kernel_version
 
-    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+    return CheckCode::Unknown('Could not determine kernel release') if release.nil?
 
     # If the target is Ubuntu...
     if version =~ /[uU]buntu/

--- a/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
+++ b/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
@@ -105,6 +105,8 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_rex_release
     version = kernel_version
 
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+
     # If the target is Ubuntu...
     if version =~ /[uU]buntu/
 

--- a/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
+++ b/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
@@ -102,6 +102,11 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_release
     version = kernel_version
 
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
+
     # If the target is Ubuntu...
     if version =~ /[uU]buntu/
       version_array = release.split('-')
@@ -113,13 +118,13 @@ class MetasploitModule < Msf::Exploit::Local
 
       # First check if we are past the 5.11.x kernel releases and into at the time of
       # writing beta versions of Ubuntu. If so,the target isn't vuln.
-      if Rex::Version.new(major_version) >= Rex::Version.new('5.12.0')
+      if v >= Rex::Version.new('5.12.0')
         return CheckCode::Safe("Target Ubuntu kernel version is #{major_version}-#{minor_version} which is not vulnerable!")
-      elsif (Rex::Version.new(major_version) == Rex::Version.new('5.11.0')) && (Rex::Version.new(minor_version) >= Rex::Version.new('17.18'))
+      elsif (v == Rex::Version.new('5.11.0')) && (Rex::Version.new(minor_version) >= Rex::Version.new('17.18'))
         return CheckCode::Safe('Target Ubuntu kernel version is running a 5.11.x build however it has updated to a patched version!')
-      elsif (Rex::Version.new(major_version) == Rex::Version.new('5.8.0')) && (Rex::Version.new(minor_version) >= Rex::Version.new('53.60'))
+      elsif (v == Rex::Version.new('5.8.0')) && (Rex::Version.new(minor_version) >= Rex::Version.new('53.60'))
         return CheckCode::Safe('Target Ubuntu kernel version is running a 5.8.x build however it has updated to a patched version!')
-      elsif (Rex::Version.new(major_version) != Rex::Version.new('5.8.0')) && (Rex::Version.new(major_version) != Rex::Version.new('5.11.0')) # Only Ubuntu 20.04.02, Groovy, and Hirsuite are affected, other releases used a kernel either too old or which was patched.
+      elsif (v != Rex::Version.new('5.8.0')) && (v != Rex::Version.new('5.11.0')) # Only Ubuntu 20.04.02, Groovy, and Hirsuite are affected, other releases used a kernel either too old or which was patched.
         return CheckCode::Unknown('Unknown target kernel version, recommend manually checking if target kernel is vulnerable.')
       end
     elsif release =~ /\.fc3[2,3,4]\./
@@ -132,11 +137,11 @@ class MetasploitModule < Msf::Exploit::Local
         fail_with(Failure::UnexpectedReply, 'The target Fedora server does not have the expected minor kernel version format!')
       end
       minor_version = version_array[1].split('.')[0]
-      if Rex::Version.new(major_version) >= Rex::Version.new('5.11.20')
+      if v > Rex::Version.new('5.11.20')
         return CheckCode::Safe("Target Fedora kernel version is #{major_version}-#{minor_version} which is not vulnerable!")
-      elsif Rex::Version.new(major_version) == Rex::Version.new('5.11.20') && Rex::Version.new(minor_version) >= Rex::Version.new('300')
+      elsif v == Rex::Version.new('5.11.20') && Rex::Version.new(minor_version) >= Rex::Version.new('300')
         return CheckCode::Safe('Target Fedora system is running a 5.11.20 kernel however it has been patched!')
-      elsif Rex::Version.new(major_version) <= Rex::Version.new('5.7')
+      elsif v <= Rex::Version.new('5.7')
         return CheckCode::Safe('Running a Fedora system with a kernel before kernel version 5.7 where the vulnerability was introduced')
       end
     else
@@ -205,7 +210,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Launching exploit...')
     print_warning('Note that things may appear to hang due to the exploit not exiting.')
     print_warning("Feel free to press CTRL+C if the shell is returned before #{datastore['CmdTimeout']} seconds are up.")
-    response = cmd_exec(executable_path.to_s, payload_path.to_s, datastore['CmdTimeout'])
+    response = create_process(executable_path.to_s, args: [payload_path.to_s], time_out: datastore['CmdTimeout'])
     if response =~ /fail/
       fail_with(Failure::NoTarget, 'The exploit failed! Check to see if you are running this against the right target and kernel version!')
       vprint_error("The response was: #{response}")

--- a/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
+++ b/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
@@ -87,6 +87,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     kernel_release = kernel_rex_release
 
+    return CheckCode::Unknown("Could not determine kernel release") if kernel_release.nil?
+
     if kernel_release[:upstream] < Rex::Version.new('5.8') ||
        kernel_release[:upstream] >= Rex::Version.new('5.16.11') ||
        (kernel_release[:upstream] >= Rex::Version.new('5.15.25') && kernel_release[:upstream] < Rex::Version.new('5.16')) ||

--- a/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
+++ b/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
@@ -85,7 +85,10 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("System architecture #{arch} is not supported without live compilation")
     end
 
-    kernel_version = Rex::Version.new kernel_release.split('-').first
+    kernel_version = kernel_rex_version
+    if kernel_version.nil?
+      return CheckCode::Unknown('Could not determine kernel version')
+    end
     if kernel_version < Rex::Version.new('5.8') ||
        kernel_version >= Rex::Version.new('5.16.11') ||
        (kernel_version >= Rex::Version.new('5.15.25') && kernel_version < Rex::Version.new('5.16')) ||

--- a/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
+++ b/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     kernel_release = kernel_rex_release
 
-    return CheckCode::Unknown("Could not determine kernel release") if kernel_release.nil?
+    return CheckCode::Unknown('Could not determine kernel release') if kernel_release.nil?
 
     if kernel_release[:upstream] < Rex::Version.new('5.8') ||
        kernel_release[:upstream] >= Rex::Version.new('5.16.11') ||

--- a/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
+++ b/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
@@ -85,18 +85,16 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("System architecture #{arch} is not supported without live compilation")
     end
 
-    kernel_version = kernel_rex_version
-    if kernel_version.nil?
-      return CheckCode::Unknown('Could not determine kernel version')
-    end
-    if kernel_version < Rex::Version.new('5.8') ||
-       kernel_version >= Rex::Version.new('5.16.11') ||
-       (kernel_version >= Rex::Version.new('5.15.25') && kernel_version < Rex::Version.new('5.16')) ||
-       (kernel_version >= Rex::Version.new('5.10.102') && kernel_version < Rex::Version.new('5.11'))
-      return CheckCode::Safe("Linux kernel version #{kernel_version} is not vulnerable")
+    kernel_release = kernel_rex_release
+
+    if kernel_release[:upstream] < Rex::Version.new('5.8') ||
+       kernel_release[:upstream] >= Rex::Version.new('5.16.11') ||
+       (kernel_release[:upstream] >= Rex::Version.new('5.15.25') && kernel_release[:upstream] < Rex::Version.new('5.16')) ||
+       (kernel_release[:upstream] >= Rex::Version.new('5.10.102') && kernel_release[:upstream] < Rex::Version.new('5.11'))
+      return CheckCode::Safe("Linux kernel version #{kernel_release[:upstream]} is not vulnerable")
     end
 
-    CheckCode::Appears("Linux kernel version found: #{kernel_version}")
+    CheckCode::Appears("Linux kernel version found: #{kernel_release[:upstream]}")
   end
 
   def exp_dir

--- a/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
@@ -82,17 +82,13 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     # Check the kernel version to see if its in a vulnerable range
-    release = kernel_release
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
-    end
+    release = kernel_rex_release
 
-    if v > Rex::Version.new('5.14-rc7') || v < Rex::Version.new('5.12-rc3')
-      vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
+    if release[:upstream] > Rex::Version.new('5.14-rc7') || release[:upstream] < Rex::Version.new('5.12-rc3')
+      vprint_error "Kernel version #{release[:upstream]} is not vulnerable"
+      return CheckCode::Safe
     end
-    vprint_good "Kernel version #{release} appears to be vulnerable"
+    vprint_good "Kernel version #{release[:upstream]} appears to be vulnerable"
 
     # make sure we have enough CPUs. Minimum 2 required
     cpu = get_cpu_info

--- a/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
@@ -83,9 +83,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_rex_release
-    
-    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
-    
+
+    return CheckCode::Unknown('Could not determine kernel release') if release.nil?
+
     if release[:upstream] > Rex::Version.new('5.14-rc7') || release[:upstream] < Rex::Version.new('5.12-rc3')
       vprint_error "Kernel version #{release[:upstream]} is not vulnerable"
       return CheckCode::Safe

--- a/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
@@ -83,8 +83,12 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_release
-    if Rex::Version.new(release.split('-').first) > Rex::Version.new('5.14-rc7') ||
-       Rex::Version.new(release.split('-').first) < Rex::Version.new('5.12-rc3')
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
+
+    if v > Rex::Version.new('5.14-rc7') || v < Rex::Version.new('5.12-rc3')
       vprint_error "Kernel version #{release} is not vulnerable"
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end

--- a/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
@@ -83,7 +83,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_rex_release
-
+    
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+    
     if release[:upstream] > Rex::Version.new('5.14-rc7') || release[:upstream] < Rex::Version.new('5.12-rc3')
       vprint_error "Kernel version #{release[:upstream]} is not vulnerable"
       return CheckCode::Safe

--- a/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
@@ -77,6 +77,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     kernel_release = kernel_rex_release
+    
+    return CheckCode::Unknown("Could not determine kernel release") if kernel_release.nil?
 
     if kernel_release[:upstream] < Rex::Version.new('5.11') ||
        kernel_release[:upstream].between?(Rex::Version.new('5.15.91'), Rex::Version.new('5.16')) ||

--- a/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
@@ -77,8 +77,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     kernel_release = kernel_rex_release
-    
-    return CheckCode::Unknown("Could not determine kernel release") if kernel_release.nil?
+
+    return CheckCode::Unknown('Could not determine kernel release') if kernel_release.nil?
 
     if kernel_release[:upstream] < Rex::Version.new('5.11') ||
        kernel_release[:upstream].between?(Rex::Version.new('5.15.91'), Rex::Version.new('5.16')) ||

--- a/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
@@ -76,14 +76,12 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("System architecture #{kernel_arch} is not supported")
     end
 
-    kernel_version = kernel_rex_version
-    if kernel_version.nil?
-      return CheckCode::Unknown('Could not determine kernel version')
-    end
-    if kernel_version < Rex::Version.new('5.11') ||
-       kernel_version.between?(Rex::Version.new('5.15.91'), Rex::Version.new('5.16')) ||
-       Rex::Version.new('6.1.9') <= kernel_version
-      return CheckCode::Safe("Linux kernel version #{kernel_version} is not vulnerable")
+    kernel_release = kernel_rex_release
+
+    if kernel_release[:upstream] < Rex::Version.new('5.11') ||
+       kernel_release[:upstream].between?(Rex::Version.new('5.15.91'), Rex::Version.new('5.16')) ||
+       Rex::Version.new('6.1.9') <= kernel_release[:upstream]
+      return CheckCode::Safe("Linux kernel version #{kernel_release[:upstream]} is not vulnerable")
     end
 
     unless userns_enabled?
@@ -92,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good('Unprivileged user namespaces are permitted')
 
-    CheckCode::Appears("Linux kernel version found: #{kernel_version}")
+    CheckCode::Appears("Linux kernel version found: #{kernel_release[:upstream]}")
   end
 
   def base_dir

--- a/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2023_0386_overlayfs_priv_esc.rb
@@ -76,7 +76,10 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("System architecture #{kernel_arch} is not supported")
     end
 
-    kernel_version = Rex::Version.new(kernel_release.split('-').first)
+    kernel_version = kernel_rex_version
+    if kernel_version.nil?
+      return CheckCode::Unknown('Could not determine kernel version')
+    end
     if kernel_version < Rex::Version.new('5.11') ||
        kernel_version.between?(Rex::Version.new('5.15.91'), Rex::Version.new('5.16')) ||
        Rex::Version.new('6.1.9') <= kernel_version

--- a/modules/exploits/linux/local/docker_cgroup_escape.rb
+++ b/modules/exploits/linux/local/docker_cgroup_escape.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Local
     # https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0492
     release = kernel_rex_release
 
-    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+    return CheckCode::Unknown('Could not determine kernel release') if release.nil?
 
     return CheckCode::Unknown('Could not determine the version') unless release[:distro_suffix] =~ /(\d+\.\d+)/
 

--- a/modules/exploits/linux/local/docker_cgroup_escape.rb
+++ b/modules/exploits/linux/local/docker_cgroup_escape.rb
@@ -85,6 +85,8 @@ class MetasploitModule < Msf::Exploit::Local
     # https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0492
     release = kernel_rex_release
 
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+
     return CheckCode::Unknown('Could not determine the version') unless release[:distro_suffix] =~ /(\d+\.\d+)/
 
     begin

--- a/modules/exploits/linux/local/docker_cgroup_escape.rb
+++ b/modules/exploits/linux/local/docker_cgroup_escape.rb
@@ -83,17 +83,21 @@ class MetasploitModule < Msf::Exploit::Local
     print_status('Unable to determine host OS, this check method is unlikely to be accurate if the host isn\'t Ubuntu')
     release = kernel_release
     # https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0492
+    release_short = kernel_rex_version(release)
+    if release_short.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
+
     begin
-      release_short = Rex::Version.new(release.split('-').first)
       release_long = Rex::Version.new(release.split('-')[0..1].join('-'))
-      if release_short >= Rex::Version.new('5.13.0') && release_long < Rex::Version.new('5.13.0-37.42') || # Ubuntu 21.10
-         release_short >= Rex::Version.new('5.4.0') && release_long < Rex::Version.new('5.4.0-105.119') || # Ubuntu 20.04 LTS
-         release_short >= Rex::Version.new('4.15.0') && release_long < Rex::Version.new('4.15.0-173.182') || # Ubuntu 18.04 LTS
-         release_short >= Rex::Version.new('4.4.0') && release_long < Rex::Version.new('4.4.0-222.255') # Ubuntu 16.04 ESM
-        return CheckCode::Vulnerable("IF host OS is Ubuntu, kernel version #{release} is vulnerable")
-      end
-    rescue ArgumentError => e
-      return CheckCode::Safe("Error determining or processing kernel release (#{release}) into known format: #{e}")
+    rescue ArgumentError
+      return CheckCode::Unknown("Could not parse extended kernel version from: #{release}")
+    end
+    if release_short >= Rex::Version.new('5.13.0') && release_long < Rex::Version.new('5.13.0-37.42') || # Ubuntu 21.10
+       release_short >= Rex::Version.new('5.4.0') && release_long < Rex::Version.new('5.4.0-105.119') || # Ubuntu 20.04 LTS
+       release_short >= Rex::Version.new('4.15.0') && release_long < Rex::Version.new('4.15.0-173.182') || # Ubuntu 18.04 LTS
+       release_short >= Rex::Version.new('4.4.0') && release_long < Rex::Version.new('4.4.0-222.255') # Ubuntu 16.04 ESM
+      return CheckCode::Vulnerable("IF host OS is Ubuntu, kernel version #{release} is vulnerable")
     end
 
     CheckCode::Safe("Kernel version #{release} may not be vulnerable depending on the host OS")

--- a/modules/exploits/linux/local/docker_cgroup_escape.rb
+++ b/modules/exploits/linux/local/docker_cgroup_escape.rb
@@ -81,22 +81,21 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     print_status('Unable to determine host OS, this check method is unlikely to be accurate if the host isn\'t Ubuntu')
-    release = kernel_release
+
     # https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-0492
-    release_short = kernel_rex_version(release)
-    if release_short.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
-    end
+    release = kernel_rex_release
+
+    return CheckCode::Unknown('Could not determine the version') unless release[:distro_suffix] =~ /(\d+\.\d+)/
 
     begin
-      release_long = Rex::Version.new(release.split('-')[0..1].join('-'))
+      Rex::Version.new(Regexp.last_match(1))
     rescue ArgumentError
       return CheckCode::Unknown("Could not parse extended kernel version from: #{release}")
     end
-    if release_short >= Rex::Version.new('5.13.0') && release_long < Rex::Version.new('5.13.0-37.42') || # Ubuntu 21.10
-       release_short >= Rex::Version.new('5.4.0') && release_long < Rex::Version.new('5.4.0-105.119') || # Ubuntu 20.04 LTS
-       release_short >= Rex::Version.new('4.15.0') && release_long < Rex::Version.new('4.15.0-173.182') || # Ubuntu 18.04 LTS
-       release_short >= Rex::Version.new('4.4.0') && release_long < Rex::Version.new('4.4.0-222.255') # Ubuntu 16.04 ESM
+    if release[:upstream] >= Rex::Version.new('5.13.0') && release_long < Rex::Version.new('5.13.0-37.42') || # Ubuntu 21.10
+       release[:upstream] >= Rex::Version.new('5.4.0') && release_long < Rex::Version.new('5.4.0-105.119') || # Ubuntu 20.04 LTS
+       release[:upstream] >= Rex::Version.new('4.15.0') && release_long < Rex::Version.new('4.15.0-173.182') || # Ubuntu 18.04 LTS
+       release[:upstream] >= Rex::Version.new('4.4.0') && release_long < Rex::Version.new('4.4.0-222.255') # Ubuntu 16.04 ESM
       return CheckCode::Vulnerable("IF host OS is Ubuntu, kernel version #{release} is vulnerable")
     end
 

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -135,6 +135,8 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     release = kernel_rex_release
+
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
     
     if release[:upstream] < Rex::Version.new('2.6.36')
       vprint_error "Linux kernel version #{release[:upstream} is not vulnerable"

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -134,12 +134,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    kernel_ver = kernel_release
-    if Rex::Version.new(kernel_ver.split('-').first) < Rex::Version.new('2.6.36')
-      vprint_error "Linux kernel version #{kernel_ver} is not vulnerable"
-      return CheckCode::Safe("Kernel version #{kernel_ver} is not vulnerable")
+    release = kernel_rex_release
+    
+    if release[:upstream] < Rex::Version.new('2.6.36')
+      vprint_error "Linux kernel version #{release[:upstream} is not vulnerable"
+      return CheckCode::Safe
     end
-    vprint_good "Linux kernel version #{kernel_ver} is vulnerable"
+    vprint_good "Linux kernel version #{release[:upstream} is vulnerable"
 
     arch = kernel_hardware
     unless arch.include? 'x86_64'

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -138,10 +138,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     return CheckCode::Unknown("Could not determine kernel release") if release.nil?
     if release[:upstream] < Rex::Version.new('2.6.36')
-      vprint_error "Linux kernel version #{release[:upstream} is not vulnerable"
+      vprint_error "Linux kernel version #{release[:upstream]} is not vulnerable"
       return CheckCode::Safe
     end
-    vprint_good "Linux kernel version #{release[:upstream} is vulnerable"
+    vprint_good "Linux kernel version #{release[:upstream]} is vulnerable"
 
     arch = kernel_hardware
     unless arch.include? 'x86_64'

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -137,7 +137,6 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_rex_release
 
     return CheckCode::Unknown("Could not determine kernel release") if release.nil?
-    
     if release[:upstream] < Rex::Version.new('2.6.36')
       vprint_error "Linux kernel version #{release[:upstream} is not vulnerable"
       return CheckCode::Safe

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -160,6 +160,8 @@ class MetasploitModule < Msf::Exploit::Local
     # Patched in 4.18.19 and 4.19.2
     release = kernel_rex_release
 
+    return CheckCode::Unknown("Could not determine kernel release") if kernel_release.nil?
+
     if release[:upstream] < Rex::Version.new('4.15') ||
        release[:upstream] >= Rex::Version.new('4.19.2') ||
        (release[:upstream] >= Rex::Version.new('4.18.19') && release[:upstream] < Rex::Version.new('4.19'))

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -159,7 +159,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Patched in 4.18.19 and 4.19.2
     release = kernel_release
-    v = Rex::Version.new release.split('-').first
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
     if v < Rex::Version.new('4.15') ||
        v >= Rex::Version.new('4.19.2') ||
        (v >= Rex::Version.new('4.18.19') && v < Rex::Version.new('4.19'))

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     register_file_for_cleanup path
-    chmod path, 0755
+    chmod path, 0o755
   end
 
   def strip_comments(c_code)
@@ -158,18 +158,15 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Patched in 4.18.19 and 4.19.2
-    release = kernel_release
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    release = kernel_rex_release
+
+    if release[:upstream] < Rex::Version.new('4.15') ||
+       release[:upstream] >= Rex::Version.new('4.19.2') ||
+       (release[:upstream] >= Rex::Version.new('4.18.19') && release[:upstream] < Rex::Version.new('4.19'))
+      vprint_error "Kernel version #{release[:upstream]} is not vulnerable"
+      return CheckCode::Safe
     end
-    if v < Rex::Version.new('4.15') ||
-       v >= Rex::Version.new('4.19.2') ||
-       (v >= Rex::Version.new('4.18.19') && v < Rex::Version.new('4.19'))
-      vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
-    end
-    vprint_good "Kernel version #{release} appears to be vulnerable"
+    vprint_good "Kernel version #{release[:upstream]} appears to be vulnerable"
 
     config = kernel_config
     if config.nil?

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' => [[ 'Auto', {} ]],
         'DefaultOptions' => {
           'Payload' => 'linux/x64/meterpreter/reverse_tcp',
-          'PrependFork' => true,
+          'PrependFork' => true
         },
         'Notes' => {
           'Reliability' => [ REPEATABLE_SESSION ],
@@ -72,13 +72,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Introduced in 4.10, but also backported
     # Patched in 4.4.185, 4.9.185, 4.14.133, 4.19.58, 5.1.17
-    release = kernel_release
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
-    end
+    release = kernel_rex_release
 
-    if v >= Rex::Version.new('5.1.17') || v < Rex::Version.new('3')
+    if release >= Rex::Version.new('5.1.17') || release < Rex::Version.new('3')
       vprint_error "Kernel version #{release} is not vulnerable"
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -73,7 +73,10 @@ class MetasploitModule < Msf::Exploit::Local
     # Introduced in 4.10, but also backported
     # Patched in 4.4.185, 4.9.185, 4.14.133, 4.19.58, 5.1.17
     release = kernel_release
-    v = Rex::Version.new release.split('-').first
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
 
     if v >= Rex::Version.new('5.1.17') || v < Rex::Version.new('3')
       vprint_error "Kernel version #{release} is not vulnerable"

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -74,6 +74,8 @@ class MetasploitModule < Msf::Exploit::Local
     # Patched in 4.4.185, 4.9.185, 4.14.133, 4.19.58, 5.1.17
     release = kernel_rex_release
 
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+
     if release >= Rex::Version.new('5.1.17') || release < Rex::Version.new('3')
       vprint_error "Kernel version #{release} is not vulnerable"
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")

--- a/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
@@ -91,8 +91,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = kernel_release
-    unless Rex::Version.new(version.split('-').first) >= Rex::Version.new('2.6.30') &&
-           Rex::Version.new(version.split('-').first) < Rex::Version.new('2.6.37')
+    v = kernel_rex_version(version)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{version}")
+    end
+    unless v >= Rex::Version.new('2.6.30') && v < Rex::Version.new('2.6.37')
       return CheckCode::Safe("Linux kernel version #{version} is not vulnerable")
     end
 

--- a/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
@@ -90,16 +90,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = kernel_release
-    v = kernel_rex_version(version)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{version}")
-    end
-    unless v >= Rex::Version.new('2.6.30') && v < Rex::Version.new('2.6.37')
+    release = kernel_rex_release
+
+    unless release[:upstream] >= Rex::Version.new('2.6.30') && release[:upstream] < Rex::Version.new('2.6.37')
       return CheckCode::Safe("Linux kernel version #{version} is not vulnerable")
     end
 
-    vprint_good "Linux kernel version #{version} appears to be vulnerable"
+    vprint_good "Linux kernel version #{release[:upstream]} appears to be vulnerable"
 
     unless cmd_exec('/sbin/modinfo rds').to_s.include? 'Reliable Datagram Sockets'
       return CheckCode::Safe('RDS kernel module is not available')
@@ -107,11 +104,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good 'RDS kernel module is available'
 
-    if modules_disabled?
-      unless cmd_exec('/sbin/lsmod').to_s.include? 'rds'
-        return CheckCode::Safe('RDS kernel module is not loadable')
-      end
+    if modules_disabled? && !cmd_exec('/sbin/lsmod').to_s.include?('rds')
+      return CheckCode::Safe('RDS kernel module is not loadable')
     end
+
     vprint_good 'RDS kernel module is loadable'
 
     CheckCode::Appears("Kernel version #{version} appears to be vulnerable")

--- a/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
@@ -92,6 +92,8 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     release = kernel_rex_release
 
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+
     unless release[:upstream] >= Rex::Version.new('2.6.30') && release[:upstream] < Rex::Version.new('2.6.37')
       return CheckCode::Safe("Linux kernel version #{version} is not vulnerable")
     end

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -3,6 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'English'
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
@@ -88,19 +89,14 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = Rex::Version.new kernel_release.split('-').first
+    version = kernel_rex_release
 
-    if version.to_s.eql? ''
-      vprint_error 'Could not determine the kernel version'
-      return CheckCode::Unknown('Could not determine kernel version')
-    end
-
-    if version.between?(Rex::Version.new('2.4.4'), Rex::Version.new('2.4.37.4')) ||
-       version.between?(Rex::Version.new('2.6.0'), Rex::Version.new('2.6.30.4'))
-      vprint_good "Kernel version #{version} appears to be vulnerable"
+    if version[:upstream].between?(Rex::Version.new('2.4.4'), Rex::Version.new('2.4.37.4')) ||
+       version[:upstream].between?(Rex::Version.new('2.6.0'), Rex::Version.new('2.6.30.4'))
+      vprint_good "Kernel version #{version[:upstream]} appears to be vulnerable"
     else
-      vprint_error "Kernel version #{version} is not vulnerable"
-      return CheckCode::Safe("Kernel version #{version} is not vulnerable")
+      vprint_error "Kernel version #{version[:upstream]} is not vulnerable"
+      return CheckCode::Safe
     end
 
     arch = kernel_hardware
@@ -500,9 +496,9 @@ int main(int argc, char **argv) {
         elf = Msf::Util::EXE.to_linux_x86_elf framework, foo
       end
     rescue StandardError
-      print_error "Metasm Encoding failed: #{$!}"
-      elog "Metasm Encoding failed: #{$!.class} : #{$!}"
-      elog "Call stack:\n#{$!.backtrace.join("\n")}"
+      print_error "Metasm Encoding failed: #{$ERROR_INFO}"
+      elog "Metasm Encoding failed: #{$ERROR_INFO.class} : #{$ERROR_INFO}"
+      elog "Call stack:\n#{$ERROR_INFO.backtrace.join("\n")}"
       return
     end
 

--- a/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
+++ b/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
@@ -74,6 +74,8 @@ class MetasploitModule < Msf::Exploit::Local
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_rex_release
 
+    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+
     unless release[:upstream] >= Rex::Version.new('4.14') && release[:upstream] < Rex::Version.new('5.17')
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end

--- a/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
+++ b/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_rex_release
 
-    return CheckCode::Unknown("Could not determine kernel release") if release.nil?
+    return CheckCode::Unknown('Could not determine kernel release') if release.nil?
 
     unless release[:upstream] >= Rex::Version.new('4.14') && release[:upstream] < Rex::Version.new('5.17')
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")

--- a/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
+++ b/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     return CheckCode::Unknown('Could not determine kernel release') if release.nil?
 
-    unless release[:upstream] >= Rex::Version.new('4.14') && release[:upstream] < Rex::Version.new('5.17')
+    unless release[:distro_suffix] == 'rc1' && release[:upstream] >= Rex::Version.new('4.14') && release[:upstream] < Rex::Version.new('5.17')
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
 

--- a/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
+++ b/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
           a free'd 'file' object.
 
           We use this bug to overwrite a SUID binary with our payload and gain root.
-          Linux kernel 4.14-rc1 - 5.17-rc1 are vulnerable.
+          Linux kernel 4.14 - 5.16.x are vulnerable.
 
           Successfully tested against Ubuntu 22.04.01 with kernel 5.13.12-051312-generic.
         },
@@ -74,13 +74,12 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_release
-    begin
-      unless Rex::Version.new(release) > Rex::Version.new('4.14-rc1') &&
-             Rex::Version.new(release) < Rex::Version.new('5.17-rc1')
-        return CheckCode::Safe("Kernel version #{release} is not vulnerable")
-      end
-    rescue ArgumentError => e
-      return CheckCode::Safe("Error determining or processing kernel release (#{release}) into known format: #{e}")
+    v = kernel_rex_version(release)
+    if v.nil?
+      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
+    end
+    unless v >= Rex::Version.new('4.14') && v < Rex::Version.new('5.17')
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
 
     vprint_good "Kernel version #{release} appears to be vulnerable"

--- a/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
+++ b/modules/exploits/linux/local/vmwgfx_fd_priv_esc.rb
@@ -1,4 +1,3 @@
-##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -73,12 +72,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     # Check the kernel version to see if its in a vulnerable range
-    release = kernel_release
-    v = kernel_rex_version(release)
-    if v.nil?
-      return CheckCode::Unknown("Could not determine kernel version from release string: #{release}")
-    end
-    unless v >= Rex::Version.new('4.14') && v < Rex::Version.new('5.17')
+    release = kernel_rex_release
+
+    unless release[:upstream] >= Rex::Version.new('4.14') && release[:upstream] < Rex::Version.new('5.17')
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
 

--- a/spec/lib/msf/core/post/linux/kernel_spec.rb
+++ b/spec/lib/msf/core/post/linux/kernel_spec.rb
@@ -109,63 +109,56 @@ RSpec.describe Msf::Post::Linux::Kernel do
     end
   end
 
-  describe '#kernel_rex_version' do
+  describe '#kernel_rex_release' do
     [
-      { release: '5.15.0-25-generic', expected: '5.15.0', label: 'Ubuntu' },
-      { release: '5.13.0-37.42', expected: '5.13.0', label: 'Ubuntu (docker cgroup)' },
-      { release: '4.14.355-275.572.amzn2.x86_64', expected: '4.14.355', label: 'Amazon Linux 2' },
-      { release: '5.4.129-72.229.amzn2int.x86_64', expected: '5.4.129', label: 'Amazon Linux 2 (int)' },
-      { release: '4.0.4-301.fc22.x86_64', expected: '4.0.4', label: 'Fedora' },
-      { release: '3.10.0-1160.el7.x86_64', expected: '3.10.0', label: 'RHEL/CentOS' },
-      { release: '6.11.2-amd64', expected: '6.11.2', label: 'Debian' },
-      { release: '6.6.7-arch1-1', expected: '6.6.7', label: 'Arch Linux' },
-      { release: '5.4.0', expected: '5.4.0', label: 'simple version (no suffix)' },
-      { release: '5.14.21-150500.55.83-default', expected: '5.14.21', label: 'SUSE/openSUSE' },
-      { release: '6.6.63-0-lts', expected: '6.6.63', label: 'Alpine Linux' },
+      { release: '5.15.0-25-generic', expected_upstream: '5.15.0', expected_suffix: '25-generic', label: 'Ubuntu' },
+      { release: '5.13.0-37.42', expected_upstream: '5.13.0', expected_suffix: '37.42', label: 'Ubuntu (docker cgroup)' },
+      { release: '4.14.355-275.572.amzn2.x86_64', expected_upstream: '4.14.355', expected_suffix: '275.572.amzn2.x86_64', label: 'Amazon Linux 2' },
+      { release: '5.4.129-72.229.amzn2int.x86_64', expected_upstream: '5.4.129', expected_suffix: '72.229.amzn2int.x86_64', label: 'Amazon Linux 2 (int)' },
+      { release: '4.0.4-301.fc22.x86_64', expected_upstream: '4.0.4', expected_suffix: '301.fc22.x86_64', label: 'Fedora' },
+      { release: '3.10.0-1160.el7.x86_64', expected_upstream: '3.10.0', expected_suffix: '1160.el7.x86_64', label: 'RHEL/CentOS' },
+      { release: '6.11.2-amd64', expected_upstream: '6.11.2', expected_suffix: 'amd64', label: 'Debian' },
+      { release: '6.6.7-arch1-1', expected_upstream: '6.6.7', expected_suffix: 'arch1-1', label: 'Arch Linux' },
+      { release: '5.14.21-150500.55.83-default', expected_upstream: '5.14.21', expected_suffix: '150500.55.83-default', label: 'SUSE/openSUSE' },
+      { release: '6.6.63-0-lts', expected_upstream: '6.6.63', expected_suffix: '0-lts', label: 'Alpine Linux' },
     ].each do |test_case|
       context "with #{test_case[:label]} kernel (#{test_case[:release]})" do
-        it "returns Rex::Version #{test_case[:expected]}" do
+        it "returns a hash with upstream Rex::Version #{test_case[:expected_upstream]} and distro suffix #{test_case[:expected_suffix]}" do
           allow(subject).to receive(:cmd_exec).and_return(test_case[:release])
-          result = subject.kernel_rex_version
-          expect(result).to be_a(Rex::Version)
-          expect(result).to eq(Rex::Version.new(test_case[:expected]))
+          result = subject.kernel_rex_release
+          expect(result).to be_a(Hash)
+          expect(result[:upstream]).to be_a(Rex::Version)
+          expect(result[:upstream]).to eq(Rex::Version.new(test_case[:expected_upstream]))
+          expect(result[:distro_suffix]).to eq(test_case[:expected_suffix])
         end
-      end
-    end
-
-    context 'when a pre-fetched release string is provided' do
-      it 'uses the provided string instead of calling kernel_release' do
-        expect(subject).not_to receive(:cmd_exec)
-        result = subject.kernel_rex_version('5.15.0-25-generic')
-        expect(result).to eq(Rex::Version.new('5.15.0'))
       end
     end
 
     context 'when kernel_release returns a blank string' do
       it 'returns nil' do
         allow(subject).to receive(:cmd_exec).and_return('')
-        expect(subject.kernel_rex_version).to be_nil
+        expect(subject.kernel_rex_release).to be_nil
       end
     end
 
     context 'when kernel_release returns nil' do
       it 'returns nil' do
         allow(subject).to receive(:cmd_exec).and_return(nil)
-        expect(subject.kernel_rex_version).to be_nil
+        expect(subject.kernel_rex_release).to be_nil
       end
     end
 
-    context 'when the version string before the first hyphen is not parseable' do
+    context 'when the version string is not parseable' do
       it 'returns nil' do
-        result = subject.kernel_rex_version('xyz-not-a-version')
-        expect(result).to be_nil
+        allow(subject).to receive(:cmd_exec).and_return('xyz-not-a-version')
+        expect(subject.kernel_rex_release).to be_nil
       end
     end
 
     context 'when version comparison is used' do
-      it 'allows comparison with other Rex::Version objects' do
+      it 'allows comparison with other Rex::Version objects via the :upstream key' do
         allow(subject).to receive(:cmd_exec).and_return('5.15.0-25-generic')
-        v = subject.kernel_rex_version
+        v = subject.kernel_rex_release[:upstream]
         expect(v).to be > Rex::Version.new('5.14.0')
         expect(v).to be < Rex::Version.new('5.16.0')
         expect(v).to eq(Rex::Version.new('5.15.0'))

--- a/spec/lib/msf/core/post/linux/kernel_spec.rb
+++ b/spec/lib/msf/core/post/linux/kernel_spec.rb
@@ -108,4 +108,68 @@ RSpec.describe Msf::Post::Linux::Kernel do
       end
     end
   end
+
+  describe '#kernel_rex_version' do
+    [
+      { release: '5.15.0-25-generic', expected: '5.15.0', label: 'Ubuntu' },
+      { release: '5.13.0-37.42', expected: '5.13.0', label: 'Ubuntu (docker cgroup)' },
+      { release: '4.14.355-275.572.amzn2.x86_64', expected: '4.14.355', label: 'Amazon Linux 2' },
+      { release: '5.4.129-72.229.amzn2int.x86_64', expected: '5.4.129', label: 'Amazon Linux 2 (int)' },
+      { release: '4.0.4-301.fc22.x86_64', expected: '4.0.4', label: 'Fedora' },
+      { release: '3.10.0-1160.el7.x86_64', expected: '3.10.0', label: 'RHEL/CentOS' },
+      { release: '6.11.2-amd64', expected: '6.11.2', label: 'Debian' },
+      { release: '6.6.7-arch1-1', expected: '6.6.7', label: 'Arch Linux' },
+      { release: '5.4.0', expected: '5.4.0', label: 'simple version (no suffix)' },
+      { release: '5.14.21-150500.55.83-default', expected: '5.14.21', label: 'SUSE/openSUSE' },
+      { release: '6.6.63-0-lts', expected: '6.6.63', label: 'Alpine Linux' },
+    ].each do |test_case|
+      context "with #{test_case[:label]} kernel (#{test_case[:release]})" do
+        it "returns Rex::Version #{test_case[:expected]}" do
+          allow(subject).to receive(:cmd_exec).and_return(test_case[:release])
+          result = subject.kernel_rex_version
+          expect(result).to be_a(Rex::Version)
+          expect(result).to eq(Rex::Version.new(test_case[:expected]))
+        end
+      end
+    end
+
+    context 'when a pre-fetched release string is provided' do
+      it 'uses the provided string instead of calling kernel_release' do
+        expect(subject).not_to receive(:cmd_exec)
+        result = subject.kernel_rex_version('5.15.0-25-generic')
+        expect(result).to eq(Rex::Version.new('5.15.0'))
+      end
+    end
+
+    context 'when kernel_release returns a blank string' do
+      it 'returns nil' do
+        allow(subject).to receive(:cmd_exec).and_return('')
+        expect(subject.kernel_rex_version).to be_nil
+      end
+    end
+
+    context 'when kernel_release returns nil' do
+      it 'returns nil' do
+        allow(subject).to receive(:cmd_exec).and_return(nil)
+        expect(subject.kernel_rex_version).to be_nil
+      end
+    end
+
+    context 'when the version string before the first hyphen is not parseable' do
+      it 'returns nil' do
+        result = subject.kernel_rex_version('xyz-not-a-version')
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when version comparison is used' do
+      it 'allows comparison with other Rex::Version objects' do
+        allow(subject).to receive(:cmd_exec).and_return('5.15.0-25-generic')
+        v = subject.kernel_rex_version
+        expect(v).to be > Rex::Version.new('5.14.0')
+        expect(v).to be < Rex::Version.new('5.16.0')
+        expect(v).to eq(Rex::Version.new('5.15.0'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds `kernel_rex_version` to `Msf::Post::Linux::Kernel` that extracts the upstream kernel version from `uname -r` and returns a `Rex::Version`. This replaces the `split('-').first` pattern duplicated across 15 modules that crashed with `ArgumentError` on distro-specific suffixes (Amazon Linux, Fedora, RHEL, SUSE, etc.).

- Modules now return `CheckCode::Unknown` instead of `CheckCode::Safe` when version can't be parsed
- Removes `rescue ArgumentError` band-aids added in #19813
- Fixes `vmwgfx_fd_priv_esc` boundary (`>` to `>=`) that excluded kernel 4.14.0
- Fixes `cve_2021_3490` Fedora dead code (`>=` to `>` for 5.11.20)

Fixes #19855

## Verification

- [ ] `bundle exec rspec spec/lib/msf/core/post/linux/kernel_spec.rb`
- [ ] **Verify** 34 examples, 0 failures
- [ ] `bundle exec ruby msftidy.rb vmwgfx_fd_priv_esc.rb docker_cgroup_escape.rb modules/exploits/example_linux_priv_esc.rb`
- [ ] **Verify** no new offenses
- [ ] `grep -rn "Rex::Version.new.*kernel_release" modules/exploits/`
- [ ] **Verify** zero matches (no module passes raw kernel_release to Rex::Version)
- [ ] Start msfconsole
- [ ] `irb`
- [ ] `Rex::Version.new("4.14.355-275.572.amzn2.x86_64")`
- [ ] **Verify** it raises `ArgumentError` (the original bug)
- [ ] `Rex::Version.new("4.14.355-275.572.amzn2.x86_64".split('-').first)`
- [ ] **Verify** returns `Rex::Version "4.14.355"` (what `kernel_rex_version` does)
- [ ] `use exploit/linux/local/vmwgfx_fd_priv_esc`
- [ ] **Verify** module loads without errors