### PR TITLE
better wriable_dir for windows persistence

### DIFF
--- a/lib/msf/core/exploit/local/persistence.rb
+++ b/lib/msf/core/exploit/local/persistence.rb
@@ -39,12 +39,12 @@ module Msf
     def writable_dir
       # base the WritableDir default off of the persistence module path to avoid
       # needing to probe the target directly, or deal with one offs like ssh sessions
-      return datastore['WritableDir'] unless datastore['WritableDir'].empty?
+      return expand_path(datastore['WritableDir']) unless datastore['WritableDir'].empty?
 
       mod_path = self.class.file_path.downcase.tr('\\', '/')
 
       if mod_path.include?('/windows/')
-        '%TEMP%'
+        expand_path('%TEMP%')
       elsif mod_path.include?('/multi/')
         print_warning('Please set the WritableDir datastore option or the module is likely to fail')
         ''

--- a/modules/exploits/multi/persistence/burp_extension.rb
+++ b/modules/exploits/multi/persistence/burp_extension.rb
@@ -98,9 +98,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def get_userconfig_path

--- a/modules/exploits/multi/persistence/burp_extension.rb
+++ b/modules/exploits/multi/persistence/burp_extension.rb
@@ -96,15 +96,6 @@ class MetasploitModule < Msf::Exploit::Local
     return cmd_exec('echo ~').strip
   end
 
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
-  end
-
   def get_userconfig_path
     unless datastore['CONFIG_FILE'].blank?
       return nil unless file?(datastore['CONFIG_FILE'])

--- a/modules/exploits/windows/persistence/accessibility_features_debugger.rb
+++ b/modules/exploits/windows/persistence/accessibility_features_debugger.rb
@@ -124,15 +124,6 @@ class MetasploitModule < Msf::Exploit::Local
     "#{DEBUG_REG_PATH}\\#{get_target_exe_name}"
   end
 
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
-  end
-
   def check
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
     return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)

--- a/modules/exploits/windows/persistence/accessibility_features_debugger.rb
+++ b/modules/exploits/windows/persistence/accessibility_features_debugger.rb
@@ -126,9 +126,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/assistive_technology.rb
+++ b/modules/exploits/windows/persistence/assistive_technology.rb
@@ -74,9 +74,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/assistive_technology.rb
+++ b/modules/exploits/windows/persistence/assistive_technology.rb
@@ -72,15 +72,6 @@ class MetasploitModule < Msf::Exploit::Local
     registry_setvaldata(target_key, 'TerminateOnDesktopSwitch', 0, 'REG_DWORD')
   end
 
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
-  end
-
   def check
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
     return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
@@ -107,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Local
     create_at(at_name, payload_pathname)
     vprint_status('Setting AT to start during login')
     current_value = registry_getvaldata(STARUP_REG_PATH, 'Configuration')
-    new_value = current_value.empty? ? [] : current_value.split(',').map(&:strip)
+    new_value = (current_value.nil? || current_value.empty?) ? [] : current_value.split(',').map(&:strip)
     new_value.append(at_name)
     registry_setvaldata(STARUP_REG_PATH, 'Configuration', new_value.join(','), 'REG_SZ')
 

--- a/modules/exploits/windows/persistence/image_exec_options.rb
+++ b/modules/exploits/windows/persistence/image_exec_options.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Local
           'bwatters-r7', # msf module
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ],
+        'SessionTypes' => ['meterpreter', 'shell'],
         'Targets' => [
           [ 'Automatic', {} ]
         ],
@@ -64,15 +64,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('IMAGE_FILE', [true, 'Binary to "debug"', nil])
 
     ])
-  end
-
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/image_exec_options.rb
+++ b/modules/exploits/windows/persistence/image_exec_options.rb
@@ -68,9 +68,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -34,7 +34,8 @@ class MetasploitModule < Msf::Exploit::Local
           'h00die',
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ],
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'Targets' => [
           [ 'Automatic', {} ]
         ],
@@ -62,15 +63,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   def regkey
     'HKLM\\Software\\Microsoft\\Active Setup\\Installed Components'
-  end
-
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/registry_active_setup.rb
+++ b/modules/exploits/windows/persistence/registry_active_setup.rb
@@ -66,9 +66,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Local
           'h00die',
         ],
         'Platform' => [ 'win' ],
-        'Arch' => [ARCH_X86, ARCH_X64],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'SessionTypes' => [ 'meterpreter', 'shell' ],
         'Targets' => [
           [ 'Automatic', {} ]
@@ -56,15 +56,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   def regkey
     'HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon'
-  end
-
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/registry_userinit.rb
+++ b/modules/exploits/windows/persistence/registry_userinit.rb
@@ -60,9 +60,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/service.rb
+++ b/modules/exploits/windows/persistence/service.rb
@@ -69,9 +69,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/service.rb
+++ b/modules/exploits/windows/persistence/service.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'Platform' => [ 'windows' ],
         'Targets' => [['Windows', {}]],
-        'SessionTypes' => [ 'meterpreter' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
         'Privileged' => true,
         'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'DefaultTarget' => 0,
@@ -65,15 +65,6 @@ class MetasploitModule < Msf::Exploit::Local
         OptEnum.new('METHOD', [false, 'Which method to register and start the service', 'Auto', ['Auto', 'API', 'Powershell', 'sc.exe']]),
       ]
     )
-  end
-
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/task_scheduler.rb
+++ b/modules/exploits/windows/persistence/task_scheduler.rb
@@ -62,9 +62,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def writable_dir
     d = super
-    return session.sys.config.getenv(d) if d.start_with?('%')
-
-    d
+    d.gsub(/%[^%]+%/) do |key|
+      val = session.sys.config.getenv(key)
+      # If nothing found, keep the original token and hope/pray it works on the system magically
+      val.nil? || val.empty? ? key : val
+    end
   end
 
   def check

--- a/modules/exploits/windows/persistence/task_scheduler.rb
+++ b/modules/exploits/windows/persistence/task_scheduler.rb
@@ -60,15 +60,6 @@ class MetasploitModule < Msf::Exploit::Local
     )
   end
 
-  def writable_dir
-    d = super
-    d.gsub(/%[^%]+%/) do |key|
-      val = session.sys.config.getenv(key)
-      # If nothing found, keep the original token and hope/pray it works on the system magically
-      val.nil? || val.empty? ? key : val
-    end
-  end
-
   def check
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
     return CheckCode::Safe("#{writable_dir} doesn't exist") unless exists?(writable_dir)


### PR DESCRIPTION
@adfoster-r7 addresses comment: https://github.com/rapid7/metasploit-framework/pull/20843#discussion_r2694660495

If this works and you're happy with it @adfoster-r7 I'll add it to #20814 #20839 #20843 

I created a temp module to help test with (its got a lot of extraneous stuff, but the `check` function shows the expansion):
```
##
# This module requires Metasploit: https://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

class MetasploitModule < Msf::Exploit::Local
  Rank = ExcellentRanking

  include Msf::Post::File
  include Msf::Exploit::EXE
  include Msf::Exploit::Local::Persistence
  prepend Msf::Exploit::Remote::AutoCheck
  include Msf::Post::Windows::Registry
  include Msf::Post::Windows::Priv

  AT_REG_PATH = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Accessibility\\ATs'
  STARUP_REG_PATH = 'HKCU\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Accessibility'

  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Writable Dir Test',
        'Description' => %q{
          This module achieves persistence by registering a custom Assistive Technology (AT) in the Windows registry.
          Then it configures the system to launch the AT executable during user logon or desktop switch (such as with
          an admin prived program).
          Requires Windows 8 or higher and administrative privileges.
        },
        'Author' => ['h00die'],
        'Platform' => ['win'],
        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
        'SessionTypes' => ['meterpreter', 'shell'],
        'References' => [
          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
          ['ATT&CK', Mitre::Attack::Technique::T1546_008_ACCESSIBILITY_FEATURES],
          ['URL', 'https://www.hexacorn.com/blog/2016/07/22/beyond-good-ol-run-key-part-42/'],
          ['URL', 'https://msdn.microsoft.com/ru-ru/library/windows/desktop/bb879984.aspx']
        ],
        'Targets' => [
          [ 'Automatic', {} ]
        ],
        'DefaultTarget' => 0,
        'DisclosureDate' => '2016-07-22',
        'Notes' => {
          'Stability' => [CRASH_SAFE],
          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
        }
      )
    )

    register_options([
      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
      OptString.new('NAME', [false, 'Name of assistive technolog to create. Random string as default.']),
      OptString.new('DESCRIPTION', [false, 'Description of assistive technolog to create. Random string as default.']),
    ])
  end

  def writable_dir
    d = super
    expanded = d.gsub(/%([^%]+)%/) do
      key = "%#{::Regexp.last_match(1)}%"
      val = session.sys.config.getenv(key)

      # If nothing found, keep the original token and hope/pray it works on the system magically
      val.nil? || val.empty? ? key : val
    end
    expanded
  end

  def check
    puts writable_dir
  end

  def install_persistence
  end
end

```

And showing it works:

```
msf exploit(multi/script/web_delivery) > use exploit/windows/persistence/tester 
[*] Using configured payload windows/meterpreter/reverse_tcp
msf exploit(windows/persistence/tester) > set session 1
session => 1
msf exploit(windows/persistence/tester) > set writabledir %TEMP%/test
writabledir => %TEMP%/test
msf exploit(windows/persistence/tester) > exploit
[*] Exploit running as background job 1.
[*] Exploit completed, but no session was created.
msf exploit(windows/persistence/tester) > 
[*] Started reverse TCP handler on 1.1.1.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
C:\Users\windows\AppData\Local\Temp/test
```
