### PR TITLE
Remove "frozen_string_literal: true" directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,6 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 - Ruby (see `.ruby-version` for the current version). Minimum supported: 3.1+
 - Follow the project's `.rubocop.yml` configuration — run `rubocop` on changed files before submitting
 - Run `ruby tools/dev/msftidy.rb <module_file_path>` to catch common module issues
-- Add `# frozen_string_literal: true` to new files (the RuboCop cop is disabled project-wide for legacy code, but new files should include it)
 - No enforced line length limit, but keep code readable
 - Use `%q{}` for long multi-line strings (curly braces preferred for module descriptions)
 - Multiline block comments are acceptable for embedded code snippets/payloads


### PR DESCRIPTION
`frozen_string_literal: true` breaks modules where the author has an associated email address in the [mailmap](https://github.com/rapid7/metasploit-framework/blob/master/.mailmap).

See: https://github.com/rapid7/metasploit-framework/actions/runs/23700493046/job/69043237173

```
  1) modules it should behave like all modules with module type can be instantiated auxiliary scanner/smb/smb_eventlog_file_existence behaves like a module with valid metadata verifies modules metadata
     Failure/Error: self.name.strip! if self.name.present?

     FrozenError:
       can't modify frozen String: "bcoles"
     Shared Example Group: "a module with valid metadata" called from ./spec/support/shared/examples/all_modules_with_module_type_can_be_instantiated.rb:35
     Shared Example Group: "all modules with module type can be instantiated" called from ./spec/modules_spec.rb:6
[...]
```
