### PR TITLE
Fix uninitialized constant HTTP::CookieJar by correcting load order in http_cookie_jar.rb

### DIFF
--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -1,7 +1,7 @@
 # 3rd party gems
-require 'http/cookie_jar/hash_store'
-require 'http/cookie_jar'
 require 'http/cookie'
+require 'http/cookie_jar'
+require 'http/cookie_jar/hash_store'
 
 # This class is a collection of Http Cookies with some built in convenience methods.
 # Acts as a wrapper for the +::HTTP::CookieJar+ (https://www.rubydoc.info/gems/http-cookie/1.0.2/HTTP/CookieJar) class.


### PR DESCRIPTION
This PR fixes a critical load order issue in `http_cookie_jar.rb` that causes `msfconsole` to crash with `uninitialized constant HTTP::CookieJar` or `CookieJar is not a class` when loading HTTP-based modules on environments using Ruby 3.3.0+ (such as recent Kali Linux rolling updates).

The newer Zeitwerk autoloader strictly enforces load order. Previously, `http_cookie_jar.rb` required `http/cookie_jar/hash_store` before the base `http/cookie` classes were loaded into memory, causing a crash during module parsing.

This change simply reverses the `require` order of the `http-cookie` gem files to load the base classes before the dependent storage classes.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole` on a system running Ruby 3.3.0+ (e.g., latest Kali Linux).
- [x] Run `use exploit/unix/webapp/elfinder_php_connector_exiftran_cmd_injection` (or any web module dependent on `HttpClient`).
- [x] **Verify** the module loads successfully without the `[-] The supplied module name is ambiguous: uninitialized constant HTTP` error.
- [x] **Verify** the `info` command works for the loaded module.