### PR TITLE
Add documentation for wordpress_pingback_access module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
@@ -1,5 +1,3 @@
-# WordPress Pingback Access Scanner
-
 ## Vulnerable Application
 
 This module checks for accessible WordPress pingback functionality.
@@ -16,22 +14,14 @@ To test this module:
 2. Ensure `/xmlrpc.php` is accessible
 3. Pingback functionality should not be disabled
 
----
-
 ## Verification Steps
 
-1. Start Metasploit:
-`msfconsole`
-2. Load the module:
-`use auxiliary/scanner/http/wordpress_pingback_access`
-3. Set the target:
-`set RHOSTS <target_ip_or_domain>`
-4. Run the module:
-`run`
+1. Start Metasploit: `msfconsole`
+2. Load the module: `use auxiliary/scanner/http/wordpress_pingback_access`
+3. Set the target: `set RHOSTS <target_ip_or_domain>`
+4. Run the module: `run`
 
-5. If vulnerable, the module will indicate that pingback access is enabled.
-
----
+If vulnerable, the module will indicate that pingback access is enabled.
 
 ## Options
 
@@ -44,8 +34,6 @@ Target port (default: 80 or 443 depending on SSL).
 ### THREADS
 Number of concurrent threads.
 
----
-
 ## Scenarios
 
 This module can be used in:
@@ -53,11 +41,3 @@ This module can be used in:
 - Security assessments to identify exposed XML-RPC endpoints
 - Detecting potential DDoS amplification vectors
 - Enumerating WordPress misconfigurations
-
----
-
-## Version and OS
-
-Tested on:
-- WordPress 5.x / 6.x
-- Kali Linux

--- a/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
@@ -1,0 +1,63 @@
+# WordPress Pingback Access Scanner
+
+## Vulnerable Application
+
+This module checks for accessible WordPress pingback functionality.
+
+Pingback is an XML-RPC feature in WordPress that allows blogs to notify each other of references. If enabled, it can be abused for:
+
+- DDoS amplification attacks
+- Internal network scanning
+- Information disclosure
+
+To test this module:
+
+1. Set up a WordPress instance (any version with XML-RPC enabled)
+2. Ensure `/xmlrpc.php` is accessible
+3. Pingback functionality should not be disabled
+
+---
+
+## Verification Steps
+
+1. Start Metasploit:
+`msfconsole`
+2. Load the module:
+`use auxiliary/scanner/http/wordpress_pingback_access`
+3. Set the target:
+`set RHOSTS <target_ip_or_domain>`
+4. Run the module:
+`run`
+
+5. If vulnerable, the module will indicate that pingback access is enabled.
+
+---
+
+## Options
+
+### RHOSTS
+Target address or range of addresses.
+
+### RPORT
+Target port (default: 80 or 443 depending on SSL).
+
+### THREADS
+Number of concurrent threads.
+
+---
+
+## Scenarios
+
+This module can be used in:
+
+- Security assessments to identify exposed XML-RPC endpoints
+- Detecting potential DDoS amplification vectors
+- Enumerating WordPress misconfigurations
+
+---
+
+## Version and OS
+
+Tested on:
+- WordPress 5.x / 6.x
+- Kali Linux

--- a/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
@@ -2,7 +2,8 @@
 
 This module checks for accessible WordPress pingback functionality.
 
-Pingback is an XML-RPC feature in WordPress that allows blogs to notify each other of references. If enabled, it can be abused for:
+Pingback is an XML-RPC feature in WordPress that allows blogs to notify each other of references.
+If enabled, it can be abused for:
 
 - DDoS amplification attacks
 - Internal network scanning
@@ -16,45 +17,28 @@ To test this module:
 
 ## Verification Steps
 
-1. Start Metasploit:
-   `msfconsole`
-
-2. Load the module:
-   `use auxiliary/scanner/http/wordpress_pingback_access`
-
-3. Set the target:
-   `set RHOSTS example.com`
-
-4. Run the module:
-   `run`
+1. Start Metasploit: `msfconsole`
+2. Load the module: `use auxiliary/scanner/http/wordpress_pingback_access`
+3. Set the target: `set RHOSTS example.com`
+4. Run the module: `run`
 
 If vulnerable, the module will indicate that pingback access is enabled.
 
 ## Options
 
-### RHOSTS
-Target address or range of addresses.
-
-### RPORT
-Target port (default: 80 or 443 depending on SSL).
-
-### THREADS
-Number of concurrent threads.
+This module has no additional options beyond the standard ones.
 
 ## Scenarios
 
-Example run:
-
+Example usage against a WordPress site with pingback enabled:
 ```bash
-msfconsole
-use auxiliary/scanner/http/wordpress_pingback_access
-set RHOSTS example.com
-run
-```
-
-```
+msf > use auxiliary/scanner/http/wordpress_pingback_access
+msf auxiliary(scanner/http/wordpress_pingback_access) > set RHOSTS example.com
+RHOSTS => example.com
+msf auxiliary(scanner/http/wordpress_pingback_access) > run
 [*] Checking pingback access on example.com
 [+] Pingback is enabled and accessible at /xmlrpc.php
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
+msf auxiliary(scanner/http/wordpress_pingback_access) >
 ```

--- a/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_pingback_access.md
@@ -16,10 +16,17 @@ To test this module:
 
 ## Verification Steps
 
-1. Start Metasploit: `msfconsole`
-2. Load the module: `use auxiliary/scanner/http/wordpress_pingback_access`
-3. Set the target: `set RHOSTS <target_ip_or_domain>`
-4. Run the module: `run`
+1. Start Metasploit:
+   `msfconsole`
+
+2. Load the module:
+   `use auxiliary/scanner/http/wordpress_pingback_access`
+
+3. Set the target:
+   `set RHOSTS example.com`
+
+4. Run the module:
+   `run`
 
 If vulnerable, the module will indicate that pingback access is enabled.
 
@@ -36,8 +43,18 @@ Number of concurrent threads.
 
 ## Scenarios
 
-This module can be used in:
+Example run:
 
-- Security assessments to identify exposed XML-RPC endpoints
-- Detecting potential DDoS amplification vectors
-- Enumerating WordPress misconfigurations
+```bash
+msfconsole
+use auxiliary/scanner/http/wordpress_pingback_access
+set RHOSTS example.com
+run
+```
+
+```
+[*] Checking pingback access on example.com
+[+] Pingback is enabled and accessible at /xmlrpc.php
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```


### PR DESCRIPTION
This PR adds documentation for the wordpress_pingback_access module, including:

- Vulnerable application details
- Verification steps
- Options
- Usage scenarios

Follows the standard documentation template.