### PR TITLE
Updates description for BeyondTrust command injection

### DIFF
--- a/modules/exploits/linux/http/beyondtrust_pra_rs_command_injection.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_command_injection.rb
@@ -18,15 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'BeyondTrust Privileged Remote Access (PRA) and Remote Support (RS) unauthenticated Remote Code Execution',
         'Description' => %q{
           This exploit achieves unauthenticated remote code execution against BeyondTrust Privileged Remote
-          Access (PRA) and Remote Support (RS). It leverages three different vulnerabilities depending on the
-          user-selected target.
-
-          The default target leverages CVE-2026-1731, a direct command injection affecting RS versions 25.3.1
-          and prior, and PRA versions 24.3.4 and prior.
-
-          Alternatively, the module can leverage a chain of CVE-2025-1094 (SQL injection in PostgreSQL)
-          and CVE-2024-12356 (argument injection), affecting RS and PRA versions 24.3.1 and prior.
-
+          Access (PRA) and Remote Support (RS). The module targets CVE-2026-1731, a direct command injection affecting RS versions 25.3.1 and prior, and PRA versions 24.3.4 and prior.
           Exploitation occurs with the privileges of the site user of the targeted BeyondTrust product site.
         },
         'License' => MSF_LICENSE,


### PR DESCRIPTION
This fixes the description in the new BeyondTrust module - as it was previously part of different BeyondTrust module, the description still mentioned the original module. This PR removes the unnecessary parts and adjust the description to the current state of module.