### PR TITLE
Add MITRE ATT&CK tags for two modules

### DIFF
--- a/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
+++ b/modules/auxiliary/admin/ldap/ad_cs_cert_template.rb
@@ -55,7 +55,9 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [
           [ 'URL', 'https://posts.specterops.io/certified-pre-owned-d95910965cd2' ],
           [ 'URL', 'https://github.com/GhostPack/Certify' ],
-          [ 'URL', 'https://github.com/ly4k/Certipy' ]
+          [ 'URL', 'https://github.com/ly4k/Certipy' ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1649_STEAL_OR_FORGE_AUTHENTICATION_CERTIFICATES ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1484_DOMAIN_OR_TENANT_POLICY_MODIFICATION ]
         ],
         'License' => MSF_LICENSE,
         'Actions' => [

--- a/modules/auxiliary/scanner/ntp/timeroast.rb
+++ b/modules/auxiliary/scanner/ntp/timeroast.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'References' => [
           ['URL', 'https://github.com/SecuraBV/Timeroast/'],
-          ['URL', 'https://www.secura.com/uploads/whitepapers/Secura-WP-Timeroasting-v3.pdf']
+          ['URL', 'https://www.secura.com/uploads/whitepapers/Secura-WP-Timeroasting-v3.pdf'],
+          ['ATT&CK', Mitre::Attack::Technique::T1110_002_PASSWORD_CRACKING]
         ],
         'Notes' => {
           'Stability' => [],


### PR DESCRIPTION
This adds the MITRE ATT&CK tags for the last two modules called out in https://github.com/rapid7/metasploit-framework/issues/20802, allowing us to close the ticket.

