### PR TITLE
Extend automatic encoder selection to payloads module

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -560,10 +560,8 @@ class Payload < Msf::Module
 
     # Prefer encoders that are known to be reliable
     preferred_encoders = [
-      'generic/none',
       'x86/shikata_ga_nai',
-      'x64/zutto_dekiru',
-      'cmd/base64',
+      'cmd/base64'
     ]
 
     preferred_encoders.each do |type|

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -567,8 +567,11 @@ class Payload < Msf::Module
 
       return configure_encoder.call(encoder)
     end
-
-    return compatible_encoders&.first
+    encoder = compatible_encoders&.first
+    if encoder
+      return configure_encoder.call(encoder)
+    end
+    nil
   end
 
   #

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -543,7 +543,8 @@ class Payload < Msf::Module
       else
         mod.datastore['ENCODER'] = encoder
       end
-
+      e = mod.framework.encoders.create(encoder)
+      e.share_datastore(mod.datastore)
       encoder
     end
 

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -528,8 +528,12 @@ class Payload < Msf::Module
   end
 
   def self.choose_encoder(mod)
-    payload_name = mod.datastore['PAYLOAD']
-    payload = mod.framework.payloads.create(payload_name)
+    if mod.type == Msf::MODULE_PAYLOAD
+      payload = mod
+    else
+      payload_name = mod.datastore['PAYLOAD']
+      payload = mod.framework.payloads.create(payload_name)
+    end
     return nil unless payload
     compatible_encoders = payload.compatible_encoders.map(&:first)
     configure_encoder = lambda do |encoder|

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -535,7 +535,14 @@ class Payload < Msf::Module
       payload = mod.framework.payloads.create(payload_name)
     end
     return nil unless payload
-    compatible_encoders = payload.compatible_encoders.map(&:first)
+    
+    begin
+      compatible_encoders = payload.compatible_encoders.map(&:first)
+    rescue Msf::NoCompatiblePayloadError
+      # If there are no compatible encoders or searching for compatible encoder fails (generic payloads), we will use the generic/none encoder, which doesn't actually do any encoding but will allow payloads that require an encoder to be used
+      compatible_encoders = ["generic/none"]
+    end
+
     configure_encoder = lambda do |encoder|
       if payload.datastore.is_a?(Msf::DataStore)
         payload_defaults = { 'ENCODER' => encoder }
@@ -547,7 +554,6 @@ class Payload < Msf::Module
       e.share_datastore(mod.datastore)
       encoder
     end
-
     # If there is only one compatible encoder, return it immediately
     if compatible_encoders.length == 1
       return configure_encoder.call(compatible_encoders.first)

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -440,13 +440,14 @@ class Payload < Msf::Module
   # Returns the array of compatible encoders for this payload instance.
   #
   def compatible_encoders
-    encoders = []
+    # generic/none should always be option
+    encoders = [ ["generic/none" , framework.encoders['generic/none']] ]
 
     framework.encoders.each_module_ranked(
       'Arch' => self.arch, 'Platform' => self.platform) { |name, mod|
       encoders << [ name, mod ]
     }
-
+    
     return encoders
   end
 
@@ -535,12 +536,10 @@ class Payload < Msf::Module
       payload = mod.framework.payloads.create(payload_name)
     end
     return nil unless payload
-    
+
     begin
-      compatible_encoders = payload.compatible_encoders.map(&:first)
+      compatible_encoders = payload.compatible_encoders.map(&:first)    
     rescue Msf::NoCompatiblePayloadError
-      # If there are no compatible encoders or searching for compatible encoder fails (generic payloads), we will use the generic/none encoder, which doesn't actually do any encoding but will allow payloads that require an encoder to be used
-      compatible_encoders = ["generic/none"]
     end
 
     configure_encoder = lambda do |encoder|
@@ -561,6 +560,7 @@ class Payload < Msf::Module
 
     # Prefer encoders that are known to be reliable
     preferred_encoders = [
+      'generic/none',
       'x86/shikata_ga_nai',
       'x64/zutto_dekiru',
       'cmd/base64',

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -560,7 +560,6 @@ class Payload < Msf::Module
 
     # Prefer encoders that are known to be reliable
     preferred_encoders = [
-      'x86/shikata_ga_nai',
       'cmd/base64'
     ]
 

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -272,6 +272,9 @@ module Msf
             options = tab_complete_option(active_module, str, words)
             flags + options
           end
+          def self.choose_encoder(mod)
+            Msf::Payload.choose_encoder(mod)
+          end
         end
       end
     end


### PR DESCRIPTION
automatic encoder selection for payloads when using `use payload/< payload>`

```
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > use payload/cmd/linux/http/mipsbe/meterpreter/reverse_tcp 
[*] No encoder configured, defaulting to cmd/base64
msf payload(cmd/linux/http/mipsbe/meterpreter/reverse_tcp) >
```