### PR TITLE
Add KerberosTicketTrace support for AS/TGS/AP exchanges

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'msf/core/exploit/remote/kerberos/clock_skew'
+require 'rex/proto/kerberos/kerberos_logger_subscriber'
 
 module Msf
   class Exploit
@@ -46,7 +47,9 @@ module Msf
             register_advanced_options(
               [
                 OptString.new('KrbClockSkew', [true, 'Adjust Kerberos client clock by this offset (e.g. 90s, -5m, 1h)', '0s'],
-                              regex: Msf::Exploit::Remote::Kerberos::ClockSkew::CLOCK_SKEW_REGEX)
+                              regex: Msf::Exploit::Remote::Kerberos::ClockSkew::CLOCK_SKEW_REGEX),
+                OptBool.new('KerberosTicketTrace', [false, 'Show AS/TGS/AP Kerberos requests and responses', false]),
+                OptString.new('KerberosTicketTraceColors', [false, 'Kerberos request and response colors for KerberosTicketTrace (unset to disable)', 'red/blu'])
               ], self.class
             )
           end
@@ -134,6 +137,7 @@ module Msf
             remote_host = has_session ? session.client.peerhost : rhost
             # Can't use session.client.rport as a fallback here with an LDAP session as that's port 389. We need port 88.
             remote_port = has_session ? 88 : rport
+            subscriber = opts.key?(:subscriber) ? opts[:subscriber] : kerberos_trace_subscriber
 
             kerb_client = Rex::Proto::Kerberos::Client.new(
               host: opts[:rhost] || remote_host,
@@ -144,7 +148,8 @@ module Msf
                 'Msf' => framework,
                 'MsfExploit' => framework_module
               },
-              protocol: 'tcp'
+              protocol: 'tcp',
+              subscriber: subscriber
             )
 
             disconnect if kerberos_client
@@ -487,6 +492,16 @@ module Msf
 
           def framework_module
             self
+          end
+
+          def kerberos_trace_subscriber
+            logger = framework_module
+
+            if logger.respond_to?(:print_line) && logger.respond_to?(:datastore)
+              Rex::Proto::Kerberos::KerberosLoggerSubscriber.new(logger: logger)
+            else
+              Rex::Proto::Kerberos::KerberosSubscriber.new
+            end
           end
 
           private

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -664,6 +664,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     options.fetch(:ticket_storage, @ticket_storage).store_ccache(ccache, host: rhost)
 
     credential = ccache.credentials.first
+    kerberos_trace_subscriber.on_credential(credential, source: 'TGT')
     session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
       type: credential.keyblock.enctype.value,
       value: credential.keyblock.data.value
@@ -782,6 +783,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       client: client,
       server: sname
     )
+    credential = ccache.credentials.first
+    kerberos_trace_subscriber.on_credential(credential, source: 'TGS')
 
     tgs_ticket = tgs_res.ticket
     tgs_auth = decrypt_kdc_tgs_rep_enc_part(
@@ -790,7 +793,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
 
-    [tgs_ticket, tgs_auth, ccache.credentials.first]
+    [tgs_ticket, tgs_auth, credential]
   end
 
   private
@@ -1073,8 +1076,10 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     )
 
     ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(delegated_tgs_res, delegated_tgs_auth)
+    delegated_credential = ccache.credentials.first
+    kerberos_trace_subscriber.on_credential(delegated_credential, source: 'Delegation TGS')
 
-    [delegated_tgs_ticket, delegated_tgs_auth, ccache.credentials.first]
+    [delegated_tgs_ticket, delegated_tgs_auth, delegated_credential]
   end
 
   # Search the database for a credential object that can be used for authentication.

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -664,7 +664,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     options.fetch(:ticket_storage, @ticket_storage).store_ccache(ccache, host: rhost)
 
     credential = ccache.credentials.first
-    kerberos_trace_subscriber.on_credential(credential, source: 'TGT')
     session_key = Rex::Proto::Kerberos::Model::EncryptionKey.new(
       type: credential.keyblock.enctype.value,
       value: credential.keyblock.data.value
@@ -783,8 +782,6 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       client: client,
       server: sname
     )
-    credential = ccache.credentials.first
-    kerberos_trace_subscriber.on_credential(credential, source: 'TGS')
 
     tgs_ticket = tgs_res.ticket
     tgs_auth = decrypt_kdc_tgs_rep_enc_part(
@@ -793,7 +790,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       msg_type: Rex::Proto::Kerberos::Crypto::KeyUsage::TGS_REP_ENCPART_SESSION_KEY
     )
 
-    [tgs_ticket, tgs_auth, credential]
+    [tgs_ticket, tgs_auth, ccache.credentials.first]
   end
 
   private
@@ -1076,10 +1073,8 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
     )
 
     ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.from_responses(delegated_tgs_res, delegated_tgs_auth)
-    delegated_credential = ccache.credentials.first
-    kerberos_trace_subscriber.on_credential(delegated_credential, source: 'Delegation TGS')
 
-    [delegated_tgs_ticket, delegated_tgs_auth, delegated_credential]
+    [delegated_tgs_ticket, delegated_tgs_auth, ccache.credentials.first]
   end
 
   # Search the database for a credential object that can be used for authentication.

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -285,7 +285,9 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
       auth_context = authenticate_via_krb5_ccache_credential_tgt(auth_context[:credential], options)
     end
 
-    ap_request_asn1 = auth_context.delete(:service_ap_request).to_asn1
+    service_ap_request = auth_context.delete(:service_ap_request)
+    kerberos_trace_subscriber.on_request(service_ap_request)
+    ap_request_asn1 = service_ap_request.to_asn1
 
     mechanism = options.fetch(:mechanism) { self.mechanism }
     if mechanism == Rex::Proto::Gss::Mechanism::SPNEGO
@@ -332,6 +334,7 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
         }
       when TOK_ID_KRB_ERROR
         krb_err = Rex::Proto::Kerberos::Model::KrbError.decode(data)
+        kerberos_trace_subscriber.on_response(krb_err)
         print_error("#{peer} - Received KRB-ERR.")
 
         raise ::Rex::Proto::Kerberos::Model::Error::KerberosError.new(res: krb_err)

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
@@ -44,6 +44,16 @@ module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
         regex: Msf::Exploit::Remote::Kerberos::ClockSkew::CLOCK_SKEW_REGEX,
         conditions: option_conditions
       ),
+      Msf::OptBool.new(
+        'KerberosTicketTrace',
+        [false, 'Show AS/TGS/AP Kerberos requests and responses', false],
+        conditions: option_conditions
+      ),
+      Msf::OptString.new(
+        'KerberosTicketTraceColors',
+        [false, 'Kerberos request and response colors for KerberosTicketTrace (unset to disable)', 'red/blu'],
+        conditions: option_conditions
+      ),
       Msf::OptAddress.new(
         'DomainControllerRhost',
         [false, 'The resolvable rhost for the Domain Controller'],

--- a/lib/rex/proto/kerberos/client.rb
+++ b/lib/rex/proto/kerberos/client.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex/stopwatch'
+require 'rex/proto/kerberos/kerberos_subscriber'
 
 module Rex
   module Proto
@@ -29,6 +30,9 @@ module Rex
         # @!attribute context
         #   @return [Hash] The Msf context where the connection belongs to
         attr_accessor :context
+        # @!attribute subscriber
+        #   @return [Rex::Proto::Kerberos::KerberosSubscriber] Subscriber used for tracing Kerberos
+        attr_accessor :subscriber
 
         def initialize(opts = {})
           self.host = opts[:host]
@@ -37,6 +41,7 @@ module Rex
           self.timeout  = (opts[:timeout] || 10).to_i
           self.protocol = opts[:protocol] || 'tcp'
           self.context  = opts[:context] || {}
+          self.subscriber = opts[:subscriber] || KerberosSubscriber.new
         end
 
         # Creates a connection through a Rex socket
@@ -76,6 +81,7 @@ module Rex
         # @raise [NotImplementedError] if the transport protocol isn't supported
         def send_request(req)
           connect
+          subscriber.on_request(req)
 
           sent = 0
           case protocol
@@ -112,6 +118,7 @@ module Rex
             raise ::RuntimeError, 'Kerberos Client: unknown transport protocol'
           end
 
+          subscriber.on_response(res)
           res
         end
 

--- a/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
@@ -1,9 +1,11 @@
 # -*- coding: binary -*-
 
 require 'json'
+require 'set'
 require 'time'
 require 'rex/proto/kerberos/model'
 require 'rex/proto/kerberos/kerberos_subscriber'
+require 'rex/proto/kerberos/credential_cache/krb5_ccache_presenter'
 
 module Rex
 module Proto
@@ -11,9 +13,6 @@ module Kerberos
 
   # Logs Kerberos requests/responses
   class KerberosLoggerSubscriber < KerberosSubscriber
-    # Limit binary previews to keep logs readable and avoid dumping large blobs.
-    BINARY_PREVIEW_SIZE = 32
-
     def initialize(logger:)
       super()
       raise RuntimeError, "Incompatible logger" unless logger.respond_to?(:print_line) && logger.respond_to?(:datastore)
@@ -43,6 +42,15 @@ module Kerberos
       @logger.print_line("%clr#{response_color}#{format_message(response)}%clr")
     end
 
+    # (see Rex::Proto::Kerberos::KerberosSubscriber#on_credential)
+    def on_credential(credential, source: nil)
+      return unless trace_enabled?
+      return if credential.nil?
+
+      print_credential_header(source)
+      @logger.print_line(format_credential(credential))
+    end
+
     private
 
     def trace_enabled?
@@ -62,6 +70,12 @@ module Kerberos
     def print_header(direction, message)
       @logger.print_line('#' * 20)
       @logger.print_line("# Kerberos #{direction}: #{message_type_name(message)}")
+      @logger.print_line('#' * 20)
+    end
+
+    def print_credential_header(source)
+      @logger.print_line('#' * 20)
+      @logger.print_line("# Kerberos Credential#{source ? ": #{source}" : ''}")
       @logger.print_line('#' * 20)
     end
 
@@ -101,6 +115,16 @@ module Kerberos
       end
     end
 
+    def format_credential(credential)
+      rendered_credential = ticket_presenter.present_cred(credential)
+      [
+        'Creds: 1',
+        "  Credential[0]:\n#{rendered_credential.indent(4)}"
+      ].join("\n")
+    rescue StandardError => e
+      "Credential presenter error: #{e.class}: #{e.message}"
+    end
+
     def serialize_element(element)
       element.attributes.each_with_object({}) do |attribute, output|
         value = element.public_send(attribute)
@@ -130,10 +154,17 @@ module Kerberos
       case value
       when Array
         value.map { |entry| serialize_value(entry) }
+      when Set
+        value.to_a.map { |entry| serialize_value(entry) }
       when Hash
         value.each_with_object({}) do |(key, entry), output|
           output[key.to_s] = serialize_value(entry)
         end
+      when Rex::Proto::Kerberos::Model::KerberosFlags
+        {
+          'value' => value.to_i,
+          'flags' => value.enabled_flag_names.map(&:to_s)
+        }
       when Time
         value.utc.iso8601
       when String
@@ -154,10 +185,12 @@ module Kerberos
     def serialize_string(value)
       return value if printable_string?(value)
 
-      # Show a short hex prefix when strings are binary/non-printable.
-      preview = value.byteslice(0, BINARY_PREVIEW_SIZE).to_s.unpack1('H*')
-      suffix = value.bytesize > BINARY_PREVIEW_SIZE ? '...' : ''
-      "[binary #{value.bytesize} bytes: #{preview}#{suffix}]"
+      # Expand binary/non-printable strings fully in hex.
+      "[binary #{value.bytesize} bytes: #{value.unpack1('H*')}]"
+    end
+
+    def ticket_presenter
+      @ticket_presenter ||= Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(nil)
     end
 
     def printable_string?(value)

--- a/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
@@ -1,11 +1,9 @@
 # -*- coding: binary -*-
 
 require 'json'
-require 'set'
 require 'time'
 require 'rex/proto/kerberos/model'
 require 'rex/proto/kerberos/kerberos_subscriber'
-require 'rex/proto/kerberos/credential_cache/krb5_ccache_presenter'
 
 module Rex
 module Proto
@@ -13,6 +11,9 @@ module Kerberos
 
   # Logs Kerberos requests/responses
   class KerberosLoggerSubscriber < KerberosSubscriber
+    # Limit binary previews to keep logs readable and avoid dumping large blobs.
+    BINARY_PREVIEW_SIZE = 32
+
     def initialize(logger:)
       super()
       raise RuntimeError, "Incompatible logger" unless logger.respond_to?(:print_line) && logger.respond_to?(:datastore)
@@ -42,15 +43,6 @@ module Kerberos
       @logger.print_line("%clr#{response_color}#{format_message(response)}%clr")
     end
 
-    # (see Rex::Proto::Kerberos::KerberosSubscriber#on_credential)
-    def on_credential(credential, source: nil)
-      return unless trace_enabled?
-      return if credential.nil?
-
-      print_credential_header(source)
-      @logger.print_line(format_credential(credential))
-    end
-
     private
 
     def trace_enabled?
@@ -70,12 +62,6 @@ module Kerberos
     def print_header(direction, message)
       @logger.print_line('#' * 20)
       @logger.print_line("# Kerberos #{direction}: #{message_type_name(message)}")
-      @logger.print_line('#' * 20)
-    end
-
-    def print_credential_header(source)
-      @logger.print_line('#' * 20)
-      @logger.print_line("# Kerberos Credential#{source ? ": #{source}" : ''}")
       @logger.print_line('#' * 20)
     end
 
@@ -115,16 +101,6 @@ module Kerberos
       end
     end
 
-    def format_credential(credential)
-      rendered_credential = ticket_presenter.present_cred(credential)
-      [
-        'Creds: 1',
-        "  Credential[0]:\n#{rendered_credential.indent(4)}"
-      ].join("\n")
-    rescue StandardError => e
-      "Credential presenter error: #{e.class}: #{e.message}"
-    end
-
     def serialize_element(element)
       element.attributes.each_with_object({}) do |attribute, output|
         value = element.public_send(attribute)
@@ -154,17 +130,10 @@ module Kerberos
       case value
       when Array
         value.map { |entry| serialize_value(entry) }
-      when Set
-        value.to_a.map { |entry| serialize_value(entry) }
       when Hash
         value.each_with_object({}) do |(key, entry), output|
           output[key.to_s] = serialize_value(entry)
         end
-      when Rex::Proto::Kerberos::Model::KerberosFlags
-        {
-          'value' => value.to_i,
-          'flags' => value.enabled_flag_names.map(&:to_s)
-        }
       when Time
         value.utc.iso8601
       when String
@@ -185,12 +154,10 @@ module Kerberos
     def serialize_string(value)
       return value if printable_string?(value)
 
-      # Expand binary/non-printable strings fully in hex.
-      "[binary #{value.bytesize} bytes: #{value.unpack1('H*')}]"
-    end
-
-    def ticket_presenter
-      @ticket_presenter ||= Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(nil)
+      # Show a short hex prefix when strings are binary/non-printable.
+      preview = value.byteslice(0, BINARY_PREVIEW_SIZE).to_s.unpack1('H*')
+      suffix = value.bytesize > BINARY_PREVIEW_SIZE ? '...' : ''
+      "[binary #{value.bytesize} bytes: #{preview}#{suffix}]"
     end
 
     def printable_string?(value)

--- a/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
@@ -1,0 +1,182 @@
+# -*- coding: binary -*-
+
+require 'json'
+require 'time'
+require 'rex/proto/kerberos/model'
+require 'rex/proto/kerberos/kerberos_subscriber'
+
+module Rex
+module Proto
+module Kerberos
+
+  # Logs Kerberos requests/responses
+  class KerberosLoggerSubscriber < KerberosSubscriber
+    # Limit binary previews to keep logs readable and avoid dumping large blobs.
+    BINARY_PREVIEW_SIZE = 32
+
+    def initialize(logger:)
+      super()
+      raise RuntimeError, "Incompatible logger" unless logger.respond_to?(:print_line) && logger.respond_to?(:datastore)
+      @logger = logger
+    end
+
+    # (see Rex::Proto::Kerberos::KerberosSubscriber#on_request)
+    def on_request(request)
+      return unless trace_enabled?
+
+      request_color, _response_color = trace_colors
+      print_header('Request', request)
+      @logger.print_line("%clr#{request_color}#{format_message(request)}%clr")
+    end
+
+    # (see Rex::Proto::Kerberos::KerberosSubscriber#on_response)
+    def on_response(response)
+      return unless trace_enabled?
+
+      _request_color, response_color = trace_colors
+      print_header('Response', response)
+      if response.nil?
+        @logger.print_line('No response received')
+        return
+      end
+
+      @logger.print_line("%clr#{response_color}#{format_message(response)}%clr")
+    end
+
+    private
+
+    def trace_enabled?
+      @logger.datastore['KerberosTicketTrace']
+    end
+
+    def trace_colors
+      configured_trace_colors = @logger.datastore['KerberosTicketTraceColors']
+      # Keep HttpTrace-compatible default formatting: request/response color pair.
+      trace_colors = blank_value?(configured_trace_colors) ? 'red/blu' : configured_trace_colors
+      trace_colors += '/' if trace_colors.count('/') == 0
+      trace_colors.gsub('/', ' / ').split('/').map do |color|
+        blank_value?(color&.strip) ? '' : "%bld%#{color.strip}"
+      end
+    end
+
+    def print_header(direction, message)
+      @logger.print_line('#' * 20)
+      @logger.print_line("# Kerberos #{direction}: #{message_type_name(message)}")
+      @logger.print_line('#' * 20)
+    end
+
+    def message_type_name(message)
+      msg_type = message.msg_type if message.respond_to?(:msg_type)
+      case msg_type
+      when Rex::Proto::Kerberos::Model::AS_REQ
+        'AS-REQ'
+      when Rex::Proto::Kerberos::Model::AS_REP
+        'AS-REP'
+      when Rex::Proto::Kerberos::Model::TGS_REQ
+        'TGS-REQ'
+      when Rex::Proto::Kerberos::Model::TGS_REP
+        'TGS-REP'
+      when Rex::Proto::Kerberos::Model::AP_REQ
+        'AP-REQ'
+      when Rex::Proto::Kerberos::Model::AP_REP
+        'AP-REP'
+      when Rex::Proto::Kerberos::Model::KRB_ERROR
+        'KRB-ERROR'
+      when nil
+        'UNKNOWN'
+      else
+        "UNKNOWN (#{msg_type})"
+      end
+    end
+
+    def format_message(message)
+      return 'null' if message.nil?
+
+      if message.respond_to?(:attributes)
+        # Kerberos model objects are serialized into stable JSON for easier diffing/debugging.
+        JSON.pretty_generate(serialize_element(message))
+      else
+        # Fall back for non-model objects.
+        message.to_s
+      end
+    end
+
+    def serialize_element(element)
+      element.attributes.each_with_object({}) do |attribute, output|
+        value = element.public_send(attribute)
+        next if value.nil?
+
+        output[attribute.to_s] = serialize_value(value)
+      end
+    end
+
+    def serialize_value(value)
+      if value.respond_to?(:attributes)
+        # Recursively serialize nested Kerberos model objects.
+        serialize_element(value)
+      elsif kerberos_error_code?(value)
+        # Normalize ErrorCode-like objects to a compact structured form.
+        {
+          'name' => value.name,
+          'value' => value.value,
+          'description' => value.description
+        }
+      else
+        serialize_scalar_value(value)
+      end
+    end
+
+    def serialize_scalar_value(value)
+      case value
+      when Array
+        value.map { |entry| serialize_value(entry) }
+      when Hash
+        value.each_with_object({}) do |(key, entry), output|
+          output[key.to_s] = serialize_value(entry)
+        end
+      when Time
+        value.utc.iso8601
+      when String
+        serialize_string(value)
+      when Symbol
+        value.to_s
+      when Integer, Float, TrueClass, FalseClass, NilClass
+        value
+      else
+        value.to_s
+      end
+    end
+
+    def kerberos_error_code?(value)
+      value.respond_to?(:name) && value.respond_to?(:value) && value.respond_to?(:description)
+    end
+
+    def serialize_string(value)
+      return value if printable_string?(value)
+
+      # Show a short hex prefix when strings are binary/non-printable.
+      preview = value.byteslice(0, BINARY_PREVIEW_SIZE).to_s.unpack1('H*')
+      suffix = value.bytesize > BINARY_PREVIEW_SIZE ? '...' : ''
+      "[binary #{value.bytesize} bytes: #{preview}#{suffix}]"
+    end
+
+    def printable_string?(value)
+      utf8_value = value.dup.force_encoding(::Encoding::UTF_8)
+      utf8_value.valid_encoding? && utf8_value.match?(/\A[[:print:]\r\n\t ]*\z/)
+    rescue ::Encoding::CompatibilityError
+      false
+    end
+
+    def blank_value?(value)
+      # Avoid depending on ActiveSupport's `blank?` for this Rex-level helper.
+      return true if value.nil? || value == false
+      return value.strip.empty? if value.respond_to?(:strip)
+      return value.empty? if value.respond_to?(:empty?)
+
+      false
+    end
+  end
+
+end
+end
+end

--- a/lib/rex/proto/kerberos/kerberos_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_subscriber.rb
@@ -15,12 +15,6 @@ module Kerberos
     def on_response(response)
       nil
     end
-
-    # @param credential [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential]
-    # @param source [String,nil]
-    def on_credential(credential, source: nil)
-      nil
-    end
   end
 
 end

--- a/lib/rex/proto/kerberos/kerberos_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_subscriber.rb
@@ -15,6 +15,12 @@ module Kerberos
     def on_response(response)
       nil
     end
+
+    # @param credential [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential]
+    # @param source [String,nil]
+    def on_credential(credential, source: nil)
+      nil
+    end
   end
 
 end

--- a/lib/rex/proto/kerberos/kerberos_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_subscriber.rb
@@ -1,0 +1,22 @@
+# -*- coding: binary -*-
+
+module Rex
+module Proto
+module Kerberos
+
+  # Subscriber interface for observing Kerberos request/response messages.
+  class KerberosSubscriber
+    # @param request [Rex::Proto::Kerberos::Model::KdcRequest, Rex::Proto::Kerberos::Model::ApReq]
+    def on_request(request)
+      nil
+    end
+
+    # @param response [Rex::Proto::Kerberos::Model::KdcResponse, Rex::Proto::Kerberos::Model::ApRep, Rex::Proto::Kerberos::Model::KrbError]
+    def on_response(response)
+      nil
+    end
+  end
+
+end
+end
+end

--- a/spec/lib/rex/proto/kerberos/client_spec.rb
+++ b/spec/lib/rex/proto/kerberos/client_spec.rb
@@ -24,11 +24,13 @@ RSpec.describe Rex::Proto::Kerberos::Client do
 
   let(:rhost) { '127.0.0.1' }
   let(:rport) { 88 }
+  let(:subscriber) { instance_double(Rex::Proto::Kerberos::KerberosSubscriber, on_request: nil, on_response: nil) }
 
   subject(:client) do
     opts = {
       host: rhost,
       port: rport,
+      subscriber: subscriber
     }
     described_class.new(opts)
   end
@@ -119,6 +121,7 @@ RSpec.describe Rex::Proto::Kerberos::Client do
     context "when TCP connection" do
       it "returns the written data length" do
         request = Rex::Proto::Kerberos::Model::KdcRequest.decode(sample_asn1_request)
+        expect(subscriber).to receive(:on_request).with(request)
         expect(subject.send_request(request)).to eq(req_length)
       end
     end
@@ -171,6 +174,7 @@ RSpec.describe Rex::Proto::Kerberos::Client do
           subject.connect
           subject.connection.write(res_error)
           subject.connection.seek(0)
+          expect(subscriber).to receive(:on_response).with(instance_of(Rex::Proto::Kerberos::Model::KrbError))
           expect(subject.recv_response).to be_a(Rex::Proto::Kerberos::Model::KrbError)
         end
       end
@@ -180,6 +184,7 @@ RSpec.describe Rex::Proto::Kerberos::Client do
           subject.connect
           subject.connection.write(res_valid)
           subject.connection.seek(0)
+          expect(subscriber).to receive(:on_response).with(instance_of(Rex::Proto::Kerberos::Model::KdcResponse))
           expect(subject.recv_response).to be_a(Rex::Proto::Kerberos::Model::KdcResponse)
         end
       end

--- a/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
+++ b/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
@@ -1,300 +1,335 @@
-# -*- coding:binary -*-
+# -*- coding: binary -*-
 
+require 'set'
 require 'spec_helper'
 
 RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
   include_context 'Msf::UIDriver'
 
-  let(:mock_module) { instance_double(Msf::Exploit, datastore: mock_datastore) }
+  subject(:subscriber) { described_class.new(logger: logger) }
 
-  subject(:subscriber) do
-    capture_logging(mock_module)
-    described_class.new(logger: mock_module)
-  end
-
+  let(:trace_enabled) { true }
+  let(:trace_colors) { nil }
   let(:mock_datastore) do
     {
-      'KerberosTicketTrace' => true
+      'KerberosTicketTrace' => trace_enabled,
+      'KerberosTicketTraceColors' => trace_colors
     }
   end
+  let(:logger) { instance_double(Msf::Exploit, datastore: mock_datastore) }
+  let(:output_text) { @output&.join("\n") }
 
-  let(:request) do
-    build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REQ)
-  end
+  describe '#initialize' do
+    subject(:build_subscriber) { described_class.new(logger: logger) }
 
-  let(:response) do
-    build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REP)
+    context 'when logger responds to print_line and datastore' do
+      let(:logger) { double('logger', print_line: nil, datastore: {}) }
+
+      it 'initializes successfully' do
+        expect { build_subscriber }.not_to raise_error
+      end
+    end
+
+    context 'when logger does not respond to print_line' do
+      let(:logger) { double('logger', datastore: {}) }
+
+      it 'raises an incompatible logger error' do
+        expect { build_subscriber }.to raise_error(RuntimeError, 'Incompatible logger')
+      end
+    end
+
+    context 'when logger does not respond to datastore' do
+      let(:logger) { double('logger', print_line: nil) }
+
+      it 'raises an incompatible logger error' do
+        expect { build_subscriber }.to raise_error(RuntimeError, 'Incompatible logger')
+      end
+    end
   end
 
   describe '#on_request' do
-    let(:normal_request_output) do
-      [
-        '####################',
-        '# Kerberos Request: AS-REQ',
-        '####################',
-        '%clr%bld%red{',
-        '  "pvno": 5,',
-        "  \"msg_type\": #{Rex::Proto::Kerberos::Model::AS_REQ},",
-        '  "crealm": "EXAMPLE.LOCAL"',
-        '}%clr'
-      ]
+    subject(:log_request) { subscriber.on_request(request_message) }
+
+    let(:request_message) { build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REQ) }
+
+    before do
+      capture_logging(logger)
     end
 
-    context 'when KerberosTicketTrace is enabled' do
-      it 'logs AS-REQ messages with default request color' do
-        subscriber.on_request(request)
-
-        expect(@output).to eq(normal_request_output)
+    context 'when KerberosTicketTrace is enabled with default colors' do
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr%bld%red{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
       end
-    end
 
-    context 'when KerberosTicketTrace is disabled' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => false
-        }
-      end
+      it 'prints a colored request header and JSON payload' do
+        log_request
 
-      it 'does not log request data' do
-        subscriber.on_request(request)
-
-        expect(@output).to be_nil
+        expect(output_text).to eq(expected_output)
       end
     end
 
-    context 'when KerberosTicketTrace is unset' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => nil
-        }
-      end
+    context 'when KerberosTicketTrace is false' do
+      let(:trace_enabled) { false }
 
-      it 'does not log request data' do
-        subscriber.on_request(request)
+      it 'does not print anything' do
+        log_request
 
-        expect(@output).to be_nil
+        expect(output_text).to be_nil
       end
     end
 
-    context 'when KerberosTicketTraceColors is set' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => 'blu/grn'
-        }
-      end
+    context 'when KerberosTicketTrace is nil' do
+      let(:trace_enabled) { nil }
 
-      it 'uses custom request color' do
-        subscriber.on_request(request)
+      it 'does not print anything' do
+        log_request
 
-        expect(@output[3]).to eq('%clr%bld%blu{')
+        expect(output_text).to be_nil
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to a single request color with trailing slash' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => 'yel/'
-        }
+    context 'when request msg_type is unknown' do
+      let(:request_message) { build_kerberos_message(msg_type: 999) }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: UNKNOWN (999)
+          ####################
+          %clr%bld%red{
+            "pvno": 5,
+            "msg_type": 999,
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'prints UNKNOWN with the numeric msg_type' do
+        log_request
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when request object does not expose attributes' do
+      let(:request_message) { 'raw-payload' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: UNKNOWN
+          ####################
+          %clr%bld%redraw-payload%clr
+        EOF
+      end
+
+      it 'falls back to to_s formatting' do
+        log_request
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to red/blu' do
+      let(:trace_colors) { 'red/blu' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr%bld%red{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
       end
 
       it 'uses the configured request color' do
-        subscriber.on_request(request)
+        log_request
 
-        expect(@output[3]).to eq('%clr%bld%yel{')
+        expect(output_text).to eq(expected_output)
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to response color only with a leading slash' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => '/yel'
-        }
+    context 'when KerberosTicketTraceColors is set to yel/' do
+      let(:trace_colors) { 'yel/' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr%bld%yel{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
       end
 
-      it 'logs request without color formatting' do
-        subscriber.on_request(request)
+      it 'uses the configured request color with a blank response color' do
+        log_request
 
-        expect(@output[3]).to eq('%clr{')
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to slash only' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => '/'
-        }
-      end
-
-      it 'logs request without color formatting' do
-        subscriber.on_request(request)
-
-        expect(@output[3]).to eq('%clr{')
+        expect(output_text).to eq(expected_output)
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to a single color without slash' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => 'yel'
-        }
+    context 'when KerberosTicketTraceColors is set to /grn' do
+      let(:trace_colors) { '/grn' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
       end
 
-      it 'uses the configured request color' do
-        subscriber.on_request(request)
+      it 'uses no request color when the request side is blank' do
+        log_request
 
-        expect(@output[3]).to eq('%clr%bld%yel{')
-      end
-    end
-
-    context 'when request type is unknown' do
-      let(:request) do
-        build_kerberos_message(msg_type: 999)
-      end
-
-      it 'logs request with UNKNOWN header' do
-        subscriber.on_request(request)
-
-        expect(@output).to include('# Kerberos Request: UNKNOWN (999)')
-      end
-    end
-  end
-
-  describe '#on_response' do
-    let(:normal_response_output) do
-      [
-        '####################',
-        '# Kerberos Response: AS-REP',
-        '####################',
-        '%clr%bld%blu{',
-        '  "pvno": 5,',
-        "  \"msg_type\": #{Rex::Proto::Kerberos::Model::AS_REP},",
-        '  "crealm": "EXAMPLE.LOCAL"',
-        '}%clr'
-      ]
-    end
-
-    let(:nil_response_output) do
-      [
-        '####################',
-        '# Kerberos Response: UNKNOWN',
-        '####################',
-        'No response received'
-      ]
-    end
-
-    context 'when KerberosTicketTrace is enabled' do
-      it 'logs AS-REP messages with default response color' do
-        subscriber.on_response(response)
-
-        expect(@output).to eq(normal_response_output)
-      end
-
-      it 'logs missing responses' do
-        subscriber.on_response(nil)
-
-        expect(@output).to eq(nil_response_output)
+        expect(output_text).to eq(expected_output)
       end
     end
 
-    context 'when KerberosTicketTraceColors is set' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => 'blu/grn'
-        }
+    context 'when KerberosTicketTraceColors is set to blu' do
+      let(:trace_colors) { 'blu' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr%bld%blu{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
       end
 
-      it 'uses custom response color' do
-        subscriber.on_response(response)
+      it 'treats a single color as request-only' do
+        log_request
 
-        expect(@output[3]).to eq('%clr%bld%grn{')
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to a single request color with trailing slash' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => 'yel/'
-        }
-      end
-
-      it 'logs response without color formatting' do
-        subscriber.on_response(response)
-
-        expect(@output[3]).to eq('%clr{')
+        expect(output_text).to eq(expected_output)
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to response color only with a leading slash' do
-      let(:mock_datastore) do
-        {
-          'KerberosTicketTrace' => true,
-          'KerberosTicketTraceColors' => '/yel'
-        }
+    context 'when KerberosTicketTraceColors is set to /' do
+      let(:trace_colors) { '/' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
       end
 
-      it 'uses the configured response color' do
-        subscriber.on_response(response)
+      it 'disables both request and response color prefixes' do
+        log_request
 
-        expect(@output[3]).to eq('%clr%bld%yel{')
-      end
-    end
-  end
-
-  describe 'request message type mapping' do
-    {
-      Rex::Proto::Kerberos::Model::AS_REQ => 'AS-REQ',
-      Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
-      Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
-      Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
-    }.each do |msg_type, msg_name|
-      it "maps request msg_type #{msg_type} to #{msg_name}" do
-        subscriber.on_request(build_kerberos_message(msg_type: msg_type))
-
-        expect(@output).to include("# Kerberos Request: #{msg_name}")
+        expect(output_text).to eq(expected_output)
       end
     end
-  end
 
-  describe 'response message type mapping' do
+    context 'when KerberosTicketTraceColors is blank' do
+      let(:trace_colors) { '   ' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr%bld%red{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'falls back to default red/blu colors' do
+        log_request
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
     {
       Rex::Proto::Kerberos::Model::AS_REP => 'AS-REP',
+      Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
       Rex::Proto::Kerberos::Model::TGS_REP => 'TGS-REP',
+      Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
       Rex::Proto::Kerberos::Model::AP_REP => 'AP-REP',
       Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
     }.each do |msg_type, msg_name|
-      it "maps response msg_type #{msg_type} to #{msg_name}" do
-        subscriber.on_response(build_kerberos_message(msg_type: msg_type))
+      context "when request msg_type is #{msg_name}" do
+        let(:request_message) { build_kerberos_message(msg_type: msg_type) }
+        let(:expected_output) do
+          <<~EOF.rstrip
+            ####################
+            # Kerberos Request: #{msg_name}
+            ####################
+            %clr%bld%red{
+              "pvno": 5,
+              "msg_type": #{msg_type},
+              "crealm": "EXAMPLE.LOCAL"
+            }%clr
+          EOF
+        end
 
-        expect(@output).to include("# Kerberos Response: #{msg_name}")
+        it 'maps message type to the expected label' do
+          log_request
+
+          expect(output_text).to eq(expected_output)
+        end
       end
     end
-  end
 
-  describe 'value serialization' do
-    context 'when serializing a binary string' do
-      let(:binary_preview) { '00' * 32 }
-      let(:request) do
+    context 'when serializing a binary string field' do
+      let(:binary_hex) { '00' * 40 }
+      let(:request_message) do
         build_kerberos_message(
           msg_type: Rex::Proto::Kerberos::Model::AS_REQ,
           fields: { ticket: ("\x00".b * 40) }
         )
       end
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REQ
+          ####################
+          %clr%bld%red{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
+            "crealm": "EXAMPLE.LOCAL",
+            "ticket": "[binary 40 bytes: #{binary_hex}]"
+          }%clr
+        EOF
+      end
 
-      it 'logs a bounded binary preview instead of raw data' do
-        subscriber.on_request(request)
+      it 'prints binary data as tagged hex bytes' do
+        log_request
 
-        expect(@output.any? { |line| line.include?("[binary 40 bytes: #{binary_preview}...]") }).to be(true)
+        expect(output_text).to eq(expected_output)
       end
     end
 
-    context 'when serializing structured values' do
+    context 'when serializing structured scalar values' do
       let(:error_code) do
         double(
           'error_code',
@@ -303,30 +338,489 @@ RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
           description: 'Message stream modified'
         )
       end
-
       let(:request_time) { Time.utc(2026, 3, 7, 12, 0, 0) }
-      let(:request) do
+      let(:kdc_options) do
+        Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags([
+          Rex::Proto::Kerberos::Model::KdcOptionFlags::FORWARDABLE,
+          Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE
+        ])
+      end
+      let(:request_message) do
         build_kerberos_message(
           msg_type: Rex::Proto::Kerberos::Model::KRB_ERROR,
           fields: {
             stime: request_time,
             tags: %i[ap error],
             metadata: { source: :kdc },
-            error_code: error_code
+            error_code: error_code,
+            options: kdc_options,
+            etype_set: Set.new([18, 17])
           }
         )
       end
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: KRB-ERROR
+          ####################
+          %clr%bld%red{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::KRB_ERROR},
+            "crealm": "EXAMPLE.LOCAL",
+            "stime": "2026-03-07T12:00:00Z",
+            "tags": [
+              "ap",
+              "error"
+            ],
+            "metadata": {
+              "source": "kdc"
+            },
+            "error_code": {
+              "name": "KRB_AP_ERR_MODIFIED",
+              "value": 41,
+              "description": "Message stream modified"
+            },
+            "options": {
+              "value": #{kdc_options.to_i},
+              "flags": [
+                "FORWARDABLE",
+                "RENEWABLE"
+              ]
+            },
+            "etype_set": [
+              18,
+              17
+            ]
+          }%clr
+        EOF
+      end
 
-      it 'serializes time, symbols, hashes, arrays and error-code objects' do
-        subscriber.on_request(request)
+      it 'normalizes time, symbols, flags, sets and error code objects' do
+        log_request
 
-        expect(@output).to include('  "stime": "2026-03-07T12:00:00Z",')
-        expect(@output).to include('    "ap",')
-        expect(@output).to include('    "error"')
-        expect(@output).to include('    "source": "kdc"')
-        expect(@output).to include('    "name": "KRB_AP_ERR_MODIFIED",')
-        expect(@output).to include('    "value": 41,')
-        expect(@output).to include('    "description": "Message stream modified"')
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when serializing nested Kerberos model objects' do
+      let(:ticket) do
+        Rex::Proto::Kerberos::Model::Ticket.new(
+          tkt_vno: 5,
+          realm: 'EXAMPLE.LOCAL',
+          sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
+            name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
+            name_string: %w[krbtgt EXAMPLE.LOCAL]
+          ),
+          enc_part: Rex::Proto::Kerberos::Model::EncryptedData.new(
+            etype: Rex::Proto::Kerberos::Crypto::Encryption::AES256,
+            kvno: 2,
+            cipher: "\x01\x02\x03".b
+          )
+        )
+      end
+      let(:request_message) do
+        build_kerberos_message(
+          msg_type: Rex::Proto::Kerberos::Model::AS_REP,
+          fields: { ticket: ticket }
+        )
+      end
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Request: AS-REP
+          ####################
+          %clr%bld%red{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
+            "crealm": "EXAMPLE.LOCAL",
+            "ticket": {
+              "tkt_vno": 5,
+              "realm": "EXAMPLE.LOCAL",
+              "sname": {
+                "name_type": #{Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST},
+                "name_string": [
+                  "krbtgt",
+                  "EXAMPLE.LOCAL"
+                ]
+              },
+              "enc_part": {
+                "etype": #{Rex::Proto::Kerberos::Crypto::Encryption::AES256},
+                "kvno": 2,
+                "cipher": "[binary 3 bytes: 010203]"
+              }
+            }
+          }%clr
+        EOF
+      end
+
+      it 'recursively serializes nested model attributes' do
+        log_request
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+  end
+
+  describe '#on_response' do
+    subject(:log_response) { subscriber.on_response(response_message) }
+
+    let(:response_message) { build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REP) }
+
+    before do
+      capture_logging(logger)
+    end
+
+    context 'when KerberosTicketTrace is enabled with default colors' do
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: AS-REP
+          ####################
+          %clr%bld%blu{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'prints a colored response header and JSON payload' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when response is nil' do
+      let(:response_message) { nil }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: UNKNOWN
+          ####################
+          No response received
+        EOF
+      end
+
+      it 'prints a no-response message' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when KerberosTicketTrace is false' do
+      let(:trace_enabled) { false }
+
+      it 'does not print anything' do
+        log_response
+
+        expect(output_text).to be_nil
+      end
+    end
+
+    context 'when KerberosTicketTrace is nil' do
+      let(:trace_enabled) { nil }
+
+      it 'does not print anything' do
+        log_response
+
+        expect(output_text).to be_nil
+      end
+    end
+
+    context 'when response msg_type is unknown' do
+      let(:response_message) { build_kerberos_message(msg_type: 31_337) }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: UNKNOWN (31337)
+          ####################
+          %clr%bld%blu{
+            "pvno": 5,
+            "msg_type": 31337,
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'prints UNKNOWN with the numeric msg_type' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when response object does not expose attributes' do
+      let(:response_message) { :raw_payload }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: UNKNOWN
+          ####################
+          %clr%bld%bluraw_payload%clr
+        EOF
+      end
+
+      it 'falls back to to_s formatting' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to red/blu' do
+      let(:trace_colors) { 'red/blu' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: AS-REP
+          ####################
+          %clr%bld%blu{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'uses the configured response color' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to yel/' do
+      let(:trace_colors) { 'yel/' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: AS-REP
+          ####################
+          %clr{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'uses no response color when the response side is blank' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to /grn' do
+      let(:trace_colors) { '/grn' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: AS-REP
+          ####################
+          %clr%bld%grn{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'uses the configured response color' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to blu' do
+      let(:trace_colors) { 'blu' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: AS-REP
+          ####################
+          %clr{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'treats a single color as request-only' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to /' do
+      let(:trace_colors) { '/' }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Response: AS-REP
+          ####################
+          %clr{
+            "pvno": 5,
+            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
+            "crealm": "EXAMPLE.LOCAL"
+          }%clr
+        EOF
+      end
+
+      it 'disables both request and response color prefixes' do
+        log_response
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    {
+      Rex::Proto::Kerberos::Model::AS_REQ => 'AS-REQ',
+      Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
+      Rex::Proto::Kerberos::Model::TGS_REP => 'TGS-REP',
+      Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
+      Rex::Proto::Kerberos::Model::AP_REP => 'AP-REP',
+      Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
+    }.each do |msg_type, msg_name|
+      context "when response msg_type is #{msg_name}" do
+        let(:response_message) { build_kerberos_message(msg_type: msg_type) }
+        let(:expected_output) do
+          <<~EOF.rstrip
+            ####################
+            # Kerberos Response: #{msg_name}
+            ####################
+            %clr%bld%blu{
+              "pvno": 5,
+              "msg_type": #{msg_type},
+              "crealm": "EXAMPLE.LOCAL"
+            }%clr
+          EOF
+        end
+
+        it 'maps message type to the expected label' do
+          log_response
+
+          expect(output_text).to eq(expected_output)
+        end
+      end
+    end
+  end
+
+  describe '#on_credential' do
+    subject(:log_credential) { subscriber.on_credential(credential_to_log, source: source) }
+
+    let(:credential) { double('credential') }
+    let(:credential_to_log) { credential }
+    let(:source) { 'TGS' }
+    let(:presented_credential) do
+      <<~EOF.rstrip
+        Server: krbtgt/EXAMPLE.LOCAL@EXAMPLE.LOCAL
+        Client: Administrator@EXAMPLE.LOCAL
+        Ticket etype: 18 (AES256)
+        Key: deadbeef
+      EOF
+    end
+    let(:presenter) do
+      instance_double(
+        Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter,
+        present_cred: presented_credential
+      )
+    end
+
+    before do
+      capture_logging(logger)
+      allow(Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter).to receive(:new).with(nil).and_return(presenter)
+    end
+
+    context 'when trace is enabled and credential is present' do
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Credential: TGS
+          ####################
+          Creds: 1
+            Credential[0]:
+              Server: krbtgt/EXAMPLE.LOCAL@EXAMPLE.LOCAL
+              Client: Administrator@EXAMPLE.LOCAL
+              Ticket etype: 18 (AES256)
+              Key: deadbeef
+        EOF
+      end
+
+      it 'prints presenter output under the credential header' do
+        log_credential
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when source is nil' do
+      let(:source) { nil }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Credential
+          ####################
+          Creds: 1
+            Credential[0]:
+              Server: krbtgt/EXAMPLE.LOCAL@EXAMPLE.LOCAL
+              Client: Administrator@EXAMPLE.LOCAL
+              Ticket etype: 18 (AES256)
+              Key: deadbeef
+        EOF
+      end
+
+      it 'omits the source suffix from the header' do
+        log_credential
+
+        expect(output_text).to eq(expected_output)
+      end
+    end
+
+    context 'when credential is nil' do
+      let(:credential_to_log) { nil }
+
+      it 'does not print anything' do
+        log_credential
+
+        expect(output_text).to be_nil
+      end
+    end
+
+    context 'when KerberosTicketTrace is false' do
+      let(:trace_enabled) { false }
+
+      it 'does not print anything' do
+        log_credential
+
+        expect(output_text).to be_nil
+      end
+    end
+
+    context 'when presenter raises an error' do
+      let(:presenter) { instance_double(Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter) }
+      let(:expected_output) do
+        <<~EOF.rstrip
+          ####################
+          # Kerberos Credential: TGS
+          ####################
+          Credential presenter error: RuntimeError: boom
+        EOF
+      end
+
+      before do
+        allow(presenter).to receive(:present_cred).with(credential).and_raise(RuntimeError, 'boom')
+      end
+
+      it 'prints the presenter error message' do
+        log_credential
+
+        expect(output_text).to eq(expected_output)
       end
     end
   end

--- a/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
+++ b/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
@@ -1,0 +1,347 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
+  include_context 'Msf::UIDriver'
+
+  let(:mock_module) { instance_double(Msf::Exploit, datastore: mock_datastore) }
+
+  subject(:subscriber) do
+    capture_logging(mock_module)
+    described_class.new(logger: mock_module)
+  end
+
+  let(:mock_datastore) do
+    {
+      'KerberosTicketTrace' => true
+    }
+  end
+
+  let(:request) do
+    build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REQ)
+  end
+
+  let(:response) do
+    build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REP)
+  end
+
+  describe '#on_request' do
+    let(:normal_request_output) do
+      [
+        '####################',
+        '# Kerberos Request: AS-REQ',
+        '####################',
+        '%clr%bld%red{',
+        '  "pvno": 5,',
+        "  \"msg_type\": #{Rex::Proto::Kerberos::Model::AS_REQ},",
+        '  "crealm": "EXAMPLE.LOCAL"',
+        '}%clr'
+      ]
+    end
+
+    context 'when KerberosTicketTrace is enabled' do
+      it 'logs AS-REQ messages with default request color' do
+        subscriber.on_request(request)
+
+        expect(@output).to eq(normal_request_output)
+      end
+    end
+
+    context 'when KerberosTicketTrace is disabled' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => false
+        }
+      end
+
+      it 'does not log request data' do
+        subscriber.on_request(request)
+
+        expect(@output).to be_nil
+      end
+    end
+
+    context 'when KerberosTicketTrace is unset' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => nil
+        }
+      end
+
+      it 'does not log request data' do
+        subscriber.on_request(request)
+
+        expect(@output).to be_nil
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'blu/grn'
+        }
+      end
+
+      it 'uses custom request color' do
+        subscriber.on_request(request)
+
+        expect(@output[3]).to eq('%clr%bld%blu{')
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to a single request color with trailing slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'yel/'
+        }
+      end
+
+      it 'uses the configured request color' do
+        subscriber.on_request(request)
+
+        expect(@output[3]).to eq('%clr%bld%yel{')
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to response color only with a leading slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => '/yel'
+        }
+      end
+
+      it 'logs request without color formatting' do
+        subscriber.on_request(request)
+
+        expect(@output[3]).to eq('%clr{')
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to slash only' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => '/'
+        }
+      end
+
+      it 'logs request without color formatting' do
+        subscriber.on_request(request)
+
+        expect(@output[3]).to eq('%clr{')
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to a single color without slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'yel'
+        }
+      end
+
+      it 'uses the configured request color' do
+        subscriber.on_request(request)
+
+        expect(@output[3]).to eq('%clr%bld%yel{')
+      end
+    end
+
+    context 'when request type is unknown' do
+      let(:request) do
+        build_kerberos_message(msg_type: 999)
+      end
+
+      it 'logs request with UNKNOWN header' do
+        subscriber.on_request(request)
+
+        expect(@output).to include('# Kerberos Request: UNKNOWN (999)')
+      end
+    end
+  end
+
+  describe '#on_response' do
+    let(:normal_response_output) do
+      [
+        '####################',
+        '# Kerberos Response: AS-REP',
+        '####################',
+        '%clr%bld%blu{',
+        '  "pvno": 5,',
+        "  \"msg_type\": #{Rex::Proto::Kerberos::Model::AS_REP},",
+        '  "crealm": "EXAMPLE.LOCAL"',
+        '}%clr'
+      ]
+    end
+
+    let(:nil_response_output) do
+      [
+        '####################',
+        '# Kerberos Response: UNKNOWN',
+        '####################',
+        'No response received'
+      ]
+    end
+
+    context 'when KerberosTicketTrace is enabled' do
+      it 'logs AS-REP messages with default response color' do
+        subscriber.on_response(response)
+
+        expect(@output).to eq(normal_response_output)
+      end
+
+      it 'logs missing responses' do
+        subscriber.on_response(nil)
+
+        expect(@output).to eq(nil_response_output)
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'blu/grn'
+        }
+      end
+
+      it 'uses custom response color' do
+        subscriber.on_response(response)
+
+        expect(@output[3]).to eq('%clr%bld%grn{')
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to a single request color with trailing slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'yel/'
+        }
+      end
+
+      it 'logs response without color formatting' do
+        subscriber.on_response(response)
+
+        expect(@output[3]).to eq('%clr{')
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to response color only with a leading slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => '/yel'
+        }
+      end
+
+      it 'uses the configured response color' do
+        subscriber.on_response(response)
+
+        expect(@output[3]).to eq('%clr%bld%yel{')
+      end
+    end
+  end
+
+  describe 'request message type mapping' do
+    {
+      Rex::Proto::Kerberos::Model::AS_REQ => 'AS-REQ',
+      Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
+      Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
+      Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
+    }.each do |msg_type, msg_name|
+      it "maps request msg_type #{msg_type} to #{msg_name}" do
+        subscriber.on_request(build_kerberos_message(msg_type: msg_type))
+
+        expect(@output).to include("# Kerberos Request: #{msg_name}")
+      end
+    end
+  end
+
+  describe 'response message type mapping' do
+    {
+      Rex::Proto::Kerberos::Model::AS_REP => 'AS-REP',
+      Rex::Proto::Kerberos::Model::TGS_REP => 'TGS-REP',
+      Rex::Proto::Kerberos::Model::AP_REP => 'AP-REP',
+      Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
+    }.each do |msg_type, msg_name|
+      it "maps response msg_type #{msg_type} to #{msg_name}" do
+        subscriber.on_response(build_kerberos_message(msg_type: msg_type))
+
+        expect(@output).to include("# Kerberos Response: #{msg_name}")
+      end
+    end
+  end
+
+  describe 'value serialization' do
+    context 'when serializing a binary string' do
+      let(:binary_preview) { '00' * 32 }
+      let(:request) do
+        build_kerberos_message(
+          msg_type: Rex::Proto::Kerberos::Model::AS_REQ,
+          fields: { ticket: ("\x00".b * 40) }
+        )
+      end
+
+      it 'logs a bounded binary preview instead of raw data' do
+        subscriber.on_request(request)
+
+        expect(@output.any? { |line| line.include?("[binary 40 bytes: #{binary_preview}...]") }).to be(true)
+      end
+    end
+
+    context 'when serializing structured values' do
+      let(:error_code) do
+        double(
+          'error_code',
+          name: 'KRB_AP_ERR_MODIFIED',
+          value: 41,
+          description: 'Message stream modified'
+        )
+      end
+
+      let(:request_time) { Time.utc(2026, 3, 7, 12, 0, 0) }
+      let(:request) do
+        build_kerberos_message(
+          msg_type: Rex::Proto::Kerberos::Model::KRB_ERROR,
+          fields: {
+            stime: request_time,
+            tags: %i[ap error],
+            metadata: { source: :kdc },
+            error_code: error_code
+          }
+        )
+      end
+
+      it 'serializes time, symbols, hashes, arrays and error-code objects' do
+        subscriber.on_request(request)
+
+        expect(@output).to include('  "stime": "2026-03-07T12:00:00Z",')
+        expect(@output).to include('    "ap",')
+        expect(@output).to include('    "error"')
+        expect(@output).to include('    "source": "kdc"')
+        expect(@output).to include('    "name": "KRB_AP_ERR_MODIFIED",')
+        expect(@output).to include('    "value": 41,')
+        expect(@output).to include('    "description": "Message stream modified"')
+      end
+    end
+  end
+
+  def build_kerberos_message(msg_type:, fields: {})
+    payload = {
+      pvno: 5,
+      msg_type: msg_type,
+      crealm: 'EXAMPLE.LOCAL'
+    }.merge(fields)
+
+    double(
+      'kerberos_message',
+      attributes: payload.keys,
+      **payload
+    )
+  end
+end

--- a/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
+++ b/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
@@ -1,335 +1,300 @@
-# -*- coding: binary -*-
+# -*- coding:binary -*-
 
-require 'set'
 require 'spec_helper'
 
 RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
   include_context 'Msf::UIDriver'
 
-  subject(:subscriber) { described_class.new(logger: logger) }
+  let(:mock_module) { instance_double(Msf::Exploit, datastore: mock_datastore) }
 
-  let(:trace_enabled) { true }
-  let(:trace_colors) { nil }
+  subject(:subscriber) do
+    capture_logging(mock_module)
+    described_class.new(logger: mock_module)
+  end
+
   let(:mock_datastore) do
     {
-      'KerberosTicketTrace' => trace_enabled,
-      'KerberosTicketTraceColors' => trace_colors
+      'KerberosTicketTrace' => true
     }
   end
-  let(:logger) { instance_double(Msf::Exploit, datastore: mock_datastore) }
-  let(:output_text) { @output&.join("\n") }
 
-  describe '#initialize' do
-    subject(:build_subscriber) { described_class.new(logger: logger) }
+  let(:request) do
+    build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REQ)
+  end
 
-    context 'when logger responds to print_line and datastore' do
-      let(:logger) { double('logger', print_line: nil, datastore: {}) }
-
-      it 'initializes successfully' do
-        expect { build_subscriber }.not_to raise_error
-      end
-    end
-
-    context 'when logger does not respond to print_line' do
-      let(:logger) { double('logger', datastore: {}) }
-
-      it 'raises an incompatible logger error' do
-        expect { build_subscriber }.to raise_error(RuntimeError, 'Incompatible logger')
-      end
-    end
-
-    context 'when logger does not respond to datastore' do
-      let(:logger) { double('logger', print_line: nil) }
-
-      it 'raises an incompatible logger error' do
-        expect { build_subscriber }.to raise_error(RuntimeError, 'Incompatible logger')
-      end
-    end
+  let(:response) do
+    build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REP)
   end
 
   describe '#on_request' do
-    subject(:log_request) { subscriber.on_request(request_message) }
-
-    let(:request_message) { build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REQ) }
-
-    before do
-      capture_logging(logger)
+    let(:normal_request_output) do
+      [
+        '####################',
+        '# Kerberos Request: AS-REQ',
+        '####################',
+        '%clr%bld%red{',
+        '  "pvno": 5,',
+        "  \"msg_type\": #{Rex::Proto::Kerberos::Model::AS_REQ},",
+        '  "crealm": "EXAMPLE.LOCAL"',
+        '}%clr'
+      ]
     end
 
-    context 'when KerberosTicketTrace is enabled with default colors' do
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr%bld%red{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
+    context 'when KerberosTicketTrace is enabled' do
+      it 'logs AS-REQ messages with default request color' do
+        subscriber.on_request(request)
 
-      it 'prints a colored request header and JSON payload' do
-        log_request
-
-        expect(output_text).to eq(expected_output)
+        expect(@output).to eq(normal_request_output)
       end
     end
 
-    context 'when KerberosTicketTrace is false' do
-      let(:trace_enabled) { false }
+    context 'when KerberosTicketTrace is disabled' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => false
+        }
+      end
 
-      it 'does not print anything' do
-        log_request
+      it 'does not log request data' do
+        subscriber.on_request(request)
 
-        expect(output_text).to be_nil
+        expect(@output).to be_nil
       end
     end
 
-    context 'when KerberosTicketTrace is nil' do
-      let(:trace_enabled) { nil }
+    context 'when KerberosTicketTrace is unset' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => nil
+        }
+      end
 
-      it 'does not print anything' do
-        log_request
+      it 'does not log request data' do
+        subscriber.on_request(request)
 
-        expect(output_text).to be_nil
+        expect(@output).to be_nil
       end
     end
 
-    context 'when request msg_type is unknown' do
-      let(:request_message) { build_kerberos_message(msg_type: 999) }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: UNKNOWN (999)
-          ####################
-          %clr%bld%red{
-            "pvno": 5,
-            "msg_type": 999,
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
+    context 'when KerberosTicketTraceColors is set' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'blu/grn'
+        }
       end
 
-      it 'prints UNKNOWN with the numeric msg_type' do
-        log_request
+      it 'uses custom request color' do
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output[3]).to eq('%clr%bld%blu{')
       end
     end
 
-    context 'when request object does not expose attributes' do
-      let(:request_message) { 'raw-payload' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: UNKNOWN
-          ####################
-          %clr%bld%redraw-payload%clr
-        EOF
-      end
-
-      it 'falls back to to_s formatting' do
-        log_request
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to red/blu' do
-      let(:trace_colors) { 'red/blu' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr%bld%red{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
+    context 'when KerberosTicketTraceColors is set to a single request color with trailing slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'yel/'
+        }
       end
 
       it 'uses the configured request color' do
-        log_request
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output[3]).to eq('%clr%bld%yel{')
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to yel/' do
-      let(:trace_colors) { 'yel/' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr%bld%yel{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
+    context 'when KerberosTicketTraceColors is set to response color only with a leading slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => '/yel'
+        }
       end
 
-      it 'uses the configured request color with a blank response color' do
-        log_request
+      it 'logs request without color formatting' do
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output[3]).to eq('%clr{')
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to /grn' do
-      let(:trace_colors) { '/grn' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
+    context 'when KerberosTicketTraceColors is set to slash only' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => '/'
+        }
       end
 
-      it 'uses no request color when the request side is blank' do
-        log_request
+      it 'logs request without color formatting' do
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output[3]).to eq('%clr{')
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to blu' do
-      let(:trace_colors) { 'blu' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr%bld%blu{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
+    context 'when KerberosTicketTraceColors is set to a single color without slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'yel'
+        }
       end
 
-      it 'treats a single color as request-only' do
-        log_request
+      it 'uses the configured request color' do
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output[3]).to eq('%clr%bld%yel{')
       end
     end
 
-    context 'when KerberosTicketTraceColors is set to /' do
-      let(:trace_colors) { '/' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
+    context 'when request type is unknown' do
+      let(:request) do
+        build_kerberos_message(msg_type: 999)
       end
 
-      it 'disables both request and response color prefixes' do
-        log_request
+      it 'logs request with UNKNOWN header' do
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output).to include('# Kerberos Request: UNKNOWN (999)')
+      end
+    end
+  end
+
+  describe '#on_response' do
+    let(:normal_response_output) do
+      [
+        '####################',
+        '# Kerberos Response: AS-REP',
+        '####################',
+        '%clr%bld%blu{',
+        '  "pvno": 5,',
+        "  \"msg_type\": #{Rex::Proto::Kerberos::Model::AS_REP},",
+        '  "crealm": "EXAMPLE.LOCAL"',
+        '}%clr'
+      ]
+    end
+
+    let(:nil_response_output) do
+      [
+        '####################',
+        '# Kerberos Response: UNKNOWN',
+        '####################',
+        'No response received'
+      ]
+    end
+
+    context 'when KerberosTicketTrace is enabled' do
+      it 'logs AS-REP messages with default response color' do
+        subscriber.on_response(response)
+
+        expect(@output).to eq(normal_response_output)
+      end
+
+      it 'logs missing responses' do
+        subscriber.on_response(nil)
+
+        expect(@output).to eq(nil_response_output)
       end
     end
 
-    context 'when KerberosTicketTraceColors is blank' do
-      let(:trace_colors) { '   ' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr%bld%red{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
+    context 'when KerberosTicketTraceColors is set' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'blu/grn'
+        }
       end
 
-      it 'falls back to default red/blu colors' do
-        log_request
+      it 'uses custom response color' do
+        subscriber.on_response(response)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output[3]).to eq('%clr%bld%grn{')
       end
     end
 
+    context 'when KerberosTicketTraceColors is set to a single request color with trailing slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => 'yel/'
+        }
+      end
+
+      it 'logs response without color formatting' do
+        subscriber.on_response(response)
+
+        expect(@output[3]).to eq('%clr{')
+      end
+    end
+
+    context 'when KerberosTicketTraceColors is set to response color only with a leading slash' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceColors' => '/yel'
+        }
+      end
+
+      it 'uses the configured response color' do
+        subscriber.on_response(response)
+
+        expect(@output[3]).to eq('%clr%bld%yel{')
+      end
+    end
+  end
+
+  describe 'request message type mapping' do
+    {
+      Rex::Proto::Kerberos::Model::AS_REQ => 'AS-REQ',
+      Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
+      Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
+      Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
+    }.each do |msg_type, msg_name|
+      it "maps request msg_type #{msg_type} to #{msg_name}" do
+        subscriber.on_request(build_kerberos_message(msg_type: msg_type))
+
+        expect(@output).to include("# Kerberos Request: #{msg_name}")
+      end
+    end
+  end
+
+  describe 'response message type mapping' do
     {
       Rex::Proto::Kerberos::Model::AS_REP => 'AS-REP',
-      Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
       Rex::Proto::Kerberos::Model::TGS_REP => 'TGS-REP',
-      Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
       Rex::Proto::Kerberos::Model::AP_REP => 'AP-REP',
       Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
     }.each do |msg_type, msg_name|
-      context "when request msg_type is #{msg_name}" do
-        let(:request_message) { build_kerberos_message(msg_type: msg_type) }
-        let(:expected_output) do
-          <<~EOF.rstrip
-            ####################
-            # Kerberos Request: #{msg_name}
-            ####################
-            %clr%bld%red{
-              "pvno": 5,
-              "msg_type": #{msg_type},
-              "crealm": "EXAMPLE.LOCAL"
-            }%clr
-          EOF
-        end
+      it "maps response msg_type #{msg_type} to #{msg_name}" do
+        subscriber.on_response(build_kerberos_message(msg_type: msg_type))
 
-        it 'maps message type to the expected label' do
-          log_request
-
-          expect(output_text).to eq(expected_output)
-        end
+        expect(@output).to include("# Kerberos Response: #{msg_name}")
       end
     end
+  end
 
-    context 'when serializing a binary string field' do
-      let(:binary_hex) { '00' * 40 }
-      let(:request_message) do
+  describe 'value serialization' do
+    context 'when serializing a binary string' do
+      let(:binary_preview) { '00' * 32 }
+      let(:request) do
         build_kerberos_message(
           msg_type: Rex::Proto::Kerberos::Model::AS_REQ,
           fields: { ticket: ("\x00".b * 40) }
         )
       end
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REQ
-          ####################
-          %clr%bld%red{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REQ},
-            "crealm": "EXAMPLE.LOCAL",
-            "ticket": "[binary 40 bytes: #{binary_hex}]"
-          }%clr
-        EOF
-      end
 
-      it 'prints binary data as tagged hex bytes' do
-        log_request
+      it 'logs a bounded binary preview instead of raw data' do
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
+        expect(@output.any? { |line| line.include?("[binary 40 bytes: #{binary_preview}...]") }).to be(true)
       end
     end
 
-    context 'when serializing structured scalar values' do
+    context 'when serializing structured values' do
       let(:error_code) do
         double(
           'error_code',
@@ -338,489 +303,30 @@ RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
           description: 'Message stream modified'
         )
       end
+
       let(:request_time) { Time.utc(2026, 3, 7, 12, 0, 0) }
-      let(:kdc_options) do
-        Rex::Proto::Kerberos::Model::KdcOptionFlags.from_flags([
-          Rex::Proto::Kerberos::Model::KdcOptionFlags::FORWARDABLE,
-          Rex::Proto::Kerberos::Model::KdcOptionFlags::RENEWABLE
-        ])
-      end
-      let(:request_message) do
+      let(:request) do
         build_kerberos_message(
           msg_type: Rex::Proto::Kerberos::Model::KRB_ERROR,
           fields: {
             stime: request_time,
             tags: %i[ap error],
             metadata: { source: :kdc },
-            error_code: error_code,
-            options: kdc_options,
-            etype_set: Set.new([18, 17])
+            error_code: error_code
           }
         )
       end
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: KRB-ERROR
-          ####################
-          %clr%bld%red{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::KRB_ERROR},
-            "crealm": "EXAMPLE.LOCAL",
-            "stime": "2026-03-07T12:00:00Z",
-            "tags": [
-              "ap",
-              "error"
-            ],
-            "metadata": {
-              "source": "kdc"
-            },
-            "error_code": {
-              "name": "KRB_AP_ERR_MODIFIED",
-              "value": 41,
-              "description": "Message stream modified"
-            },
-            "options": {
-              "value": #{kdc_options.to_i},
-              "flags": [
-                "FORWARDABLE",
-                "RENEWABLE"
-              ]
-            },
-            "etype_set": [
-              18,
-              17
-            ]
-          }%clr
-        EOF
-      end
 
-      it 'normalizes time, symbols, flags, sets and error code objects' do
-        log_request
+      it 'serializes time, symbols, hashes, arrays and error-code objects' do
+        subscriber.on_request(request)
 
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when serializing nested Kerberos model objects' do
-      let(:ticket) do
-        Rex::Proto::Kerberos::Model::Ticket.new(
-          tkt_vno: 5,
-          realm: 'EXAMPLE.LOCAL',
-          sname: Rex::Proto::Kerberos::Model::PrincipalName.new(
-            name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
-            name_string: %w[krbtgt EXAMPLE.LOCAL]
-          ),
-          enc_part: Rex::Proto::Kerberos::Model::EncryptedData.new(
-            etype: Rex::Proto::Kerberos::Crypto::Encryption::AES256,
-            kvno: 2,
-            cipher: "\x01\x02\x03".b
-          )
-        )
-      end
-      let(:request_message) do
-        build_kerberos_message(
-          msg_type: Rex::Proto::Kerberos::Model::AS_REP,
-          fields: { ticket: ticket }
-        )
-      end
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Request: AS-REP
-          ####################
-          %clr%bld%red{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
-            "crealm": "EXAMPLE.LOCAL",
-            "ticket": {
-              "tkt_vno": 5,
-              "realm": "EXAMPLE.LOCAL",
-              "sname": {
-                "name_type": #{Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST},
-                "name_string": [
-                  "krbtgt",
-                  "EXAMPLE.LOCAL"
-                ]
-              },
-              "enc_part": {
-                "etype": #{Rex::Proto::Kerberos::Crypto::Encryption::AES256},
-                "kvno": 2,
-                "cipher": "[binary 3 bytes: 010203]"
-              }
-            }
-          }%clr
-        EOF
-      end
-
-      it 'recursively serializes nested model attributes' do
-        log_request
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-  end
-
-  describe '#on_response' do
-    subject(:log_response) { subscriber.on_response(response_message) }
-
-    let(:response_message) { build_kerberos_message(msg_type: Rex::Proto::Kerberos::Model::AS_REP) }
-
-    before do
-      capture_logging(logger)
-    end
-
-    context 'when KerberosTicketTrace is enabled with default colors' do
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: AS-REP
-          ####################
-          %clr%bld%blu{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
-
-      it 'prints a colored response header and JSON payload' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when response is nil' do
-      let(:response_message) { nil }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: UNKNOWN
-          ####################
-          No response received
-        EOF
-      end
-
-      it 'prints a no-response message' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when KerberosTicketTrace is false' do
-      let(:trace_enabled) { false }
-
-      it 'does not print anything' do
-        log_response
-
-        expect(output_text).to be_nil
-      end
-    end
-
-    context 'when KerberosTicketTrace is nil' do
-      let(:trace_enabled) { nil }
-
-      it 'does not print anything' do
-        log_response
-
-        expect(output_text).to be_nil
-      end
-    end
-
-    context 'when response msg_type is unknown' do
-      let(:response_message) { build_kerberos_message(msg_type: 31_337) }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: UNKNOWN (31337)
-          ####################
-          %clr%bld%blu{
-            "pvno": 5,
-            "msg_type": 31337,
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
-
-      it 'prints UNKNOWN with the numeric msg_type' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when response object does not expose attributes' do
-      let(:response_message) { :raw_payload }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: UNKNOWN
-          ####################
-          %clr%bld%bluraw_payload%clr
-        EOF
-      end
-
-      it 'falls back to to_s formatting' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to red/blu' do
-      let(:trace_colors) { 'red/blu' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: AS-REP
-          ####################
-          %clr%bld%blu{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
-
-      it 'uses the configured response color' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to yel/' do
-      let(:trace_colors) { 'yel/' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: AS-REP
-          ####################
-          %clr{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
-
-      it 'uses no response color when the response side is blank' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to /grn' do
-      let(:trace_colors) { '/grn' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: AS-REP
-          ####################
-          %clr%bld%grn{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
-
-      it 'uses the configured response color' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to blu' do
-      let(:trace_colors) { 'blu' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: AS-REP
-          ####################
-          %clr{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
-
-      it 'treats a single color as request-only' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when KerberosTicketTraceColors is set to /' do
-      let(:trace_colors) { '/' }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Response: AS-REP
-          ####################
-          %clr{
-            "pvno": 5,
-            "msg_type": #{Rex::Proto::Kerberos::Model::AS_REP},
-            "crealm": "EXAMPLE.LOCAL"
-          }%clr
-        EOF
-      end
-
-      it 'disables both request and response color prefixes' do
-        log_response
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    {
-      Rex::Proto::Kerberos::Model::AS_REQ => 'AS-REQ',
-      Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
-      Rex::Proto::Kerberos::Model::TGS_REP => 'TGS-REP',
-      Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
-      Rex::Proto::Kerberos::Model::AP_REP => 'AP-REP',
-      Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR'
-    }.each do |msg_type, msg_name|
-      context "when response msg_type is #{msg_name}" do
-        let(:response_message) { build_kerberos_message(msg_type: msg_type) }
-        let(:expected_output) do
-          <<~EOF.rstrip
-            ####################
-            # Kerberos Response: #{msg_name}
-            ####################
-            %clr%bld%blu{
-              "pvno": 5,
-              "msg_type": #{msg_type},
-              "crealm": "EXAMPLE.LOCAL"
-            }%clr
-          EOF
-        end
-
-        it 'maps message type to the expected label' do
-          log_response
-
-          expect(output_text).to eq(expected_output)
-        end
-      end
-    end
-  end
-
-  describe '#on_credential' do
-    subject(:log_credential) { subscriber.on_credential(credential_to_log, source: source) }
-
-    let(:credential) { double('credential') }
-    let(:credential_to_log) { credential }
-    let(:source) { 'TGS' }
-    let(:presented_credential) do
-      <<~EOF.rstrip
-        Server: krbtgt/EXAMPLE.LOCAL@EXAMPLE.LOCAL
-        Client: Administrator@EXAMPLE.LOCAL
-        Ticket etype: 18 (AES256)
-        Key: deadbeef
-      EOF
-    end
-    let(:presenter) do
-      instance_double(
-        Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter,
-        present_cred: presented_credential
-      )
-    end
-
-    before do
-      capture_logging(logger)
-      allow(Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter).to receive(:new).with(nil).and_return(presenter)
-    end
-
-    context 'when trace is enabled and credential is present' do
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Credential: TGS
-          ####################
-          Creds: 1
-            Credential[0]:
-              Server: krbtgt/EXAMPLE.LOCAL@EXAMPLE.LOCAL
-              Client: Administrator@EXAMPLE.LOCAL
-              Ticket etype: 18 (AES256)
-              Key: deadbeef
-        EOF
-      end
-
-      it 'prints presenter output under the credential header' do
-        log_credential
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when source is nil' do
-      let(:source) { nil }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Credential
-          ####################
-          Creds: 1
-            Credential[0]:
-              Server: krbtgt/EXAMPLE.LOCAL@EXAMPLE.LOCAL
-              Client: Administrator@EXAMPLE.LOCAL
-              Ticket etype: 18 (AES256)
-              Key: deadbeef
-        EOF
-      end
-
-      it 'omits the source suffix from the header' do
-        log_credential
-
-        expect(output_text).to eq(expected_output)
-      end
-    end
-
-    context 'when credential is nil' do
-      let(:credential_to_log) { nil }
-
-      it 'does not print anything' do
-        log_credential
-
-        expect(output_text).to be_nil
-      end
-    end
-
-    context 'when KerberosTicketTrace is false' do
-      let(:trace_enabled) { false }
-
-      it 'does not print anything' do
-        log_credential
-
-        expect(output_text).to be_nil
-      end
-    end
-
-    context 'when presenter raises an error' do
-      let(:presenter) { instance_double(Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter) }
-      let(:expected_output) do
-        <<~EOF.rstrip
-          ####################
-          # Kerberos Credential: TGS
-          ####################
-          Credential presenter error: RuntimeError: boom
-        EOF
-      end
-
-      before do
-        allow(presenter).to receive(:present_cred).with(credential).and_raise(RuntimeError, 'boom')
-      end
-
-      it 'prints the presenter error message' do
-        log_credential
-
-        expect(output_text).to eq(expected_output)
+        expect(@output).to include('  "stime": "2026-03-07T12:00:00Z",')
+        expect(@output).to include('    "ap",')
+        expect(@output).to include('    "error"')
+        expect(@output).to include('    "source": "kdc"')
+        expect(@output).to include('    "name": "KRB_AP_ERR_MODIFIED",')
+        expect(@output).to include('    "value": 41,')
+        expect(@output).to include('    "description": "Message stream modified"')
       end
     end
   end


### PR DESCRIPTION
## Summary
This PR extends `KerberosTicketTrace` to provide end-to-end Kerberos tracing across KDC and service-authentication stages.

- Adds trace coverage for `AS-REQ/AS-REP` and `TGS-REQ/TGS-REP`.
- Adds AP-stage tracing for `AP-REQ` generation and `AP-REP` / `KRB-ERROR` handling.
- Introduces structured Kerberos logging with configurable request/response colors.

## Motivation
`KerberosTicketTrace` did not previously provide consistent visibility across the full Kerberos exchange lifecycle.

## Implementation Details
- Introduced a Kerberos subscriber/logger path for request/response tracing.
- Wired trace callbacks into Kerberos client send/receive flow for AS/TGS exchanges.
- Added AP-stage hooks in service authentication:
  - log outgoing service `AP-REQ`
  - log incoming `AP-REP` or `KRB-ERROR` during GSS init response parsing
- Kept trace behavior gated by `KerberosTicketTrace` datastore option.

## Testing
- Expanded Kerberos logger specs to cover:
  - trace enabled/disabled behavior
  - color parsing variants
  - message type mapping (`AS`, `TGS`, `AP`, `KRB-ERROR`)
  - serialization behavior (structured values and bounded binary previews)
