### PR TITLE
Fix crash on older Ruby versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
-    bigdecimal (3.2.3)
+    bigdecimal (3.3.1)
     bindata (2.4.15)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -491,7 +491,7 @@ GEM
       netrc (~> 0.8)
     rex-arch (0.1.19)
       rex-text
-    rex-bin_tools (0.1.10)
+    rex-bin_tools (0.1.15)
       metasm
       rex-arch
       rex-core


### PR DESCRIPTION
Fix crash on older Ruby versions when scanning binary files

- https://github.com/rapid7/rex-bin_tools/compare/v0.1.10...v0.1.15

## Verification

Ensure CI passes