### PR TITLE
Adds specs for post/auxiliary module cleanup

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -184,7 +184,6 @@ protected
         raise
       end
     rescue Msf::Auxiliary::Complete
-      mod.cleanup
       return
     rescue Msf::Auxiliary::Failed => e
       mod.error = e
@@ -196,21 +195,18 @@ protected
       end
       mod.fail_detail ||= e.to_s
 
-      mod.cleanup
       return
     rescue ::Timeout::Error => e
       mod.error = e
       mod.fail_reason = Msf::Module::Failure::TimeoutExpired
       mod.fail_detail ||= e.to_s
       mod.print_error("Auxiliary triggered a timeout exception")
-      mod.cleanup
       return
     rescue ::Interrupt => e
       mod.error = e
       mod.fail_reason = Msf::Module::Failure::UserInterrupt
       mod.fail_detail ||= e.to_s
       mod.print_error("Stopping running against current target...")
-      mod.cleanup
       mod.print_status("Control-C again to force quit all targets.")
       begin
         Rex.sleep(0.5)
@@ -237,7 +233,6 @@ protected
       end
 
       elog('Auxiliary failed', error: e)
-      mod.cleanup
 
     end
     return result

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -112,26 +112,21 @@ protected
         mod.run
       else
         mod.print_error("Session not found")
-        mod.cleanup
         return
       end
     rescue Msf::Post::Complete
-      mod.cleanup
       return
     rescue Msf::Post::Failed => e
       mod.error = e
       mod.print_error("Post aborted due to failure: #{e.message}")
-      mod.cleanup
       return
     rescue ::Timeout::Error => e
       mod.error = e
       mod.print_error("Post triggered a timeout exception")
-      mod.cleanup
       return
     rescue ::Interrupt => e
       mod.error = e
       mod.print_error("Post interrupted by the console user")
-      mod.cleanup
       return
     rescue ::Msf::OptionValidateError => e
       mod.error = e
@@ -148,7 +143,6 @@ protected
       end
 
       elog('Post failed', error: e)
-      mod.cleanup
 
       return
     end

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -176,7 +176,8 @@ class ExploitDriver
       begin
         job_run_proc(ctx)
       rescue ::Interrupt
-        job_cleanup_proc(ctx)
+        # ensure skips cleanup when keep_handler is true, so handle it here
+        job_cleanup_proc(ctx) if keep_handler
         raise $!
       ensure
         # For multi exploit targets.

--- a/spec/lib/msf/base/simple/auxiliary_spec.rb
+++ b/spec/lib/msf/base/simple/auxiliary_spec.rb
@@ -1,0 +1,139 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Simple::Auxiliary do
+  let(:cleanup_calls) { [] }
+
+  let(:events_double) do
+    double('events').tap do |e|
+      allow(e).to receive(:on_module_run)
+      allow(e).to receive(:on_module_complete)
+    end
+  end
+
+  let(:framework_double) do
+    double('framework', events: events_double)
+  end
+
+  let(:job_listener) { Msf::Simple::NoopJobListener.instance }
+
+  let(:mod) do
+    calls_ref = cleanup_calls
+    fw_double = framework_double
+
+    instance = Object.new
+    instance.define_singleton_method(:framework) { fw_double }
+    instance.define_singleton_method(:setup) {}
+    instance.define_singleton_method(:print_error) { |_msg| }
+    instance.define_singleton_method(:print_status) { |_msg| }
+    instance.define_singleton_method(:elog) { |_msg, **_kw| }
+    instance.define_singleton_method(:fail_reason) { Msf::Module::Failure::None }
+    instance.define_singleton_method(:fail_reason=) { |_v| }
+    instance.define_singleton_method(:fail_detail) { nil }
+    instance.define_singleton_method(:fail_detail=) { |_v| }
+    instance.define_singleton_method(:error=) { |_v| }
+    instance.define_singleton_method(:report_failure) {}
+    instance.define_singleton_method(:cleanup) { calls_ref << 1 }
+    instance
+  end
+
+  let(:run_uuid) { 'test-run-uuid-1234' }
+  let(:ctx) { [mod, run_uuid, job_listener] }
+
+  def run_proc(ctx, &block)
+    block ||= proc { |_m| }
+    described_class.send(:job_run_proc, ctx, &block)
+  end
+
+  def cleanup_proc(ctx)
+    described_class.send(:job_cleanup_proc, ctx)
+  end
+
+  describe '.job_run_proc' do
+    context 'when the module raises Auxiliary::Failed' do
+      it 'does not call cleanup' do
+        run_proc(ctx) { raise Msf::Auxiliary::Failed, 'intentional failure' }
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module raises Auxiliary::Complete' do
+      it 'does not call cleanup' do
+        run_proc(ctx) { raise Msf::Auxiliary::Complete }
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module raises Timeout::Error' do
+      it 'does not call cleanup' do
+        run_proc(ctx) { raise ::Timeout::Error }
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module raises a generic Exception' do
+      it 'does not call cleanup' do
+        run_proc(ctx) { raise 'unexpected error' }
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module completes normally' do
+      it 'does not call cleanup' do
+        run_proc(ctx) { nil }
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+  end
+
+  describe '.job_cleanup_proc' do
+    it 'calls cleanup exactly once' do
+      cleanup_proc(ctx)
+      expect(cleanup_calls.length).to eq(1)
+    end
+  end
+
+  describe 'cleanup is called exactly once across job_run_proc + job_cleanup_proc' do
+    def run_then_cleanup(ctx, &block)
+      block ||= proc { |_m| }
+      run_proc(ctx, &block)
+      cleanup_proc(ctx)
+    end
+
+    context 'when the module raises Auxiliary::Failed' do
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(ctx) { raise Msf::Auxiliary::Failed, 'intentional failure' }
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module raises Auxiliary::Complete' do
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(ctx) { raise Msf::Auxiliary::Complete }
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module raises Timeout::Error' do
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(ctx) { raise ::Timeout::Error }
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module raises a generic Exception' do
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(ctx) { raise 'unexpected error' }
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module completes normally' do
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(ctx) { nil }
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/lib/msf/base/simple/post_spec.rb
+++ b/spec/lib/msf/base/simple/post_spec.rb
@@ -1,0 +1,222 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Simple::Post do
+  let(:cleanup_calls) { [] }
+
+  let(:events_double) do
+    double('events').tap do |e|
+      allow(e).to receive(:on_module_run)
+      allow(e).to receive(:on_module_complete)
+      allow(e).to receive(:on_session_module_run)
+    end
+  end
+
+  let(:sessions_double) do
+    double('sessions').tap do |s|
+      allow(s).to receive(:get).and_return(nil)
+    end
+  end
+
+  let(:framework_double) do
+    double('framework',
+           events: events_double,
+           sessions: sessions_double)
+  end
+
+  let(:mod) do
+    calls_ref = cleanup_calls
+    fw_double = framework_double
+
+    instance = Object.new
+    instance.define_singleton_method(:framework) { fw_double }
+    instance.define_singleton_method(:setup) {}
+    instance.define_singleton_method(:print_error) { |_msg| }
+    instance.define_singleton_method(:print_status) { |_msg| }
+    instance.define_singleton_method(:elog) { |_msg, **_kw| }
+    instance.define_singleton_method(:datastore) { { 'SESSION' => '1' } }
+    instance.define_singleton_method(:error=) { |_v| }
+    instance.define_singleton_method(:run) { nil }
+    instance.define_singleton_method(:cleanup) { calls_ref << 1 }
+    instance
+  end
+
+  def run_proc(mod)
+    described_class.send(:job_run_proc, [mod])
+  end
+
+  def cleanup_proc(mod)
+    described_class.send(:job_cleanup_proc, [mod])
+  end
+
+  describe '.job_run_proc' do
+    context 'when the session is not found' do
+      it 'does not call cleanup' do
+        run_proc(mod)
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module raises Post::Failed' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise Msf::Post::Failed, 'intentional failure' }
+      end
+
+      it 'does not call cleanup' do
+        run_proc(mod)
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module raises Post::Complete' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise Msf::Post::Complete }
+      end
+
+      it 'does not call cleanup' do
+        run_proc(mod)
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module raises Timeout::Error' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise ::Timeout::Error }
+      end
+
+      it 'does not call cleanup' do
+        run_proc(mod)
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module raises a generic Exception' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise 'unexpected error' }
+      end
+
+      it 'does not call cleanup' do
+        run_proc(mod)
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+
+    context 'when the module completes normally' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { nil }
+      end
+
+      it 'does not call cleanup' do
+        run_proc(mod)
+        expect(cleanup_calls.length).to eq(0)
+      end
+    end
+  end
+
+  describe '.job_cleanup_proc' do
+    it 'calls cleanup exactly once' do
+      cleanup_proc(mod)
+      expect(cleanup_calls.length).to eq(1)
+    end
+  end
+
+  describe 'cleanup is called exactly once across job_run_proc + job_cleanup_proc' do
+    def run_then_cleanup(mod)
+      run_proc(mod)
+      cleanup_proc(mod)
+    end
+
+    context 'when the session is not found' do
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(mod)
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module raises Post::Failed' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise Msf::Post::Failed, 'intentional failure' }
+      end
+
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(mod)
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module raises Post::Complete' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise Msf::Post::Complete }
+      end
+
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(mod)
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module raises Timeout::Error' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise ::Timeout::Error }
+      end
+
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(mod)
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module raises a generic Exception' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { raise 'unexpected error' }
+      end
+
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(mod)
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+
+    context 'when the module completes normally' do
+      let(:session_double) { double('session') }
+
+      before do
+        allow(sessions_double).to receive(:get).and_return(session_double)
+        allow(mod).to receive(:run) { nil }
+      end
+
+      it 'calls cleanup exactly once total' do
+        run_then_cleanup(mod)
+        expect(cleanup_calls.length).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #18138

Post and Auxiliary modules were invoking mod.cleanup twice when exiting through error paths (fail_with, Timeout, Interrupt, or unhandled exceptions). Cleanup was first triggered inside the rescue blocks of job_run_proc and then executed again by job_cleanup_proc, which run_simple calls unconditionally.

Root cause: job_run_proc explicitly called mod.cleanup in each rescue clause, while run_simple always invoked job_cleanup_proc afterward, resulting in duplicate cleanup.

Resolution: Removed direct mod.cleanup calls from all rescue blocks in job_run_proc for Msf::Simple::Post and Msf::Simple::Auxiliary. The synchronous execution path is now wrapped in begin/ensure so job_cleanup_proc runs exactly once regardless of how execution exits. Applied the same fix in ExploitDriver, where an Interrupt rescue caused duplicate cleanup during multi-target runs.

Verification: Executed the updated test suite (24 examples), all passing:
bundle exec rspec spec/lib/msf/base/simple/