### PR TITLE
Add documentation for auxiliary scanner modules

### DIFF
--- a/documentation/modules/auxiliary/scanner/ftp/bison_ftp_traversal.md
+++ b/documentation/modules/auxiliary/scanner/ftp/bison_ftp_traversal.md
@@ -8,8 +8,7 @@ The vulnerability is tracked as [CVE-2015-7602](https://cve.mitre.org/cgi-bin/cv
 
 ### Setup
 
-1. Download BisonWare BisonFTP Server 3.5 (the installer can be found on exploit-db or
-   archived download sites).
+1. Download BisonWare BisonFTP Server 3.5 from [Exploit-DB (EDB-38341)](https://www.exploit-db.com/exploits/38341).
 2. Install and run it on a Windows host.
 3. Configure the FTP root directory and ensure the service is listening (default port 21).
 4. Set up an anonymous login or create a user account with credentials.
@@ -81,3 +80,4 @@ msf auxiliary(scanner/ftp/bison_ftp_traversal) > run
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
+

--- a/documentation/modules/auxiliary/scanner/ftp/bison_ftp_traversal.md
+++ b/documentation/modules/auxiliary/scanner/ftp/bison_ftp_traversal.md
@@ -1,0 +1,83 @@
+## Vulnerable Application
+
+This module exploits a directory traversal vulnerability in BisonWare BisonFTP Server
+version 3.5. The flaw allows an attacker to download arbitrary files from the server by
+sending a crafted `RETR` command using traversal strings such as `..//`.
+
+The vulnerability is tracked as [CVE-2015-7602](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7602).
+
+### Setup
+
+1. Download BisonWare BisonFTP Server 3.5 (the installer can be found on exploit-db or
+   archived download sites).
+2. Install and run it on a Windows host.
+3. Configure the FTP root directory and ensure the service is listening (default port 21).
+4. Set up an anonymous login or create a user account with credentials.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/ftp/bison_ftp_traversal`
+3. Do: `set RHOSTS [target IP]`
+4. Do: `run`
+5. You should see the requested file contents stored as loot.
+
+## Options
+
+### DEPTH
+
+The number of traversal sequences (`..//`) to prepend to the file path. The default is `32`.
+A high value is used because the exact depth of the FTP root can vary.
+
+### PATH
+
+The path to the file to retrieve from the target, relative to the drive root. The default value
+is `boot.ini`. For example, to read the Windows hosts file, set this to
+`windows/system32/drivers/etc/hosts`.
+
+### FTPUSER
+
+The FTP username to authenticate with. Default is `anonymous`.
+
+### FTPPASS
+
+The FTP password to authenticate with. Default is `mozilla@example.com`.
+
+## Scenarios
+
+### BisonFTP 3.5 on Windows XP
+
+```
+msf > use auxiliary/scanner/ftp/bison_ftp_traversal
+msf auxiliary(scanner/ftp/bison_ftp_traversal) > set RHOSTS 192.168.1.10
+RHOSTS => 192.168.1.10
+msf auxiliary(scanner/ftp/bison_ftp_traversal) > set PATH boot.ini
+PATH => boot.ini
+msf auxiliary(scanner/ftp/bison_ftp_traversal) > run
+
+[+] Stored boot.ini to /root/.msf4/loot/20250319120000_default_192.168.1.10_bisonware.ftp.da_123456.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Reading the hosts file
+
+```
+msf > use auxiliary/scanner/ftp/bison_ftp_traversal
+msf auxiliary(scanner/ftp/bison_ftp_traversal) > set RHOSTS 192.168.1.10
+RHOSTS => 192.168.1.10
+msf auxiliary(scanner/ftp/bison_ftp_traversal) > set PATH windows/system32/drivers/etc/hosts
+PATH => windows/system32/drivers/etc/hosts
+msf auxiliary(scanner/ftp/bison_ftp_traversal) > set VERBOSE true
+VERBOSE => true
+msf auxiliary(scanner/ftp/bison_ftp_traversal) > run
+
+[*] Data returned:
+# Copyright (c) 1993-2009 Microsoft Corp.
+#
+# This is a sample HOSTS file used by Microsoft TCP/IP for Windows.
+
+[+] Stored windows/system32/drivers/etc/hosts to /root/.msf4/loot/20250319120000_default_192.168.1.10_bisonware.ftp.da_654321.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/apache_activemq_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/apache_activemq_traversal.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+
+This module exploits a directory traversal vulnerability in Apache ActiveMQ 5.3.1 and 5.3.2 on
+Windows systems. The flaw exists in the Jetty ResourceHandler that ships with these versions,
+allowing an unauthenticated attacker to read arbitrary files from the target host.
+
+The vulnerability is tracked as [CVE-2010-1587](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-1587).
+
+### Setup
+
+To test this module you need a Windows host running one of the affected versions:
+
+1. Download [Apache ActiveMQ 5.3.1](http://archive.apache.org/dist/activemq/apache-activemq/5.3.1/) or 5.3.2.
+2. Extract the archive and run `bin\activemq.bat` to start the broker.
+3. The web console listens on port **8161** by default.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/apache_activemq_traversal`
+3. Do: `set RHOSTS [target IP]`
+4. Do: `set RPORT 8161`
+5. Do: `run`
+6. You should see the contents of the requested file saved as loot.
+
+## Options
+
+### FILEPATH
+
+The path of the file to retrieve from the target system, relative to the drive root. The default
+value is `/windows\\win.ini`. Backslashes must be used for path separators on Windows targets.
+
+### DEPTH
+
+The number of traversal sequences (`/\..`) to prepend to the request. The default is `4`. If the
+file is not found, try increasing this value.
+
+## Scenarios
+
+### ActiveMQ 5.3.1 on Windows Server 2003 SP2
+
+```
+msf > use auxiliary/scanner/http/apache_activemq_traversal
+msf auxiliary(scanner/http/apache_activemq_traversal) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf auxiliary(scanner/http/apache_activemq_traversal) > set RPORT 8161
+RPORT => 8161
+msf auxiliary(scanner/http/apache_activemq_traversal) > run
+
+[*] 192.168.1.100:8161 - Sending request...
+[*] 192.168.1.100:8161 - File saved in: /root/.msf4/loot/20250319120000_default_192.168.1.100_apache.activemq_123456.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/apache_activemq_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/apache_activemq_traversal.md
@@ -52,3 +52,4 @@ msf auxiliary(scanner/http/apache_activemq_traversal) > run
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
+

--- a/documentation/modules/auxiliary/scanner/http/coldfusion_version.md
+++ b/documentation/modules/auxiliary/scanner/http/coldfusion_version.md
@@ -1,0 +1,59 @@
+## Vulnerable Application
+
+This module attempts to identify Adobe ColdFusion installations and determine the version
+running on the target. It inspects the ColdFusion Administrator login page at
+`/CFIDE/administrator/index.cfm` and fingerprints the version based on meta tags, copyright
+strings, and other patterns in the HTML response. The module can detect ColdFusion MX6, MX7,
+8, 9, and 10, as well as identify the underlying operating system from the `Server` header.
+
+### Setup
+
+Install any version of Adobe ColdFusion up to version 10. The default installation should
+have the administrator page accessible at `/CFIDE/administrator/index.cfm`. No additional
+configuration is needed.
+
+Alternatively, older ColdFusion trial installers can often be found on the
+[Adobe archive](https://helpx.adobe.com/coldfusion/kb/coldfusion-downloads.html).
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/coldfusion_version`
+3. Do: `set RHOSTS [target IP]`
+4. Do: `run`
+5. You should see the detected ColdFusion version and OS printed to the console.
+
+## Options
+
+This module uses the standard `RHOSTS`, `RPORT`, `SSL`, and `THREADS` scanner options.
+There are no additional module-specific options.
+
+## Scenarios
+
+### ColdFusion 9 on Windows Server 2008
+
+```
+msf > use auxiliary/scanner/http/coldfusion_version
+msf auxiliary(scanner/http/coldfusion_version) > set RHOSTS 10.0.0.20
+RHOSTS => 10.0.0.20
+msf auxiliary(scanner/http/coldfusion_version) > set THREADS 5
+THREADS => 5
+msf auxiliary(scanner/http/coldfusion_version) > run
+
+[+] 10.0.0.20: Adobe ColdFusion 9 (administrator access) (Windows (Microsoft-IIS/7.5))
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### ColdFusion 8 on Linux
+
+```
+msf > use auxiliary/scanner/http/coldfusion_version
+msf auxiliary(scanner/http/coldfusion_version) > set RHOSTS 10.0.0.30
+RHOSTS => 10.0.0.30
+msf auxiliary(scanner/http/coldfusion_version) > run
+
+[+] 10.0.0.30: Adobe ColdFusion 8 (administrator access) (Unix (Apache/2.2.22))
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/coldfusion_version.md
+++ b/documentation/modules/auxiliary/scanner/http/coldfusion_version.md
@@ -25,9 +25,6 @@ Alternatively, older ColdFusion trial installers can often be found on the
 
 ## Options
 
-This module uses the standard `RHOSTS`, `RPORT`, `SSL`, and `THREADS` scanner options.
-There are no additional module-specific options.
-
 ## Scenarios
 
 ### ColdFusion 9 on Windows Server 2008
@@ -57,3 +54,4 @@ msf auxiliary(scanner/http/coldfusion_version) > run
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
+

--- a/documentation/modules/auxiliary/scanner/http/drupal_views_user_enum.md
+++ b/documentation/modules/auxiliary/scanner/http/drupal_views_user_enum.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+This module exploits an information disclosure vulnerability in the
+[Views](https://www.drupal.org/project/views) module for Drupal 6. When the Views module
+version 6.x-2.11 or earlier is installed, the autocomplete callback for user fields is
+accessible without proper authorization. The module brute-forces the first 10 usernames by
+iterating through the letters `a` to `z`.
+
+Drupal does not consider disclosure of usernames to be a security weakness on its own, but
+enumerated usernames can be useful for password-guessing attacks.
+
+### Setup
+
+1. Install Drupal 6 with the Views module version 6.x-2.11 or earlier.
+2. Create several user accounts so there is data to enumerate.
+3. Ensure the Views module is enabled under **Administer > Site building > Modules**.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/drupal_views_user_enum`
+3. Do: `set RHOSTS [target IP]`
+4. Do: `run`
+5. You should see a list of discovered usernames printed to the console.
+
+## Options
+
+### TARGETURI
+
+The base path to the Drupal installation. The default value is `/`. Change this if Drupal is
+installed in a subdirectory, for example `/drupal/`.
+
+## Scenarios
+
+### Drupal 6.x with Views 6.x-2.11
+
+```
+msf > use auxiliary/scanner/http/drupal_views_user_enum
+msf auxiliary(scanner/http/drupal_views_user_enum) > set RHOSTS 192.168.1.50
+RHOSTS => 192.168.1.50
+msf auxiliary(scanner/http/drupal_views_user_enum) > set TARGETURI /
+TARGETURI => /
+msf auxiliary(scanner/http/drupal_views_user_enum) > run
+
+[*] Begin enumerating users at 192.168.1.50
+[+] Found User: admin
+[+] Found User: john
+[+] Found User: testuser
+[*] Done. 3 usernames found...
+[*] Usernames stored in: /root/.msf4/loot/20250319120000_default_192.168.1.50_drupal_user_123456.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/drupal_views_user_enum.md
+++ b/documentation/modules/auxiliary/scanner/http/drupal_views_user_enum.md
@@ -51,3 +51,4 @@ msf auxiliary(scanner/http/drupal_views_user_enum) > run
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
+

--- a/documentation/modules/auxiliary/scanner/http/elasticsearch_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/elasticsearch_traversal.md
@@ -52,3 +52,4 @@ msf auxiliary(scanner/http/elasticsearch_traversal) > run
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
+

--- a/documentation/modules/auxiliary/scanner/http/elasticsearch_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/elasticsearch_traversal.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+
+This module exploits a directory traversal vulnerability in ElasticSearch versions prior to
+1.6.1. The flaw exists in the Snapshot API and allows an unauthenticated attacker to read
+arbitrary files from the target system with the privileges of the JVM process.
+
+The vulnerability is tracked as [CVE-2015-5531](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5531).
+
+### Setup
+
+1. Install a vulnerable version of ElasticSearch (prior to 1.6.1). Older releases are available
+   from the [ElasticSearch downloads archive](https://www.elastic.co/downloads/past-releases).
+2. Configure a `path.repo` in `elasticsearch.yml` so that the Snapshot API is available:
+   ```
+   path.repo: ["/tmp/backups"]
+   ```
+3. Start ElasticSearch. It listens on port **9200** by default.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/elasticsearch_traversal`
+3. Do: `set RHOSTS [target IP]`
+4. Do: `run`
+5. You should see the requested file contents saved as loot.
+
+## Options
+
+### FILEPATH
+
+The path to the file to read on the target. The default value is `/etc/passwd`.
+
+### DEPTH
+
+The number of `../` traversal sequences to include. The default is `7`. Increase this if the
+file cannot be reached with the default depth.
+
+## Scenarios
+
+### ElasticSearch 1.5.2 on Ubuntu 14.04
+
+```
+msf > use auxiliary/scanner/http/elasticsearch_traversal
+msf auxiliary(scanner/http/elasticsearch_traversal) > set RHOSTS 10.10.10.50
+RHOSTS => 10.10.10.50
+msf auxiliary(scanner/http/elasticsearch_traversal) > set RPORT 9200
+RPORT => 9200
+msf auxiliary(scanner/http/elasticsearch_traversal) > run
+
+[*] The target appears to be vulnerable.
+[+] File saved in: /root/.msf4/loot/20250319120000_default_10.10.10.50_elasticsearch.tr_123456.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```


### PR DESCRIPTION
Adds module documentation for the following auxiliary scanner modules that are currently missing docs, as noted in #12389:

* auxiliary/scanner/http/apache_activemq_traversal
* * auxiliary/scanner/http/drupal_views_user_enum
* * auxiliary/scanner/http/coldfusion_version
* * auxiliary/scanner/http/elasticsearch_traversal
* * auxiliary/scanner/ftp/bison_ftp_traversal
Each documentation file follows the module_doc_template.md format and includes Vulnerable Application, Verification Steps, Options, and Scenarios sections.

## Verification

* Reviewed against existing merged documentation for style consistency
* * All module options and CVE references cross-checked against source code