### PR TITLE
Add CertificateTracePresenter and certificate/CSR tracing support

### DIFF
--- a/lib/msf.rb
+++ b/lib/msf.rb
@@ -11,6 +11,7 @@ end
 
 require 'msf/core/exception' # TODO: temporary require until we can split up the exceptions file and namespace properly
 require 'msf/core/constants'
+require 'msf/core/trace/certificate_trace_presenter'
 require 'msf_autoload'
 
 MsfAutoload.instance

--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -1,0 +1,88 @@
+# -*- coding: binary -*-
+
+module Msf
+  # Shared helpers for tracing X.509 certificates encountered during a module run
+  # (for example the client certificate presented for PKINIT, or a certificate
+  # issued via AD CS / MS-ICPR). Registers the +CertificateTrace+ and
+  # +CertificateTraceColors+ advanced options and dispatches formatted, optionally
+  # colorized output through Msf::Trace::CertificateTracePresenter.
+  #
+  # Include this mixin in any module or mixin that wants certificate tracing, then
+  # call #certificate_trace with the certificate of interest.
+  module Exploit::Remote::CertificateTrace
+    def initialize(info = {})
+      super
+
+      register_advanced_options(
+        [
+          OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', ['off', 'metadata', 'full']]),
+          OptString.new('CertificateTraceColors', [false, 'Certificate trace color (e.g. red/blu, unset to disable)', 'red/blu'])
+        ], Msf::Exploit::Remote::CertificateTrace
+      )
+    end
+
+    # Returns true if CertificateTracePresenter is loaded and tracing is enabled.
+    #
+    # @return [Boolean]
+    def certificate_trace_enabled?
+      return false unless defined?(Msf::Trace::CertificateTracePresenter)
+      return false unless respond_to?(:datastore) && datastore
+
+      mode = datastore['CertificateTrace']
+      mode && mode != 'off'
+    end
+
+    # Dispatches a certificate trace at the configured verbosity level. Builds a
+    # presenter, routes to the appropriate to_s_* method, applies the configured
+    # color, then prints via the module instance.
+    #
+    # Color convention mirrors HttpTraceColors: the second color in the "req/resp"
+    # pair is used for certificate output since a cert is always a received
+    # (response-side) artifact.
+    #
+    # @param cert [OpenSSL::X509::Certificate, OpenSSL::PKCS12, String]
+    # @return [void]
+    def certificate_trace(cert)
+      return unless certificate_trace_enabled?
+
+      mode = datastore['CertificateTrace']
+      presenter = Msf::Trace::CertificateTracePresenter.new(cert)
+
+      output = case mode
+               when 'metadata'
+                 presenter.to_s_metadata
+               when 'full'
+                 presenter.to_s_full
+               else
+                 vprint_warning("Unknown CertificateTrace mode: #{mode}")
+                 nil
+               end
+      return unless output
+
+      print_line(certificate_trace_colorize(output))
+    end
+
+    private
+
+    # Wraps +text+ in the configured certificate trace color escape sequences.
+    # Parses +CertificateTraceColors+ the same way HttpTraceColors is parsed:
+    # "req_color/resp_color" - the response (second) color is applied to cert
+    # output. Either side may be blank to disable coloring for that side.
+    #
+    # @param text [String]
+    # @return [String]
+    def certificate_trace_colorize(text)
+      colors = datastore['CertificateTraceColors'].to_s
+      colors = 'red/blu' if colors.blank?
+      colors += '/' if colors.count('/') == 0
+
+      _req_color, resp_color = colors.gsub('/', ' / ').split('/').map do |c|
+        c&.strip.blank? ? '' : "%bld%#{c.strip}"
+      end
+
+      return text if resp_color.blank?
+
+      "%clr#{resp_color}#{text}%clr"
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -16,6 +16,7 @@ module Msf
           include Msf::Exploit::Remote::Kerberos::Client::TgsResponse
           include Msf::Exploit::Remote::Kerberos::Client::Pac
           include Msf::Exploit::Remote::Kerberos::Client::Pkinit
+          include Msf::Exploit::Remote::CertificateTrace
 
           # https://datatracker.ietf.org/doc/html/rfc4121#section-4.1
           TOK_ID_KRB_AP_REQ = "\x01\x00"
@@ -45,8 +46,7 @@ module Msf
 
             register_advanced_options(
               [
-                OptTimedelta.new('KrbClockSkew', [true, 'Adjust Kerberos client clock by this offset (e.g. 90s, -5m, 1h)', '0s']),
-                OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', ['off', 'metadata', 'full']])
+                OptTimedelta.new('KrbClockSkew', [true, 'Adjust Kerberos client clock by this offset (e.g. 90s, -5m, 1h)', '0s'])
               ], self.class
             )
           end
@@ -214,40 +214,6 @@ module Msf
                 end
               end
             end
-          end
-
-          # Returns true if CertificateTracePresenter is loaded and tracing is enabled.
-          #
-          # @return [Boolean]
-          def certificate_trace_enabled?
-            return false unless defined?(Msf::Trace::CertificateTracePresenter)
-            return false unless respond_to?(:datastore) && datastore
-
-            mode = datastore['CertificateTrace']
-            mode && mode != 'off'
-          end
-
-          # Dispatches a certificate trace at the correct verbosity level.
-          # Builds a presenter and routes to the appropriate to_s_* method,
-          # then prints via the module instance.
-          #
-          # @param cert [OpenSSL::X509::Certificate, OpenSSL::PKCS12, String]
-          def certificate_trace(cert)
-            return unless certificate_trace_enabled?
-
-            mode = datastore['CertificateTrace']
-            presenter = Msf::Trace::CertificateTracePresenter.new(cert)
-
-            output = case mode
-                     when 'metadata'
-                       presenter.to_s_metadata
-                     when 'full'
-                       presenter.to_s_full
-                     else
-                       vprint_warning("Unknown CertificateTrace mode: #{mode}")
-                       nil
-                     end
-            print_line(output) if output
           end
 
           # Send a TGT request using PKINIT (certificate) authentication

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -46,7 +46,7 @@ module Msf
             register_advanced_options(
               [
                 OptTimedelta.new('KrbClockSkew', [true, 'Adjust Kerberos client clock by this offset (e.g. 90s, -5m, 1h)', '0s']),
-                OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', ['off', 'metadata', 'full', 'csr']])
+                OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', ['off', 'metadata', 'full']])
               ], self.class
             )
           end
@@ -241,7 +241,7 @@ module Msf
             output = case mode
                      when 'metadata'
                        presenter.to_s_metadata
-                     when 'full', 'csr'
+                     when 'full'
                        presenter.to_s_full
                      else
                        vprint_warning("Unknown CertificateTrace mode: #{mode}")

--- a/lib/msf/core/exploit/remote/kerberos/client.rb
+++ b/lib/msf/core/exploit/remote/kerberos/client.rb
@@ -45,7 +45,8 @@ module Msf
 
             register_advanced_options(
               [
-                OptTimedelta.new('KrbClockSkew', [true, 'Adjust Kerberos client clock by this offset (e.g. 90s, -5m, 1h)', '0s'])
+                OptTimedelta.new('KrbClockSkew', [true, 'Adjust Kerberos client clock by this offset (e.g. 90s, -5m, 1h)', '0s']),
+                OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', ['off', 'metadata', 'full', 'csr']])
               ], self.class
             )
           end
@@ -215,6 +216,40 @@ module Msf
             end
           end
 
+          # Returns true if CertificateTracePresenter is loaded and tracing is enabled.
+          #
+          # @return [Boolean]
+          def certificate_trace_enabled?
+            return false unless defined?(Msf::Trace::CertificateTracePresenter)
+            return false unless respond_to?(:datastore) && datastore
+
+            mode = datastore['CertificateTrace']
+            mode && mode != 'off'
+          end
+
+          # Dispatches a certificate trace at the correct verbosity level.
+          # Builds a presenter and routes to the appropriate to_s_* method,
+          # then prints via the module instance.
+          #
+          # @param cert [OpenSSL::X509::Certificate, OpenSSL::PKCS12, String]
+          def certificate_trace(cert)
+            return unless certificate_trace_enabled?
+
+            mode = datastore['CertificateTrace']
+            presenter = Msf::Trace::CertificateTracePresenter.new(cert)
+
+            output = case mode
+                     when 'metadata'
+                       presenter.to_s_metadata
+                     when 'full', 'csr'
+                       presenter.to_s_full
+                     else
+                       vprint_warning("Unknown CertificateTrace mode: #{mode}")
+                       nil
+                     end
+            print_line(output) if output
+          end
+
           # Send a TGT request using PKINIT (certificate) authentication
           #
           # @param options [Hash]
@@ -227,6 +262,13 @@ module Msf
           # @return [Msf::Exploit::Remote::Kerberos::Model::TgtResponse] The TGT response and the key
           def send_request_tgt_pkinit(options = {})
             pfx = options[:pfx]
+
+            # Trace the client certificate being submitted for PKINIT authentication.
+            # Surfaces cert details at the moment the certificate is presented to the KDC.
+            if pfx.respond_to?(:certificate)
+              certificate_trace(pfx.certificate)
+            end
+
             request_pac = options.fetch(:request_pac, true)
             realm = options[:realm]
             server_name = options[:server_name] || "krbtgt/#{realm}"

--- a/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
+++ b/lib/msf/core/exploit/remote/kerberos/service_authenticator/base.rb
@@ -90,8 +90,11 @@ class Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base
                 :print_status,
                 :print_good,
                 :print_error,
+                :print_line,
                 :vprint_error,
                 :vprint_status,
+                :vprint_warning,
+                :datastore,
                 :workspace
 
   # Flags - https://datatracker.ietf.org/doc/html/rfc4121#section-4.1.1.1

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -17,6 +17,7 @@ module Exploit::Remote::MsIcpr
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::CertRequest
   include Msf::Exploit::Remote::LDAP::ActiveDirectory::AdCsOpts
+  include Msf::Exploit::Remote::CertificateTrace
 
   ADCS_CA_SERVICE_NAME = 'adcs-ca'
 
@@ -103,6 +104,7 @@ module Exploit::Remote::MsIcpr
     case response[:status]
     when :issued
       print_good('The requested certificate was issued.')
+      certificate_trace(response[:certificate])
     when :submitted
       print_warning('The requested certificate was submitted for review.')
     else

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -83,7 +83,8 @@ module Msf
 
         lines = [base]
         lines << "  Serial     : #{@cert.serial}"
-        lines << "  Version    : #{@cert.version}"
+        # OpenSSL exposes the zero-based encoded X.509 version (v3 == 2).
+        lines << "  Version    : v#{@cert.version + 1}"
         lines << "  Public Key : #{format_public_key(@cert.public_key)}"
 
         identities = parse_san_identities
@@ -143,19 +144,37 @@ module Msf
         @cert.subject.to_a.find { |name, _, _| name == 'CN' }&.dig(1)
       end
 
+      # Resolve auth identities (UPN, email) from the certificate's subjectAltName.
+      #
+      # AD-issued certificates encode the UPN as an otherName GeneralName, which
+      # OpenSSL does not format reliably as a string across versions. Decode the
+      # extension as ASN.1 instead, mirroring the PKINIT SAN handling in
+      # Msf::Exploit::Remote::Kerberos::Client::Pkinit#extract_user_and_realm.
+      #
+      # @return [Hash{Symbol => String}] identity values keyed by :upn / :email
       def parse_san_identities
-        san = @cert.extensions&.find { |e| e.oid == 'subjectAltName' }
-        return {} unless san
-
         result = {}
-        san.value.split(/,\s*/).each do |entry|
-          case entry.strip
-          when /\Aothername:\s*UPN:(.+)\z/i
-            result[:upn] = ::Regexp.last_match(1).strip
-          when /\Aemail:(.+)\z/i
-            result[:email] = ::Regexp.last_match(1).strip
+        return result unless @cert&.extensions
+
+        @cert.extensions.select { |ext| ext.oid == 'subjectAltName' }.each do |san_extension|
+          asn_san = OpenSSL::ASN1.decode(san_extension)
+          octet_string = asn_san.value.find { |value| value.is_a?(OpenSSL::ASN1::OctetString) }
+          next unless octet_string
+
+          OpenSSL::ASN1.decode(octet_string.value).value.each do |san_entry|
+            case san_entry.tag
+            when 0 # otherName - AD stores the UPN principal name here
+              next unless san_entry.value[0]&.value == 'msUPN'
+
+              result[:upn] ||= san_entry.value[1].value[0].value
+            when 1 # rfc822Name (email)
+              result[:email] ||= san_entry.value
+            end
           end
+        rescue StandardError
+          next
         end
+
         result
       end
 

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -17,7 +17,7 @@ module Msf
     #   mod.print_line(presenter.to_s_metadata)
     #   mod.print_line(presenter.to_s_full)
     #
-    #   # CSR mode — expects raw DER/PEM CSR bytes, not a certificate:
+    #   # CSR mode - expects raw DER/PEM CSR bytes, not a certificate:
     #   mod.print_line(presenter.to_s_csr(csr_raw))
     class CertificateTracePresenter
 
@@ -112,13 +112,13 @@ module Msf
 
       # Returns a formatted CSR string from raw CSR bytes.
       #
-      # This method expects raw DER or PEM encoded CSR bytes — not a certificate
+      # This method expects raw DER or PEM encoded CSR bytes - not a certificate
       # object. The 'csr' trace mode is intended for PKINIT pre-authentication
       # flows where the CSR is constructed and submitted separately from the
       # certificate. Callers must pass the CSR bytes directly rather than
       # converting from a certificate.
       #
-      # Instance method — consistent with the presenter pattern.
+      # Instance method - consistent with the presenter pattern.
       #
       # @param csr_raw [String] DER or PEM encoded certificate signing request
       # @return [String, nil] nil if CSR could not be parsed

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -38,6 +38,25 @@ module Msf
         '1.3.6.1.4.1.311.25.2' => 'AD DS Security Extension (SID)'
       }.freeze
 
+      # Standard PKIX extensions OpenSSL renders as clean, human-readable text.
+      # For any other extension - notably the Microsoft AD CS enrollment OIDs -
+      # OpenSSL emits a lossy byte dump (raw bytes on OpenSSL, non-printables
+      # collapsed to '.' on LibreSSL), so we hex-encode the raw extnValue
+      # instead of printing mojibake. Matched against the short name OpenSSL
+      # reports for recognised OIDs.
+      OPENSSL_READABLE_EXTENSIONS = %w[
+        basicConstraints
+        authorityKeyIdentifier
+        subjectKeyIdentifier
+        crlDistributionPoints
+        authorityInfoAccess
+        certificatePolicies
+        issuerAltName
+        nameConstraints
+        nsComment
+        nsCertType
+      ].freeze
+
       # Priority order for resolving a single auth identity from the cert.
       # UPN is the primary AD identity; email and CN are fallbacks.
       IDENTITY_SOURCES = [
@@ -172,12 +191,13 @@ module Msf
 
       # Render an extension value as human-readable text.
       #
-      # OpenSSL formats the standard extensions (subjectKeyIdentifier,
-      # crlDistributionPoints, etc.) well, but for OIDs it does not understand -
+      # OpenSSL formats the standard PKIX extensions (subjectKeyIdentifier,
+      # crlDistributionPoints, etc.) well, but for OIDs it cannot decode -
       # notably the Microsoft AD CS enrollment extensions - Extension#value
-      # returns raw bytes with non-printables collapsed to '.', surfacing as
-      # mojibake such as "...U.s.e.r". Decode the MS template extensions we
-      # recognise; otherwise defer to OpenSSL's own rendering.
+      # returns a lossy byte dump that surfaces as mojibake such as "...U.s.e.r".
+      # Decode the MS template extensions we recognise; defer to OpenSSL for the
+      # standard extensions it renders cleanly; hex-encode everything else so the
+      # raw bytes stay unambiguous and copy-pasteable.
       #
       # @param ext [OpenSSL::X509::Extension]
       # @return [String]
@@ -185,14 +205,17 @@ module Msf
         case normalize_oid(ext.oid)
         when CERT_TEMPLATE_NAME_OID
           asn1 = inner_extension_asn1(ext)
-          asn1 ? clean_text(asn1.value) : ext.value
+          return clean_text(asn1.value) if asn1
         when CERT_TEMPLATE_INFO_OID
-          format_template_information(ext)
-        else
-          ext.value
+          decoded = format_template_information(ext)
+          return decoded if decoded
         end
+
+        return ext.value if OPENSSL_READABLE_EXTENSIONS.include?(ext.oid)
+
+        hex_encode(raw_extension_bytes(ext) || ext.value)
       rescue StandardError
-        ext.value
+        hex_encode(raw_extension_bytes(ext) || ext.value)
       end
 
       # Resolve an extension OID to its dotted numeric form. OpenSSL may surface
@@ -227,15 +250,34 @@ module Msf
       # SEQUENCE { templateID OID, majorVersion INTEGER, minorVersion INTEGER OPTIONAL }.
       #
       # @param ext [OpenSSL::X509::Extension]
-      # @return [String]
+      # @return [String, nil] nil if the extension could not be decoded
       def format_template_information(ext)
         asn1 = inner_extension_asn1(ext)
-        return ext.value unless asn1.respond_to?(:value) && asn1.value.is_a?(Array)
+        return nil unless asn1.respond_to?(:value) && asn1.value.is_a?(Array)
 
         oid, major, minor = asn1.value.map { |v| v&.value }
         out = "Template #{oid}"
         out += " (v#{major}#{minor ? ".#{minor}" : ''})" if major
         out
+      end
+
+      # Extract the raw extnValue octets carried inside an extension. Extension#to_der
+      # wraps the value in an OCTET STRING; return those inner bytes so they can be
+      # hex-encoded rather than dumped through OpenSSL's lossy string rendering.
+      #
+      # @param ext [OpenSSL::X509::Extension]
+      # @return [String, nil]
+      def raw_extension_bytes(ext)
+        seq = OpenSSL::ASN1.decode(ext.to_der)
+        seq.value.find { |v| v.is_a?(OpenSSL::ASN1::OctetString) }&.value
+      rescue OpenSSL::ASN1::ASN1Error
+        nil
+      end
+
+      # @param str [String]
+      # @return [String] uppercase colon-separated hex (e.g. "30:0C:06:0A")
+      def hex_encode(str)
+        str.to_s.b.unpack1('H*').upcase.scan(/../).join(':')
       end
 
       # Normalise a decoded ASN.1 string value to clean UTF-8. BMPString content

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -29,12 +29,19 @@ module Msf
       CERT_TEMPLATE_NAME_OID = '1.3.6.1.4.1.311.20.2'
       CERT_TEMPLATE_INFO_OID = '1.3.6.1.4.1.311.21.7'
 
+      # Microsoft Application Policies extension. Its content is a
+      # CertificatePolicies SEQUENCE OF PolicyInformation, which the framework
+      # already decodes for the icpr_cert workflow; we resolve each policy OID to
+      # its friendly label rather than dumping the raw bytes (the policy OIDs -
+      # e.g. Client Authentication - are central to ESC attack triage).
+      APPLICATION_POLICIES_OID = '1.3.6.1.4.1.311.21.10'
+
       # Friendly labels for extension OIDs that OpenSSL leaves as raw numeric
       # strings (predominantly Microsoft enrollment OIDs on AD CS certificates).
       EXTENSION_OID_NAMES = {
         CERT_TEMPLATE_NAME_OID => 'Certificate Template Name',
         CERT_TEMPLATE_INFO_OID => 'Certificate Template Information',
-        '1.3.6.1.4.1.311.21.10' => 'Application Policies',
+        APPLICATION_POLICIES_OID => 'Application Policies',
         '1.3.6.1.4.1.311.25.2' => 'AD DS Security Extension (SID)'
       }.freeze
 
@@ -209,6 +216,9 @@ module Msf
         when CERT_TEMPLATE_INFO_OID
           decoded = format_template_information(ext)
           return decoded if decoded
+        when APPLICATION_POLICIES_OID
+          decoded = format_application_policies(ext)
+          return decoded if decoded
         end
 
         return ext.value if OPENSSL_READABLE_EXTENSIONS.include?(ext.oid)
@@ -259,6 +269,27 @@ module Msf
         out = "Template #{oid}"
         out += " (v#{major}#{minor ? ".#{minor}" : ''})" if major
         out
+      end
+
+      # Decode the Microsoft Application Policies extension to its policy OIDs and
+      # friendly labels. The extnValue is a CertificatePolicies structure; reuse
+      # the framework's parser and OID table so the output matches what the
+      # icpr_cert module already prints (Msf::Exploit::Remote::CertRequest).
+      #
+      # @param ext [OpenSSL::X509::Extension]
+      # @return [String, nil] e.g. "1.3.6.1.5.5.7.3.2 (Client Authentication)", nil if undecodable
+      def format_application_policies(ext)
+        policies = Rex::Proto::CryptoAsn1::X509::CertificatePolicies.parse(ext.value_der)
+        labels = policies.value.map do |policy_info|
+          oid_string = policy_info[:policyIdentifier].value
+          oid = Rex::Proto::CryptoAsn1::OIDs.value(oid_string)
+          oid&.label.to_s.empty? ? oid_string : "#{oid_string} (#{oid.label})"
+        end
+        return nil if labels.empty?
+
+        labels.join(', ')
+      rescue StandardError
+        nil
       end
 
       # Extract the raw extnValue octets carried inside an extension. Extension#to_der

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -4,7 +4,7 @@ require 'openssl'
 
 module Msf
   module Trace
-    # Presenter for X.509 certificates (and optionally raw CSR data).
+    # Presenter for X.509 certificates.
     #
     # Follows the same responsibility split as
     # Rex::Proto::Kerberos::CredentialCache::Krb5CCachePresenter:
@@ -16,15 +16,27 @@ module Msf
     #   presenter = Msf::Trace::CertificateTracePresenter.new(cert)
     #   mod.print_line(presenter.to_s_metadata)
     #   mod.print_line(presenter.to_s_full)
-    #
-    #   # CSR mode - expects raw DER/PEM CSR bytes, not a certificate:
-    #   mod.print_line(presenter.to_s_csr(csr_raw))
     class CertificateTracePresenter
 
       SEPARATOR = ('[CertificateTrace] ' + ('-' * 38)).freeze
 
       # OIDs surfaced as named fields in to_s_full; excluded from the raw extension dump.
       NAMED_OIDS = %w[subjectAltName extendedKeyUsage keyUsage].freeze
+
+      # Microsoft AD CS enrollment extensions whose content carries the template
+      # name / template version. OpenSSL has no friendly decoder for these, so we
+      # decode them ourselves below.
+      CERT_TEMPLATE_NAME_OID = '1.3.6.1.4.1.311.20.2'
+      CERT_TEMPLATE_INFO_OID = '1.3.6.1.4.1.311.21.7'
+
+      # Friendly labels for extension OIDs that OpenSSL leaves as raw numeric
+      # strings (predominantly Microsoft enrollment OIDs on AD CS certificates).
+      EXTENSION_OID_NAMES = {
+        CERT_TEMPLATE_NAME_OID => 'Certificate Template Name',
+        CERT_TEMPLATE_INFO_OID => 'Certificate Template Information',
+        '1.3.6.1.4.1.311.21.10' => 'Application Policies',
+        '1.3.6.1.4.1.311.25.2' => 'AD DS Security Extension (SID)'
+      }.freeze
 
       # Priority order for resolving a single auth identity from the cert.
       # UPN is the primary AD identity; email and CN are fallbacks.
@@ -105,37 +117,13 @@ module Msf
         other = @cert.extensions.reject { |e| NAMED_OIDS.include?(e.oid) }
         if other.any?
           lines << '  Extensions :'
-          other.each { |e| lines << "    #{e.oid} : #{e.value}" }
+          other.each do |e|
+            label = EXTENSION_OID_NAMES[normalize_oid(e.oid)] || e.oid
+            lines << "    #{label} : #{format_extension(e)}"
+          end
         end
 
         lines.join("\n")
-      end
-
-      # Returns a formatted CSR string from raw CSR bytes.
-      #
-      # This method expects raw DER or PEM encoded CSR bytes - not a certificate
-      # object. The 'csr' trace mode is intended for PKINIT pre-authentication
-      # flows where the CSR is constructed and submitted separately from the
-      # certificate. Callers must pass the CSR bytes directly rather than
-      # converting from a certificate.
-      #
-      # Instance method - consistent with the presenter pattern.
-      #
-      # @param csr_raw [String] DER or PEM encoded certificate signing request
-      # @return [String, nil] nil if CSR could not be parsed
-      def to_s_csr(csr_raw)
-        return nil unless csr_raw
-
-        csr = OpenSSL::X509::Request.new(csr_raw)
-
-        [
-          SEPARATOR,
-          "  CSR Subject : #{csr.subject}",
-          "  CSR Pub Key : #{format_public_key(csr.public_key)}",
-          "  CSR Sig Alg : #{csr.signature_algorithm}"
-        ].join("\n")
-      rescue OpenSSL::X509::RequestError
-        nil
       end
 
       private
@@ -180,6 +168,87 @@ module Msf
 
       def extension_value(oid)
         @cert.extensions&.find { |e| e.oid == oid }&.value
+      end
+
+      # Render an extension value as human-readable text.
+      #
+      # OpenSSL formats the standard extensions (subjectKeyIdentifier,
+      # crlDistributionPoints, etc.) well, but for OIDs it does not understand -
+      # notably the Microsoft AD CS enrollment extensions - Extension#value
+      # returns raw bytes with non-printables collapsed to '.', surfacing as
+      # mojibake such as "...U.s.e.r". Decode the MS template extensions we
+      # recognise; otherwise defer to OpenSSL's own rendering.
+      #
+      # @param ext [OpenSSL::X509::Extension]
+      # @return [String]
+      def format_extension(ext)
+        case normalize_oid(ext.oid)
+        when CERT_TEMPLATE_NAME_OID
+          asn1 = inner_extension_asn1(ext)
+          asn1 ? clean_text(asn1.value) : ext.value
+        when CERT_TEMPLATE_INFO_OID
+          format_template_information(ext)
+        else
+          ext.value
+        end
+      rescue StandardError
+        ext.value
+      end
+
+      # Resolve an extension OID to its dotted numeric form. OpenSSL may surface
+      # a registered short name (e.g. "ms-cert-templ") rather than the numeric
+      # OID depending on its object table / OPENSSL_CONF, so normalise before
+      # matching.
+      #
+      # @param oid [String]
+      # @return [String]
+      def normalize_oid(oid)
+        OpenSSL::ASN1::ObjectId.new(oid).oid
+      rescue OpenSSL::ASN1::ASN1Error
+        oid
+      end
+
+      # Decode the DER content carried inside an extension. Extension#to_der wraps
+      # the value in an OCTET STRING; return the parsed ASN.1 of that inner content.
+      #
+      # @param ext [OpenSSL::X509::Extension]
+      # @return [OpenSSL::ASN1::ASN1Data, nil]
+      def inner_extension_asn1(ext)
+        seq = OpenSSL::ASN1.decode(ext.to_der)
+        octet = seq.value.find { |v| v.is_a?(OpenSSL::ASN1::OctetString) }
+        return nil unless octet
+
+        OpenSSL::ASN1.decode(octet.value)
+      rescue OpenSSL::ASN1::ASN1Error
+        nil
+      end
+
+      # Format the Microsoft Certificate Template Information extension:
+      # SEQUENCE { templateID OID, majorVersion INTEGER, minorVersion INTEGER OPTIONAL }.
+      #
+      # @param ext [OpenSSL::X509::Extension]
+      # @return [String]
+      def format_template_information(ext)
+        asn1 = inner_extension_asn1(ext)
+        return ext.value unless asn1.respond_to?(:value) && asn1.value.is_a?(Array)
+
+        oid, major, minor = asn1.value.map { |v| v&.value }
+        out = "Template #{oid}"
+        out += " (v#{major}#{minor ? ".#{minor}" : ''})" if major
+        out
+      end
+
+      # Normalise a decoded ASN.1 string value to clean UTF-8. BMPString content
+      # arrives as UTF-16, so re-encode and strip embedded NUL bytes.
+      #
+      # @param str [String]
+      # @return [String]
+      def clean_text(str)
+        s = str.to_s
+        s = s.encode('UTF-8', 'UTF-16BE') if s.encoding == ::Encoding::UTF_16BE
+        s = s.b.force_encoding('UTF-8')
+        s = s.scrub('?') unless s.valid_encoding?
+        s.delete("\u0000")
       end
 
       def format_public_key(pk)

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -1,0 +1,182 @@
+# -*- coding: binary -*-
+
+require 'openssl'
+
+module Msf
+  module Trace
+    # Presenter for X.509 certificates (and optionally raw CSR data).
+    #
+    # Follows the same responsibility split as
+    # Rex::Proto::Kerberos::CredentialCache::Krb5CCachePresenter:
+    # this class constructs formatted strings only. The caller (module instance)
+    # is responsible for invoking its own print methods so output is correctly
+    # associated with the running module.
+    #
+    # Usage:
+    #   presenter = Msf::Trace::CertificateTracePresenter.new(cert)
+    #   mod.print_line(presenter.to_s_metadata)
+    #   mod.print_line(presenter.to_s_full)
+    #
+    #   # CSR mode — expects raw DER/PEM CSR bytes, not a certificate:
+    #   mod.print_line(presenter.to_s_csr(csr_raw))
+    class CertificateTracePresenter
+
+      SEPARATOR = ('[CertificateTrace] ' + ('-' * 38)).freeze
+
+      # OIDs surfaced as named fields in to_s_full; excluded from the raw extension dump.
+      NAMED_OIDS = %w[subjectAltName extendedKeyUsage keyUsage].freeze
+
+      # Priority order for resolving a single auth identity from the cert.
+      # UPN is the primary AD identity; email and CN are fallbacks.
+      IDENTITY_SOURCES = [
+        [:upn, 'UPN'],
+        [:email, 'Email SAN'],
+        [:cn, 'Subject CN']
+      ].freeze
+
+      # Attempt to coerce input into an OpenSSL::X509::Certificate.
+      # Accepts a live certificate object, an OpenSSL::PKCS12 bundle (extracts
+      # the leaf certificate), or raw DER/PEM bytes.
+      #
+      # @param cert [OpenSSL::X509::Certificate, OpenSSL::PKCS12, String]
+      # @return [OpenSSL::X509::Certificate, nil]
+      def self.coerce(cert)
+        return cert if cert.is_a?(OpenSSL::X509::Certificate)
+        return cert.certificate if cert.is_a?(OpenSSL::PKCS12)
+        return OpenSSL::X509::Certificate.new(cert) if cert.is_a?(String)
+
+        nil
+      rescue OpenSSL::X509::CertificateError, OpenSSL::PKCS12::PKCS12Error
+        nil
+      end
+
+      # @param cert [OpenSSL::X509::Certificate, OpenSSL::PKCS12, String]
+      def initialize(cert)
+        @cert = self.class.coerce(cert)
+      end
+
+      # Returns a formatted metadata string: subject, issuer, validity, SHA-256 fingerprint.
+      #
+      # @return [String, nil] nil if certificate could not be parsed
+      def to_s_metadata
+        return nil unless @cert
+
+        fingerprint = OpenSSL::Digest::SHA256.hexdigest(@cert.to_der)
+
+        [
+          SEPARATOR,
+          "  Subject    : #{@cert.subject}",
+          "  Issuer     : #{@cert.issuer}",
+          "  Not Before : #{@cert.not_before}",
+          "  Not After  : #{@cert.not_after}",
+          "  SHA-256    : #{fingerprint}"
+        ].join("\n")
+      end
+
+      # Returns a formatted full string: metadata + serial, version, public key algorithm,
+      # SAN / EKU / Key Usage as named fields, then remaining extensions.
+      #
+      # @return [String, nil] nil if certificate could not be parsed
+      def to_s_full
+        base = to_s_metadata
+        return nil unless base
+
+        lines = [base]
+        lines << "  Serial     : #{@cert.serial}"
+        lines << "  Version    : #{@cert.version}"
+        lines << "  Public Key : #{format_public_key(@cert.public_key)}"
+
+        identities = parse_san_identities
+        identity_key, identity_label = IDENTITY_SOURCES.find { |key, _| identities[key] }
+        identity_value = identity_key ? identities[identity_key] : subject_cn
+        identity_source = identity_key ? identity_label : 'Subject CN'
+        lines << "  Identity   : #{identity_value} (#{identity_source})" if identity_value
+
+        san = extension_value('subjectAltName')
+        lines << "  SAN        : #{san}" if san
+
+        eku = extension_value('extendedKeyUsage')
+        lines << "  EKU        : #{eku}" if eku
+
+        ku = extension_value('keyUsage')
+        lines << "  Key Usage  : #{ku}" if ku
+
+        other = @cert.extensions.reject { |e| NAMED_OIDS.include?(e.oid) }
+        if other.any?
+          lines << '  Extensions :'
+          other.each { |e| lines << "    #{e.oid} : #{e.value}" }
+        end
+
+        lines.join("\n")
+      end
+
+      # Returns a formatted CSR string from raw CSR bytes.
+      #
+      # This method expects raw DER or PEM encoded CSR bytes — not a certificate
+      # object. The 'csr' trace mode is intended for PKINIT pre-authentication
+      # flows where the CSR is constructed and submitted separately from the
+      # certificate. Callers must pass the CSR bytes directly rather than
+      # converting from a certificate.
+      #
+      # Instance method — consistent with the presenter pattern.
+      #
+      # @param csr_raw [String] DER or PEM encoded certificate signing request
+      # @return [String, nil] nil if CSR could not be parsed
+      def to_s_csr(csr_raw)
+        return nil unless csr_raw
+
+        csr = OpenSSL::X509::Request.new(csr_raw)
+
+        [
+          SEPARATOR,
+          "  CSR Subject : #{csr.subject}",
+          "  CSR Pub Key : #{format_public_key(csr.public_key)}",
+          "  CSR Sig Alg : #{csr.signature_algorithm}"
+        ].join("\n")
+      rescue OpenSSL::X509::RequestError
+        nil
+      end
+
+      private
+
+      def subject_cn
+        @cert.subject.to_a.find { |name, _, _| name == 'CN' }&.dig(1)
+      end
+
+      def parse_san_identities
+        san = @cert.extensions&.find { |e| e.oid == 'subjectAltName' }
+        return {} unless san
+
+        result = {}
+        san.value.split(/,\s*/).each do |entry|
+          case entry.strip
+          when /\Aothername:\s*UPN:(.+)\z/i
+            result[:upn] = ::Regexp.last_match(1).strip
+          when /\Aemail:(.+)\z/i
+            result[:email] = ::Regexp.last_match(1).strip
+          end
+        end
+        result
+      end
+
+      def extension_value(oid)
+        @cert.extensions&.find { |e| e.oid == oid }&.value
+      end
+
+      def format_public_key(pk)
+        case pk
+        when OpenSSL::PKey::RSA
+          "RSA-#{pk.n.num_bits}"
+        when OpenSSL::PKey::EC
+          "EC-#{pk.group.degree}"
+        when OpenSSL::PKey::DSA
+          "DSA-#{pk.p.num_bits}"
+        else
+          pk.class.name.split('::').last
+        end
+      rescue StandardError
+        'unknown'
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/core/trace/certificate_trace_presenter'
+
+RSpec.describe Msf::Exploit::Remote::CertificateTrace do
+  include_context 'Msf::Simple::Framework'
+
+  let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+
+  let(:cert) do
+    c = OpenSSL::X509::Certificate.new
+    c.subject = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
+    c.issuer = OpenSSL::X509::Name.parse('/CN=CONTOSO-CA/DC=CONTOSO/DC=LOCAL')
+    c.public_key = key.public_key
+    c.serial = OpenSSL::BN.new('1')
+    c.version = 2
+    c.not_before = Time.utc(2026, 1, 1)
+    c.not_after = Time.utc(2027, 1, 1)
+    c.sign(key, OpenSSL::Digest::SHA256.new)
+    c
+  end
+
+  subject do
+    klass = Class.new(Msf::Exploit) do
+      include Msf::Exploit::Remote::CertificateTrace
+    end
+    mod = klass.new
+    allow(mod).to receive(:framework).and_return(framework)
+    mod
+  end
+
+  # ── option registration ──────────────────────────────────────────────────────
+
+  describe 'option registration' do
+    it 'registers the CertificateTrace advanced option' do
+      expect(subject.datastore.has_key?('CertificateTrace')).to be true
+    end
+
+    it 'defaults to off' do
+      expect(subject.datastore['CertificateTrace']).to eq('off')
+    end
+
+    it 'accepts metadata as a valid value' do
+      subject.datastore['CertificateTrace'] = 'metadata'
+      expect(subject.datastore['CertificateTrace']).to eq('metadata')
+    end
+
+    it 'accepts full as a valid value' do
+      subject.datastore['CertificateTrace'] = 'full'
+      expect(subject.datastore['CertificateTrace']).to eq('full')
+    end
+
+    it 'registers the CertificateTraceColors advanced option' do
+      expect(subject.datastore.has_key?('CertificateTraceColors')).to be true
+    end
+
+    it 'defaults CertificateTraceColors to red/blu' do
+      expect(subject.datastore['CertificateTraceColors']).to eq('red/blu')
+    end
+  end
+
+  # ── #certificate_trace_enabled? ─────────────────────────────────────────────
+
+  describe '#certificate_trace_enabled?' do
+    it 'returns false when mode is off' do
+      subject.datastore['CertificateTrace'] = 'off'
+      expect(subject.certificate_trace_enabled?).to be false
+    end
+
+    it 'returns true when mode is metadata' do
+      subject.datastore['CertificateTrace'] = 'metadata'
+      expect(subject.certificate_trace_enabled?).to be true
+    end
+
+    it 'returns true when mode is full' do
+      subject.datastore['CertificateTrace'] = 'full'
+      expect(subject.certificate_trace_enabled?).to be true
+    end
+  end
+
+  # ── #certificate_trace ───────────────────────────────────────────────────────
+
+  describe '#certificate_trace' do
+    context 'when tracing is off' do
+      it 'produces no output' do
+        subject.datastore['CertificateTrace'] = 'off'
+        expect(subject).not_to receive(:print_line)
+        subject.certificate_trace(cert)
+      end
+    end
+
+    context 'when mode is metadata' do
+      before { subject.datastore['CertificateTrace'] = 'metadata' }
+
+      it 'prints a line containing [CertificateTrace]' do
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.certificate_trace(cert)
+      end
+
+      it 'includes the subject CN' do
+        expect(subject).to receive(:print_line).with(include('Administrator'))
+        subject.certificate_trace(cert)
+      end
+
+      it 'does not include Serial (metadata mode omits extended fields)' do
+        expect(subject).to receive(:print_line).with(satisfy { |s| !s.include?('Serial') })
+        subject.certificate_trace(cert)
+      end
+    end
+
+    context 'when mode is full' do
+      before { subject.datastore['CertificateTrace'] = 'full' }
+
+      it 'prints a line containing [CertificateTrace]' do
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.certificate_trace(cert)
+      end
+
+      it 'includes Serial in full mode' do
+        expect(subject).to receive(:print_line).with(include('Serial'))
+        subject.certificate_trace(cert)
+      end
+
+      it 'includes Version in full mode' do
+        expect(subject).to receive(:print_line).with(include('Version'))
+        subject.certificate_trace(cert)
+      end
+    end
+
+    context 'with a PKCS12 bundle' do
+      let(:pfx) { OpenSSL::PKCS12.create('', 'test', key, cert) }
+
+      it 'extracts and traces the leaf certificate without raising' do
+        subject.datastore['CertificateTrace'] = 'metadata'
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.certificate_trace(pfx)
+      end
+    end
+
+    context 'with an invalid certificate' do
+      it 'produces no output and does not raise' do
+        subject.datastore['CertificateTrace'] = 'full'
+        expect(subject).not_to receive(:print_line)
+        expect { subject.certificate_trace('not a cert') }.not_to raise_error
+      end
+    end
+
+    context 'color wrapping' do
+      before { subject.datastore['CertificateTrace'] = 'metadata' }
+
+      it 'wraps output in the response color escape sequences by default' do
+        expect(subject).to receive(:print_line).with(satisfy { |s|
+          s.include?('%bld%blu') && s.include?('%clr')
+        })
+        subject.certificate_trace(cert)
+      end
+
+      it 'uses a custom color when CertificateTraceColors is set' do
+        subject.datastore['CertificateTraceColors'] = 'red/grn'
+        expect(subject).to receive(:print_line).with(satisfy { |s|
+          s.include?('%bld%grn') && s.include?('%clr')
+        })
+        subject.certificate_trace(cert)
+      end
+
+      it 'falls back to default red/blu when CertificateTraceColors is blank' do
+        subject.datastore['CertificateTraceColors'] = ''
+        expect(subject).to receive(:print_line).with(satisfy { |s|
+          s.include?('%bld%blu') && s.include?('%clr')
+        })
+        subject.certificate_trace(cert)
+      end
+
+      it 'omits color when only the request side is set (blank response color)' do
+        subject.datastore['CertificateTraceColors'] = 'red/'
+        expect(subject).to receive(:print_line).with(satisfy { |s|
+          !s.include?('%bld%') && s.include?('[CertificateTrace]')
+        })
+        subject.certificate_trace(cert)
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
+++ b/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
@@ -341,7 +341,34 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
         expect(subject).to include('1.3.6.1.4.1.99999.1')
       end
 
-      it 'defers to OpenSSL and does not emit non-printable bytes in the extensions block' do
+      it 'hex-encodes the raw bytes instead of emitting mojibake' do
+        expect(subject).to include('00:01:02:FF')
+      end
+
+      it 'does not emit non-printable bytes in the extensions block' do
+        ext_lines = subject.lines.select { |l| l.start_with?('    ') }.join
+        expect(ext_lines).not_to match(/[^[:print:]\t]/)
+      end
+    end
+
+    context 'with a labeled Microsoft enrollment extension OpenSSL cannot decode' do
+      # Application Policies (1.3.6.1.4.1.311.21.10): OpenSSL knows the OID name
+      # but renders its structured content as a lossy byte dump.
+      subject do
+        content = OpenSSL::ASN1::Sequence.new(
+          [OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::ObjectId.new('1.3.6.1.5.5.7.3.2')])]
+        ).to_der
+        described_class.new(cert_with_raw_extension('1.3.6.1.4.1.311.21.10', content)).to_s_full
+      end
+
+      it 'hex-encodes the raw extnValue' do
+        expected_hex = OpenSSL::ASN1::Sequence.new(
+          [OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::ObjectId.new('1.3.6.1.5.5.7.3.2')])]
+        ).to_der.b.unpack1('H*').upcase.scan(/../).join(':')
+        expect(subject).to include(expected_hex)
+      end
+
+      it 'does not emit non-printable bytes in the extensions block' do
         ext_lines = subject.lines.select { |l| l.start_with?('    ') }.join
         expect(ext_lines).not_to match(/[^[:print:]\t]/)
       end

--- a/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
+++ b/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
@@ -265,48 +265,86 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
     end
   end
 
-  # ── #to_s_csr (instance method) ─────────────────────────────────────────────
-  describe '#to_s_csr' do
-    let(:csr) do
-      req            = OpenSSL::X509::Request.new
-      req.subject    = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
-      req.public_key = key.public_key
-      req.sign(key, OpenSSL::Digest::SHA256.new)
-      req
+  # ── #to_s_full extension value decoding (Microsoft AD CS OIDs) ───────────────
+  describe '#to_s_full extension value decoding' do
+    # Build a self-signed cert carrying a single raw extension whose extnValue
+    # OCTET STRING wraps the supplied bytes.
+    def cert_with_raw_extension(oid, content)
+      c            = OpenSSL::X509::Certificate.new
+      c.subject    = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
+      c.issuer     = OpenSSL::X509::Name.parse('/CN=CONTOSO-CA/DC=CONTOSO/DC=LOCAL')
+      c.public_key = key.public_key
+      c.serial     = OpenSSL::BN.new('7')
+      c.version    = 2
+      c.not_before = Time.utc(2026, 1, 1)
+      c.not_after  = Time.utc(2027, 1, 1)
+
+      ext_der = OpenSSL::ASN1::Sequence.new(
+        [
+          OpenSSL::ASN1::ObjectId.new(oid),
+          OpenSSL::ASN1::OctetString.new(content)
+        ]
+      ).to_der
+      c.add_extension(OpenSSL::X509::Extension.new(ext_der))
+      c.sign(key, OpenSSL::Digest::SHA256.new)
+      c
     end
 
-    it 'is an instance method, not a class method' do
-      expect(presenter).to respond_to(:to_s_csr)
-      expect(described_class).not_to respond_to(:to_s_csr)
+    context 'with a Microsoft Certificate Template Name extension (BMPString)' do
+      subject do
+        content = OpenSSL::ASN1::BMPString.new('User'.encode('UTF-16BE').b).to_der
+        described_class.new(cert_with_raw_extension('1.3.6.1.4.1.311.20.2', content)).to_s_full
+      end
+
+      it 'labels the OID with a friendly name' do
+        expect(subject).to include('Certificate Template Name')
+      end
+
+      it 'decodes the BMPString value to readable text' do
+        expect(subject).to include('User')
+      end
+
+      it 'does not emit NUL bytes from the UTF-16 encoding' do
+        expect(subject).not_to include("\u0000")
+      end
     end
 
-    it 'returns a string for valid CSR DER bytes' do
-      result = presenter.to_s_csr(csr.to_der)
-      expect(result).to be_a(String)
+    context 'with a Microsoft Certificate Template Information extension' do
+      subject do
+        content = OpenSSL::ASN1::Sequence.new(
+          [
+            OpenSSL::ASN1::ObjectId.new('1.3.6.1.4.1.311.21.8.1.2.3'),
+            OpenSSL::ASN1::Integer.new(100),
+            OpenSSL::ASN1::Integer.new(5)
+          ]
+        ).to_der
+        described_class.new(cert_with_raw_extension('1.3.6.1.4.1.311.21.7', content)).to_s_full
+      end
+
+      it 'labels the OID with a friendly name' do
+        expect(subject).to include('Certificate Template Information')
+      end
+
+      it 'renders the template OID and version' do
+        expect(subject).to include('Template 1.3.6.1.4.1.311.21.8.1.2.3')
+        expect(subject).to include('v100.5')
+      end
     end
 
-    it 'includes CSR subject' do
-      result = presenter.to_s_csr(csr.to_der)
-      expect(result).to include('Administrator')
-    end
+    context 'with an unrecognized binary extension' do
+      subject do
+        described_class.new(cert_with_raw_extension('1.3.6.1.4.1.99999.1', "\x00\x01\x02\xFF".b)).to_s_full
+      end
 
-    it 'includes CSR public key as algorithm and bit size' do
-      result = presenter.to_s_csr(csr.to_der)
-      expect(result).to include('CSR Pub Key')
-      expect(result).to include('RSA-')
-    end
+      it 'renders without raising and labels it by OID' do
+        expect(subject).to be_a(String)
+        expect(subject).to include('1.3.6.1.4.1.99999.1')
+      end
 
-    it 'includes signature algorithm label' do
-      result = presenter.to_s_csr(csr.to_der)
-      expect(result).to include('CSR Sig Alg')
-    end
-
-    it 'returns nil for invalid CSR bytes' do
-      expect(presenter.to_s_csr('garbage')).to be_nil
-    end
-
-    it 'returns nil when csr_raw is nil' do
-      expect(presenter.to_s_csr(nil)).to be_nil
+      it 'defers to OpenSSL and does not emit non-printable bytes in the extensions block' do
+        ext_lines = subject.lines.select { |l| l.start_with?('    ') }.join
+        expect(ext_lines).not_to match(/[^[:print:]\t]/)
+      end
     end
   end
 end

--- a/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
+++ b/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
@@ -129,8 +129,10 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
       expect(subject).to include('12345')
     end
 
-    it 'includes version' do
+    it 'includes the certificate version as a one-based value' do
       expect(subject).to include('Version')
+      # OpenSSL encodes a v3 certificate as version 2; users expect "v3".
+      expect(subject).to include('v3')
     end
 
     it 'includes public key as algorithm and bit size, not raw PEM' do

--- a/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
+++ b/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
@@ -351,26 +351,52 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
       end
     end
 
-    context 'with a labeled Microsoft enrollment extension OpenSSL cannot decode' do
-      # Application Policies (1.3.6.1.4.1.311.21.10): OpenSSL knows the OID name
-      # but renders its structured content as a lossy byte dump.
+    context 'with a Microsoft Application Policies extension' do
+      # Application Policies (1.3.6.1.4.1.311.21.10) wraps a CertificatePolicies
+      # SEQUENCE OF PolicyInformation. OpenSSL knows the OID name but renders the
+      # structured content as a lossy byte dump, so the presenter decodes the
+      # policy OIDs and resolves them to friendly labels.
       subject do
         content = OpenSSL::ASN1::Sequence.new(
-          [OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::ObjectId.new('1.3.6.1.5.5.7.3.2')])]
+          [
+            OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::ObjectId.new('1.3.6.1.5.5.7.3.2')]),
+            OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::ObjectId.new('1.3.6.1.5.5.7.3.1')])
+          ]
         ).to_der
         described_class.new(cert_with_raw_extension('1.3.6.1.4.1.311.21.10', content)).to_s_full
       end
 
-      it 'hex-encodes the raw extnValue' do
-        expected_hex = OpenSSL::ASN1::Sequence.new(
-          [OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::ObjectId.new('1.3.6.1.5.5.7.3.2')])]
-        ).to_der.b.unpack1('H*').upcase.scan(/../).join(':')
-        expect(subject).to include(expected_hex)
+      it 'labels the OID with a friendly name' do
+        expect(subject).to include('Application Policies')
+      end
+
+      it 'decodes each policy OID to its dotted value and label' do
+        expect(subject).to include('1.3.6.1.5.5.7.3.2 (Client Authentication)')
+        expect(subject).to include('1.3.6.1.5.5.7.3.1 (Server Authentication)')
+      end
+
+      it 'does not hex-encode the structured content' do
+        expect(subject).not_to include('30:0')
       end
 
       it 'does not emit non-printable bytes in the extensions block' do
         ext_lines = subject.lines.select { |l| l.start_with?('    ') }.join
         expect(ext_lines).not_to match(/[^[:print:]\t]/)
+      end
+    end
+
+    context 'with an Application Policies OID that has no friendly label' do
+      # OID_ANY_APPLICATION_POLICY is in the framework's OID table but carries no
+      # label; it should still print as its dotted value, never a hex dump.
+      subject do
+        content = OpenSSL::ASN1::Sequence.new(
+          [OpenSSL::ASN1::Sequence.new([OpenSSL::ASN1::ObjectId.new('1.3.6.1.4.1.311.10.12.1')])]
+        ).to_der
+        described_class.new(cert_with_raw_extension('1.3.6.1.4.1.311.21.10', content)).to_s_full
+      end
+
+      it 'prints the bare OID with no label parenthetical' do
+        expect(subject).to match(/Application Policies : 1\.3\.6\.1\.4\.1\.311\.10\.12\.1(\s|$)/)
       end
     end
   end

--- a/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
+++ b/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
@@ -1,0 +1,310 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'openssl'
+require 'msf/core/trace/certificate_trace_presenter'
+
+RSpec.describe Msf::Trace::CertificateTracePresenter do
+  # ── Shared cert fixture ──────────────────────────────────────────────────────
+
+  let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+
+  let(:cert) do
+    c            = OpenSSL::X509::Certificate.new
+    c.subject    = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
+    c.issuer     = OpenSSL::X509::Name.parse('/CN=CONTOSO-CA/DC=CONTOSO/DC=LOCAL')
+    c.public_key = key.public_key
+    c.serial     = OpenSSL::BN.new('12345')
+    c.version    = 2
+    c.not_before = Time.utc(2026, 1, 1)
+    c.not_after  = Time.utc(2027, 1, 1)
+    c.sign(key, OpenSSL::Digest::SHA256.new)
+    c
+  end
+
+  # Certificate with SAN, EKU, and Key Usage extensions — mirrors a real ADCS-issued cert.
+  let(:cert_with_extensions) do
+    c            = OpenSSL::X509::Certificate.new
+    c.subject    = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
+    c.issuer     = OpenSSL::X509::Name.parse('/CN=CONTOSO-CA/DC=CONTOSO/DC=LOCAL')
+    c.public_key = key.public_key
+    c.serial     = OpenSSL::BN.new('99999')
+    c.version    = 2
+    c.not_before = Time.utc(2026, 1, 1)
+    c.not_after  = Time.utc(2027, 1, 1)
+
+    ef = OpenSSL::X509::ExtensionFactory.new
+    ef.subject_certificate = c
+    ef.issuer_certificate  = c
+    c.add_extension(ef.create_extension('subjectAltName', 'email:admin@contoso.local'))
+    c.add_extension(ef.create_extension('extendedKeyUsage', 'clientAuth'))
+    c.add_extension(ef.create_extension('keyUsage', 'digitalSignature', true))
+    c.sign(key, OpenSSL::Digest::SHA256.new)
+    c
+  end
+
+  let(:pfx) { OpenSSL::PKCS12.create('', 'Administrator', key, cert) }
+
+  let(:presenter) { described_class.new(cert) }
+
+  # ── .coerce ──────────────────────────────────────────────────────────────────
+  describe '.coerce' do
+    it 'passes through an existing OpenSSL::X509::Certificate unchanged' do
+      expect(described_class.coerce(cert)).to equal(cert)
+    end
+
+    it 'coerces DER bytes to an OpenSSL::X509::Certificate' do
+      result = described_class.coerce(cert.to_der)
+      expect(result).to be_a(OpenSSL::X509::Certificate)
+    end
+
+    it 'returns nil for invalid input' do
+      expect(described_class.coerce('not a cert')).to be_nil
+    end
+
+    it 'extracts the leaf certificate from an OpenSSL::PKCS12 bundle' do
+      result = described_class.coerce(pfx)
+      expect(result).to be_a(OpenSSL::X509::Certificate)
+    end
+
+    it 'initializes correctly from a PKCS12 bundle' do
+      expect(described_class.new(pfx).to_s_metadata).to include('Administrator')
+    end
+  end
+
+  # ── #to_s_metadata ──────────────────────────────────────────────────────────
+  describe '#to_s_metadata' do
+    subject { presenter.to_s_metadata }
+
+    it 'returns a string' do
+      expect(subject).to be_a(String)
+    end
+
+    it 'includes the separator' do
+      expect(subject).to include('[CertificateTrace]')
+    end
+
+    it 'includes subject' do
+      expect(subject).to include('Administrator')
+    end
+
+    it 'includes issuer' do
+      expect(subject).to include('CONTOSO-CA')
+    end
+
+    it 'includes validity window labels' do
+      expect(subject).to include('Not Before')
+      expect(subject).to include('Not After')
+    end
+
+    it 'includes SHA-256 label' do
+      expect(subject).to include('SHA-256')
+    end
+
+    it 'SHA-256 value matches OpenSSL::Digest::SHA256.hexdigest' do
+      expected = OpenSSL::Digest::SHA256.hexdigest(cert.to_der)
+      expect(subject).to include(expected)
+    end
+
+    it 'returns nil when certificate cannot be parsed' do
+      expect(described_class.new('garbage').to_s_metadata).to be_nil
+    end
+
+    it 'accepts DER bytes without raising' do
+      expect { described_class.new(cert.to_der).to_s_metadata }.not_to raise_error
+    end
+  end
+
+  # ── #to_s_full ───────────────────────────────────────────────────────────────
+  describe '#to_s_full' do
+    subject { presenter.to_s_full }
+
+    it 'includes everything from metadata' do
+      expect(subject).to include('Administrator')
+      expect(subject).to include('SHA-256')
+    end
+
+    it 'includes serial number' do
+      expect(subject).to include('Serial')
+      expect(subject).to include('12345')
+    end
+
+    it 'includes version' do
+      expect(subject).to include('Version')
+    end
+
+    it 'includes public key as algorithm and bit size, not raw PEM' do
+      expect(subject).to include('RSA-2048')
+      expect(subject).not_to include('-----BEGIN')
+    end
+
+    it 'returns nil when certificate cannot be parsed' do
+      expect(described_class.new('garbage').to_s_full).to be_nil
+    end
+
+    it 'accepts DER bytes without raising' do
+      expect { described_class.new(cert.to_der).to_s_full }.not_to raise_error
+    end
+
+    it 'does not crash when certificate has no extensions' do
+      expect { described_class.new(cert).to_s_full }.not_to raise_error
+    end
+  end
+
+  # ── #to_s_full with SAN / EKU / Key Usage ────────────────────────────────────
+  describe '#to_s_full with authentication-relevant extensions' do
+    subject { described_class.new(cert_with_extensions).to_s_full }
+
+    it 'includes SAN as a named field' do
+      expect(subject).to include('SAN')
+    end
+
+    it 'includes the SAN value' do
+      expect(subject).to include('admin@contoso.local')
+    end
+
+    it 'includes EKU as a named field' do
+      expect(subject).to include('EKU')
+    end
+
+    it 'includes Key Usage as a named field' do
+      expect(subject).to include('Key Usage')
+    end
+
+    it 'does not dump SAN inside the raw Extensions block' do
+      lines = subject.lines
+      ext_block_start = lines.index { |l| l.include?('Extensions :') }
+      if ext_block_start
+        ext_lines = lines[(ext_block_start + 1)..].take_while { |l| l.start_with?('    ') }
+        san_in_raw = ext_lines.any? { |l| l.include?('subjectAltName') }
+        expect(san_in_raw).to be false
+      end
+    end
+  end
+
+  # ── identity mapping ────────────────────────────────────────────────────────
+
+  describe '#to_s_full identity mapping' do
+    let(:cert_with_upn) do
+      c            = OpenSSL::X509::Certificate.new
+      c.subject    = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
+      c.issuer     = OpenSSL::X509::Name.parse('/CN=CONTOSO-CA/DC=CONTOSO/DC=LOCAL')
+      c.public_key = key.public_key
+      c.serial     = OpenSSL::BN.new('1')
+      c.version    = 2
+      c.not_before = Time.utc(2026, 1, 1)
+      c.not_after  = Time.utc(2027, 1, 1)
+
+      san_conf = ["[alt_names]", "otherName = 1.3.6.1.4.1.311.20.2.3;UTF8:admin@CONTOSO.LOCAL"]
+      config = OpenSSL::Config.parse(san_conf.join("\n"))
+      factory = OpenSSL::X509::ExtensionFactory.new
+      factory.config = config
+      c.add_extension(factory.create_extension('subjectAltName', '@alt_names', false))
+      c.sign(key, OpenSSL::Digest::SHA256.new)
+      c
+    end
+
+    let(:cert_with_email_san) do
+      c            = OpenSSL::X509::Certificate.new
+      c.subject    = OpenSSL::X509::Name.parse('/CN=Alice/DC=CONTOSO/DC=LOCAL')
+      c.issuer     = OpenSSL::X509::Name.parse('/CN=CONTOSO-CA/DC=CONTOSO/DC=LOCAL')
+      c.public_key = key.public_key
+      c.serial     = OpenSSL::BN.new('2')
+      c.version    = 2
+      c.not_before = Time.utc(2026, 1, 1)
+      c.not_after  = Time.utc(2027, 1, 1)
+
+      ef = OpenSSL::X509::ExtensionFactory.new
+      ef.subject_certificate = c
+      ef.issuer_certificate  = c
+      c.add_extension(ef.create_extension('subjectAltName', 'email:alice@contoso.local'))
+      c.sign(key, OpenSSL::Digest::SHA256.new)
+      c
+    end
+
+    context 'when cert has a UPN SAN' do
+      subject { described_class.new(cert_with_upn).to_s_full }
+
+      it 'includes Identity label' do
+        expect(subject).to include('Identity')
+      end
+
+      it 'shows the UPN value' do
+        expect(subject).to include('admin@CONTOSO.LOCAL')
+      end
+
+      it 'labels the source as UPN' do
+        expect(subject).to include('UPN')
+      end
+    end
+
+    context 'when cert has an email SAN but no UPN' do
+      subject { described_class.new(cert_with_email_san).to_s_full }
+
+      it 'shows the email identity' do
+        expect(subject).to include('alice@contoso.local')
+      end
+
+      it 'labels the source as Email SAN' do
+        expect(subject).to include('Email SAN')
+      end
+    end
+
+    context 'when cert has no SAN' do
+      subject { described_class.new(cert).to_s_full }
+
+      it 'falls back to Subject CN' do
+        expect(subject).to include('Administrator')
+      end
+
+      it 'labels the source as Subject CN' do
+        expect(subject).to include('Subject CN')
+      end
+    end
+  end
+
+  # ── #to_s_csr (instance method) ─────────────────────────────────────────────
+  describe '#to_s_csr' do
+    let(:csr) do
+      req            = OpenSSL::X509::Request.new
+      req.subject    = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
+      req.public_key = key.public_key
+      req.sign(key, OpenSSL::Digest::SHA256.new)
+      req
+    end
+
+    it 'is an instance method, not a class method' do
+      expect(presenter).to respond_to(:to_s_csr)
+      expect(described_class).not_to respond_to(:to_s_csr)
+    end
+
+    it 'returns a string for valid CSR DER bytes' do
+      result = presenter.to_s_csr(csr.to_der)
+      expect(result).to be_a(String)
+    end
+
+    it 'includes CSR subject' do
+      result = presenter.to_s_csr(csr.to_der)
+      expect(result).to include('Administrator')
+    end
+
+    it 'includes CSR public key as algorithm and bit size' do
+      result = presenter.to_s_csr(csr.to_der)
+      expect(result).to include('CSR Pub Key')
+      expect(result).to include('RSA-')
+    end
+
+    it 'includes signature algorithm label' do
+      result = presenter.to_s_csr(csr.to_der)
+      expect(result).to include('CSR Sig Alg')
+    end
+
+    it 'returns nil for invalid CSR bytes' do
+      expect(presenter.to_s_csr('garbage')).to be_nil
+    end
+
+    it 'returns nil when csr_raw is nil' do
+      expect(presenter.to_s_csr(nil)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR introduces `CertificateTracePresenter`, implementing certificate tracing using the Presenter pattern aligned with existing Metasploit conventions.

The presenter is responsible for constructing formatted output strings, while the module instance handles printing via `print_line`, ensuring output is correctly associated with module execution.

Key features:
- Adds certificate tracing with `metadata` and `full` modes
- Maintains clean separation of concerns (string construction vs output handling)
- Integrates with the Kerberos client dispatcher for consistent tracing behavior

This PR builds on the Kerberos tracing refactor and is intentionally scoped to certificate functionality to keep review manageable.

---

## Verification

Steps to verify the functionality:

- [x] Start `msfconsole`
- [x] Load a Kerberos-enabled module (e.g., modules using `Msf::Exploit::Remote::Kerberos`)
- [x] Enable certificate tracing:
      ```
      set CertificateTrace metadata
      ```
- [x] Execute the module and **verify**:
  - Certificate subject, issuer, validity, and SHA-256 fingerprint are displayed
- [x] Switch to full mode:
      ```
      set CertificateTrace full
      ```
- [x] Execute again and **verify**:
  - Additional fields such as serial, version, extensions, and public key are displayed
- [x] **Verify** no crashes occur when certificate data is invalid or missing
- [x] **Verify** output is printed via module instance (not directly from presenter)
- [x] **Verify** no unintended output is produced when tracing is disabled (`off`)

---

## Note

- This PR does not introduce a new exploit module; it enhances tracing and debugging capabilities.
- All output remains consistent with Metasploit's approach to debugging visibility.
- CSR tracing was dropped from this PR (the `to_s_csr` path was unused); it can be added in a follow-up wired to a real CSR source.
