### PR TITLE
bump postgres from 9.6 to 14.19 for gem tests

### DIFF
--- a/.github/workflows/shared_gem_verify_rails.yml
+++ b/.github/workflows/shared_gem_verify_rails.yml
@@ -55,7 +55,7 @@ jobs:
           - '3.4'
         rails: ${{ fromJSON(needs.prepare_matrix.outputs.rails_versions) }}
         postgres:
-          - '9.6'
+          - '14.19'
           - '16.8'
         os:
           - ubuntu-latest


### PR DESCRIPTION
bump postgres from 9.6 to 14.19 for gem tests
