### PR TITLE
Fix service inconsistencies in create_credential vs report_service

### DIFF
--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -307,6 +307,23 @@ module Msf::DBManager::Cred
     service
   end
 
+  def create_credential_core(opts = {})
+    core = super
+    return core if core.nil?
+    origin = opts[:origin]
+    if origin.is_a?(Metasploit::Credential::Origin::Service)
+      retry_transaction do
+        login = Metasploit::Credential::Login.where(
+          core_id: core.id,
+          service_id: origin.service_id
+        ).first_or_initialize
+        login.status = Metasploit::Model::Login::Status::UNTRIED if login.status.blank?
+        login.save!
+      end
+    end
+    core
+  end
+
   alias :report_auth :report_auth_info
   alias :report_cred :report_auth_info
 end

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -303,7 +303,9 @@ module Msf::DBManager::Cred
     opts = opts.merge(service_name: opts[:service_name].to_s.downcase) if opts[:service_name]
     service = super(opts)
     return service if service.nil?
-    service.info = opts[:info] if opts.key?(:info)
+    if opts.key?(:info)
+      service.info = opts[:info].nil? ? '' : opts[:info]
+    end
     service.save! if service.changed?
     service
   end

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -299,6 +299,14 @@ module Msf::DBManager::Cred
     }
   end
 
+  def create_credential_service(opts = {})
+    service = super
+    return service if service.nil?
+    service.info = opts[:info] if opts.key?(:info)
+    service.save! if service.changed?
+    service
+  end
+
   alias :report_auth :report_auth_info
   alias :report_cred :report_auth_info
 end

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -300,7 +300,8 @@ module Msf::DBManager::Cred
   end
 
   def create_credential_service(opts = {})
-    service = super
+    opts = opts.merge(service_name: opts[:service_name].to_s.downcase) if opts[:service_name]
+    service = super(opts)
     return service if service.nil?
     service.info = opts[:info] if opts.key?(:info)
     service.save! if service.changed?

--- a/spec/support/shared/examples/msf/db_manager/cred.rb
+++ b/spec/support/shared/examples/msf/db_manager/cred.rb
@@ -12,4 +12,55 @@ RSpec.shared_examples_for 'Msf::DBManager::Cred' do
   it { is_expected.to respond_to :create_credential }
   it { is_expected.to respond_to :update_credential }
   it { is_expected.to respond_to :delete_credentials }
+
+  unless ENV['REMOTE_DB']
+    describe '#create_credential_service' do
+      let(:workspace) { subject.default_workspace }
+      let(:host_addr) { '192.0.2.1' }
+      let(:base_opts) do
+        {
+          address: host_addr,
+          port: 80,
+          service_name: 'http',
+          protocol: 'tcp',
+          workspace_id: workspace.id
+        }
+      end
+
+      context 'when :info is provided' do
+        it 'persists the info string on the created service' do
+          service = subject.create_credential_service(base_opts.merge(info: 'Apache httpd 2.4'))
+          expect(service).to be_persisted
+          expect(service.info).to eq('Apache httpd 2.4')
+        end
+      end
+
+      context 'when :info is not provided' do
+        it 'creates the service without raising an error' do
+          service = subject.create_credential_service(base_opts)
+          expect(service).to be_persisted
+          expect(service.port).to eq(80)
+          expect(service.proto).to eq('tcp')
+        end
+      end
+
+      context 'when the service already exists' do
+        before do
+          subject.create_credential_service(base_opts)
+        end
+
+        it 'updates the info on the existing service when :info is provided' do
+          service = subject.create_credential_service(base_opts.merge(info: 'updated banner'))
+          expect(service.info).to eq('updated banner')
+          expect(Mdm::Service.joins(:host).where(hosts: { address: host_addr }, port: 80).count).to eq(1)
+        end
+
+        it 'does not alter info when :info is absent' do
+          subject.create_credential_service(base_opts.merge(info: 'original banner'))
+          service = subject.create_credential_service(base_opts)
+          expect(service.info).to eq('original banner')
+        end
+      end
+    end
+  end
 end

--- a/spec/support/shared/examples/msf/db_manager/cred.rb
+++ b/spec/support/shared/examples/msf/db_manager/cred.rb
@@ -35,6 +35,14 @@ RSpec.shared_examples_for 'Msf::DBManager::Cred' do
         end
       end
 
+      context 'when :info is nil' do
+        it 'normalizes info to an empty string' do
+          service = subject.create_credential_service(base_opts.merge(info: nil))
+          expect(service).to be_persisted
+          expect(service.info).to eq('')
+        end
+      end
+      
       context 'when :info is not provided' do
         it 'creates the service without raising an error' do
           service = subject.create_credential_service(base_opts)

--- a/spec/support/shared/examples/msf/db_manager/cred.rb
+++ b/spec/support/shared/examples/msf/db_manager/cred.rb
@@ -61,6 +61,13 @@ RSpec.shared_examples_for 'Msf::DBManager::Cred' do
           expect(service.info).to eq('original banner')
         end
       end
+
+      context 'when :service_name has mixed case' do
+        it 'lowercases the service name to match report_service behavior' do
+          service = subject.create_credential_service(base_opts.merge(service_name: 'HTTP'))
+          expect(service.name).to eq('http')
+        end
+      end
     end
 
     describe '#create_credential_core' do

--- a/spec/support/shared/examples/msf/db_manager/cred.rb
+++ b/spec/support/shared/examples/msf/db_manager/cred.rb
@@ -62,5 +62,54 @@ RSpec.shared_examples_for 'Msf::DBManager::Cred' do
         end
       end
     end
+
+    describe '#create_credential_core' do
+      let(:workspace) { subject.default_workspace }
+      let(:host_addr) { '192.0.2.1' }
+      let(:module_fullname) { 'auxiliary/test/module' }
+
+      it 'creates a Login when origin is a service origin' do
+        core = subject.create_credential(
+          address: host_addr,
+          port: 22,
+          service_name: 'ssh',
+          protocol: 'tcp',
+          workspace_id: workspace.id,
+          origin_type: :service,
+          module_fullname: module_fullname,
+          username: 'admin'
+        )
+        expect(core).to be_persisted
+        expect(core.logins.count).to eq(1)
+        expect(core.logins.first.status).to eq(Metasploit::Model::Login::Status::UNTRIED)
+      end
+
+      it 'creates separate Logins when the same credential is found on different services' do
+        core1 = subject.create_credential(
+          address: host_addr,
+          port: 22,
+          service_name: 'ssh',
+          protocol: 'tcp',
+          workspace_id: workspace.id,
+          origin_type: :service,
+          module_fullname: module_fullname,
+          username: 'admin'
+        )
+
+        core2 = subject.create_credential(
+          address: '192.0.2.2',
+          port: 80,
+          service_name: 'http',
+          protocol: 'tcp',
+          workspace_id: workspace.id,
+          origin_type: :service,
+          module_fullname: module_fullname,
+          username: 'admin'
+        )
+
+        expect(core1.id).to eq(core2.id)
+        expect(core1.logins.reload.count).to eq(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #21156
Overrides create_credential_service and create_credential_core in `Msf::DBManager::Cred` to fix three inconsistencies between report_service and create_credential:
1. Persist the `:info` field when creating services via create_credential.
2. Create a Login for service origins so credentials are visible for every  service they were discovered on.
3. Lowercase `:service_name` to match report_service behavior.

## Verification

1. Place modules/exploits/service_vs_test_example.rb from issue #21156
2. msfconsole
3. services -d && creds -d
4. use exploit/service_vs_test_example
5. recheck
6. services  --> all 4 services have info populated, names lowercased
7. creds --> 2 entries (same core, one per service)
