### PR TITLE
Add Windows Kernel Pointer Exposure Enumerator (Info Gathering)

### DIFF
--- a/documentation/modules/post/windows/gather/forensics/windows_kernel_pointer.md
+++ b/documentation/modules/post/windows/gather/forensics/windows_kernel_pointer.md
@@ -1,0 +1,173 @@
+# Windows Kernel Pointer Exposure Enumerator
+
+## Vulnerable Application
+
+This module enumerates kernel object pointers exposed via `NtQuerySystemInformation` with the `SystemExtendedHandleInformation` class (info class 64). It works on all x64 versions of Windows 10 and 11, regardless of patch level, as it does not exploit a vulnerability but rather enumerates information already accessible to user-mode processes.
+
+The module is particularly useful for detecting CVE-2026-20805, an information disclosure vulnerability where ALPC port handles leak kernel object addresses. However, it serves a broader purpose as a general kernel pointer enumeration tool for research and educational purposes.
+
+### Tested Windows Versions
+
+- Windows 10 2004 (Build 19041) ✓
+- Windows 10 20H2 (Build 19042) ✓
+- Windows 10 21H1 (Build 19043) ✓
+- Windows 10 21H2 (Build 19044) ✓
+- Windows 10 22H2 (Build 19045) ✓
+- Windows 11 21H2 (Build 22000) ✓
+- Windows 11 22H2 (Build 22621) ✓
+- Windows 11 23H2 (Build 22631) ✓
+
+### Requirements
+
+- A Meterpreter session on a target x64 Windows system
+- No special privileges required (works from low-privileged user contexts)
+
+## Verification Steps
+
+1. Obtain a Meterpreter session on a Windows x64 target:
+msf6 > use exploit/multi/handler
+msf6 exploit(multi/handler) > set payload windows/x64/meterpreter/reverse\_tcp
+msf6 exploit(multi/handler) > set LHOST <your\_ip>
+msf6 exploit(multi/handler) > run
+[\*] Meterpreter session 1 opened
+2. Background the session and load the module:
+meterpreter > background
+msf6 > use post/windows/gather/windows\_kernel\_pointer\_enum
+3. Set the session ID and run the module:
+msf6 post(windows/gather/windows\_kernel\_pointer\_enum) > set SESSION 1
+msf6 post(windows/gather/windows\_kernel\_pointer\_enum) > run
+
+## Options
+
+### MAX\_HANDLES
+
+Maximum number of handles to process (0 = unlimited). Default: `50000`
+
+This option limits the number of handles processed to prevent excessive memory usage or timeout on systems with very large handle tables. On typical Windows systems, the handle count ranges from 30,000 to 100,000. Setting this to 0 will process all handles, but may increase runtime.
+
+### TIMEOUT
+
+Maximum time in seconds to wait for enumeration to complete. Default: `30`
+
+The enumeration process can take longer on systems with very large handle tables. Increase this value if you encounter timeout errors.
+
+### EXPORT\_CSV
+
+Export results to a CSV file. Default: `null`
+
+When set to `true`, the module will save the complete pointer data to a CSV file in Metasploit's loot directory. The file includes process ID, type index, type hint, handle value, access mask, and kernel address for each pointer found.
+
+## Scenarios
+
+### Basic Enumeration on Windows 10
+
+This scenario demonstrates a standard run of the module on a Windows 10 system, showing the complete output including buffer size negotiation and result analysis.
+
+```javascript
+msf6 post(windows/gather/windows_kernel_pointer_enum) > set SESSION 1
+SESSION => 1
+msf6 post(windows/gather/windows_kernel_pointer_enum) > run
+
+[*] Windows Kernel Pointer Exposure Enumerator
+================================================================================
+[*] Target: DESKTOP-KQAH94Q
+[*] OS: Windows 10 2004 (10.0 Build 19041).
+[*] Arch: x64
+[*] User: NT AUTHORITY\SYSTEM
+[*] Enumerating kernel object pointers...
+[*] Attempt 1: Trying buffer size 1048576 bytes
+[*] Buffer too small, need 1283696 bytes
+[*] Attempt 2: Trying buffer size 1283696 bytes
+[*] Buffer too small, need 1283776 bytes
+[*] Attempt 3: Trying buffer size 1283776 bytes
+[+] Success with buffer size 1283776
+[+] System has 32094 total handles
+[*] Processing 32094 handles...
+[*]   Processed 10000/32094 handles (found 2000 kernel addresses)...
+[*]   Processed 20000/32094 handles (found 4000 kernel addresses)...
+[+] Processed 26745 handles, found 5349 kernel addresses
+[+] Enumerated 5349 kernel object pointers
+
+================================================================================
+KERNEL POINTER EXPOSURE RESULTS
+================================================================================
+
+SUMMARY STATISTICS:
+  Total pointers: 5349
+  Unique addresses: 5087
+  Address range: 0xffffa80a92c637d0 - 0xffffe00afba7e660
+
+OBJECT TYPE DISTRIBUTION:
+  Type 7 (Process): 118 pointers (2.21%)
+  Type 8 (Thread): 174 pointers (3.25%)
+  Type 16 (Key): 1201 pointers (22.45%)
+  Type 24 (File): 19 pointers (0.36%)
+  Type 35 (ALPC Port): 137 pointers (2.56%)
+  Type 36 (ALPC Port): 365 pointers (6.82%)
+  Type 37 (ALPC Port): 287 pointers (5.37%)
+  Type 42 (ALPC Section): 165 pointers (3.08%)
+  Type 44 (ALPC): 506 pointers (9.46%)
+  Type 46 (ALPC): 284 pointers (5.31%)
+
+--------------------------------------------------------------------------------
+ALPC OBJECT ANALYSIS (Type Indices 32-48)
+--------------------------------------------------------------------------------
+  Total ALPC pointers: 1755
+  Found in 69 processes
+
+  Processes with ALPC pointers:
+    System (PID: 4): 175 ALPC pointers
+    WinStore.App.exe (PID: 788): 129 ALPC pointers
+    explorer.exe (PID: 4080): 122 ALPC pointers
+    dwm.exe (PID: 964): 55 ALPC pointers
+    lsass.exe (PID: 632): 43 ALPC pointers
+
+  Sample ALPC kernel addresses:
+    1. Type 44: 0xffffa80a92d182d0
+    2. Type 44: 0xffffa80a92cff450
+    3. Type 44: 0xffffa80a92d19c50
+    4. Type 37: 0xffffe00af5459190
+    5. Type 44: 0xffffa80a9422bbd0
+
+================================================================================
+[+] Results exported to: /home/kali/.msf4/loot/20260302132544_default_192.168.91.133_windows.kernel.p_795889.txt (250.32 KB)
+[*] Post module execution completed
+```
+
+### Exporting Results to CSV
+
+This scenario demonstrates exporting the complete dataset to CSV for further analysis.
+
+```javascript
+msf6 post(windows/gather/windows_kernel_pointer_enum) > set EXPORT_CSV true
+EXPORT_CSV => true
+msf6 post(windows/gather/windows_kernel_pointer_enum) > run
+
+[+] Results exported to: /home/kali/.msf4/loot/20260302132544_default_192.168.91.133_windows.kernel.p_795889.txt (250.32 KB)
+```
+
+View the first 10 lines of the CSV:
+
+```javascript
+$ cat /home/kali/.msf4/loot/20260302132544_default_192.168.91.133_windows.kernel.p_795889.txt | head -n 10
+
+PID,TypeIndex,TypeHint,Handle,Access,Address
+4,7,Process,0x4,0x7777777,0xffffe00af4697040
+4,3,Unknown,0x1c,0x3600017,0xffffa80a92c637d0
+4,16,Key,0x34,0x7600003,0xffffe00af4674a20
+4,8,Thread,0x4c,0x7777777,0xffffe00af47bd080
+4,44,ALPC,0x64,0x400031,0xffffa80a92d182d0
+4,7,Process,0x7c,0x10052,0xffffe00af9ab12c0
+4,44,ALPC,0x94,0x3600077,0xffffa80a92cff450
+4,44,ALPC,0xac,0x3600077,0xffffa80a92d19c50
+4,44,ALPC,0xc4,0x20,0xffffa80a9422b540
+```
+
+### 
+
+## Notes
+
+- **CRASH\_SAFE**: This module performs read-only operations and does not modify any kernel memory
+- **No special privileges required**: Works from any user context, including low-privileged users
+- **Educational purpose**: Designed for research and learning about Windows kernel internals
+- **Object type hints**: Type names are inferred from empirical observation and may not be 100% accurate across all Windows versions

--- a/documentation/modules/post/windows/gather/forensics/windows_kernel_pointer.md
+++ b/documentation/modules/post/windows/gather/forensics/windows_kernel_pointer.md
@@ -63,7 +63,7 @@ When set to `true`, the module will save the complete pointer data to a CSV fil
 
 This scenario demonstrates a standard run of the module on a Windows 10 system, showing the complete output including buffer size negotiation and result analysis.
 
-```javascript
+```text
 msf6 post(windows/gather/windows_kernel_pointer_enum) > set SESSION 1
 SESSION => 1
 msf6 post(windows/gather/windows_kernel_pointer_enum) > run
@@ -138,7 +138,7 @@ ALPC OBJECT ANALYSIS (Type Indices 32-48)
 
 This scenario demonstrates exporting the complete dataset to CSV for further analysis.
 
-```javascript
+```text
 msf6 post(windows/gather/windows_kernel_pointer_enum) > set EXPORT_CSV true
 EXPORT_CSV => true
 msf6 post(windows/gather/windows_kernel_pointer_enum) > run
@@ -148,7 +148,7 @@ msf6 post(windows/gather/windows_kernel_pointer_enum) > run
 
 View the first 10 lines of the CSV:
 
-```javascript
+```text
 $ cat /home/kali/.msf4/loot/20260302132544_default_192.168.91.133_windows.kernel.p_795889.txt | head -n 10
 
 PID,TypeIndex,TypeHint,Handle,Access,Address

--- a/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
+++ b/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
@@ -3,12 +3,11 @@
 require 'active_support/core_ext/object/blank'
 
 module Msf
-  module Exploit
-    module Local
-      module WindowsKernel
+  module Exploit::Local::WindowsKernel::HandleEnum
+
+    SYSTEMHANDLEINFORMATION = 64.freeze
         # HandleEnum provides methods for enumerating Windows kernel handles
         # via NtQuerySystemInformation for security research purposes.
-        module HandleEnum
           def enum_system_handles(session, max_handles = 50000, timeout = 30)
             pointers = []
             max_attempts = 5
@@ -27,7 +26,7 @@ module Msf
                     return nil
                   end
 
-                  result = session.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
+                  result = session.railgun.ntdll.NtQuerySystemInformation(SYSTEMHANDLEINFORMATION, buffer, buffer_size, 4)
 
                   if result.blank?
                     print_error('HandleEnum: NtQuerySystemInformation returned nil/empty')
@@ -172,6 +171,3 @@ module Msf
           end
         end
       end
-    end
-  end
-end

--- a/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
+++ b/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
@@ -4,6 +4,9 @@ module Msf
   module Exploit
     module Local
       module WindowsKernel
+        # HandleEnum provides methods for enumerating and analyzing Windows kernel handles
+        # via NtQuerySystemInformation. This library is used by post modules to detect
+        # kernel pointer exposure and analyze KASLR effectiveness.
         module HandleEnum
           # Enumerate system handles using NtQuerySystemInformation
           def enum_system_handles(session, max_handles = 50000, timeout = 30)
@@ -95,7 +98,7 @@ module Msf
                         type_index: type_idx
                       }
                     end
-                  rescue => e
+                  rescue StandardError => e
                     vprint_error("HandleEnum: Error parsing handle #{i}: #{e.message}")
                   end
                 end
@@ -105,7 +108,7 @@ module Msf
             rescue Timeout::Error
               print_error("HandleEnum: Enumeration timed out after #{timeout} seconds")
               return nil
-            rescue => e
+            rescue StandardError => e
               print_error("HandleEnum: Error during enumeration: #{e.message}")
               return nil
             end
@@ -116,6 +119,7 @@ module Msf
           # Check if an address is a valid kernel address
           def kernel_address?(addr)
             return false if addr.nil? || addr == 0
+
             high_bits = (addr >> 48) & 0xFFFF
             high_bits == 0xFFFF
           end
@@ -154,7 +158,7 @@ module Msf
               session.sys.process.each_process do |p|
                 return p['name'] if p['pid'] == pid
               end
-            rescue ::StandardError
+            rescue StandardError
               nil
             end
             "PID:#{pid}"

--- a/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
+++ b/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
@@ -1,0 +1,177 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Exploit
+    module Local
+      module WindowsKernel
+        module HandleEnum
+          # Enumerate system handles using NtQuerySystemInformation
+          def enum_system_handles(session, max_handles = 50000, timeout = 30)
+            pointers = []
+            max_attempts = 5
+            attempt = 0
+            buffer_size = 1024 * 1024
+
+            begin
+              Timeout.timeout(timeout) do
+                while attempt < max_attempts
+                  vprint_status("HandleEnum: Attempt #{attempt + 1}: Trying buffer size #{buffer_size} bytes")
+
+                  begin
+                    buffer = "\x00" * buffer_size
+                  rescue ArgumentError
+                    print_error("HandleEnum: Failed to allocate buffer of size #{buffer_size}")
+                    return nil
+                  end
+
+                  result = session.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
+
+                  if result.nil?
+                    print_error('HandleEnum: NtQuerySystemInformation returned nil')
+                    return nil
+                  end
+
+                  if result['return'] == 0
+                    vprint_good("HandleEnum: Success with buffer size #{buffer_size}")
+                    data = result['SystemInformation']
+                    break
+                  elsif result['return'] == 0xC0000004
+                    if result['ReturnLength'] && result['ReturnLength'] > buffer_size
+                      buffer_size = result['ReturnLength']
+                      vprint_status("HandleEnum: Buffer too small, need #{buffer_size} bytes")
+                    else
+                      buffer_size *= 2
+                      vprint_status("HandleEnum: Doubling buffer to #{buffer_size} bytes")
+                    end
+                    attempt += 1
+                  else
+                    print_error("HandleEnum: NtQuerySystemInformation failed: 0x#{result['return'].to_s(16)}")
+                    return nil
+                  end
+                end
+
+                if attempt >= max_attempts
+                  print_error("HandleEnum: Failed to get valid buffer after #{max_attempts} attempts")
+                  return nil
+                end
+
+                if data.nil? || data.length < 16
+                  print_error('HandleEnum: Invalid response data')
+                  return nil
+                end
+
+                num_handles = data[0, 8].unpack('Q').first
+                vprint_good("HandleEnum: System has #{num_handles} total handles")
+
+                if max_handles > 0 && num_handles > max_handles
+                  vprint_status("HandleEnum: Limiting to #{max_handles} handles")
+                  num_handles = max_handles
+                end
+
+                vprint_status("HandleEnum: Processing #{num_handles} handles...")
+
+                offset = 16
+                entry_size = 48
+
+                num_handles.times do |i|
+                  entry_offset = offset + (i * entry_size)
+                  break if entry_offset + entry_size > data.length
+
+                  entry = data[entry_offset, entry_size]
+
+                  begin
+                    object_ptr = entry[0, 8].unpack('Q').first
+                    pid = entry[8, 8].unpack('Q').first
+                    handle = entry[16, 8].unpack('Q').first
+                    access = entry[24, 4].unpack('V').first
+                    type_idx = entry[30, 2].unpack('v').first
+
+                    if kernel_address?(object_ptr)
+                      pointers << {
+                        address: object_ptr,
+                        pid: pid,
+                        handle: handle,
+                        access: access,
+                        type_index: type_idx
+                      }
+                    end
+                  rescue => e
+                    vprint_error("HandleEnum: Error parsing handle #{i}: #{e.message}")
+                  end
+                end
+
+                vprint_good("HandleEnum: Processed #{num_handles} handles, found #{pointers.size} kernel addresses")
+              end
+            rescue Timeout::Error
+              print_error("HandleEnum: Enumeration timed out after #{timeout} seconds")
+              return nil
+            rescue => e
+              print_error("HandleEnum: Error during enumeration: #{e.message}")
+              return nil
+            end
+
+            pointers
+          end
+
+          # Check if an address is a valid kernel address
+          def kernel_address?(addr)
+            return false if addr.nil? || addr == 0
+            high_bits = (addr >> 48) & 0xFFFF
+            high_bits == 0xFFFF
+          end
+
+          # Get object type hint from type index
+          def get_type_hint(type_idx)
+            hints = {
+              7 => 'Process',
+              8 => 'Thread',
+              16 => 'Key',
+              24 => 'File',
+              32 => 'ALPC',
+              33 => 'ALPC',
+              34 => 'ALPC',
+              35 => 'ALPC Port',
+              36 => 'ALPC Port',
+              37 => 'ALPC Port',
+              38 => 'ALPC Port',
+              39 => 'ALPC Port',
+              40 => 'ALPC Port',
+              41 => 'ALPC Port',
+              42 => 'ALPC Section',
+              43 => 'ALPC',
+              44 => 'ALPC',
+              45 => 'ALPC',
+              46 => 'ALPC',
+              47 => 'ALPC',
+              48 => 'ALPC'
+            }
+            hints[type_idx] || 'Unknown'
+          end
+
+          # Get process name from PID
+          def get_process_name(session, pid)
+            begin
+              session.sys.process.each_process do |p|
+                return p['name'] if p['pid'] == pid
+              end
+            rescue ::StandardError
+              nil
+            end
+            "PID:#{pid}"
+          end
+
+          # Format file size for display
+          def format_file_size(bytes)
+            if bytes < 1024
+              "#{bytes} bytes"
+            elsif bytes < 1024 * 1024
+              "#{(bytes / 1024.0).round(2)} KB"
+            else
+              "#{(bytes / (1024.0 * 1024.0)).round(2)} MB"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
+++ b/lib/msf/core/exploit/local/windows_kernel/handle_enum.rb
@@ -1,14 +1,14 @@
 # -*- coding: binary -*-
 
+require 'active_support/core_ext/object/blank'
+
 module Msf
   module Exploit
     module Local
       module WindowsKernel
-        # HandleEnum provides methods for enumerating and analyzing Windows kernel handles
-        # via NtQuerySystemInformation. This library is used by post modules to detect
-        # kernel pointer exposure and analyze KASLR effectiveness.
+        # HandleEnum provides methods for enumerating Windows kernel handles
+        # via NtQuerySystemInformation for security research purposes.
         module HandleEnum
-          # Enumerate system handles using NtQuerySystemInformation
           def enum_system_handles(session, max_handles = 50000, timeout = 30)
             pointers = []
             max_attempts = 5
@@ -29,8 +29,8 @@ module Msf
 
                   result = session.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
 
-                  if result.nil?
-                    print_error('HandleEnum: NtQuerySystemInformation returned nil')
+                  if result.blank?
+                    print_error('HandleEnum: NtQuerySystemInformation returned nil/empty')
                     return nil
                   end
 
@@ -58,7 +58,7 @@ module Msf
                   return nil
                 end
 
-                if data.nil? || data.length < 16
+                if data.blank? || data.length < 16
                   print_error('HandleEnum: Invalid response data')
                   return nil
                 end
@@ -116,7 +116,6 @@ module Msf
             pointers
           end
 
-          # Check if an address is a valid kernel address
           def kernel_address?(addr)
             return false if addr.nil? || addr == 0
 
@@ -124,7 +123,6 @@ module Msf
             high_bits == 0xFFFF
           end
 
-          # Get object type hint from type index
           def get_type_hint(type_idx)
             hints = {
               7 => 'Process',
@@ -152,7 +150,6 @@ module Msf
             hints[type_idx] || 'Unknown'
           end
 
-          # Get process name from PID
           def get_process_name(session, pid)
             begin
               session.sys.process.each_process do |p|
@@ -164,7 +161,6 @@ module Msf
             "PID:#{pid}"
           end
 
-          # Format file size for display
           def format_file_size(bytes)
             if bytes < 1024
               "#{bytes} bytes"

--- a/modules/auxiliary/gather/windows_kernel_pointer_enum.rb
+++ b/modules/auxiliary/gather/windows_kernel_pointer_enum.rb
@@ -1,0 +1,373 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Process
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Windows Kernel Pointer Exposure Enumerator',
+      'Description'    => %q{
+        This module enumerates kernel object pointers exposed via
+        NtQuerySystemInformation with SystemExtendedHandleInformation.
+        
+        It categorizes exposed pointers by object type and provides
+        observational data about kernel address space layout for
+        research and educational purposes.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+        'CharlesQuinnDev'
+      ],
+      'Platform'       => ['win'],
+      'SessionTypes'   => ['meterpreter'],
+      'Notes'          => {
+        'Stability'   => [CRASH_SAFE],
+        'Reliability' => [],
+        'SideEffects' => []
+      }
+    ))
+    
+    register_options([
+      OptInt.new('SESSION', [true, 'The session to run this module on']),
+      OptInt.new('MAX_HANDLES', [true, 'Maximum handles to process (0 = unlimited)', 50000]),
+      OptInt.new('TIMEOUT', [true, 'Timeout in seconds for enumeration', 30]),
+      OptString.new('EXPORT_CSV', [false, 'Export results to CSV file', nil])
+    ])
+  end
+
+  def run
+    # Get session from datastore
+    session_id = datastore['SESSION']
+    if session_id.nil?
+      print_error("No session selected. Use 'set SESSION [id]'")
+      return
+    end
+
+    # Get the actual session object
+    @sess = framework.sessions.get(session_id)
+    if @sess.nil?
+      print_error("Invalid session ID: #{session_id}")
+      return
+    end
+
+    print_status("Windows Kernel Pointer Exposure Enumerator")
+    print_line("=" * 80)
+    
+    # Validate environment
+    unless validate_environment
+      print_error("Environment validation failed")
+      return
+    end
+    
+    # Enumerate pointers
+    print_status("Enumerating kernel object pointers...")
+    
+    @pointers = enumerate_pointers
+    
+    if @pointers.nil? || @pointers.empty?
+      print_error("Failed to enumerate kernel pointers")
+      return
+    end
+    
+    print_good("Enumerated #{@pointers.size} kernel object pointers")
+    
+    # Display results
+    display_results
+    
+    # Export if requested
+    export_results if datastore['EXPORT_CSV']
+  end
+
+  def validate_environment
+    begin
+      # Get system info from session
+      sysinfo = @sess.sys.config.sysinfo
+      @os = sysinfo['OS']
+      @arch = sysinfo['Architecture']
+      @computer = sysinfo['Computer']
+      
+      print_status("Target: #{@computer}")
+      print_status("OS: #{@os}")
+      print_status("Arch: #{@arch}")
+      print_status("User: #{@sess.sys.config.getuid}")
+      
+      # Check architecture
+      unless @arch =~ /x64|64|amd64/i
+        print_error("This module only supports x64 systems")
+        return false
+      end
+      
+      true
+    rescue => e
+      print_error("Failed to get system info: #{e.message}")
+      false
+    end
+  end
+
+  def enumerate_pointers
+    pointers = []
+    max_attempts = 5
+    attempt = 0
+    buffer_size = 1024 * 1024  # Start with 1MB
+    
+    begin
+      Timeout.timeout(datastore['TIMEOUT']) do
+        while attempt < max_attempts
+          # SystemExtendedHandleInformation = 64
+          print_status("Attempt #{attempt + 1}: Trying buffer size #{buffer_size} bytes")
+          
+          # Allocate buffer
+          begin
+            buffer = "\x00" * buffer_size
+          rescue ArgumentError
+            print_error("Failed to allocate buffer of size #{buffer_size}")
+            return nil
+          end
+          
+          # Make the call
+          result = @sess.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
+          
+          if result.nil?
+            print_error("NtQuerySystemInformation returned nil")
+            return nil
+          end
+          
+          # Check return status
+          if result['return'] == 0  # STATUS_SUCCESS
+            print_good("Success with buffer size #{buffer_size}")
+            data = result['SystemInformation']
+            break
+          elsif result['return'] == 0xC0000004  # STATUS_INFO_LENGTH_MISMATCH
+            if result['ReturnLength'] && result['ReturnLength'] > buffer_size
+              buffer_size = result['ReturnLength']
+              print_status("Buffer too small, need #{buffer_size} bytes")
+            else
+              # Try doubling
+              buffer_size *= 2
+              print_status("Doubling buffer to #{buffer_size} bytes")
+            end
+            attempt += 1
+          else
+            print_error("NtQuerySystemInformation failed: 0x#{result['return'].to_s(16)}")
+            return nil
+          end
+        end
+        
+        if attempt >= max_attempts
+          print_error("Failed to get valid buffer after #{max_attempts} attempts")
+          return nil
+        end
+        
+        # Parse the data
+        if data.nil? || data.length < 16
+          print_error("Invalid response data")
+          return nil
+        end
+        
+        # Get number of handles (first 8 bytes)
+        num_handles = data[0, 8].unpack('Q').first
+        print_good("System has #{num_handles} total handles")
+        
+        # Apply limit
+        max_handles = datastore['MAX_HANDLES']
+        if max_handles > 0 && num_handles > max_handles
+          print_status("Limiting to #{max_handles} handles")
+          num_handles = max_handles
+        end
+        
+        print_status("Processing #{num_handles} handles...")
+        
+        # Parse handle entries
+        offset = 16  # Skip NumberOfHandles (8) + Reserved (8)
+        entry_size = 48  # Size of SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX
+        
+        processed = 0
+        kernel_pointers = 0
+        
+        num_handles.times do |i|
+          entry_offset = offset + (i * entry_size)
+          break if entry_offset + entry_size > data.length
+          
+          entry = data[entry_offset, entry_size]
+          
+          begin
+            # Parse entry fields
+            object_ptr = entry[0, 8].unpack('Q').first
+            pid = entry[8, 8].unpack('Q').first
+            handle = entry[16, 8].unpack('Q').first
+            access = entry[24, 4].unpack('V').first
+            type_idx = entry[30, 2].unpack('v').first
+            
+            # Validate kernel address
+            if is_kernel_address?(object_ptr)
+              pointers << {
+                address: object_ptr,
+                pid: pid,
+                handle: handle,
+                access: access,
+                type_index: type_idx
+              }
+              kernel_pointers += 1
+            end
+            
+            processed += 1
+            
+            # Show progress every 10,000 handles
+            if processed % 10000 == 0
+              print_status("  Processed #{processed}/#{num_handles} handles (found #{kernel_pointers} kernel addresses)...")
+            end
+            
+          rescue => e
+            vprint_error("Error parsing handle #{i}: #{e.message}")
+          end
+        end
+        
+        print_good("Processed #{processed} handles, found #{kernel_pointers} kernel addresses")
+      end
+    rescue Timeout::Error
+      print_error("Enumeration timed out after #{datastore['TIMEOUT']} seconds")
+      return nil
+    rescue => e
+      print_error("Error during enumeration: #{e.message}")
+      return nil
+    end
+    
+    pointers
+  end
+
+  def is_kernel_address?(addr)
+    return false if addr.nil? || addr == 0
+    
+    # x64 canonical kernel addresses have bits 48-63 set to 0xFFFF
+    high_bits = (addr >> 48) & 0xFFFF
+    high_bits == 0xFFFF
+  end
+
+  def display_results
+    print_line
+    print_line("=" * 80)
+    print_line("KERNEL POINTER EXPOSURE RESULTS")
+    print_line("=" * 80)
+    
+    # Summary stats
+    print_line("\nSUMMARY STATISTICS:")
+    print_line("  Total pointers: #{@pointers.size}")
+    
+    # Unique addresses
+    unique = @pointers.uniq { |p| p[:address] }.size
+    print_line("  Unique addresses: #{unique}")
+    
+    # Address range
+    if @pointers.any?
+      min_addr = @pointers.map { |p| p[:address] }.min
+      max_addr = @pointers.map { |p| p[:address] }.max
+      print_line("  Address range: 0x#{min_addr.to_s(16)} - 0x#{max_addr.to_s(16)}")
+    end
+    
+    # Group by type
+    by_type = @pointers.group_by { |p| p[:type_index] }
+    
+    print_line("\nOBJECT TYPE DISTRIBUTION:")
+    by_type.sort.each do |type, ptrs|
+      pct = (ptrs.size.to_f / @pointers.size * 100).round(2)
+      type_name = get_type_hint(type)
+      print_line("  Type #{type} (#{type_name}): #{ptrs.size} pointers (#{pct}%)")
+    end
+    
+    # ALPC specific summary
+    alpc_pointers = @pointers.select { |p| (32..48).include?(p[:type_index]) }
+    
+    if alpc_pointers.any?
+      print_line("\n" + "-" * 80)
+      print_line("ALPC OBJECT ANALYSIS (Type Indices 32-48)")
+      print_line("-" * 80)
+      
+      print_line("  Total ALPC pointers: #{alpc_pointers.size}")
+      
+      # Group ALPC by process
+      by_pid = alpc_pointers.group_by { |p| p[:pid] }
+      print_line("  Found in #{by_pid.size} processes")
+      
+      # Show process list
+      print_line("\n  Processes with ALPC pointers:")
+      by_pid.sort_by { |_, v| -v.size }.first(10).each do |pid, ptrs|
+        proc_name = get_process_name(pid)
+        print_line("    #{proc_name} (PID: #{pid}): #{ptrs.size} ALPC pointers")
+      end
+      
+      # Show sample addresses
+      print_line("\n  Sample ALPC kernel addresses:")
+      alpc_pointers.first(10).each_with_index do |p, i|
+        print_line("    #{i+1}. Type #{p[:type_index]}: 0x#{p[:address].to_s(16)}")
+      end
+    end
+    
+    print_line("\n" + "=" * 80)
+  end
+  
+  def get_type_hint(type_idx)
+    hints = {
+      7 => "Process",
+      8 => "Thread",
+      16 => "Key",
+      24 => "File",
+      32 => "ALPC",
+      33 => "ALPC",
+      34 => "ALPC",
+      35 => "ALPC Port",
+      36 => "ALPC Port",
+      37 => "ALPC Port",
+      38 => "ALPC Port",
+      39 => "ALPC Port",
+      40 => "ALPC Port",
+      41 => "ALPC Port",
+      42 => "ALPC Section",
+      43 => "ALPC",
+      44 => "ALPC",
+      45 => "ALPC",
+      46 => "ALPC",
+      47 => "ALPC",
+      48 => "ALPC"
+    }
+    hints[type_idx] || "Unknown"
+  end
+
+  def get_process_name(pid)
+    begin
+      @sess.sys.process.each_process do |p|
+        return p['name'] if p['pid'] == pid
+      end
+    rescue
+    end
+    "PID:#{pid}"
+  end
+
+  def export_results
+    return unless datastore['EXPORT_CSV']
+    
+    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+    filename = "kernel_pointers_#{timestamp}.csv"
+    
+    csv = "PID,TypeIndex,TypeHint,Handle,Access,Address\n"
+    @pointers.each do |p|
+      type_hint = get_type_hint(p[:type_index])
+      csv += "#{p[:pid]},#{p[:type_index]},#{type_hint},0x#{p[:handle].to_s(16)},0x#{p[:access].to_s(8)},0x#{p[:address].to_s(16)}\n"
+    end
+    
+    stored_path = store_loot(
+      'windows.kernel.pointers',
+      'text/csv',
+      @sess,
+      csv,
+      filename,
+      'Windows Kernel Pointer Enumeration Results'
+    )
+    
+    print_good("Results exported to: #{stored_path}")
+  end
+end

--- a/modules/post/windows/gather/windows_kernel_pointer_enum.rb
+++ b/modules/post/windows/gather/windows_kernel_pointer_enum.rb
@@ -9,29 +9,30 @@ class MetasploitModule < Msf::Post
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Windows Kernel Pointer Exposure Enumerator',
-      'Description'    => %q{
-        This module enumerates kernel object pointers exposed via
-        NtQuerySystemInformation with SystemExtendedHandleInformation.
-        
-        It categorizes exposed pointers by object type and provides
-        observational data about kernel address space layout for
-        research and educational purposes.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [
-         'CharlesQuinnDev'
-      ]
-      'Platform'       => ['win'],
-      'SessionTypes'   => ['meterpreter'],
-      'Notes'          => {
-        'Stability'   => [CRASH_SAFE],
-        'Reliability' => [],
-        'SideEffects' => []
-      }
-    ))
-    
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Kernel Pointer Exposure Enumerator',
+        'Description' => %q{
+          This module enumerates kernel object pointers exposed via
+          NtQuerySystemInformation with SystemExtendedHandleInformation.
+
+          It categorizes exposed pointers by object type and provides
+          observational data about kernel address space layout for
+          research and educational purposes.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['CharlesQuinnDev'],
+        'Platform' => 'win',
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
     register_options([
       OptInt.new('MAX_HANDLES', [true, 'Maximum handles to process (0 = unlimited)', 50000]),
       OptInt.new('TIMEOUT', [true, 'Timeout in seconds for enumeration', 30]),
@@ -40,93 +41,82 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    print_status("Windows Kernel Pointer Exposure Enumerator")
-    print_line("=" * 80)
-    
-    # Validate environment
+    print_status('Windows Kernel Pointer Exposure Enumerator')
+    print_line('=' * 80)
+
     unless validate_environment
-      print_error("Environment validation failed")
+      print_error('Environment validation failed')
       return
     end
-    
-    # Enumerate pointers
-    print_status("Enumerating kernel object pointers...")
-    
+
+    print_status('Enumerating kernel object pointers...')
+
     @pointers = enumerate_pointers
-    
+
     if @pointers.nil? || @pointers.empty?
-      print_error("Failed to enumerate kernel pointers")
+      print_error('Failed to enumerate kernel pointers')
       return
     end
-    
+
     print_good("Enumerated #{@pointers.size} kernel object pointers")
-    
-    # Display results
+
     display_results
-    
-    # Export if requested
+
     export_results if datastore['EXPORT_CSV']
   end
 
   def validate_environment
-    begin
-      # Get system info from session
-      sysinfo = session.sys.config.sysinfo
-      @os = sysinfo['OS']
-      @arch = sysinfo['Architecture']
-      @computer = sysinfo['Computer']
-      
-      print_status("Target: #{@computer}")
-      print_status("OS: #{@os}")
-      print_status("Arch: #{@arch}")
-      print_status("User: #{session.sys.config.getuid}")
-      
-      # Check architecture
-      unless @arch =~ /x64|64|amd64/i
-        print_error("This module only supports x64 systems")
-        return false
-      end
-      
-      true
-    rescue => e
-      print_error("Failed to get system info: #{e.message}")
-      false
+    sysinfo = session.sys.config.sysinfo
+    @os = sysinfo['OS']
+    @arch = sysinfo['Architecture']
+    @computer = sysinfo['Computer']
+
+    print_status("Target: #{@computer}")
+    print_status("OS: #{@os}")
+    print_status("Arch: #{@arch}")
+    print_status("User: #{session.sys.config.getuid}")
+
+    unless @arch =~ /x64|64|amd64/i
+      print_error('This module only supports x64 systems')
+      return false
     end
+
+    true
+  rescue StandardError => e
+    print_error("Failed to get system info: #{e.message}")
+    false
   end
 
   def enumerate_pointers
     pointers = []
     max_attempts = 5
     attempt = 0
-    buffer_size = 1024 * 1024  # Start with 1MB
-    
+    buffer_size = 1024 * 1024
+
     begin
       Timeout.timeout(datastore['TIMEOUT']) do
         while attempt < max_attempts
           print_status("Attempt #{attempt + 1}: Trying buffer size #{buffer_size} bytes")
-          
-          # Allocate buffer
+
           begin
             buffer = "\x00" * buffer_size
           rescue ArgumentError
             print_error("Failed to allocate buffer of size #{buffer_size}")
             return nil
           end
-          
-          # Make the call
+
           result = session.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
-          
+
           if result.nil?
-            print_error("NtQuerySystemInformation returned nil")
+            print_error('NtQuerySystemInformation returned nil')
             return nil
           end
-          
-          # Check return status
-          if result['return'] == 0  # STATUS_SUCCESS
+
+          if result['return'] == 0
             print_good("Success with buffer size #{buffer_size}")
             data = result['SystemInformation']
             break
-          elsif result['return'] == 0xC0000004  # STATUS_INFO_LENGTH_MISMATCH
+          elsif result['return'] == 0xC0000004
             if result['ReturnLength'] && result['ReturnLength'] > buffer_size
               buffer_size = result['ReturnLength']
               print_status("Buffer too small, need #{buffer_size} bytes")
@@ -140,52 +130,48 @@ class MetasploitModule < Msf::Post
             return nil
           end
         end
-        
+
         if attempt >= max_attempts
           print_error("Failed to get valid buffer after #{max_attempts} attempts")
           return nil
         end
-        
-        # Parse the data
+
         if data.nil? || data.length < 16
-          print_error("Invalid response data")
+          print_error('Invalid response data')
           return nil
         end
-        
-        # Get number of handles (first 8 bytes)
+
         num_handles = data[0, 8].unpack('Q').first
         print_good("System has #{num_handles} total handles")
-        
-        # Apply limit
+
         max_handles = datastore['MAX_HANDLES']
         if max_handles > 0 && num_handles > max_handles
           print_status("Limiting to #{max_handles} handles")
           num_handles = max_handles
         end
-        
+
         print_status("Processing #{num_handles} handles...")
-        
-        # Parse handle entries
+
         offset = 16
         entry_size = 48
-        
+
         processed = 0
         kernel_pointers = 0
-        
+
         num_handles.times do |i|
           entry_offset = offset + (i * entry_size)
           break if entry_offset + entry_size > data.length
-          
+
           entry = data[entry_offset, entry_size]
-          
+
           begin
             object_ptr = entry[0, 8].unpack('Q').first
             pid = entry[8, 8].unpack('Q').first
             handle = entry[16, 8].unpack('Q').first
             access = entry[24, 4].unpack('V').first
             type_idx = entry[30, 2].unpack('v').first
-            
-            if is_kernel_address?(object_ptr)
+
+            if kernel_address?(object_ptr)
               pointers << {
                 address: object_ptr,
                 pid: pid,
@@ -195,116 +181,116 @@ class MetasploitModule < Msf::Post
               }
               kernel_pointers += 1
             end
-            
+
             processed += 1
-            
+
             if processed % 10000 == 0
               print_status("  Processed #{processed}/#{num_handles} handles (found #{kernel_pointers} kernel addresses)...")
             end
-            
-          rescue => e
+          rescue StandardError => e
             vprint_error("Error parsing handle #{i}: #{e.message}")
           end
         end
-        
+
         print_good("Processed #{processed} handles, found #{kernel_pointers} kernel addresses")
       end
     rescue Timeout::Error
       print_error("Enumeration timed out after #{datastore['TIMEOUT']} seconds")
       return nil
-    rescue => e
+    rescue StandardError => e
       print_error("Error during enumeration: #{e.message}")
       return nil
     end
-    
+
     pointers
   end
 
-  def is_kernel_address?(addr)
+  def kernel_address?(addr)
     return false if addr.nil? || addr == 0
+
     high_bits = (addr >> 48) & 0xFFFF
     high_bits == 0xFFFF
   end
 
   def display_results
     print_line
-    print_line("=" * 80)
-    print_line("KERNEL POINTER EXPOSURE RESULTS")
-    print_line("=" * 80)
-    
+    print_line('=' * 80)
+    print_line('KERNEL POINTER EXPOSURE RESULTS')
+    print_line('=' * 80)
+
     print_line("\nSUMMARY STATISTICS:")
     print_line("  Total pointers: #{@pointers.size}")
-    
+
     unique = @pointers.uniq { |p| p[:address] }.size
     print_line("  Unique addresses: #{unique}")
-    
+
     if @pointers.any?
       min_addr = @pointers.map { |p| p[:address] }.min
       max_addr = @pointers.map { |p| p[:address] }.max
       print_line("  Address range: 0x#{min_addr.to_s(16)} - 0x#{max_addr.to_s(16)}")
     end
-    
+
     by_type = @pointers.group_by { |p| p[:type_index] }
-    
+
     print_line("\nOBJECT TYPE DISTRIBUTION:")
     by_type.sort.each do |type, ptrs|
       pct = (ptrs.size.to_f / @pointers.size * 100).round(2)
       type_name = get_type_hint(type)
       print_line("  Type #{type} (#{type_name}): #{ptrs.size} pointers (#{pct}%)")
     end
-    
+
     alpc_pointers = @pointers.select { |p| (32..48).include?(p[:type_index]) }
-    
+
     if alpc_pointers.any?
-      print_line("\n" + "-" * 80)
-      print_line("ALPC OBJECT ANALYSIS (Type Indices 32-48)")
-      print_line("-" * 80)
-      
+      print_line("\n" + '-' * 80)
+      print_line('ALPC OBJECT ANALYSIS (Type Indices 32-48)')
+      print_line('-' * 80)
+
       print_line("  Total ALPC pointers: #{alpc_pointers.size}")
-      
+
       by_pid = alpc_pointers.group_by { |p| p[:pid] }
       print_line("  Found in #{by_pid.size} processes")
-      
+
       print_line("\n  Processes with ALPC pointers:")
       by_pid.sort_by { |_, v| -v.size }.first(10).each do |pid, ptrs|
         proc_name = get_process_name(pid)
         print_line("    #{proc_name} (PID: #{pid}): #{ptrs.size} ALPC pointers")
       end
-      
+
       print_line("\n  Sample ALPC kernel addresses:")
       alpc_pointers.first(10).each_with_index do |p, i|
-        print_line("    #{i+1}. Type #{p[:type_index]}: 0x#{p[:address].to_s(16)}")
+        print_line("    #{i + 1}. Type #{p[:type_index]}: 0x#{p[:address].to_s(16)}")
       end
     end
-    
-    print_line("\n" + "=" * 80)
+
+    print_line("\n" + '=' * 80)
   end
-  
+
   def get_type_hint(type_idx)
     hints = {
-      7 => "Process",
-      8 => "Thread",
-      16 => "Key",
-      24 => "File",
-      32 => "ALPC",
-      33 => "ALPC",
-      34 => "ALPC",
-      35 => "ALPC Port",
-      36 => "ALPC Port",
-      37 => "ALPC Port",
-      38 => "ALPC Port",
-      39 => "ALPC Port",
-      40 => "ALPC Port",
-      41 => "ALPC Port",
-      42 => "ALPC Section",
-      43 => "ALPC",
-      44 => "ALPC",
-      45 => "ALPC",
-      46 => "ALPC",
-      47 => "ALPC",
-      48 => "ALPC"
+      7 => 'Process',
+      8 => 'Thread',
+      16 => 'Key',
+      24 => 'File',
+      32 => 'ALPC',
+      33 => 'ALPC',
+      34 => 'ALPC',
+      35 => 'ALPC Port',
+      36 => 'ALPC Port',
+      37 => 'ALPC Port',
+      38 => 'ALPC Port',
+      39 => 'ALPC Port',
+      40 => 'ALPC Port',
+      41 => 'ALPC Port',
+      42 => 'ALPC Section',
+      43 => 'ALPC',
+      44 => 'ALPC',
+      45 => 'ALPC',
+      46 => 'ALPC',
+      47 => 'ALPC',
+      48 => 'ALPC'
     }
-    hints[type_idx] || "Unknown"
+    hints[type_idx] || 'Unknown'
   end
 
   def get_process_name(pid)
@@ -312,33 +298,33 @@ class MetasploitModule < Msf::Post
       session.sys.process.each_process do |p|
         return p['name'] if p['pid'] == pid
       end
-    rescue
+    rescue ::StandardError
+      nil
     end
     "PID:#{pid}"
   end
 
   def export_results
     return unless datastore['EXPORT_CSV']
-    
-    timestamp = Time.now.strftime("%Y%m%d_%H%M%S")
+
+    timestamp = Time.now.strftime('%Y%m%d_%H%M%S')
     filename = "kernel_pointers_#{timestamp}.csv"
-    
+
     csv = "PID,TypeIndex,TypeHint,Handle,Access,Address\n"
     @pointers.each do |p|
       type_hint = get_type_hint(p[:type_index])
       csv += "#{p[:pid]},#{p[:type_index]},#{type_hint},0x#{p[:handle].to_s(16)},0x#{p[:access].to_s(8)},0x#{p[:address].to_s(16)}\n"
     end
-    
-    # Calculate size for user info
+
     csv_size = csv.bytesize
-    if csv_size < 1024
-      size_str = "#{csv_size} bytes"
-    elsif csv_size < 1024 * 1024
-      size_str = "#{(csv_size / 1024.0).round(2)} KB"
-    else
-      size_str = "#{(csv_size / (1024.0 * 1024.0)).round(2)} MB"
-    end
-    
+    size_str = if csv_size < 1024
+                 "#{csv_size} bytes"
+               elsif csv_size < 1024 * 1024
+                 "#{(csv_size / 1024.0).round(2)} KB"
+               else
+                 "#{(csv_size / (1024.0 * 1024.0)).round(2)} MB"
+               end
+
     stored_path = store_loot(
       'windows.kernel.pointers',
       'text/csv',
@@ -347,7 +333,7 @@ class MetasploitModule < Msf::Post
       filename,
       'Windows Kernel Pointer Enumeration Results'
     )
-    
+
     print_good("Results exported to: #{stored_path} (#{size_str})")
   end
 end

--- a/modules/post/windows/gather/windows_kernel_pointer_enum.rb
+++ b/modules/post/windows/gather/windows_kernel_pointer_enum.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core/exploit/local/windows_kernel/handle_enum'
-
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
@@ -47,10 +45,7 @@ class MetasploitModule < Msf::Post
     print_status('Windows Kernel Pointer Exposure Enumerator')
     print_line('=' * 80)
 
-    unless validate_environment
-      print_error('Environment validation failed')
-      return
-    end
+    fail_with(Failure::NotVulnerable, 'Unsupported environment') unless validate_environment
 
     print_status('Enumerating kernel object pointers...')
 

--- a/modules/post/windows/gather/windows_kernel_pointer_enum.rb
+++ b/modules/post/windows/gather/windows_kernel_pointer_enum.rb
@@ -3,10 +3,13 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'msf/core/exploit/local/windows_kernel/handle_enum'
+
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Local::WindowsKernel::HandleEnum
 
   def initialize(info = {})
     super(
@@ -36,7 +39,7 @@ class MetasploitModule < Msf::Post
     register_options([
       OptInt.new('MAX_HANDLES', [true, 'Maximum handles to process (0 = unlimited)', 50000]),
       OptInt.new('TIMEOUT', [true, 'Timeout in seconds for enumeration', 30]),
-      OptString.new('EXPORT_CSV', [false, 'Export results to CSV file', nil])
+      OptString.new('EXPORT_CSV', [false, 'Export results to CSV file'])
     ])
   end
 
@@ -51,7 +54,7 @@ class MetasploitModule < Msf::Post
 
     print_status('Enumerating kernel object pointers...')
 
-    @pointers = enumerate_pointers
+    @pointers = enum_system_handles(session, datastore['MAX_HANDLES'], datastore['TIMEOUT'])
 
     if @pointers.nil? || @pointers.empty?
       print_error('Failed to enumerate kernel pointers')
@@ -66,150 +69,27 @@ class MetasploitModule < Msf::Post
   end
 
   def validate_environment
-    sysinfo = session.sys.config.sysinfo
-    @os = sysinfo['OS']
-    @arch = sysinfo['Architecture']
-    @computer = sysinfo['Computer']
-
-    print_status("Target: #{@computer}")
-    print_status("OS: #{@os}")
-    print_status("Arch: #{@arch}")
-    print_status("User: #{session.sys.config.getuid}")
-
-    unless @arch =~ /x64|64|amd64/i
-      print_error('This module only supports x64 systems')
-      return false
-    end
-
-    true
-  rescue StandardError => e
-    print_error("Failed to get system info: #{e.message}")
-    false
-  end
-
-  def enumerate_pointers
-    pointers = []
-    max_attempts = 5
-    attempt = 0
-    buffer_size = 1024 * 1024
-
     begin
-      Timeout.timeout(datastore['TIMEOUT']) do
-        while attempt < max_attempts
-          print_status("Attempt #{attempt + 1}: Trying buffer size #{buffer_size} bytes")
+      sysinfo = session.sys.config.sysinfo
+      @os = sysinfo['OS']
+      @arch = sysinfo['Architecture']
+      @computer = sysinfo['Computer']
 
-          begin
-            buffer = "\x00" * buffer_size
-          rescue ArgumentError
-            print_error("Failed to allocate buffer of size #{buffer_size}")
-            return nil
-          end
+      print_status("Target: #{@computer}")
+      print_status("OS: #{@os}")
+      print_status("Arch: #{@arch}")
+      print_status("User: #{session.sys.config.getuid}")
 
-          result = session.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
-
-          if result.nil?
-            print_error('NtQuerySystemInformation returned nil')
-            return nil
-          end
-
-          if result['return'] == 0
-            print_good("Success with buffer size #{buffer_size}")
-            data = result['SystemInformation']
-            break
-          elsif result['return'] == 0xC0000004
-            if result['ReturnLength'] && result['ReturnLength'] > buffer_size
-              buffer_size = result['ReturnLength']
-              print_status("Buffer too small, need #{buffer_size} bytes")
-            else
-              buffer_size *= 2
-              print_status("Doubling buffer to #{buffer_size} bytes")
-            end
-            attempt += 1
-          else
-            print_error("NtQuerySystemInformation failed: 0x#{result['return'].to_s(16)}")
-            return nil
-          end
-        end
-
-        if attempt >= max_attempts
-          print_error("Failed to get valid buffer after #{max_attempts} attempts")
-          return nil
-        end
-
-        if data.nil? || data.length < 16
-          print_error('Invalid response data')
-          return nil
-        end
-
-        num_handles = data[0, 8].unpack('Q').first
-        print_good("System has #{num_handles} total handles")
-
-        max_handles = datastore['MAX_HANDLES']
-        if max_handles > 0 && num_handles > max_handles
-          print_status("Limiting to #{max_handles} handles")
-          num_handles = max_handles
-        end
-
-        print_status("Processing #{num_handles} handles...")
-
-        offset = 16
-        entry_size = 48
-
-        processed = 0
-        kernel_pointers = 0
-
-        num_handles.times do |i|
-          entry_offset = offset + (i * entry_size)
-          break if entry_offset + entry_size > data.length
-
-          entry = data[entry_offset, entry_size]
-
-          begin
-            object_ptr = entry[0, 8].unpack('Q').first
-            pid = entry[8, 8].unpack('Q').first
-            handle = entry[16, 8].unpack('Q').first
-            access = entry[24, 4].unpack('V').first
-            type_idx = entry[30, 2].unpack('v').first
-
-            if kernel_address?(object_ptr)
-              pointers << {
-                address: object_ptr,
-                pid: pid,
-                handle: handle,
-                access: access,
-                type_index: type_idx
-              }
-              kernel_pointers += 1
-            end
-
-            processed += 1
-
-            if processed % 10000 == 0
-              print_status("  Processed #{processed}/#{num_handles} handles (found #{kernel_pointers} kernel addresses)...")
-            end
-          rescue StandardError => e
-            vprint_error("Error parsing handle #{i}: #{e.message}")
-          end
-        end
-
-        print_good("Processed #{processed} handles, found #{kernel_pointers} kernel addresses")
+      unless @arch =~ /x64|64|amd64/i
+        print_error('This module only supports x64 systems')
+        return false
       end
-    rescue Timeout::Error
-      print_error("Enumeration timed out after #{datastore['TIMEOUT']} seconds")
-      return nil
+
+      true
     rescue StandardError => e
-      print_error("Error during enumeration: #{e.message}")
-      return nil
+      print_error("Failed to get system info: #{e.message}")
+      false
     end
-
-    pointers
-  end
-
-  def kernel_address?(addr)
-    return false if addr.nil? || addr == 0
-
-    high_bits = (addr >> 48) & 0xFFFF
-    high_bits == 0xFFFF
   end
 
   def display_results
@@ -253,7 +133,7 @@ class MetasploitModule < Msf::Post
 
       print_line("\n  Processes with ALPC pointers:")
       by_pid.sort_by { |_, v| -v.size }.first(10).each do |pid, ptrs|
-        proc_name = get_process_name(pid)
+        proc_name = get_process_name(session, pid)
         print_line("    #{proc_name} (PID: #{pid}): #{ptrs.size} ALPC pointers")
       end
 
@@ -264,44 +144,6 @@ class MetasploitModule < Msf::Post
     end
 
     print_line("\n" + '=' * 80)
-  end
-
-  def get_type_hint(type_idx)
-    hints = {
-      7 => 'Process',
-      8 => 'Thread',
-      16 => 'Key',
-      24 => 'File',
-      32 => 'ALPC',
-      33 => 'ALPC',
-      34 => 'ALPC',
-      35 => 'ALPC Port',
-      36 => 'ALPC Port',
-      37 => 'ALPC Port',
-      38 => 'ALPC Port',
-      39 => 'ALPC Port',
-      40 => 'ALPC Port',
-      41 => 'ALPC Port',
-      42 => 'ALPC Section',
-      43 => 'ALPC',
-      44 => 'ALPC',
-      45 => 'ALPC',
-      46 => 'ALPC',
-      47 => 'ALPC',
-      48 => 'ALPC'
-    }
-    hints[type_idx] || 'Unknown'
-  end
-
-  def get_process_name(pid)
-    begin
-      session.sys.process.each_process do |p|
-        return p['name'] if p['pid'] == pid
-      end
-    rescue ::StandardError
-      nil
-    end
-    "PID:#{pid}"
   end
 
   def export_results
@@ -316,14 +158,7 @@ class MetasploitModule < Msf::Post
       csv += "#{p[:pid]},#{p[:type_index]},#{type_hint},0x#{p[:handle].to_s(16)},0x#{p[:access].to_s(8)},0x#{p[:address].to_s(16)}\n"
     end
 
-    csv_size = csv.bytesize
-    size_str = if csv_size < 1024
-                 "#{csv_size} bytes"
-               elsif csv_size < 1024 * 1024
-                 "#{(csv_size / 1024.0).round(2)} KB"
-               else
-                 "#{(csv_size / (1024.0 * 1024.0)).round(2)} MB"
-               end
+    size_str = format_file_size(csv.bytesize)
 
     stored_path = store_loot(
       'windows.kernel.pointers',

--- a/modules/post/windows/gather/windows_kernel_pointer_enum.rb
+++ b/modules/post/windows/gather/windows_kernel_pointer_enum.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-class MetasploitModule < Msf::Auxiliary
+class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
   include Msf::Auxiliary::Report
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'License'        => MSF_LICENSE,
       'Author'         => [
-        'CharlesQuinnDev'
-      ],
+         'CharlesQuinnDev'
+      ]
       'Platform'       => ['win'],
       'SessionTypes'   => ['meterpreter'],
       'Notes'          => {
@@ -33,7 +33,6 @@ class MetasploitModule < Msf::Auxiliary
     ))
     
     register_options([
-      OptInt.new('SESSION', [true, 'The session to run this module on']),
       OptInt.new('MAX_HANDLES', [true, 'Maximum handles to process (0 = unlimited)', 50000]),
       OptInt.new('TIMEOUT', [true, 'Timeout in seconds for enumeration', 30]),
       OptString.new('EXPORT_CSV', [false, 'Export results to CSV file', nil])
@@ -41,20 +40,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    # Get session from datastore
-    session_id = datastore['SESSION']
-    if session_id.nil?
-      print_error("No session selected. Use 'set SESSION [id]'")
-      return
-    end
-
-    # Get the actual session object
-    @sess = framework.sessions.get(session_id)
-    if @sess.nil?
-      print_error("Invalid session ID: #{session_id}")
-      return
-    end
-
     print_status("Windows Kernel Pointer Exposure Enumerator")
     print_line("=" * 80)
     
@@ -86,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
   def validate_environment
     begin
       # Get system info from session
-      sysinfo = @sess.sys.config.sysinfo
+      sysinfo = session.sys.config.sysinfo
       @os = sysinfo['OS']
       @arch = sysinfo['Architecture']
       @computer = sysinfo['Computer']
@@ -94,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Target: #{@computer}")
       print_status("OS: #{@os}")
       print_status("Arch: #{@arch}")
-      print_status("User: #{@sess.sys.config.getuid}")
+      print_status("User: #{session.sys.config.getuid}")
       
       # Check architecture
       unless @arch =~ /x64|64|amd64/i
@@ -118,7 +103,6 @@ class MetasploitModule < Msf::Auxiliary
     begin
       Timeout.timeout(datastore['TIMEOUT']) do
         while attempt < max_attempts
-          # SystemExtendedHandleInformation = 64
           print_status("Attempt #{attempt + 1}: Trying buffer size #{buffer_size} bytes")
           
           # Allocate buffer
@@ -130,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
           end
           
           # Make the call
-          result = @sess.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
+          result = session.railgun.ntdll.NtQuerySystemInformation(64, buffer, buffer_size, 4)
           
           if result.nil?
             print_error("NtQuerySystemInformation returned nil")
@@ -147,7 +131,6 @@ class MetasploitModule < Msf::Auxiliary
               buffer_size = result['ReturnLength']
               print_status("Buffer too small, need #{buffer_size} bytes")
             else
-              # Try doubling
               buffer_size *= 2
               print_status("Doubling buffer to #{buffer_size} bytes")
             end
@@ -183,8 +166,8 @@ class MetasploitModule < Msf::Auxiliary
         print_status("Processing #{num_handles} handles...")
         
         # Parse handle entries
-        offset = 16  # Skip NumberOfHandles (8) + Reserved (8)
-        entry_size = 48  # Size of SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX
+        offset = 16
+        entry_size = 48
         
         processed = 0
         kernel_pointers = 0
@@ -196,14 +179,12 @@ class MetasploitModule < Msf::Auxiliary
           entry = data[entry_offset, entry_size]
           
           begin
-            # Parse entry fields
             object_ptr = entry[0, 8].unpack('Q').first
             pid = entry[8, 8].unpack('Q').first
             handle = entry[16, 8].unpack('Q').first
             access = entry[24, 4].unpack('V').first
             type_idx = entry[30, 2].unpack('v').first
             
-            # Validate kernel address
             if is_kernel_address?(object_ptr)
               pointers << {
                 address: object_ptr,
@@ -217,7 +198,6 @@ class MetasploitModule < Msf::Auxiliary
             
             processed += 1
             
-            # Show progress every 10,000 handles
             if processed % 10000 == 0
               print_status("  Processed #{processed}/#{num_handles} handles (found #{kernel_pointers} kernel addresses)...")
             end
@@ -242,8 +222,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def is_kernel_address?(addr)
     return false if addr.nil? || addr == 0
-    
-    # x64 canonical kernel addresses have bits 48-63 set to 0xFFFF
     high_bits = (addr >> 48) & 0xFFFF
     high_bits == 0xFFFF
   end
@@ -254,22 +232,18 @@ class MetasploitModule < Msf::Auxiliary
     print_line("KERNEL POINTER EXPOSURE RESULTS")
     print_line("=" * 80)
     
-    # Summary stats
     print_line("\nSUMMARY STATISTICS:")
     print_line("  Total pointers: #{@pointers.size}")
     
-    # Unique addresses
     unique = @pointers.uniq { |p| p[:address] }.size
     print_line("  Unique addresses: #{unique}")
     
-    # Address range
     if @pointers.any?
       min_addr = @pointers.map { |p| p[:address] }.min
       max_addr = @pointers.map { |p| p[:address] }.max
       print_line("  Address range: 0x#{min_addr.to_s(16)} - 0x#{max_addr.to_s(16)}")
     end
     
-    # Group by type
     by_type = @pointers.group_by { |p| p[:type_index] }
     
     print_line("\nOBJECT TYPE DISTRIBUTION:")
@@ -279,7 +253,6 @@ class MetasploitModule < Msf::Auxiliary
       print_line("  Type #{type} (#{type_name}): #{ptrs.size} pointers (#{pct}%)")
     end
     
-    # ALPC specific summary
     alpc_pointers = @pointers.select { |p| (32..48).include?(p[:type_index]) }
     
     if alpc_pointers.any?
@@ -289,18 +262,15 @@ class MetasploitModule < Msf::Auxiliary
       
       print_line("  Total ALPC pointers: #{alpc_pointers.size}")
       
-      # Group ALPC by process
       by_pid = alpc_pointers.group_by { |p| p[:pid] }
       print_line("  Found in #{by_pid.size} processes")
       
-      # Show process list
       print_line("\n  Processes with ALPC pointers:")
       by_pid.sort_by { |_, v| -v.size }.first(10).each do |pid, ptrs|
         proc_name = get_process_name(pid)
         print_line("    #{proc_name} (PID: #{pid}): #{ptrs.size} ALPC pointers")
       end
       
-      # Show sample addresses
       print_line("\n  Sample ALPC kernel addresses:")
       alpc_pointers.first(10).each_with_index do |p, i|
         print_line("    #{i+1}. Type #{p[:type_index]}: 0x#{p[:address].to_s(16)}")
@@ -339,7 +309,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def get_process_name(pid)
     begin
-      @sess.sys.process.each_process do |p|
+      session.sys.process.each_process do |p|
         return p['name'] if p['pid'] == pid
       end
     rescue
@@ -359,15 +329,25 @@ class MetasploitModule < Msf::Auxiliary
       csv += "#{p[:pid]},#{p[:type_index]},#{type_hint},0x#{p[:handle].to_s(16)},0x#{p[:access].to_s(8)},0x#{p[:address].to_s(16)}\n"
     end
     
+    # Calculate size for user info
+    csv_size = csv.bytesize
+    if csv_size < 1024
+      size_str = "#{csv_size} bytes"
+    elsif csv_size < 1024 * 1024
+      size_str = "#{(csv_size / 1024.0).round(2)} KB"
+    else
+      size_str = "#{(csv_size / (1024.0 * 1024.0)).round(2)} MB"
+    end
+    
     stored_path = store_loot(
       'windows.kernel.pointers',
       'text/csv',
-      @sess,
+      session,
       csv,
       filename,
       'Windows Kernel Pointer Enumeration Results'
     )
     
-    print_good("Results exported to: #{stored_path}")
+    print_good("Results exported to: #{stored_path} (#{size_str})")
   end
 end

--- a/modules/post/windows/gather/windows_kernel_pointer_enum.rb
+++ b/modules/post/windows/gather/windows_kernel_pointer_enum.rb
@@ -69,27 +69,25 @@ class MetasploitModule < Msf::Post
   end
 
   def validate_environment
-    begin
-      sysinfo = session.sys.config.sysinfo
-      @os = sysinfo['OS']
-      @arch = sysinfo['Architecture']
-      @computer = sysinfo['Computer']
+    sysinfo = session.sys.config.sysinfo
+    @os = sysinfo['OS']
+    @arch = sysinfo['Architecture']
+    @computer = sysinfo['Computer']
 
-      print_status("Target: #{@computer}")
-      print_status("OS: #{@os}")
-      print_status("Arch: #{@arch}")
-      print_status("User: #{session.sys.config.getuid}")
+    print_status("Target: #{@computer}")
+    print_status("OS: #{@os}")
+    print_status("Arch: #{@arch}")
+    print_status("User: #{session.sys.config.getuid}")
 
-      unless @arch =~ /x64|64|amd64/i
-        print_error('This module only supports x64 systems')
-        return false
-      end
-
-      true
-    rescue StandardError => e
-      print_error("Failed to get system info: #{e.message}")
-      false
+    unless @arch =~ /x64|64|amd64/i
+      print_error('This module only supports x64 systems')
+      return false
     end
+
+    true
+  rescue StandardError => e
+    print_error("Failed to get system info: #{e.message}")
+    false
   end
 
   def display_results


### PR DESCRIPTION
This auxiliary module enumerates kernel object pointers exposed via NtQuerySystemInformation (SystemExtendedHandleInformation) on x64 Windows systems.

It provides statistical analysis of pointer distribution, object types, and ALPC usage for research and educational purposes.

This module does not attempt privilege escalation or memory manipulation. It strictly collects observable handle metadata.

**Tested Platforms:**

- Windows 10 2004 (Build 19041) x64

- Meterpreter session

- Tested under SYSTEM and standard user contexts

**Small Snippet from Output ->**

```
[*] Enumerated 5561 kernel object pointers
[*] Address range: 0xffff888708c63d20 - 0xffffaf857d5117b0
[*] Found ALPC pointers in 69 processes
```
**Intended Use Cases**

- Educational study of Windows handle table internals

- Observing kernel pointer exposure patterns across Windows versions

- Research into ALPC object distribution and handle metadata
