### PR TITLE
Fix msftidy heading in codeblock edgecase

### DIFF
--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -257,7 +257,7 @@ class MsftidyDoc
         warn("Instructional text not removed", idx)
       end
 
-      if ln =~ /^# /
+      if !in_codeblock && ln =~ /^# /
         warn("No H1 (#) headers.  If this is code, indent.", idx)
       end
 


### PR DESCRIPTION
Fix msftidy heading in codeblock edgecase, which triggered incorrectly in this scenario:

``````

...

Verify the module worked:

```
# list files in directory: <- was incorrectly detected as a header
ls -lah
```

...
``````

## Verification

- Ensure CI passes