### PR TITLE
fix: correct typo 'recieved' to 'received' in two files

### DIFF
--- a/lib/metasploit/framework/password_crackers/jtr/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/jtr/formatter.rb
@@ -118,7 +118,7 @@ module Metasploit
                 return "#{username}:#{private_data}:#{db_id}:"
               end
             else
-              puts "[X] JTR Formatter (params_to_jtr) recieved an unknown private_type: #{private_type} (#{private_type.class})"
+              puts "[X] JTR Formatter (params_to_jtr) received an unknown private_type: #{private_type} (#{private_type.class})"
             end
 
             nil

--- a/lib/msf/core/exploit/smb/shadow_mitm_dispatcher.rb
+++ b/lib/msf/core/exploit/smb/shadow_mitm_dispatcher.rb
@@ -169,7 +169,7 @@ module Exploit::SMB
           pkt = PacketFu::Packet.parse(data)
           break pkt if (pkt.tcp_header.tcp_seq == @tcp_ack) || (@tcp_ack == 0)
         end
-        raise Errno::ECONNRESET, 'Recieved a RST packet' if pkt.tcp_header.tcp_flags.rst == 1
+        raise Errno::ECONNRESET, 'Received a RST packet' if pkt.tcp_header.tcp_flags.rst == 1
         #puts "#{pkt.tcp_header.tcp_seq} == #{@tcp_ack}"
         @tcp_ack = pkt.tcp_header.tcp_seq + pkt.tcp_header.body.size
         @tcp_ack += 1 if pkt.tcp_header.tcp_flags.syn == 1


### PR DESCRIPTION
## What this change does
Fixes a spelling typo — 'recieved' corrected to 'received' in two files.

No GitHub issue number — simple typo fix.

## Files changed
- lib/metasploit/framework/password_crackers/jtr/formatter.rb (line 121)
- lib/msf/core/exploit/smb/shadow_mitm_dispatcher.rb (line 172)

## Verification
No functional change — only spelling correction in string literals.

- [ ] Confirm string in formatter.rb reads 'received' not 'recieved'
- [ ] Confirm string in shadow_mitm_dispatcher.rb reads 'Received' not 'Recieved'
- [ ] Run existing tests to confirm no breakage