### PR TITLE
New module For LDAP Signing Check

### DIFF
--- a/modules/auxiliary/scanner/ldap/ldap_signing_check.rb
+++ b/modules/auxiliary/scanner/ldap/ldap_signing_check.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::LDAP
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'LDAP Signing Requirement Check',
+        'Description' => %q{
+          This module checks whether an LDAP server enforces LDAP signing.
+
+          The module attempts an authenticated LDAP bind while forcing
+          LDAP signing to be disabled. If the server requires signing,
+          the bind will fail indicating that stronger authentication is required.
+
+          This behavior is commonly observed on Microsoft Active Directory
+          Domain Controllers where the policy "Domain controller: LDAP
+          server signing requirements" is set to "Require signing".
+        },
+        'Author' => [
+          'Bhaskar Bhar',
+          'Spencer McIntyre'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://github.com/rapid7/metasploit-framework/pull/19127'],
+          ['URL', 'https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/enable-ldap-signing-in-windows-server']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(389)
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptEnum.new(
+          'LDAP::Signing',
+          [true, 'LDAP signing behavior', 'disabled', ['auto', 'disabled', 'required']]
+        )
+      ]
+    )
+  end
+
+  def run_host(_ip)
+    print_status("#{ip}:#{rport} - Checking LDAP signing enforcement")
+
+    begin
+      ldap_connect do |ldap|
+        if ldap.bind
+          print_good("#{ip}:#{rport} - LDAP signing NOT required")
+        else
+          print_good("#{ip}:#{rport} - LDAP signing is required or enforced")
+        end
+      end
+    rescue StandardError => e
+      if e.message.downcase.include?('stronger authentication')
+        print_good("#{ip}:#{rport} - LDAP signing is required")
+      else
+        print_error("#{ip}:#{rport} - LDAP error: #{e.message}")
+      end
+    end
+  end
+end

--- a/modules/auxiliary/server/relay/smb_to_ldap.rb
+++ b/modules/auxiliary/server/relay/smb_to_ldap.rb
@@ -2,6 +2,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+require 'net/ldap'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB::RelayServer
@@ -79,8 +80,37 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def check
+    print_status('Checking LDAP server configuration...')
+
+    begin
+      ldap = Net::LDAP.new(
+        host: datastore['RHOSTS'],
+        port: datastore['RPORT'],
+        connect_timeout: 10
+      )
+
+      if ldap.bind
+        print_good('LDAP server allows unsigned binds')
+        return Msf::Exploit::CheckCode::Appears('LDAP signing not required')
+      else
+        print_error('LDAP signing likely required')
+        return Msf::Exploit::CheckCode::Safe('LDAP signing required')
+      end
+    rescue ::Rex::ConnectionError
+      print_error('Could not connect to the LDAP server')
+      print_status("Check if the target is reachable and LDAP port #{datastore['RPORT']} is open")
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    rescue Net::LDAP::Error => e
+      print_error("LDAP connection error: #{e}")
+      print_status('The LDAP server may be unreachable or blocked by a firewall')
+      return Msf::Exploit::CheckCode::Unknown('LDAP error occurred')
+    end
+  end
+
   def run
     check_options
+    check
 
     start_service
     print_status('Server started.')

--- a/modules/auxiliary/server/relay/smb_to_ldap.rb
+++ b/modules/auxiliary/server/relay/smb_to_ldap.rb
@@ -80,34 +80,6 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def check
-    print_status('Checking LDAP server configuration...')
-
-    begin
-      ldap = Net::LDAP.new(
-        host: datastore['RHOSTS'],
-        port: datastore['RPORT'],
-        connect_timeout: 10
-      )
-
-      if ldap.bind
-        print_good('LDAP server allows unsigned binds')
-        return Msf::Exploit::CheckCode::Appears('LDAP signing not required')
-      else
-        print_error('LDAP signing likely required')
-        return Msf::Exploit::CheckCode::Safe('LDAP signing required')
-      end
-    rescue ::Rex::ConnectionError
-      print_error('Could not connect to the LDAP server')
-      print_status("Check if the target is reachable and LDAP port #{datastore['RPORT']} is open")
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
-    rescue Net::LDAP::Error => e
-      print_error("LDAP connection error: #{e}")
-      print_status('The LDAP server may be unreachable or blocked by a firewall')
-      return Msf::Exploit::CheckCode::Unknown('LDAP error occurred')
-    end
-  end
-
   def run
     check_options
     check


### PR DESCRIPTION

# auxiliary/server/relay/smb_to_ldap: add LDAP configuration check before starting relay

## Summary

This PR adds a **pre-execution LDAP configuration check** to the module:

`auxiliary/server/relay/smb_to_ldap`

The module now attempts an **anonymous LDAP bind** before starting the SMB relay server in order to determine whether unsigned LDAP communication is allowed.

If the bind succeeds, the module informs the user that unsigned binds are permitted and that SMB→LDAP relay may succeed.  
If the bind fails, the module warns that LDAP signing or authentication requirements may prevent relay attacks.

This improvement provides early feedback to operators and avoids running relay attacks against targets where LDAP signing or authentication requirements will cause them to fail.

Fixes: https://github.com/rapid7/metasploit-framework/issues/20468

---

# Verification

### Test Environment

Attacker:
```
Debian
Metasploit Framework (development build)
```

LDAP Server(For my case it was Debian 13 so I used OpenLDAP):
```
OpenLDAP (slapd)
```

Base DN(Example):

```
dc=lab,dc=local
```

---

## Scenario 1 — LDAP allows unsigned binds

Steps:

- Start `msfconsole`
- `use auxiliary/server/relay/smb_to_ldap`
- `set RHOSTS 127.0.0.1`
- `run`

Expected output:

```
[*] Checking LDAP server configuration...
[+] LDAP server allows unsigned binds
[*] SMB Server is running. Listening on 0.0.0.0:445
```

This confirms the module correctly detects that unsigned LDAP binds are allowed.

---

## Scenario 2 — Anonymous bind disabled

Anonymous bind was disabled to simulate a secured LDAP configuration.

Command used:

```bash
sudo ldapmodify -Y EXTERNAL -H ldapi:/// <<EOF
dn: cn=config
changetype: modify
add: olcDisallows
olcDisallows: bind_anon
EOF
```

After restarting `slapd`, anonymous bind fails:

```
ldap_bind: Inappropriate authentication (48)
additional info: anonymous bind disallowed
```

Running the module again:

- `use auxiliary/server/relay/smb_to_ldap`
- `set RHOSTS 127.0.0.1`
- `run`

Expected output:

```
[*] Checking LDAP server configuration...
[-] LDAP signing likely required
[*] SMB Server is running. Listening on 0.0.0.0:445
```

This confirms the module correctly warns that relay is likely to fail.

---

## Notes

This check detects **anonymous bind behavior**, which commonly correlates with LDAP signing or authentication requirements. While it does not directly detect LDAP signing policy, it provides useful early feedback before running the relay server.

---

## Screenshots

Two screenshots are attached showing:

1. LDAP unsigned bind allowed  
<img width="830" height="166" alt="Screenshot 2026-03-04 092715" src="https://github.com/user-attachments/assets/bd8aedd7-3895-41ea-bdd0-6e14c05c7ad0" />

2. Anonymous bind disabled
<img width="819" height="200" alt="Screenshot 2026-03-04 093119" src="https://github.com/user-attachments/assets/426f235c-8c61-42ca-abfb-1970427665f8" />
