### PR TITLE
Fix binary-safe Mach-O detection

### DIFF
--- a/lib/msf/util/exe/common.rb
+++ b/lib/msf/util/exe/common.rb
@@ -117,7 +117,8 @@ module Msf::Util::EXE::Common
     end
 
     def macho?(code)
-      code[0..3] == "\xCF\xFA\xED\xFE" || code[0..3] == "\xCE\xFA\xED\xFE" || code[0..3] == "\xCA\xFE\xBA\xBE"
+      magic = code&.byteslice(0, 4)
+      magic == "\xCF\xFA\xED\xFE".b || magic == "\xCE\xFA\xED\xFE".b || magic == "\xCA\xFE\xBA\xBE".b
     end
 
     # Create an ELF executable containing the payload provided in +code+


### PR DESCRIPTION
Fixes #21047 
Fixes Mach-O detection for macOS mettle payloads.

It was misdetecting valid Mach-O binaries under Ruby 3, so framework wrapped them again and produced a broken payload. This makes the check binary-safe so the original mettle Mach-O is used directly.