### PR TITLE
Adds options to report summary to overide verbose output

### DIFF
--- a/lib/msf/core/auxiliary/report_summary.rb
+++ b/lib/msf/core/auxiliary/report_summary.rb
@@ -22,6 +22,7 @@ module Msf
           register_options(
             [
               OptBool.new('ShowSuccessfulLogins', [false, 'Outputs a table of successful logins', true]),
+              OptBool.new('VerboseIfSingleHost', [false, 'Force verbose logging if there is only one host scanned', true]),
             ]
           )
         end
@@ -170,8 +171,11 @@ module Msf
       #
       # @param [Object] host_count The number of hosts
       def conditional_verbose_output(host_count)
+        return unless datastore['VerboseIfSingleHost']
+
         if host_count == 1
           datastore['Verbose'] = true
+          print_warning('One host detected - enabling verbose mode - to disable use %grnset VerboseIfSingleHost false%clr')
         end
       end
 


### PR DESCRIPTION
Pre-requisite context:

Some of the current login scanners are very quiet and don't output anything useful, which is confusing for new users. To improve this behavior, the report summary will override the verbose level in the datastore to `true` so there's useful output when targeting one host.

Scenario:

If a user runs one of the login scanner modules with `verbose=false` - the current implementation overrides this when there's one host present.

Now we allow this behavior to be overridden by the user.

Default output:

<img width="1838" height="646" alt="image" src="https://github.com/user-attachments/assets/7dbb7aca-3d21-4b90-920f-abcb0467ef7f" />

With the override disabled:

<img width="1266" height="226" alt="image" src="https://github.com/user-attachments/assets/3914871f-6511-4d01-9fb1-e3099e87280a" />

## Verification
- [ ] CI is green