### PR TITLE
Fix sign-extension formula in marshal validator

### DIFF
--- a/lib/msf/core/db_manager/import/marshal_validator.rb
+++ b/lib/msf/core/db_manager/import/marshal_validator.rb
@@ -85,7 +85,7 @@ module Msf
         # This follows Ruby's Marshal integer encoding scheme.
         def read_marshal_int
           c = read_byte
-          c = (c ^ 256) - 256 if c > 127 # sign-extend
+          c -= 256 if c > 127 # sign-extend
 
           if c == 0
             0


### PR DESCRIPTION
I kept hitting an odd edge case running rspec, and I think it might be due to a bad sign extension prevention formula.

<details><summary>Errors</summary>


```
  1) Msf::DBManager::Import::MarshalValidator.safe_load with permitted _dump/_load classes loads a Time inside a hash when Time is permitted
     Failure/Error:
       raise MarshalValidationError,
             "Unknown Marshal type byte 0x#{type.to_s(16)} (#{type.chr.inspect}) " \
             "at offset #{@pos - 1} ��� refusing to deserialize"
     
     Msf::DBManager::Import::MarshalValidationError:
       Unknown Marshal type byte 0xb0 ("\xB0") at offset 90 ? refusing to deserialize
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:211:in `validate_value'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:179:in `block in validate_value'
     # <internal:numeric>:237:in `times'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:178:in `validate_value'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:189:in `block in validate_value'
     # <internal:numeric>:237:in `times'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:187:in `validate_value'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:42:in `validate!'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:53:in `safe_load'
     # ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:68:in `block (4 levels) in <top (required)>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:263:in `instance_exec'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:263:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:352:in `call'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-rails-8.0.2/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:457:in `instance_exec'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:457:in `instance_exec'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:390:in `execute_with'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:352:in `call'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:486:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:468:in `with_around_example_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:259:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:653:in `block in run_examples'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:649:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:649:in `run_examples'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:614:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/configuration.rb:2097:in `with_suite_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/reporter.rb:74:in `report'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:89:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:71:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/exe/rspec:4:in `<top (required)>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/rspec:25:in `load'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/rspec:25:in `<main>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/ruby_executable_hooks:22:in `eval'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/ruby_executable_hooks:22:in `<main>'

  2) Msf::DBManager::Import::MarshalValidator.safe_load with permitted _dump/_load classes loads a Time inside an array when Time is permitted
     Failure/Error:
       raise MarshalValidationError,
             "Unknown Marshal type byte 0x#{type.to_s(16)} (#{type.chr.inspect}) " \
             "at offset #{@pos - 1} ��� refusing to deserialize"
     
     Msf::DBManager::Import::MarshalValidationError:
       Unknown Marshal type byte 0xb0 ("\xB0") at offset 72 ? refusing to deserialize
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:211:in `validate_value'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:179:in `block in validate_value'
     # <internal:numeric>:237:in `times'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:178:in `validate_value'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:184:in `block in validate_value'
     # <internal:numeric>:237:in `times'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:184:in `validate_value'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:42:in `validate!'
     # ./lib/msf/core/db_manager/import/marshal_validator.rb:53:in `safe_load'
     # ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:75:in `block (4 levels) in <top (required)>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:263:in `instance_exec'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:263:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:511:in `block in with_around_and_singleton_context_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:468:in `block in with_around_example_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:486:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:626:in `block in run_around_example_hooks_for'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:352:in `call'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-rails-8.0.2/lib/rspec/rails/adapters.rb:75:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:457:in `instance_exec'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:457:in `instance_exec'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:390:in `execute_with'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:628:in `block (2 levels) in run_around_example_hooks_for'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:352:in `call'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:629:in `run_around_example_hooks_for'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/hooks.rb:486:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:468:in `with_around_example_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:511:in `with_around_and_singleton_context_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example.rb:259:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:653:in `block in run_examples'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:649:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:649:in `run_examples'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:614:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `block in run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/example_group.rb:615:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `map'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/configuration.rb:2097:in `with_suite_hooks'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:116:in `block in run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/reporter.rb:74:in `report'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:115:in `run_specs'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:89:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:71:in `run'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/lib/rspec/core/runner.rb:45:in `invoke'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rspec-core-3.13.5/exe/rspec:4:in `<top (required)>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/rspec:25:in `load'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/rspec:25:in `<main>'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/ruby_executable_hooks:22:in `eval'
     # /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/bin/ruby_executable_hooks:22:in `<main>'

Top 10 slowest examples (0.04818 seconds, 15.6% of total time):
  Msf::DBManager::Import::MarshalValidator#validate! returns true for safe data
    0.00906 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:198
  Msf::DBManager::Import::MarshalValidator.safe_load with safe primitive types loads a large integer (Bignum)
    0.00712 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:35
  Msf::DBManager::Import::MarshalValidator.safe_load with safe primitive types loads a small positive integer
    0.00589 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:23
  Msf::DBManager::Import::MarshalValidator.safe_load with safe compound types loads a hash with symbol keys
    0.00537 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:113
  Msf::DBManager::Import::MarshalValidator.safe_load with permitted _dump/_load classes loads a Time inside a hash when Time is permitted
    0.00379 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:65
  Msf::DBManager::Import::MarshalValidator.safe_load with safe compound types loads deeply nested structures
    0.00358 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:130
  Msf::DBManager::Import::MarshalValidator.safe_load with permitted _dump/_load classes loads a Time inside an array when Time is permitted
    0.00349 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:73
  Msf::DBManager::Import::MarshalValidator.safe_load with safe primitive types loads a symbol
    0.00337 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:44
  Msf::DBManager::Import::MarshalValidator.safe_load with safe primitive types loads nil
    0.00328 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:11
  Msf::DBManager::Import::MarshalValidator.safe_load with safe primitive types loads true
    0.00324 seconds ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:15

Finished in 0.30826 seconds (files took 3.07 seconds to load)
36 examples, 2 failures

Failed examples:

rspec ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:65 # Msf::DBManager::Import::MarshalValidator.safe_load with permitted _dump/_load classes loads a Time inside a hash when Time is permitted
rspec ./spec/lib/msf/core/db_manager/import/marshal_validator_spec.rb:73 # Msf::DBManager::Import::MarshalValidator.safe_load with permitted _dump/_load classes loads a Time inside an array when Time is permitted


```

</details>

Specifically, I was running into a case where:
```

tmoose@ubuntu-dev2024:~/rapid7/metasploit-framework$ irb
3.3.8 :001 > Marshal.dump(Time.now)
 => "\x04\bIu:\tTime\r\xD2\x8D\x1F\x80\xC0\xDF\xA9\"\n:\rnano_numi\x02\xA6\x01:\rnano_deni\x06:\rsubmicro\"\aB :\voffseti\xFE\xB0\xB9:\tzoneI\"\bCDT\x06:\x06EF" 
3.3.8 :002 > 

```

Given the method

```

        def read_marshal_int
          c = read_byte
          c = (c ^ 256) - 256 if c > 127 # sign-extend

          if c == 0
            0
          elsif c > 0 && c <= 4
            # c bytes follow, little-endian positive
            n = 0
            c.times { |i| n |= read_byte << (8 * i) }
            n
          elsif c >= -4 && c < 0
            # -c bytes follow, little-endian negative
            n = -1
            (-c).times { |i| n &= ~(0xff << (8 * i)); n |= read_byte << (8 * i) }
            n
          else
            # Small integer: encoded directly
            c > 0 ? c - 5 : c + 5
          end
        end
```

When we hit the `\xFE\xB0\xB9`, (If I understand the code right) we should recognize that `xFE` is -2, so we should expect 2 negative integers to follow.  Instead, if we plug the existing code into calc:

FE XOR 0100 = 01FE

01FE-0100 = 00FE

That does not perform the sign extension as expected, so we read `xFE` as an integer, then get confused with the subsequent two integers: xB0 and xB9.

To fix this, we can just subtract 256 from the value if it is more than 127:

FE-100= FFFE


