### PR TITLE
Add WordPress service reporting to HTTP mixin #20958

### DIFF
--- a/lib/msf/core/exploit/remote/http/wordpress/base.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/base.rb
@@ -29,10 +29,37 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Base
       )
     end
 
-    return res if res && res.code == 200 && res.body && wordpress_detect_regexes.any? { |r| res.body =~ r }
+    if res && res.code == 200 && res.body && wordpress_detect_regexes.any? { |r| res.body =~ r }
+      report_wordpress_service
+      return res
+    end
+
     return nil
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
     print_error("Error connecting to #{target_uri}: #{e}")
     return nil
+  end
+
+  def report_wordpress_service
+    return unless framework.db&.active
+
+    report_service(
+      host:  rhost,
+      port:  rport,
+      proto: 'tcp',
+      name:  'wordpress',
+      info:  'WordPress CMS',
+      parents: {
+        host:  rhost,
+        port:  rport,
+        proto: 'tcp',
+        name:  ssl ? 'https' : 'http',
+        parents: {
+          host:  rhost,
+          port:  rport,
+          proto: 'tcp'
+        }
+      }
+    )
   end
 end

--- a/lib/msf/core/exploit/remote/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/version.rb
@@ -151,7 +151,8 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       # Try again using the style.css file
       return check_theme_version_from_style(name, fixed_version, vuln_introduced_version) if type == :theme
     end
-
+    
+    report_wordpress_service
     version_res = extract_and_check_version(res.body.to_s, :readme, type, fixed_version, vuln_introduced_version)
     if version_res == Msf::Exploit::CheckCode::Detected && type == :theme
       # If no version could be found in readme.txt for a theme, try style.css

--- a/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Base do
 
   describe '#wordpress_and_online?' do
     before :example do
+      allow(subject).to receive(:report_wordpress_service)
       allow(subject).to receive(:send_request_cgi) do
         res = Rex::Proto::Http::Response.new
         res.code = wp_code

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
 
   describe '#check_version_from_readme' do
     before :example do
+      allow(subject).to receive(:report_wordpress_service)
       allow(subject).to receive(:send_request_cgi) do |opts|
         res = Rex::Proto::Http::Response.new
         res.code = wp_code


### PR DESCRIPTION
## Summary

Relates to #20958

When WordPress is confirmed via `wordpress_and_online?` or 
`check_version_from_readme`, the service is now reported to the 
database with its parent HTTP/HTTPS service chain:

This improves reporting for approximately 30 modules that use the 
WordPress HTTP mixin without requiring any changes to those modules.

## Changes

- Added `report_wordpress_service` helper to `Msf::Exploit::Remote::HTTP::Wordpress::Base`
- Called from `wordpress_and_online?` on successful WordPress detection
- Called from `check_version_from_readme` on successful readme retrieval
- Updated specs to mock `report_wordpress_service` in both `base_spec.rb` and `version_spec.rb`

## Verification

Tested against a local WordPress 6.9.1 instance:

```
./msfconsole -q -x "use auxiliary/scanner/http/wordpress_login_enum; set RHOSTS 127.0.0.1; set RPORT 8080; set WPCHECK true; run; services; exit"
WARN: Unresolved or ambiguous specs during Gem::Specification.reset:
      stringio (>= 0)
      Available/installed versions of this gem:
      - 3.1.1
      - 3.0.4
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
RHOSTS => 127.0.0.1
RPORT => 8080
WPCHECK => true
[*] / - WordPress Version 6.9.1 detected
[*] 127.0.0.1:8080        - / - WordPress User-Enumeration - Running User Enumeration
[*] 127.0.0.1:8080        - / - WordPress User-Validation - Running User Validation
[*] 127.0.0.1:8080        - [1/0] - / - WordPress Brute Force - Running Bruteforce
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
Services
========

host      port  proto  name       state  info         resource  parents
----      ----  -----  ----       -----  ----         --------  -------
127.0.0.  8080  tcp               open                {}
1
127.0.0.  8080  tcp    wordpress  open   WordPress C  {}        http (8080/tcp
1                                        MS                     )
127.0.0.  8080  tcp    http       open                {}        (8080/tcp)
1


```

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/wordpress_login_enum` (or any WordPress module)
- [ ] Set `RHOSTS` to a WordPress target
- [ ] Run the module
- [ ] **Verify** `services` in msfconsole shows WordPress reported with parent http/https service
- [ ] **Verify** existing module behavior is unchanged