### PR TITLE
Add RISC-V arch support to Linux local exploit modules

### DIFF
--- a/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
@@ -48,6 +48,8 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_X64,
           ARCH_ARMLE,
           ARCH_AARCH64,
+          ARCH_RISCV64LE,
+          ARCH_RISCV32LE,
           ARCH_PPC,
           ARCH_MIPSLE,
           ARCH_MIPSBE

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -43,6 +43,8 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_X64,
           ARCH_ARMLE,
           ARCH_AARCH64,
+          ARCH_RISCV64LE,
+          ARCH_RISCV32LE,
           ARCH_PPC,
           ARCH_MIPSLE,
           ARCH_MIPSBE

--- a/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
@@ -51,6 +51,8 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_X64,
           ARCH_ARMLE,
           ARCH_AARCH64,
+          ARCH_RISCV64LE,
+          ARCH_RISCV32LE,
           ARCH_PPC,
           ARCH_MIPSLE,
           ARCH_MIPSBE

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Local
           'Author' => ['forzoni'],
           'DisclosureDate' => '2016-06-28',
           'Platform' => 'linux',
-          'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
+          'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_RISCV64LE, ARCH_RISCV32LE, ARCH_MIPSLE, ARCH_MIPSBE],
           'Targets' => [ ['Automatic', {}] ],
           'DefaultOptions' => { 'PrependFork' => true, 'WfsDelay' => 60 },
           'SessionTypes' => ['shell', 'meterpreter'],

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Local
           'License' => MSF_LICENSE,
           'Author' => ['stealthcopter'],
           'Platform' => 'linux',
-          'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
+          'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_RISCV64LE, ARCH_RISCV32LE, ARCH_MIPSLE, ARCH_MIPSBE],
           'Targets' => [['Automatic', {}]],
           'DefaultOptions' => { 'PrependFork' => true, 'WfsDelay' => 20 },
           'SessionTypes' => ['shell', 'meterpreter'],

--- a/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
@@ -49,6 +49,8 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_X64,
           ARCH_ARMLE,
           ARCH_AARCH64,
+          ARCH_RISCV64LE,
+          ARCH_RISCV32LE,
           ARCH_PPC,
           ARCH_MIPSLE,
           ARCH_MIPSBE

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -55,6 +55,8 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_X64,
           ARCH_ARMLE,
           ARCH_AARCH64,
+          ARCH_RISCV64LE,
+          ARCH_RISCV32LE,
           ARCH_PPC,
           ARCH_MIPSLE,
           ARCH_MIPSBE

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -53,6 +53,8 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_X64,
           ARCH_ARMLE,
           ARCH_AARCH64,
+          ARCH_RISCV64LE,
+          ARCH_RISCV32LE,
           ARCH_PPC,
           ARCH_MIPSLE,
           ARCH_MIPSBE

--- a/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
+++ b/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
@@ -56,6 +56,8 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_X64,
           ARCH_ARMLE,
           ARCH_AARCH64,
+          ARCH_RISCV64LE,
+          ARCH_RISCV32LE,
           ARCH_PPC,
           ARCH_MIPSLE,
           ARCH_MIPSBE


### PR DESCRIPTION
Add ARCH_RISCV64LE and ARCH_RISCV32LE to the supported architecture lists of 9 Linux local privilege escalation modules that use generic EXE payload dropping and are not dependent on pre-compiled architecture-specific exploit binaries.

This allows these modules to be used on RISC-V targets with the existing RISC-V payload set.

Untested, but as these modules execute arbitrary compiled executables (and are primarily userland exploits), there is no immediately obvious reason why it would not work. A couple of the modules exploit old bugs which pre-date RISC-V support, so it is extremely unlikely that RISC-V will ever be a valid target - but it doesn't hurt to support it.
