### PR TITLE
Fix base64 encoder

### DIFF
--- a/modules/encoders/cmd/base64.rb
+++ b/modules/encoders/cmd/base64.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder
 
     register_advanced_options(
       [
-        OptEnum.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', '', %w[base64 base64-long base64-short openssl] ])
+        OptEnum.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', 'base64', %w[base64 base64-long base64-short openssl] ])
       ]
     )
   end


### PR DESCRIPTION
fix the base64 cmd encoder setting a correct default option