### PR TITLE
Disable Windows Server 2022 CI

### DIFF
--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -284,21 +284,21 @@ jobs:
         run: |
           Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
           dir
-          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-          $WorkLoads = '--config "D:\a\metasploit-payloads\metasploit-payloads\metasploit-payloads\c\meterpreter\vs-configs\vs2022.vsconfig"'
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"", $WorkLoads, '--quiet', '--norestart', '--nocache')
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-          if ($process.ExitCode -eq 0) {
-            Write-Host "components have been successfully added"
-          } else {
-            Write-Host "components were not installed"
-            exit 1
-          }
-          Set-Location "D:\a\metasploit-payloads\metasploit-payloads\metasploit-payloads\c\meterpreter"
-          $r = Invoke-Command -ScriptBlock { cmd.exe /c 'git submodule init && git submodule update' }
-          Write-Host $r
-          $r = Invoke-Command -ScriptBlock { cmd.exe /c '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" && make.bat' }
-          Write-Host $r
+        # $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+        # $WorkLoads = '--config "D:\a\metasploit-payloads\metasploit-payloads\metasploit-payloads\c\meterpreter\vs-configs\vs2022.vsconfig"'
+        # $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"", $WorkLoads, '--quiet', '--norestart', '--nocache')
+        # $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+        # if ($process.ExitCode -eq 0) {
+        #   Write-Host "components have been successfully added"
+        # } else {
+        #   Write-Host "components were not installed"
+        #   exit 1
+        # }
+        # Set-Location "D:\a\metasploit-payloads\metasploit-payloads\metasploit-payloads\c\meterpreter"
+        # $r = Invoke-Command -ScriptBlock { cmd.exe /c 'git submodule init && git submodule update' }
+        # Write-Host $r
+        # $r = Invoke-Command -ScriptBlock { cmd.exe /c '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" && make.bat' }
+        # Write-Host $r
         working-directory: metasploit-payloads
 
       - name: Build Windows payloads via Visual Studio 2025 Build (Windows)


### PR DESCRIPTION
Fixes: #21334 

This disable the Windows Server 2022 meterpreter build that fails because the XP package is missing in current visual studio installs and cannot be fetched remotely.