### PR TITLE
Replace Pathname with string prefix removal in directory module loader

### DIFF
--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -42,15 +42,13 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
 
       next unless ::File.directory?(full_entry_path) && module_manager.type_enabled?(type)
 
-      full_entry_pathname = Pathname.new(full_entry_path)
+      type_dir_prefix = "#{full_entry_path}#{::File::SEPARATOR}"
 
       # Try to load modules from all the files in the supplied path
       Rex::Find.find(full_entry_path) do |entry_descendant_path|
         if module_path?(entry_descendant_path)
-          entry_descendant_pathname = Pathname.new(entry_descendant_path)
-          relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
-          relative_entry_descendant_path = relative_entry_descendant_pathname.to_s
-          next if File::basename(relative_entry_descendant_path).start_with?('example')
+          relative_entry_descendant_path = entry_descendant_path.delete_prefix(type_dir_prefix)
+          next if ::File.basename(relative_entry_descendant_path).start_with?('example')
           # The module_reference_name doesn't have a file extension
           module_reference_name = module_reference_name_from_path(relative_entry_descendant_path)
 


### PR DESCRIPTION
`Msf::Modules::Loader::Directory#each_module_reference_name` created two `Pathname` objects per module file and called `relative_path_from` to derive the module reference name. With ~5,000 module files this produced ~170,000 calls to `Pathname#chop_basename` internally.

Since `Rex::Find.find` always yields absolute paths rooted at `full_entry_path`, simple `String#delete_prefix` achieves the same result without allocating `Pathname` objects.
