### PR TITLE
Fix NoMethodError in Kerberos client decoding by adding ASN.1 structural validation

### DIFF
--- a/lib/rex/proto/kerberos/client.rb
+++ b/lib/rex/proto/kerberos/client.rb
@@ -219,8 +219,31 @@ module Rex
         # @return [<Rex::Proto::Kerberos::Model::KrbError, Rex::Proto::Kerberos::Model::KdcResponse, Rex::Proto::Kerberos::Model::KrbError>] the kerberos message response
         # @raise [Rex::Proto::Kerberos::Model::Error::KerberosDecodingError] if the response can't be processed
         def decode_kerb_response(data)
-          asn1 = OpenSSL::ASN1.decode(data)
-          msg_type = asn1.value[0].value[1].value[0].value
+          begin
+            asn1 = OpenSSL::ASN1.decode(data)
+          rescue OpenSSL::ASN1::ASN1Error => e
+            raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, "Kerberos Client: Failed to decode ASN.1: #{e.message}"
+          end
+
+          # Safely navigate the ASN.1 structure to extract the message type.
+          # The structure is expected to be an Application Tag wrapper around a Sequence,
+          # where the element with context-specific tag [1] contains the msg-type integer.
+          # Reference: RFC 4120 sections 5.2.1, 5.4.1, 5.9.1
+          msg_type = begin
+            if asn1.is_a?(OpenSSL::ASN1::ASN1Data) && asn1.value.is_a?(Array) && asn1.value[0].is_a?(OpenSSL::ASN1::Sequence)
+              seq_value = asn1.value[0].value
+              # Find the element with context-specific tag 1 (msg-type)
+              msg_type_tag = seq_value.find { |elem| elem.is_a?(OpenSSL::ASN1::ASN1Data) && elem.tag == 1 }
+              # Extract the Integer value from the tagged element
+              if msg_type_tag && msg_type_tag.value.is_a?(Array) && msg_type_tag.value[0].is_a?(OpenSSL::ASN1::Integer)
+                msg_type_tag.value[0].value
+              end
+            end
+          rescue StandardError
+            nil
+          end
+
+          raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Kerberos Client: Invalid or truncated ASN.1 response structure' if msg_type.nil?
 
           case msg_type
           when Rex::Proto::Kerberos::Model::KRB_ERROR
@@ -230,7 +253,7 @@ module Rex
           when Rex::Proto::Kerberos::Model::AP_REP
             res = Rex::Proto::Kerberos::Model::ApRep.decode(asn1)
           else
-            raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, 'Kerberos Client: Unknown response'
+            raise ::Rex::Proto::Kerberos::Model::Error::KerberosDecodingError, "Kerberos Client: Unknown response type: #{msg_type}"
           end
 
           res


### PR DESCRIPTION
## Description
This PR  fixes issue #21089 adds defensive structural validation to the Kerberos client's ASN.1 response decoding logic in `lib/rex/proto/kerberos/client.rb`. 

Previously, the `decode_kerb_response` method performed deep nested indexing into the `OpenSSL::ASN1` object (e.g., `asn1.value[0].value[1].value[0].value`) without validating that each level was a sequence or contained the expected tags. If a KDC (malicious or misconfigured) returned a malformed response or a simple ASN.1 type (like an Integer) instead of the expected Sequence, Metasploit would crash with a `NoMethodError: undefined method 'value' for nil:NilClass`.

The fix introduces:
- A `begin...rescue` block for the initial ASN.1 decoding to catch `OpenSSL::ASN1::ASN1Error`.
- Safe navigation and structural validation of the ASN.1 tree.
- Explicit type-checking for each node before accessing its value.
- Mapping of structural failures to `Rex::Proto::Kerberos::Model::Error::KerberosDecodingError`, ensuring a graceful failure instead of a process crash.

## Verification

### Standalone Reproduction Script
Since this is a core library bug, verification is best handled via a standalone script that simulates a malformed KDC response.

1.  Create a file `repro.rb`:
    ```ruby
    require 'openssl'
    require 'rex/proto/kerberos/client'
    require 'rex/proto/kerberos/model/error/kerberos_decoding_error'

    # Mock class to test the module
    class KerberosTest
      include Rex::Proto::Kerberos::Client
      def initialize; @options = {}; end
    end

    test = KerberosTest.new
    # Malformed data: a single ASN.1 Integer instead of a Sequence
    data = OpenSSL::ASN1::Integer.new(1234).to_der

    puts "[*] Testing decode_kerb_response with malformed data..."
    begin
      test.send(:decode_kerb_response, data)
      puts "[-] FAIL: Did not raise an error"
    rescue Rex::Proto::Kerberos::Model::Error::KerberosDecodingError => e
      puts "[+] SUCCESS: Caught expected error: #{e.message}"
    rescue NoMethodError => e
      puts "[-] FAIL: Still crashing with NoMethodError: #{e.message}"
    end
    ```
2.  **Verify** that before the fix, the script crashes with `NoMethodError`.
3.  **Verify** that after the fix, the script successfully catches the `KerberosDecodingError`.
4.  **Verify** that existing Kerberos modules (e.g., `auxiliary/admin/kerberos/forge_ticket`) still function correctly under normal conditions.

## Documentation
No new user-facing documentation is required as this is a core library robustness improvement.
