### PR TITLE
Add cleanup toggle to file mixin mkdir method

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -118,7 +118,7 @@ module Msf::Post::File
   alias ls dir
 
   # create and mark directory for cleanup
-  def mkdir(path)
+  def mkdir(path, cleanup: true)
     result = nil
     vprint_status("Creating directory #{path}")
     if session.type == 'meterpreter'
@@ -132,7 +132,7 @@ module Msf::Post::File
       result = cmd_exec("mkdir -p '#{path}'")
     end
     vprint_status("#{path} created")
-    register_dir_for_cleanup(path)
+    register_dir_for_cleanup(path) if cleanup
     result
   end
 

--- a/spec/lib/msf/core/post/file_spec.rb
+++ b/spec/lib/msf/core/post/file_spec.rb
@@ -9,6 +9,38 @@ RSpec.describe Msf::Post::File do
     klass.allocate
   end
 
+  describe '#mkdir' do
+    let(:path) { '/tmp/test_dir' }
+
+    subject do
+      described_mixin = described_class
+      klass = Class.new do
+        include described_mixin
+        attr_accessor :session
+        def cmd_exec(_cmd); ''; end
+        def vprint_status(_msg); end
+        def register_dir_for_cleanup(_path); end
+      end
+      obj = klass.allocate
+      obj.session = double('session', type: 'shell', platform: 'linux')
+      obj
+    end
+
+    before(:each) do
+      allow(subject).to receive(:register_dir_for_cleanup)
+    end
+
+    it 'registers the directory for cleanup by default' do
+      subject.mkdir(path)
+      expect(subject).to have_received(:register_dir_for_cleanup).with(path)
+    end
+
+    it 'does not register the directory for cleanup when cleanup is false' do
+      subject.mkdir(path, cleanup: false)
+      expect(subject).not_to have_received(:register_dir_for_cleanup)
+    end
+  end
+
   describe '#_can_echo?' do
     [
       # printable examples


### PR DESCRIPTION
Fixes #21264

This PR adds a `cleanup` keyword argument to `Msf::Post::File#mkdir` so callers can skip automatic directory cleanup registration. Defaults to `true` for backward compatibility. This is useful for persistence modules where directories should survive after module completion.

## Verification

List the steps needed to make sure this thing works

- [x] Get a meterpreter/shell session on a target
- [x] In a post module, call `mkdir('/tmp/persist_dir', cleanup: false)`
- [x] Run module to completion
- [x] Verify `/tmp/persist_dir` still exists on target after cleanup
- [x] In a post module, call `mkdir('/tmp/temp_dir')` (no cleanup arg)
- [x] Run module to completion
- [x] Verify`/tmp/temp_dir` is removed after cleanup