### PR TITLE
Fix #21022: msfrpcd JSON-RPC SSL certificate check logic

### DIFF
--- a/msfrpcd
+++ b/msfrpcd
@@ -208,8 +208,8 @@ if $PROGRAM_NAME == __FILE__
   begin
     if json_rpc
 
-      if !File.file?(ws_ssl_key_default) || !File.file?(ws_ssl_cert_default)
-        $stdout.puts "[-] It doesn't appear msfdb has been run; please run 'msfdb init' first."
+      if opts['SSL'] && (!File.file?(ws_ssl_key) || !File.file?(ws_ssl_cert))
+        $stdout.puts "[-] It doesn't appear msfdb has been run; please run 'msfdb init' first to generate SSL certificates."
         abort
       end
 


### PR DESCRIPTION
### Description
This PR fixes issue #21022 where starting a JSON-RPC server with `msfrpcd -j` would incorrectly demand SSL certificates (and suggest running `msfdb init`) even when SSL was disabled via `-S` or when custom certificate paths were provided via `-k` and `-c`.

The logic in `msfrpcd` has been updated to:
1. **SSL Awareness:** Only perform the certificate existence check if SSL is enabled (`opts['SSL'] == true`).
2. **Dynamic Path Resolution:** Verify the actual certificate paths being used (respecting custom paths provided via command-line arguments) rather than strictly checking the default locations.
3. **Improved Error Messaging:** Update the error message to clarify that `msfdb init` is specifically suggested for certificate generation.

**Fixes:** #21022

---

### Verification

- [X] **Scenario 1: SSL Disabled**
  - Ensure default certificates are missing from the configuration directory (`~/.msf4/`).
  - Run: `msfrpcd -j -S -a 127.0.0.1 -p 55553 -P yourpassword`
  - **Verify:** The server no longer blocks with the error `[-] It doesn't appear msfdb has been run...`

- [X] **Scenario 2: SSL Enabled (Missing Certs)**
  - Ensure default certificates are missing.
  - Run: `msfrpcd -j -a 127.0.0.1 -p 55553 -P yourpassword`
  - **Verify:** The warning correctly appears, prompting the user to run `msfdb init` to generate certificates.

- [X] **Scenario 3: Custom Certificate Paths**
  - Provide paths to existing key/cert files using `-k` and `-c`.
  - Run: `msfrpcd -j -k /path/to/key.pem -c /path/to/cert.pem -P password`
  - **Verify:** The script validates the custom paths correctly instead of defaulting to the home directory check.