### PR TITLE
Bump the setup-php version to 2.37.0

### DIFF
--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -112,8 +112,18 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
 
-      - uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
-        if: ${{ matrix.meterpreter.name == 'php' }}
+      # Use setup-php@2.31.1 for Windows (PHP 5.3 on windows-2022 is broken with later versions while PHP 7.4 and 8.3
+      # are broken on MacOS with this version)
+      - name: Use setup-php@2.31.1 to install PHP for Windows runners
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231
+        if: ${{ matrix.meterpreter.name == 'php' && runner.os == 'Windows' }}
+        with:
+          php-version: ${{ matrix.meterpreter.runtime_version }}
+          tools: none
+
+      - name: Use setup-php@2.37.0 to install PHP for non-Windows runners
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f
+        if: ${{ matrix.meterpreter.name == 'php' && runner.os != 'Windows' }}
         with:
           php-version: ${{ matrix.meterpreter.runtime_version }}
           tools: none


### PR DESCRIPTION
This fixes the PHP setup for 7.4 and 8.3 on the macos-15-intel runners. This issue has been causing CI failsure on multiple PRs lately. Right now, this issue is preventing the new tests added in #21143 from running. If we can get this merged, we'll be able to run those tests and verify that the code changes are working on these systems.

Keeps Windows pinned to 2.31.1 (by commit of course) but bumps everything else to 2.37.0. Supposedly there's no overlap where everything we need will "just work" any more. Windows breaks on 2.32.0 and PHP 7.4 & 8.3 on macos-15-intel isn't fixed until 2.36.0.