### PR TITLE
Feat/adcs/api consolidation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ GEM
       mutex_m
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.20)
+    metasploit-credential (6.0.21)
       bigdecimal
       csv
       drb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ PATH
       lru_redux
       metasm
       metasploit-concern
-      metasploit-credential
+      metasploit-credential (>= 6.0.21)
       metasploit-model
       metasploit-payloads (= 2.0.245)
       metasploit_data_models (>= 6.0.15)

--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -9,18 +9,6 @@ require 'rex/proto/x509/request'
 module Msf
 
   module Exploit::Remote::CertRequest
-
-    # [2.2.2.7.7.4 szOID_NTDS_CA_SECURITY_EXT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/e563cff8-1af6-4e6f-a655-7571ca482e71)
-    OID_NTDS_CA_SECURITY_EXT = '1.3.6.1.4.1.311.25.2'.freeze
-    # [2.2.2.7.5 szOID_NT_PRINCIPAL_NAME](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/ea9ef420-4cbf-44bc-b093-c4175139f90f)
-    OID_NT_PRINCIPAL_NAME = '1.3.6.1.4.1.311.20.2.3'.freeze
-    # [[MS-WCCE]: Windows Client Certificate Enrollment Protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-winerrata/c39fd72a-da21-4b13-b329-c35d61f74a60)
-    OID_NTDS_OBJECTSID = '1.3.6.1.4.1.311.25.2.1'.freeze
-    # [[MS-WCCE]: 2.2.2.7.10 szENROLLMENT_NAME_VALUE_PAIR](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/92f07a54-2889-45e3-afd0-94b60daa80ec)
-    OID_ENROLLMENT_NAME_VALUE_PAIR = '1.3.6.1.4.1.311.13.2.1'.freeze
-    # [[MS-WCCE]: 2.2.2.7.7.3 Encoding a Certificate Application Policy Extension](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/160b96b1-c431-457a-8eed-27c11873f378)
-    OID_APPLICATION_CERT_POLICIES = '1.3.6.1.4.1.311.21.10'.freeze
-
     # @param opts [Hash]
     # @option opts [String] :username the CN to embed in the CSR subject
     # @option opts [OpenSSL::PKey::RSA] :private_key an existing key to sign with; a new one is generated when omitted
@@ -260,11 +248,11 @@ module Msf
     # @param [OpenSSL::X509::Certificate] cert
     # @return [String, nil] The SID if it was found, otherwise nil.
     def get_cert_msext_sid(cert)
-      ext = cert.extensions.find { |e| e.oid == OID_NTDS_CA_SECURITY_EXT }
+      ext = cert.extensions.find { |e| e.oid == Rex::Proto::X509::OID_NTDS_CA_SECURITY_EXT }
       return unless ext
 
       ntds_ca_security_ext = Rex::Proto::CryptoAsn1::NtdsCaSecurityExt.parse(ext.value_der)
-      return unless ntds_ca_security_ext[:OtherName][:type_id].value == OID_NTDS_OBJECTSID
+      return unless ntds_ca_security_ext[:OtherName][:type_id].value == Rex::Proto::X509::OID_NTDS_OBJECTSID
 
       ntds_ca_security_ext[:OtherName][:value].value
     end
@@ -277,7 +265,7 @@ module Msf
       return [] unless (san = get_cert_san(cert))
 
       san[:GeneralNames].value.select do |gn|
-        gn[:otherName][:type_id]&.value == OID_NT_PRINCIPAL_NAME
+        gn[:otherName][:type_id]&.value == Rex::Proto::X509::OID_NT_PRINCIPAL_NAME
       end.map do |gn|
         RASN1::Types::Utf8String.parse(gn[:otherName][:value].value, explicit: 0, constructed: true).value
       end

--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -10,6 +10,20 @@ module Msf
 
   module Exploit::Remote::CertRequest
 
+    # @param opts [Hash]
+    # @option opts [String] :username the CN to embed in the CSR subject
+    # @option opts [OpenSSL::PKey::RSA] :private_key an existing key to sign with; a new one is generated when omitted
+    # @option opts [Integer] :rsa_key_size key size in bits (default: RSAKeySize datastore option, or 2048)
+    # @option opts [String] :algorithm digest algorithm (default: DigestAlgorithm datastore option, or 'SHA256')
+    # @option opts [String] :alt_dns DNS subjectAltName value
+    # @option opts [String] :alt_upn UPN subjectAltName value (Microsoft OID)
+    # @option opts [String] :alt_sid SID subjectAltName value (Microsoft NTDS CA security extension)
+    # @option opts [Array<String>] :add_cert_app_policy application policy OIDs to embed
+    # @option opts [OpenSSL::PKCS12] :pkcs12 agent certificate used to sign an on-behalf-of request
+    # @option opts [String] :on_behalf_of UPN of the subject to request a certificate on behalf of
+    # @return [Array(Rex::Proto::X509::Request, OpenSSL::PKey::RSA)] the signed CSR and the private key used to sign it;
+    #   when both +:pkcs12+ and +:on_behalf_of+ are supplied the first element is a
+    #   {Rex::Proto::CryptoAsn1::Cms::ContentInfo} wrapping the inner CMC request instead
     def create_csr(opts={})
       rsa_key_size = opts.fetch(:rsa_key_size) { datastore['RSAKeySize'].blank? ? 2048 : datastore['RSAKeySize'].to_i }
       # can we double check if the key size is correct here when we are passed a private key?
@@ -18,9 +32,10 @@ module Msf
         elog("RSA key size mismatch")
         raise ArgumentError, "RSA key size mismatch in create_csr()"
       end
-      vprint_status("RSA key size: #{rsa_key_size}")
+
       user = opts[:username]
       status_msg = "Requesting a certificate for user #{user}"
+      status_msg << " - RSA key size: #{rsa_key_size}"
       alt_dns = opts.fetch(:alt_dns) { datastore['ALT_DNS'].blank? ? nil : datastore['ALT_DNS'] }
       alt_sid = opts.fetch(:alt_sid) { datastore['ALT_SID'].blank? ? nil : datastore['ALT_SID'] }
       alt_upn = opts.fetch(:alt_upn) { datastore['ALT_UPN'].blank? ? nil : datastore['ALT_UPN'] }
@@ -59,8 +74,9 @@ module Msf
         )
       end
       vprint_status status_msg
-      csr
+
+      [csr, private_key]
     end
-end
+  end
 end
 

--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -21,7 +21,9 @@ module Msf
     # @option opts [Array<String>] :add_cert_app_policy application policy OIDs to embed
     # @option opts [OpenSSL::PKCS12] :pkcs12 agent certificate used to sign an on-behalf-of request
     # @option opts [String] :on_behalf_of UPN of the subject to request a certificate on behalf of
-    # @return [Array(Rex::Proto::X509::Request, OpenSSL::PKey::RSA)] the signed CSR and the private key used to sign it;
+    # @option opts [String] :cert_template the certificate template to request (default: CERT_TEMPLATE datastore option)
+    # @return [Array(Rex::Proto::X509::Request, OpenSSL::PKey::RSA, Hash)] the signed CSR, the private key used to sign
+    #   it, and a hash of enrollment request attributes (e.g. +CertificateTemplate+, +SAN+);
     #   when both +:pkcs12+ and +:on_behalf_of+ are supplied the first element is a
     #   {Rex::Proto::CryptoAsn1::Cms::ContentInfo} wrapping the inner CMC request instead
     def create_csr(opts={})
@@ -34,16 +36,18 @@ module Msf
       end
 
       user = opts[:username]
-      status_msg = "Requesting a certificate for user #{user}"
+      status_msg = "Building a certificate request for user #{user}"
       status_msg << " - RSA key size: #{rsa_key_size}"
       alt_dns = opts.fetch(:alt_dns) { datastore['ALT_DNS'].blank? ? nil : datastore['ALT_DNS'] }
       alt_sid = opts.fetch(:alt_sid) { datastore['ALT_SID'].blank? ? nil : datastore['ALT_SID'] }
       alt_upn = opts.fetch(:alt_upn) { datastore['ALT_UPN'].blank? ? nil : datastore['ALT_UPN'] }
       algorithm = opts.fetch(:algorithm) { datastore['DigestAlgorithm'].blank? ? 'SHA256' : datastore['DigestAlgorithm'] }
       application_policies = opts.fetch(:add_cert_app_policy) { datastore['ADD_CERT_APP_POLICY'].blank? ? nil : datastore['ADD_CERT_APP_POLICY'].split(/[;,]\s*|\s+/) }
+      cert_template = opts.fetch(:cert_template) { datastore['CERT_TEMPLATE'].blank? ? nil : datastore['CERT_TEMPLATE'] }
       status_msg << " - alternate DNS: #{alt_dns}" if alt_dns
       status_msg << " - alternate UPN: #{alt_upn}" if alt_upn
       status_msg << " - digest algorithm: #{algorithm}" if algorithm
+      status_msg << " - template: #{cert_template}" if cert_template
       csr = Rex::Proto::X509::Request.build_csr(
         cn: user,
         private_key: private_key,
@@ -75,7 +79,18 @@ module Msf
       end
       vprint_status status_msg
 
-      [csr, private_key]
+      attributes = {}
+      attributes['CertificateTemplate'] = cert_template if cert_template
+      san = []
+      san << "dns=#{alt_dns}" if alt_dns
+      san << "upn=#{alt_upn}" if alt_upn
+      if alt_sid
+        san << "url=#{Rex::Proto::X509::SAN_URL_PREFIX}#{alt_sid}"
+        san << "url=#{alt_sid}"
+      end
+      attributes['SAN'] = san.join('&') unless san.empty?
+
+      [csr, private_key, attributes]
     end
   end
 end

--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -21,7 +21,7 @@ module Msf
     # @option opts [Array<String>] :add_cert_app_policy application policy OIDs to embed
     # @option opts [OpenSSL::PKCS12] :pkcs12 agent certificate used to sign an on-behalf-of request
     # @option opts [String] :on_behalf_of UPN of the subject to request a certificate on behalf of
-    # @option opts [String] :cert_template the certificate template to request (default: CERT_TEMPLATE datastore option)
+    # @option opts [String] :cert_template the AD CS certificate template to request
     # @return [Array(Rex::Proto::X509::Request, OpenSSL::PKey::RSA, Hash)] the signed CSR, the private key used to sign
     #   it, and a hash of enrollment request attributes (e.g. +CertificateTemplate+, +SAN+);
     #   when both +:pkcs12+ and +:on_behalf_of+ are supplied the first element is a
@@ -36,7 +36,7 @@ module Msf
       end
 
       user = opts[:username]
-      status_msg = "Building a certificate request for user #{user}"
+      status_msg = "Building a certificate signing request for user #{user}"
       status_msg << " - RSA key size: #{rsa_key_size}"
       alt_dns = opts.fetch(:alt_dns) { datastore['ALT_DNS'].blank? ? nil : datastore['ALT_DNS'] }
       alt_sid = opts.fetch(:alt_sid) { datastore['ALT_SID'].blank? ? nil : datastore['ALT_SID'] }
@@ -44,10 +44,12 @@ module Msf
       algorithm = opts.fetch(:algorithm) { datastore['DigestAlgorithm'].blank? ? 'SHA256' : datastore['DigestAlgorithm'] }
       application_policies = opts.fetch(:add_cert_app_policy) { datastore['ADD_CERT_APP_POLICY'].blank? ? nil : datastore['ADD_CERT_APP_POLICY'].split(/[;,]\s*|\s+/) }
       cert_template = opts.fetch(:cert_template) { datastore['CERT_TEMPLATE'].blank? ? nil : datastore['CERT_TEMPLATE'] }
+
       status_msg << " - alternate DNS: #{alt_dns}" if alt_dns
       status_msg << " - alternate UPN: #{alt_upn}" if alt_upn
       status_msg << " - digest algorithm: #{algorithm}" if algorithm
       status_msg << " - template: #{cert_template}" if cert_template
+      
       csr = Rex::Proto::X509::Request.build_csr(
         cn: user,
         private_key: private_key,
@@ -77,6 +79,7 @@ module Msf
           algorithm: algorithm
         )
       end
+      # todo: Check this prints and makes sense
       vprint_status status_msg
 
       attributes = {}

--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -146,7 +146,7 @@ module Msf
         return
       end
 
-      if (policy_oids = get_cert_policy_oids(certificate))
+      if policy_oids
         print_status('Certificate Policies:')
         policy_oids.each do |oid|
           print_status("  * #{oid.value}" + (oid.label.present? ? " (#{oid.label})" : ''))

--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -10,6 +10,17 @@ module Msf
 
   module Exploit::Remote::CertRequest
 
+    # [2.2.2.7.7.4 szOID_NTDS_CA_SECURITY_EXT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/e563cff8-1af6-4e6f-a655-7571ca482e71)
+    OID_NTDS_CA_SECURITY_EXT = '1.3.6.1.4.1.311.25.2'.freeze
+    # [2.2.2.7.5 szOID_NT_PRINCIPAL_NAME](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/ea9ef420-4cbf-44bc-b093-c4175139f90f)
+    OID_NT_PRINCIPAL_NAME = '1.3.6.1.4.1.311.20.2.3'.freeze
+    # [[MS-WCCE]: Windows Client Certificate Enrollment Protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-winerrata/c39fd72a-da21-4b13-b329-c35d61f74a60)
+    OID_NTDS_OBJECTSID = '1.3.6.1.4.1.311.25.2.1'.freeze
+    # [[MS-WCCE]: 2.2.2.7.10 szENROLLMENT_NAME_VALUE_PAIR](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/92f07a54-2889-45e3-afd0-94b60daa80ec)
+    OID_ENROLLMENT_NAME_VALUE_PAIR = '1.3.6.1.4.1.311.13.2.1'.freeze
+    # [[MS-WCCE]: 2.2.2.7.7.3 Encoding a Certificate Application Policy Extension](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/160b96b1-c431-457a-8eed-27c11873f378)
+    OID_APPLICATION_CERT_POLICIES = '1.3.6.1.4.1.311.21.10'.freeze
+
     # @param opts [Hash]
     # @option opts [String] :username the CN to embed in the CSR subject
     # @option opts [OpenSSL::PKey::RSA] :private_key an existing key to sign with; a new one is generated when omitted
@@ -79,7 +90,6 @@ module Msf
           algorithm: algorithm
         )
       end
-      # todo: Check this prints and makes sense
       vprint_status status_msg
 
       attributes = {}
@@ -94,6 +104,236 @@ module Msf
       attributes['SAN'] = san.join('&') unless san.empty?
 
       [csr, private_key, attributes]
+    end
+
+    # Build a CSR and coordinate the full ADCS certificate enrollment lifecycle.
+    #
+    # Constructs a CSR via {#create_csr}, yields it together with the enrollment
+    # attributes to the caller-supplied block, which is responsible for the
+    # actual transport (MS-ICPR, Web Enrollment, etc.).  After the block returns
+    # a certificate, this method validates policy OIDs, logs certificate fields,
+    # stores the PKCS#12 as loot, and optionally records a credential.
+    #
+    # @param opts [Hash] options forwarded to {#create_csr} plus the following:
+    # @option opts [String] :username the CN to embed in the CSR subject
+    # @option opts [String] :domain the AD domain used as the credential realm
+    #   when a UPN domain cannot be derived from the certificate
+    # @option opts [Hash] :service_data service attributes used to create a
+    #   credential record; when omitted no credential is stored
+    # @yieldparam csr [Rex::Proto::X509::Request, Rex::Proto::CryptoAsn1::Cms::ContentInfo]
+    #   the signed CSR (or CMC-wrapped request for on-behalf-of enrollments)
+    # @yieldparam attributes [Hash] enrollment request attributes
+    #   (e.g. +CertificateTemplate+, +SAN+) to pass to the CA
+    # @yieldreturn [OpenSSL::X509::Certificate, nil] the issued certificate, or
+    #   +nil+ to abort enrollment
+    # @return [OpenSSL::PKCS12, nil] the PKCS#12 bundle containing the issued
+    #   certificate and private key, or +nil+ if the block returned +nil+ or
+    #   policy OID validation failed
+    def with_adcs_certificate_request(opts, &block)
+      csr, private_key, attributes = create_csr(opts)
+
+      vprint_status('Submitting the certificate signing request to the target...')
+      certificate = block.call(csr, attributes)
+      return unless certificate
+
+      application_policies = opts.fetch(:add_cert_app_policy) do
+        (datastore['ADD_CERT_APP_POLICY'].blank? ? nil : datastore['ADD_CERT_APP_POLICY'].split(/[;,]\s*|\s+/))
+      end
+
+      policy_oids = get_cert_policy_oids(certificate)
+      if application_policies.present? && !(application_policies - policy_oids.map(&:value)).empty?
+        print_error('Certificate application policy OIDs were submitted, but some are missing in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019) or the template is not vulnerable.')
+        return
+      end
+
+      if (policy_oids = get_cert_policy_oids(certificate))
+        print_status('Certificate Policies:')
+        policy_oids.each do |oid|
+          print_status("  * #{oid.value}" + (oid.label.present? ? " (#{oid.label})" : ''))
+        end
+      end
+
+      unless (dns = get_cert_san_dns(certificate)).empty?
+        print_status("Certificate DNS: #{dns.join(', ')}")
+      end
+
+      unless (email = get_cert_san_email(certificate)).empty?
+        print_status("Certificate Email: #{email.join(', ')}")
+      end
+
+      if (sid = get_cert_msext_sid(certificate))
+        print_status("Certificate SID: #{sid}")
+      end
+
+      unless (upn = get_cert_msext_upn(certificate)).empty?
+        print_status("Certificate UPN: #{upn.join(', ')}")
+      end
+
+      unless (uri = get_cert_san_uri(certificate)).empty?
+        print_status("Certificate URI: #{uri.join(', ')}")
+      end
+
+      pkcs12 = OpenSSL::PKCS12.create('', '', private_key, certificate)
+
+      upn_username = upn_domain = nil
+      unless upn&.first.blank?
+        info = "#{upn&.first} Certificate"
+        # TODO: I was under the impression a single certificate can only have one UPN associated with it.
+        #       But here, `upn` can be an array of UPN's. This will need to be sorted out.
+        upn_username, upn_domain = upn&.first&.split('@')
+      else
+        info = "#{opts[:domain]}\\#{opts[:username]} Certificate"
+      end
+
+      if (service_data = opts[:service_data])
+        # Only log a credential if we have service data to associate with it
+        credential_data = {
+          **service_data,
+          address: service_data[:host],
+          port: rport,
+          protocol: service_data[:proto],
+          service_name: service_data[:name],
+          workspace_id: myworkspace_id,
+          username: upn_username || opts[:username],
+          private_type: :pkcs12,
+          private_data: Base64.strict_encode64(pkcs12.to_der),
+          private_metadata: {
+            adcs_ca: datastore['CA'],
+            adcs_template: opts.fetch(:cert_template) { datastore['CERT_TEMPLATE'].blank? ? nil : datastore['CERT_TEMPLATE'] }
+          },
+          realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+          realm_value: upn_domain || opts[:domain],
+          origin_type: :service,
+          module_fullname: fullname
+        }
+        create_credential(credential_data)
+      end
+
+      stored_path = store_loot('windows.ad.cs', 'application/x-pkcs12', rhost, pkcs12.to_der, 'certificate.pfx', info)
+      print_status("Certificate stored at: #{stored_path}")
+
+      pkcs12
+    end
+
+    # Get the certificate policy OIDs from the certificate.
+    #
+    # @param [OpenSSL::X509::Certificate] cert
+    # @return [Array<Rex::Proto::CryptoAsn1::ObjectId>] The policy OIDs if any were found.
+    def get_cert_policy_oids(cert)
+      all_oids = []
+
+      # ms-app-policies (CertificatePolicies) - existing handling
+      if (ext = cert.extensions.find { |e| e.oid == 'ms-app-policies' })
+        begin
+          cert_policies = Rex::Proto::CryptoAsn1::X509::CertificatePolicies.parse(ext.value_der)
+          cert_policies.value.each do |policy_info|
+            oid_string = policy_info[:policyIdentifier].value
+            all_oids << (Rex::Proto::CryptoAsn1::OIDs.value(oid_string) || Rex::Proto::CryptoAsn1::ObjectId.new(oid_string))
+          end
+        rescue StandardError => e
+          vprint_error("Failed to parse ms-app-policies from certificate with subject:\"#{cert.subject.to_s}\" and issuer:\"#{cert.issuer.to_s}\". #{e.class}: #{e.message}")
+        end
+      end
+
+      # extendedKeyUsage - SEQUENCE OF OBJECT IDENTIFIER
+      if (eku_ext = cert.extensions.find { |e| e.oid == 'extendedKeyUsage' })
+        begin
+          asn1 = OpenSSL::ASN1.decode(eku_ext.value_der)
+          # asn1 should be a Sequence whose children are OBJECT IDENTIFIER nodes
+          if asn1.is_a?(OpenSSL::ASN1::Sequence)
+            asn1.value.each do |node|
+              next unless node.is_a?(OpenSSL::ASN1::ObjectId)
+              oid_string = node.value
+              all_oids << (Rex::Proto::CryptoAsn1::OIDs.value(oid_string) || Rex::Proto::CryptoAsn1::ObjectId.new(oid_string))
+            end
+          end
+        rescue StandardError => e
+          vprint_error("Failed to parse extendedKeyUsage from certificate with subject:\"#{cert.subject.to_s}\" and issuer:\"#{cert.issuer.to_s}\". #{e.class}: #{e.message}")
+        end
+      end
+
+      all_oids
+    end
+
+    # Get the object security identifier (SID) from the certificate. This is a Microsoft specific extension.
+    #
+    # @param [OpenSSL::X509::Certificate] cert
+    # @return [String, nil] The SID if it was found, otherwise nil.
+    def get_cert_msext_sid(cert)
+      ext = cert.extensions.find { |e| e.oid == OID_NTDS_CA_SECURITY_EXT }
+      return unless ext
+
+      ntds_ca_security_ext = Rex::Proto::CryptoAsn1::NtdsCaSecurityExt.parse(ext.value_der)
+      return unless ntds_ca_security_ext[:OtherName][:type_id].value == OID_NTDS_OBJECTSID
+
+      ntds_ca_security_ext[:OtherName][:value].value
+    end
+
+    # Get the User Principal Name (UPN) from the certificate. This is a Microsoft specific extension.
+    #
+    # @param [OpenSSL::X509::Certificate] cert
+    # @return [Array<String>] The UPNs if any were found.
+    def get_cert_msext_upn(cert)
+      return [] unless (san = get_cert_san(cert))
+
+      san[:GeneralNames].value.select do |gn|
+        gn[:otherName][:type_id]&.value == OID_NT_PRINCIPAL_NAME
+      end.map do |gn|
+        RASN1::Types::Utf8String.parse(gn[:otherName][:value].value, explicit: 0, constructed: true).value
+      end
+    end
+
+    # Get the SubjectAltName (SAN) field from the certificate.
+    #
+    # @param [OpenSSL::X509::Certificate] cert
+    # @return [Rex::Proto::CryptoAsn1::X509::SubjectAltName] The parsed SAN.
+    def get_cert_san(cert)
+      ext = cert.extensions.find { |e| e.oid == 'subjectAltName' }
+      return unless ext
+
+      Rex::Proto::CryptoAsn1::X509::SubjectAltName.parse(ext.value_der)
+    end
+
+    # Get the DNS hostnames from the certificate.
+    #
+    # @param [OpenSSL::X509::Certificate] cert
+    # @return [Array<String>] The DNS names if any were found.
+    def get_cert_san_dns(cert)
+      return [] unless (san = get_cert_san(cert))
+
+      san[:GeneralNames].value.select do |gn|
+        gn[:dNSName].value?
+      end.map do |gn|
+        gn[:dNSName].value
+      end
+    end
+
+    # Get the E-mail addresses from the certificate.
+    #
+    # @param [OpenSSL::X509::Certificate] cert
+    # @return [Array<String>] The E-mail addresses if any were found.
+    def get_cert_san_email(cert)
+      return [] unless (san = get_cert_san(cert))
+
+      san[:GeneralNames].value.select do |gn|
+        gn[:rfc822Name].value?
+      end.map do |gn|
+        gn[:rfc822Name].value
+      end
+    end
+
+    # Get the URI/URL from the certificate.
+    #
+    # @param [OpenSSL::X509::Certificate] cert
+    # @return [Array<String>] The URIs/URLs if any were found.
+    def get_cert_san_uri(cert)
+      return [] unless (san = get_cert_san(cert))
+
+      san[:GeneralNames].value.select do |gn|
+        gn[:uniformResourceIdentifier].value?
+      end.map do |gn|
+        gn[:uniformResourceIdentifier].value
+      end
     end
   end
 end

--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -173,14 +173,9 @@ module Msf
         info = "#{opts[:domain]}\\#{opts[:username]} Certificate"
       end
 
-      if (service_data = opts[:service_data])
+      if (service = opts[:service])
         # Only log a credential if we have service data to associate with it
         credential_data = {
-          **service_data,
-          address: service_data[:host],
-          port: rport,
-          protocol: service_data[:proto],
-          service_name: service_data[:name],
           workspace_id: myworkspace_id,
           username: upn_username || opts[:username],
           private_type: :pkcs12,
@@ -192,6 +187,7 @@ module Msf
           realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
           realm_value: upn_domain || opts[:domain],
           origin_type: :service,
+          service: service,
           module_fullname: fullname
         }
         create_credential(credential_data)

--- a/lib/msf/core/exploit/remote/http/web_enrollment.rb
+++ b/lib/msf/core/exploit/remote/http/web_enrollment.rb
@@ -37,6 +37,11 @@ module Msf
 
           def retrieve_certs(target_ip, authenticated_client, connection_identity, cert_templates)
             cert_templates.each do |cert_template|
+              if cert_issued?(connection_identity, cert_template)
+                print_status("Certificate already created for #{connection_identity} using #{cert_template}, skipping...")
+                next
+              end
+
               retrieve_cert(target_ip, authenticated_client, connection_identity, cert_template)
             end
           end
@@ -46,17 +51,9 @@ module Msf
           end
 
           def retrieve_cert(target_ip, authenticated_connection, connection_identity, cert_template)
-            if cert_issued?(connection_identity, cert_template)
-              print_status("Certificate already created for #{connection_identity} using #{cert_template}, skipping...")
-              return nil
-            end
-
             vprint_status("Creating certificate request for #{connection_identity} using the #{cert_template} template")
             opts = { username: connection_identity.split('\\').last }
-            rsa_key_size = datastore['RSAKeySize'].blank? ? 2048 : datastore['RSAKeySize'].to_i
-            private_key = OpenSSL::PKey::RSA.new(rsa_key_size)
-            opts[:private_key] = private_key
-            csr = create_csr(opts)
+            csr, private_key = create_csr(opts)
 
             cert_template_string = "CertificateTemplate:#{cert_template}"
             vprint_status('Requesting target generate certificate...')

--- a/lib/msf/core/exploit/remote/http/web_enrollment.rb
+++ b/lib/msf/core/exploit/remote/http/web_enrollment.rb
@@ -63,8 +63,6 @@ module Msf
             end
           end
 
-          module_function
-
           def do_request_cert(http_client, opts, csr, attributes)
             res = send_request_raw(
               {

--- a/lib/msf/core/exploit/remote/http/web_enrollment.rb
+++ b/lib/msf/core/exploit/remote/http/web_enrollment.rb
@@ -51,12 +51,11 @@ module Msf
           end
 
           def retrieve_cert(target_ip, authenticated_connection, connection_identity, cert_template)
-            vprint_status("Creating certificate request for #{connection_identity} using the #{cert_template} template")
             opts = { username: connection_identity.split('\\').last, cert_template: cert_template }
             csr, private_key, attributes = create_csr(opts)
 
             cert_attrib = attributes.map { |k, v| "#{k}:#{v}" }.join("\n")
-            vprint_status('Requesting target generate certificate...')
+            vprint_status('Submitting the certificate signing request to the target...')
             res = send_request_raw(
               {
                 'client' => authenticated_connection,
@@ -75,18 +74,18 @@ module Msf
               }
             )
             if res&.code == 200 && res.body.include?('request was denied')
-              print_bad("Certificate request denied using template #{cert_template} and #{connection_identity}")
+              print_bad("Certificate request denied using template #{cert_template} for #{connection_identity}")
               return nil
             end
             if res&.code == 200 && res.body.include?('request failed')
-              print_bad("Certificate request failed using template #{cert_template} and #{connection_identity}")
+              print_bad("Certificate request failed using template #{cert_template} for #{connection_identity}")
               return nil
             end
             if res&.code == 401 && res.body.include?('invalid credentials')
-              print_bad("Invalid Credential Error returned when using template #{cert_template} and #{connection_identity}")
+              print_bad("Invalid Credential Error returned when using template #{cert_template} for #{connection_identity}")
               return nil
             end
-            print_good("Certificate generated using template #{cert_template} and #{connection_identity}")
+            print_good("Certificate generated using template #{cert_template} for #{connection_identity}")
             add_cert_entry(connection_identity, cert_template)
             begin
               location_tag = res.body.match(/^.*location="(.*)"/)[1]

--- a/lib/msf/core/exploit/remote/http/web_enrollment.rb
+++ b/lib/msf/core/exploit/remote/http/web_enrollment.rb
@@ -52,10 +52,10 @@ module Msf
 
           def retrieve_cert(target_ip, authenticated_connection, connection_identity, cert_template)
             vprint_status("Creating certificate request for #{connection_identity} using the #{cert_template} template")
-            opts = { username: connection_identity.split('\\').last }
-            csr, private_key = create_csr(opts)
+            opts = { username: connection_identity.split('\\').last, cert_template: cert_template }
+            csr, private_key, attributes = create_csr(opts)
 
-            cert_template_string = "CertificateTemplate:#{cert_template}"
+            cert_attrib = attributes.map { |k, v| "#{k}:#{v}" }.join("\n")
             vprint_status('Requesting target generate certificate...')
             res = send_request_raw(
               {
@@ -66,7 +66,7 @@ module Msf
                 'vars_post' => {
                   'Mode' => 'newreq',
                   'CertRequest' => Rex::Text.encode_base64(csr.to_der.to_s),
-                  'CertAttrib' => cert_template_string,
+                  'CertAttrib' => cert_attrib,
                   'TargetStoreFlags' => 0,
                   'SaveCert' => 'yes',
                   'ThumbPrint' => ''

--- a/lib/msf/core/exploit/remote/http/web_enrollment.rb
+++ b/lib/msf/core/exploit/remote/http/web_enrollment.rb
@@ -11,11 +11,11 @@ module Msf
           include Msf::Exploit::Remote::CertRequest
           include Msf::Exploit::Remote::LDAP::ActiveDirectory::AdCsOpts
 
-          def get_cert_templates(authenticated_client)
+          def get_cert_templates(http_client)
             print_status('Retrieving available template list, this may take a few minutes')
             res = send_request_raw(
               {
-                'client' => authenticated_client,
+                'client' => http_client,
                 'method' => 'GET',
                 'uri' => normalize_uri(target_uri, 'certrqxt.asp')
               }
@@ -35,14 +35,14 @@ module Msf
             end
           end
 
-          def retrieve_certs(target_ip, authenticated_client, connection_identity, cert_templates)
+          def retrieve_certs(http_client, connection_identity, cert_templates)
             cert_templates.each do |cert_template|
               if cert_issued?(connection_identity, cert_template)
                 print_status("Certificate already created for #{connection_identity} using #{cert_template}, skipping...")
                 next
               end
 
-              retrieve_cert(target_ip, authenticated_client, connection_identity, cert_template)
+              retrieve_cert(http_client, connection_identity, cert_template)
             end
           end
 
@@ -50,22 +50,32 @@ module Msf
             !!@issued_certs[connection_identity]&.include?(cert_template)
           end
 
-          def retrieve_cert(target_ip, authenticated_connection, connection_identity, cert_template)
-            opts = { username: connection_identity.split('\\').last, cert_template: cert_template }
-            csr, private_key, attributes = create_csr(opts)
+          def retrieve_cert(http_client, connection_identity, cert_template)
+            opts = {
+              username: connection_identity.split('\\').last,
+              domain: connection_identity.split('\\').first,  # this is slightly inconsistent since it's the NETBIOS domain name not FQDN
+              cert_template: cert_template,
+              service_data: web_enrollment_service_data
+            }
 
-            cert_attrib = attributes.map { |k, v| "#{k}:#{v}" }.join("\n")
-            vprint_status('Submitting the certificate signing request to the target...')
+            with_adcs_certificate_request(opts) do |csr, attributes|
+              do_request_cert(http_client, opts, csr, attributes)
+            end
+          end
+
+          module_function
+
+          def do_request_cert(http_client, opts, csr, attributes)
             res = send_request_raw(
               {
-                'client' => authenticated_connection,
+                'client' => http_client,
                 'method' => 'POST',
                 'uri' => normalize_uri(datastore['TARGETURI'], 'certfnsh.asp'),
                 'ctype' => 'application/x-www-form-urlencoded',
                 'vars_post' => {
                   'Mode' => 'newreq',
                   'CertRequest' => Rex::Text.encode_base64(csr.to_der.to_s),
-                  'CertAttrib' => cert_attrib,
+                  'CertAttrib' => attributes.map { |k, v| "#{k}:#{v}" }.join("\n"),
                   'TargetStoreFlags' => 0,
                   'SaveCert' => 'yes',
                   'ThumbPrint' => ''
@@ -73,10 +83,15 @@ module Msf
                 'cgi' => true
               }
             )
+
+            cert_template = opts[:cert_template]
+            connection_identity = "#{opts[:domain]}\\#{opts[:username]}"
+
             if res&.code == 200 && res.body.include?('request was denied')
               print_bad("Certificate request denied using template #{cert_template} for #{connection_identity}")
               return nil
             end
+
             if res&.code == 200 && res.body.include?('request failed')
               print_bad("Certificate request failed using template #{cert_template} for #{connection_identity}")
               return nil
@@ -87,6 +102,7 @@ module Msf
             end
             print_good("Certificate generated using template #{cert_template} for #{connection_identity}")
             add_cert_entry(connection_identity, cert_template)
+
             begin
               location_tag = res.body.match(/^.*location="(.*)"/)[1]
             rescue NoMethodError
@@ -98,22 +114,22 @@ module Msf
             vprint_status("Attempting to download the certificate from #{location_uri}")
             res = send_request_raw(
               {
-                'client' => authenticated_connection,
+                'client' => http_client,
                 'method' => 'GET',
                 'uri' => location_uri
               }
             )
-            info = "#{connection_identity} Certificate"
-            certificate = OpenSSL::X509::Certificate.new(res.body)
-            pkcs12 = OpenSSL::PKCS12.create('', '', private_key, certificate)
-            stored_path = store_loot('windows.ad.cs',
-                                     'application/x-pkcs12',
-                                     target_ip,
-                                     pkcs12.to_der,
-                                     'certificate.pfx',
-                                     info)
-            print_good("Certificate using template #{cert_template} saved to #{stored_path}")
-            certificate
+            OpenSSL::X509::Certificate.new(res.body)
+          end
+
+          def web_enrollment_service_data
+            {
+              host: rhost,
+              port: rport,
+              proto: 'tcp',
+              name: 'http',
+              info: "AD CS Web Enrollment",
+            }
           end
         end
       end

--- a/lib/msf/core/exploit/remote/http/web_enrollment.rb
+++ b/lib/msf/core/exploit/remote/http/web_enrollment.rb
@@ -55,11 +55,16 @@ module Msf
               username: connection_identity.split('\\').last,
               domain: connection_identity.split('\\').first,  # this is slightly inconsistent since it's the NETBIOS domain name not FQDN
               cert_template: cert_template,
-              service_data: web_enrollment_service_data
             }
 
             with_adcs_certificate_request(opts) do |csr, attributes|
-              do_request_cert(http_client, opts, csr, attributes)
+              if (certificate = do_request_cert(http_client, opts, csr, attributes))
+                # Unlike with MS-ICPR we're not confident the target is the AD CS service we think it is until a
+                # certificate is issued so wait and only report the service if it worked
+                opts[:service] = report_web_enrollment_service
+              end
+
+              certificate
             end
           end
 
@@ -85,16 +90,21 @@ module Msf
             cert_template = opts[:cert_template]
             connection_identity = "#{opts[:domain]}\\#{opts[:username]}"
 
-            if res&.code == 200 && res.body.include?('request was denied')
+            if res.nil?
+              print_bad('Certificate request failed, no response was received from the server')
+              return nil
+            end
+
+            if res.code == 200 && res.body.include?('request was denied')
               print_bad("Certificate request denied using template #{cert_template} for #{connection_identity}")
               return nil
             end
 
-            if res&.code == 200 && res.body.include?('request failed')
+            if res.code == 200 && res.body.include?('request failed')
               print_bad("Certificate request failed using template #{cert_template} for #{connection_identity}")
               return nil
             end
-            if res&.code == 401 && res.body.include?('invalid credentials')
+            if res.code == 401 && res.body.include?('invalid credentials')
               print_bad("Invalid Credential Error returned when using template #{cert_template} for #{connection_identity}")
               return nil
             end
@@ -120,14 +130,17 @@ module Msf
             OpenSSL::X509::Certificate.new(res.body)
           end
 
-          def web_enrollment_service_data
-            {
-              host: rhost,
-              port: rport,
-              proto: 'tcp',
-              name: 'http',
-              info: "AD CS Web Enrollment",
-            }
+          def report_web_enrollment_service
+            common = { host: rhost, port: rport, proto: 'tcp' }
+            report_service({
+              name: 'AD CS Web Enrollment',
+              parents: {
+                name: ssl ? 'https' : 'http',
+                parents: {
+                  name: 'tcp'
+                }.merge(common)
+              }.merge(common)
+            }.merge(common))
           end
         end
       end

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -147,15 +147,10 @@ module Exploit::Remote::HttpClient
   # Connects to an HTTP server.
   #
   def connect(opts={})
-    dossl = false
-    if(opts.has_key?('SSL'))
-      dossl = opts['SSL']
-    else
-      dossl = ssl
-    end
+    dossl = opts.fetch('SSL') { ssl }
 
-    client_username = opts['username'] || datastore['HttpUsername'] || ''
-    client_password = opts['password'] || datastore['HttpPassword'] || ''
+    client_username = opts.fetch('username') { datastore['HttpUsername'] || '' }
+    client_password = opts.fetch('password') { datastore['HttpPassword'] || '' }
 
     http_logger_subscriber = Rex::Proto::Http::HttpLoggerSubscriber.new(logger: self)
 
@@ -171,8 +166,8 @@ module Exploit::Remote::HttpClient
         hostname: datastore['HTTP::Rhostname'],
         proxies: datastore['Proxies'],
         realm: datastore['DOMAIN'],
-        username: datastore['HttpUsername'],
-        password: datastore['HttpPassword'],
+        username: client_username,
+        password: client_password,
         framework: framework,
         framework_module: self,
         cache_file: datastore['HTTP::Krb5Ccname'].blank? ? nil : datastore['HTTP::Krb5Ccname'],

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -103,22 +103,14 @@ module Exploit::Remote::MsIcpr
     # Calls to this come from different places with different imports
     # and different opts hash values, so we need this here to make
     # sure all the data we need is populated
-    user = opts[:username] || datastore['SMBUser']
-    rsa_key_size = datastore['RSAKeySize'].blank? ? 2048 : datastore['RSAKeySize'].to_i
-    private_key = opts[:private_key] || OpenSSL::PKey::RSA.new(rsa_key_size)
-    if private_key.n.num_bits != rsa_key_size
-      elog("RSA key size mismatch")
-      raise ArgumentError, "RSA key size mismatch in do_request_cert"
-    end
-    opts[:private_key] = private_key
-    opts[:username] = user
-    status_msg = "Requesting a certificate for user #{user}"
+    opts[:username] = opts.fetch(:username) { datastore['SMBUser'] }
+    status_msg = "Requesting a certificate for user #{opts[:username]}"
     alt_dns = opts[:alt_dns] || (datastore['ALT_DNS'].blank? ? nil : datastore['ALT_DNS'])
     alt_sid = opts[:alt_sid] || (datastore['ALT_SID'].blank? ? nil : datastore['ALT_SID'])
     alt_upn = opts[:alt_upn] || (datastore['ALT_UPN'].blank? ? nil : datastore['ALT_UPN'])
     application_policies = opts[:add_cert_app_policy] || (datastore['ADD_CERT_APP_POLICY'].blank? ? nil : datastore['ADD_CERT_APP_POLICY'].split(/[;,]\s*|\s+/))
 
-    csr = create_csr(opts)
+    csr, private_key = create_csr(opts)
     cert_template = opts[:cert_template] || datastore['CERT_TEMPLATE']
     status_msg << " - template: #{cert_template}"
     attributes = { 'CertificateTemplate' => cert_template }

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -108,6 +108,7 @@ module Exploit::Remote::MsIcpr
 
     csr, private_key, attributes = create_csr(opts)
 
+    vprint_status('Submitting the certificate signing request to the target...')
     response = icpr.cert_server_request(
       attributes: attributes,
       authority: datastore['CA'],
@@ -203,7 +204,10 @@ module Exploit::Remote::MsIcpr
       username: upn_username || datastore['SMBUser'],
       private_type: :pkcs12,
       private_data: Base64.strict_encode64(pkcs12.to_der),
-      private_metadata: { adcs_ca: datastore['CA'], adcs_template: cert_template },
+      private_metadata: {
+        adcs_ca: datastore['CA'],
+        adcs_template: opts.fetch(:cert_template) { datastore['CERT_TEMPLATE'].blank? ? nil : datastore['CERT_TEMPLATE'] }
+      },
       realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
       realm_value: upn_domain || simple.client.default_domain,
       origin_type: :service,

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -104,28 +104,9 @@ module Exploit::Remote::MsIcpr
     # and different opts hash values, so we need this here to make
     # sure all the data we need is populated
     opts[:username] = opts.fetch(:username) { datastore['SMBUser'] }
-    status_msg = "Requesting a certificate for user #{opts[:username]}"
-    alt_dns = opts[:alt_dns] || (datastore['ALT_DNS'].blank? ? nil : datastore['ALT_DNS'])
-    alt_sid = opts[:alt_sid] || (datastore['ALT_SID'].blank? ? nil : datastore['ALT_SID'])
-    alt_upn = opts[:alt_upn] || (datastore['ALT_UPN'].blank? ? nil : datastore['ALT_UPN'])
     application_policies = opts[:add_cert_app_policy] || (datastore['ADD_CERT_APP_POLICY'].blank? ? nil : datastore['ADD_CERT_APP_POLICY'].split(/[;,]\s*|\s+/))
 
-    csr, private_key = create_csr(opts)
-    cert_template = opts[:cert_template] || datastore['CERT_TEMPLATE']
-    status_msg << " - template: #{cert_template}"
-    attributes = { 'CertificateTemplate' => cert_template }
-    san = []
-    san << "dns=#{alt_dns}" if alt_dns
-    san << "upn=#{alt_upn}" if alt_upn
-
-    if alt_sid
-      san << "url=#{SAN_URL_PREFIX}#{alt_sid}"
-      san << "url=#{alt_sid}"
-    end
-
-    attributes['SAN'] = san.join('&') unless san.empty?
-
-    vprint_status(status_msg)
+    csr, private_key, attributes = create_csr(opts)
 
     response = icpr.cert_server_request(
       attributes: attributes,

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -70,7 +70,7 @@ module Exploit::Remote::MsIcpr
   rescue RubySMB::Dcerpc::Error::DcerpcError => e
     elog(e.message, error: e)
     raise MsIcprUnexpectedReplyError, e.message
-  rescue RubySMB::Error::RubySMBError
+  rescue RubySMB::Error::RubySMBError => e
     elog(e.message, error: e)
     raise MsIcprUnknownError, e.message
   end

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -18,20 +18,6 @@ module Exploit::Remote::MsIcpr
   include Msf::Exploit::Remote::CertRequest
   include Msf::Exploit::Remote::LDAP::ActiveDirectory::AdCsOpts
 
-  # [2.2.2.7.7.4 szOID_NTDS_CA_SECURITY_EXT](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/e563cff8-1af6-4e6f-a655-7571ca482e71)
-  OID_NTDS_CA_SECURITY_EXT = '1.3.6.1.4.1.311.25.2'.freeze
-  # [2.2.2.7.5 szOID_NT_PRINCIPAL_NAME](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/ea9ef420-4cbf-44bc-b093-c4175139f90f)
-  OID_NT_PRINCIPAL_NAME = '1.3.6.1.4.1.311.20.2.3'.freeze
-  # [[MS-WCCE]: Windows Client Certificate Enrollment Protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-winerrata/c39fd72a-da21-4b13-b329-c35d61f74a60)
-  OID_NTDS_OBJECTSID = '1.3.6.1.4.1.311.25.2.1'.freeze
-  # [[MS-WCCE]: 2.2.2.7.10 szENROLLMENT_NAME_VALUE_PAIR](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/92f07a54-2889-45e3-afd0-94b60daa80ec)
-  OID_ENROLLMENT_NAME_VALUE_PAIR = '1.3.6.1.4.1.311.13.2.1'.freeze
-  # [[MS-WCCE]: 2.2.2.7.7.3 Encoding a Certificate Application Policy Extension](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/160b96b1-c431-457a-8eed-27c11873f378)
-  OID_APPLICATION_CERT_POLICIES = '1.3.6.1.4.1.311.21.10'.freeze
-
-  # [[SAN URL prefix for strong SID mapping for KDCs running Windows Server Preview Build 25246 and later](https://techcommunity.microsoft.com/blog/askds/preview-of-san-uri-for-certificate-strong-mapping-for-kb5014754/3789785)]
-  SAN_URL_PREFIX = "tag:microsoft.com,2022-09-14:sid:"
-
   ADCS_CA_SERVICE_NAME = 'adcs-ca'
 
   class MsIcprError < StandardError; end
@@ -67,7 +53,16 @@ module Exploit::Remote::MsIcpr
       raise MsIcprUnexpectedReplyError, "Connection failed (unexpected status: #{e.status_name})"
     end
 
-    do_request_cert(icpr, opts)
+    opts = opts.dup # Don't alter the caller's instance
+    # Calls to this come from different places with different imports  and different opts hash values, so we need this
+    # here to make sure all the data we need is populated
+    opts[:username] = opts.fetch(:username) { datastore['SMBUser'] }
+    opts[:domain] = opts.fetch(:domain) { simple.client.default_domain }
+    opts[:service_data] = icpr_service_data
+
+    with_adcs_certificate_request(opts) do |csr, attributes|
+      do_request_cert(icpr, opts, csr, attributes)
+    end
 
   rescue RubySMB::Dcerpc::Error::FaultError => e
     elog(e.message, error: e)
@@ -99,16 +94,7 @@ module Exploit::Remote::MsIcpr
     icpr
   end
 
-  def do_request_cert(icpr, opts)
-    # Calls to this come from different places with different imports
-    # and different opts hash values, so we need this here to make
-    # sure all the data we need is populated
-    opts[:username] = opts.fetch(:username) { datastore['SMBUser'] }
-    application_policies = opts[:add_cert_app_policy] || (datastore['ADD_CERT_APP_POLICY'].blank? ? nil : datastore['ADD_CERT_APP_POLICY'].split(/[;,]\s*|\s+/))
-
-    csr, private_key, attributes = create_csr(opts)
-
-    vprint_status('Submitting the certificate signing request to the target...')
+  def do_request_cert(icpr, opts, csr, attributes)
     response = icpr.cert_server_request(
       attributes: attributes,
       authority: datastore['CA'],
@@ -142,205 +128,7 @@ module Exploit::Remote::MsIcpr
       end
     end
 
-    report_service({
-      name: ADCS_CA_SERVICE_NAME,
-      resource: { ADCS_CA_SERVICE_NAME => { name: datastore['CA'] } },
-      host: icpr.tree.client.dispatcher.tcp_socket.peerhost,
-      port: icpr.tree.client.dispatcher.tcp_socket.peerport,
-      proto: 'tcp',
-      parents: report_icertpassage_service
-    })
-
-    return unless response[:certificate]
-
-    policy_oids = get_cert_policy_oids(response[:certificate])
-    if application_policies.present? && !(application_policies - policy_oids.map(&:value)).empty?
-      print_error('Certificate application policy OIDs were submitted, but some are missing in the response. This indicates the target has received the patch for ESC15 (CVE-2024-49019) or the template is not vulnerable.')
-      return
-    end
-
-    if policy_oids
-      print_status('Certificate Policies:')
-      policy_oids.each do |oid|
-        print_status("  * #{oid.value}" + (oid.label.present? ? " (#{oid.label})" : ''))
-      end
-    end
-
-    unless (dns = get_cert_san_dns(response[:certificate])).empty?
-      print_status("Certificate DNS: #{dns.join(', ')}")
-    end
-
-    unless (email = get_cert_san_email(response[:certificate])).empty?
-      print_status("Certificate Email: #{email.join(', ')}")
-    end
-
-    if (sid = get_cert_msext_sid(response[:certificate]))
-      print_status("Certificate SID: #{sid}")
-    end
-
-    unless (upn = get_cert_msext_upn(response[:certificate])).empty?
-      print_status("Certificate UPN: #{upn.join(', ')}")
-    end
-
-    unless (uri = get_cert_san_uri(response[:certificate])).empty?
-      print_status("Certificate URI: #{uri.join(', ')}")
-    end
-
-    pkcs12 = OpenSSL::PKCS12.create('', '', private_key, response[:certificate])
-    # see: https://pki-tutorial.readthedocs.io/en/latest/mime.html#mime-types
-    info = "#{simple.client.default_domain}\\#{datastore['SMBUser']} Certificate"
-    # TODO: I was under the impression a single certificate can only have one UPN associated with it.
-    #       But here, `upn` can be an array of UPN's. This will need to be sorted out.
-    upn_username, upn_domain = upn&.first&.split('@')
-
-    service_data = icpr_service_data
-    credential_data = {
-      **service_data,
-      address: service_data[:host],
-      port: rport,
-      protocol: service_data[:proto],
-      service_name: service_data[:name],
-      workspace_id: myworkspace_id,
-      username: upn_username || datastore['SMBUser'],
-      private_type: :pkcs12,
-      private_data: Base64.strict_encode64(pkcs12.to_der),
-      private_metadata: {
-        adcs_ca: datastore['CA'],
-        adcs_template: opts.fetch(:cert_template) { datastore['CERT_TEMPLATE'].blank? ? nil : datastore['CERT_TEMPLATE'] }
-      },
-      realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
-      realm_value: upn_domain || simple.client.default_domain,
-      origin_type: :service,
-      module_fullname: fullname
-    }
-    create_credential(credential_data)
-
-    stored_path = store_loot('windows.ad.cs', 'application/x-pkcs12', rhost, pkcs12.to_der, 'certificate.pfx', info)
-    print_status("Certificate stored at: #{stored_path}")
-
-    pkcs12
-  end
-
-  # Get the certificate policy OIDs from the certificate.
-  #
-  # @param [OpenSSL::X509::Certificate] cert
-  # @return [Array<Rex::Proto::CryptoAsn1::ObjectId>] The policy OIDs if any were found.
-  def get_cert_policy_oids(cert)
-    all_oids = []
-
-    # ms-app-policies (CertificatePolicies) - existing handling
-    if (ext = cert.extensions.find { |e| e.oid == 'ms-app-policies' })
-      begin
-        cert_policies = Rex::Proto::CryptoAsn1::X509::CertificatePolicies.parse(ext.value_der)
-        cert_policies.value.each do |policy_info|
-          oid_string = policy_info[:policyIdentifier].value
-          all_oids << (Rex::Proto::CryptoAsn1::OIDs.value(oid_string) || Rex::Proto::CryptoAsn1::ObjectId.new(oid_string))
-        end
-      rescue StandardError => e
-        vprint_error("Failed to parse ms-app-policies from certificate with subject:\"#{cert.subject.to_s}\" and issuer:\"#{cert.issuer.to_s}\". #{e.class}: #{e.message}")
-      end
-    end
-
-    # extendedKeyUsage - SEQUENCE OF OBJECT IDENTIFIER
-    if (eku_ext = cert.extensions.find { |e| e.oid == 'extendedKeyUsage' })
-      begin
-        asn1 = OpenSSL::ASN1.decode(eku_ext.value_der)
-        # asn1 should be a Sequence whose children are OBJECT IDENTIFIER nodes
-        if asn1.is_a?(OpenSSL::ASN1::Sequence)
-          asn1.value.each do |node|
-            next unless node.is_a?(OpenSSL::ASN1::ObjectId)
-            oid_string = node.value
-            all_oids << (Rex::Proto::CryptoAsn1::OIDs.value(oid_string) || Rex::Proto::CryptoAsn1::ObjectId.new(oid_string))
-          end
-        end
-      rescue StandardError => e
-        vprint_error("Failed to parse extendedKeyUsage from certificate with subject:\"#{cert.subject.to_s}\" and issuer:\"#{cert.issuer.to_s}\". #{e.class}: #{e.message}")
-      end
-    end
-
-    all_oids
-  end
-
-
-  # Get the object security identifier (SID) from the certificate. This is a Microsoft specific extension.
-  #
-  # @param [OpenSSL::X509::Certificate] cert
-  # @return [String, nil] The SID if it was found, otherwise nil.
-  def get_cert_msext_sid(cert)
-    ext = cert.extensions.find { |e| e.oid == OID_NTDS_CA_SECURITY_EXT }
-    return unless ext
-
-    ntds_ca_security_ext = Rex::Proto::CryptoAsn1::NtdsCaSecurityExt.parse(ext.value_der)
-    return unless ntds_ca_security_ext[:OtherName][:type_id].value == OID_NTDS_OBJECTSID
-
-    ntds_ca_security_ext[:OtherName][:value].value
-  end
-
-  # Get the User Principal Name (UPN) from the certificate. This is a Microsoft specific extension.
-  #
-  # @param [OpenSSL::X509::Certificate] cert
-  # @return [Array<String>] The UPNs if any were found.
-  def get_cert_msext_upn(cert)
-    return [] unless (san = get_cert_san(cert))
-
-    san[:GeneralNames].value.select do |gn|
-      gn[:otherName][:type_id]&.value == OID_NT_PRINCIPAL_NAME
-    end.map do |gn|
-      RASN1::Types::Utf8String.parse(gn[:otherName][:value].value, explicit: 0, constructed: true).value
-    end
-  end
-
-  # Get the SubjectAltName (SAN) field from the certificate.
-  #
-  # @param [OpenSSL::X509::Certificate] cert
-  # @return [Rex::Proto::CryptoAsn1::X509::SubjectAltName] The parsed SAN.
-  def get_cert_san(cert)
-    ext = cert.extensions.find { |e| e.oid == 'subjectAltName' }
-    return unless ext
-
-    Rex::Proto::CryptoAsn1::X509::SubjectAltName.parse(ext.value_der)
-  end
-
-  # Get the DNS hostnames from the certificate.
-  #
-  # @param [OpenSSL::X509::Certificate] cert
-  # @return [Array<String>] The DNS names if any were found.
-  def get_cert_san_dns(cert)
-    return [] unless (san = get_cert_san(cert))
-
-    san[:GeneralNames].value.select do |gn|
-      gn[:dNSName].value?
-    end.map do |gn|
-      gn[:dNSName].value
-    end
-  end
-
-  # Get the E-mail addresses from the certificate.
-  #
-  # @param [OpenSSL::X509::Certificate] cert
-  # @return [Array<String>] The E-mail addresses if any were found.
-  def get_cert_san_email(cert)
-    return [] unless (san = get_cert_san(cert))
-
-    san[:GeneralNames].value.select do |gn|
-      gn[:rfc822Name].value?
-    end.map do |gn|
-      gn[:rfc822Name].value
-    end
-  end
-
-  # Get the URI/URL from the certificate.
-  #
-  # @param [OpenSSL::X509::Certificate] cert
-  # @return [Array<String>] The URIs/URLs if any were found.
-  def get_cert_san_uri(cert)
-    return [] unless (san = get_cert_san(cert))
-
-    san[:GeneralNames].value.select do |gn|
-      gn[:uniformResourceIdentifier].value?
-    end.map do |gn|
-      gn[:uniformResourceIdentifier].value
-    end
+    response[:certificate]
   end
 
   def icpr_service_data

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -52,7 +52,7 @@ module Exploit::Remote::MsIcpr
 
   end
 
-  def request_certificate(opts = {})
+  def icpr_request_certificate(opts = {})
     tree = opts[:tree] || connect_ipc
 
     begin

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -58,7 +58,7 @@ module Exploit::Remote::MsIcpr
     # here to make sure all the data we need is populated
     opts[:username] = opts.fetch(:username) { datastore['SMBUser'] }
     opts[:domain] = opts.fetch(:domain) { simple.client.default_domain }
-    opts[:service_data] = icpr_service_data
+    opts[:service] = report_icertpassage_service
 
     with_adcs_certificate_request(opts) do |csr, attributes|
       do_request_cert(icpr, opts, csr, attributes)
@@ -129,17 +129,6 @@ module Exploit::Remote::MsIcpr
     end
 
     response[:certificate]
-  end
-
-  def icpr_service_data
-    {
-      host: rhost,
-      port: rport,
-      host_name: simple.client.default_name,
-      proto: 'tcp',
-      name: 'smb',
-      info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
-    }
   end
 
   def report_icertpassage_service

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   # Metasploit::Concern hooks
   spec.add_runtime_dependency 'metasploit-concern'
   # Metasploit::Credential database models
-  spec.add_runtime_dependency 'metasploit-credential'
+  spec.add_runtime_dependency 'metasploit-credential', '>= 6.0.21'
   # Database models shared between framework and Pro.
   spec.add_runtime_dependency 'metasploit_data_models', '>= 6.0.15'
   # Things that would normally be part of the database model, but which

--- a/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2022_26923_certifried.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
     }
     opts[:tree] = connect_smb(opts)
     opts[:cert_template] = 'Machine'
-    cert = request_certificate(opts)
+    cert = icpr_request_certificate(opts)
     fail_with(Failure::UnexpectedReply, 'Unable to request the certificate.') unless cert
 
     if ['AUTHENTICATE', 'PRIVESC'].include?(action.name)

--- a/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
+++ b/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
@@ -224,7 +224,7 @@ class MetasploitModule < Msf::Auxiliary
       datastore['SMBUser'] = datastore['TARGET_USERNAME']
       datastore['SMBPass'] = smbpass
       datastore['RHOSTS'] = ca_ip
-      request_certificate(opts)
+      icpr_request_certificate(opts)
     end
   ensure
     datastore['RHOSTS'] = @dc_ip

--- a/modules/auxiliary/admin/dcerpc/icpr_cert.rb
+++ b/modules/auxiliary/admin/dcerpc/icpr_cert.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def action_request_cert
     with_ipc_tree do |opts|
-      request_certificate(opts)
+      icpr_request_certificate(opts)
     end
   end
 

--- a/modules/auxiliary/admin/http/web_enrollment_cert.rb
+++ b/modules/auxiliary/admin/http/web_enrollment_cert.rb
@@ -105,23 +105,25 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(target_ip)
     validate
-    if datastore['HTTP::Auth'] == 'ntlm' || datastore['HTTP::Auth'] == 'auto'
-      queried_domain = pull_domain(target_ip, target_uri)
-      if queried_domain.nil?
-        fail_with(Failure::UnexpectedReply, 'Failed to automatically populate DOMAIN; please do so manually and retry')
-      end
 
-      # The queried_domain value is coming is as a UTF-16LE string encoded in ASCII 8-bit.
-      # We need to normalize it so we can do the string compares later
-      datastore_domain = datastore['DOMAIN']
-      queried_domain.force_encoding('UTF-16LE')
-      queried_domain = queried_domain.encode(datastore_domain.encoding)
-
-      if datastore['DOMAIN'] != 'WORKSTATION' && queried_domain != datastore_domain
-        fail_with(Failure::UnexpectedReply, "Server claims to be a member of #{queried_domain} domain and does not match the datastore domain entry #{datastore['DOMAIN']}")
-      end
-      connection_identity = queried_domain + '\\' + datastore['HttpUsername']
+    queried_domain = pull_domain(target_ip, target_uri)
+    if queried_domain.nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to automatically populate DOMAIN; please do so manually and retry')
     end
+
+    # The queried_domain value is coming is as a UTF-16LE string encoded in ASCII 8-bit.
+    # We need to normalize it so we can do the string compares later
+    datastore_domain = datastore['DOMAIN']
+    queried_domain.force_encoding('UTF-16LE')
+    queried_domain = queried_domain.encode(datastore_domain.encoding)
+
+    # kerberos requires DOMAIN be the FQDN but in other cases check if DOMAIN is set to something other than the NETBIOS
+    # domain name that was returned from the NTLM handshake which would imply an operator error
+    if datastore['HTTP::Auth'] != 'kerberos' && datastore['DOMAIN'].present? && datastore['DOMAIN'] != 'WORKSTATION' && queried_domain != datastore_domain
+      fail_with(Failure::UnexpectedReply, "Server claims to be a member of #{queried_domain} domain and does not match the datastore domain entry #{datastore['DOMAIN']}")
+    end
+    connection_identity = queried_domain + '\\' + datastore['HttpUsername']
+
     http_client = connect(
       {
         'rhost' => target_ip,

--- a/modules/auxiliary/admin/http/web_enrollment_cert.rb
+++ b/modules/auxiliary/admin/http/web_enrollment_cert.rb
@@ -139,12 +139,12 @@ class MetasploitModule < Msf::Auxiliary
         print_status('***Templates with CT_FLAG_MACHINE_TYPE set like Machine and DomainController will not display as available, even if they are.***')
         print_good("Available Certificates for #{connection_identity} on #{datastore['RHOST']}: #{cert_templates.join(', ')}")
         if datastore['MODE'] == 'ALL'
-          retrieve_certs(target_ip, http_client, connection_identity, cert_templates)
+          retrieve_certs(http_client, connection_identity, cert_templates)
         end
       end
     when 'SPECIFIC_TEMPLATE'
       cert_template = datastore['CERT_TEMPLATE']
-      retrieve_cert(target_ip, http_client, connection_identity, cert_template)
+      retrieve_cert(http_client, connection_identity, cert_template)
     end
   end
 

--- a/modules/auxiliary/admin/http/web_enrollment_cert.rb
+++ b/modules/auxiliary/admin/http/web_enrollment_cert.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def validate
     super
+
     case datastore['MODE']
     when 'SPECIFIC_TEMPLATE'
       if datastore['CERT_TEMPLATE'].blank?
@@ -53,13 +54,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def pull_domain(target_ip, target_uri)
-    temp_username = datastore['HttpUsername']
-    temp_password = datastore['HttpPassword']
     begin
       vprint_status("Checking #{target_ip} URL #{target_uri}")
-      # datastore and options must be nil to fail login so we get ntlm challenge
-      datastore['HttpUsername'] = nil
-      datastore['HttpPassword'] = nil
       res = send_request_cgi({
         'rhost' => target_ip,
         'encode' => true,
@@ -75,12 +71,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Timeout::Error, ::Errno::EPIPE
       vprint_error('Timeout error')
       return
-    ensure
-      datastore['HttpUsername'] = temp_username
-      datastore['HttpPassword'] = temp_password
     end
-    datastore['HttpUsername'] = temp_username
-    datastore['HttpPassword'] = temp_password
 
     return nil if res.nil?
 

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -128,11 +128,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def on_relay_success(relay_connection:, relay_identity:)
-    target_ip = relay_connection.target.ip
     case datastore['MODE']
     when 'AUTO'
       cert_template = relay_identity.end_with?('$') ? ['DomainController', 'Machine'] : ['User']
-      retrieve_certs(target_ip, relay_connection, relay_identity, cert_template)
+      retrieve_certs(relay_connection, relay_identity, cert_template)
     when 'ALL', 'QUERY_ONLY'
       cert_templates = get_cert_templates(relay_connection)
       unless cert_templates.nil? || cert_templates.empty?

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -139,12 +139,12 @@ class MetasploitModule < Msf::Auxiliary
         print_status('***Templates with CT_FLAG_MACHINE_TYPE set like Machine and DomainController will not display as available, even if they are.***')
         print_good("Available Certificates for #{relay_identity} on #{datastore['RELAY_TARGET']}: #{cert_templates.join(', ')}")
         if datastore['MODE'] == 'ALL'
-          retrieve_certs(target_ip, relay_connection, relay_identity, cert_templates)
+          retrieve_certs(relay_connection, relay_identity, cert_templates)
         end
       end
     when 'SPECIFIC_TEMPLATE'
       cert_template = datastore['CERT_TEMPLATE']
-      retrieve_cert(target_ip, relay_connection, relay_identity, cert_template)
+      retrieve_cert(relay_connection, relay_identity, cert_template)
     end
 
     vprint_status('Relay tasks complete; waiting for next login attempt.')

--- a/spec/lib/msf/core/exploit/remote/cert_request_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/cert_request_spec.rb
@@ -96,18 +96,18 @@ RSpec.describe Msf::Exploit::Remote::CertRequest do
   describe '#create_csr' do
     context 'with a private key supplied via opts' do
       it 'returns an OpenSSL::X509::Request' do
-        result = subject.create_csr(username: 'alice', private_key: rsa_key)
-        expect(result).to be_a(OpenSSL::X509::Request)
+        csr, _key = subject.create_csr(username: 'alice', private_key: rsa_key)
+        expect(csr).to be_a(OpenSSL::X509::Request)
       end
 
       it 'signs the CSR with the provided key' do
-        result = subject.create_csr(username: 'alice', private_key: rsa_key)
-        expect(result.verify(rsa_key.public_key)).to be true
+        csr, _key = subject.create_csr(username: 'alice', private_key: rsa_key)
+        expect(csr.verify(rsa_key.public_key)).to be true
       end
 
       it 'sets the CN to the provided username' do
-        result = subject.create_csr(username: 'alice', private_key: rsa_key)
-        expect(result.subject.to_s).to include('alice')
+        csr, _key = subject.create_csr(username: 'alice', private_key: rsa_key)
+        expect(csr.subject.to_s).to include('alice')
       end
 
       context 'when the key size matches the expected rsa_key_size' do
@@ -117,8 +117,8 @@ RSpec.describe Msf::Exploit::Remote::CertRequest do
         end
 
         it 'returns a CSR' do
-          result = subject.create_csr(username: 'alice', private_key: rsa_key, rsa_key_size: 2048)
-          expect(result).to be_a(OpenSSL::X509::Request)
+          csr, _key = subject.create_csr(username: 'alice', private_key: rsa_key, rsa_key_size: 2048)
+          expect(csr).to be_a(OpenSSL::X509::Request)
         end
       end
 
@@ -154,8 +154,8 @@ RSpec.describe Msf::Exploit::Remote::CertRequest do
       end
 
       it 'returns a valid OpenSSL::X509::Request' do
-        result = subject.create_csr(username: 'alice')
-        expect(result).to be_a(OpenSSL::X509::Request)
+        csr, _key = subject.create_csr(username: 'alice')
+        expect(csr).to be_a(OpenSSL::X509::Request)
       end
     end
 
@@ -282,13 +282,13 @@ RSpec.describe Msf::Exploit::Remote::CertRequest do
       end
 
       it 'calls build_on_behalf_of and returns a ContentInfo object' do
-        result = subject.create_csr(
+        csr, _key = subject.create_csr(
           username: 'alice',
           private_key: rsa_key,
           pkcs12: pkcs12,
           on_behalf_of: 'DOMAIN\\administrator'
         )
-        expect(result).to be_a(Rex::Proto::CryptoAsn1::Cms::ContentInfo)
+        expect(csr).to be_a(Rex::Proto::CryptoAsn1::Cms::ContentInfo)
       end
 
       it 'passes on_behalf_of to build_on_behalf_of' do
@@ -314,20 +314,20 @@ RSpec.describe Msf::Exploit::Remote::CertRequest do
 
       it 'skips build_on_behalf_of and returns a plain CSR' do
         expect(Rex::Proto::X509::Request).not_to receive(:build_on_behalf_of)
-        result = subject.create_csr(username: 'alice', private_key: rsa_key, pkcs12: pkcs12)
-        expect(result).to be_a(OpenSSL::X509::Request)
+        csr, _key = subject.create_csr(username: 'alice', private_key: rsa_key, pkcs12: pkcs12)
+        expect(csr).to be_a(OpenSSL::X509::Request)
       end
     end
 
     context 'with on_behalf_of but no pkcs12' do
       it 'skips build_on_behalf_of and returns a plain CSR' do
         expect(Rex::Proto::X509::Request).not_to receive(:build_on_behalf_of)
-        result = subject.create_csr(
+        csr, _key = subject.create_csr(
           username: 'alice',
           private_key: rsa_key,
           on_behalf_of: 'DOMAIN\\administrator'
         )
-        expect(result).to be_a(OpenSSL::X509::Request)
+        expect(csr).to be_a(OpenSSL::X509::Request)
       end
     end
 

--- a/spec/lib/msf/core/exploit/remote/cert_request_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/cert_request_spec.rb
@@ -362,5 +362,79 @@ RSpec.describe Msf::Exploit::Remote::CertRequest do
         subject.create_csr(username: 'alice', private_key: rsa_key)
       end
     end
+
+    context 'returned attributes' do
+      context 'with cert_template supplied via opts' do
+        it 'sets CertificateTemplate in the returned attributes' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key, cert_template: 'AdminTemplate')
+          expect(attrs['CertificateTemplate']).to eq('AdminTemplate')
+        end
+      end
+
+      context 'with cert_template supplied via datastore' do
+        before { subject.datastore['CERT_TEMPLATE'] = 'UserTemplate' }
+
+        it 'sets CertificateTemplate from the datastore' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key)
+          expect(attrs['CertificateTemplate']).to eq('UserTemplate')
+        end
+      end
+
+      context 'when no cert_template is supplied' do
+        it 'does not include CertificateTemplate in the returned attributes' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key)
+          expect(attrs).not_to have_key('CertificateTemplate')
+        end
+      end
+
+      context 'with alt_dns supplied via opts' do
+        it 'includes dns in the SAN attribute' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key, alt_dns: 'host.example.com')
+          expect(attrs['SAN']).to include('dns=host.example.com')
+        end
+      end
+
+      context 'with alt_upn supplied via opts' do
+        it 'includes upn in the SAN attribute' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key, alt_upn: 'alice@example.com')
+          expect(attrs['SAN']).to include('upn=alice@example.com')
+        end
+      end
+
+      context 'with alt_sid supplied via opts' do
+        let(:sid) { 'S-1-5-21-1234567890-1234567890-1234567890-500' }
+
+        before { allow(Rex::Proto::X509::Request).to receive(:build_csr).and_return(double('csr', to_der: '')) }
+
+        it 'includes the prefixed URL SAN entry in the returned attributes' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key, alt_sid: sid)
+          expect(attrs['SAN']).to include("url=#{Rex::Proto::X509::SAN_URL_PREFIX}#{sid}")
+        end
+
+        it 'includes the bare URL SAN entry in the returned attributes' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key, alt_sid: sid)
+          expect(attrs['SAN']).to include("url=#{sid}")
+        end
+      end
+
+      context 'with alt_dns and alt_upn supplied' do
+        it 'joins both SAN entries with &' do
+          _csr, _key, attrs = subject.create_csr(
+            username: 'alice', private_key: rsa_key,
+            alt_dns: 'host.example.com', alt_upn: 'alice@example.com'
+          )
+          expect(attrs['SAN']).to include('dns=host.example.com')
+          expect(attrs['SAN']).to include('upn=alice@example.com')
+          expect(attrs['SAN']).to include('&')
+        end
+      end
+
+      context 'when no SAN values are set' do
+        it 'does not include SAN in the returned attributes' do
+          _csr, _key, attrs = subject.create_csr(username: 'alice', private_key: rsa_key)
+          expect(attrs).not_to have_key('SAN')
+        end
+      end
+    end
   end
 end

--- a/spec/lib/msf/core/exploit/remote/http/web_enrollment_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/http/web_enrollment_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       def store_loot(_name, _type, _host, _data, _filename, _info)
         '/tmp/cert.pfx'
       end
+
+      def rhost
+        '192.0.2.1'
+      end
+
+      def rport
+        443
+      end
     end
     mod = klass.new
     allow(mod).to receive(:vprint_status)
@@ -172,27 +180,27 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
     it 'calls retrieve_cert for each template' do
       templates = %w[UserTemplate AdminTemplate]
       templates.each do |t|
-        expect(subject).to receive(:retrieve_cert).with('192.168.1.1', authenticated_client, 'DOMAIN\\user', t)
+        expect(subject).to receive(:retrieve_cert).with(authenticated_client, 'DOMAIN\\user', t)
       end
-      subject.retrieve_certs('192.168.1.1', authenticated_client, 'DOMAIN\\user', templates)
+      subject.retrieve_certs(authenticated_client, 'DOMAIN\\user', templates)
     end
 
     it 'does nothing when the template list is empty' do
       expect(subject).not_to receive(:retrieve_cert)
-      subject.retrieve_certs('192.168.1.1', authenticated_client, 'DOMAIN\\user', [])
+      subject.retrieve_certs(authenticated_client, 'DOMAIN\\user', [])
     end
 
     context 'when a cert has already been issued' do
       before { subject.add_cert_entry('DOMAIN\\user', 'UserTemplate') }
 
       it 'skips retrieve_cert for the already-issued template' do
-        expect(subject).not_to receive(:retrieve_cert).with('192.168.1.1', authenticated_client, 'DOMAIN\\user', 'UserTemplate')
-        subject.retrieve_certs('192.168.1.1', authenticated_client, 'DOMAIN\\user', ['UserTemplate'])
+        expect(subject).not_to receive(:retrieve_cert).with(authenticated_client, 'DOMAIN\\user', 'UserTemplate')
+        subject.retrieve_certs(authenticated_client, 'DOMAIN\\user', ['UserTemplate'])
       end
 
       it 'still calls retrieve_cert for other templates' do
-        expect(subject).to receive(:retrieve_cert).with('192.168.1.1', authenticated_client, 'DOMAIN\\user', 'AdminTemplate')
-        subject.retrieve_certs('192.168.1.1', authenticated_client, 'DOMAIN\\user', %w[UserTemplate AdminTemplate])
+        expect(subject).to receive(:retrieve_cert).with(authenticated_client, 'DOMAIN\\user', 'AdminTemplate')
+        subject.retrieve_certs(authenticated_client, 'DOMAIN\\user', %w[UserTemplate AdminTemplate])
       end
     end
   end
@@ -216,7 +224,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       end
 
       it 'returns nil' do
-        expect(subject.retrieve_cert(target_ip, authenticated_client, identity, template)).to be_nil
+        expect(subject.retrieve_cert(authenticated_client, identity, template)).to be_nil
       end
     end
 
@@ -230,7 +238,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       end
 
       it 'returns nil' do
-        expect(subject.retrieve_cert(target_ip, authenticated_client, identity, template)).to be_nil
+        expect(subject.retrieve_cert(authenticated_client, identity, template)).to be_nil
       end
     end
 
@@ -244,7 +252,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       end
 
       it 'returns nil' do
-        expect(subject.retrieve_cert(target_ip, authenticated_client, identity, template)).to be_nil
+        expect(subject.retrieve_cert(authenticated_client, identity, template)).to be_nil
       end
     end
 
@@ -258,11 +266,11 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       end
 
       it 'returns nil' do
-        expect(subject.retrieve_cert(target_ip, authenticated_client, identity, template)).to be_nil
+        expect(subject.retrieve_cert(authenticated_client, identity, template)).to be_nil
       end
 
       it 'adds the cert entry before discovering the missing location tag' do
-        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
+        subject.retrieve_cert(authenticated_client, identity, template)
         expect(subject.cert_issued?(identity, template)).to be true
       end
     end
@@ -290,15 +298,17 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
         allow(subject).to receive(:create_csr).and_return([csr, rsa_key, { 'CertificateTemplate' => template }])
         allow(subject).to receive(:send_request_raw).and_return(post_res, get_res)
         allow(subject).to receive(:store_loot).and_return('/tmp/cert.pfx')
+        # Return nil for service so credential creation is skipped in with_adcs_certificate_request
+        allow(subject).to receive(:report_web_enrollment_service).and_return(nil)
       end
 
-      it 'returns an OpenSSL::X509::Certificate' do
-        result = subject.retrieve_cert(target_ip, authenticated_client, identity, template)
-        expect(result).to be_a(OpenSSL::X509::Certificate)
+      it 'returns an OpenSSL::PKCS12' do
+        result = subject.retrieve_cert(authenticated_client, identity, template)
+        expect(result).to be_a(OpenSSL::PKCS12)
       end
 
       it 'records the issued cert entry' do
-        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
+        subject.retrieve_cert(authenticated_client, identity, template)
         expect(subject.cert_issued?(identity, template)).to be true
       end
 
@@ -306,12 +316,12 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
         expect(subject).to receive(:store_loot).with(
           'windows.ad.cs',
           'application/x-pkcs12',
-          target_ip,
+          anything,
           anything,
           'certificate.pfx',
           "#{identity} Certificate"
         )
-        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
+        subject.retrieve_cert(authenticated_client, identity, template)
       end
 
       it 'posts CertAttrib with key:value format' do
@@ -319,7 +329,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
           hash_including('vars_post' => hash_including('CertAttrib' => "CertificateTemplate:#{template}"))
         ).and_return(post_res)
         allow(subject).to receive(:send_request_raw).and_return(get_res)
-        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
+        subject.retrieve_cert(authenticated_client, identity, template)
       end
     end
   end

--- a/spec/lib/msf/core/exploit/remote/http/web_enrollment_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/http/web_enrollment_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       let(:res) { double('response', code: 200, body: 'Certificate request was denied by policy') }
 
       before do
-        allow(subject).to receive(:create_csr).and_return(csr)
+        allow(subject).to receive(:create_csr).and_return([csr, nil, {}])
         allow(subject).to receive(:send_request_raw).and_return(res)
       end
 
@@ -225,7 +225,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       let(:res) { double('response', code: 200, body: 'Certificate request failed due to an error') }
 
       before do
-        allow(subject).to receive(:create_csr).and_return(csr)
+        allow(subject).to receive(:create_csr).and_return([csr, nil, {}])
         allow(subject).to receive(:send_request_raw).and_return(res)
       end
 
@@ -239,7 +239,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       let(:res) { double('response', code: 401, body: 'Error: invalid credentials provided') }
 
       before do
-        allow(subject).to receive(:create_csr).and_return(csr)
+        allow(subject).to receive(:create_csr).and_return([csr, nil, {}])
         allow(subject).to receive(:send_request_raw).and_return(res)
       end
 
@@ -253,7 +253,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       let(:res) { double('response', code: 200, body: 'Certificate generated successfully, no location here') }
 
       before do
-        allow(subject).to receive(:create_csr).and_return(csr)
+        allow(subject).to receive(:create_csr).and_return([csr, nil, {}])
         allow(subject).to receive(:send_request_raw).and_return(res)
       end
 
@@ -287,7 +287,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       let(:get_res) { double('response', code: 200, body: certificate.to_der) }
 
       before do
-        allow(subject).to receive(:create_csr).and_return([csr, rsa_key])
+        allow(subject).to receive(:create_csr).and_return([csr, rsa_key, { 'CertificateTemplate' => template }])
         allow(subject).to receive(:send_request_raw).and_return(post_res, get_res)
         allow(subject).to receive(:store_loot).and_return('/tmp/cert.pfx')
       end
@@ -311,6 +311,14 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
           'certificate.pfx',
           "#{identity} Certificate"
         )
+        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
+      end
+
+      it 'posts CertAttrib with key:value format' do
+        expect(subject).to receive(:send_request_raw).with(
+          hash_including('vars_post' => hash_including('CertAttrib' => "CertificateTemplate:#{template}"))
+        ).and_return(post_res)
+        allow(subject).to receive(:send_request_raw).and_return(get_res)
         subject.retrieve_cert(target_ip, authenticated_client, identity, template)
       end
     end

--- a/spec/lib/msf/core/exploit/remote/http/web_enrollment_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/http/web_enrollment_spec.rb
@@ -167,6 +167,8 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
   describe '#retrieve_certs' do
     let(:authenticated_client) { double('authenticated_client') }
 
+    before { subject.instance_variable_set(:@issued_certs, {}) }
+
     it 'calls retrieve_cert for each template' do
       templates = %w[UserTemplate AdminTemplate]
       templates.each do |t|
@@ -179,6 +181,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       expect(subject).not_to receive(:retrieve_cert)
       subject.retrieve_certs('192.168.1.1', authenticated_client, 'DOMAIN\\user', [])
     end
+
+    context 'when a cert has already been issued' do
+      before { subject.add_cert_entry('DOMAIN\\user', 'UserTemplate') }
+
+      it 'skips retrieve_cert for the already-issued template' do
+        expect(subject).not_to receive(:retrieve_cert).with('192.168.1.1', authenticated_client, 'DOMAIN\\user', 'UserTemplate')
+        subject.retrieve_certs('192.168.1.1', authenticated_client, 'DOMAIN\\user', ['UserTemplate'])
+      end
+
+      it 'still calls retrieve_cert for other templates' do
+        expect(subject).to receive(:retrieve_cert).with('192.168.1.1', authenticated_client, 'DOMAIN\\user', 'AdminTemplate')
+        subject.retrieve_certs('192.168.1.1', authenticated_client, 'DOMAIN\\user', %w[UserTemplate AdminTemplate])
+      end
+    end
   end
 
   # -------------------------------------------------------------------------
@@ -189,43 +205,6 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
     let(:template) { 'UserTemplate' }
 
     before { subject.instance_variable_set(:@issued_certs, {}) }
-
-    context 'when generating the RSA key' do
-      let(:csr_double) { double('csr', to_der: 'der_bytes') }
-      let(:denied_res) { double('response', code: 200, body: 'request was denied') }
-
-      it 'uses the default key size of 2048 when RSAKeySize is blank' do
-        allow(subject).to receive(:create_csr).and_return(csr_double)
-        allow(subject).to receive(:send_request_raw).and_return(denied_res)
-        expect(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_call_original
-        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
-      end
-
-      it 'uses the RSAKeySize from the datastore when set' do
-        subject.datastore['RSAKeySize'] = '4096'
-        allow(subject).to receive(:create_csr).and_return(csr_double)
-        allow(subject).to receive(:send_request_raw).and_return(denied_res)
-        expect(OpenSSL::PKey::RSA).to receive(:new).with(4096).and_call_original
-        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
-      end
-
-      it 'passes the generated key to create_csr' do
-        generated_key = OpenSSL::PKey::RSA.new(2048)
-        allow(OpenSSL::PKey::RSA).to receive(:new).and_return(generated_key)
-        allow(subject).to receive(:send_request_raw).and_return(denied_res)
-        expect(subject).to receive(:create_csr).with(hash_including(private_key: generated_key)).and_return(csr_double)
-        subject.retrieve_cert(target_ip, authenticated_client, identity, template)
-      end
-    end
-
-    context 'when the cert has already been issued' do
-      before { subject.add_cert_entry(identity, template) }
-
-      it 'returns nil without making an HTTP request' do
-        expect(subject).not_to receive(:send_request_raw)
-        expect(subject.retrieve_cert(target_ip, authenticated_client, identity, template)).to be_nil
-      end
-    end
 
     context 'when the POST response is 200 with body containing "request was denied"' do
       let(:csr) { double('csr', to_der: 'der_bytes') }
@@ -308,10 +287,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::WebEnrollment do
       let(:get_res) { double('response', code: 200, body: certificate.to_der) }
 
       before do
-        # Force retrieve_cert to use rsa_key so the generated key matches the certificate
-        rsa_key
-        allow(OpenSSL::PKey::RSA).to receive(:new).and_return(rsa_key)
-        allow(subject).to receive(:create_csr).and_return(csr)
+        allow(subject).to receive(:create_csr).and_return([csr, rsa_key])
         allow(subject).to receive(:send_request_raw).and_return(post_res, get_res)
         allow(subject).to receive(:store_loot).and_return('/tmp/cert.pfx')
       end

--- a/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
 
     context 'when the cert has the NTDS CA security extension' do
       it 'returns the SID string' do
-        ntds_ext = OpenSSL::X509::Extension.new(Msf::Exploit::Remote::CertRequest::OID_NTDS_CA_SECURITY_EXT, ntds_ext_der, false)
+        ntds_ext = OpenSSL::X509::Extension.new(Rex::Proto::X509::OID_NTDS_CA_SECURITY_EXT, ntds_ext_der, false)
         cert = build_test_cert(rsa_key, extensions: [ntds_ext])
         expect(subject.get_cert_msext_sid(cert)).to eq('S-1-5-21-3402587289-1488798532-3618296993-1105')
       end
@@ -219,7 +219,7 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
           type_id: '1.2.3.4.5',
           value: 'S-1-5-21-0-0-0-0'
         }).to_der
-        ntds_ext = OpenSSL::X509::Extension.new(Msf::Exploit::Remote::CertRequest::OID_NTDS_CA_SECURITY_EXT, bogus_ext_der, false)
+        ntds_ext = OpenSSL::X509::Extension.new(Rex::Proto::X509::OID_NTDS_CA_SECURITY_EXT, bogus_ext_der, false)
         cert = build_test_cert(rsa_key, extensions: [ntds_ext])
         expect(subject.get_cert_msext_sid(cert)).to be_nil
       end

--- a/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
@@ -302,46 +302,10 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
     end
 
     context 'RSA key generation' do
-      it 'generates a 2048-bit key by default' do
-        expect(OpenSSL::PKey::RSA).to receive(:new).with(2048).and_return(rsa_key)
-        subject.send(:do_request_cert, icpr, { username: 'alice' })
-      end
-
-      it 'uses the RSAKeySize from the datastore' do
-        subject.datastore['RSAKeySize'] = '4096'
-        allow(rsa_key).to receive(:n).and_return(double('OpenSSL::BN', num_bits: 4096))
-        expect(OpenSSL::PKey::RSA).to receive(:new).with(4096).and_return(rsa_key)
-        subject.send(:do_request_cert, icpr, { username: 'alice' })
-      end
-
       it 'uses a private key supplied in opts without generating one' do
         rsa_key # force let evaluation before stubbing
         expect(OpenSSL::PKey::RSA).not_to receive(:new)
         subject.send(:do_request_cert, icpr, { username: 'alice', private_key: rsa_key })
-      end
-
-      it 'passes the key to create_csr via opts' do
-        allow(OpenSSL::PKey::RSA).to receive(:new).and_return(rsa_key)
-        expect(subject).to receive(:create_csr).with(hash_including(private_key: rsa_key))
-        subject.send(:do_request_cert, icpr, { username: 'alice' })
-      end
-    end
-
-    context 'key size mismatch' do
-      let(:wrong_size_key) { OpenSSL::PKey::RSA.new(1024) }
-
-      it 'raises ArgumentError' do
-        expect { subject.send(:do_request_cert, icpr, { username: 'alice', private_key: wrong_size_key }) }.to raise_error(ArgumentError, /RSA key size mismatch/)
-      end
-
-      it 'logs an RSA key size mismatch error' do
-        expect(subject).to receive(:elog).with('RSA key size mismatch')
-        expect { subject.send(:do_request_cert, icpr, { username: 'alice', private_key: wrong_size_key }) }.to raise_error(ArgumentError)
-      end
-
-      it 'does not call create_csr' do
-        expect(subject).not_to receive(:create_csr)
-        expect { subject.send(:do_request_cert, icpr, { username: 'alice', private_key: wrong_size_key }) }.to raise_error(ArgumentError)
       end
     end
 

--- a/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
     let(:csr_double) { double('csr', to_der: 'der') }
 
     before do
-      allow(subject).to receive(:create_csr).and_return(csr_double)
+      allow(subject).to receive(:create_csr).and_return([csr_double, rsa_key, {}])
       allow(icpr).to receive(:cert_server_request).and_return({ status: :issued })
     end
 
@@ -309,57 +309,12 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
       end
     end
 
-    context 'certificate template' do
-      it 'uses cert_template from opts' do
-        expect(icpr).to receive(:cert_server_request).with(hash_including(
-          attributes: hash_including('CertificateTemplate' => 'AdminTemplate')
-        ))
-        subject.send(:do_request_cert, icpr, { username: 'alice', private_key: rsa_key, cert_template: 'AdminTemplate' })
-      end
-
-      it 'falls back to datastore CERT_TEMPLATE' do
-        subject.datastore['CERT_TEMPLATE'] = 'UserTemplate'
-        expect(icpr).to receive(:cert_server_request).with(hash_including(
-          attributes: hash_including('CertificateTemplate' => 'UserTemplate')
-        ))
-        subject.send(:do_request_cert, icpr, { username: 'alice', private_key: rsa_key })
-      end
-    end
-
-    context 'SAN attributes' do
-      it 'includes dns SAN when alt_dns is in opts' do
-        expect(icpr).to receive(:cert_server_request).with(hash_including(
-          attributes: hash_including('SAN' => 'dns=host.example.com')
-        ))
-        subject.send(:do_request_cert, icpr, { username: 'alice', private_key: rsa_key, alt_dns: 'host.example.com' })
-      end
-
-      it 'includes upn SAN when alt_upn is in opts' do
-        expect(icpr).to receive(:cert_server_request).with(hash_including(
-          attributes: hash_including('SAN' => 'upn=alice@example.com')
-        ))
-        subject.send(:do_request_cert, icpr, { username: 'alice', private_key: rsa_key, alt_upn: 'alice@example.com' })
-      end
-
-      it 'includes both dns and upn SANs when both are set' do
-        expect(icpr).to receive(:cert_server_request) do |args|
-          san = args[:attributes]['SAN']
-          expect(san).to include('dns=host.example.com')
-          expect(san).to include('upn=alice@example.com')
-          { status: :issued }
-        end
-        subject.send(:do_request_cert, icpr, {
-          username: 'alice', private_key: rsa_key,
-          alt_dns: 'host.example.com', alt_upn: 'alice@example.com'
-        })
-      end
-
-      it 'omits SAN attribute entirely when no alt values are set' do
-        expect(icpr).to receive(:cert_server_request) do |args|
-          expect(args[:attributes]).not_to have_key('SAN')
-          { status: :issued }
-        end
-        subject.send(:do_request_cert, icpr, { username: 'alice', private_key: rsa_key })
+    context 'attributes pass-through' do
+      it 'passes the attributes hash from create_csr directly to cert_server_request' do
+        attrs = { 'CertificateTemplate' => 'TestTemplate', 'SAN' => 'upn=alice@example.com' }
+        allow(subject).to receive(:create_csr).and_return([csr_double, rsa_key, attrs])
+        expect(icpr).to receive(:cert_server_request).with(hash_including(attributes: attrs))
+        subject.send(:do_request_cert, icpr, { username: 'alice' })
       end
     end
   end

--- a/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
@@ -58,107 +58,107 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
   end
 
   # -------------------------------------------------------------------------
-  describe '.get_cert_san' do
+  describe '#get_cert_san' do
     context 'when the cert has no subjectAltName extension' do
       it 'returns nil' do
         cert = build_test_cert(rsa_key)
-        expect(described_class.get_cert_san(cert)).to be_nil
+        expect(subject.get_cert_san(cert)).to be_nil
       end
     end
 
     context 'when the cert has a subjectAltName extension' do
       it 'returns a SubjectAltName object' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com')])
-        expect(described_class.get_cert_san(cert)).to be_a(Rex::Proto::CryptoAsn1::X509::SubjectAltName)
+        expect(subject.get_cert_san(cert)).to be_a(Rex::Proto::CryptoAsn1::X509::SubjectAltName)
       end
     end
   end
 
   # -------------------------------------------------------------------------
-  describe '.get_cert_san_dns' do
+  describe '#get_cert_san_dns' do
     context 'when the cert has no subjectAltName' do
       it 'returns an empty array' do
         cert = build_test_cert(rsa_key)
-        expect(described_class.get_cert_san_dns(cert)).to eq([])
+        expect(subject.get_cert_san_dns(cert)).to eq([])
       end
     end
 
     context 'when the cert has a single DNS SAN' do
       it 'returns the DNS name' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com')])
-        expect(described_class.get_cert_san_dns(cert)).to eq(['host.example.com'])
+        expect(subject.get_cert_san_dns(cert)).to eq(['host.example.com'])
       end
     end
 
     context 'when the cert has multiple DNS SANs' do
       it 'returns all DNS names' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com, DNS:other.example.com')])
-        expect(described_class.get_cert_san_dns(cert)).to contain_exactly('host.example.com', 'other.example.com')
+        expect(subject.get_cert_san_dns(cert)).to contain_exactly('host.example.com', 'other.example.com')
       end
     end
 
     context 'when the SAN contains a mix of DNS and non-DNS entries' do
       it 'returns only the DNS names' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com, email:alice@example.com')])
-        expect(described_class.get_cert_san_dns(cert)).to eq(['host.example.com'])
+        expect(subject.get_cert_san_dns(cert)).to eq(['host.example.com'])
       end
     end
   end
 
   # -------------------------------------------------------------------------
-  describe '.get_cert_san_email' do
+  describe '#get_cert_san_email' do
     context 'when the cert has no subjectAltName' do
       it 'returns an empty array' do
         cert = build_test_cert(rsa_key)
-        expect(described_class.get_cert_san_email(cert)).to eq([])
+        expect(subject.get_cert_san_email(cert)).to eq([])
       end
     end
 
     context 'when the cert has an email SAN' do
       it 'returns the email address' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('email:alice@example.com')])
-        expect(described_class.get_cert_san_email(cert)).to eq(['alice@example.com'])
+        expect(subject.get_cert_san_email(cert)).to eq(['alice@example.com'])
       end
     end
 
     context 'when the SAN contains a mix of email and non-email entries' do
       it 'returns only email addresses' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com, email:alice@example.com')])
-        expect(described_class.get_cert_san_email(cert)).to eq(['alice@example.com'])
+        expect(subject.get_cert_san_email(cert)).to eq(['alice@example.com'])
       end
     end
   end
 
   # -------------------------------------------------------------------------
-  describe '.get_cert_san_uri' do
+  describe '#get_cert_san_uri' do
     context 'when the cert has no subjectAltName' do
       it 'returns an empty array' do
         cert = build_test_cert(rsa_key)
-        expect(described_class.get_cert_san_uri(cert)).to eq([])
+        expect(subject.get_cert_san_uri(cert)).to eq([])
       end
     end
 
     context 'when the cert has a URI SAN' do
       it 'returns the URI' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('URI:http://example.com')])
-        expect(described_class.get_cert_san_uri(cert)).to eq(['http://example.com'])
+        expect(subject.get_cert_san_uri(cert)).to eq(['http://example.com'])
       end
     end
 
     context 'when the SAN contains a mix of URI and non-URI entries' do
       it 'returns only URIs' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com, URI:http://example.com')])
-        expect(described_class.get_cert_san_uri(cert)).to eq(['http://example.com'])
+        expect(subject.get_cert_san_uri(cert)).to eq(['http://example.com'])
       end
     end
   end
 
   # -------------------------------------------------------------------------
-  describe '.get_cert_msext_upn' do
+  describe '#get_cert_msext_upn' do
     context 'when the cert has no subjectAltName' do
       it 'returns an empty array' do
         cert = build_test_cert(rsa_key)
-        expect(described_class.get_cert_msext_upn(cert)).to eq([])
+        expect(subject.get_cert_msext_upn(cert)).to eq([])
       end
     end
 
@@ -166,7 +166,7 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
       it 'returns the UPN value' do
         config = "[alt_names]\notherName = 1.3.6.1.4.1.311.20.2.3;UTF8:alice@example.com"
         cert = build_test_cert(rsa_key, extensions: [san_extension_from_config(config)])
-        expect(described_class.get_cert_msext_upn(cert)).to eq(['alice@example.com'])
+        expect(subject.get_cert_msext_upn(cert)).to eq(['alice@example.com'])
       end
     end
 
@@ -174,20 +174,20 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
       it 'returns an empty array' do
         config = "[alt_names]\notherName = 1.3.6.1.4.1.311.20.2.99;UTF8:notaupn"
         cert = build_test_cert(rsa_key, extensions: [san_extension_from_config(config)])
-        expect(described_class.get_cert_msext_upn(cert)).to eq([])
+        expect(subject.get_cert_msext_upn(cert)).to eq([])
       end
     end
 
     context 'when the SAN contains only a DNS entry' do
       it 'returns an empty array' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com')])
-        expect(described_class.get_cert_msext_upn(cert)).to eq([])
+        expect(subject.get_cert_msext_upn(cert)).to eq([])
       end
     end
   end
 
   # -------------------------------------------------------------------------
-  describe '.get_cert_msext_sid' do
+  describe '#get_cert_msext_sid' do
     # Known DER encoding from spec/lib/rex/proto/crypto_asn1_spec.rb
     # Contains SID "S-1-5-21-3402587289-1488798532-3618296993-1105"
     let(:ntds_ext_der) do
@@ -200,15 +200,15 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
     context 'when the cert has no NTDS CA security extension' do
       it 'returns nil' do
         cert = build_test_cert(rsa_key)
-        expect(described_class.get_cert_msext_sid(cert)).to be_nil
+        expect(subject.get_cert_msext_sid(cert)).to be_nil
       end
     end
 
     context 'when the cert has the NTDS CA security extension' do
       it 'returns the SID string' do
-        ntds_ext = OpenSSL::X509::Extension.new(described_class::OID_NTDS_CA_SECURITY_EXT, ntds_ext_der, false)
+        ntds_ext = OpenSSL::X509::Extension.new(Msf::Exploit::Remote::CertRequest::OID_NTDS_CA_SECURITY_EXT, ntds_ext_der, false)
         cert = build_test_cert(rsa_key, extensions: [ntds_ext])
-        expect(described_class.get_cert_msext_sid(cert)).to eq('S-1-5-21-3402587289-1488798532-3618296993-1105')
+        expect(subject.get_cert_msext_sid(cert)).to eq('S-1-5-21-3402587289-1488798532-3618296993-1105')
       end
     end
 
@@ -219,15 +219,15 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
           type_id: '1.2.3.4.5',
           value: 'S-1-5-21-0-0-0-0'
         }).to_der
-        ntds_ext = OpenSSL::X509::Extension.new(described_class::OID_NTDS_CA_SECURITY_EXT, bogus_ext_der, false)
+        ntds_ext = OpenSSL::X509::Extension.new(Msf::Exploit::Remote::CertRequest::OID_NTDS_CA_SECURITY_EXT, bogus_ext_der, false)
         cert = build_test_cert(rsa_key, extensions: [ntds_ext])
-        expect(described_class.get_cert_msext_sid(cert)).to be_nil
+        expect(subject.get_cert_msext_sid(cert)).to be_nil
       end
     end
   end
 
   # -------------------------------------------------------------------------
-  describe '.get_cert_policy_oids' do
+  describe '#get_cert_policy_oids' do
     let(:eku_extension) do
       stub = OpenSSL::X509::Certificate.new
       factory = OpenSSL::X509::ExtensionFactory.new
@@ -247,14 +247,14 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
     context 'when the cert has no policy extensions' do
       it 'returns an empty array' do
         cert = build_test_cert(rsa_key)
-        expect(described_class.get_cert_policy_oids(cert)).to eq([])
+        expect(subject.get_cert_policy_oids(cert)).to eq([])
       end
     end
 
     context 'when the cert has extendedKeyUsage with clientAuth' do
       it 'includes the clientAuth OID' do
         cert = build_test_cert(rsa_key, extensions: [eku_extension])
-        oids = described_class.get_cert_policy_oids(cert)
+        oids = subject.get_cert_policy_oids(cert)
         # OpenSSL returns the short name ('clientAuth') when parsing EKU DER
         expect(oids.map(&:value)).to include('clientAuth')
       end
@@ -263,7 +263,7 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
     context 'when the cert has multiple EKU OIDs' do
       it 'returns all OIDs' do
         cert = build_test_cert(rsa_key, extensions: [multi_eku_extension])
-        oid_values = described_class.get_cert_policy_oids(cert).map(&:value)
+        oid_values = subject.get_cert_policy_oids(cert).map(&:value)
         # OpenSSL returns short names when parsing EKU DER
         expect(oid_values).to include('clientAuth')
         expect(oid_values).to include('emailProtection')
@@ -273,7 +273,7 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
     context 'when the cert has a SAN extension but no policy extensions' do
       it 'returns an empty array' do
         cert = build_test_cert(rsa_key, extensions: [san_extension('DNS:host.example.com')])
-        expect(described_class.get_cert_policy_oids(cert)).to eq([])
+        expect(subject.get_cert_policy_oids(cert)).to eq([])
       end
     end
   end
@@ -281,40 +281,74 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
   # -------------------------------------------------------------------------
   describe '#do_request_cert' do
     let(:icpr) { double('icpr') }
-    let(:csr_double) { double('csr', to_der: 'der') }
+    let(:csr_double) { double('csr') }
+    let(:attributes) { { 'CertificateTemplate' => 'UserTemplate' } }
+    let(:certificate) { double('certificate') }
 
     before do
-      allow(subject).to receive(:create_csr).and_return([csr_double, rsa_key, {}])
-      allow(icpr).to receive(:cert_server_request).and_return({ status: :issued })
+      subject.datastore['CA'] = 'MyCA'
     end
 
-    context 'username resolution' do
-      it 'uses opts[:username] when provided' do
-        expect(subject).to receive(:create_csr).with(hash_including(username: 'alice'))
-        subject.send(:do_request_cert, icpr, { username: 'alice' })
+    context 'when the certificate is issued' do
+      before do
+        allow(icpr).to receive(:cert_server_request).and_return({ status: :issued, certificate: certificate })
       end
 
-      it 'falls back to datastore SMBUser when opts has no username' do
-        subject.datastore['SMBUser'] = 'bob'
-        expect(subject).to receive(:create_csr).with(hash_including(username: 'bob'))
-        subject.send(:do_request_cert, icpr, {})
+      it 'passes csr, attributes, and CA authority to cert_server_request' do
+        expect(icpr).to receive(:cert_server_request).with(
+          attributes: attributes,
+          authority: 'MyCA',
+          csr: csr_double
+        )
+        subject.send(:do_request_cert, icpr, {}, csr_double, attributes)
       end
-    end
 
-    context 'RSA key generation' do
-      it 'uses a private key supplied in opts without generating one' do
-        rsa_key # force let evaluation before stubbing
-        expect(OpenSSL::PKey::RSA).not_to receive(:new)
-        subject.send(:do_request_cert, icpr, { username: 'alice', private_key: rsa_key })
+      it 'returns the certificate' do
+        result = subject.send(:do_request_cert, icpr, {}, csr_double, attributes)
+        expect(result).to eq(certificate)
       end
     end
 
     context 'attributes pass-through' do
-      it 'passes the attributes hash from create_csr directly to cert_server_request' do
-        attrs = { 'CertificateTemplate' => 'TestTemplate', 'SAN' => 'upn=alice@example.com' }
-        allow(subject).to receive(:create_csr).and_return([csr_double, rsa_key, attrs])
-        expect(icpr).to receive(:cert_server_request).with(hash_including(attributes: attrs))
-        subject.send(:do_request_cert, icpr, { username: 'alice' })
+      it 'passes the attributes hash directly to cert_server_request' do
+        custom_attrs = { 'CertificateTemplate' => 'TestTemplate', 'SAN' => 'upn=alice@example.com' }
+        allow(icpr).to receive(:cert_server_request).and_return({ status: :issued, certificate: certificate })
+        expect(icpr).to receive(:cert_server_request).with(hash_including(attributes: custom_attrs))
+        subject.send(:do_request_cert, icpr, {}, csr_double, custom_attrs)
+      end
+    end
+
+    context 'when the certificate request is denied (CERTSRV_E_ENROLL_DENIED)' do
+      let(:hresult) { ::WindowsError::HResult::CERTSRV_E_ENROLL_DENIED }
+
+      before do
+        allow(icpr).to receive(:cert_server_request).and_return({
+          status: :error,
+          disposition: hresult.value,
+          disposition_message: hresult.description
+        })
+      end
+
+      it 'raises MsIcprAuthorizationError' do
+        expect { subject.send(:do_request_cert, icpr, {}, csr_double, attributes) }
+          .to raise_error(described_class::MsIcprAuthorizationError)
+      end
+    end
+
+    context 'when the certificate template is not found (CERTSRV_E_UNSUPPORTED_CERT_TYPE)' do
+      let(:hresult) { ::WindowsError::HResult::CERTSRV_E_UNSUPPORTED_CERT_TYPE }
+
+      before do
+        allow(icpr).to receive(:cert_server_request).and_return({
+          status: :error,
+          disposition: hresult.value,
+          disposition_message: hresult.description
+        })
+      end
+
+      it 'raises MsIcprNotFoundError' do
+        expect { subject.send(:do_request_cert, icpr, {}, csr_double, attributes) }
+          .to raise_error(described_class::MsIcprNotFoundError)
       end
     end
   end
@@ -324,10 +358,15 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
     let(:tree) { double('RubySMB::SMB2::Tree') }
     let(:icpr) { double('icpr') }
 
+    let(:smb_client) { double('smb_client', default_domain: 'EXAMPLE') }
+    let(:simple) { double('simple', client: smb_client) }
+
     before do
       allow(subject).to receive(:connect_ipc).and_return(tree)
       allow(subject).to receive(:connect_icpr).with(tree).and_return(icpr)
       allow(subject).to receive(:do_request_cert)
+      allow(subject).to receive(:simple).and_return(simple)
+      allow(subject).to receive(:report_icertpassage_service).and_return({})
     end
 
     it 'calls connect_ipc when no tree is given' do

--- a/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ms_icpr_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
   end
 
   # -------------------------------------------------------------------------
-  describe '#request_certificate' do
+  describe '#icpr_request_certificate' do
     let(:tree) { double('RubySMB::SMB2::Tree') }
     let(:icpr) { double('icpr') }
 
@@ -332,12 +332,12 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
 
     it 'calls connect_ipc when no tree is given' do
       expect(subject).to receive(:connect_ipc).and_return(tree)
-      subject.request_certificate
+      subject.icpr_request_certificate
     end
 
     it 'uses the tree from opts and skips connect_ipc' do
       expect(subject).not_to receive(:connect_ipc)
-      subject.request_certificate(tree: tree)
+      subject.icpr_request_certificate(tree: tree)
     end
 
     context 'when connect_icpr raises UnexpectedStatusCode with STATUS_OBJECT_NAME_NOT_FOUND' do
@@ -349,11 +349,11 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
       end
 
       it 'raises MsIcprNotFoundError' do
-        expect { subject.request_certificate }.to raise_error(described_class::MsIcprNotFoundError)
+        expect { subject.icpr_request_certificate }.to raise_error(described_class::MsIcprNotFoundError)
       end
 
       it 'includes a descriptive message' do
-        expect { subject.request_certificate }.to raise_error(described_class::MsIcprNotFoundError, /AD CS was not found/i)
+        expect { subject.icpr_request_certificate }.to raise_error(described_class::MsIcprNotFoundError, /AD CS was not found/i)
       end
     end
 
@@ -365,11 +365,11 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
       end
 
       it 'raises MsIcprUnexpectedReplyError' do
-        expect { subject.request_certificate }.to raise_error(described_class::MsIcprUnexpectedReplyError)
+        expect { subject.icpr_request_certificate }.to raise_error(described_class::MsIcprUnexpectedReplyError)
       end
 
       it 'includes the status name in the message' do
-        expect { subject.request_certificate }.to raise_error(
+        expect { subject.icpr_request_certificate }.to raise_error(
           described_class::MsIcprUnexpectedReplyError, /STATUS_ACCESS_DENIED/
         )
       end
@@ -383,11 +383,11 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
       end
 
       it 'raises MsIcprUnexpectedReplyError' do
-        expect { subject.request_certificate }.to raise_error(described_class::MsIcprUnexpectedReplyError)
+        expect { subject.icpr_request_certificate }.to raise_error(described_class::MsIcprUnexpectedReplyError)
       end
 
       it 'includes DCERPC fault in the message' do
-        expect { subject.request_certificate }.to raise_error(
+        expect { subject.icpr_request_certificate }.to raise_error(
           described_class::MsIcprUnexpectedReplyError, /DCERPC fault/i
         )
       end
@@ -401,11 +401,11 @@ RSpec.describe Msf::Exploit::Remote::MsIcpr do
       end
 
       it 'raises MsIcprUnexpectedReplyError' do
-        expect { subject.request_certificate }.to raise_error(described_class::MsIcprUnexpectedReplyError)
+        expect { subject.icpr_request_certificate }.to raise_error(described_class::MsIcprUnexpectedReplyError)
       end
 
       it 'preserves the original error message' do
-        expect { subject.request_certificate }.to raise_error(
+        expect { subject.icpr_request_certificate }.to raise_error(
           described_class::MsIcprUnexpectedReplyError, /generic dcerpc failure/
         )
       end


### PR DESCRIPTION
This makes some changes to the new certificate request API added by #20752.

There's a new `with_adcs_certificate_request` method that's now used by both the MsIcpr and WebEnrollment mixins. This method abstracts away the enrollment process and takes a block that performs the actual request. The result is consolidation of messages that are printed to the user and more importantly, post-processing of the successfully issued certificate (assuming the happy path is taken). The post processing includes logging the certificate as a credential which the original WebEnrollment method did not do. Now when users issue certificates with one of the two WebEnrollment methods, a corresponding credential will be added. The service data needs to be updated once the pattern from #21031 is adopted.

This also makes a change to `HttpClient#connect` to fetch the username / password options from the hash even when they're `nil`. This resolves [this comment](https://github.com/rapid7/metasploit-framework/pull/20752#discussion_r3034454867) about needing to swap values in the datastore.

Also updates the credential's reported info to be the UPN when it's present.

Also fixes kerberos authentication for the `auxiliary/admin/http/web_enrollment_cert` module.

Requires:

* rapid7/metasploit-credential#197

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use the web enrollment module with a database connected
- [ ] See that kerberos authentication works with the web enrollment module
- [ ] See values extracted from the certificate when it's successfully issued like the UPN, SAN, SID, etc.
- [ ] See that an entry is added to `creds`
- [ ] See that icpr_cert still works

## Demo
The output is now much more consistent between the two modules and additional information is displayed to the user.
New output

```
msf auxiliary(admin/http/web_enrollment_cert) > run
[*] Checking 192.168.159.10 URL /certsrv/
[*] Building a certificate signing request for user aliddle - RSA key size: 2048 - digest algorithm: SHA256 - template: User
[*] Submitting the certificate signing request to the target...
[+] 192.168.159.10:88 - Received a valid TGT-Response
[*] 192.168.159.10:443    - TGT MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20260408173231_default_192.168.159.10_mit.kerberos.cca_619961.bin
[+] 192.168.159.10:88 - Received a valid TGS-Response
[*] 192.168.159.10:443    - TGS MIT Credential Cache ticket saved to /home/smcintyre/.msf4/loot/20260408173231_default_192.168.159.10_mit.kerberos.cca_333970.bin
[+] 192.168.159.10:88 - Received a valid delegation TGS-Response
[+] Certificate generated using template User for MSFLAB\aliddle
[*] Attempting to download the certificate from /certsrv/certnew.cer?ReqID=225&
[*] Using cached credential for http/dc.msflab.local@MSFLAB.LOCAL aliddle@MSFLAB.LOCAL
[*] Certificate Policies:
[*]   * msEFS
[*]   * emailProtection
[*]   * clientAuth
[*] Certificate Email: aliddle@msflab.local
[*] Certificate SID: S-1-5-21-3978004297-3499718965-4169012971-2102
[*] Certificate UPN: aliddle@msflab.local
[*] Certificate stored at: /home/smcintyre/.msf4/loot/20260408173231_default_192.168.159.10_windows.ad.cs_635823.pfx
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(admin/http/web_enrollment_cert) > creds
Credentials
===========

id   host            origin          service                         public   private                                                                                   realm         private_type  JtR Format  cracked_password
--   ----            ------          -------                         ------   -------                                                                                   -----         ------------  ----------  ----------------
298  192.168.159.10  192.168.159.10  443/tcp (ad cs web enrollment)  aliddle  subject:/DC=local/DC=msflab/CN=Users/CN=Alice Liddle/emailAddress=aliddle@ms (TRUNCATED)  msflab.local  Pkcs12 (pfx)

msf auxiliary(admin/http/web_enrollment_cert) >
```

Old
```
msf auxiliary(admin/http/web_enrollment_cert) > run
[*] Checking 192.168.159.10 URL /certsrv/
[*] Creating certificate request for MSFLAB\aliddle using the User template
[*] RSA key size: 2048
[*] Requesting a certificate for user aliddle - digest algorithm: SHA256
[*] Requesting target generate certificate...
[+] Certificate generated using template User and MSFLAB\aliddle
[*] Attempting to download the certificate from /certsrv/certnew.cer?ReqID=199&
[+] Certificate using template User saved to /home/smcintyre/.msf4/loot/20260407163637_default_192.168.159.10_windows.ad.cs_264913.pfx
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(admin/http/web_enrollment_cert) > creds
Credentials
===========

id  host  origin  service  public  private  realm  private_type  JtR Format  cracked_password
--  ----  ------  -------  ------  -------  -----  ------------  ----------  ----------------

msf auxiliary(admin/http/web_enrollment_cert) >
```