### PR TITLE
fix: correct syntax errors in Go module template

### DIFF
--- a/docs/metasploit-framework.wiki/Writing-External-GoLang-Modules.md
+++ b/docs/metasploit-framework.wiki/Writing-External-GoLang-Modules.md
@@ -17,16 +17,16 @@ Contributing modules in [GO](https://golang.org/) can be achieved in a few simpl
 import "metasploit/module"
 func main() {
   metadata := &module.Metadata{
-    Name: "<module name",
+    Name: "<module name>",
     Description: "<describe>",
     Authors: []string{"<author 1>", "<author 2>"},
-    Date: "<date module written",
+    Date: "<date module written>",
     Type:"<module type>",
     Privileged:  <true|false>,
     References:  []module.Reference{},
     Options: map[string]module.Option{	
-      "<option 1":     {Type: "<type>", Description: "<description>", Required: <true|false>, Default: "<default>"},		
-      "<option 2":     {Type: "<type>", Description: "<description>", Required: <true|false>, Default: "<default>"},
+      "<option 1>":     {Type: "<type>", Description: "<description>", Required: <true|false>, Default: "<default>"},		
+      "<option 2>":     {Type: "<type>", Description: "<description>", Required: <true|false>, Default: "<default>"},
   }}
 
   module.Init(metadata, <the entry method to your module>)


### PR DESCRIPTION
## Description

This PR updates the Writing-External-Golang-Modules.md documentation to correct syntax issues in the Go module example, specifically related to the ">" characters and placeholder formatting.

These fixes improve readability and ensure the example code is valid and easier to follow.

## Verification

- [ ] Review the updated documentation
- [ ] Ensure the corrected syntax is valid Go code
- [ ] Confirm the example is clear and free of syntax errors
