### PR TITLE
Rename *brute modules in favour of *_brute

### DIFF
--- a/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
@@ -1,4 +1,4 @@
-##
+  ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -8,6 +8,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Report
+  include Msf::Module::Deprecated
+  moved_from 'auxiliary/scanner/oracle/isqlplus_sid_brute'
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
@@ -1,4 +1,4 @@
-  ##
+##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/auxiliary/scanner/tftp/tftpbrute.rb
+++ b/modules/auxiliary/scanner/tftp/tftpbrute.rb
@@ -6,6 +6,8 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Module::Deprecated
+  moved_from 'auxiliary/scanner/tftp/tftp_brute'
 
   def initialize
     super(


### PR DESCRIPTION
Looking at other burte force modules, they all '*_brute' rather than '*brute'.
This gets TFTP to match.

`auxiliary/scanner/tftp/tftpbrute` -> `auxiliary/scanner/tftp/tftp_brute`

```console
$ find ./modules -name '*brute*'  | sort | wc -l
      21
$
$ find ./modules -name '*brute*'  | sort
./modules/auxiliary/admin/oracle/sid_brute.rb
./modules/auxiliary/gather/citrix_published_bruteforce.rb
./modules/auxiliary/gather/ibm_sametime_room_brute.rb
./modules/auxiliary/gather/nuuo_cms_bruteforce.rb
./modules/auxiliary/scanner/http/brute_dirs.rb
./modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
./modules/auxiliary/scanner/http/cisco_asa_asdm_bruteforce.rb
./modules/auxiliary/scanner/http/joomla_bruteforce_login.rb
./modules/auxiliary/scanner/http/mod_negotiation_brute.rb
./modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
./modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
./modules/auxiliary/scanner/http/typo3_bruteforce.rb
./modules/auxiliary/scanner/misc/ibm_mq_channel_brute.rb
./modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
./modules/auxiliary/scanner/oracle/sid_brute.rb
./modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
./modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
./modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
./modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
./modules/auxiliary/scanner/tftp/tftpbrute.rb
./modules/post/multi/gather/dns_bruteforce.rb
$
$ find ./modules -name '*brute*'  | grep -v '_brute'
./modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
./modules/auxiliary/scanner/tftp/tftpbrute.rb
./modules/auxiliary/scanner/http/brute_dirs.rb
$
```