### PR TITLE
Fix HttpCookie integer conversion and cookie jar docs

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-Send-an-HTTP-Request-Using-HttpClient.md
+++ b/docs/metasploit-framework.wiki/How-to-Send-an-HTTP-Request-Using-HttpClient.md
@@ -81,14 +81,17 @@ Any object passed to `cookie` that isn't an instance of HttpCookieJar will have 
 
 ----
 
-Module authors can also pass an instance of `HttpCookieJar` with the `cookie` option:
+Module authors can also pass an instance of `HttpCookieJar` with the `cookie` option.
+
+Important: Cookies added to a `HttpCookieJar` must have both `domain` and `path` set, and cookie values must be strings. Without these attributes the underlying cookie store will raise an `ArgumentError`.
 
 ```ruby
 cj = Msf::Exploit::Remote::HTTP::HttpCookieJar.new
 
-cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('PHPSESSID', @phpsessid))
-cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('AsWebStatisticsCooKie', 1))
-cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('shellinaboxCooKie', 1))
+target_host = datastore['RHOST']
+cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('PHPSESSID', @phpsessid, domain: target_host, path: '/'))
+cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('AsWebStatisticsCooKie', '1', domain: target_host, path: '/'))
+cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('shellinaboxCooKie', '1', domain: target_host, path: '/'))
 
 res = send_request_cgi({
   'method' => 'GET',

--- a/lib/msf/core/exploit/remote/http/http_cookie.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie.rb
@@ -24,7 +24,7 @@ module Msf
           # +accessed_at+, +created_at+.
           def initialize(name, value = nil, **attr_hash)
             if value
-              @cookie = ::HTTP::Cookie.new(name, value.is_a?(String) ? value : value.to_s)
+              @cookie = ::HTTP::Cookie.new(name, value.to_s)
             else
               @cookie = ::HTTP::Cookie.new(name)
             end

--- a/lib/msf/core/exploit/remote/http/http_cookie.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie.rb
@@ -24,7 +24,7 @@ module Msf
           # +accessed_at+, +created_at+.
           def initialize(name, value = nil, **attr_hash)
             if value
-              @cookie = ::HTTP::Cookie.new(name, value)
+              @cookie = ::HTTP::Cookie.new(name, value.is_a?(String) ? value : value.to_s)
             else
               @cookie = ::HTTP::Cookie.new(name)
             end

--- a/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
@@ -68,7 +68,14 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
         expect(cookie.value.class).to eql(String)
       end
     end
-
+    
+    describe 'Integer' do
+      it 'passed as value during initialization is converted to a String' do
+        c = described_class.new('test_cookie', 1)
+        expect(c.value).to eql('1')
+        expect(c.value.class).to eql(String)
+      end
+    end
     describe 'nil' do
       it 'assigned to value results in it being set to an empty string and expires is set UNIX_EPOCH' do
         v = nil


### PR DESCRIPTION
**Fix broken Cookie Jar documentation examples (#18573).**

- ```HttpCookie.new('name', 1)``` raised ```TypeError``` because the constructor passed non string values directly to ```HTTP::Cookie.new```. Now converts to string via ```to_s```.


- Updated wiki examples to include required ```domain``` and ```path``` keyword arguments and use string values.

## Verification

-  Start ```msfconsole``` and run ```irb```
- Run ```Msf::Exploit::Remote::HTTP::HttpCookie.new('test', 1)```. Verify no error, value is "1"
- Run ```cj = Msf::Exploit::Remote::HTTP::HttpCookieJar.new```
- Run ```cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('test', 'val', domain: 'example.com', path: '/'))```. Verify no error
- Run ```cj.cookies```. Verify cookie is present