### PR TITLE
Fix VERBOSE flag ignored when set before module load

### DIFF
--- a/lib/msf/core/module/ui/line/verbose.rb
+++ b/lib/msf/core/module/ui/line/verbose.rb
@@ -1,6 +1,7 @@
 module Msf::Module::UI::Line::Verbose
+  TRUE_REGEX = /^(y|yes|t|1|true)$/i
   # Verbose version of #print_line
-  def vprint_line(msg='')
-    print_line(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
+  def vprint_line(msg = '')
+    print_line(msg) if datastore['VERBOSE'].to_s =~ TRUE_REGEX || (!framework.nil? && framework.datastore['VERBOSE'].to_s =~ TRUE_REGEX)
   end
 end

--- a/lib/msf/core/module/ui/message/verbose.rb
+++ b/lib/msf/core/module/ui/message/verbose.rb
@@ -1,23 +1,25 @@
 module Msf::Module::UI::Message::Verbose
+  TRUE_REGEX = /^(y|yes|t|1|true)$/i
   # Verbose version of #print_error
-  def vprint_error(msg='')
-    print_error(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
+  def vprint_error(msg = '')
+    print_error(msg) if datastore['VERBOSE'].to_s =~ TRUE_REGEX || (!framework.nil? && framework.datastore['VERBOSE'].to_s =~ TRUE_REGEX)
   end
 
-  alias_method :vprint_bad, :vprint_error
+  alias vprint_bad vprint_error
 
   # Verbose version of #print_good
-  def vprint_good(msg='')
+  def vprint_good(msg = '')
     print_good(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
   end
+  alias vprint_bad vprint_error
 
   # Verbose version of #print_status
-  def vprint_status(msg='')
-    print_status(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
+  def vprint_status(msg = '')
+    print_status(msg) if datastore['VERBOSE'].to_s =~ TRUE_REGEX || (!framework.nil? && framework.datastore['VERBOSE'].to_s =~ TRUE_REGEX)
   end
 
   # Verbose version of #print_warning
-  def vprint_warning(msg='')
-    print_warning(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
+  def vprint_warning(msg = '')
+    print_warning(msg) if datastore['VERBOSE'].to_s =~ TRUE_REGEX || (!framework.nil? && framework.datastore['VERBOSE'].to_s =~ TRUE_REGEX)
   end
 end


### PR DESCRIPTION
Fixes #21099

When `set VERBOSE false` is called before `use <module>`, the value is stored in the framework datastore as a raw string `"false"` without going through `OptBool#normalize`. Ruby treats non-empty strings as truthy, so the verbose condition evaluated `"false"` (string) as `true`, causing verbose output to always appear regardless of the flag.

Fix by using `.to_s =~ TRUE_REGEX` for both module and framework datastore lookups, consistent with how `OptBool` normalizes boolean values.

## Verification

- [x] Start `msfconsole`
- [x] `set VERBOSE false`
- [x] `setg RHOSTS <target>`
- [x] `use auxiliary/scanner/smtp/smtp_enum`
- [x] `set USER_FILE user.txt`
- [x] `run`
- [x] **Verify** no verbose lines appear (no "Domain Name", no "Trying MAIL FROM")
- [x] Repeat with `set VERBOSE true` before `use`
- [x] **Verify** verbose lines now appear correctly
- [x] Repeat with no `set VERBOSE` at all
- [x] **Verify** no verbose lines appear (default behaviour unchanged)

```
~/Documents/metasploit-framework$ ./msfconsole -q -x 'set VERBOSE false; setg RHOSTS 192.168.28.65; use auxiliary/scanner/smtp/smtp_enum; set USER_FILE user.txt; run; exit;' 2>&1 | grep -v WARN | grep -v stringio | grep -v "gem cleanup" | grep -v "Please report" | grep -v "Available"
      - 3.1.1
      - 3.0.4
VERBOSE => false
RHOSTS => 192.168.28.65
USER_FILE => user.txt
[*] 192.168.28.65:25      - 192.168.28.65:25 Banner: 220 metasploitable.localdomain ESMTP Postfix (Ubuntu)
[*] 192.168.28.65:25      - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

~/Documents/metasploit-framework$ 

```
```
~/Documents/metasploit-framework$ ./msfconsole -q -x 'set VERBOSE true; setg RHOSTS 192.168.28.65; use auxiliary/scanner/smtp/smtp_enum; set USER_FILE user.txt; run; exit;' 2>&1 | grep -v WARN | grep -v stringio | grep -v "gem cleanup" | grep -v "Please report" | grep -v "Available"
      - 3.1.1
      - 3.0.4
VERBOSE => true
RHOSTS => 192.168.28.65
USER_FILE => user.txt
[*] 192.168.28.65:25      - 192.168.28.65:25 Banner: 220 metasploitable.localdomain ESMTP Postfix (Ubuntu)
[*] 192.168.28.65:25      - 192.168.28.65:25 Domain Name: metasploitable.localdomain
[*] 192.168.28.65:25      - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

~/Documents/metasploit-framework$ 

```

```
~/Documents/metasploit-framework$ ./msfconsole -q -x 'setg RHOSTS 192.168.28.65; use auxiliary/scanner/smtp/smtp_enum; set USER_FILE user.txt; run; exit;' 2>&1 | grep -v WARN | grep -v stringio | grep -v "gem cleanup" | grep -v "Please report" | grep -v "Available"
      - 3.1.1
      - 3.0.4
RHOSTS => 192.168.28.65
USER_FILE => user.txt
[*] 192.168.28.65:25      - 192.168.28.65:25 Banner: 220 metasploitable.localdomain ESMTP Postfix (Ubuntu)
[*] 192.168.28.65:25      - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

~/Documents/metasploit-framework$ 

```

---
> **Ramesh** | Security Researcher  
> [IoTSec.in](https://iotsec.in) - IoT & Embedded Security Research 

