### PR TITLE
Defer loading rex/metasm/octokit/etc dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
       mutex_m
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.21)
+    metasploit-credential (6.0.23)
       bigdecimal
       csv
       drb
@@ -508,7 +508,7 @@ GEM
       rex-struct2
       rex-text
     rex-core (0.1.36)
-    rex-encoder (0.1.8)
+    rex-encoder (0.1.10)
       metasm
       rex-arch
       rex-text
@@ -541,7 +541,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.64)
+    rex-socket (0.1.65)
       dnsruby
       rex-core
     rex-sslscan (0.1.13)

--- a/lib/metasploit/framework.rb
+++ b/lib/metasploit/framework.rb
@@ -6,16 +6,10 @@
 #
 
 require 'active_support'
-require 'bcrypt'
 require 'json'
 require 'msgpack'
 require 'metasploit/credential'
 require 'nokogiri'
-# railties has not autorequire defined
-# rkelly-remix is a fork of rkelly, so it's autorequire is 'rkelly' and not 'rkelly-remix'
-require 'rkelly'
-require 'robots'
-require 'zip'
 require 'msf'
 #
 # Project

--- a/lib/msf/core/db_manager/user.rb
+++ b/lib/msf/core/db_manager/user.rb
@@ -1,4 +1,3 @@
-require 'bcrypt'
 require 'securerandom'
 
 module Msf::DBManager::User

--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -2,8 +2,6 @@
 module Msf
 module Exe
 
-  require 'metasm'
-
   class SegmentAppender < SegmentInjector
 
     def payload_stub(prefix)

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -2,8 +2,6 @@
 module Msf
 module Exe
 
-  require 'metasm'
-
   class SegmentInjector
 
     attr_accessor :payload

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 require 'rex/encoder/ndr'
-require 'recog'
 
 module Msf
   module Exploit::Remote::SMB

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -11,7 +11,6 @@ require 'monitor'
 #
 
 require 'metasploit/framework/version'
-require 'rex/socket/ssl'
 require 'metasploit/framework/thread_factory_provider'
 module Msf
 

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -1,5 +1,4 @@
 # -*- coding: binary -*-
-require 'metasm'
 
 module Msf
 

--- a/lib/msf/util/document_generator/pull_request_finder.rb
+++ b/lib/msf/util/document_generator/pull_request_finder.rb
@@ -1,4 +1,3 @@
-require 'octokit'
 require 'nokogiri'
 require 'net/http'
 
@@ -38,6 +37,8 @@ module Msf
             msg = ''
             raise PullRequestFinder::Exception, 'GITHUB_OAUTH_TOKEN environment variable not set.'
           end
+
+          require 'octokit'
 
           self.owner            = 'rapid7'
           self.repository       = "#{owner}/metasploit-framework"

--- a/lib/msf/util/exe/common.rb
+++ b/lib/msf/util/exe/common.rb
@@ -6,7 +6,6 @@ module Msf::Util::EXE::Common
   require 'rex/random_identifier'
   require 'rex/zip'
   require 'rex/powershell'
-  require 'metasm'
   require 'digest/sha1'
 
   def self.included(base)

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -346,11 +346,16 @@ class MsfAutoload
 end
 
 # global autoload of common gems
+autoload :BCrypt, 'bcrypt'
+autoload :Dnsruby, 'dnsruby'
 autoload :Faker, 'faker'
 autoload :BinData, 'bindata'
+autoload :Metasm, 'metasm'
+autoload :Recog, 'recog'
 autoload :RubySMB, 'ruby_smb'
 autoload :MetasploitPayloads, 'metasploit-payloads'
 autoload :PacketFu, 'packetfu'
+autoload :Zip, 'zip'
 autoload :DidYouMean, 'did_you_mean'
 
 require 'rexml/document'

--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -3,6 +3,26 @@
 module Rex
   Root = File.join(File.expand_path(File.dirname(__FILE__)), 'rex')
   LogSource = "rex"
+
+  # library for creating Powershell scripts for exploitation purposes
+  autoload :Powershell, 'rex/powershell'
+  # Library for working with OLE
+  autoload :OLE, 'rex/ole'
+  # Library for creating and/or parsing MIME messages
+  autoload :MIME, 'rex/mime'
+  # Exploit Helper Library
+  autoload :Exploitation, 'rex/exploitation'
+  # Binary parsing tools (PE, ELF, Mach-O)
+  autoload :BinTools, 'rex/bin_tools'
+  autoload :PeParsey, 'rex/peparsey'
+  autoload :PeScan, 'rex/pescan'
+  autoload :ElfParsey, 'rex/elfparsey'
+  autoload :ElfScan, 'rex/elfscan'
+  autoload :MachParsey, 'rex/machparsey'
+  autoload :MachScan, 'rex/machscan'
+  autoload :ImageSource, 'rex/image_source'
+  # SSLScan
+  autoload :SSLScan, 'rex/sslscan/scanner'
 end
 
 #
@@ -13,8 +33,6 @@ end
 require 'rex/text'
 # Library for Generating Randomized strings valid as Identifiers such as variable names
 require 'rex/random_identifier'
-# library for creating Powershell scripts for exploitation purposes
-require 'rex/powershell'
 # Library for processing and creating Zip compatible archives
 require 'rex/zip'
 # Library for parsing offline Windows Registry files
@@ -23,16 +41,10 @@ require 'rex/registry'
 require 'rex/java'
 # Library for creating C-style Structs
 require 'rex/struct2'
-# Library for working with OLE
-require 'rex/ole'
-# Library for creating and/or parsing MIME messages
-require 'rex/mime'
 # Library for polymorphic encoders
 require 'rex/encoder'
 # Architecture subsystem
 require 'rex/arch'
-# Exploit Helper Library
-require 'rex/exploitation'
 
 # Generic classes
 require 'rex/file'
@@ -56,10 +68,6 @@ require 'rex/socket'
 
 # Compatibility
 require 'rex/compat'
-
-# SSLScan
-require 'rex/sslscan/scanner'
-require 'rex/sslscan/result'
 
 # Versions
 require 'rex/version'

--- a/lib/rex/proto/dns/packet.rb
+++ b/lib/rex/proto/dns/packet.rb
@@ -2,7 +2,6 @@
 
 require 'net/dns'
 require 'resolv'
-require 'dnsruby'
 
 module Rex
 module Proto

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 
 require 'net/dns/resolver'
-require 'dnsruby'
 
 module Rex
 module Proto

--- a/lib/rex/proto/dns/static_hostnames.rb
+++ b/lib/rex/proto/dns/static_hostnames.rb
@@ -13,6 +13,11 @@ module DNS
   class StaticHostnames
     extend Forwardable
 
+    # DNS record type constants (matching Dnsruby::Types::A and Dnsruby::Types::AAAA)
+    # Defined locally to avoid loading dnsruby during boot
+    TYPE_A    = 1
+    TYPE_AAAA = 28
+
     def_delegators :@hostnames, :each, :each_with_index, :length, :empty?, :sort_by
 
     # @param [Hash<String, IPAddr>] hostnames The hostnames to IP address mappings to initialize with.
@@ -57,7 +62,7 @@ module DNS
     # @param [Integer] type The family of address to return represented as a DNS type (either A or AAAA).
     # @return Returns the IP address if it was found, otherwise nil.
     # @rtype [IPAddr, nil]
-    def get1(hostname, type = Dnsruby::Types::A)
+    def get1(hostname, type = TYPE_A)
       get(hostname, type).first
     end
 
@@ -67,7 +72,7 @@ module DNS
     # @param [Integer] type The family of address to return represented as a DNS type (either A or AAAA).
     # @return Returns an array of IP addresses.
     # @rtype [Array<IPAddr>]
-    def get(hostname, type = Dnsruby::Types::A)
+    def get(hostname, type = TYPE_A)
       hostname = hostname.downcase
       @hostnames.fetch(hostname, {}).fetch(type, []).dup
     end
@@ -89,9 +94,9 @@ module DNS
       hostname = hostname.downcase.delete_suffix('.')
       this_host = @hostnames.fetch(hostname, {})
       if ip_address.family == ::Socket::AF_INET
-        type = Dnsruby::Types::A
+        type = TYPE_A
       else
-        type = Dnsruby::Types::AAAA
+        type = TYPE_AAAA
       end
       this_type = this_host.fetch(type, [])
       this_type << ip_address unless this_type.include?(ip_address)
@@ -108,9 +113,9 @@ module DNS
     def delete(hostname, ip_address)
       ip_address = IPAddr.new(ip_address) if ip_address.is_a?(String) && Rex::Socket.is_ip_addr?(ip_address)
       if ip_address.family == ::Socket::AF_INET
-        type = Dnsruby::Types::A
+        type = TYPE_A
       else
-        type = Dnsruby::Types::AAAA
+        type = TYPE_AAAA
       end
 
       hostname = hostname.downcase

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -3,7 +3,6 @@ require 'cgi'
 require 'uri'
 
 require 'nokogiri'
-require 'rkelly'
 
 module Rex
 module Proto
@@ -121,7 +120,7 @@ class Response < Packet
   end
 
   def gzip_decode
-    gz = Zlib::GzipReader.new(StringIO.new(self.body.to_s))    
+    gz = Zlib::GzipReader.new(StringIO.new(self.body.to_s))
 
     gz.read
   end
@@ -158,6 +157,8 @@ class Response < Packet
   # @see https://github.com/tenderlove/rkelly
   # @return [Array<RKelly::Nodes::SourceElementsNode>]
   def get_html_scripts
+    require 'rkelly'
+
     n = get_html_document
     rkelly = RKelly::Parser.new
     n.search('//script').map { |s| rkelly.parse(s.text) }

--- a/modules/payloads/stagers/netware/reverse_tcp.rb
+++ b/modules/payloads/stagers/netware/reverse_tcp.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasm'
-
 module MetasploitModule
   CachedSize = 281
 

--- a/modules/payloads/stages/netware/shell.rb
+++ b/modules/payloads/stages/netware/shell.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'metasm'
-
 module MetasploitModule
   include Msf::Sessions::CommandShellOptions
 

--- a/spec/lib/rex/proto/dns/static_hostnames_spec.rb
+++ b/spec/lib/rex/proto/dns/static_hostnames_spec.rb
@@ -3,6 +3,18 @@ require 'dnsruby'
 require 'spec_helper'
 
 RSpec.describe Rex::Proto::DNS::StaticHostnames do
+  describe '::TYPE_A' do
+    it 'matches Dnsruby::Types::A' do
+      expect(described_class::TYPE_A).to eq Dnsruby::Types::A
+    end
+  end
+
+  describe '::TYPE_AAAA' do
+    it 'matches Dnsruby::Types::AAAA' do
+      expect(described_class::TYPE_AAAA).to eq Dnsruby::Types::AAAA
+    end
+  end
+
   describe '#parse_hosts_file' do
     context 'when parsing a file' do
       let(:subject) { described_class.new }


### PR DESCRIPTION
Defer loading dependencies

Requires
- https://github.com/rapid7/rex-socket/pull/81
- https://github.com/rapid7/metasploit_data_models/pull/227
- https://github.com/rapid7/metasploit-credential/pull/200
- https://github.com/rapid7/rex-encoder/pull/6

## Verification

- Ensure CI passes
- Spot check a few modules to ensure they work as expected