### PR TITLE
Add Kerberos trace subscriber support

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'msf/core/exploit/remote/kerberos/clock_skew'
+require 'rex/proto/kerberos/kerberos_logger_subscriber'
 
 module Msf
   class Exploit
@@ -46,7 +47,9 @@ module Msf
             register_advanced_options(
               [
                 OptString.new('KrbClockSkew', [true, 'Adjust Kerberos client clock by this offset (e.g. 90s, -5m, 1h)', '0s'],
-                              regex: Msf::Exploit::Remote::Kerberos::ClockSkew::CLOCK_SKEW_REGEX)
+                              regex: Msf::Exploit::Remote::Kerberos::ClockSkew::CLOCK_SKEW_REGEX),
+                OptBool.new('KerberosTicketTrace', [false, 'Show Kerberos request and response trace output', false]),
+                OptEnum.new('KerberosTicketTraceLevel', [true, 'KerberosTicketTrace verbosity', 'summary', %w[summary raw]])
               ], self.class
             )
           end
@@ -144,7 +147,8 @@ module Msf
                 'Msf' => framework,
                 'MsfExploit' => framework_module
               },
-              protocol: 'tcp'
+              protocol: 'tcp',
+              subscriber: Rex::Proto::Kerberos::KerberosLoggerSubscriber.new(logger: self)
             )
 
             disconnect if kerberos_client

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/options.rb
@@ -1,10 +1,8 @@
 # -*- coding: binary -*-
 
-#
-# This class stores Metasploit option configuration used across service authentication
-#
 require 'msf/core/exploit/remote/kerberos/clock_skew'
 
+# This module stores Metasploit option configuration used across service authentication.
 module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
   # Create the list of options that a module must provide for Kerberos authentication via the given protocol
   # This method exists for ensuring consistency across service authentication modules
@@ -30,7 +28,7 @@ module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
     auth_options = [
       Msf::OptEnum.new(
         "#{protocol}::Auth",
-        [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, auth_methods],
+        [true, 'The Authentication mechanism to use', Msf::Exploit::Remote::AuthOption::AUTO, auth_methods]
       ),
       Msf::OptString.new(
         "#{protocol}::Rhostname",
@@ -58,6 +56,16 @@ module Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
 
     [
       *auth_options,
+      Msf::OptBool.new(
+        'KerberosTicketTrace',
+        [false, 'Show Kerberos request and response trace output', false],
+        conditions: option_conditions
+      ),
+      Msf::OptEnum.new(
+        'KerberosTicketTraceLevel',
+        [true, 'KerberosTicketTrace verbosity', 'summary', %w[summary raw]],
+        conditions: option_conditions
+      ),
       offered_enc_types_option
     ]
   end

--- a/lib/rex/proto/kerberos/client.rb
+++ b/lib/rex/proto/kerberos/client.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 
+require 'rex/proto/kerberos/kerberos_subscriber'
 require 'rex/stopwatch'
 
 module Rex
@@ -29,14 +30,18 @@ module Rex
         # @!attribute context
         #   @return [Hash] The Msf context where the connection belongs to
         attr_accessor :context
+        # @!attribute subscriber
+        #   @return [Rex::Proto::Kerberos::KerberosSubscriber] The Kerberos trace subscriber
+        attr_accessor :subscriber
 
         def initialize(opts = {})
           self.host = opts[:host]
-          self.port     = (opts[:port] || 88).to_i
-          self.proxies  = opts[:proxies]
-          self.timeout  = (opts[:timeout] || 10).to_i
+          self.port = (opts[:port] || 88).to_i
+          self.proxies = opts[:proxies]
+          self.timeout = (opts[:timeout] || 10).to_i
           self.protocol = opts[:protocol] || 'tcp'
-          self.context  = opts[:context] || {}
+          self.context = opts[:context] || {}
+          self.subscriber = opts[:subscriber] || KerberosSubscriber.new
         end
 
         # Creates a connection through a Rex socket
@@ -45,14 +50,16 @@ module Rex
         # @raise [RuntimeError] if the connection can not be created
         def connect
           return connection if connection
-          raise ArgumentError, 'Missing remote address' unless self.host && self.port
+
+          raise ArgumentError, 'Missing remote address' unless host && port
+
           case protocol
           when 'tcp'
             self.connection = create_tcp_connection
           when 'udp'
             raise ::NotImplementedError, 'Kerberos Client: UDP not supported'
           else
-            raise ::RuntimeError, 'Kerberos Client: unknown transport protocol'
+            raise 'Kerberos Client: unknown transport protocol'
           end
 
           connection
@@ -84,7 +91,7 @@ module Rex
           when 'udp'
             sent = send_request_udp(req)
           else
-            raise ::RuntimeError, 'Kerberos Client: unknown transport protocol'
+            raise 'Kerberos Client: unknown transport protocol'
           end
 
           sent
@@ -99,7 +106,7 @@ module Rex
         # @raise [NotImplementedError] if the transport protocol isn't supported
         def recv_response
           if connection.nil?
-            raise ::RuntimeError, 'Kerberos Client: connection not established'
+            raise 'Kerberos Client: connection not established'
           end
 
           res = nil
@@ -109,7 +116,7 @@ module Rex
           when 'udp'
             res = recv_response_udp
           else
-            raise ::RuntimeError, 'Kerberos Client: unknown transport protocol'
+            raise 'Kerberos Client: unknown transport protocol'
           end
 
           res
@@ -135,11 +142,11 @@ module Rex
         # @return [Rex::Socket::Tcp]
         def create_tcp_connection
           self.connection = Rex::Socket::Tcp.create(
-            'PeerHost'   => host,
-            'PeerPort'   => port.to_i,
-            'Proxies'    => proxies,
-            'Context'    => context,
-            'Timeout'    => timeout
+            'PeerHost' => host,
+            'PeerPort' => port.to_i,
+            'Proxies' => proxies,
+            'Context' => context,
+            'Timeout' => timeout
           )
         end
 
@@ -150,6 +157,7 @@ module Rex
         # @raise [RuntimeError] if the request can't be encoded
         def send_request_tcp(req)
           data = req.encode
+          notify_subscriber(:on_request, req, raw: data, context: trace_context)
           length = [data.length].pack('N')
           connection.put(length + data)
         end
@@ -201,7 +209,9 @@ module Rex
             raise ::EOFError, 'Kerberos Client: failed to read response'
           end
 
-          decode_kerb_response(data)
+          res = decode_kerb_response(data)
+          notify_subscriber(:on_response, res, raw: data, context: trace_context)
+          res
         end
 
         # UDP isn't supported
@@ -210,8 +220,6 @@ module Rex
         def recv_response_udp
           raise ::NotImplementedError, 'Kerberos Client: UDP unsupported'
         end
-
-        private
 
         # Decodes a Kerberos response
         #
@@ -234,6 +242,19 @@ module Rex
           end
 
           res
+        end
+
+        def trace_context
+          {
+            peer: "#{host}:#{port}",
+            protocol: protocol
+          }
+        end
+
+        def notify_subscriber(method_name, *args, **kwargs)
+          return unless subscriber.respond_to?(method_name)
+
+          subscriber.public_send(method_name, *args, **kwargs)
         end
       end
     end

--- a/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
@@ -1,0 +1,166 @@
+# -*- coding: binary -*-
+
+require 'rex/proto/kerberos/kerberos_subscriber'
+require 'rex/proto/kerberos/model'
+
+module Rex
+  module Proto
+    module Kerberos
+      # Formats Kerberos request and response events for console tracing.
+      class KerberosLoggerSubscriber < KerberosSubscriber
+        RAW_PREVIEW_BYTES = 32
+
+        MESSAGE_TYPES = {
+          Rex::Proto::Kerberos::Model::AS_REQ => 'AS-REQ',
+          Rex::Proto::Kerberos::Model::AS_REP => 'AS-REP',
+          Rex::Proto::Kerberos::Model::TGS_REQ => 'TGS-REQ',
+          Rex::Proto::Kerberos::Model::TGS_REP => 'TGS-REP',
+          Rex::Proto::Kerberos::Model::KRB_ERROR => 'KRB-ERROR',
+          Rex::Proto::Kerberos::Model::AP_REQ => 'AP-REQ',
+          Rex::Proto::Kerberos::Model::AP_REP => 'AP-REP'
+        }.freeze
+
+        def initialize(logger:)
+          super()
+          raise 'Incompatible logger' unless logger.respond_to?(:print_line) && logger.respond_to?(:datastore)
+
+          @logger = logger
+        end
+
+        def on_request(request, raw: nil, context: {})
+          return unless trace_enabled?
+
+          @logger.print_line('#' * 20)
+          @logger.print_line('# Kerberos Request:')
+          @logger.print_line('#' * 20)
+          @logger.print_line(request_summary(request, context))
+          request_details(request).each { |line| @logger.print_line(line) }
+          raw_details(raw).each { |line| @logger.print_line(line) }
+        end
+
+        def on_response(response, raw: nil, context: {})
+          return unless trace_enabled?
+
+          @logger.print_line('#' * 20)
+          @logger.print_line('# Kerberos Response:')
+          @logger.print_line('#' * 20)
+          @logger.print_line(response_summary(response, context))
+          response_details(response).each { |line| @logger.print_line(line) }
+          raw_details(raw).each { |line| @logger.print_line(line) }
+        end
+
+        private
+
+        def trace_enabled?
+          @logger.datastore['KerberosTicketTrace']
+        end
+
+        def trace_level
+          level = @logger.datastore['KerberosTicketTraceLevel'].to_s.downcase
+          return 'summary' if level.empty?
+          return level if %w[summary raw].include?(level)
+
+          'summary'
+        end
+
+        def raw_level?
+          trace_level == 'raw'
+        end
+
+        def request_summary(request, context)
+          body = request.req_body
+          parts = []
+          parts << "peer=#{context[:peer]}" if context[:peer]
+          parts << "msg=#{message_name(request.msg_type)}"
+          parts << "realm=#{body.realm}" if body&.realm
+          parts << "cname=#{principal_name(body&.cname)}" if body&.cname
+          parts << "sname=#{principal_name(body&.sname)}" if body&.sname
+          parts.join(' ')
+        end
+
+        def request_details(request)
+          return [] unless raw_level?
+
+          body = request.req_body
+          detail = []
+          detail << "pvno=#{request.pvno}"
+          detail << "msg_type=#{request.msg_type}"
+          detail << "pa_data_count=#{Array(request.pa_data).length}"
+          detail << "etypes=#{body.etype.join(',')}" if body&.etype&.any?
+          [detail.join(' ')]
+        end
+
+        def response_summary(response, context)
+          parts = []
+          parts << "peer=#{context[:peer]}" if context[:peer]
+
+          case response
+          when Rex::Proto::Kerberos::Model::KrbError
+            parts << "msg=#{message_name(response.msg_type)}"
+            parts << "realm=#{response.realm}" if response.realm
+            parts << "cname=#{principal_name(response.cname)}" if response.cname
+            parts << "sname=#{principal_name(response.sname)}" if response.sname
+            parts << "error=#{response.error_code.name}(#{response.error_code.value})" if response.error_code
+          when Rex::Proto::Kerberos::Model::KdcResponse
+            parts << "msg=#{message_name(response.msg_type)}"
+            parts << "realm=#{response.crealm}" if response.crealm
+            parts << "cname=#{principal_name(response.cname)}" if response.cname
+            ticket_sname = response.ticket&.sname
+            parts << "sname=#{principal_name(ticket_sname)}" if ticket_sname
+          when Rex::Proto::Kerberos::Model::ApRep
+            parts << "msg=#{message_name(response.msg_type)}"
+          else
+            parts << 'response=nil'
+          end
+
+          parts.join(' ')
+        end
+
+        def response_details(response)
+          return [] unless raw_level?
+
+          detail = []
+
+          case response
+          when Rex::Proto::Kerberos::Model::KrbError
+            detail << "pvno=#{response.pvno}"
+            detail << "msg_type=#{response.msg_type}"
+            detail << "server_time=#{response.stime.utc.iso8601}" if response.stime
+            detail << "e_data_present=#{!response.e_data.nil?}"
+          when Rex::Proto::Kerberos::Model::KdcResponse
+            detail << "pvno=#{response.pvno}"
+            detail << "msg_type=#{response.msg_type}"
+            detail << "pa_data_count=#{Array(response.pa_data).length}"
+          when Rex::Proto::Kerberos::Model::ApRep
+            detail << "pvno=#{response.pvno}"
+            detail << "msg_type=#{response.msg_type}"
+          else
+            return []
+          end
+
+          [detail.join(' ')]
+        end
+
+        def raw_details(raw)
+          return [] unless raw_level? && raw
+
+          preview = raw.to_s.b.bytes.first(RAW_PREVIEW_BYTES).map { |byte| format('%02x', byte) }.join(' ')
+          suffix = raw.to_s.b.length > RAW_PREVIEW_BYTES ? ' ...' : ''
+
+          [
+            "raw_length=#{raw.to_s.b.length}",
+            "raw_preview=#{preview}#{suffix}"
+          ]
+        end
+
+        def principal_name(principal)
+          principal&.to_s
+        end
+
+        def message_name(message_type)
+          MESSAGE_TYPES.fetch(message_type, "UNKNOWN(#{message_type})")
+        end
+      end
+    end
+  end
+end

--- a/lib/rex/proto/kerberos/kerberos_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_subscriber.rb
@@ -1,0 +1,20 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Proto
+    module Kerberos
+      # Base hook for Kerberos request and response tracing.
+      class KerberosSubscriber
+        # @param request [Rex::Proto::Kerberos::Model::KdcRequest]
+        # @param raw [String,nil]
+        # @param context [Hash]
+        def on_request(request, raw: nil, context: {}); end
+
+        # @param response [Rex::Proto::Kerberos::Model::KdcResponse, Rex::Proto::Kerberos::Model::KrbError, Rex::Proto::Kerberos::Model::ApRep]
+        # @param raw [String,nil]
+        # @param context [Hash]
+        def on_response(response, raw: nil, context: {}); end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/base/serializer/readable_text_kerberos_trace_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_kerberos_trace_spec.rb
@@ -1,0 +1,67 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+require 'rex/text'
+
+RSpec.describe Msf::Serializer::ReadableText do
+  let(:indent_string) { '' }
+
+  def kerberos_auth_options(protocol:, auth_methods:)
+    mixin = Class.new.extend(Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options)
+    mixin.kerberos_auth_options(protocol: protocol, auth_methods: auth_methods)
+  end
+
+  let(:aux_mod) do
+    mod_klass = Class.new(Msf::Auxiliary) do
+      def initialize
+        super(
+          'Name' => 'mock module',
+          'Description' => 'mock module',
+          'Author' => ['Unknown'],
+          'License' => MSF_LICENSE
+        )
+      end
+    end
+
+    mod = mod_klass.new
+    mock_framework = instance_double(::Msf::Framework, datastore: Msf::DataStore.new)
+    allow(mod).to receive(:framework).and_return(mock_framework)
+    mod
+  end
+
+  before(:each) do
+    allow(Rex::Text::Table).to receive(:wrapped_tables?).and_return(true)
+  end
+
+  describe '.dump_advanced_options' do
+    it 'includes the kerberos trace options' do
+      aux_mod.send(
+        :register_advanced_options,
+        kerberos_auth_options(protocol: 'Winrm', auth_methods: Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS)
+      )
+
+      expect(described_class.dump_advanced_options(aux_mod, indent_string)).to include(
+        'KerberosTicketTrace               false'
+      )
+      expect(described_class.dump_advanced_options(aux_mod, indent_string)).to include(
+        'KerberosTicketTraceLevel          summary'
+      )
+    end
+  end
+
+  describe '.dump_evasion_options' do
+    it 'includes the kerberos trace options' do
+      aux_mod.send(
+        :register_evasion_options,
+        kerberos_auth_options(protocol: 'Winrm', auth_methods: Msf::Exploit::Remote::AuthOption::WINRM_OPTIONS)
+      )
+
+      expect(described_class.dump_evasion_options(aux_mod, indent_string)).to include(
+        'KerberosTicketTrace               false'
+      )
+      expect(described_class.dump_evasion_options(aux_mod, indent_string)).to include(
+        'KerberosTicketTraceLevel          summary'
+      )
+    end
+  end
+end

--- a/spec/lib/rex/proto/kerberos/client_subscriber_spec.rb
+++ b/spec/lib/rex/proto/kerberos/client_subscriber_spec.rb
@@ -1,0 +1,88 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+require 'stringio'
+
+# Minimal in-memory socket used to exercise the Rex Kerberos client.
+class TestKerberosStringIO < StringIO
+  def put(data)
+    write(data)
+  end
+
+  def get_once(length, _timeout = 10)
+    read(length)
+  end
+end
+
+RSpec.describe Rex::Proto::Kerberos::Client do
+  let(:rhost) { '127.0.0.1' }
+  let(:rport) { 88 }
+
+  before(:example) do
+    allow(Rex::Socket::Tcp).to receive(:create) do
+      TestKerberosStringIO.new('', 'w+b')
+    end
+  end
+
+  describe '#send_request' do
+    let(:subscriber) { instance_double(Rex::Proto::Kerberos::KerberosSubscriber, on_request: nil) }
+    let(:request) { instance_double('KerberosRequest', encode: 'abc') }
+
+    subject(:client) do
+      described_class.new(
+        host: rhost,
+        port: rport,
+        subscriber: subscriber
+      )
+    end
+
+    it 'notifies the subscriber before sending the request' do
+      expect(subscriber).to receive(:on_request).with(
+        request,
+        raw: 'abc',
+        context: { peer: "#{rhost}:#{rport}", protocol: 'tcp' }
+      )
+
+      client.send_request(request)
+    end
+  end
+
+  describe '#recv_response' do
+    let(:subscriber) { instance_double(Rex::Proto::Kerberos::KerberosSubscriber, on_response: nil) }
+    let(:res_error) do
+      "\x00\x00\x00\x8f\x7e\x81\x8c\x30\x81\x89\xa0\x03\x02\x01\x05\xa1" \
+      "\x03\x02\x01\x1e\xa4\x11\x18\x0f\x32\x30\x31\x34\x31\x32\x31\x39" \
+      "\x31\x38\x30\x35\x30\x33\x5a\xa5\x04\x02\x02\x51\x89\xa6\x03\x02" \
+      "\x01\x18\xa9\x0c\x1b\x0a\x44\x45\x4d\x4f\x2e\x4c\x4f\x43\x41\x4c" \
+      "\xaa\x1f\x30\x1d\xa0\x03\x02\x01\x01\xa1\x16\x30\x14\x1b\x06\x6b" \
+      "\x72\x62\x74\x67\x74\x1b\x0a\x44\x45\x4d\x4f\x2e\x4c\x4f\x43\x41" \
+      "\x4c\xac\x30\x04\x2e\x30\x2c\x30\x16\xa1\x03\x02\x01\x0b\xa2\x0f" \
+      "\x04\x0d\x30\x0b\x30\x09\xa0\x03\x02\x01\x17\xa1\x02\x04\x00\x30" \
+      "\x12\xa1\x03\x02\x01\x13\xa2\x0b\x04\x09\x30\x07\x30\x05\xa0\x03" \
+      "\x02\x01\x17"
+    end
+
+    subject(:client) do
+      described_class.new(
+        host: rhost,
+        port: rport,
+        subscriber: subscriber
+      )
+    end
+
+    it 'notifies the subscriber after decoding the response' do
+      client.connect
+      client.connection.write(res_error)
+      client.connection.seek(0)
+
+      expect(subscriber).to receive(:on_response).with(
+        an_instance_of(Rex::Proto::Kerberos::Model::KrbError),
+        raw: res_error.byteslice(4, res_error.bytesize - 4),
+        context: { peer: "#{rhost}:#{rport}", protocol: 'tcp' }
+      )
+
+      client.recv_response
+    end
+  end
+end

--- a/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
+++ b/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
@@ -1,0 +1,120 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
+  include_context 'Msf::UIDriver'
+
+  let(:mock_module) { instance_double(Msf::Exploit, datastore: mock_datastore) }
+
+  subject do
+    capture_logging(mock_module)
+    described_class.new(logger: mock_module)
+  end
+
+  let(:sample_request) do
+    Rex::Proto::Kerberos::Model::KdcRequest.decode(
+      "\x6a\x82\x01\x08\x30\x82\x01\x04\xa1\x03\x02\x01" \
+      "\x05\xa2\x03\x02\x01\x0a\xa3\x5f\x30\x5d\x30\x48\xa1\x03\x02\x01" \
+      "\x02\xa2\x41\x04\x3f\x30\x3d\xa0\x03\x02\x01\x17\xa2\x36\x04\x34" \
+      "\x60\xae\x53\xa5\x0b\x56\x2e\x46\x61\xd9\xd6\x89\x98\xfc\x79\x9d" \
+      "\x45\x73\x7d\x0d\x8a\x78\x84\x4d\xd7\x7c\xc6\x50\x08\x8d\xab\x22" \
+      "\x79\xc3\x8d\xd3\xaf\x9f\x5e\xb7\xb8\x9b\x57\xc5\xc9\xc5\xea\x90" \
+      "\x89\xc3\x63\x58\x30\x11\xa1\x04\x02\x02\x00\x80\xa2\x09\x04\x07" \
+      "\x30\x05\xa0\x03\x01\x01\x00\xa4\x81\x96\x30\x81\x93\xa0\x07\x03" \
+      "\x05\x00\x50\x80\x00\x00\xa1\x11\x30\x0f\xa0\x03\x02\x01\x01\xa1" \
+      "\x08\x30\x06\x1b\x04\x6a\x75\x61\x6e\xa2\x0c\x1b\x0a\x44\x45\x4d" \
+      "\x4f\x2e\x4c\x4f\x43\x41\x4c\xa3\x1f\x30\x1d\xa0\x03\x02\x01\x01" \
+      "\xa1\x16\x30\x14\x1b\x06\x6b\x72\x62\x74\x67\x74\x1b\x0a\x44\x45" \
+      "\x4d\x4f\x2e\x4c\x4f\x43\x41\x4c\xa4\x11\x18\x0f\x31\x39\x37\x30" \
+      "\x30\x31\x30\x31\x30\x30\x30\x30\x30\x30\x5a\xa5\x11\x18\x0f\x31" \
+      "\x39\x37\x30\x30\x31\x30\x31\x30\x30\x30\x30\x30\x30\x5a\xa6\x11" \
+      "\x18\x0f\x31\x39\x37\x30\x30\x31\x30\x31\x30\x30\x30\x30\x30\x30" \
+      "\x5a\xa7\x06\x02\x04\x18\xf4\x10\x2c\xa8\x05\x30\x03\x02\x01\x17"
+    )
+  end
+
+  let(:sample_error_response) do
+    Rex::Proto::Kerberos::Client.new.send(
+      :decode_kerb_response,
+      "\x7e\x81\x8d\x30\x81\x8a\xa0\x03\x02\x01\x05\xa1\x03\x02\x01\x1e" \
+      "\xa4\x11\x18\x0f\x32\x30\x32\x32\x30\x35\x32\x36\x31\x35\x34\x33" \
+      "\x32\x38\x5a\xa5\x05\x02\x03\x0e\x51\x88\xa6\x03\x02\x01\x18\xa9" \
+      "\x0c\x1b\x0a\x44\x45\x4d\x4f\x2e\x4c\x4f\x43\x41\x4c\xaa\x1f\x30" \
+      "\x1d\xa0\x03\x02\x01\x01\xa1\x16\x30\x14\x1b\x06\x6b\x72\x62\x74" \
+      "\x67\x74\x1b\x0a\x44\x45\x4d\x4f\x2e\x4c\x4f\x43\x41\x4c\xac\x30" \
+      "\x04\x2e\x30\x2c\x30\x16\xa1\x03\x02\x01\x0b\xa2\x0f\x04\x0d\x30" \
+      "\x0b\x30\x09\xa0\x03\x02\x01\x17\xa1\x02\x04\x00\x30\x12\xa1\x03" \
+      "\x02\x01\x13\xa2\x0b\x04\x09\x30\x07\x30\x05\xa0\x03\x02\x01\x17"
+    )
+  end
+
+  describe '#on_request' do
+    let(:context) { { peer: '127.0.0.1:88' } }
+
+    context 'when KerberosTicketTrace is enabled' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceLevel' => 'summary'
+        }
+      end
+
+      it 'logs a Kerberos request summary' do
+        subject.on_request(sample_request, context: context)
+
+        expect(@output).to include('####################')
+        expect(@output).to include('# Kerberos Request:')
+        expect(@output).to include('peer=127.0.0.1:88 msg=AS-REQ realm=DEMO.LOCAL cname=juan sname=krbtgt/DEMO.LOCAL')
+      end
+    end
+
+    context 'when raw tracing is enabled' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => true,
+          'KerberosTicketTraceLevel' => 'raw'
+        }
+      end
+
+      it 'logs a redacted raw preview' do
+        subject.on_request(sample_request, raw: ("\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a"), context: context)
+
+        expect(@output).to include('pvno=5 msg_type=10 pa_data_count=2 etypes=23')
+        expect(@output).to include('raw_length=10')
+        expect(@output).to include('raw_preview=01 02 03 04 05 06 07 08 09 0a')
+      end
+    end
+
+    context 'when KerberosTicketTrace is disabled' do
+      let(:mock_datastore) do
+        {
+          'KerberosTicketTrace' => false
+        }
+      end
+
+      it 'does not log the request' do
+        subject.on_request(sample_request, context: context)
+
+        expect(@output).to eq(nil)
+      end
+    end
+  end
+
+  describe '#on_response' do
+    let(:context) { { peer: '127.0.0.1:88' } }
+    let(:mock_datastore) do
+      {
+        'KerberosTicketTrace' => true,
+        'KerberosTicketTraceLevel' => 'raw'
+      }
+    end
+
+    it 'logs a Kerberos response summary and message details' do
+      subject.on_response(sample_error_response, context: context)
+
+      expect(@output).to include('peer=127.0.0.1:88 msg=KRB-ERROR realm=DEMO.LOCAL sname=krbtgt/DEMO.LOCAL error=KDC_ERR_PREAUTH_FAILED(24)')
+      expect(@output).to include('pvno=5 msg_type=30 server_time=2022-05-26T15:43:28Z e_data_present=true')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds an initial Kerberos trace foundation for shared Kerberos client flows.

It:
- adds a subscriber hook to `Rex::Proto::Kerberos::Client`
- adds `KerberosSubscriber` and `KerberosLoggerSubscriber`
- exposes `KerberosTicketTrace` and `KerberosTicketTraceLevel` through shared Kerberos auth option paths
- adds focused RSpec coverage for subscriber notifications, logger output, and serializer output

This is an initial Kerberos trace scaffolding PR, not the full CertificateTrace/KerberosTicketTrace project.

## Verification

Run:

`bundle _2.5.22_ exec rspec spec/lib/rex/proto/kerberos/client_spec.rb spec/lib/rex/proto/kerberos/client_subscriber_spec.rb spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb spec/lib/msf/base/serializer/readable_text_kerberos_trace_spec.rb`

Expected:
- `16 examples, 0 failures`

Run:

`bundle _2.5.22_ exec msfconsole -qx "use auxiliary/gather/asrep; show advanced; exit"`

Expected:
- `KerberosTicketTrace` appears under the Kerberos auth section
- `KerberosTicketTraceLevel` appears under the Kerberos auth section
- accepted values are `summary, raw`

## Console Output

`msfconsole` showed:
- `KerberosTicketTrace false`
- `KerberosTicketTraceLevel summary`

under `When LDAP::Auth is kerberos`.

