### PR TITLE
Revert choose encoder updates

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -527,45 +527,6 @@ class Payload < Msf::Module
     nil
   end
 
-  def self.choose_encoder(mod)
-    payload_name = mod.datastore['PAYLOAD']
-    payload = mod.framework.payloads.create(payload_name)
-    return nil unless payload
-    compatible_encoders = payload.compatible_encoders.map(&:first)
-    configure_encoder = lambda do |encoder|
-      if payload.datastore.is_a?(Msf::DataStore)
-        payload_defaults = { 'ENCODER' => encoder }
-         mod.datastore.import_defaults_from_hash(payload_defaults, imported_by: 'choose_encoder')
-      else
-        mod.datastore['ENCODER'] = encoder
-      end
-
-      encoder
-    end
-
-    # If there is only one compatible encoder, return it immediately
-    if compatible_encoders.length == 1
-      return configure_encoder.call(compatible_encoders.first)
-    end
-
-    # Prefer encoders that are known to be reliable
-    preferred_encoders = [
-      'x86/shikata_ga_nai',
-      'x64/zutto_dekiru',
-      'cmd/base64',
-    ]
-
-    preferred_encoders.each do |type|
-      encoder = compatible_encoders.find { |name| name.end_with?(type) }
-
-      next unless encoder
-
-      return configure_encoder.call(encoder)
-    end
-
-    return compatible_encoders&.first
-  end
-
   #
   # A placeholder stub, to be overridden by mixins
   #

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -130,22 +130,6 @@ module Common
       end
     end
 
-    if ((mod.exploit? or mod.evasion? or mod.payload?) and mod.datastore['ENCODER'])
-      e = framework.encoders.create(mod.datastore['ENCODER'])
-
-      if (!e)
-        print_error("Invalid encoder defined: #{mod.datastore['ENCODER']}\n")
-        return
-      end
-
-      e.share_datastore(mod.datastore)
-
-      if (e)
-        e_opt = Serializer::ReadableText.dump_options(e, '   ')
-        print("\nEncoder options (#{mod.datastore['ENCODER']}):\n\n#{e_opt}\n") if (e_opt and e_opt.length > 0)
-      end
-    end
-
     # Print the selected target
     if (mod.exploit? and mod.target)
       mod_targ = Serializer::ReadableText.dump_exploit_target(mod, '   ')

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2190,25 +2190,6 @@ class Core
       end
     end
 
-    # Set ENCODER
-    if name.upcase == 'ENCODER' && active_module && active_module.exploit? && !clear
-      value = trim_path(value, 'encoder')
-
-      payload = active_module.framework.payloads.create(datastore['PAYLOAD'])
-      
-      unless payload
-        print_error("Please set a valid PAYLOAD before setting the ENCODER.")
-        return false
-      end
-
-      index_from_list(payload.compatible_encoders, value) do |mod|
-        return false unless mod && mod.respond_to?(:first)
-        # [name, class] from compatible_encoders
-        value = mod.first
-      end
-    end
-
-
     unless global || valid_options.any? { |vo| vo.casecmp?(name) }
       message = "Unknown datastore option: #{name}."
       suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -288,10 +288,6 @@ class Exploit
     Msf::Payload.choose_payload(mod)
   end
 
-  def self.choose_encoder(mod)
-    Msf::Payload.choose_encoder(mod)
-  end
-
 end
 
 end end end end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -908,14 +908,6 @@ module Msf
               print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
-            # Choose a default encoder when the module is used, not run
-            if mod.datastore['ENCODER']
-              print_status("Using configured encoder #{mod.datastore['ENCODER']}")
-            elsif dispatcher.respond_to?(:choose_encoder)
-              chosen_encoder = dispatcher.choose_encoder(mod) 
-              print_status("No encoder configured, defaulting to #{chosen_encoder}") if chosen_encoder
-            end
-
             if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.respond_to?(:actions) && mod.actions.size > 1
               print_status "Setting default action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
             end
@@ -1680,24 +1672,6 @@ module Msf
                 print("\nPayload advanced options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
               end
             end
-
-            if ((mod.exploit? or mod.evasion? or mod.payload?) and mod.datastore['ENCODER'])
-              e = framework.encoders.create(mod.datastore['ENCODER'])
-
-              if (!e)
-                print_error("Invalid encoder defined: #{mod.datastore['ENCODER']}\n")
-                return
-              end
-
-              e.share_datastore(mod.datastore)
-
-              if (e)
-                e_opt = Serializer::ReadableText.dump_advanced_options(e, '   ')
-                print("\nEncoder advanced options (#{mod.datastore['ENCODER']}):\n\n#{e_opt}\n") if (e_opt and e_opt.length > 0)
-              end
-            end
-
-
             print("\nView the full module info with the #{Msf::Ui::Tip.highlight('info')}, or #{Msf::Ui::Tip.highlight('info -d')} command.\n\n")
           end
 

--- a/modules/encoders/cmd/base64.rb
+++ b/modules/encoders/cmd/base64.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder
 
     register_advanced_options(
       [
-        OptEnum.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', '', %w[base64 base64-long base64-short openssl] ])
+        OptString.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', '', %w[base64 base64-long base64-short openssl] ])
       ]
     )
   end

--- a/modules/encoders/cmd/base64.rb
+++ b/modules/encoders/cmd/base64.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder
 
     register_advanced_options(
       [
-        OptEnum.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', 'base64', %w[base64 base64-long base64-short openssl] ])
+        OptEnum.new('Base64Decoder', [ false, 'The binary to use for base64 decoding', '', %w[base64 base64-long base64-short openssl] ])
       ]
     )
   end


### PR DESCRIPTION
Reverts the choose encoder updates pull requests that landed:

- https://github.com/rapid7/metasploit-framework/pull/21088
- https://github.com/rapid7/metasploit-framework/pull/20852


I'd like to revert these pull requests in the interim to unblock a Pro release, as there's still some active investigation on the long-term fixes for some of the other edge-cases that have popped up:

- https://github.com/rapid7/metasploit-framework/pull/21077
- https://github.com/rapid7/metasploit-framework/pull/21051

## Verification

Ensure CI passes