### PR TITLE
Return comments for hosts over RPC

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -393,6 +393,7 @@ public
   #    * 'updated_at' [Integer] Last updated at.
   #    * 'purpose' [String] Host purpose (example: server)
   #    * 'info' [String] Additional information about the host.
+  #    * 'comments' [String] The host's comments.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.hosts', {})
   def rpc_hosts(xopts)
@@ -422,6 +423,7 @@ public
       host[:updated_at] = h.updated_at.to_i
       host[:purpose] = h.purpose.to_s
       host[:info] = h.info.to_s
+      host[:comments] = h.comments.to_s
       ret[:hosts]  << host
     end
     ret


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/21247

Tested in Pro. No impact, everything works. We don't display host comments anywhere in Pro's UI.

## Before
No comment
```
>> rpc.call("db.hosts", {})
=> 
{"hosts"=>
  [{"created_at"=>1776160363,
    "address"=>"127.0.0.1",
    "mac"=>"",
    "name"=>"caea2eea7ecb",
    "state"=>"alive",
    "os_name"=>"Debian 9.6 (Linux 6.12.76-linuxkit)",
    "os_flavor"=>"",
    "os_sp"=>"",
    "os_lang"=>"",
    "updated_at"=>1776160491,
    "purpose"=>"server",
    "info"=>""}]}
```

## After
With a comment
```
>> rpc.call("db.hosts", {})
=> 
{"hosts"=>
  [{"created_at"=>1776160363,
    "address"=>"127.0.0.1",
    "mac"=>"",
    "name"=>"caea2eea7ecb",
    "state"=>"alive",
    "os_name"=>"Debian 9.6 (Linux 6.12.76-linuxkit)",
    "os_flavor"=>"",
    "os_sp"=>"",
    "os_lang"=>"",
    "updated_at"=>1776160491,
    "purpose"=>"server",
    "info"=>"",
    "comments"=>"hello world, this is a comment"}]}
```

## Verification

List the steps needed to make sure this thing works

- [ ] Have a host in the database (you can run a module, or `hosts -a x.x.x.x`
- [ ] Add comment to host using the IP `hosts -m "this is an example comment" x.x.x.x`
- [ ] Boot RPC server using `load msgrpc`
- [ ] Connect to RPC with msfrpc
- [ ] run `rpc.call("db.hosts", {})
- [ ] Confirm comment is visible
- [ ] Verify that a host without a comment in msfconsole does not crash. Instead it returns `"comments"=>""`