### PR TITLE
RPC vulns and services reports resources and parents (service only)

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -453,6 +453,8 @@ public
   #    * 'state' [String] Service state.
   #    * 'name' [String] Service name.
   #    * 'info' [String] Additional information about the service.
+  #    * 'resource' [Hash] Service resource.
+  #    * 'parents' [Array<Hash>] List of parent services with same set of keys as the service.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.services', {})
   def rpc_services( xopts)
@@ -471,18 +473,8 @@ public
     ret = {}
     ret[:services] = []
 
-    wspace.services.includes(:host).where(conditions).offset(offset).limit(limit).each do |s|
-      service = {}
-      host = s.host
-      service[:host] = host.address || "unknown"
-      service[:created_at] = s[:created_at].to_i
-      service[:updated_at] = s[:updated_at].to_i
-      service[:port] = s[:port]
-      service[:proto] = s[:proto].to_s
-      service[:state] = s[:state].to_s
-      service[:name] = s[:name].to_s
-      service[:info] = s[:info].to_s
-      ret[:services] << service
+    wspace.services.includes(:host, :parents).where(conditions).offset(offset).limit(limit).each do |s|
+      ret[:services] << process_service(s)
     end
     ret
   }
@@ -511,6 +503,7 @@ public
   #    * 'host' [String] Vulnerable host.
   #    * 'name' [String] Exploit that was used.
   #    * 'refs' [String] Vulnerability references.
+  #    * 'resource' [String] Vulnerability resource.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.vulns', {})
   def rpc_vulns(xopts)
@@ -541,6 +534,7 @@ public
       vuln[:host] = v.host.address || nil
       vuln[:name] = v.name
       vuln[:refs] = reflist.join(',')
+      vuln[:resource] = v.resource
       ret[:vulns] << vuln
     end
     ret
@@ -1987,6 +1981,35 @@ end
     end
   end
 
+
+  private
+
+  # Process an Mdm::Service object to a hash, with recursive parent lookup.
+  #
+  # @param mdm_service [Mdm::Service] The service record to process.
+  # @param recursion_count [Integer] Current recursion iteration count
+  # @return [Hash] Serialized service data.
+  def process_service(mdm_service, recursion_count = 0)
+    return { error: :recursion_limit_reached } unless recursion_count >= 0 && recursion_count < 3
+
+    service = {}
+    host = mdm_service.host
+
+    service[:host] = host.address || "unknown"
+    service[:created_at] = mdm_service[:created_at].to_i
+    service[:updated_at] = mdm_service[:updated_at].to_i
+    service[:port] = mdm_service[:port]
+    service[:proto] = mdm_service[:proto].to_s
+    service[:state] = mdm_service[:state].to_s
+    service[:name] = mdm_service[:name].to_s
+    service[:info] = mdm_service[:info].to_s
+    service[:resource] = mdm_service[:resource]
+    service[:parents] = mdm_service.parents.map do |parent|
+      process_service(parent, recursion_count + 1)
+    end
+
+    service
+  end
 
 end
 end

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -1987,10 +1987,10 @@ end
   # Process an Mdm::Service object to a hash, with recursive parent lookup.
   #
   # @param mdm_service [Mdm::Service] The service record to process.
-  # @param recursion_count [Integer] Current recursion iteration count
+  # @param recursion_depth [Integer] Current recursion iteration count
   # @return [Hash] Serialized service data.
-  def process_service(mdm_service, recursion_count = 0)
-    return { error: :recursion_limit_reached } unless recursion_count >= 0 && recursion_count < 6
+  def process_service(mdm_service, recursion_depth = 0)
+    error(500, "Recursion limit reached when processing service parents for #{mdm_service.name}") unless recursion_depth >= 0 && recursion_depth <= 10
 
     service = {}
     host = mdm_service.host
@@ -2005,7 +2005,7 @@ end
     service[:info] = mdm_service[:info].to_s
     service[:resource] = mdm_service[:resource]
     service[:parents] = mdm_service.parents.map do |parent|
-      process_service(parent, recursion_count + 1)
+      process_service(parent, recursion_depth + 1)
     end
 
     service

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -1990,7 +1990,7 @@ end
   # @param recursion_count [Integer] Current recursion iteration count
   # @return [Hash] Serialized service data.
   def process_service(mdm_service, recursion_count = 0)
-    return { error: :recursion_limit_reached } unless recursion_count >= 0 && recursion_count < 3
+    return { error: :recursion_limit_reached } unless recursion_count >= 0 && recursion_count < 6
 
     service = {}
     host = mdm_service.host


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/21250

This PR adds the reporting of `resource` for both the `db.vulns` and `db.services` RPC calls. It also adds the `parents` field to the services only.

Tested in Pro, no changes/impact.

## Before
### db.vulns
no resources
```ruby
>> rpc.call("db.vulns", {})
=> 
{"vulns"=>
  [{"port"=>389, "proto"=>"tcp", "time"=>1776246155, "host"=>"192.168.112.3", "name"=>"LDAP Login Scanner", "refs"=>""},
   {"port"=>445, "proto"=>"tcp", "time"=>1776246892, "host"=>"10.140.108.118", "name"=>"ESC15", "refs"=>"URL-https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc"},
   {"port"=>389, "proto"=>"tcp", "time"=>1776246437, "host"=>"10.140.108.118", "name"=>"LDAP Login Scanner", "refs"=>""},
   {"port"=>445, "proto"=>"tcp", "time"=>1776246891, "host"=>"10.140.108.118", "name"=>"ESC16_2", "refs"=>""},
```

### db.services
No resources and no parents
```ruby
>> rpc.call("db.services", {})
=> 
{"services"=>
  [{"host"=>"192.168.112.3", "created_at"=>1776246154, "updated_at"=>1776246154, "port"=>389, "proto"=>"tcp", "state"=>"open", "name"=>"ldap", "info"=>""},
   {"host"=>"10.140.108.118", "created_at"=>1776246437, "updated_at"=>1776246437, "port"=>389, "proto"=>"tcp", "state"=>"open", "name"=>"ldap", "info"=>""},
   {"host"=>"10.140.108.118", "created_at"=>1776246677, "updated_at"=>1776246677, "port"=>445, "proto"=>"tcp", "state"=>"open", "name"=>"icertpassage", "info"=>""},
```

## After
### db.vulns
```ruby
>> rpc.call("db.vulns", {})
=> 
{"vulns"=>
  [{"port"=>389, "proto"=>"tcp", "time"=>1776246155, "host"=>"192.168.112.3", "name"=>"LDAP Login Scanner", "refs"=>"", "resource"=>{}},
   {"port"=>445,
    "proto"=>"tcp",
    "time"=>1776246892,
    "host"=>"10.140.108.118",
    "name"=>"ESC15",
    "refs"=>"URL-https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc",
    "resource"=>{"ldap_dn"=>"CN=ESC15,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=ad,DC=pro,DC=local", "template_name"=>"ESC15"}},
   {"port"=>389, "proto"=>"tcp", "time"=>1776246437, "host"=>"10.140.108.118", "name"=>"LDAP Login Scanner", "refs"=>"", "resource"=>{}},
   {"port"=>445,
    "proto"=>"tcp",
    "time"=>1776246891,
    "host"=>"10.140.108.118",
    "name"=>"ESC16_2",
    "refs"=>"",
    "resource"=>{"ldap_dn"=>"CN=Administrator,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=ad,DC=pro,DC=local", "template_name"=>"Administrator"}},
    ...
  ]
}
```
### db.services
```ruby
>> rpc.call("db.services", {})
=> 
{"services"=>
   {"host"=>"10.140.108.118",
    "created_at"=>1776246677,
    "updated_at"=>1776246677,
    "port"=>445,
    "proto"=>"tcp",
    "state"=>"open",
    "name"=>"icertpassage",
    "info"=>"",
    "resource"=>{"dcerpc"=>{"pipe"=>"cert"}},
    "parents"=>
     [{"host"=>"10.140.108.118",
       "created_at"=>1776246676,
       "updated_at"=>1776246677,
       "port"=>445,
       "proto"=>"tcp",
       "state"=>"open",
       "name"=>"dcerpc",
       "info"=>"",
       "resource"=>{"smb"=>{"share"=>"IPC$"}},
       "parents"=>[{"host"=>"10.140.108.118", "created_at"=>1776246676, "updated_at"=>1776246676, "port"=>445, "proto"=>"tcp", "state"=>"open", "name"=>"smb", "info"=>"", "resource"=>{}, "parents"=>[]}]}]},
```

## JSON RPC
This also works for JSON RPC:
=> Vulns
```json
      {
        "port": 445,
        "proto": "tcp",
        "time": 1776246892,
        "host": "x",
        "name": "ESC15",
        "refs": "URL-https://trustedsec.com/blog/ekuwu-not-just-another-ad-cs-esc",
        "resource": {
          "ldap_dn": "CN=ESC15,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=ad,DC=pro,DC=local",
          "template_name": "ESC15"
        }
      },
```

=> services
```json
      {
        "host": "x",
        "created_at": 1776246677,
        "updated_at": 1776246677,
        "port": 445,
        "proto": "tcp",
        "state": "open",
        "name": "icertpassage",
        "info": "",
        "resource": {
          "dcerpc": {
            "pipe": "cert"
          }
        },
        "parents": [
          {
            "host": "x",
            "created_at": 1776246676,
            "updated_at": 1776246677,
            "port": 445,
            "proto": "tcp",
            "state": "open",
            "name": "dcerpc",
            "info": "",
            "resource": {
              "smb": {
                "share": "IPC$"
              }
            },
            "parents": [
              {
                "host": "x",
                "created_at": 1776246676,
                "updated_at": 1776246676,
                "port": 445,
                "proto": "tcp",
                "state": "open",
                "name": "smb",
                "info": "",
                "resource": {},
                "parents": []
              }
            ]
          }
        ]
      },
```
## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use the ldap_login, smb_login, ldap_esc_vulnerable_cert_finder modules against the persistent Pro ADCS VM
- [ ] start RPC server using `load msgrpc`
- [ ] Connect to RPC server
- [ ] Call `rpc.call("db.services", {})`
- [ ] Call `rpc.call("db.vulns", {})`
- [ ] Confirm the resources field is present for vulns
- [ ] Confirm the resources and parents fields are present for services
