### PR TITLE
Fix #21296 - Fix scanner/http/trace report_vuln crash

### DIFF
--- a/modules/auxiliary/scanner/http/trace.rb
+++ b/modules/auxiliary/scanner/http/trace.rb
@@ -46,6 +46,8 @@ class MetasploitModule < Msf::Auxiliary
           :port => rport,
           :proto => 'tcp',
           :sname => (ssl ? 'https' : 'http'),
+          :name => 'HTTP TRACE Method Enabled (Cross-Site Tracing)',
+          :refs => references,
           :info => "Vulnerable to Cross-Site Tracing"
         )
       else


### PR DESCRIPTION
Related issue: https://github.com/rapid7/metasploit-framework/issues/21296

When using `auxiliary/scanner/http/trace`, if success happened, the module would then crash as missing arguments were not being passed to report_host

## Before

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > git checkout master
[*] exec: git checkout master

Already on 'master'
Your branch is up to date with 'origin/master'.
msf > use auxiliary/scanner/http/trace
msf auxiliary(scanner/http/trace) > run
[+] 10.0.0.10:80 is vulnerable to Cross-Site Tracing
[-] Auxiliary failed: Msf::ValidationError Failed to report vuln for 10.0.0.10:80 to the database
[-] Call stack:
[-]   /usr/share/metasploit-framework2/lib/msf/core/auxiliary/report.rb:300:in `report_vuln'
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/http/trace.rb:44:in `run_host'
[-]   /usr/share/metasploit-framework2/lib/msf/core/auxiliary/scanner.rb:130:in `block (2 levels) in run'
[-]   /usr/share/metasploit-framework2/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/trace) >
msf auxiliary(scanner/http/trace) >
```

## After

```console
msf auxiliary(scanner/http/trace) > git checkout report_vuln
[*] exec: git checkout report_vuln

Switched to branch 'report_vuln'
Your branch is up to date with 'origin/report_vuln'.
msf auxiliary(scanner/http/trace) > reload
[*] Reloading module...
msf auxiliary(scanner/http/trace) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/http/trace) > run
[+] 10.0.0.10:80 is vulnerable to Cross-Site Tracing
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/http/trace) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      0      0      0

msf auxiliary(scanner/http/trace) >
```