### PR TITLE
Ensure nessus icmp vulns are registered

### DIFF
--- a/lib/msf/core/db_manager/import/nessus/xml/v2.rb
+++ b/lib/msf/core/db_manager/import/nessus/xml/v2.rb
@@ -72,6 +72,7 @@ module Msf::DBManager::Import::Nessus::XML::V2
       }
 
       host['ports'].each do |item|
+        # XXX: The value of item['port'] is the string '0' - re-evaluate if this line is required
         next if item['port'] == 0
         msf = nil
         nasl = item['nasl'].to_s
@@ -87,7 +88,6 @@ module Msf::DBManager::Import::Nessus::XML::V2
         xref = item['xref']
         msf = item['msf']
 
-        next if proto.casecmp?('icmp')
         unless Mdm::Service::PROTOS.include?(proto)
           elog("Unknown protocol '#{proto}' for #{addr}:#{port} for nessus import, defaulting to tcp")
           proto = "tcp"


### PR DESCRIPTION
Ensure imported nessus icmp vulnerabilities are registered correctly

Continuation of https://github.com/rapid7/metasploit-framework/pull/21044

## Verification

If you have access to the private qa repo `db_import qa/import_files/nessusv2.nessus` and verify there are 686 vulns registered, i.e. the icmp vulns should be present:

```
msf auxiliary(gather/asrep) > vulns

Vulnerabilities
===============

Timestamp                Host           Service                      Resource  Name                                                                        References
---------                ----           -------                      --------  ----                                                                        ----------
...
2026-03-03 08:57:44 UTC  192.168.0.3    None                         {}        ICMP Timestamp Request Remote Date Disclosure                               CVE-1999-0524,OSVDB-94,NSS-10114
...
2026-03-03 09:02:22 UTC  192.168.0.10   None                         {}        ICMP Timestamp Request Remote Date Disclosure                               CVE-1999-0524,OSVDB-94,NSS-10114
...
```