### PR TITLE
Notes returned as valid json instead of inspected string over RPC

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -1130,8 +1130,8 @@ end
   #    * 'time' [Integer] Creation date.
   #    * 'host' [String] Host address.
   #    * 'service' [String] Service name or port.
-  #    * 'type' [String] Host type.
-  #    * 'data' [String] Host data.
+  #    * 'type' [String] Note type.
+  #    * 'data' [Hash, String, nil] Note data.
   # @example Here's how you would use this from the client:
   #  # This gives you all the notes.
   #  rpc.call('db.notes', {})
@@ -1157,7 +1157,7 @@ end
       note[:host] = n.host.address if n.host
       note[:service] = n.service.name || n.service.port  if n.service
       note[:type ] = n.ntype.to_s
-      note[:data] = n.data.inspect
+      note[:data] = n.data
       ret[:notes] << note
     end
     ret


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/21249
Tested in Pro under `workspaces/1/notes`

## Before
Data is inspected, returned as a single string
```ruby
>> rpc.call("db.notes", {})
=> 
{"notes"=>
  [{"time"=>1774630729, "host"=>"", "service"=>"", "type"=>"shellcode.bin.localpath", "data"=>"{:full_path=>\"/Users/x/.msf4/local/bin.bin\"}"},
   {"time"=>1774624210, "host"=>"", "service"=>"", "type"=>"evasion.fileformat.process_herpaderping.localpath", "data"=>"{:full_path=>\"/Users/x/.msf4/local/ioxj.exe\"}"},
   {"time"=>1776072168, "host"=>"", "service"=>"", "type"=>"evasion.fileformat.syscall_inject.localpath", "data"=>"{:full_path=>\"/Users/x/.msf4/local/met.exe\"}"},
   {"time"=>1776160364, "host"=>"127.0.0.1", "service"=>"", "type"=>"host.os.session_fingerprint", "data"=>"{:name=>\"caea2eea7ecb\", :os=>\"Debian 9.6 (Linux 6.12.76-linuxkit)\", :arch=>\"x64\"}"},
   {"time"=>1776160491, "host"=>"127.0.0.1", "service"=>"", "type"=>"host.comments", "data"=>"{:host_data=>\"hello world, this is a comment\"}"}]}
```
In Pro, the data is also rendered correctly:
<img width="315" height="213" alt="image" src="https://github.com/user-attachments/assets/96db3d1b-2788-4a06-872a-e35638c00219" />

## After
Data is parsed correctly as a hash
```ruby
>> rpc.call("db.notes", {})
=> 
{"notes"=>
  [{"time"=>1774630729, "host"=>"", "service"=>"", "type"=>"shellcode.bin.localpath", "data"=>{"full_path"=>"/Users/x/.msf4/local/bin.bin"}},
   {"time"=>1774624210, "host"=>"", "service"=>"", "type"=>"evasion.fileformat.process_herpaderping.localpath", "data"=>{"full_path"=>"/Users/x/.msf4/local/ioxj.exe"}},
   {"time"=>1776072168, "host"=>"", "service"=>"", "type"=>"evasion.fileformat.syscall_inject.localpath", "data"=>{"full_path"=>"/Users/x/.msf4/local/met.exe"}},
   {"time"=>1776160364, "host"=>"127.0.0.1", "service"=>"", "type"=>"host.os.session_fingerprint", "data"=>{"name"=>"caea2eea7ecb", "os"=>"Debian 9.6 (Linux 6.12.76-linuxkit)", "arch"=>"x64"}},
   {"time"=>1776160491, "host"=>"127.0.0.1", "service"=>"", "type"=>"host.comments", "data"=>{"host_data"=>"hello world, this is a comment"}}]}
```
Pro also renders the hash correctly, with no changes to functionality:
<img width="312" height="209" alt="image" src="https://github.com/user-attachments/assets/82202845-9579-4553-83e4-026dfb6ca5da" />

In Pro, the code should handle this automatically where necessary as it calls off to:
```
def note_data_html
      if data.kind_of?(Hash)
```
which handles the `Hash` scenario.

## JSON RPC
This also works out of the box with the JSON RPC layer:
```json
      {
        "time": 1776160491,
        "host": "127.0.0.1",
        "service": "",
        "type": "host.comments",
        "data": {
          "host_data": "hello world, this is a comment"
        }
      },
      {
        "time": 1776072168,
        "host": "",
        "service": "",
        "type": "evasion.fileformat.syscall_inject.localpath",
        "data": {
          "full_path": "/Users/sjanusz/.msf4/local/met.exe"
        }
      },
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `load msgrpc`
- [ ] Run RPC client using msfrpc
- [ ] **Verify** calling `rpc.call("db.notes", {})` works and returns the expected notes data in correct format
