### PR TITLE
Fix: minor typos in Pivoting-in-Metasploit.md

### DIFF
--- a/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
@@ -567,7 +567,7 @@ index.html             100%[===========================>]  57.34K  --.-KB/s    i
 ```
 
 ### Scanning
-For scanning with Nmap, Zenmap, Nessus and others, keep in mind that ICMP and UPD traffic cannot tunnel through the proxy. So you cannot perform ping or UDP scans.
+For scanning with Nmap, Zenmap, Nessus and others, keep in mind that ICMP and UDP traffic cannot tunnel through the proxy. So you cannot perform ping or UDP scans.
 
 For Nmap and Zenmap, the below example shows the commands can be used. It is best to be selective on ports to scan since scanning through the proxy tunnel can be slow.
 

--- a/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
@@ -444,7 +444,7 @@ Now edit the `proxychains` configuration file located at `/etc/proxychains.conf`
 socks5 127.0.0.1 1080
 ```
 
-The final should look something like this:
+The final file should look something like this:
 
 ```ini
 # proxychains.conf  VER 3.1

--- a/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/Pivoting-in-Metasploit.md
@@ -444,7 +444,7 @@ Now edit the `proxychains` configuration file located at `/etc/proxychains.conf`
 socks5 127.0.0.1 1080
 ```
 
-The final final should look something like this:
+The final should look something like this:
 
 ```ini
 # proxychains.conf  VER 3.1


### PR DESCRIPTION
## Summary

Fixed a couple of small typos in the documentation:

* Removed a duplicate "final"
* Corrected "UPD" to "UDP"

## Verification

* Checked the file and confirmed the typos are fixed
* Made sure formatting looks fine

## Notes

This is a documentation-only change, no functional impact.

