### PR TITLE
Fix a deprecation notice when reporting notes

### DIFF
--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Post
     end
   end
 
-  def report(data)
+  def report(**data)
     report_note(
       host: session,
       type: 'linux.protection',
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Post
     hardening_checks.each do |check, message|
       if send(check)
         print_good message
-        report(message)
+        report(message: message)
       end
     rescue RuntimeError => e
       vprint_status(e.to_s)
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Post
               'SELinux is installed, but in permissive mode'
             end
         print_good(r)
-        report(r)
+        report(message: r)
       end
     rescue RuntimeError => e
       vprint_status(e.to_s)
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Post
               'Yama is installed, but not enabled'
             end
         print_good(r)
-        report(r)
+        report(message: r)
       end
     rescue RuntimeError => e
       vprint_status(e.to_s)
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Post
       if userns_enabled?
         r = 'User namespaces are enabled (unprivileged may be available)'
         print_good(r)
-        report(r)
+        report(message: r)
       end
     rescue RuntimeError => e
       vprint_status(e.to_s)
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Post
       next unless path.start_with? '/'
 
       print_good("#{app} found: #{path}")
-      report("#{appname}: #{path}")
+      report(message: "Found: #{appname}", path: path)
     end
   end
 
@@ -279,7 +279,7 @@ class MetasploitModule < Msf::Post
       next unless file_exist?(path) || directory?(path)
 
       print_good("#{appname} found: #{path}")
-      report("#{appname}: #{path}")
+      report(message: "#{appname}: #{path}")
     rescue RuntimeError
       print_bad("Unable to determine state of #{appname}")
       next


### PR DESCRIPTION
While testing #21194 I noticed a high volume of deprecation notices related to the modules use of `#report_note`. This fixes it by wrapping the data in a hash which is the new requirement.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a Linux Meterpreter session
- [ ] Run the `post/linux/gather/enum_protections` module
- [ ] Do not see any deprecation notices

## Demo (Old and loud)

```
msf post(linux/gather/enum_protections) > run SESSION=-1
[*] Running module against 192.168.159.128 [fedora.local]
[*] Info:
[*] 	Fedora release 43 (Forty Three)
[*] 	Linux fedora 6.19.8-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 13 22:06:06 UTC 2026 x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled

[-] [DEPRECATION] Using report_note with a non-hash data value is deprecated, please raise a Github issue with this output.
[-] Call stack:
[-]   /home/smcintyre/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/core/db_manager/note.rb:81:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:40:in `block in report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/data_service/proxy/core.rb:164:in `data_service_operation'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:38:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/core/auxiliary/report.rb:185:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:65:in `report'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:92:in `block in check_hardening'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:89:in `each'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:89:in `check_hardening'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:51:in `run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/base/simple/post.rb:112:in `job_run_proc'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/base/simple/post.rb:82:in `run_simple'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/base/simple/post.rb:91:in `run_simple'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/ui/console/command_dispatcher/post.rb:88:in `cmd_run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:582:in `run_command'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:531:in `block in run_single'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:525:in `each'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_single'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:165:in `block in run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:309:in `block in with_history_manager_context'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell/history_manager.rb:35:in `with_context'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:306:in `with_history_manager_context'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:133:in `run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/command/console.rb:54:in `start'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/command/base.rb:82:in `start'
[-]   ./msfconsole:23:in `<main>'
[-] Failed to open file: /proc/sys/kernel/exec-shield: core_channel_open: Operation failed: 1
[+] KPTI is enabled

[-] [DEPRECATION] Using report_note with a non-hash data value is deprecated, please raise a Github issue with this output.
[-] Call stack:
[-]   /home/smcintyre/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/core/db_manager/note.rb:81:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:40:in `block in report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/data_service/proxy/core.rb:164:in `data_service_operation'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:38:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/core/auxiliary/report.rb:185:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:65:in `report'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:92:in `block in check_hardening'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:89:in `each'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:89:in `check_hardening'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/modules/post/linux/gather/enum_protections.rb:51:in `run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/base/simple/post.rb:112:in `job_run_proc'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/base/simple/post.rb:82:in `run_simple'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/base/simple/post.rb:91:in `run_simple'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/ui/console/command_dispatcher/post.rb:88:in `cmd_run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:582:in `run_command'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:531:in `block in run_single'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:525:in `each'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_single'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:165:in `block in run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:309:in `block in with_history_manager_context'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell/history_manager.rb:35:in `with_context'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:306:in `with_history_manager_context'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:133:in `run'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/command/console.rb:54:in `start'
[-]   /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/command/base.rb:82:in `start'
[-]   ./msfconsole:23:in `<main>'
[+] SMEP is enabled
...
```

### New and less noisy

```
msf post(linux/gather/enum_protections) > run SESSION=-1
[*] Running module against 192.168.159.128 [fedora.local]
[*] Info:
[*] 	Fedora release 43 (Forty Three)
[*] 	Linux fedora 6.19.8-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar 13 22:06:06 UTC 2026 x86_64 GNU/Linux
[*] Finding system protections...
[+] ASLR is enabled
[-] Failed to open file: /proc/sys/kernel/exec-shield: core_channel_open: Operation failed: 1
[+] KPTI is enabled
[+] SMEP is enabled
[+] SMAP is enabled
[+] Unprivileged BPF is disabled
[+] dmesg restriction is enabled
[+] SELinux is installed and enforcing
[+] Yama is installed, but not enabled
[-] Failed to open file: /proc/sys/kernel/unprivileged_userns_clone: core_channel_open: Operation failed: 1
[+] User namespaces are enabled (unprivileged may be available)
[*] Finding installed applications via their executables...
[+] auditd found: /usr/sbin/auditd
[+] firewall-cmd found: /usr/sbin/firewall-cmd
[+] getenforce found: /usr/sbin/getenforce
[+] iptables found: /usr/sbin/iptables
[+] logrotate found: /usr/sbin/logrotate
[+] nft found: /usr/sbin/nft
[+] proxychains found: /usr/sbin/proxychains
[+] tcpdump found: /usr/sbin/tcpdump
[+] wireshark found: /usr/sbin/wireshark
[*] Finding installed applications via their configuration files...
[+] firewalld found: /etc/firewalld
[*] System protections saved to notes.
[*] Post module execution completed
msf post(linux/gather/enum_protections) > notes

Notes
=====

 Time                     Host             Service  Port  Protocol  Type              Data
 ----                     ----             -------  ----  --------  ----              ----
 2026-03-30 21:50:50 UTC  192.168.159.128                           linux.protection  {:message=>"ASLR is enabled"}
 2026-03-30 21:50:51 UTC  192.168.159.128                           linux.protection  {:message=>"KPTI is enabled"}
 2026-03-30 21:50:51 UTC  192.168.159.128                           linux.protection  {:message=>"SMEP is enabled"}
 2026-03-30 21:50:51 UTC  192.168.159.128                           linux.protection  {:message=>"SMAP is enabled"}
 2026-03-30 21:50:52 UTC  192.168.159.128                           linux.protection  {:message=>"Unprivileged BPF is disabled"}
 2026-03-30 21:50:53 UTC  192.168.159.128                           linux.protection  {:message=>"dmesg restriction is enabled"}
 2026-03-30 21:50:54 UTC  192.168.159.128                           linux.protection  {:message=>"SELinux is installed and enforcing"}
 2026-03-30 21:50:54 UTC  192.168.159.128                           linux.protection  {:message=>"Yama is installed, but not enabled"}
 2026-03-30 21:50:55 UTC  192.168.159.128                           linux.protection  {:message=>"User namespaces are enabled (unprivileged may be available)"}
 2026-03-30 21:50:56 UTC  192.168.159.128                           linux.protection  {:message=>"Found: auditd", :path=>"/usr/sbin/auditd"}
 2026-03-30 21:50:58 UTC  192.168.159.128                           linux.protection  {:message=>"Found: firewalld", :path=>"/usr/sbin/firewall-cmd"}
 2026-03-30 21:50:59 UTC  192.168.159.128                           linux.protection  {:message=>"Found: SELinux", :path=>"/usr/sbin/getenforce"}
 2026-03-30 21:51:00 UTC  192.168.159.128                           linux.protection  {:message=>"Found: iptables", :path=>"/usr/sbin/iptables"}
 2026-03-30 21:51:00 UTC  192.168.159.128                           linux.protection  {:message=>"Found: logrotate", :path=>"/usr/sbin/logrotate"}
 2026-03-30 21:51:01 UTC  192.168.159.128                           linux.protection  {:message=>"Found: nftables", :path=>"/usr/sbin/nft"}
 2026-03-30 21:51:03 UTC  192.168.159.128                           linux.protection  {:message=>"Found: ProxyChains", :path=>"/usr/sbin/proxychains"}
 2026-03-30 21:51:05 UTC  192.168.159.128                           linux.protection  {:message=>"Found: tcpdump", :path=>"/usr/sbin/tcpdump"}
 2026-03-30 21:51:06 UTC  192.168.159.128                           linux.protection  {:message=>"Found: Wireshark", :path=>"/usr/sbin/wireshark"}
 2026-03-30 21:51:08 UTC  192.168.159.128                           linux.protection  {:message=>"firewalld: /etc/firewalld"}

msf post(linux/gather/enum_protections) >
```