### PR TITLE
Fix: small typo's in Documentation

### DIFF
--- a/documentation/modules/auxiliary/admin/mssql/mssql_exec.md
+++ b/documentation/modules/auxiliary/admin/mssql/mssql_exec.md
@@ -21,7 +21,7 @@ technique leverages the [`sp_OACreate`][2] stored procedure to create an instanc
 
 ## Verification Steps
 
-1. Do: `use use admin/mssql/mssql_exec`
+1. Do: `use admin/mssql/mssql_exec`
 2. Do: `set USERNAME [username1]`
 3. Do: `set PASSWORD [password1]`
 3. Do: `set TECHNIQUE sp_oacreate` (optional, defaults to xp_cmdshell)
@@ -32,7 +32,7 @@ technique leverages the [`sp_OACreate`][2] stored procedure to create an instanc
 ## Scenarios
 
 ```
-msf > use use use admin/mssql/mssql_exec
+msf > use admin/mssql/mssql_exec
 msf auxiliary(mssql_exec) > set USERNAME username1
 USERNAME => username1
 msf auxiliary(mssql_exec) > set PASSWORD password1

--- a/documentation/modules/auxiliary/admin/scada/phoenix_command.md
+++ b/documentation/modules/auxiliary/admin/scada/phoenix_command.md
@@ -1,4 +1,4 @@
-PhoenixContact Programmable Logic Controllers are built are using a variant of
+PhoenixContact Programmable Logic Controllers are built using a variant of
 ProConOS. The communicate using a proprietary protocol over ports TCP/1962 and
 TCP/41100 or TCP/20547.  This protocol allows a user to remotely determine the
 PLC type, firmware and build number on port TCP/1962.  A user can also

--- a/documentation/modules/auxiliary/admin/vmware/vcenter_offline_mdb_extract.md
+++ b/documentation/modules/auxiliary/admin/vmware/vcenter_offline_mdb_extract.md
@@ -3,7 +3,7 @@ This module will accept files from a live vCenter appliance or from a vCenter ap
 archive; either or both files can be supplied to the module depending on the situation. The module
 will extract the vCenter SSO IdP signing credential from the vmdir database, which can be used to
 create forged SAML assertions and access the SSO directory as an administrator. The vmafd service
-contains the vCenter certificate store which from which the module will attempt to extract all vmafd
+contains the vCenter certificate store, from which the module will attempt to extract all vmafd
 certificates that also have a corresponding private key. Portions of this module are based on
 information published by Zach Hanley at Horizon3:
 

--- a/documentation/modules/auxiliary/analyze/crack_osx.md
+++ b/documentation/modules/auxiliary/analyze/crack_osx.md
@@ -88,7 +88,7 @@ Default is `false`.
 
 ### PBKDF2-HMAC-SHA512
 
-Crack SHA12 hashes. Default is `true`.
+Crack SHA512 hashes. Default is `true`.
 
 ### POT
 


### PR DESCRIPTION
## Summary

This PR fixes several small typos in documentation files.

Changes include:
- Removed duplicate `use` commands in MSSQL module examples
- Fixed minor grammar issues
- Corrected wording mistakes

These changes do not affect functionality, only improve clarity and readability.

## Verification

1. Open the updated documentation files
2. Check the corrected commands and sentences
3. Ensure examples are clear and consistent

- [ ] Verify text is correct
- [ ] Verify no functional changes
- [ ] Documentation updated