### PR TITLE
[Bug Fix] Auxiliary: Check if module is meant to have rhosts

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -62,7 +62,9 @@ class Auxiliary
 
     begin
       # Check if this is a scanner module or doesn't target remote hosts
-      if rhosts.blank? || mod.class.included_modules.include?(Msf::Auxiliary::MultipleTargetHosts)
+      if rhosts.blank? ||
+         mod.class.included_modules.include?(Msf::Auxiliary::MultipleTargetHosts) ||
+         !mod.datastore.options.key?('RHOSTS')
         mod_with_opts.run_simple(
           'Action'         => args[:action],
           'LocalInput'     => driver.input,

--- a/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
     ])
 
     deregister_options(
-      "RHOST", "USERNAME", "PASSWORD", "USER_FILE", "PASS_FILE", "USERPASS_FILE",
+      "USERNAME", "PASSWORD", "USER_FILE", "PASS_FILE", "USERPASS_FILE",
       "BLANK_PASSWORDS", "USER_AS_PASS", "REMOVE_USER_FILE", "REMOVE_PASS_FILE",
       "BRUTEFORCE_SPEED" # Slow as heck anyway
     )

--- a/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
     mod
   end
 
-  let(:aux_mod_with_option_validation) do
+  let(:aux_mod_with_rhost_option_validation) do
     mod_klass = Class.new(Msf::Auxiliary) do
       def initialize(info = {})
         super(
@@ -157,6 +157,53 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
 
         register_options(
           [
+            Msf::Opt::RHOST,
+            Msf::OptString.new('USERNAME', [ true, 'Set me to be greeted']),
+            Msf::OptString.new('PASSWORD', [ false, 'Secret value' ])
+          ]
+      )
+      end
+
+      def validate
+        super
+
+        if datastore['PASSWORD'] != 'PleaseThrowTheBall'
+          raise Msf::OptionValidateError.new({'PASSWORD' => 'Nuh uh uh, you didn\'t say the magic word.'})
+        end
+      end
+
+      def check
+        print_status('Check completed!')
+      end
+
+      def run
+        print("Hello #{datastore['USERNAME']}")
+        print_status('Run completed!')
+      end
+    end
+
+    mod = mod_klass.new
+    datastore = Msf::ModuleDataStore.new(mod)
+    allow(mod).to receive(:framework).and_return(framework)
+    mod.send(:datastore=, datastore)
+    datastore.import_options(mod.options)
+    Msf::Simple::Framework.simplify_module(mod)
+    mod
+  end
+
+  let(:aux_mod_with_file_format_option_validation) do
+    mod_klass = Class.new(Msf::Auxiliary) do
+      def initialize(info = {})
+        super(
+          'Name' => 'mock file format module',
+          'Description' => 'mock file format module',
+          'Author' => ['Unknown'],
+          'License' => MSF_LICENSE
+        )
+
+        register_options(
+          [
+            Msf::OptString.new('FILENAME', [ false, 'The file name', 'foo.zip']),
             Msf::OptString.new('USERNAME', [ true, 'Set me to be greeted']),
             Msf::OptString.new('PASSWORD', [ false, 'Secret value' ])
           ]
@@ -431,8 +478,46 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
       end
     end
 
-    context 'when running an auxiliary module with option validation' do
-      let(:current_mod) { aux_mod_with_option_validation }
+    context 'when running an auxiliary module with rhost option validation' do
+      let(:current_mod) { aux_mod_with_rhost_option_validation }
+
+      it 'reports options that fail validation' do
+        allow(current_mod).to receive(:check).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['RHOSTS'] = '192.0.2.1'
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'ThrowTheBall'
+        subject.cmd_check
+        expected_output = [
+          'Msf::OptionValidateError The following options failed to validate:',
+          'Invalid option PASSWORD: Nuh uh uh, you didn\'t say the magic word.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).not_to have_received(:check)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
+      end
+
+      it 'runs when validation passes' do
+        allow(current_mod).to receive(:check).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['RHOSTS'] = '192.0.2.1'
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'PleaseThrowTheBall'
+        subject.cmd_check
+        expected_output = [
+          'Check completed!',
+          '192.0.2.1 - Check failed: The state could not be determined.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).to have_received(:check)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
+      end
+    end
+
+    context 'when running an auxiliary module with file format option validation' do
+      let(:current_mod) { aux_mod_with_file_format_option_validation }
 
       it 'reports options that fail validation' do
         allow(current_mod).to receive(:check).and_call_original
@@ -804,8 +889,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
       end
     end
 
-    context 'when running an auxiliary module with option validation' do
-      let(:current_mod) { aux_mod_with_option_validation }
+    context 'when running an auxiliary rhost module with option validation' do
+      let(:current_mod) { aux_mod_with_rhost_option_validation }
 
       it 'reports options that fail validation' do
         allow(current_mod).to receive(:run).and_call_original
@@ -836,6 +921,45 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
           'Hello Jackson',
           'Run completed!',
           'Running module against 192.0.2.1'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).to have_received(:run)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
+      end
+    end
+
+    context 'when running an auxiliary file format module with option validation' do
+      let(:current_mod) { aux_mod_with_file_format_option_validation }
+
+      it 'reports options that fail validation' do
+        allow(current_mod).to receive(:run).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['RHOSTS'] = '192.0.2.1'
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'ThrowTheBall'
+        subject.cmd_run
+        expected_output = [
+          'Msf::OptionValidateError The following options failed to validate:',
+          'Invalid option PASSWORD: Nuh uh uh, you didn\'t say the magic word.'
+        ]
+
+        expect(@combined_output).to match_array(expected_output)
+        expect(subject.mod).not_to have_received(:run)
+        expect(subject.mod).to have_received(:validate).at_least(:once)
+      end
+
+      it 'runs when validation passes' do
+        allow(current_mod).to receive(:run).and_call_original
+        allow(current_mod).to receive(:validate).and_call_original
+        current_mod.datastore['RHOSTS'] = '192.0.2.1'
+        current_mod.datastore['USERNAME'] = 'Jackson'
+        current_mod.datastore['PASSWORD'] = 'PleaseThrowTheBall'
+        subject.cmd_run
+        expected_output = [
+          'Auxiliary module execution completed',
+          'Hello Jackson',
+          'Run completed!',
         ]
 
         expect(@combined_output).to match_array(expected_output)


### PR DESCRIPTION
Fix for: https://github.com/rapid7/metasploit-framework/issues/21121

When using `auxiliary/server/dhcp`, its a server, it doesn't have a dedlicated target/rhosts value.
However, its set globally, it will still and try and use it:

> [*] Running module against 10.0.0.10
> [*] Starting DHCP server...

Really should be like:

> [*] Auxiliary module running as background job 0.

- - -

# Demo
## Before

```console
$ msfconsole -q -x 'db_status; workspace -D; set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use auxiliary/server/dhcp; set DHCPIPSTART 10.0.0.20; set DHCPIPEND 10.0.0.25; set NETMASK 255.255.255.0; set BROADCAST 10.0.0.255; set ROUTER 10.0.0.1;  set DNSSERVER 10.0.0.1; set SRVHOST 10.0.0.1; options; advanced; workspace -v; run'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
DHCPIPSTART => 10.0.0.20
DHCPIPEND => 10.0.0.25
NETMASK => 255.255.255.0
BROADCAST => 10.0.0.255
ROUTER => 10.0.0.1
DNSSERVER => 10.0.0.1
SRVHOST => 10.0.0.1

Module options (auxiliary/server/dhcp):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   BROADCAST    10.0.0.255       no        The broadcast address to send to
   DHCPIPEND    10.0.0.25        no        The last IP to give out
   DHCPIPSTART  10.0.0.20        no        The first IP to give out
   DNSSERVER    10.0.0.1         no        The DNS server IP address
   DOMAINNAME                    no        The optional domain name to assign
   FILENAME                      no        The optional filename of a tftp boot server
   HOSTNAME                      no        The optional hostname to assign
   HOSTSTART                     no        The optional host integer counter
   NETMASK      255.255.255.0    yes       The netmask of the local subnet
   ROUTER       10.0.0.1         no        The router IP address
   SRVHOST      10.0.0.1         yes       The IP of the DHCP server


Auxiliary action:

   Name     Description
   ----     -----------
   Service  Run DHCP server



View the full module info with the info, or info -d command.


Module advanced options (auxiliary/server/dhcp):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   VERBOSE    true             no        Enable detailed status messages
   WORKSPACE                   no        Specify the workspace for this module
  # vulnerable.


View the full module info with the info, or info -d command.


Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

[*] Running module against 10.0.0.10
[*] Starting DHCP server...
^C[-] Stopping running against current target...
[*] Control-C again to force quit all targets.
[*] Auxiliary module execution completed
msf auxiliary(server/dhcp) > exit
$
```

## After

```console
$ sudo vim lib/msf/ui/console/command_dispatcher/auxiliary.rb
$
$ !msfconsole
msfconsole -q -x 'db_status; workspace -D; set VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use auxiliary/server/dhcp; set DHCPIPSTART 10.0.0.20; set DHCPIPEND 10.0.0.25; set NETMASK 255.255.255.0; set BROADCAST 10.0.0.255; set ROUTER 10.0.0.1;  set DNSSERVER 10.0.0.1; set SRVHOST 10.0.0.1; options; advanced; workspace -v; run'
[...]
Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

[*] Auxiliary module running as background job 0.
msf auxiliary(server/dhcp) >
[*] Starting DHCP server...
msf auxiliary(server/dhcp) >
msf auxiliary(server/dhcp) > exit
```