### PR TITLE
Fix annoying bug for payload cached size

### DIFF
--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -31,7 +31,8 @@ class PayloadCachedSize
       'PEXEC' => '/bin/sh',
       'HttpUserAgent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0',
       'StagerURILength' => 5,
-      'FD' => 100
+      'FD' => 100,
+      'MeterpreterDebugBuild' => false
     },
     'Encoder'     => nil,
     'DisableNops' => true
@@ -259,12 +260,6 @@ class PayloadCachedSize
     elsif adapted_arch == ARCH_X86 || mod.arch_to_s == ARCH_X86
       opts['Options'].merge!(OPTS_ARCH_X86)
     end
-
-    # if the module is a meterpreter stageless payload, ensure the MeterpreterDebugBuild is set to false.
-    if mod.refname =~ /meterpreter_/
-      opts['Options']['MeterpreterDebugBuild'] = false
-    end
-
     opts
   end
 end

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -259,6 +259,12 @@ class PayloadCachedSize
     elsif adapted_arch == ARCH_X86 || mod.arch_to_s == ARCH_X86
       opts['Options'].merge!(OPTS_ARCH_X86)
     end
+
+    # if the module is a meterpreter stageless payload, ensure the MeterpreterDebugBuild is set to false.
+    if mod.refname =~ /meterpreter_/
+      opts['Options']['MeterpreterDebugBuild'] = false
+    end
+
     opts
   end
 end


### PR DESCRIPTION
This fix a bug for the tool: `bundle exec tools/modules/update_payload_cached_sizes.rb`

if you have (like me) the `MeterpreterDebugBuild` set to true in your metasploit configuration, the cachedsize fetched will be the one of `meterpreter.<arch>.debug.dll` rather than `meterpreter.<arch>.dll`. this will force to fetch the correct dll binary.

* Ensures that for modules with `refname` matching `meterpreter_`, the `MeterpreterDebugBuild` option is explicitly set to `false` by default in the options hash.

## Verification

do `bundle exec tools/modules/update_payload_cached_sizes.rb`

with both `MeterpreterDebugBuild` set to `false` and `true`

without this fix, the cached size should change, with the fix it will not.