### PR TITLE
Fix nessus service import crash

### DIFF
--- a/lib/msf/core/db_manager/import/nessus/xml/v2.rb
+++ b/lib/msf/core/db_manager/import/nessus/xml/v2.rb
@@ -67,6 +67,10 @@ module Msf::DBManager::Import::Nessus::XML::V2
         )
       end
 
+      mapped_protos = {
+        'rmi-p4' => 'tcp'
+      }
+
       host['ports'].each do |item|
         next if item['port'] == 0
         msf = nil
@@ -74,6 +78,7 @@ module Msf::DBManager::Import::Nessus::XML::V2
         nasl_name = item['nasl_name'].to_s
         port = item['port'].to_s
         proto = item['proto'] ? item['proto'].downcase : "tcp"
+        proto = mapped_protos[proto] if mapped_protos[proto]
         sname = item['svc_name']
         severity = item['severity']
         description = item['description']
@@ -81,6 +86,12 @@ module Msf::DBManager::Import::Nessus::XML::V2
         bid = item['bid']
         xref = item['xref']
         msf = item['msf']
+
+        next if proto.casecmp?('icmp')
+        unless Mdm::Service::PROTOS.include?(proto)
+          elog("Unknown protocol '#{proto}' for #{addr}:#{port} for nessus import, defaulting to tcp")
+          proto = "tcp"
+        end
 
         yield(:port,port) if block
 


### PR DESCRIPTION
Fix nessus service import crash

## Verification

Original command:
```
db_import example.nessus
```

Test data which caused the issue, protocol `RMI-P4`

```
<ReportItem port="50204" svc_name="RMI-P4" protocol="tcp" severity="0" pluginID="11219" pluginName="Nessus SYN scanner" pluginFamily="Port scanners">
<ReportItem port="50204" svc_name="unknown" protocol="RMI-P4" severity="0" pluginID="93374" pluginName="SAP RMI-P4 Protocol Detection" pluginFamily="Service detection">
```

Other issues spotted which will need to be fixed:

```
[03/02/2026 17:40:20] [d(0)] core: Skipping service since it is not a Hash or Mdm::Service: NilClass
```

Potential fix, but it looks like `vulns` shouldn't be importing for everything in the nessus file:

```diff
--- a/lib/msf/core/db_manager/import/nessus/xml/v2.rb
+++ b/lib/msf/core/db_manager/import/nessus/xml/v2.rb
@@ -121,8 +121,9 @@ module Msf::DBManager::Import::Nessus::XML::V2
       info[:name] = name
     end
 
+    service = nil
     if port.to_i != 0
-      msf_import_service(info)
+      service = msf_import_service(info)
     end
 
     if nasl.nil? || nasl.empty? || nasl == 0 || nasl == "0"
@@ -164,6 +165,7 @@ module Msf::DBManager::Import::Nessus::XML::V2
       :info => description ? description : "",
       :refs => refs,
       :task => task,
+      :service => service
     }
 
     if port.to_i != 0
```