### PR TITLE
Fix crash when running ldap esc vulnerable cert finder

### DIFF
--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -1088,8 +1088,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def domain_controller_version_check
-    domain = adds_get_domain_info(@ldap)[:dns_name]
-    user = adds_get_current_user(@ldap)[:sAMAccountName].first.to_s
+    domain_info = adds_get_domain_info(@ldap)
+    return unless domain_info
+
+    user_info = adds_get_current_user(@ldap)
+    return unless user_info
+
+    user = [:sAMAccountName].first.to_s
+    domain = domain_info[:dns_name]
     print_status("user: #{user}, domain: #{domain}")
 
     version_raw = nil


### PR DESCRIPTION
Fixes a crash when running the ldap esc vulnerable cert finder against a target when LDAP binding fails

## Verification

### Before 🔴 

Crash:

```
msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run rhost=10.140.108.118
[*] Running module against 10.140.108.118
[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[-] Auxiliary failed: NoMethodError undefined method `[]' for nil:NilClass
[-] Call stack:
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:1091:in `domain_controller_version_check'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:1181:in `block in run'
[-]   /Users/user/.rvm/gems/ruby-3.2.5/gems/net-ldap-0.19.0/lib/net/ldap.rb:646:in `block in open'
[-]   /Users/user/.rvm/gems/ruby-3.2.5/gems/net-ldap-0.19.0/lib/net/ldap.rb:718:in `block in open'
[-]   /Users/user/.rvm/gems/ruby-3.2.5/gems/net-ldap-0.19.0/lib/net/ldap/instrumentation.rb:19:in `instrument'
[-]   /Users/user/.rvm/gems/ruby-3.2.5/gems/net-ldap-0.19.0/lib/net/ldap.rb:713:in `open'
[-]   /Users/user/.rvm/gems/ruby-3.2.5/gems/net-ldap-0.19.0/lib/net/ldap.rb:646:in `open'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:148:in `ldap_open'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/optional_session/ldap.rb:53:in `ldap_connect'
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:1163:in `run'
[*] Auxiliary module execution completed
```

### After 🟢 

No crash:

```
msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run rhost=10.140.108.118
[*] Running module against 10.140.108.118
[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[-] Auxiliary aborted due to failure: unknown: An LDAP operational error occurred. It is likely the client requires authorization! The error was: 000004DC: LdapErr: DSID-0C090C78, comment: In order to perform this operation a successful bind must be completed on the connection., data 0, v4f7c
[*] Auxiliary module execution completed
```

Module confirmed still working:

```
msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run rhost=10.140.108.118 username=sandy@ad.pro.local password=vagrant
[*] Running module against 10.140.108.118
[+] Successfully bound to the LDAP server!
[*] Discovering base DN automatically
[*] Successfully queried (sAMAccountName=sandy).
[*] user: sAMAccountName, domain: ad.pro.local
[!] Unable to determine the version of Window so these all might be false postives! WinRM authorization error: WinRM::WinRMAuthorizationError
[*] Successfully queried (objectClass=pkicertificatetemplate).
[*] Successfully queried (objectSID=S-1-5-21-2389185246-3200475687-1346508826-512).
[*] Successfully queried (objectSID=S-1-5-21-2389185246-3200475687-1346508826-513).
[*] Successfully queried (objectSID=S-1-5-21-2389185246-3200475687-1346508826-519).
[*] Successfully queried (objectSID=S-1-5-21-2389185246-3200475687-1346508826-512).
...
```