### PR TITLE
Add RAP fallback to smb_enumshares for legacy SMB hosts

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -299,7 +299,7 @@ class MetasploitModule < Msf::Auxiliary
       enum_shares(session.address)
     else
       [
-        { port: SMB1_PORT, versions: [1], backend: :ruby_smb, label: 'SMB over NetBIOS' },
+        { port: SMB1_PORT, versions: [1], backend: :ruby_smb, label: 'SMB over NetBIOS', direct: false },
         { port: SMB2_3_PORT, versions: [1, 2, 3], backend: :ruby_smb, label: 'SMB' }
       ].each do |info|
         # Update line prefix, as port changes
@@ -308,7 +308,8 @@ class MetasploitModule < Msf::Auxiliary
         # as well as making it accessible to the module mixins
         @rport = info[:port]
         vprint_status("Connecting using #{info[:label]} via #{info[:backend]}")
-        connect(versions: info[:versions], backend: info[:backend])
+        # `direct: false` on port 139 forces NetBIOS session setup for legacy hosts (Win9x/ME)
+        connect(versions: info[:versions], backend: info[:backend], direct: info[:direct])
         smb_login
         shares = enum_shares(ip)
         next if shares.nil? || shares.empty?
@@ -341,22 +342,38 @@ class MetasploitModule < Msf::Auxiliary
     shares = []
 
     begin
-      # Return all shares if `Shares` option has not been set
-      if datastore['Share'].nil?
-        shares = simple.client.net_share_enum_all(ip)
-      # Return specific share if the `Share` option has been set
-      else
-        simple.client.net_share_enum_all(ip).each { |share| shares = [share] if share[:name] == datastore['Share'] }
-      end
-      # Return an error if `Share` option has been set but no matches were found
-      print_error("No shares match #{datastore['Share']}") if shares.empty?
-    rescue RubySMB::Error::UnexpectedStatusCode => e
-      print_error("Error when trying to enumerate shares - #{e.status_code.name}")
-      return
-    rescue RubySMB::Error::InvalidPacket => e
-      vprint_error("Invalid packet received when trying to enumerate shares - #{e}")
-      return
+      all_shares = simple.client.net_share_enum_all(ip)
+    rescue RubySMB::Error::UnexpectedStatusCode, RubySMB::Error::InvalidPacket => e
+      vprint_status("SRVSVC failed (#{e}), falling back to RAP")
+      all_shares = nil
     end
+
+    if all_shares.nil?
+      begin
+        tree = simple.client.tree_connect("\\\\#{ip}\\IPC$")
+        begin
+          all_shares = tree.net_share_enum
+        ensure
+          begin
+            tree.disconnect!
+          rescue StandardError # rubocop:disable Lint/SuppressedException
+          end
+        end
+      rescue StandardError => e
+        print_error("RAP share enumeration also failed - #{e}")
+        return []
+      end
+    end
+
+    # Return all shares if `Shares` option has not been set
+    if datastore['Share'].nil?
+      shares = all_shares
+    # Return specific share if the `Share` option has been set
+    else
+      all_shares.each { |share| shares = [share] if share[:name] == datastore['Share'] }
+    end
+    # Return an error if `Share` option has been set but no matches were found
+    print_error("No shares match #{datastore['Share']}") if datastore['Share'] && shares.empty?
 
     os_info = get_os_info(ip)
     print_status(os_info) if os_info


### PR DESCRIPTION
**Depends on:** https://github.com/rapid7/ruby_smb/pull/294 (must be merged first)

  ## Summary

  - Add RAP (Remote Administration Protocol) fallback to `smb_enumshares` when SRVSVC share enumeration fails, enabling share enumeration on Windows 95/98/ME and other legacy SMB hosts that don't support DCERPC
  - Map RAP integer share types (0=DISK, 1=PRINTER, etc.) to the string format the module expects, so filtering, spidering, and reporting work unchanged
  - Add `direct: false` to the SMB1 connect call on port 139 to ensure proper NetBIOS session setup

  ## Verification

  - Against a modern SMB host: SRVSVC succeeds as before, RAP path is never reached
  - Against a legacy Win9x/ME host on port 139: SRVSVC fails with `UnexpectedStatusCode`/`InvalidPacket`, module falls back to RAP and enumerates shares successfully
  - `Share` option filtering works with both SRVSVC and RAP results

**Depends on:** https://github.com/rapid7/ruby_smb/pull/294 (must be merged first)