### PR TITLE
Remove false positive from nodejs pipelining check

### DIFF
--- a/modules/auxiliary/dos/http/nodejs_pipelining.rb
+++ b/modules/auxiliary/dos/http/nodejs_pipelining.rb
@@ -47,7 +47,8 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def check
+  # Remove due to false positives and false negatives: https://github.com/rapid7/metasploit-framework/pull/21332
+  def _check
     # http://blog.nodejs.org/2013/08/21/node-v0-10-17-stable/
     # check if we are < 0.10.17 by seeing if a malformed HTTP request is accepted
     status = Exploit::CheckCode::Safe


### PR DESCRIPTION
Remove false positive from nodejs pipelining check


When running this module against most HTTP servers, it will claims that it's vulnerable (extra debugging added):

```
msf auxiliary(dos/http/nodejs_pipelining) > recheck tcp://127.0.0.1:8000 ssl=false httptrace=true
[*] Reloading module...
GEM / HTTP/1.1
Host: 127.0.0.1:8000

HTTP/1.1 405 Method Not Allowed
Content-Type: text/html; charset=ISO-8859-1
Server: WEBrick/1.9.1 (Ruby/3.3.0/2023-12-25)
Date: Wed, 15 Apr 2026 16:48:29 GMT
Content-Length: 299
Connection: close

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
<HTML>
  <HEAD><TITLE>Method Not Allowed</TITLE></HEAD>
  <BODY>
    <H1>Method Not Allowed</H1>
    unsupported method 'GEM'.
    <HR>
    <ADDRESS>
     WEBrick/1.9.1 (Ruby/3.3.0/2023-12-25) at
     127.0.0.1:8000
    </ADDRESS>
  </BODY>
</HTML>
[+] 127.0.0.1:8000 - The target appears to be vulnerable. Node.js accepted a malformed HTTP method, likely < 0.10.17
msf auxiliary(dos/http/nodejs_pipelining) > 
```

After setting up a vuln environment, the check method doesn't work:

```
msf auxiliary(dos/http/nodejs_pipelining) > recheck tcp://127.0.0.1:9050  ssl=false httptrace=true
[*] Reloading module...
GEM / HTTP/1.1
Host: 127.0.0.1:9050

[*] 127.0.0.1:9050 - Cannot reliably check exploitability. No response to malformed HTTP request
msf auxiliary(dos/http/nodejs_pipelining) > 
```

The original check method was added here: https://github.com/rapid7/metasploit-framework/pull/2548#issuecomment-26659732

As the module's from 2013 and there doesn't seem to be a viable check method to implement currently, I'm opting to remove it for now.

## Verification

- Review the PR