### PR TITLE
Fix various smb/samba issues

### DIFF
--- a/lib/msf/core/exploit/remote/ms_samr.rb
+++ b/lib/msf/core/exploit/remote/ms_samr.rb
@@ -60,7 +60,7 @@ module Exploit::Remote::MsSamr
   rescue RubySMB::Dcerpc::Error::DcerpcError => e
     elog(e.message, error: e)
     raise MsSamrUnexpectedReplyError, e.message
-  rescue RubySMB::Error::RubySMBError
+  rescue RubySMB::Error::RubySMBError => e
     elog(e.message, error: e)
     raise MsSamrUnknownError, e.message
   end

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -80,6 +80,7 @@ class MetasploitModule < Msf::Auxiliary
       command = "#{cmd} /C echo reg.exe QUERY HKU ^> %SYSTEMDRIVE%#{text} > #{bat} & #{cmd} /C start cmd.exe /C #{bat}"
       out = psexec(command)
       output = get_output(ip, smbshare, text)
+      return nil unless output
       cleanout = Array.new
       output.each_line { |line| cleanout << line.chomp if line.include?("HKEY") && line.split("-").size == 8 && !line.split("-")[7].include?("_") }
       return cleanout

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -311,7 +311,7 @@ class MetasploitModule < Msf::Auxiliary
           connect(versions: [1, 2, 3])
         end
         smb_login
-        break unless enum_shares(ip).empty?
+        break unless enum_shares(ip)&.empty?
       rescue ::Interrupt
         raise $ERROR_INFO
       rescue Errno::ECONNRESET => e

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -311,7 +311,9 @@ class MetasploitModule < Msf::Auxiliary
           connect(versions: [1, 2, 3])
         end
         smb_login
-        break unless enum_shares(ip)&.empty?
+        shares = enum_shares(ip)
+        next if shares.nil? || shares.empty?
+        break
       rescue ::Interrupt
         raise $ERROR_INFO
       rescue Errno::ECONNRESET => e

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -108,7 +108,12 @@ class MetasploitModule < Msf::Auxiliary
   def run_service_domain(tree, smb_domain: nil)
     @smb_domain = smb_domain
 
-    samr_con = connect_samr(tree)
+    begin
+      samr_con = connect_samr(tree)
+    rescue ::Exception => e
+      print_error("SAMR connection failed: #{e.class} #{e}")
+      return nil
+    end
 
     lockout_info = samr_con.samr.samr_query_information_domain(
       domain_handle: samr_con.domain_handle,
@@ -132,8 +137,10 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
   ensure
-    samr_con.samr.close_handle(samr_con.domain_handle) if samr_con.domain_handle
-    samr_con.samr.close_handle(samr_con.server_handle) if samr_con.server_handle
+    if samr_con
+      samr_con.samr.close_handle(samr_con.domain_handle) if samr_con.domain_handle
+      samr_con.samr.close_handle(samr_con.server_handle) if samr_con.server_handle
+    end
   end
 
   def report_username(domain, username)

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -270,10 +270,6 @@ class MetasploitModule < Msf::Auxiliary
     # Private can be nil if we authenticated with Kerberos and a cached ticket was used. No need to report this.
     return unless result.credential.private
 
-    if !datastore['RECORD_GUEST'] && (result.access_level == Metasploit::Framework::LoginScanner::SMB::AccessLevels::GUEST)
-      return
-    end
-
     service_data = {
       address: ip,
       port: port,
@@ -281,6 +277,14 @@ class MetasploitModule < Msf::Auxiliary
       protocol: 'tcp',
       workspace_id: myworkspace_id
     }
+
+    report_service(
+      host: service_data[:address],
+      port: service_data[:port],
+      proto: service_data[:protocol],
+      name: service_data[:service_name]
+    )
+    return if !datastore['RECORD_GUEST'] && result.access_level == Metasploit::Framework::LoginScanner::SMB::AccessLevels::GUEST
 
     credential_data = {
       module_fullname: fullname,

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -196,7 +196,9 @@ class MetasploitModule < Msf::Auxiliary
     results_table = format_results(results)
     results_table.rows = results_table.rows.uniq # Remove potentially duplicate entries from port 139 & 445
 
-    print_line
-    print_line results_table.to_s
+    unless results_table.rows.empty?
+      print_line
+      print_line results_table.to_s
+    end
   end
 end

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -177,6 +177,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Each result contains 0 or more arrays containing: SID Type, Name, RID
     results.compact.each do |result_set|
+      next unless result_set.respond_to?(:each)
       result_set.each { |result| sids_table << result }
     end
 

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -127,6 +127,9 @@ class MetasploitModule < Msf::Auxiliary
            ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
            ::Rex::Proto::SMB::Exceptions::NoReply => e
       elog(e)
+    rescue ::Rex::Proto::DCERPC::Exceptions::Fault => e
+      elog(e)
+      return false
     rescue ::Exception => e
       if e.to_s =~ /execution expired/i
         # So what happens here is that when you trigger the buggy code path, you hit this:

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -210,6 +210,8 @@ class MetasploitModule < Msf::Auxiliary
     samba_info = ''
     smb_ports = [445, 139]
     smb_ports.each do |port|
+      # Update line prefix, as port changes
+      remove_instance_variable(:@print_prefix) if instance_variable_defined?(:@print_prefix)
       @smb_port = port
       samba_info = get_samba_info
       vprint_status("Samba version: #{samba_info}")

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -207,35 +207,34 @@ class MetasploitModule < Msf::Auxiliary
 
   # Check command
   def check_host(ip)
-    samba_info = ''
+    @samba_info = ''
     smb_ports = [445, 139]
     smb_ports.each do |port|
       # Update line prefix, as port changes
       remove_instance_variable(:@print_prefix) if instance_variable_defined?(:@print_prefix)
       @smb_port = port
-      samba_info = get_samba_info
-      vprint_status("Samba version: #{samba_info}")
+      @samba_info = get_samba_info
+      vprint_status("Samba version: #{@samba_info}")
 
-      if samba_info !~ /^samba/i
+      if @samba_info !~ /^samba/i
         vprint_status("Target isn't Samba, no check will run.")
         return Exploit::CheckCode::Safe('Target is not running Samba')
       end
 
       if datastore['PASSIVE']
-        if maybe_vulnerable?(samba_info)
-          flag_vuln_host(ip, samba_info)
+        if maybe_vulnerable?(@samba_info)
+          flag_vuln_host(ip, @samba_info)
           return Exploit::CheckCode::Appears('Samba version appears to be vulnerable based on version check')
         end
       else
         # Explicit: Actually triggers the bug
         if is_vulnerable?(ip)
-          flag_vuln_host(ip, samba_info)
-          return Exploit::CheckCode::Vulnerable('Samba uninitialized credential vulnerability confirmed')
+          flag_vuln_host(ip, @samba_info)
         end
       end
     end
 
-    return Exploit::CheckCode::Detected('Samba detected but vulnerability could not be confirmed') if samba_info =~ /^samba/i
+    return Exploit::CheckCode::Detected('Samba detected but vulnerability could not be confirmed') if @samba_info =~ /^samba/i
 
     Exploit::CheckCode::Safe('Target does not appear to be running Samba')
   end
@@ -254,7 +253,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     peer = "#{ip}:#{rport}"
-    case check_host(ip)
+    result = check_host(ip)
+    case result
     when Exploit::CheckCode::Vulnerable
       print_good("The target is vulnerable to CVE-2015-0240.")
     when Exploit::CheckCode::Appears
@@ -264,5 +264,14 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_status("The target appears to be safe")
     end
+
+    report_service(
+      :host  => ip,
+      :port  => rport,
+      :proto => 'tcp',
+      :name  => 'smb',
+      :info  => @samba_info.to_s
+    ) if [Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears, Exploit::CheckCode::Detected].include?(result)
   end
 end
+

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -318,7 +318,7 @@ class MetasploitModule < Msf::Auxiliary
             })
           end
 
-          # Report the service with a friendly banner
+          # Report the service with a detailed friendly banner
           report_service(
             host: ip,
             port: rport,
@@ -338,19 +338,20 @@ class MetasploitModule < Msf::Auxiliary
           )
         elsif smb1_fingerprint['native_os'] || smb1_fingerprint['native_lm']
           desc = "#{smb1_fingerprint['native_os']} (#{smb1_fingerprint['native_lm']})"
-          report_service(host: ip, port: rport, name: 'smb', info: desc)
+
+          # Report the service with a friendly banner
+          report_service(
+            host: ip,
+            port: rport,
+            proto: 'tcp',
+            name: 'smb',
+            info: desc
+          )
+
           lines << { type: :status, message: "  Host could not be identified: #{desc}" }
         else
           lines << { type: :status, message: '  Host could not be identified', verbose: true }
         end
-
-        report_service(
-          host: ip,
-          port: rport,
-          proto: 'tcp',
-          name: 'smb',
-          info: "#{smb_desc}. #{os_desc}"
-        )
 
         # Report a smb.fingerprint hash of attributes for OS fingerprinting
         report_note(


### PR DESCRIPTION
REF: 

- https://github.com/rapid7/metasploit-framework/issues/21337
- https://github.com/rapid7/metasploit-framework/issues/21338
- https://github.com/rapid7/metasploit-framework/issues/21339

```console
msf > use auxiliary/scanner/smb/smb_enumshares
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf auxiliary(scanner/smb/smb_enumshares) >
msf auxiliary(scanner/smb/smb_enumshares) > options

Module options (auxiliary/scanner/smb/smb_enumshares):

   Name                    Current Setting                         Required  Description
   ----                    ---------------                         --------  -----------
   HIGHLIGHT_NAME_PATTERN  username|password|user|pass|Groups.xml  yes       PCRE regex of resource names to highlight
   LogSpider               3                                       no        0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt) (Accepted: 0, 1, 2, 3)
   MaxDepth                999                                     yes       Max number of subdirectories to spider
   Share                                                           no        Show only the specified share
   ShowFiles               false                                   yes       Show detailed information when spidering
   SpiderProfiles          true                                    no        Spider only user profiles when share is a disk share
   SpiderShares            false                                   no        Spider shares recursively


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     10.0.0.10        no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/smb/smb_enumshares) >
msf auxiliary(scanner/smb/smb_enumshares) > run
[*] 10.0.0.10: - Connecting to the server...
[-] 10.0.0.10: - Invalid packet received when trying to enumerate shares - The response seems to be an SMB1 NtCreateAndxResponse but an error occurs while parsing it. It is probably missing the required extended information.
[*] 10.0.0.10: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_enumshares) >
msf auxiliary(scanner/smb/smb_enumshares) > use auxiliary/scanner/smb/smb_enumusers
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf auxiliary(scanner/smb/smb_enumusers) >
msf auxiliary(scanner/smb/smb_enumusers) > options

Module options (auxiliary/scanner/smb/smb_enumusers):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DB_ALL_USERS  false            no        Add all enumerated usernames to the database


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     10.0.0.10        no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      445              no        The target port (TCP)
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/smb/smb_enumusers) >
msf auxiliary(scanner/smb/smb_enumusers) > run
[*] 10.0.0.10:445 - Connecting to Security Account Manager (SAM) Remote Protocol
[-] 10.0.0.10:445 - SAMR connection failed: Msf::Exploit::Remote::MsSamr::MsSamrUnknownError The server responded with an unexpected status code: STATUS_OBJECT_NAME_NOT_FOUND
[*] 10.0.0.10:445 - Connecting to Security Account Manager (SAM) Remote Protocol
[-] 10.0.0.10:445 - SAMR connection failed: Msf::Exploit::Remote::MsSamr::MsSamrUnknownError The server responded with an unexpected status code: STATUS_OBJECT_NAME_NOT_FOUND
[*] 10.0.0.10: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_enumusers) >
msf auxiliary(scanner/smb/smb_enumusers) > use auxiliary/scanner/smb/smb_lookupsid
[*] Setting default action LOCAL - view all 2 actions with the show actions command
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf auxiliary(scanner/smb/smb_lookupsid) >
msf auxiliary(scanner/smb/smb_lookupsid) > options

Module options (auxiliary/scanner/smb/smb_lookupsid):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   MaxRID  4000             no        Maximum RID to check
   MinRID  500              no        Starting RID to check


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     10.0.0.10        no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      445              no        The target port (TCP)
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


Auxiliary action:

   Name   Description
   ----   -----------
   LOCAL  Enumerate local accounts



View the full module info with the info, or info -d command.

msf auxiliary(scanner/smb/smb_lookupsid) >
msf auxiliary(scanner/smb/smb_lookupsid) > run
[*] 10.0.0.10:445 - Connecting to Local Security Authority (LSA) Remote Protocol
[-] 10.0.0.10:445 - Error: RubySMB::Error::UnexpectedStatusCode The server responded with an unexpected status code: STATUS_OBJECT_NAME_NOT_FOUND

SMB Lookup SIDs Output
======================

    Type  Name  RID
    ----  ----  ---

[*] 10.0.0.10: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_lookupsid) >
```