### PR TITLE
Add documentation for PayloadUUIDSeed global variable

### DIFF
--- a/documentation/cli/msfconsole.md
+++ b/documentation/cli/msfconsole.md
@@ -51,3 +51,31 @@ Target a set of IPv6 hosts:
 Target a block from a resolved domain name:
 
     set RHOSTS www.example.test/24
+### PayloadUUIDSeed
+The `PayloadUUIDSeed` option allows users to define a custom string used during the generation of a payload's Unique Identifier (UUID). 
+
+* **Stealth:** Providing a unique seed ensures that the resulting payload signature is distinct from default generated payloads.
+* **Tracking:** It helps identify which specific campaign or listener a payload belongs to when it calls back.
+U nano 8.7.1     documentation/cli/msfconsole.md *            
+### Examples
+
+Terminate the first sessions:
+
+    sessions -k 1
+
+Stop some extra running jobs:
+
+    jobs -k 2-6,7,8,11..15
+
+Check a set of IP addresses:
+
+    check 127.168.0.0/16, 127.0.0-2.1-4,15 127.0.0.255
+
+Target a set of IPv6 hosts:
+
+    set RHOSTS fe80::3990:0000/110, ::1-::f0f0
+
+Target a block from a resolved domain name:
+
+    set RHOSTS www.example.test/24
+c


### PR DESCRIPTION
## Description
This PR adds documentation for the `PayloadUUIDSeed` global variable to the `msfconsole.md` CLI guide. 

While researching core options, I noticed that `PayloadUUIDSeed` was missing from the manual. This variable is crucial for users who need to:
1. **Improve Stealth:** By seeding the UUID, users can avoid default signatures.
2. **Track Campaigns:** It allows for better identification of specific payloads calling back to a handler.

## Verification
- [x] Verified the variable exists in `lib/msf/core/payload/uuid.rb`
- [x] Confirmed the documentation renders correctly in Markdown.
- [x] Verified no existing entries for this variable in `documentation/cli/msfconsole.md`.