### PR TITLE
Fix: minor syntax and formatting issues in documentation

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-parse-an-HTTP-response.md
+++ b/docs/metasploit-framework.wiki/How-to-parse-an-HTTP-response.md
@@ -64,7 +64,7 @@ Consider the following example as your HTML response:
 		<div id="french">Bonjour</div>
 	</div>
 </body>
-<html>
+</html>
 ```
 
 **Basic usage of #at**

--- a/docs/metasploit-framework.wiki/Metasploit-URL-support-proposal.md
+++ b/docs/metasploit-framework.wiki/Metasploit-URL-support-proposal.md
@@ -14,7 +14,7 @@ Metasploit currently provides multiple options for configuring target details:
 
 Configuring this amount of options is cumbersome and time consuming on a per module basis. 
 
-Although it is is possible to globally setting common values with the `setg` command - and to individually override the ports on a per module basis, it is still an arduous task:
+Although it is possible to globally setting common values with the `setg` command - and to individually override the ports on a per module basis, it is still an arduous task:
 
 ```
 setg RHOSTS x.x.x.x

--- a/docs/metasploit-framework.wiki/Writing-External-Metasploit-Modules.md
+++ b/docs/metasploit-framework.wiki/Writing-External-Metasploit-Modules.md
@@ -151,7 +151,7 @@ Run
     "id": {"type": "string"},
     "method": {"enum": ["run"]},
     "params": {
-      "type": "object"
+      "type": "object",
       "additionalProperties": false,
       "patternProperties": {
         "^[^=]*$": {
@@ -181,7 +181,7 @@ Run
     "id": {"type": "string"},
     "result": {
       "type": "object",
-      "required": ["message"]
+      "required": ["message"],
       "properties": {
         "message": {"type": "string"},
         "return": {"type": "string"}


### PR DESCRIPTION
## Summary
Fix minor syntax and formatting issues across documentation files.

## Changes
- Corrected HTML closing tag structure
- Fixed duplicated wording ("is is" → "is")
- Added missing commas in JSON examples

## Verification
- Reviewed changes manually
- Ensured formatting and syntax are correct
- Confirmed no functional changes were introduced

## Notes
These are documentation-only fixes and do not affect functionality.