### PR TITLE
LDAP Reporting Improvements

### DIFF
--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -191,42 +191,47 @@ module Msf::DBManager::Service
   end
 
   def process_service_chain(host, services)
-    return if services.nil? || host.nil?
-    return unless services.is_a?(Hash) || services.is_a?(::Array)
     return unless host.is_a?(Mdm::Host)
+
+    return if services.nil?
 
     services = [services] unless services.is_a?(Array)
     services.map do |service|
-      return unless service.is_a?(Hash)
-      return if service[:port].nil? || service[:proto].nil?
+      case service
+      when ::Mdm::Service
+        service_obj = service
+      when ::Hash
+        next if service[:port].nil? || service[:proto].nil?
 
-      parents = nil
-      if service[:parents]&.any?
-        parents = process_service_chain(host, service[:parents])
-      end
-
-      service_info = {
-        port: service[:port].to_i,
-        proto: service[:proto].to_s.downcase,
-      }
-      service_info[:name] = service[:name].downcase if service[:name]
-      service_info[:resource] = service[:resource] if service[:resource]
-      service_obj = host.services.find_or_create_by(service_info)
-      if service_obj.id.nil?
-        elog("Failed to create service #{service_info.inspect} for host #{host.name} (#{host.address})")
-        return
-      end
-      service_obj.state ||= Msf::ServiceState::Open
-      service_obj.info = service[:info] ? service[:info] : ''
-
-      if parents
-        parents.each do |parent|
-          service_obj.parents << parent if parent && !service_obj.parents.include?(parent)
+        parents = nil
+        if service[:parents]&.any?
+          parents = process_service_chain(host, service[:parents])
         end
+
+        service_info = {
+          port: service[:port].to_i,
+          proto: service[:proto].to_s.downcase,
+        }
+        service_info[:name] = service[:name].downcase if service[:name]
+        service_info[:resource] = service[:resource] if service[:resource]
+        service_obj = host.services.find_or_create_by(service_info)
+        if service_obj.id.nil?
+          elog("Failed to create service #{service_info.inspect} for host #{host.name} (#{host.address})")
+          return
+        end
+        service_obj.state ||= Msf::ServiceState::Open
+        service_obj.info = service[:info] ? service[:info] : ''
+
+        if parents
+          parents.each do |parent|
+            service_obj.parents << parent if parent && !service_obj.parents.include?(parent)
+          end
+        end
+      else
+        next
       end
 
       service_obj
-    end
-
+    end.compact
   end
 end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -61,11 +61,15 @@ module Msf
       datastore['RPORT']
     end
 
+    def ssl
+      !!datastore['SSL']
+    end
+
     # Return the peer as a host:port formatted string.
     #
     # @return [String] A string containing the peer details in RHOST:RPORT format.
     def peer
-      "#{rhost}:#{rport}"
+      Rex::Socket.to_authority(rhost, rport)
     end
 
     # Set the various connection options to use when connecting to the
@@ -226,6 +230,7 @@ module Msf
       case bind_result[:code]
       when 0
         vprint_good('Successfully bound to the LDAP server!')
+        report_ldap_service
       when 1
         fail_with(Msf::Module::Failure::NoAccess, "An operational error occurred, perhaps due to lack of authorization. The error was: #{bind_result[:error_message].strip}")
       when 7
@@ -244,6 +249,16 @@ module Msf
       else
         fail_with(Msf::Module::Failure::Unknown, "Unknown error occurred whilst binding: #{bind_result[:error_message].strip}")
       end
+    end
+
+    def report_ldap_service
+      report_service(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        name: 'ldap',
+        parents: ssl ? { name: 'ssl', host: rhost, port: rport, proto: 'tcp' } : nil
+      )
     end
 
     # Validate the query result and check whether the query succeeded.

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -254,12 +254,15 @@ module Msf
     end
 
     def report_ldap_service
+      transport_srv = { name: 'tcp', host: rhost, port: rport, proto: 'tcp', parents: nil }
+      parents = ssl ? { name: 'ssl', host: rhost, port: rport, proto: 'tcp', parents: [transport_srv] } : [transport_srv]
+
       report_service(
         host: rhost,
         port: rport,
         proto: 'tcp',
         name: 'ldap',
-        parents: ldap_client_ssl ? { name: 'ssl', host: rhost, port: rport, proto: 'tcp' } : nil
+        parents: parents
       )
     end
 

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -65,6 +65,8 @@ module Msf
       !!datastore['SSL']
     end
 
+    alias ldap_client_ssl ssl
+
     # Return the peer as a host:port formatted string.
     #
     # @return [String] A string containing the peer details in RHOST:RPORT format.
@@ -104,7 +106,7 @@ module Msf
       end
 
       begin
-        result = ldap_connect_opts(rhost, rport, datastore['LDAP::ConnectTimeout'], ssl: datastore['SSL'], opts: opts)
+        result = ldap_connect_opts(rhost, rport, datastore['LDAP::ConnectTimeout'], ssl: ldap_client_ssl, opts: opts)
       rescue Msf::ValidationError => e
         fail_with(Msf::Module::Failure::BadConfig, e.message)
       end
@@ -257,7 +259,7 @@ module Msf
         port: rport,
         proto: 'tcp',
         name: 'ldap',
-        parents: ssl ? { name: 'ssl', host: rhost, port: rport, proto: 'tcp' } : nil
+        parents: ldap_client_ssl ? { name: 'ssl', host: rhost, port: rport, proto: 'tcp' } : nil
       )
     end
 

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -568,8 +568,8 @@ module Exploit::Remote::MsIcpr
     report_service({
       name: 'icertpassage',
       resource: { dcerpc: { pipe: 'cert' } },
-      host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
-      port: icpr.tree.client.dispatcher.tcp_socket.peerport,
+      host: simple.peerhost,
+      port: simple.peerport,
       proto: 'tcp',
       parents: report_dcerpc_service
      })

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -224,7 +224,7 @@ module Exploit::Remote::MsIcpr
 
     report_service({
       name: ADCS_CA_SERVICE_NAME,
-      resource: { name: datastore['CA'] },
+      resource: { ADCS_CA_SERVICE_NAME => { name: datastore['CA'] } },
       host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
       port: icpr.tree.client.dispatcher.tcp_socket.peerport,
       proto: 'tcp',

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -30,6 +30,8 @@ module Exploit::Remote::MsIcpr
   # [[SAN URL prefix for strong SID mapping for KDCs running Windows Server Preview Build 25246 and later](https://techcommunity.microsoft.com/blog/askds/preview-of-san-uri-for-certificate-strong-mapping-for-kb5014754/3789785)]
   SAN_URL_PREFIX = "tag:microsoft.com,2022-09-14:sid:"
 
+  ADCS_CA_SERVICE_NAME = 'adcs-ca'
+
   class MsIcprError < StandardError; end
   class MsIcprConnectionError < MsIcprError; end
   class MsIcprAuthenticationError < MsIcprError; end
@@ -131,7 +133,7 @@ module Exploit::Remote::MsIcpr
     vprint_good('Bound to \\cert')
 
     report_service(
-      name: 'ICertPassage',
+      name: 'icertpassage',
       resource: { dcerpc: { pipe: 'cert' } },
       host: tree.client.dispatcher.tcp_socket.peerhost,
       port: tree.client.dispatcher.tcp_socket.peerport,
@@ -233,6 +235,21 @@ module Exploit::Remote::MsIcpr
         raise MsIcprUnknownError.new(hresult.description)
       end
     end
+
+    report_service({
+      name: ADCS_CA_SERVICE_NAME,
+      resource: { name: datastore['CA'] },
+      host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
+      port: icpr.tree.client.dispatcher.tcp_socket.peerport,
+      proto: 'tcp',
+      parents: {
+        name: 'icertpassage',
+        resource: { dcerpc: { pipe: 'cert' } },
+        host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
+        port: icpr.tree.client.dispatcher.tcp_socket.peerport,
+        proto: 'tcp'
+       }
+    })
 
     return unless response[:certificate]
 

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -132,21 +132,7 @@ module Exploit::Remote::MsIcpr
     )
     vprint_good('Bound to \\cert')
 
-    report_service(
-      name: 'icertpassage',
-      resource: { dcerpc: { pipe: 'cert' } },
-      host: tree.client.dispatcher.tcp_socket.peerhost,
-      port: tree.client.dispatcher.tcp_socket.peerport,
-      proto: 'tcp',
-      parents: {
-          name: 'dcerpc',
-          info: "Module: #{fullname}",
-          host: tree.client.dispatcher.tcp_socket.peerhost,
-          port: tree.client.dispatcher.tcp_socket.peerport,
-          proto: 'tcp',
-          resource: { smb: { share: 'IPC$' } }
-        }
-      )
+    report_icertpassage_service
 
     icpr
   end
@@ -242,13 +228,7 @@ module Exploit::Remote::MsIcpr
       host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
       port: icpr.tree.client.dispatcher.tcp_socket.peerport,
       proto: 'tcp',
-      parents: {
-        name: 'icertpassage',
-        resource: { dcerpc: { pipe: 'cert' } },
-        host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
-        port: icpr.tree.client.dispatcher.tcp_socket.peerport,
-        proto: 'tcp'
-       }
+      parents: report_icertpassage_service
     })
 
     return unless response[:certificate]
@@ -582,6 +562,17 @@ module Exploit::Remote::MsIcpr
       name: 'smb',
       info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
     }
+  end
+
+  def report_icertpassage_service
+    report_service({
+      name: 'icertpassage',
+      resource: { dcerpc: { pipe: 'cert' } },
+      host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
+      port: icpr.tree.client.dispatcher.tcp_socket.peerport,
+      proto: 'tcp',
+      parents: report_dcerpc_service
+     })
   end
 end
 end

--- a/lib/msf/core/exploit/remote/smb/client/ipc.rb
+++ b/lib/msf/core/exploit/remote/smb/client/ipc.rb
@@ -33,6 +33,12 @@ module Msf
         raise SmbIpcAuthenticationError, "Unable to authenticate ([#{e.class}] #{e})."
       end
 
+      report_dcerpc_service
+
+      ipc_tree
+    end
+
+    def report_dcerpc_service
       report_service(
         name: 'dcerpc',
         info: "Module: #{fullname}",
@@ -45,11 +51,15 @@ module Msf
           host: simple.peerhost,
           port: simple.peerport,
           proto: 'tcp',
-          info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
+          info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})",
+          parents: {
+            name: 'tcp',
+            host: simple.peerhost,
+            port: simple.peerport,
+            proto: 'tcp'
+          }
         }
       )
-
-      ipc_tree
     end
 
     def disconnect_ipc(ipc_tree)

--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -121,7 +121,15 @@ class MetasploitModule < Msf::Auxiliary
         return Exploit::CheckCode::Safe('The object can not be written to.')
       end
 
-      Exploit::CheckCode::Vulnerable('The object can be written to.')
+      Exploit::CheckCode::Vulnerable(
+        'The object can be written to.',
+        vuln: {
+          resource: {
+            ldap_dn: obj.dn
+          },
+          service: report_ldap_service
+        }
+      )
     end
   end
 

--- a/modules/auxiliary/admin/ldap/shadow_credentials.rb
+++ b/modules/auxiliary/admin/ldap/shadow_credentials.rb
@@ -143,7 +143,15 @@ class MetasploitModule < Msf::Auxiliary
         return Exploit::CheckCode::Unknown('Failed to check the permissions on the target object.')
       end
 
-      Exploit::CheckCode::Vulnerable('The object can be written to.')
+      Exploit::CheckCode::Vulnerable(
+        'The object can be written to.',
+        vuln: {
+          resource: {
+            ldap_dn: obj.dn
+          },
+          service: report_ldap_service
+        }
+      )
     end
   end
 

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -611,13 +611,7 @@ class MetasploitModule < Msf::Auxiliary
     ca_server_ip_address = get_ip_addresses_by_fqdn(ca_server_fqdn)&.first
 
     if ca_server_ip_address
-      report_service({
-        host: ca_server_ip_address,
-        port: 445,
-        proto: 'tcp',
-        name: 'AD CS',
-        info: "AD CS CA name: #{ldap_object[:name][0]}"
-      })
+      report_service_icertpassage(ca_server_ip_address, ca_name: ldap_object[:name][0])
 
       report_host({
         host: ca_server_ip_address,
@@ -888,13 +882,7 @@ class MetasploitModule < Msf::Auxiliary
           info = nil if info.blank?
 
           hash[:ca_servers].each_value do |ca_server|
-            service = report_service(
-              host: ca_server[:ip_address],
-              port: 445,
-              proto: 'tcp',
-              name: 'AD CS',
-              info: "AD CS CA name: #{ca_server[:name]}"
-            )
+            service = report_service_icertpassage(ca_server[:ip_address], ca_name: ca_server[:name])
 
             if ca_server[:ip_address].present?
               vuln = report_vuln(
@@ -902,11 +890,11 @@ class MetasploitModule < Msf::Auxiliary
                 host: ca_server[:ip_address],
                 port: 445,
                 proto: 'tcp',
-                sname: 'AD CS',
-                name: "#{vuln} - #{key}",
+                name: "#{vuln}",
                 info: info,
                 refs: REFERENCES[vuln],
-                service: service
+                service: service,
+                resource: { template_name: key, ldap_dn: hash[:dn] }
               )
             else
               vuln = nil
@@ -1094,7 +1082,7 @@ class MetasploitModule < Msf::Auxiliary
     user_info = adds_get_current_user(@ldap)
     return unless user_info
 
-    user = [:sAMAccountName].first.to_s
+    user = user_info[:sAMAccountName].first.to_s
     domain = domain_info[:dns_name]
     print_status("user: #{user}, domain: #{domain}")
 
@@ -1240,5 +1228,39 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::NoAccess, e.message)
   rescue Net::LDAP::Error => e
     fail_with(Failure::Unknown, "#{e.class}: #{e.message}")
+  end
+
+  def report_service_icertpassage(host, ca_name:)
+    common = {
+      host: host,
+      port: 445,
+      proto: 'tcp'
+    }
+
+    report_service({
+      name: 'adcs-ca',
+      resource: {
+        'name' => ca_name
+      },
+      parents: {
+        name: 'icertpassage',
+        resource: {
+          'dcerpc' => {
+            'pipe' => 'cert'
+          }
+        },
+        parents: {
+          name: 'dcerpc',
+          resource: {
+            'smb' => {
+              'share' => 'IPC$'
+            }
+          },
+          parents: {
+            name: 'smb'
+          }.merge(common)
+        }.merge(common)
+      }.merge(common)
+    }.merge(common))
   end
 end

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -890,7 +890,7 @@ class MetasploitModule < Msf::Auxiliary
                 host: ca_server[:ip_address],
                 port: 445,
                 proto: 'tcp',
-                name: "#{vuln}",
+                name: vuln.to_s,
                 info: info,
                 refs: REFERENCES[vuln],
                 service: service,

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -1257,7 +1257,10 @@ class MetasploitModule < Msf::Auxiliary
             }
           },
           parents: {
-            name: 'smb'
+            name: 'smb',
+            parents: {
+              name: 'tcp'
+            }
           }.merge(common)
         }.merge(common)
       }.merge(common)

--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -1238,7 +1238,7 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     report_service({
-      name: 'adcs-ca',
+      name: ::Msf::Exploit::Remote::MsIcpr::ADCS_CA_SERVICE_NAME,
       resource: {
         'name' => ca_name
       },

--- a/modules/auxiliary/gather/ldap_passwords.rb
+++ b/modules/auxiliary/gather/ldap_passwords.rb
@@ -438,7 +438,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def this_ldap_service
     # use this so we're not reporting the service over and over again
-    @_this_ldap_service ||= report_ldap_service
+    @this_ldap_service ||= report_ldap_service
   end
 
   def report_creds(username, private_data, private_type, jtr_format)

--- a/modules/auxiliary/gather/ldap_passwords.rb
+++ b/modules/auxiliary/gather/ldap_passwords.rb
@@ -366,10 +366,14 @@ class MetasploitModule < Msf::Auxiliary
           artifacts.jtr_format = Metasploit::Framework::Hashes.identify_hash(artifacts.private_data)
         end
 
-        if attr.include?('password')
-          artifacts.private_type = :password
-        else
-          artifacts.private_type = :nonreplayable_hash
+        if artifacts.private_type.blank?
+          if artifacts.jtr_format == 'nt'
+            artifacts.private_type = :ntlm_hash
+          elsif artifacts.jtr_format.blank? && attr.include?('password')
+            artifacts.private_type = :password
+          else
+            artifacts.private_type = :nonreplayable_hash
+          end
         end
       end
 

--- a/modules/auxiliary/gather/ldap_passwords.rb
+++ b/modules/auxiliary/gather/ldap_passwords.rb
@@ -413,7 +413,7 @@ class MetasploitModule < Msf::Auxiliary
         when :krb_enc_key
           report_vuln(common.merge({
             name: 'Kerberos encryption key found in LDAP',
-            info: "Module #{fullname} found a kerberos encryption key in LDAP.",
+            info: "Module #{fullname} found a Kerberos encryption key in LDAP.",
             refs: [
               SiteReference.new('CWE', '312'), # CWE-312: Cleartext Storage of Sensitive Information
             ]
@@ -421,9 +421,9 @@ class MetasploitModule < Msf::Auxiliary
         when :ntlm_hash
           report_vuln(common.merge({
             name: 'NTLM hash found in LDAP',
-            info: "Module #{fullname} found a NTLM hash in LDAP.",
+            info: "Module #{fullname} found an NTLM hash in LDAP.",
             refs: [
-              SiteReference.new('CWE', '512') # CWE-522: Insufficiently Protected Credentials
+              SiteReference.new('CWE', '522') # CWE-522: Insufficiently Protected Credentials
             ]
           }))
         when :password

--- a/modules/auxiliary/gather/ldap_passwords.rb
+++ b/modules/auxiliary/gather/ldap_passwords.rb
@@ -237,7 +237,12 @@ class MetasploitModule < Msf::Auxiliary
       # observed sambapassword history with either 56 or 64 zeros
       next if attr == 'sambapasswordhistory' && private_data =~ /^(0{64}|0{56})$/
 
-      artifacts = SecretArtifact.new(public_data: username, private_data: private_data, private_type: :password)
+      artifacts = SecretArtifact.new(
+        public_data: username,
+        private_data: private_data,
+        private_type: :password,
+        object_dn: entry.dn
+      )
 
       case attr
       when 'sambalmpassword'
@@ -282,7 +287,8 @@ class MetasploitModule < Msf::Auxiliary
             public_data: username,
             private_data: "#{EMPTY_LM.unpack1('H*')}:#{OpenSSL::Digest::MD4.digest(current_password).unpack1('H*')}",
             private_type: :ntlm_hash,
-            jtr_format: 'nt,lm'
+            jtr_format: 'nt,lm',
+            object_dn: entry.dn
           )
 
           artifacts << SecretArtifact.new(
@@ -292,7 +298,8 @@ class MetasploitModule < Msf::Auxiliary
               key: aes256_cts_hmac_sha1_96(encoded_current_password, salt),
               salt: salt
             ),
-            private_type: :krb_enc_key
+            private_type: :krb_enc_key,
+            object_dn: entry.dn
           )
           artifacts << SecretArtifact.new(
             public_data: username,
@@ -301,7 +308,8 @@ class MetasploitModule < Msf::Auxiliary
               key: aes128_cts_hmac_sha1_96(encoded_current_password, salt),
               salt: salt
             ),
-            private_type: :krb_enc_key
+            private_type: :krb_enc_key,
+            object_dn: entry.dn
           )
         end
       when 'mslaps-password'
@@ -384,6 +392,40 @@ class MetasploitModule < Msf::Auxiliary
         print_good("Credential found in #{attr}: #{formatted} #{artifact.annotation}")
 
         report_creds(artifact.public_data, artifact.private_data, artifact.private_type, artifact.jtr_format)
+
+        common = {
+          host: rhost,
+          port: rport,
+          service: this_ldap_service,
+          resource: { ldap_dn: artifact.object_dn }
+        }
+
+        case artifact.private_type
+        when :krb_enc_key
+          report_vuln(common.merge({
+            name: 'Kerberos encryption key found in LDAP',
+            info: "Module #{fullname} found a kerberos encryption key in LDAP.",
+            refs: [
+              SiteReference.new('CWE', '312'), # CWE-312: Cleartext Storage of Sensitive Information
+            ]
+          }))
+        when :ntlm_hash
+          report_vuln(common.merge({
+            name: 'NTLM hash found in LDAP',
+            info: "Module #{fullname} found a NTLM hash in LDAP.",
+            refs: [
+              SiteReference.new('CWE', '512') # CWE-522: Insufficiently Protected Credentials
+            ]
+          }))
+        when :password
+          report_vuln(common.merge({
+            name: 'Plaintext credentials found in LDAP',
+            info: "Module #{fullname} found plaintext credentials in LDAP.",
+            refs: [
+              SiteReference.new('CWE', '256') # CWE-256: Plaintext Storage of a Password
+            ]
+          }))
+        end
       end
 
       # only increment once because the iteration is per-attribute so report one credential found even if it's reported
@@ -392,6 +434,11 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     creds_found
+  end
+
+  def this_ldap_service
+    # use this so we're not reporting the service over and over again
+    @_this_ldap_service ||= report_ldap_service
   end
 
   def report_creds(username, private_data, private_type, jtr_format)
@@ -493,7 +540,7 @@ class MetasploitModule < Msf::Auxiliary
     JSON.parse(RubySMB::Field::Stringz16.read(plaintext).value)
   end
 
-  SecretArtifact = Struct.new(:public_data, :private_data, :private_type, :jtr_format, :annotation)
+  SecretArtifact = Struct.new(:public_data, :private_data, :private_type, :jtr_format, :annotation, :object_dn)
 
   # https://blog.xpnsec.com/lapsv2-internals/#:~:text=msLAPS%2DEncryptedPassword%20attribute
   # https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-ada2/b6ea7b78-64da-48d3-87cb-2cff378e4597

--- a/modules/auxiliary/gather/ldap_passwords.rb
+++ b/modules/auxiliary/gather/ldap_passwords.rb
@@ -365,7 +365,12 @@ class MetasploitModule < Msf::Auxiliary
           end
           artifacts.jtr_format = Metasploit::Framework::Hashes.identify_hash(artifacts.private_data)
         end
-        artifacts.private_type = :nonreplayable_hash
+
+        if attr.include?('password')
+          artifacts.private_type = :password
+        else
+          artifacts.private_type = :nonreplayable_hash
+        end
       end
 
       Array.wrap(artifacts).each do |artifact|

--- a/spec/support/shared/examples/msf/db_manager/service.rb
+++ b/spec/support/shared/examples/msf/db_manager/service.rb
@@ -418,12 +418,12 @@ RSpec.shared_examples_for 'Msf::DBManager::Service' do
         expect(subject.process_service_chain(nil, service_hash)).to be_nil
       end
 
-      it 'returns nil if required service parameters are missing' do
+      it 'returns [] if required service parameters are missing' do
         # Missing port
-        expect(subject.process_service_chain(host, { name: 'http', proto: 'tcp' })).to be_nil
+        expect(subject.process_service_chain(host, { name: 'http', proto: 'tcp' })).to eq []
 
         # Missing proto
-        expect(subject.process_service_chain(host, { name: 'http', port: 80 })).to be_nil
+        expect(subject.process_service_chain(host, { name: 'http', port: 80 })).to eq []
       end
     end
   end

--- a/spec/support/shared/examples/msf/db_manager/vuln.rb
+++ b/spec/support/shared/examples/msf/db_manager/vuln.rb
@@ -29,7 +29,6 @@ RSpec.shared_examples_for 'Msf::DBManager::Vuln' do
       it 'creates a vuln' do
         vuln = subject.report_vuln(
           host: '192.0.2.1',
-          sname: 'AD CS',
           name: "vuln name",
           info: 'vuln info',
           refs: ['https://example.com'],


### PR DESCRIPTION
This updates a handful of LDAP related modules to report the LDAP and ADCS services automatically. It also updates vulnerability reporting to include the LDAP object's DN so users can tell *exactly* where the vulnerability is. This also means vulnerabilities can use common names, so for example all the instances of ESC# are grouped together, but reported separately for each object that's vulnerable as uniquely keyed by the template that's affected.

Closes #20959 

## Verification

None of the functionality of the modules really changed, we're just reporting more info.

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ldap_passwords` and run it, see a vulnerability reported for the plaintext credentials, NTLM hashes and Kerberos keys that are found, see a DN for each
- [ ] `use auxiliary/admin/ldap/rbcd` and run the check method, see a vulnerability reported that's associated with the service and includes the affected object
- [ ] `use auxiliary/admin/ldap/shadow_credentials` and run the check method, see a vulnerability reported that's associated with the service and includes the affected object
- [ ] `use auxiliary/gather/ldap_esc_vulnerable_cert_finder` and run it, see vulnerabilities reported for each of the findins with the template info
- [ ] `use auxiliary/admin/dcerpc/icpr_cert` and run it, see that the service is reported with the CA name, note that it's consistent with what was reported by the ldap_esc_vulnerable_cert_finder module

## Example
After running through this content in my test environment, these are the services and vulns I have reported:
```
msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > services
Services
========

host            port  proto  name          state  info                                                                                         resource                    parents
----            ----  -----  ----          -----  ----                                                                                         --------                    -------
192.168.159.10  389   tcp    ldap          open                                                                                                {}
192.168.159.10  445   tcp    dcerpc        open   Module: auxiliary/admin/dcerpc/icpr_cert                                                     {"smb":{"share":"IPC$"}}    smb (445/tcp)
192.168.159.10  445   tcp    icertpassage  open                                                                                                {"dcerpc":{"pipe":"cert"}}  dcerpc (445/tcp)
192.168.159.10  445   tcp    adcs-ca       open                                                                                                {"name":"msflab-DC-CA"}     icertpassage (445/tcp)
192.168.159.10  445   tcp    smb           open   Module: auxiliary/admin/dcerpc/icpr_cert, last negotiated version: SMBv3 (dialect = 0x0311)  {}
192.168.159.10  636   tcp    ssl           open                                                                                                {}
192.168.159.10  636   tcp    ldap          open                                                                                                {}                          ssl (636/tcp)

msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > vulns

Vulnerabilities
===============

Timestamp                Host            Service            Resource                                                                             Name                                   References
---------                ----            -------            --------                                                                             ----                                   ----------
2026-02-27 20:07:28 UTC  192.168.159.10  ldap (389/tcp)     {"ldap_dn"=>"CN=Jabberwock,CN=Managed Service Accounts,DC=msflab,DC=local"}          NTLM hash found in LDAP                CWE-512
2026-02-27 20:07:28 UTC  192.168.159.10  ldap (389/tcp)     {"ldap_dn"=>"CN=Jabberwock,CN=Managed Service Accounts,DC=msflab,DC=local"}          Kerberos encryption key found in LDAP  CWE-312
2026-02-27 20:15:42 UTC  192.168.159.10  ldap (389/tcp)     {"ldap_dn"=>"CN=Alice Liddle,CN=Users,DC=msflab,DC=local"}                           Role Base Constrained Delegation       URL-https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/resource-based-constrained-delegation-ad-c
                                                                                                                                                                                        omputer-object-take-over-and-privilged-code-execution,URL-https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd,URL-h
                                                                                                                                                                                        ttps://github.com/SecureAuthCorp/impacket/blob/3c6713e309cae871d685fa443d3e21b7026a2155/examples/rbcd.py,ATT&CK-T1098,ATT&CK-T1558
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=DomainControllerAuthentication,CN=Certificate Templates,CN=Public K  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            ey Services,CN=Services,CN=Configuration,DC=msflab,DC=local", "template_name"=>"Dom
                                                            ainControllerAuthentication"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=EFS,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            Configuration,DC=msflab,DC=local", "template_name"=>"EFS"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=EFS,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=  ESC16_2
                                                            Configuration,DC=msflab,DC=local", "template_name"=>"EFS"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Se  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            rvices,CN=Configuration,DC=msflab,DC=local", "template_name"=>"Administrator"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Se  ESC10                                  URL-https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7
                                                            rvices,CN=Configuration,DC=msflab,DC=local", "template_name"=>"Administrator"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Se  ESC16_2
                                                            rvices,CN=Configuration,DC=msflab,DC=local", "template_name"=>"Administrator"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Se  ESC16_1
                                                            rvices,CN=Configuration,DC=msflab,DC=local", "template_name"=>"Administrator"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=DirectoryEmailReplication,CN=Certificate Templates,CN=Public Key Se  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            rvices,CN=Services,CN=Configuration,DC=msflab,DC=local", "template_name"=>"Director
                                                            yEmailReplication"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=DomainController,CN=Certificate Templates,CN=Public Key Services,CN  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            =Services,CN=Configuration,DC=msflab,DC=local", "template_name"=>"DomainController"
                                                            }
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=EFS,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=  ESC16_1
                                                            Configuration,DC=msflab,DC=local", "template_name"=>"EFS"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=EFSRecovery,CN=Certificate Templates,CN=Public Key Services,CN=Serv  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            ices,CN=Configuration,DC=msflab,DC=local", "template_name"=>"EFSRecovery"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=EFSRecovery,CN=Certificate Templates,CN=Public Key Services,CN=Serv  ESC16_2
                                                            ices,CN=Configuration,DC=msflab,DC=local", "template_name"=>"EFSRecovery"}
2026-02-27 20:15:54 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=EFSRecovery,CN=Certificate Templates,CN=Public Key Services,CN=Serv  ESC16_1
                                                            ices,CN=Configuration,DC=msflab,DC=local", "template_name"=>"EFSRecovery"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC13-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servi  ESC10                                  URL-https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7
                                                            ces,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC13-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC1-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC1                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC1-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC13-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servi  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            ces,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC13-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC13-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servi  ESC13                                  URL-https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
                                                            ces,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC13-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC13-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servi  ESC16_2
                                                            ces,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC13-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC13-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servi  ESC16_1
                                                            ces,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC13-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC15-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servi  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            ces,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC15-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC15-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servi  ESC15                                  URL-https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc
                                                            ces,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC15-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC2-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC2                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC2-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC2-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC10                                  URL-https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC2-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC2-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC16_2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC2-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC2-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC16_1
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC2-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC3-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC3                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC3-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC3-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC16_2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC3-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC3-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC16_1
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC3-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC4-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC4-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC4-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC10                                  URL-https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC4-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC4-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC16_2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC4-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=ESC4-Test,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC16_1
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"ESC4-Test"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=KerberosAuthentication,CN=Certificate Templates,CN=Public Key Servi  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            ces,CN=Services,CN=Configuration,DC=msflab,DC=local", "template_name"=>"KerberosAut
                                                            hentication"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=Machine,CN=Certificate Templates,CN=Public Key Services,CN=Services  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            ,CN=Configuration,DC=msflab,DC=local", "template_name"=>"Machine"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=MachineEnrollmentAgent,CN=Certificate Templates,CN=Public Key Servi  ESC3                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            ces,CN=Services,CN=Configuration,DC=msflab,DC=local", "template_name"=>"MachineEnro
                                                            llmentAgent"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            =Configuration,DC=msflab,DC=local", "template_name"=>"User"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=SubCA,CN=Certificate Templates,CN=Public Key Services,CN=Services,C  ESC1                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            N=Configuration,DC=msflab,DC=local", "template_name"=>"SubCA"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN  ESC10                                  URL-https://research.ifcr.dk/certipy-4-0-esc9-esc10-bloodhound-gui-new-authentication-and-request-methods-and-more-7237d88061f7
                                                            =Configuration,DC=msflab,DC=local", "template_name"=>"User"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN  ESC16_2
                                                            =Configuration,DC=msflab,DC=local", "template_name"=>"User"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN  ESC16_1
                                                            =Configuration,DC=msflab,DC=local", "template_name"=>"User"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=WebServer,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC4                                   URL-https://posts.specterops.io/certified-pre-owned-d95910965cd2
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"WebServer"}
2026-02-27 20:15:55 UTC  192.168.159.10  adcs-ca (445/tcp)  {"ldap_dn"=>"CN=WebServer,CN=Certificate Templates,CN=Public Key Services,CN=Servic  ESC15                                  URL-https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc
                                                            es,CN=Configuration,DC=msflab,DC=local", "template_name"=>"WebServer"}

msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > 
```