### PR TITLE
Fix msfvenom UTF-8 encoding error

### DIFF
--- a/lib/msf/core/payload/windows/exec.rb
+++ b/lib/msf/core/payload/windows/exec.rb
@@ -65,7 +65,7 @@ module Payload::Windows::Exec
   # Returns the command string to use for execution
   #
   def command_string
-    return datastore['CMD'] || ''
+    return (datastore['CMD'] || '').b
   end
 
 end


### PR DESCRIPTION
`msfvenom` was crashing with incompatible character encoding when the `CMD` option contained non ASCII characters (e.g. Cyrillic, Chinese, Arabic).
The fix forces the `CMD` string to binary encoding before appending it to the shellcode, so the two can be concatenated without conflict.
Fixes #19093

## Verification

-  Run `msfvenom -p windows/exec cmd="без разницы" -f python`
-  Verify the payload generates successfully without an encoding error
-  Run `msfvenom -p windows/exec cmd="calc.exe" -f python`
-  Verify normal ASCII commands still work as before
