### PR TITLE
Metadata::Obj: Deduplicate notes hash strings and memoize `Obj#path` to reduce retained memory in the module metadata cache

### DIFF
--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -36,6 +36,22 @@ class Obj
       @platform_list_cache[platform_string] ||= build_platform_list(platform_string)
     end
 
+    # Deduplicate notes hash keys and string values via the frozen string table.
+    # Keys like "Stability", "SideEffects", "Reliability" repeat across thousands
+    # of modules; values like "crash-safe", "ioc-in-logs" repeat hundreds of times.
+    def dedup_notes(notes)
+      notes.each_with_object({}) do |(k, v), h|
+        h[-k] = case v
+                when Array
+                  v.map { |e| e.is_a?(String) ? -e : e }
+                when String
+                  -v
+                else
+                  v
+                end
+      end
+    end
+
     private
 
     def build_platform_list(platform_string)
@@ -295,7 +311,7 @@ class Obj
     @post_auth           = obj_hash['post_auth']
     @default_credential  = obj_hash['default_credential']
     notes                = obj_hash['notes']
-    @notes               = (notes.nil? || notes.empty?) ? EMPTY_HASH : notes
+    @notes               = (notes.nil? || notes.empty?) ? EMPTY_HASH : Obj.dedup_notes(notes)
     @needs_cleanup       = obj_hash['needs_cleanup']
     @session_types       = obj_hash['session_types']
     @autofilter_ports    = obj_hash['autofilter_ports']

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -273,7 +273,7 @@ class Obj
 
   def path
     if @is_install_path
-      return ::File.join(Msf::Config.install_root, @path)
+      return @full_path ||= ::File.join(Msf::Config.install_root, @path)
     end
 
     @path


### PR DESCRIPTION
Deduplicate notes hash keys and values in metadata Obj

Notes keys ("Stability", "SideEffects", "Reliability") and values
("crash-safe", "ioc-in-logs", etc.) are repeated across thousands of
modules. Use frozen string dedup (-str) to share a single object per
unique string, reducing ~24K string allocations to ~185 shared objects.

---

Memoize Obj#path to avoid repeated File.join

The install_root path is immutable at runtime, so cache the computed
full path on first access instead of calling File.join on every call.