### PR TITLE
Update nmap_document to properly import hostnames from nmap scans

### DIFF
--- a/lib/rex/parser/nmap_document.rb
+++ b/lib/rex/parser/nmap_document.rb
@@ -154,8 +154,19 @@ module Rex
 
     def record_hostname(attrs)
       return unless in_tag("host")
-      if attr_hash(attrs)["type"] == "PTR"
-        @state[:hostname] = attr_hash(attrs)["name"]
+      hash = attr_hash(attrs)
+      name = hash["name"]
+      return if name.nil? || name.empty?
+      # Prefer PTR (reverse-DNS) hostnames, but fall back to user-supplied
+      # hostnames so scans driven by `nmap -iL hostnames.txt` still populate
+      # the hostname column. Once a PTR is recorded for the current host it
+      # is never downgraded back to a user-supplied entry.
+      if hash["type"] == "PTR"
+        @state[:hostname] = name
+        @state[:hostname_type] = "PTR"
+      elsif @state[:hostname_type] != "PTR"
+        @state[:hostname] = name
+        @state[:hostname_type] = hash["type"]
       end
     end
 

--- a/lib/rex/parser/nmap_document.rb
+++ b/lib/rex/parser/nmap_document.rb
@@ -163,6 +163,8 @@ module Rex
       # is never downgraded back to a user-supplied entry.
       if hash["type"] == "PTR"
         @state[:hostname] = name
+      elsif @state[:hostname].nil?
+        @state[:hostname] = name
       end
     end
 

--- a/lib/rex/parser/nmap_document.rb
+++ b/lib/rex/parser/nmap_document.rb
@@ -163,10 +163,6 @@ module Rex
       # is never downgraded back to a user-supplied entry.
       if hash["type"] == "PTR"
         @state[:hostname] = name
-        @state[:hostname_type] = "PTR"
-      elsif @state[:hostname_type] != "PTR"
-        @state[:hostname] = name
-        @state[:hostname_type] = hash["type"]
       end
     end
 


### PR DESCRIPTION
Nokogiri SAX importer only captures PTR entries and silently drops user-type ones, so any scan whose targets came from a hostname list loses its hostnames unless DNS also produced a PTR record.

This update will import hostnames supplied by user to nmap for scanning, even if a PTR record is unavailable.