### PR TITLE
Various search improvements

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -416,7 +416,7 @@ module Msf
               'rank'                 => 'Sort modules by their exploitability rank',
               'date'                 => 'Sort modules by their disclosure date. Alias for disclosure_date',
               'disclosure_date'      => 'Sort modules by their disclosure date',
-              'name'                 => 'Sort modules by their name',
+              'name'                 => 'Sort modules by their descriptive name (title)',
               'type'                 => 'Sort modules by their type',
               'check'                => 'Sort modules by whether or not they have a check method',
               'action'                => 'Sort modules by whether or not they have actions',
@@ -1813,11 +1813,11 @@ module Msf
                 'WordWrap' => false,
                 'Columns' => [
                   '#',
-                  'Name',
+                  'Full Name',
                   'Disclosure Date',
                   'Rank',
                   'Check',
-                  'Description'
+                  'Name'
                 ],
                 'ColProps' => {
                   'Rank' => {
@@ -1829,7 +1829,7 @@ module Msf
                       Msf::Ui::Console::TablePrint::RankStyler.new
                     ]
                   },
-                  'Name' => {
+                  'Full Name' => {
                     'Strip' => false,
                     'Stylers' => [Msf::Ui::Console::TablePrint::HighlightSubstringStyler.new(search_terms)]
                   },
@@ -1843,7 +1843,7 @@ module Msf
                       *table_hierarchy_formatters,
                     ]
                   },
-                  'Description' => {
+                  'Name' => {
                     'Stylers' => [
                       Msf::Ui::Console::TablePrint::HighlightSubstringStyler.new(search_terms)
                     ]

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -23,7 +23,7 @@ module Msf
             ['-u', '--use']             => [false, 'Use module if there is one result'],
             ['-s', '--sort-ascending']  => [true,  'Sort search results by the specified column in ascending order', '<column>'],
             ['-r', '--sort-descending'] => [false, 'Reverse the order of search results to descending order'],
-            ['-c', '--show-child']      => [true,  'How to display child items. Always hide, always show, show when matched (hide, show, matched)', '<mode>']
+            ['-c', '--hide-child']      => [false, 'Hide child items such as actions, targets and akas (default: show)']
           )
 
           @@favorite_opts = Rex::Parser::Arguments.new(
@@ -456,7 +456,7 @@ module Msf
             sort_attribute = framework.datastore['SearchSort'] || 'name'
             valid_sort_attributes = ['rank', 'date', 'disclosure_date', 'fullname', 'name', 'type', 'check', 'action']
             child_mode = framework.datastore['SearchChildMode'] || 'show'
-            valid_child_mode = ['hide','show','matched']
+            valid_child_mode = ['hide','show']
             reverse_sort = false
             ignore_use_exact_match = false
 
@@ -478,7 +478,7 @@ module Msf
               when '-r'
                 reverse_sort = true
               when '-c'
-                child_mode = val
+                child_mode = 'hide'
               else
                 match += val + ' '
               end
@@ -573,11 +573,6 @@ module Msf
 
                   if (m.actions&.length || 0) > 1
                     m.actions.each do |action|
-                      next if child_mode == 'matched' &&
-                              !(
-                                action['name'].to_s.strip.downcase.include?(match.to_s.strip.downcase) ||
-                                action['description'].to_s.strip.downcase.include?(match.to_s.strip.downcase)
-                              )
                       @module_search_results_with_usage_metadata << { mod: m, datastore: { 'ACTION' => action['name'] } }
                       count += 1
                       tbl << [
@@ -593,7 +588,6 @@ module Msf
 
                   if (m.targets&.length || 0) > 1
                     m.targets.each do |target|
-                      next if child_mode == 'matched' && !target.to_s.strip.downcase.include?(match.to_s.strip.downcase)
                       @module_search_results_with_usage_metadata << { mod: m, datastore: { 'TARGET' => target } }
                       count += 1
                       tbl << [
@@ -609,7 +603,6 @@ module Msf
 
                   if (m.notes&.[]('AKA')&.length || 0) > 1
                     m.notes['AKA'].each do |aka|
-                      next if child_mode == 'matched' && !aka.to_s.strip.downcase.include?(match.to_s.strip.downcase)
                       @module_search_results_with_usage_metadata << { mod: m }
                       count += 1
                       tbl << [

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -435,7 +435,7 @@ module Msf
             print_line "Global Settings For Search Results:"
             {
               'SearchSort'         => 'Set the default sort order (-s)',
-              'SearchChildMode'    => 'Set the default for displaying child items (-c)',
+              'SearchChildMode'    => 'Set the default for displaying child items. Supported options are: "hide" or "show" (-c). ',
             }.each_pair do |keyword, description|
               print_line "  #{keyword.ljust 17}:  #{description}"
             end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -22,7 +22,8 @@ module Msf
             ['-S', '--filter']          => [true,  'Regex pattern used to filter search results', '<filter>'],
             ['-u', '--use']             => [false, 'Use module if there is one result'],
             ['-s', '--sort-ascending']  => [true,  'Sort search results by the specified column in ascending order', '<column>'],
-            ['-r', '--sort-descending'] => [true,  'Reverse the order of search results to descending order', '<column>']
+            ['-r', '--sort-descending'] => [true,  'Reverse the order of search results to descending order', '<column>'],
+            ['-c', '--show-child']      => [true,  'How to display child items. Always hide, always show, show when matched (hide, show, matched)', '<mode>']
           )
 
           @@favorite_opts = Rex::Parser::Arguments.new(
@@ -445,6 +446,8 @@ module Msf
             search_terms = []
             sort_attribute  = 'name'
             valid_sort_attributes = ['rank', 'date', 'disclosure_date', 'name', 'type', 'check', 'action']
+            child_mode = 'show'
+            valid_child_mode = ['hide','show','matched']
             reverse_sort = false
             ignore_use_exact_match = false
 
@@ -465,6 +468,8 @@ module Msf
                 sort_attribute = val
               when '-r'
                 reverse_sort = true
+              when '-c'
+                child_mode = val
               else
                 match += val + ' '
               end
@@ -481,6 +486,11 @@ module Msf
 
             if sort_attribute && !valid_sort_attributes.include?(sort_attribute)
               print_error("Supported options for the -s flag are: #{valid_sort_attributes}")
+              return false
+            end
+
+            if child_mode && !valid_child_mode.include?(child_mode)
+              print_error("Supported options for the -c flag are: #{valid_child_mode}")
               return false
             end
 
@@ -542,7 +552,7 @@ module Msf
                   m.name,
                 ]
 
-                if framework.features.enabled?(Msf::FeatureManager::HIERARCHICAL_SEARCH_TABLE)
+                if framework.features.enabled?(Msf::FeatureManager::HIERARCHICAL_SEARCH_TABLE) && child_mode != 'hide'
                   total_children_rows = (m.actions&.length || 0) + (m.targets&.length || 0) + (m.notes&.[]('AKA')&.length || 0)
                   show_child_items = total_children_rows > 1
                   next unless show_child_items
@@ -554,6 +564,11 @@ module Msf
 
                   if (m.actions&.length || 0) > 1
                     m.actions.each do |action|
+                      next if child_mode == 'matched' &&
+                              !(
+                                action['name'].to_s.strip.downcase.include?(match.to_s.strip.downcase) ||
+                                action['description'].to_s.strip.downcase.include?(match.to_s.strip.downcase)
+                              )
                       @module_search_results_with_usage_metadata << { mod: m, datastore: { 'ACTION' => action['name'] } }
                       count += 1
                       tbl << [
@@ -569,6 +584,7 @@ module Msf
 
                   if (m.targets&.length || 0) > 1
                     m.targets.each do |target|
+                      next if child_mode == 'matched' && !target.to_s.strip.downcase.include?(match.to_s.strip.downcase)
                       @module_search_results_with_usage_metadata << { mod: m, datastore: { 'TARGET' => target } }
                       count += 1
                       tbl << [
@@ -584,6 +600,7 @@ module Msf
 
                   if (m.notes&.[]('AKA')&.length || 0) > 1
                     m.notes['AKA'].each do |aka|
+                      next if child_mode == 'matched' && !aka.to_s.strip.downcase.include?(match.to_s.strip.downcase)
                       @module_search_results_with_usage_metadata << { mod: m }
                       count += 1
                       tbl << [

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -432,6 +432,14 @@ module Msf
             print_line "  search type:exploit -s type -r"
             print_line "  search att&ck:T1059"
             print_line
+            print_line "Global Settings For Search Results:"
+            {
+              'SearchSort'         => 'Set the default sort order (-s)',
+              'SearchChildMode'    => 'Set the default for displaying child items (-c)',
+            }.each_pair do |keyword, description|
+              print_line "  #{keyword.ljust 17}:  #{description}"
+            end
+            print_line
           end
 
           #
@@ -445,9 +453,9 @@ module Msf
             use          = false
             count        = -1
             search_terms = []
-            sort_attribute  = 'name'
+            sort_attribute = framework.datastore['SearchSort'] || 'name'
             valid_sort_attributes = ['rank', 'date', 'disclosure_date', 'fullname', 'name', 'type', 'check', 'action']
-            child_mode = 'show'
+            child_mode = framework.datastore['SearchChildMode'] || 'show'
             valid_child_mode = ['hide','show','matched']
             reverse_sort = false
             ignore_use_exact_match = false

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -22,7 +22,7 @@ module Msf
             ['-S', '--filter']          => [true,  'Regex pattern used to filter search results', '<filter>'],
             ['-u', '--use']             => [false, 'Use module if there is one result'],
             ['-s', '--sort-ascending']  => [true,  'Sort search results by the specified column in ascending order', '<column>'],
-            ['-r', '--sort-descending'] => [true,  'Reverse the order of search results to descending order', '<column>'],
+            ['-r', '--sort-descending'] => [false, 'Reverse the order of search results to descending order'],
             ['-c', '--show-child']      => [true,  'How to display child items. Always hide, always show, show when matched (hide, show, matched)', '<mode>']
           )
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -416,6 +416,7 @@ module Msf
               'rank'                 => 'Sort modules by their exploitability rank',
               'date'                 => 'Sort modules by their disclosure date. Alias for disclosure_date',
               'disclosure_date'      => 'Sort modules by their disclosure date',
+              'fullname'             => 'Sort modules by their full name',
               'name'                 => 'Sort modules by their descriptive name (title)',
               'type'                 => 'Sort modules by their type',
               'check'                => 'Sort modules by whether or not they have a check method',
@@ -445,7 +446,7 @@ module Msf
             count        = -1
             search_terms = []
             sort_attribute  = 'name'
-            valid_sort_attributes = ['rank', 'date', 'disclosure_date', 'name', 'type', 'check', 'action']
+            valid_sort_attributes = ['rank', 'date', 'disclosure_date', 'fullname', 'name', 'type', 'check', 'action']
             child_mode = 'show'
             valid_child_mode = ['hide','show','matched']
             reverse_sort = false

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-
 module Msf
   module Ui
     module Console
@@ -22,8 +21,8 @@ module Msf
             ['-o', '--output']          => [true,  'Send output to a file in csv format', '<filename>'],
             ['-S', '--filter']          => [true,  'Regex pattern used to filter search results', '<filter>'],
             ['-u', '--use']             => [false, 'Use module if there is one result'],
-            ['-s', '--sort-ascending']  => [true, 'Sort search results by the specified column in ascending order', '<column>'],
-            ['-r', '--sort-descending'] => [true, 'Reverse the order of search results to descending order', '<column>']
+            ['-s', '--sort-ascending']  => [true,  'Sort search results by the specified column in ascending order', '<column>'],
+            ['-r', '--sort-descending'] => [true,  'Reverse the order of search results to descending order', '<column>']
           )
 
           @@favorite_opts = Rex::Parser::Arguments.new(
@@ -445,7 +444,7 @@ module Msf
             count        = -1
             search_terms = []
             sort_attribute  = 'name'
-            valid_sort_attributes = ['action', 'rank','disclosure_date','name','date','type','check']
+            valid_sort_attributes = ['rank', 'date', 'disclosure_date', 'name', 'type', 'check', 'action']
             reverse_sort = false
             ignore_use_exact_match = false
 
@@ -493,11 +492,12 @@ module Msf
                 @module_search_results = Msf::Modules::Metadata::Cache.instance.find(search_params)
 
                 @module_search_results.sort_by! do |module_metadata|
-                  if sort_attribute == 'action'
+                  case sort_attribute
+                  when 'action'
                     module_metadata.actions&.any? ? 0 : 1
-                  elsif sort_attribute == 'check'
+                  when 'check'
                     module_metadata.check ? 0 : 1
-                  elsif sort_attribute == 'disclosure_date' || sort_attribute == 'date'
+                  when 'disclosure_date', 'date'
                     # Not all modules have disclosure_date, i.e. multi/handler
                     module_metadata.disclosure_date || Time.utc(0)
                   else
@@ -551,6 +551,7 @@ module Msf
                   # Note: We still use visual indicators for blank values as it's easier to read
                   # We can't always use a generic formatter/styler, as it would be applied to the 'parent' rows too
                   blank_value = '.'
+
                   if (m.actions&.length || 0) > 1
                     m.actions.each do |action|
                       @module_search_results_with_usage_metadata << { mod: m, datastore: { 'ACTION' => action['name'] } }


### PR DESCRIPTION
Related issue: https://github.com/rapid7/metasploit-framework/issues/21257

This addresses a few issues I had with `search`:

- Able to hide "child" items (e.g. `\_aka`, `\_targets`, `\_actions`) from search results
- Able to sort by a module fullname (aka path)
- Able to set global settings so default scan be set
- Fix a few incorrect/inconsistency terms

```console
msf > search -h
[...]
OPTIONS:

    -c, --show-child <mode>        How to display child items. Always hide, always show, show when matched (hide, show, matched)
[...]
msf >
msf > search RPCSS
[...]
   0   exploit/windows/local/cve_2020_17136             2020-03-10       normal     Yes    CVE-2020-1170 Cloud Filter Arbitrary File Creation EOP
   1   exploit/windows/dcerpc/ms03_026_dcom             2003-07-16       great      Yes    MS03-026 Microsoft RPC DCOM Interface Overflow
   2   exploit/windows/http/sitecore_xp_cve_2021_42237  2021-11-02       excellent  Yes    Sitecore Experience Platform (XP) PreAuth Deserialization RCE
   3     \_ target: Windows Command                     .                .          .      .
   4     \_ target: Windows Dropper                     .                .          .      .
   5     \_ target: PowerShell Stager                   .                .          .      .
   6   post/windows/escalate/getsystem                  .                normal     No     Windows Escalation
   7     \_ AKA: Named Pipe Impersonation               .                .          .      .
   8     \_ AKA: Token Duplication                      .                .          .      .
   9     \_ AKA: RPCSS                                  .                .          .      .
   10    \_ AKA: PrintSpooler                           .                .          .      .
   11    \_ AKA: EFSRPC                                 .                .          .      .
   12    \_ AKA: EfsPotato                              .                .          .      .
[...]
msf >
msf > search -c show RPCSS
# Same output as above
msf >
msf > search -c hide RPCSS
[...]
   0  exploit/windows/local/cve_2020_17136             2020-03-10       normal     Yes    CVE-2020-1170 Cloud Filter Arbitrary File Creation EOP
   1  exploit/windows/dcerpc/ms03_026_dcom             2003-07-16       great      Yes    MS03-026 Microsoft RPC DCOM Interface Overflow
   2  exploit/windows/http/sitecore_xp_cve_2021_42237  2021-11-02       excellent  Yes    Sitecore Experience Platform (XP) PreAuth Deserialization RCE
   3  post/windows/escalate/getsystem                  .                normal     No     Windows Escalation
[...]
msf >
msf > search -c matched RPCSS
[///]
   0  exploit/windows/local/cve_2020_17136             2020-03-10       normal     Yes    CVE-2020-1170 Cloud Filter Arbitrary File Creation EOP
   1  exploit/windows/dcerpc/ms03_026_dcom             2003-07-16       great      Yes    MS03-026 Microsoft RPC DCOM Interface Overflow
   2  exploit/windows/http/sitecore_xp_cve_2021_42237  2021-11-02       excellent  Yes    Sitecore Experience Platform (XP) PreAuth Deserialization RCE
   3  post/windows/escalate/getsystem                  .                normal     No     Windows Escalation
   4    \_ AKA: RPCSS                                  .                .          .      .
[...]
msf >
msf > search -c foo RPCSS
[-] Supported options for the -c flag are: ["hide", "show", "matched"]
msf >
```