### PR TITLE
Return notes for module over RPC

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -226,6 +226,7 @@ class RPC_Module < RPC_Base
     res['privileged'] = m.privileged?
     res['check'] = m.has_check?
     res['default_options'] = m.default_options
+    res['notes'] = m.notes
 
     res['references'] = []
     m.references.each do |r|


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/21248

Tested in Pro by accessing some pages where module information would be displayed. No issues found.

## Before
No module notes
```
>> rpc.call('module.info', 'exploit', 'windows/smb/ms08_067_netapi')
=> 
{"type"=>"exploit",
 ...
 "SideEffects"=>["unknown-side-effects"]},
 "references"=>[["CVE", "2008-4250"], ["OSVDB", "49243"], ["MSB", "MS08-067"], ["URL", "https://www.rapid7.com/db/vulnerabilities/dcerpc-ms-netapi-netpathcanonicalize-dos/"]],
```

## After
Now includes notes
```
>> rpc.call('module.info', 'exploit', 'windows/smb/ms08_067_netapi')
=> 
{"type"=>"exploit",
 ...
 "notes"=>{"AKA"=>["ECLIPSEDWING"], "Stability"=>["unknown-stability"], "Reliability"=>["unknown-reliability"], "SideEffects"=>["unknown-side-effects"]},
 "references"=>[["CVE", "2008-4250"], ["OSVDB", "49243"], ["MSB", "MS08-067"], ["URL", "https://www.rapid7.com/db/vulnerabilities/dcerpc-ms-netapi-netpathcanonicalize-dos/"]],
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `load msgrpc`
- [ ] start msfrpc
- [ ] query for module info using `rpc.call('module.info', 'exploit', 'windows/smb/ms08_067_netapi')`
- [ ] Confirm the `notes` data is present