### PR TITLE
Simplify get_parent_path with rindex instead of split/join

### DIFF
--- a/lib/msf/core/module_manager/cache.rb
+++ b/lib/msf/core/module_manager/cache.rb
@@ -207,8 +207,10 @@ module Msf::ModuleManager::Cache
   end
 
   def get_parent_path(module_path, type)
-    # The load path is assumed to be the next level above the type directory
-    type_dir = File.join('', Mdm::Module::Detail::DIRECTORY_BY_TYPE[type], '')
-    module_path.split(type_dir)[0..-2].join(type_dir) # TODO: rewrite
+    # The load path is the directory above the type directory (e.g. everything
+    # before "/exploits/" in the module's absolute path).
+    type_dir = "#{File::SEPARATOR}#{Mdm::Module::Detail::DIRECTORY_BY_TYPE[type]}#{File::SEPARATOR}"
+    idx = module_path.rindex(type_dir)
+    idx ? module_path[0, idx] : module_path
   end
 end


### PR DESCRIPTION
Replace `File.join` + `String#split` + array slice + `Array#join` with a single `String#rindex` lookup. This avoids allocating intermediate arrays and strings on every call (once per cached module during startup).

(Also fixes a `TODO: rewrite`).
