### PR TITLE
Update checkcode usage in aux modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ require:
   - ./lib/rubocop/cop/lint/detect_metadata_trailing_leading_whitespace.rb
   - ./lib/rubocop/cop/lint/detect_outdated_cmd_exec_api.rb
   - ./lib/rubocop/cop/lint/datastore_srvhost_usage.rb
+  - ./lib/rubocop/cop/lint/bare_check_code_in_non_exploit.rb
 
 Layout/SpaceBeforeBrackets:
   Enabled: true
@@ -684,3 +685,14 @@ Lint/DetectOutdatedCmdExecApi:
     Detects outdated usage of cmd_exec with separate arguments.
     Use `create_process(executable, args: [], time_out: 15, opts: {})` API with an args array instead.
   Enabled: true
+
+Lint/BareCheckCodeInNonExploit:
+  Description: >-
+    Use Exploit::CheckCode instead of bare CheckCode in non-exploit modules.
+    Bare CheckCode will raise a NameError at runtime in auxiliary, post, and evasion modules
+    because CheckCode is defined inside Msf::Exploit which is not in their ancestor chain.
+  Enabled: true
+  Include:
+    - 'modules/auxiliary/**/*'
+    - 'modules/post/**/*'
+    - 'modules/evasion/**/*'

--- a/lib/rubocop/cop/lint/bare_check_code_in_non_exploit.rb
+++ b/lib/rubocop/cop/lint/bare_check_code_in_non_exploit.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Detects usage of bare `CheckCode::*` without the `Exploit::` prefix in
+      # auxiliary, post, and evasion modules.
+      #
+      # These modules inherit from `Msf::Auxiliary`, `Msf::Post`, or `Msf::Evasion` — not
+      # `Msf::Exploit` — so bare `CheckCode::*` will raise a `NameError` at runtime because
+      # `CheckCode` is defined inside `Msf::Exploit` and is not in the ancestor chain.
+      #
+      # @example
+      #   # bad - raises NameError at runtime
+      #   CheckCode::Safe
+      #   CheckCode::Vulnerable
+      #   CheckCode::Appears('message')
+      #
+      #   # good
+      #   Exploit::CheckCode::Safe
+      #   Exploit::CheckCode::Vulnerable
+      #   Exploit::CheckCode::Appears('message')
+      #
+      #   # also acceptable
+      #   Msf::Exploit::CheckCode::Safe
+      class BareCheckCodeInNonExploit < Base
+        extend AutoCorrector
+
+        MSG = 'Use `Exploit::CheckCode` instead of bare `CheckCode` in non-exploit modules. ' \
+              'Bare `CheckCode` will raise a NameError at runtime.'
+
+        # Matches bare `CheckCode::Something` (e.g. CheckCode::Safe)
+        # but NOT `Exploit::CheckCode::Something` or `Msf::Exploit::CheckCode::Something`
+        def_node_matcher :bare_check_code?, <<~PATTERN
+          (const
+            (const nil? :CheckCode) _)
+        PATTERN
+
+        # Matches bare `CheckCode::Something(...)` method calls.
+        # e.g. CheckCode::Appears('msg') parses as:
+        #   (send (const nil :CheckCode) :Appears (str "msg"))
+        def_node_matcher :bare_check_code_call?, <<~PATTERN
+          (send
+            (const nil? :CheckCode) ...)
+        PATTERN
+
+        def on_const(node)
+          return unless in_non_exploit_module?(node)
+          return unless bare_check_code?(node)
+          # Don't flag if the parent is already a higher const (avoid double-flagging)
+          return if node.parent&.const_type? && node.parent.children.first == node
+
+          add_offense(node) do |corrector|
+            check_code_const = find_root_const(node)
+            corrector.insert_before(check_code_const, 'Exploit::') if check_code_const
+          end
+        end
+
+        def on_send(node)
+          return unless in_non_exploit_module?(node)
+          return unless bare_check_code_call?(node)
+
+          add_offense(node.receiver) do |corrector|
+            check_code_const = find_root_const(node.receiver)
+            corrector.insert_before(check_code_const, 'Exploit::') if check_code_const
+          end
+        end
+
+        private
+
+        # Walk up the AST to find if we're inside a class that inherits from
+        # Msf::Auxiliary, Msf::Post, or Msf::Evasion
+        def in_non_exploit_module?(node)
+          node.each_ancestor(:class).any? do |class_node|
+            superclass = class_node.parent_class
+            next false unless superclass
+
+            superclass_name = superclass.source
+            superclass_name.match?(/\bMsf::(Auxiliary|Post|Evasion)\b/)
+          end
+        end
+
+        # Find the root const node in a const chain (the leftmost constant)
+        def find_root_const(node)
+          current = node
+          while current.const_type? && current.children.first&.const_type?
+            current = current.children.first
+          end
+          current
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
@@ -101,9 +101,9 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::UnexpectedReply, windows_error)
     end
 
-    return CheckCode::Detected unless status == 0
+    return Exploit::CheckCode::Detected unless status == 0
 
-    CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable
   end
 
   def run
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_remove_password
-    fail_with(Failure::Unknown, 'Failed to authenticate to the server by leveraging the vulnerability') unless check == CheckCode::Vulnerable
+    fail_with(Failure::Unknown, 'Failed to authenticate to the server by leveraging the vulnerability') unless check == Exploit::CheckCode::Vulnerable
 
     print_good('Successfully authenticated')
 

--- a/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
+++ b/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
   def check
     res = post_auth_bypass_request({ data: {} })
 
-    return CheckCode::Unknown('Connection failed') unless res
+    return Exploit::CheckCode::Unknown('Connection failed') unless res
 
     return Exploit::CheckCode::Safe('Received a 403 Forbidden response') if res.code == 403
 

--- a/modules/auxiliary/admin/http/idsecure_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/idsecure_auth_bypass.rb
@@ -47,19 +47,19 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => normalize_uri(target_uri.path, 'api/util/configUI')
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return Exploit::CheckCode::Unknown
     end
 
-    return CheckCode::Unknown unless res&.code == 401
+    return Exploit::CheckCode::Unknown unless res&.code == 401
 
     data = res.get_json_document
     version = data['Version']
-    return CheckCode::Unknown if version.nil?
+    return Exploit::CheckCode::Unknown if version.nil?
 
     print_status('Got version: ' + version)
-    return CheckCode::Safe unless Rex::Version.new(version) <= Rex::Version.new('4.7.43.0')
+    return Exploit::CheckCode::Safe unless Rex::Version.new(version) <= Rex::Version.new('4.7.43.0')
 
-    return CheckCode::Appears
+    return Exploit::CheckCode::Appears
   end
 
   def run

--- a/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
+++ b/modules/auxiliary/admin/http/whatsup_gold_sqli.rb
@@ -51,14 +51,14 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path, 'NmConsole/app.json')
     })
 
-    return CheckCode::Unknown unless res && res.code == 200
+    return Exploit::CheckCode::Unknown unless res && res.code == 200
 
     data = res.get_json_document
     data_js = data['js']
     version_path = data_js.find { |item| item['path'] =~ /app-/ }['path']
     version = version_path[/app-(.*)\.js/, 1]
     if version.nil?
-      return CheckCode::Unknown
+      return Exploit::CheckCode::Unknown
     else
       vprint_status('Version retrieved: ' + version)
     end

--- a/modules/auxiliary/admin/scada/mypro_mgr_creds.rb
+++ b/modules/auxiliary/admin/scada/mypro_mgr_creds.rb
@@ -64,19 +64,19 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => normalize_uri(target_uri.path, 'assets/index-DBkpc6FO.js')
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return Exploit::CheckCode::Unknown
     end
 
     if res.to_s =~ /const S="([^"]+)"/
       version = ::Regexp.last_match(1)
       vprint_status('Version retrieved: ' + version)
       if Rex::Version.new(version) <= Rex::Version.new('1.3')
-        return CheckCode::Appears
+        return Exploit::CheckCode::Appears
       end
 
-      return CheckCode::Safe
+      return Exploit::CheckCode::Safe
     end
-    return CheckCode::Unknown
+    return Exploit::CheckCode::Unknown
   end
 
   def run

--- a/modules/auxiliary/gather/gitlab_authenticated_subgroups_file_read.rb
+++ b/modules/auxiliary/gather/gitlab_authenticated_subgroups_file_read.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
     version = Rex::Version.new(gitlab_version)
 
     if version != Rex::Version.new('16.0.0')
-      return CheckCode::Safe("Detected GitLab version #{version} which is not vulnerable")
+      return Exploit::CheckCode::Safe("Detected GitLab version #{version} which is not vulnerable")
     end
 
     report_vuln(

--- a/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
+++ b/modules/auxiliary/gather/glpi_inventory_plugin_unauth_sqli.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       @sqli = get_sqli_object
     rescue SQLExecutionError => e
-      return CheckCode::Unknown("#{e.class}: #{e.message}")
+      return Exploit::CheckCode::Unknown("#{e.class}: #{e.message}")
     end
 
     return Exploit::CheckCode::Unknown(GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG

--- a/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
+++ b/modules/auxiliary/gather/magento_xxe_cve_2024_34102.rb
@@ -55,14 +55,14 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path, '/magento_version')
     })
 
-    return CheckCode::Unknown('Could not detect the version.') unless res&.code == 200
+    return Exploit::CheckCode::Unknown('Could not detect the version.') unless res&.code == 200
 
     # Magento/2.4 (Community)
     version, edition = res.body.scan(%r{Magento/([\d.]+) \(([^)]+)\)}).first
 
     version = Rex::Version.new(version)
 
-    return CheckCode::Safe("Detected Magento #{edition} edition version #{version} which is not vulnerable") unless
+    return Exploit::CheckCode::Safe("Detected Magento #{edition} edition version #{version} which is not vulnerable") unless
       version <= (Rex::Version.new('2.4.7')) ||
       version <= (Rex::Version.new('2.4.6-p5')) ||
       version <= (Rex::Version.new('2.4.5-p7')) ||
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
         )
       )
 
-    CheckCode::Appears("Detected Magento #{edition} edition version #{version} which is vulnerable")
+    Exploit::CheckCode::Appears("Detected Magento #{edition} edition version #{version} which is vulnerable")
   end
 
   def ent_eval

--- a/modules/auxiliary/gather/onedev_arbitrary_file_read.rb
+++ b/modules/auxiliary/gather/onedev_arbitrary_file_read.rb
@@ -57,10 +57,10 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path)
     })
 
-    return CheckCode::Unknown('Request failed') unless res
+    return Exploit::CheckCode::Unknown('Request failed') unless res
 
     unless ['OneDev', "var redirect = '/~login';"].any? { |f| res.body.include? f }
-      return CheckCode::Unknown("The target isn't a OneDev instance.")
+      return Exploit::CheckCode::Unknown("The target isn't a OneDev instance.")
     end
 
     version = res.body.scan(/OneDev ([\d.]+)/).first
@@ -70,19 +70,19 @@ class MetasploitModule < Msf::Auxiliary
         res = read_file(datastore['PROJECT_NAME'], '/etc/passwd')
 
         if res.body.include? 'root:x:0:0:root:'
-          return CheckCode::Vulnerable('OneDev instance is vulnerable.')
+          return Exploit::CheckCode::Vulnerable('OneDev instance is vulnerable.')
         else
-          return CheckCode::Safe('OneDev instance is not vulnerable.')
+          return Exploit::CheckCode::Safe('OneDev instance is not vulnerable.')
         end
       end
-      return CheckCode::Unknown('Unable to detect the OneDev version, as the instance does not have anonymous access enabled.')
+      return Exploit::CheckCode::Unknown('Unable to detect the OneDev version, as the instance does not have anonymous access enabled.')
     end
 
     version = Rex::Version.new(version[0])
 
-    return CheckCode::Safe("OneDev #{version} is not vulnerable.") if version > Rex::Version.new('11.0.8')
+    return Exploit::CheckCode::Safe("OneDev #{version} is not vulnerable.") if version > Rex::Version.new('11.0.8')
 
-    CheckCode::Appears("OneDev #{version} is vulnerable.")
+    Exploit::CheckCode::Appears("OneDev #{version} is vulnerable.")
   end
 
   def validate_project_exists(project)

--- a/modules/auxiliary/gather/pacsserver_traversal.rb
+++ b/modules/auxiliary/gather/pacsserver_traversal.rb
@@ -55,17 +55,17 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => normalize_uri(target_uri.path, 'index.html')
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown('Connection failed')
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     if res&.code == 200
       data = res.to_s
       if data.include?('Sante PACS Server PG')
-        return CheckCode::Detected('Sante PACS Server PG seems to be running on the server.')
+        return Exploit::CheckCode::Detected('Sante PACS Server PG seems to be running on the server.')
       end
 
     end
-    return CheckCode::Safe
+    return Exploit::CheckCode::Safe
   end
 
   def run

--- a/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
+++ b/modules/auxiliary/gather/solarwinds_webhelpdesk_backdoor.rb
@@ -46,15 +46,15 @@ class MetasploitModule < Msf::Auxiliary
 
   def check
     @auth = auth
-    return CheckCode::Unknown('Target is unreachable') unless @auth
+    return Exploit::CheckCode::Unknown('Target is unreachable') unless @auth
 
     if @auth.code == 401
-      return CheckCode::Safe
+      return Exploit::CheckCode::Safe
     elsif @auth.code == 200
-      return CheckCode::Appears
+      return Exploit::CheckCode::Appears
     end
 
-    CheckCode::Unknown
+    Exploit::CheckCode::Unknown
   end
 
   def auth

--- a/modules/auxiliary/gather/upsmon_traversal.rb
+++ b/modules/auxiliary/gather/upsmon_traversal.rb
@@ -58,18 +58,18 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => normalize_uri(target_uri.path, 'index.html ')
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown('Connection failed')
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     if res&.code == 200
       data = res.to_s
       if data.include?('My Web Server 1') && data.include?('UPSMON PRO WEB')
-        return CheckCode::Detected('UPSMON PRO Web seems to be running on target system.')
+        return Exploit::CheckCode::Detected('UPSMON PRO Web seems to be running on target system.')
       end
 
-      return CheckCode::Safe
+      return Exploit::CheckCode::Safe
     end
-    return CheckCode::Unknown
+    return Exploit::CheckCode::Unknown
   end
 
   def print_ini_field(label, value)

--- a/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def check_host(_ip)
     version = get_version
-    return CheckCode::Unknown("#{peer} - Could not connect to web service, or unexpected response") if version.nil?
+    return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service, or unexpected response") if version.nil?
 
     if Rex::Version.new(version) <= Rex::Version.new('7.13.3') && Rex::Version.new(version) >= Rex::Version.new('7.10.0')
       return Exploit::CheckCode::Appears("Exploitable Version Detected: #{version}")

--- a/spec/rubocop/cop/lint/bare_check_code_in_non_exploit_spec.rb
+++ b/spec/rubocop/cop/lint/bare_check_code_in_non_exploit_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'rubocop/cop/lint/bare_check_code_in_non_exploit'
+require 'rubocop/rspec/support'
+
+RSpec.describe RuboCop::Cop::Lint::BareCheckCodeInNonExploit, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  context 'in an auxiliary module' do
+    it 'registers an offense for bare CheckCode::Safe' do
+      expect_offense(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            CheckCode::Safe
+            ^^^^^^^^^^^^^^^ Lint/BareCheckCodeInNonExploit: Use `Exploit::CheckCode` instead of bare `CheckCode` in non-exploit modules. Bare `CheckCode` will raise a NameError at runtime.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            Exploit::CheckCode::Safe
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for bare CheckCode::Unknown' do
+      expect_offense(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            CheckCode::Unknown
+            ^^^^^^^^^^^^^^^^^^ Lint/BareCheckCodeInNonExploit: Use `Exploit::CheckCode` instead of bare `CheckCode` in non-exploit modules. Bare `CheckCode` will raise a NameError at runtime.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            Exploit::CheckCode::Unknown
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for bare CheckCode::Appears with a message argument' do
+      expect_offense(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            CheckCode::Appears('Version is vulnerable')
+            ^^^^^^^^^ Lint/BareCheckCodeInNonExploit: Use `Exploit::CheckCode` instead of bare `CheckCode` in non-exploit modules. Bare `CheckCode` will raise a NameError at runtime.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            Exploit::CheckCode::Appears('Version is vulnerable')
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offense for bare CheckCode::Vulnerable with details kwarg' do
+      expect_offense(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            CheckCode::Vulnerable(details: { version: '1.0' })
+            ^^^^^^^^^ Lint/BareCheckCodeInNonExploit: Use `Exploit::CheckCode` instead of bare `CheckCode` in non-exploit modules. Bare `CheckCode` will raise a NameError at runtime.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            Exploit::CheckCode::Vulnerable(details: { version: '1.0' })
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Exploit::CheckCode::Safe' do
+      expect_no_offenses(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            Exploit::CheckCode::Safe
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Exploit::CheckCode::Safe' do
+      expect_no_offenses(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            Exploit::CheckCode::Safe
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for Exploit::CheckCode::Appears with message' do
+      expect_no_offenses(<<~RUBY)
+        class MetasploitModule < Msf::Auxiliary
+          def check
+            Exploit::CheckCode::Appears('Version is vulnerable')
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'in a post module' do
+    it 'registers an offense for bare CheckCode::Safe' do
+      expect_offense(<<~RUBY)
+        class MetasploitModule < Msf::Post
+          def check
+            CheckCode::Safe
+            ^^^^^^^^^^^^^^^ Lint/BareCheckCodeInNonExploit: Use `Exploit::CheckCode` instead of bare `CheckCode` in non-exploit modules. Bare `CheckCode` will raise a NameError at runtime.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MetasploitModule < Msf::Post
+          def check
+            Exploit::CheckCode::Safe
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'in an evasion module' do
+    it 'registers an offense for bare CheckCode::Safe' do
+      expect_offense(<<~RUBY)
+        class MetasploitModule < Msf::Evasion
+          def check
+            CheckCode::Safe
+            ^^^^^^^^^^^^^^^ Lint/BareCheckCodeInNonExploit: Use `Exploit::CheckCode` instead of bare `CheckCode` in non-exploit modules. Bare `CheckCode` will raise a NameError at runtime.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MetasploitModule < Msf::Evasion
+          def check
+            Exploit::CheckCode::Safe
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'in an exploit module' do
+    it 'does not register an offense for bare CheckCode::Safe' do
+      expect_no_offenses(<<~RUBY)
+        class MetasploitModule < Msf::Exploit
+          def check
+            CheckCode::Safe
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'outside a module class' do
+    it 'does not register an offense for bare CheckCode::Safe' do
+      expect_no_offenses(<<~RUBY)
+        CheckCode::Safe
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Fixes a crash when running auxiliary modules that incorrectly reference checkcodes

Specifically it explicitly uses the correct module namespace for the checkcode usage in aux modules, to avoid issues like this:

<img width="2035" height="437" alt="image" src="https://github.com/user-attachments/assets/1377d14b-61dc-466f-80a1-a8740543c549" />


Local msfconsole usage:

```
msf auxiliary(scanner/http/elasticsearch_memory_disclosure) > recheck rhost=127.0.0.1 rport=3790
[*] Reloading module...
[-] Auxiliary failed: NameError uninitialized constant Msf::Modules::Auxiliary__Scanner__Http__Elasticsearch_memory_disclosure::MetasploitModule::CheckCode
[-] Call stack:
[-]   /tmp/metasploit-framework/modules/auxiliary/scanner/http/elasticsearch_memory_disclosure.rb:87:in `check_host'
[-]   /tmp/metasploit-framework/lib/msf/core/auxiliary/multiple_target_hosts.rb:22:in `check'
[-] 127.0.0.1:3790 - Check failed: The state could not be determined.
```

## Verification

- Ensure CI passes