### PR TITLE
Update Gitlab mixin logs

### DIFF
--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -426,15 +426,15 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   def convert_to_rex_version_range(version)
     return nil unless version
 
-    report_gitlab_service(version)
-
     if version.is_a?(Array) && version.length == 2
       low_version, high_version = version
       low_version = Rex::Version.new(low_version)
       high_version = Rex::Version.new(high_version)
+      report_gitlab_service("#{low_version.to_s} - #{high_version.to_s}")
       [low_version, high_version]
    else
       version = Rex::Version.new(version)
+      report_gitlab_service(version.to_s)
       [version, version]
    end
   end
@@ -443,12 +443,16 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   #
   # @return [[Rex::Version(low_version), Rex::Version(high_version)],nil] Gitlab version if found, nil otherwise
   def gitlab_version
-    version =
-      gitlab_version_css(normalize_uri(target_uri.path)) ||
-      gitlab_version_rest ||
-      gitlab_version_help_commit(normalize_uri(target_uri.path))
+    version = gitlab_version_css(normalize_uri(target_uri.path))
+    return convert_to_rex_version_range(version) if version
+    
+    version = gitlab_version_rest
+    return convert_to_rex_version_range(version) if version
 
-    convert_to_rex_version_range(version)
+    version = gitlab_version_help_commit(normalize_uri(target_uri.path))
+    return convert_to_rex_version_range(version) if version
+
+    nil 
   end
 
   # Report GitLab as an application service with HTTP(S) and TCP parent services.
@@ -456,10 +460,7 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   # @param [String,Array<String>] version GitLab version value or range
   #
   # @return [void]
-  def report_gitlab_service(version)
-    return unless respond_to?(:report_service)
-
-    version_info = version.is_a?(Array) ? version.join(' - ') : version
+  def report_gitlab_service(version_info)
 
     report_service(
       host: rhost,

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -443,16 +443,12 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   #
   # @return [[Rex::Version(low_version), Rex::Version(high_version)],nil] Gitlab version if found, nil otherwise
   def gitlab_version
-    version = gitlab_version_css(normalize_uri(target_uri.path))
-    return convert_to_rex_version_range(version) if version
+    version =
+      gitlab_version_css(normalize_uri(target_uri.path)) ||
+      gitlab_version_rest ||
+      gitlab_version_help_commit(normalize_uri(target_uri.path))
 
-    version = gitlab_version_rest
-    return convert_to_rex_version_range(version) if version
-
-    version = gitlab_version_help_commit(normalize_uri(target_uri.path))
-    return convert_to_rex_version_range(version) if version
-
-    nil
+    convert_to_rex_version_range(version)
   end
 
   # Report GitLab as an application service with HTTP(S) and TCP parent services.

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -424,7 +424,9 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   #
   # @return [[Rex::Version(low_version), Rex::Version(high_version)],nil] Gitlab version range if found, nil otherwise
   def convert_to_rex_version_range(version)
-    return nil unless version
+def convert_to_rex_version_range(version)
+return nil unless version
+report_gitlab_service(version)
 
     if version.is_a?(Array) && version.length == 2
       low_version, high_version = version

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -424,19 +424,19 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   #
   # @return [[Rex::Version(low_version), Rex::Version(high_version)],nil] Gitlab version range if found, nil otherwise
   def convert_to_rex_version_range(version)
-def convert_to_rex_version_range(version)
-return nil unless version
-report_gitlab_service(version)
+    return nil unless version
+
+    report_gitlab_service(version)
 
     if version.is_a?(Array) && version.length == 2
       low_version, high_version = version
       low_version = Rex::Version.new(low_version)
       high_version = Rex::Version.new(high_version)
       [low_version, high_version]
-    else
+   else
       version = Rex::Version.new(version)
       [version, version]
-    end
+   end
   end
 
   # Extracts the Gitlab version information and returns a version range.
@@ -444,22 +444,13 @@ report_gitlab_service(version)
   # @return [[Rex::Version(low_version), Rex::Version(high_version)],nil] Gitlab version if found, nil otherwise
   def gitlab_version
     version = gitlab_version_css(normalize_uri(target_uri.path))
-    if version
-      report_gitlab_service(version)
-      return convert_to_rex_version_range(version)
-    end
+    return convert_to_rex_version_range(version) if version
 
     version = gitlab_version_rest
-    if version
-      report_gitlab_service(version)
-      return convert_to_rex_version_range(version)
-    end
+    return convert_to_rex_version_range(version) if version
 
     version = gitlab_version_help_commit(normalize_uri(target_uri.path))
-    if version
-      report_gitlab_service(version)
-      return convert_to_rex_version_range(version)
-    end
+    return convert_to_rex_version_range(version) if version
 
     nil
   end

--- a/lib/msf/core/exploit/remote/http/gitlab/version.rb
+++ b/lib/msf/core/exploit/remote/http/gitlab/version.rb
@@ -442,16 +442,58 @@ module Msf::Exploit::Remote::HTTP::Gitlab::Version
   # @return [[Rex::Version(low_version), Rex::Version(high_version)],nil] Gitlab version if found, nil otherwise
   def gitlab_version
     version = gitlab_version_css(normalize_uri(target_uri.path))
-    return convert_to_rex_version_range(version) if version
+    if version
+      report_gitlab_service(version)
+      return convert_to_rex_version_range(version)
+    end
 
     version = gitlab_version_rest
-    return convert_to_rex_version_range(version) if version
+    if version
+      report_gitlab_service(version)
+      return convert_to_rex_version_range(version)
+    end
 
     version = gitlab_version_help_commit(normalize_uri(target_uri.path))
-    return convert_to_rex_version_range(version) if version
+    if version
+      report_gitlab_service(version)
+      return convert_to_rex_version_range(version)
+    end
 
     nil
   end
+
+  # Report GitLab as an application service with HTTP(S) and TCP parent services.
+  #
+  # @param [String,Array<String>] version GitLab version value or range
+  #
+  # @return [void]
+  def report_gitlab_service(version)
+    return unless respond_to?(:report_service)
+
+    version_info = version.is_a?(Array) ? version.join(' - ') : version
+
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'GitLab',
+      info: "GitLab #{version_info}",
+      parents: {
+        name: ssl ? 'https' : 'http',
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        parents: {
+          name: 'tcp',
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          parents: nil
+        }
+      }
+    )
+  end
+
 
   # Checks the name of a CSS file to fingerprint the version
   #


### PR DESCRIPTION
This PR fixes [#20971](https://github.com/rapid7/metasploit-framework/issues/20971) by updating Gitlab::Version#gitlab_version to report detected GitLab version information using the new service reporting API.

When a version is successfully identified, the module now registers GitLab as an application service with an HTTP/HTTPS parent (and TCP hierarchy), ensuring proper service structure

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/gitlab_version`
- [ ] set RHOSTS <target_ip that has git lab service>
- [ ] set RPORT 8080
- [ ] set SSL false
- [ ] set TARGETURI /
- [ ] run
- [ ] services
<img width="1000" height="637" alt="Screenshot 2026-02-23 053945" src="https://github.com/user-attachments/assets/416efa62-3dfe-4440-be5a-62773fe782a9" />
