### PR TITLE
Fix elasticsearch traversal check support

### DIFF
--- a/lib/msf/core/auxiliary/multiple_target_hosts.rb
+++ b/lib/msf/core/auxiliary/multiple_target_hosts.rb
@@ -17,12 +17,10 @@ module Auxiliary::MultipleTargetHosts
   end
 
   def check
+    return Exploit::CheckCode::Unsupported unless has_check?
+
     nmod = replicant
-    begin
-      nmod.check_host(datastore['RHOST'])
-    rescue NoMethodError
-      Exploit::CheckCode::Unsupported
-    end
+    nmod.check_host(datastore['RHOST'])
   end
 
 end

--- a/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
@@ -54,17 +54,21 @@ class MetasploitModule < Msf::Auxiliary
       'data' => '{"type":"fs","settings":{"location":"dsr"}}'
     )
 
+    return Exploit::CheckCode::Unknown('Failed to connect to the target.') unless res1
+
     res2 = send_request_raw(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '_snapshot', 'pwnie'),
       'data' => '{"type":"fs","settings":{"location":"dsr/snapshot-ev1l"}}'
     )
 
+    return Exploit::CheckCode::Unknown('Failed to connect to the target.') unless res2
+
     if res1.body.include?('true') && res2.body.include?('true')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Successfully created snapshot repositories, suggesting the Snapshot API is vulnerable to CVE-2015-5531.')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Failed to create snapshot repositories.')
   end
 
   def read_file(file)
@@ -82,7 +86,12 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => travs
     )
 
-    if res && res.code == 400
+    unless res
+      print_error("No response received from the target.")
+      return nil
+    end
+
+    if res.code == 400
       return res.body
     else
       print_status("Server returned HTTP response code: #{res.code}")
@@ -95,8 +104,8 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Checking if it's a vulnerable ElasticSearch")
 
     check_code = check_host(ip)
-    print_status("#{check_code.message}")
-    if check_host(ip) != Exploit::CheckCode::Appears
+    print_status(check_code.message)
+    unless check_code == Exploit::CheckCode::Appears
       return
     end
 


### PR DESCRIPTION
Fixes the `check` method for `scanner/http/elasticsearch_traversal`

## Verification

Before:
```
msf auxiliary(scanner/http/elasticsearch_traversal) > check rhost=127.0.0.1
[*] 127.0.0.1:9200 - This module does not support check.
```
Check code bug fix:

```
msf auxiliary(scanner/http/elasticsearch_traversal) > check 127.0.0.1
[-] Auxiliary failed: NoMethodError undefined method `body' for nil
[-] Call stack:
[-]   /Users/user/Documents/code/metasploit-framework/modules/auxiliary/scanner/http/elasticsearch_traversal.rb:63:in `check_host'
[-]   /Users/user/Documents/code/metasploit-framework/lib/msf/core/auxiliary/multiple_target_hosts.rb:23:in `check'
[-] 127.0.0.1:9200 - Check failed: The state could not be determined.
```

Module bug fix:
```
msf auxiliary(scanner/http/elasticsearch_traversal) > recheck 127.0.0.1
[*] Reloading module...
[*] 127.0.0.1:9200 - Cannot reliably check exploitability. Failed to connect to the target.
```

Vuln target:
```
msf auxiliary(scanner/http/elasticsearch_traversal) > check 10.140.113.233
[*] 10.140.113.233:9200 - The target appears to be vulnerable. Successfully created snapshot repositories, suggesting the Snapshot API is vulnerable to CVE-2015-5531.
```