### PR TITLE
Fix LocalJumpError in wordpress module scanner

### DIFF
--- a/modules/auxiliary/scanner/http/wp_perfect_survey_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_perfect_survey_sqli.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
       next GET_SQLI_OBJECT_FAILED_ERROR_MSG unless res.code == 200
 
       html_content = res.get_json_document['html']
-      fail_with(Failure::Unknown, 'HTML content is empty') unless html_content
+      next GET_SQLI_OBJECT_FAILED_ERROR_MSG unless html_content
 
       # Extract data from response
       match_data = /survey_question_p">([^<]+)/.match(html_content)

--- a/modules/auxiliary/scanner/http/wp_perfect_survey_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_perfect_survey_sqli.rb
@@ -63,18 +63,18 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       # Validate response
-      return GET_SQLI_OBJECT_FAILED_ERROR_MSG unless res
-      return GET_SQLI_OBJECT_FAILED_ERROR_MSG unless res.code == 200
+      next GET_SQLI_OBJECT_FAILED_ERROR_MSG unless res
+      next GET_SQLI_OBJECT_FAILED_ERROR_MSG unless res.code == 200
 
       html_content = res.get_json_document['html']
       fail_with(Failure::Unknown, 'HTML content is empty') unless html_content
 
       # Extract data from response
       match_data = /survey_question_p">([^<]+)/.match(html_content)
-      return GET_SQLI_OBJECT_FAILED_ERROR_MSG unless match_data
+      next GET_SQLI_OBJECT_FAILED_ERROR_MSG unless match_data
 
       extracted_data = match_data.captures[0]
-      return GET_SQLI_OBJECT_FAILED_ERROR_MSG unless extracted_data
+      next GET_SQLI_OBJECT_FAILED_ERROR_MSG unless extracted_data
 
       extracted_data
     end


### PR DESCRIPTION
Fixes crash in the wordpress perfect survey SQLi module when run against invalid or unreachable targets by correcting control flow inside the SQLi block.

Closes #21013

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/wp_perfect_survey_sqli`
- [ ] Run `run rhost=127.0.0.1`
- [ ] Verify the module does not crash with LocalJumpError
- [ ] Verify the module returns not vulnerable for invalid/unreachable targets