### PR TITLE
Fix duplicate handler jobs caused by stop_handler on repeated run

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -239,11 +239,13 @@ module ReverseHttp
     self.service.server_name = datastore['HttpServerName']
 
     # Add the new resource
-    service.add_resource((luri + "/").gsub("//", "/"),
+    resource_path = (luri + "/").gsub("//", "/")
+    service.add_resource(resource_path,
       'Proc' => Proc.new { |cli, req|
         on_request(cli, req)
       },
       'VirtualDirectory' => true)
+    self.resource_added = true
 
     print_status("Started #{scheme.upcase} reverse handler on #{listener_uri(local_addr)}")
     lookup_proxy_settings
@@ -259,13 +261,17 @@ module ReverseHttp
   #
   def stop_handler
     if self.service
-      self.service.remove_resource((luri + "/").gsub("//", "/"))
+      if self.resource_added
+        self.service.remove_resource((luri + "/").gsub("//", "/"))
+        self.resource_added = false
+      end
       self.service.deref
       self.service = nil
     end
   end
 
   attr_accessor :service # :nodoc:
+  attr_accessor :resource_added # :nodoc:
 
 protected
 

--- a/spec/lib/msf/core/handler/reverse_http_spec.rb
+++ b/spec/lib/msf/core/handler/reverse_http_spec.rb
@@ -32,6 +32,40 @@ RSpec.describe Msf::Handler::ReverseHttp do
 
   end
 
+  describe '#stop_handler' do
+    let(:mock_service) { double('service') }
+    let(:payload) { create_payload }
+
+    context 'when add_resource raised and resource was not added' do
+      before do
+        payload.service = mock_service
+        payload.resource_added = false
+      end
+
+      it 'does not remove the resource but still derefs the service' do
+        expect(mock_service).not_to receive(:remove_resource)
+        expect(mock_service).to receive(:deref)
+        payload.stop_handler
+        expect(payload.service).to be_nil
+      end
+    end
+
+    context 'when the resource was successfully added' do
+      before do
+        payload.service = mock_service
+        payload.resource_added = true
+      end
+
+      it 'removes the resource and derefs the service' do
+        expect(mock_service).to receive(:remove_resource).with('/')
+        expect(mock_service).to receive(:deref)
+        payload.stop_handler
+        expect(payload.service).to be_nil
+        expect(payload.resource_added).to eq(false)
+      end
+    end
+  end
+
   describe '#luri' do
     subject(:luri) do
       create_payload.luri


### PR DESCRIPTION
Fixes #19958 

Running the same ```exploit/multi/handler``` three times on the same port results in 2 jobs where only 1 should exist. The root cause is in ```stop_handler``` in ```reverse_http.rb```, when a handler fails because the ```/``` resource is already registered, its cleanup still removes that resource from the shared HTTP server, even though it was not the one that added it. This allows the next attempt to re register the resource and create a duplicate job.
The fix tracks whether each handler instance successfully added its resource via a ```resource_added``` flag, and only removes it in ```stop_handler``` if it was the one that added it.


## Verification


- Start msfconsole
- use exploit/multi/handler
- set payload windows/x64/meterpreter/reverse_https
- set LHOST lo
- run -j
- Wait ~1 second
- run -j
- Wait ~1 second
- run -j
- jobs
- Verify only 1 job is listed
- Verify the 2nd and 3rd runs both fail with The supplied resource '/' is already added.
- Verify the first handler still functions correctly and can receive connections