### PR TITLE
Update the cached payload size

### DIFF
--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 39726
+  CachedSize = 39837
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
Updates the cached size for a PHP meterpreter payload to get CI passing again

## Verification

- [x] Verify the cached size is correct now in the CI test, there might be other failures but not any related to incorrect cached payload sizes

Related: #20913 🔥 