### PR TITLE
Fix crash with frozen string literals

### DIFF
--- a/lib/msf/core/author.rb
+++ b/lib/msf/core/author.rb
@@ -161,8 +161,6 @@ class Msf::Author
       end
     end
 
-    self.name.strip! if self.name.present?
-
     # The parse succeeds only when a name is found
     self.name.present?
   end
@@ -170,6 +168,7 @@ class Msf::Author
   # Sets the name of the author and updates the email if it's a known author.
   # @param name [String] the name to set
   def name=(name)
+    name = name.strip if name.present?
     if KNOWN.has_key?(name)
       self.email = KNOWN[name]
     end

--- a/modules/auxiliary/scanner/misc/cups_browsed_info_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/cups_browsed_info_disclosure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/21215

## Verification

- Verify that CI passes
- Verified that the cups_browsed_info_disclosure module runs