### PR TITLE
Running-Private-Modules.md: Remove duplicate lines

### DIFF
--- a/docs/metasploit-framework.wiki/Running-Private-Modules.md
+++ b/docs/metasploit-framework.wiki/Running-Private-Modules.md
@@ -37,8 +37,6 @@ For full details:
 If you already have msfconsole running, use a `reload_all` command to pick up your new modules. If not, just start msfconsole and they'll be picked up automatically. If you'd like to test with something generic, I have a module posted up as a gist, here: <https://gist.github.com/todb-r7/5935519>, so let's give it a shot:
 
 ```bash
-mkdir -p $HOME/.msf4/modules/exploits/test
-curl -Lo ~/.msf4/modules/exploits/test/test_module.rb https://gist.github.com/todb-r7/5935519/raw/17f7e40ab9054051c1f7e0655c6f8c8a1787d4f5/test_module.rb
 todb@ubuntu:~$ mkdir -p $HOME/.msf4/modules/exploits/test
 todb@ubuntu:~$ curl -Lo ~/.msf4/modules/exploits/test/test_module.rb https://gist.github.com/todb-r7/5935519/raw/6e5d2da61c82b0aa8cec36825363118e9dd5f86b/test_module.rb
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current


### PR DESCRIPTION
2x commands are in there twice, once with prompt, once without.

REF: https://docs.metasploit.com/docs/using-metasploit/intermediate/running-private-modules.html

