### PR TITLE
Docs core dispatcher v2Docs: Add technical YARD documentation for Core command dispatcher

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -201,6 +201,7 @@ class Core
   #
   # Displays help for the color command.
   #
+  # @return [void]
   def cmd_color_help
     print_line "Usage: color <'true'|'false'|'auto'>"
     print_line
@@ -227,8 +228,7 @@ class Core
   #
   # @param str [String] the string currently being typed before tab was hit
   # @param words [Array<String>] the previously completed words on the command line.  words is always
-  # at least 1 when tab completion has reached this stage since the command itself has been completed
-  #
+  # @return [Array<String>] List of possible completions (auto, true, false).
   def cmd_color_tabs(str, words)
     return [] if words.length > 1
     %w[auto true false]
@@ -246,6 +246,8 @@ class Core
   #
   # Change the current working directory
   #
+  # @param args [Array<String>] The directory path to change to.
+  # @return [void]
   def cmd_cd(*args)
     if(args.length == 0)
       print_error("No path specified")

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -198,7 +198,9 @@ class Core
     "Core"
   end
 
-
+  #
+  # Displays help for the color command.
+  #
   def cmd_color_help
     print_line "Usage: color <'true'|'false'|'auto'>"
     print_line
@@ -231,7 +233,9 @@ class Core
     return [] if words.length > 1
     %w[auto true false]
   end
-
+  #
+  # Displays help for the cd command.
+  #
   def cmd_cd_help
     print_line "Usage: cd <directory>"
     print_line
@@ -313,7 +317,9 @@ class Core
 
     []
   end
-
+  #
+  # Displays useful Metasploit tips and tricks.
+  #
   def cmd_tips_help
     print_line "Usage: tips [options]"
     print_line


### PR DESCRIPTION
## Summary

This PR follows the documentation improvements introduced in #21279 and originally discussed in #21225.

While #21279 focuses on the Modules command dispatcher, this PR applies similar technical YARD documentation improvements to the Core command dispatcher to maintain consistency across dispatcher components.

These changes remain documentation-only and do not modify runtime behavior.

## Changes

- Added YARD documentation for:
  - cmd_cd
  - cmd_color
  - help-related dispatcher methods

- Added @param tags for method arguments
- Added @return tags for return values
- Documentation-only changes (no logic modifications)

## Purpose

These updates improve developer clarity and assist in generating accurate framework documentation while maintaining existing functionality.

## Verification

* `ruby -c lib/msf/ui/console/command_dispatcher/core.rb` → Syntax OK
* Verified `cd` command works in `msfconsole`
* Verified `color` command works in `msfconsole`
* Confirmed no runtime behavior changes

Please let me know if any additional verification steps would be helpful.
