### PR TITLE
Fix version check in ldap_esc_vulnerable_cert_finder

### DIFF
--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -1094,7 +1094,7 @@ class MetasploitModule < Msf::Auxiliary
     user_info = adds_get_current_user(@ldap)
     return unless user_info
 
-    user = [:sAMAccountName].first.to_s
+    user = user_info[:sAMAccountName].first.to_s
     domain = domain_info[:dns_name]
     print_status("user: #{user}, domain: #{domain}")
 


### PR DESCRIPTION
The version check in `ldap_esc_vulnerable_cert_finder` is currently broken as the username it uses to authenticate over WinRM, gets set to the string `sAMAccountName` instead of the actual value of sAMAccountName.

This was only introduced a couple of weeks ago in a separate bug fix - this should get everything working smoothly again. 

## Verification 
### Before
 ```
 msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] user: sAMAccountName, domain: kerberos.issue
[!] Unable to determine the version of Window so these all might be false postives! WinRM authorization error: WinRM::WinRMAuthorizationError
```

### After 
```
msf auxiliary(gather/ldap_esc_vulnerable_cert_finder) > run
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] user: Administrator, domain: kerberos.issue
[*] Detected target Windows version: 10.0.17763.7792
[-] Auxiliary aborted due to failure: not-vulnerable: Detected Windows Server 2019 version 10.0.17763.7792 which is at-or-above the September 2025 threshold (10.0.17763.7792). Target appears patched. Weak certificate mappings/ ESC techniques are not exploitable on this domain controller
[*] Auxiliary module execution completed
```