### PR TITLE
auxiliary/scanner/ftp/anonymous: Add report_service()

### DIFF
--- a/modules/auxiliary/scanner/ftp/anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/anonymous.rb
@@ -46,6 +46,14 @@ class MetasploitModule < Msf::Auxiliary
           access_type = 'Read-only'
         end
         register_creds(target_host, access_type)
+      elsif banner
+        report_service(
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          name: 'ftp',
+          info: banner
+        )
       end
 
       disconnect

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'ProFTPD-1.3.3c Backdoor Command Execution',
+        'Name' => 'ProFTPD 1.3.3c Backdoor Command Execution',
         'Description' => %q{
           This module exploits a malicious backdoor that was added to the
           ProFTPD download archive. This backdoor was present in the proftpd-1.3.3c.tar.[bz2|gz]

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'VSFTPD v2.3.4 Backdoor Command Execution',
+        'Name' => 'VSFTPD 2.3.4 Backdoor Command Execution',
         'Description' => %q{
           This module exploits a malicious backdoor that was added to the VSFTPD download
           archive. This backdoor was introduced into the vsftpd-2.3.4.tar.gz archive between


### PR DESCRIPTION
Previously would only log service if FTP service was working AND anonymous enabled.
Now it will log if FTP service is working regardless of anonymous.

```console
msf auxiliary(scanner/ftp/anonymous) > options

Module options (auxiliary/scanner/ftp/anonymous):

   Name     Current Setting      Required  Description
   ----     ---------------      --------  -----------
   FTPPASS  mozilla@example.com  no        The password for the specified username
   FTPUSER  anonymous            no        The username to authenticate as
   RHOSTS   10.0.0.10            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    2121                 yes       The target port (TCP)
   THREADS  1                    yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ftp/anonymous) >
msf auxiliary(scanner/ftp/anonymous) > run
[*] 10.0.0.10:2121        - Connecting to FTP server 10.0.0.10:2121...
[*] 10.0.0.10:2121        - Connected to target FTP server.
[*] 10.0.0.10:2121        - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:2121        - Sending password...
[-] 10.0.0.10:2121        - The server rejected our password
[*] 10.0.0.10:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/anonymous) >
msf auxiliary(scanner/ftp/anonymous) > services
Services
========

host       port  proto  name  state  info                                              resource  parents
----       ----  -----  ----  -----  ----                                              --------  -------
10.0.0.10  2121  tcp    ftp   open   ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]  {}

msf auxiliary(scanner/ftp/anonymous) >
```