### PR TITLE
Cookie Jar Documentain Fix

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-Send-an-HTTP-Request-Using-HttpClient.md
+++ b/docs/metasploit-framework.wiki/How-to-Send-an-HTTP-Request-Using-HttpClient.md
@@ -86,7 +86,7 @@ Module authors can also pass an instance of `HttpCookieJar` with the `cookie` op
 ```ruby
 cj = Msf::Exploit::Remote::HTTP::HttpCookieJar.new
 
-cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('PHPSESSID', @phpsessid))
+cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('PHPSESSID', @phpsessid, domain: 'example.com', path: '/'))
 cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('AsWebStatisticsCooKie', 1))
 cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('shellinaboxCooKie', 1))
 


### PR DESCRIPTION
This PR fixes a broken code example in the HTTP library documentation for HttpCookieJar (specifically in how-to-send-an-http-request-using-httpclient.md).

Previously, copying and pasting the example into irb resulted in an ArgumentError: domain is missing because the http-cookie library requires a domain parameter to instantiate a new cookie object. I updated the snippet to include domain: 'example.com', path: '/' so developers have a fully functional, runnable example.

Fixes issue #18573

Verification
[x] Start msfconsole
[x] Drop into the interactive Ruby shell by typing irb
[x] Paste the updated code from the documentation:

cj = Msf::Exploit::Remote::HTTP::HttpCookieJar.new
cj.add(Msf::Exploit::Remote::HTTP::HttpCookie.new('PHPSESSID', 'dummy_value', domain: 'example.com', path: '/'))

[x] Verify the command succeeds and returns the HttpCookieJar object without throwing the ArgumentError: domain is missing exception.
[x] Verify the code block is formatted correctly in the markdown file.