### PR TITLE
Log SMB services

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -203,7 +203,7 @@ module Msf
             { :use_spn => datastore['NTLM::SendSPN'], :name =>  simple_client.peerhost }
           )
         ensure
-          if simple_client.client.negotiated_smb_version.present?
+          if simple_client.client.dialect.present?
             report_smb_service(client: simple_client)
           end
         end
@@ -920,7 +920,8 @@ module Msf
         if client.present?
           peerhost = client.dispatcher.tcp_socket.peerhost
           peerport = client.dispatcher.tcp_socket.peerport
-          info << ", last negotiated version: SMBv#{client.negotiated_smb_version} (dialect = #{client.dialect})"
+          smb_version = client.respond_to?(:negotiated_smb_version) ? client.negotiated_smb_version : 1
+          info << ", last negotiated version: SMBv#{smb_version} (dialect = #{client.dialect})"
         else
           peerhost = rhost
           peerport = rport

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -186,21 +186,27 @@ module Msf
           simple_client.client.kerberos_authenticator = kerberos_authenticator
         end
 
-        simple_client.login(
-          datastore['SMBName'],
-          username,
-          password,
-          domain,
-          datastore['SMB::VerifySignature'],
-          datastore['NTLM::UseNTLMv2'],
-          datastore['NTLM::UseNTLM2_session'],
-          datastore['NTLM::SendLM'],
-          datastore['NTLM::UseLMKey'],
-          datastore['NTLM::SendNTLM'],
-          datastore['SMB::Native_OS'],
-          datastore['SMB::Native_LM'],
-          { :use_spn => datastore['NTLM::SendSPN'], :name =>  simple_client.peerhost }
-        )
+        begin
+          simple_client.login(
+            datastore['SMBName'],
+            username,
+            password,
+            domain,
+            datastore['SMB::VerifySignature'],
+            datastore['NTLM::UseNTLMv2'],
+            datastore['NTLM::UseNTLM2_session'],
+            datastore['NTLM::SendLM'],
+            datastore['NTLM::UseLMKey'],
+            datastore['NTLM::SendNTLM'],
+            datastore['SMB::Native_OS'],
+            datastore['SMB::Native_LM'],
+            { :use_spn => datastore['NTLM::SendSPN'], :name =>  simple_client.peerhost }
+          )
+        ensure
+          if simple_client.client.negotiated_smb_version.present?
+            report_smb_service(client: simple_client)
+          end
+        end
         # XXX: Any reason to connect to the IPC$ share in this method?
         simple_client.client.tree_connect("\\\\#{simple_client.peerhost}\\IPC$")
       end
@@ -902,6 +908,37 @@ module Msf
         end
 
         shares
+      end
+
+      def report_smb_service(client: nil)
+        info = "Module: #{fullname}"
+
+        client = simple.client if client.nil? && simple.present?
+        client = client.client if client.is_a?(Rex::Proto::SMB::SimpleClient)
+
+        # simple is only set if the global option is true when calling #connect, which it is by default
+        if client.present?
+          peerhost = client.dispatcher.tcp_socket.peerhost
+          peerport = client.dispatcher.tcp_socket.peerport
+          info << ", last negotiated version: SMBv#{client.negotiated_smb_version} (dialect = #{client.dialect})"
+        else
+          peerhost = rhost
+          peerport = rport
+        end
+
+        report_service(
+          name: 'smb',
+          host: peerhost,
+          port: peerport,
+          proto: 'tcp',
+          info: info,
+          parents: {
+            name: 'tcp',
+            host: peerhost,
+            port: peerport,
+            proto: 'tcp'
+          }
+        )
       end
 
       # @return [Rex::Proto::SMB::SimpleClient]

--- a/lib/msf/core/exploit/remote/smb/client/ipc.rb
+++ b/lib/msf/core/exploit/remote/smb/client/ipc.rb
@@ -46,19 +46,7 @@ module Msf
         port: simple.peerport,
         proto: 'tcp',
         resource: { smb: { share: 'IPC$' } },
-        parents: {
-          name: 'smb',
-          host: simple.peerhost,
-          port: simple.peerport,
-          proto: 'tcp',
-          info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})",
-          parents: {
-            name: 'tcp',
-            host: simple.peerhost,
-            port: simple.peerport,
-            proto: 'tcp'
-          }
-        }
+        parents: report_smb_service
       )
     end
 


### PR DESCRIPTION
This was suggested today. Basically we should be logging SMB services. After some testing `#connect` didn't seem like a reliable place to do it so it logs the service in `#smb_login`. If authentication fails, the client still logs what dialect was negotiated so we log the service even if we couldn't authenticate to it.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use an SMB module an see that it reports the service
- [ ] Check different failure conditions and see that when it makes sense to that the service is reported

## Demo
The demo shows the different failures and that the services are reported sensible, no connection -> no service, authentication fails -> service reported, authentication succeeds -> service reported.

```
msf exploit(windows/smb/psexec) > services -d
Services
========

host  port  proto  name  state  info  resource  parents
----  ----  -----  ----  -----  ----  --------  -------

msf exploit(windows/smb/psexec) > run RPORT=444
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:444 - Connecting to the server...
[-] 192.168.159.10:444 - Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (192.168.159.10:444).
[*] Exploit completed, but no session was created.
msf exploit(windows/smb/psexec) > services 
Services
========

host  port  proto  name  state  info  resource  parents
----  ----  -----  ----  -----  ----  --------  -------

msf exploit(windows/smb/psexec) > run RPORT=445 SMBUser=jackson
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'jackson'...
[-] 192.168.159.10:445 - Exploit failed [no-access]: Rex::Proto::SMB::Exceptions::LoginError Login Failed: (0xc000006d) STATUS_LOGON_FAILURE: The attempted logon is invalid. This is either due to a bad username or authentication information.
[*] Exploit completed, but no session was created.
msf exploit(windows/smb/psexec) > services 
Services
========

host            port  proto  name  state  info                                                                                   resource  parents
----            ----  -----  ----  -----  ----                                                                                   --------  -------
192.168.159.10  445   tcp    smb   open   Module: exploit/windows/smb/psexec, last negotiated version: SMBv3 (dialect = 0x0311)  {}        tcp (445/tcp)
192.168.159.10  445   tcp    tcp   open                                                                                          {}

msf exploit(windows/smb/psexec) > services -d
Services
========

host            port  proto  name  state  info                                                                                   resource  parents
----            ----  -----  ----  -----  ----                                                                                   --------  -------
192.168.159.10  445   tcp    smb   open   Module: exploit/windows/smb/psexec, last negotiated version: SMBv3 (dialect = 0x0311)  {}        tcp (445/tcp)
192.168.159.10  445   tcp    tcp   open                                                                                          {}

[*] Deleted 2 services
msf exploit(windows/smb/psexec) > run RPORT=445 SMBUser=smcintyre
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[*] 192.168.159.10:445 - Selecting PowerShell target
[*] 192.168.159.10:445 - Executing the payload...
[+] 192.168.159.10:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (199238 bytes) to 192.168.159.10
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.10:64612) at 2026-04-09 17:31:10 -0400

meterpreter > exit
[*] Shutting down session: 1

[*] 192.168.159.10 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(windows/smb/psexec) > services 
Services
========

host            port  proto  name  state  info                                                                                   resource  parents
----            ----  -----  ----  -----  ----                                                                                   --------  -------
192.168.159.10  445   tcp    smb   open   Module: exploit/windows/smb/psexec, last negotiated version: SMBv3 (dialect = 0x0311)  {}        tcp (445/tcp)
192.168.159.10  445   tcp    tcp   open                                                                                          {}

msf exploit(windows/smb/psexec) > 
```
