### PR TITLE
Add support for printing module name prefix

### DIFF
--- a/lib/msf/core/module/ui/message.rb
+++ b/lib/msf/core/module/ui/message.rb
@@ -27,7 +27,11 @@ module Msf::Module::UI::Message
       if xn.is_a?(Integer)
         prefix << "[%04d] " % xn
       end
+    end
 
+    if (module_name_output = (datastore['ModuleNameOutput'] ||
+        (framework && framework.datastore['ModuleNameOutput'])))
+      prefix << "[#{module_name_output}] "
     end
     prefix
   end


### PR DESCRIPTION
Add support for printing module name prefix

## Verification

Similar to `TimestampOutput` and `ExploitNumber` this value will be set by Pro when wanting to output additional module name details