### PR TITLE
Add global datastore option configuration

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -559,7 +559,7 @@ Shell Banner:
       end
     else
       # XXX: No vprint_status here
-      if framework.datastore['VERBOSE'].to_s == 'true'
+      if framework.datastore['VERBOSE']
         print_status("You are executing expressions in #{binding.receiver}")
       end
 

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -9,23 +9,27 @@ module Msf
 ###
 class DataStore
 
-  # The global framework datastore doesn't currently import options
-  # For now, store an ad-hoc list of keys that the shell handles
-  #
-  # This list could be removed if framework's bootup sequence registers
-  # these as datastore options
-  GLOBAL_KEYS = %w[
-    ConsoleLogging
-    LogLevel
-    MinimumRank
-    SessionLogging
-    TimestampOutput
-    Prompt
-    PromptChar
-    PromptTimeFormat
-    MeterpreterPrompt
-    SessionTlvLogging
-  ]
+  # Typed option definitions for globally-scoped datastore keys.
+  # These are registered on the framework datastore at startup so that
+  # normalization (e.g. OptBool converting "true" to true) applies even
+  # when no module is active.
+  GLOBAL_OPTION_DEFINITIONS = OptionContainer.new([
+    OptBool.new('ConsoleLogging',      [false, 'Log all console input and output', false]),
+    OptInt.new('LogLevel',             [false, 'Verbosity of logs (default 0, max 3)', 0]),
+    OptEnum.new('MinimumRank',         [false, 'The minimum rank of exploits that will run without explicit confirmation', 'manual', RankingName.values]),
+    OptBool.new('SessionLogging',      [false, 'Log all input and output for sessions', false]),
+    OptBool.new('TimestampOutput',     [false, 'Prefix all console output with a timestamp', false]),
+    OptBool.new('VERBOSE',             [false, 'Enable detailed status messages - the specific behavior can differ per module', false]),
+    OptString.new('Prompt',            [false, 'The prompt string', nil]),
+    OptString.new('PromptChar',        [false, 'The prompt character', nil]),
+    OptString.new('PromptTimeFormat',  [false, 'Format for timestamp escapes in prompts', nil]),
+    OptString.new('MeterpreterPrompt', [false, 'The meterpreter prompt string', nil]),
+    OptSessionTlvLogging.new('SessionTlvLogging', [false, 'Log all incoming and outgoing TLV packets', nil]),
+  ])
+
+  # Backward-compatible list of known global key names, derived from the
+  # typed option definitions above.
+  GLOBAL_KEYS = GLOBAL_OPTION_DEFINITIONS.keys.freeze
 
   #
   # Initializes the data store's internal state.
@@ -136,7 +140,7 @@ class DataStore
 
   #
   # This method is a helper method that imports the default value for
-  # all of the supplied options
+  # all of the supplied options.
   #
   def import_options(options, imported_by = nil, overwrite = true)
     options.each_option do |name, option|
@@ -350,7 +354,7 @@ class DataStore
       end
     else
       other.each do |k, v|
-        self.store(k, v)
+        self[k] = v
       end
     end
 

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -70,6 +70,7 @@ class Framework
     self.events    = EventDispatcher.new(self)
     self.modules   = ModuleManager.new(self,types)
     self.datastore = DataStore.new
+    self.datastore.import_options(DataStore::GLOBAL_OPTION_DEFINITIONS)
     self.jobs      = Rex::JobContainer.new
     self.analyze   = Analyze.new(self)
     self.plugins   = PluginManager.new(self)

--- a/lib/msf/core/opt_session_tlv_logging.rb
+++ b/lib/msf/core/opt_session_tlv_logging.rb
@@ -1,0 +1,40 @@
+# -*- coding: binary -*-
+
+module Msf
+  ###
+  #
+  # Session TLV Logging option.
+  #
+  # Valid values: 'true', 'false', 'console', or 'file:<path>'
+  #
+  ###
+  class OptSessionTlvLogging < OptBase
+    VALID_KEYWORDS = %w[true false console].freeze
+
+    def initialize(in_name, attrs = [], **kwargs)
+      super
+    end
+
+    def type
+      'sessiontlvlogging'
+    end
+
+    def validate_on_assignment?
+      true
+    end
+
+    def valid?(value, check_empty: true, datastore: nil)
+      return false if !super(value, check_empty: check_empty)
+      return true if value.nil? || value.to_s.strip.empty?
+
+      self.class.valid_tlv_logging?(value.to_s.strip)
+    end
+
+    def self.valid_tlv_logging?(value)
+      return true if VALID_KEYWORDS.any? { |kw| value.casecmp?(kw) }
+      return true if value.start_with?('file:') && value.split('file:', 2).last.length > 0
+
+      false
+    end
+  end
+end

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -19,6 +19,7 @@ module Msf
   autoload :OptPort, 'msf/core/opt_port'
   autoload :OptRaw, 'msf/core/opt_raw'
   autoload :OptRegexp, 'msf/core/opt_regexp'
+  autoload :OptSessionTlvLogging, 'msf/core/opt_session_tlv_logging'
   autoload :OptString, 'msf/core/opt_string'
 
   #

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -151,8 +151,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
         driver.input.reset_tab_completion
       end
     else
-      # XXX: No vprint_status here either
-      if framework.datastore['VERBOSE'].to_s == 'true'
+      # XXX: No vprint_status in this context
+      if framework.datastore['VERBOSE']
         print_status("You are executing expressions in #{binding.receiver}")
       end
 
@@ -242,9 +242,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       print_warning("LocalEditor or $VISUAL/$EDITOR should be set. Falling back on #{editor}.")
     end
 
-    # XXX: No vprint_status in this context?
-    # XXX: VERBOSE is a string instead of Bool??
-    print_status("Launching #{editor} #{path}") if framework.datastore['VERBOSE'].to_s == 'true'
+    # XXX: No vprint_status in this context
+    print_status("Launching #{editor} #{path}") if framework.datastore['VERBOSE']
 
     unless system(*editor.split, path)
       print_error("Could not execute #{editor} #{path}")
@@ -333,9 +332,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       print_warning("LocalPager or $PAGER/$MANPAGER should be set. Falling back on #{pager}.")
     end
 
-    # XXX: No vprint_status in this context?
-    # XXX: VERBOSE is a string instead of Bool??
-    print_status("Launching #{pager} #{path}") if framework.datastore['VERBOSE'].to_s == 'true'
+    # XXX: No vprint_status in this context
+    print_status("Launching #{pager} #{path}") if framework.datastore['VERBOSE']
 
     unless system(*pager.split, path)
       print_error("Could not execute #{pager} #{path}")

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1619,18 +1619,21 @@ module Msf
               'Postfix' => "\n",
               'Columns' => columns
             )
-            [
-              [ 'ConsoleLogging', framework.datastore['ConsoleLogging'] || "false", 'Log all console input and output' ],
-              [ 'LogLevel', framework.datastore['LogLevel'] || "0", 'Verbosity of logs (default 0, max 3)' ],
-              [ 'MinimumRank', framework.datastore['MinimumRank'] || "0", 'The minimum rank of exploits that will run without explicit confirmation' ],
-              [ 'SessionLogging', framework.datastore['SessionLogging'] || "false", 'Log all input and output for sessions' ],
-              [ 'SessionTlvLogging', framework.datastore['SessionTlvLogging'] || "false", 'Log all incoming and outgoing TLV packets' ],
-              [ 'TimestampOutput', framework.datastore['TimestampOutput'] || "false", 'Prefix all console output with a timestamp' ],
-              [ 'Prompt', framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt.to_s.gsub(/%.../,"") , "The prompt string" ],
-              [ 'PromptChar', framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar.to_s.gsub(/%.../,""), "The prompt character" ],
-              [ 'PromptTimeFormat', framework.datastore['PromptTimeFormat'] || Time::DATE_FORMATS[:db].to_s, 'Format for timestamp escapes in prompts' ],
-              [ 'MeterpreterPrompt', framework.datastore['MeterpreterPrompt'] || '%undmeterpreter%clr', 'The meterpreter prompt string' ],
-            ].each { |r| tbl << r }
+
+            # Display-only defaults for options whose actual defaults are managed
+            # by the UI layer (driver prompt constants, time format, etc.)
+            computed_defaults = {
+              'Prompt'            => Msf::Ui::Console::Driver::DefaultPrompt.to_s.gsub(/%.../, ''),
+              'PromptChar'        => Msf::Ui::Console::Driver::DefaultPromptChar.to_s.gsub(/%.../, ''),
+              'PromptTimeFormat'  => Time::DATE_FORMATS[:db].to_s,
+              'MeterpreterPrompt' => '%undmeterpreter%clr',
+            }
+
+            Msf::DataStore::GLOBAL_OPTION_DEFINITIONS.each_option do |name, opt|
+              val = framework.datastore[name]
+              display_value = val.nil? ? (opt.default.nil? ? '' : opt.default.to_s) : val.to_s
+              tbl << [ name, display_value, opt.desc ]
+            end
 
             print(tbl.to_s)
           end

--- a/lib/msf/ui/console/command_dispatcher/session.rb
+++ b/lib/msf/ui/console/command_dispatcher/session.rb
@@ -101,7 +101,7 @@ module Msf
               end
             else
               # XXX: No vprint_status here
-              if framework.datastore['VERBOSE'].to_s == 'true'
+              if framework.datastore['VERBOSE']
                 print_status("You are executing expressions in #{binding.receiver}")
               end
 

--- a/spec/lib/msf/core/data_store_spec.rb
+++ b/spec/lib/msf/core/data_store_spec.rb
@@ -33,6 +33,42 @@ end
 
 RSpec.describe Msf::DataStore do
 
+  describe ".GLOBAL_OPTION_DEFINITIONS" do
+    it "contains only OptBase subclass instances" do
+      Msf::DataStore::GLOBAL_OPTION_DEFINITIONS.each_option do |_name, opt|
+        expect(opt).to be_a(Msf::OptBase)
+      end
+    end
+
+    it "defines the expected option types" do
+      defs = Msf::DataStore::GLOBAL_OPTION_DEFINITIONS
+      expect(defs['ConsoleLogging']).to be_a(Msf::OptBool)
+      expect(defs['LogLevel']).to be_a(Msf::OptInt)
+      expect(defs['MinimumRank']).to be_a(Msf::OptEnum)
+      expect(defs['SessionLogging']).to be_a(Msf::OptBool)
+      expect(defs['TimestampOutput']).to be_a(Msf::OptBool)
+      expect(defs['VERBOSE']).to be_a(Msf::OptBool)
+      expect(defs['SessionTlvLogging']).to be_a(Msf::OptSessionTlvLogging)
+    end
+
+    it "derives GLOBAL_KEYS with the same key names" do
+      expected_keys = %w[
+        ConsoleLogging
+        LogLevel
+        MinimumRank
+        SessionLogging
+        TimestampOutput
+        VERBOSE
+        Prompt
+        PromptChar
+        PromptTimeFormat
+        MeterpreterPrompt
+        SessionTlvLogging
+      ]
+      expect(Msf::DataStore::GLOBAL_KEYS).to match_array(expected_keys)
+    end
+  end
+
   describe "#import_option" do
     subject do
       s = described_class.new
@@ -102,7 +138,57 @@ RSpec.describe Msf::DataStore do
     end
 
     it_behaves_like "datastore"
-  end
 
+    context "normalizes values loaded from an INI config file" do
+      subject do
+        ds = described_class.new
+        ds.import_options(Msf::DataStore::GLOBAL_OPTION_DEFINITIONS)
+        ds
+      end
+
+      it "normalizes boolean and integer strings" do
+        ini_instance = double group?: true,
+                              :[] => {
+                                "VERBOSE" => "true",
+                                "ConsoleLogging" => "false",
+                                "LogLevel" => "3"
+                              }
+        ini_class = double from_file: ini_instance
+        stub_const("Rex::Parser::Ini", ini_class)
+
+        subject.from_file("path")
+
+        expect(subject['VERBOSE']).to eq true
+        expect(subject['ConsoleLogging']).to eq false
+        expect(subject['LogLevel']).to eq 3
+      end
+    end
+
+    it "registers each option by name" do
+      options = Msf::OptionContainer.new([
+        Msf::OptBool.new('TestBool', [false, 'A bool', false]),
+        Msf::OptInt.new('TestInt', [false, 'An int', 0]),
+      ])
+      subject.import_options(options)
+      expect(subject.options['TestBool']).to be_a(Msf::OptBool)
+      expect(subject.options['TestInt']).to be_a(Msf::OptInt)
+    end
+
+    it "normalizes values through registered options" do
+      options = Msf::OptionContainer.new([Msf::OptBool.new('MyFlag', [false, 'A flag', false])])
+      subject.import_options(options)
+      subject['MyFlag'] = 'true'
+      expect(subject['MyFlag']).to eq true
+    end
+
+    it "registers options from a standalone OptionContainer" do
+      options = Msf::OptionContainer.new
+      options.add_options([
+        Msf::OptString.new('Foo', [false, 'A string', nil])
+      ])
+      subject.import_options(options)
+      expect(subject.options['Foo']).to be_a(Msf::OptString)
+    end
+  end
 
 end

--- a/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
+++ b/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
@@ -420,12 +420,8 @@ RSpec.shared_examples_for 'a datastore' do
         s
       end
 
-      # Note: This aligns the first implementation of the DataStore class.
-      # In certain scenarios it does not seem like desired behavior.
-      it 'does not perform option validation' do
-        subject.merge!({ 'FloatValue' => 'invalid_value' })
-
-        expect(subject['FloatValue']).to eq('invalid_value')
+      it 'does perform option validation' do
+        expect { subject.merge!({ 'FloatValue' => 'invalid_value' }) }.to raise_error(Msf::OptionValidateError, / Value 'invalid_value' is not valid for option 'FloatValue'/)
       end
     end
   end

--- a/spec/lib/msf/core/framework_spec.rb
+++ b/spec/lib/msf/core/framework_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe Msf::Framework do
         framework
       }.not_to change { Thread.list.count }
     end
+
+    it 'registers global option definitions on the datastore' do
+      Msf::DataStore::GLOBAL_KEYS.each do |key|
+        expect(framework.datastore.options).to have_key(key)
+      end
+
+      framework.datastore['VERBOSE'] = 'true'
+      expect(framework.datastore['VERBOSE']).to eq true
+
+      framework.datastore['VERBOSE'] = 'false'
+      expect(framework.datastore['VERBOSE']).to eq false
+    end
   end
 
   describe "#version" do

--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
       allow(driver).to receive(:on_variable_set)
     end
 
+    context 'with global flag and no active module' do
+      it 'should normalize boolean true on the global datastore' do
+        subject.cmd_set('-g', 'VERBOSE', 'true')
+        expect(framework.datastore['VERBOSE']).to eq true
+      end
+
+      it 'should normalize boolean false on the global datastore' do
+        subject.cmd_set('-g', 'VERBOSE', 'false')
+        expect(framework.datastore['VERBOSE']).to eq false
+      end
+    end
+
     context 'with an exploit active module' do
       let(:mod) do
         mod_klass = Class.new(Msf::Exploit) do


### PR DESCRIPTION
Fixes a bug when setting `verbose` logging as false globally would still cause verbose logging to occur

Fixes https://github.com/rapid7/metasploit-framework/issues/21099

## Verification

- Ensure CI passes
- Ensure the original bug is fixed https://github.com/rapid7/metasploit-framework/issues/21099
For ease of debugging I also added:
```diff
diff --git a/modules/auxiliary/scanner/smtp/smtp_enum.rb b/modules/auxiliary/scanner/smtp/smtp_enum.rb
index 37cf107b563..99c4b8dbc5f 100644
--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -67,6 +67,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    puts "verbose=#{datastore['VERBOSE'].inspect} #{datastore['VERBOSE'].class} - #{framework.datastore['VERBOSE'].inspect} #{framework.datastore['VERBOSE'].class}"
+
```
- Ensure functionality still works when loading config from a file:
```
msfconsole -q
setg verbose true
save
exit
```