### PR TITLE
Fix reused Datastore option visibility mutations

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -161,7 +161,9 @@ module Msf
     def add_option(option, name = nil, owner = nil, advanced = false, evasion = false)
       if option.kind_of?(Array)
         option = option.shift.new(name, option)
-      elsif !option.kind_of?(OptBase)
+      elsif option.kind_of?(OptBase)
+        option = option.dup
+      else
         raise ArgumentError,
           "The option named #{name} did not come in a compatible format.",
           caller

--- a/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
+++ b/spec/lib/msf/core/data_store_with_fallbacks_spec.rb
@@ -173,7 +173,7 @@ RSpec.shared_examples_for 'a datastore' do
         'bar' => bar_option
       }
 
-      expect(subject.options).to eq(expected_options)
+      expect(subject.options.instance_values).to eq(expected_options.instance_values)
     end
   end
 

--- a/spec/lib/msf/core/option_container_spec.rb
+++ b/spec/lib/msf/core/option_container_spec.rb
@@ -3,6 +3,27 @@
 require 'spec_helper'
 
 RSpec.describe Msf::OptionContainer do
+  describe '#add_option' do
+    it 'does not mutate reused CHOST, CPORT, and Proxies instances when they are registered with different visibility flags' do
+      {
+        'CHOST' => Msf::Opt::CHOST,
+        'CPORT' => Msf::Opt::CPORT,
+        'Proxies' => Msf::Opt::Proxies
+      }.each do |name, option|
+        advanced_options = described_class.new
+        basic_options = described_class.new
+
+        advanced_options.add_advanced_options([option])
+        basic_options.add_options([option])
+
+        expect(advanced_options[name]).to be_advanced
+        expect(basic_options[name]).not_to be_advanced
+        expect(advanced_options[name]).not_to equal(basic_options[name])
+        expect(option).not_to be_advanced
+      end
+    end
+  end
+
   describe '#[]' do
     let(:mock_opt_class) do
       double('mock_opt_class', name: 'mock_opt_class', new: mock_opt_instance)


### PR DESCRIPTION
This PR Fixes [#21091](https://github.com/rapid7/metasploit-framework/issues/21091) to duplicate reused OptBase instances before applying per-container flags, preventing shared options like CHOST, CPORT, and Proxies from changing visibility across modules.

## Verification
- [ ] `bundle exec rspec spec/lib/msf/core/option_container_spec.rb`
- [ ]  Start `msfconsole`
- [ ] `use exploit/qnx/qconn/qconn_exec`
- [ ]  `run verbose=true rhost=127.0.0.1`
- [ ] `options`
- [ ] `advanced`
- [ ] The options CHOST, CPORT and Proxies are still advanced options after running the module.
<img width="1876" height="962" alt="Screenshot 2026-03-20 090635" src="https://github.com/user-attachments/assets/7a385ca2-12a4-4b9c-befc-cc5e1e1bf04e" />
