### PR TITLE
Fixes VBS payload format generating

### DIFF
--- a/lib/msf/util/exe/bsd.rb
+++ b/lib/msf/util/exe/bsd.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Bsd
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Bsd::X86

--- a/lib/msf/util/exe/bsd/x64.rb
+++ b/lib/msf/util/exe/bsd/x64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Bsd::X64
   include Msf::Util::EXE::Common
 

--- a/lib/msf/util/exe/bsd/x86.rb
+++ b/lib/msf/util/exe/bsd/x86.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Bsd::X86
   include Msf::Util::EXE::Common
 

--- a/lib/msf/util/exe/common.rb
+++ b/lib/msf/util/exe/common.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Common
   require 'rex'
   require 'rex/peparsey'

--- a/lib/msf/util/exe/linux.rb
+++ b/lib/msf/util/exe/linux.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux
   
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/aarch64.rb
+++ b/lib/msf/util/exe/linux/aarch64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Aarch64
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/armbe.rb
+++ b/lib/msf/util/exe/linux/armbe.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Armbe
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/armle.rb
+++ b/lib/msf/util/exe/linux/armle.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Armle
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/common.rb
+++ b/lib/msf/util/exe/linux/common.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Common
   include Msf::Util::EXE::Common
   def self.included(base)

--- a/lib/msf/util/exe/linux/loongarch64.rb
+++ b/lib/msf/util/exe/linux/loongarch64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Loongarch64
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/mips64.rb
+++ b/lib/msf/util/exe/linux/mips64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Mips64
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/mipsbe.rb
+++ b/lib/msf/util/exe/linux/mipsbe.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Mipsbe
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/mipsle.rb
+++ b/lib/msf/util/exe/linux/mipsle.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Mipsle
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/ppc.rb
+++ b/lib/msf/util/exe/linux/ppc.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Ppc
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/ppc64.rb
+++ b/lib/msf/util/exe/linux/ppc64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Ppc64
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/ppce500v2.rb
+++ b/lib/msf/util/exe/linux/ppce500v2.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Ppce500v2
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/riscv32le.rb
+++ b/lib/msf/util/exe/linux/riscv32le.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Riscv32le
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/riscv64le.rb
+++ b/lib/msf/util/exe/linux/riscv64le.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Riscv64le
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/x64.rb
+++ b/lib/msf/util/exe/linux/x64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::X64
 include Msf::Util::EXE::Linux::Common
   

--- a/lib/msf/util/exe/linux/x86.rb
+++ b/lib/msf/util/exe/linux/x86.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::X86
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/linux/zarch.rb
+++ b/lib/msf/util/exe/linux/zarch.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Linux::Zarch
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Linux::Common

--- a/lib/msf/util/exe/osx.rb
+++ b/lib/msf/util/exe/osx.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::OSX
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::OSX::Common

--- a/lib/msf/util/exe/osx/aarch64.rb
+++ b/lib/msf/util/exe/osx/aarch64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::OSX::Aarch64 
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::OSX::Common

--- a/lib/msf/util/exe/osx/app.rb
+++ b/lib/msf/util/exe/osx/app.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::OSX::App
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::OSX::Common

--- a/lib/msf/util/exe/osx/armle.rb
+++ b/lib/msf/util/exe/osx/armle.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::OSX::Armle
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::OSX::Common

--- a/lib/msf/util/exe/osx/common.rb
+++ b/lib/msf/util/exe/osx/common.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::OSX::Common
   include Msf::Util::EXE::Common
   def self.included(base)

--- a/lib/msf/util/exe/osx/ppc.rb
+++ b/lib/msf/util/exe/osx/ppc.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
  module Msf::Util::EXE::OSX::Ppc
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::OSX::Common

--- a/lib/msf/util/exe/osx/x64.rb
+++ b/lib/msf/util/exe/osx/x64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::OSX::X64
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::OSX::Common

--- a/lib/msf/util/exe/osx/x86.rb
+++ b/lib/msf/util/exe/osx/x86.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::OSX::X86
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::OSX::Common

--- a/lib/msf/util/exe/solaris.rb
+++ b/lib/msf/util/exe/solaris.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Solaris
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Solaris::X86

--- a/lib/msf/util/exe/solaris/x86.rb
+++ b/lib/msf/util/exe/solaris/x86.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Solaris::X86
   include Msf::Util::EXE::Common
 

--- a/lib/msf/util/exe/windows.rb
+++ b/lib/msf/util/exe/windows.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Windows
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Windows::Common

--- a/lib/msf/util/exe/windows/aarch64.rb
+++ b/lib/msf/util/exe/windows/aarch64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Windows::Aarch64
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Windows::Common

--- a/lib/msf/util/exe/windows/common.rb
+++ b/lib/msf/util/exe/windows/common.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Windows::Common
   include Msf::Util::EXE::Common
 

--- a/lib/msf/util/exe/windows/x64.rb
+++ b/lib/msf/util/exe/windows/x64.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Windows::X64
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Windows::Common

--- a/lib/msf/util/exe/windows/x86.rb
+++ b/lib/msf/util/exe/windows/x86.rb
@@ -284,11 +284,11 @@ module Msf::Util::EXE::Windows::X86
 
       pe[136, 4] = [rand(0x100000000)].pack('V')
 
-      ci = pe.index("\x31\xc9" * 160)
+      ci = pe.index("\x31\xc9".b * 160)
       unless ci
         raise RuntimeError, "Invalid Win32 PE OLD EXE template: missing first \"\\x31\\xc9\""
       end
-      cd = pe.index("\x31\xc9" * 160, ci + 320)
+      cd = pe.index("\x31\xc9".b * 160, ci + 320)
       unless cd
         raise RuntimeError, "Invalid Win32 PE OLD EXE template: missing second \"\\x31\\xc9\""
       end

--- a/lib/msf/util/exe/windows/x86.rb
+++ b/lib/msf/util/exe/windows/x86.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Util::EXE::Windows::X86
   include Msf::Util::EXE::Common
   include Msf::Util::EXE::Windows::Common
@@ -284,11 +285,11 @@ module Msf::Util::EXE::Windows::X86
 
       pe[136, 4] = [rand(0x100000000)].pack('V')
 
-      ci = pe.index("\x31\xc9".b * 160)
+      ci = pe.index("\x31\xc9" * 160)
       unless ci
         raise RuntimeError, "Invalid Win32 PE OLD EXE template: missing first \"\\x31\\xc9\""
       end
-      cd = pe.index("\x31\xc9".b * 160, ci + 320)
+      cd = pe.index("\x31\xc9" * 160, ci + 320)
       unless cd
         raise RuntimeError, "Invalid Win32 PE OLD EXE template: missing second \"\\x31\\xc9\""
       end


### PR DESCRIPTION
Fixes #21170

This PR introduces small fix spotted in #21170. The bug causes payloads in VBS format to fail. The original code 
```ruby
ci = pe.index("\x31\xc9" * 160)
```
failed due to incompatible character encoding between ASCII and UTF-8. This is likely caused by different Ruby versions. 
