### PR TITLE
Update metasploit data models

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ PATH
       metasploit-credential
       metasploit-model
       metasploit-payloads (= 2.0.240)
-      metasploit_data_models (>= 6.0.7)
+      metasploit_data_models (>= 6.0.15)
       metasploit_payloads-mettle (= 1.0.46)
       mqtt
       msgpack (~> 1.6.0)
@@ -353,7 +353,7 @@ GEM
       mutex_m
       railties (~> 7.0)
     metasploit-payloads (2.0.240)
-    metasploit_data_models (6.0.12)
+    metasploit_data_models (6.0.15)
       activerecord (~> 7.0)
       activesupport (~> 7.0)
       arel-helpers

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_21_114306) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_30_124052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -576,6 +576,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_21_114306) do
     t.index ["module_run_id"], name: "index_sessions_on_module_run_id"
   end
 
+  create_table "sessions_tags", force: :cascade do |t|
+    t.integer "session_id"
+    t.integer "tag_id"
+    t.index ["session_id", "tag_id"], name: "index_sessions_tags_on_session_id_and_tag_id", unique: true
+  end
+
   create_table "tags", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "name", limit: 1024
@@ -646,6 +652,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_21_114306) do
     t.string "company"
     t.string "prefs", limit: 524288
     t.boolean "admin", default: true, null: false
+    t.boolean "sso_enabled", default: false, null: false
   end
 
   create_table "vuln_attempts", id: :serial, force: :cascade do |t|

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |spec|
   # Metasploit::Credential database models
   spec.add_runtime_dependency 'metasploit-credential'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models', '>= 6.0.7'
+  spec.add_runtime_dependency 'metasploit_data_models', '>= 6.0.15'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'


### PR DESCRIPTION
Update metasploit data models to pull in:

https://github.com/rapid7/metasploit_data_models/compare/v6.0.12...v6.0.15

Specifically, these are pre-requisite pull requests for supporting single sign on in Metasploit Pro and adding tags to sessions

## Verification

Ensure CI passes