### PR TITLE
smb_enumshares: Allow for SMB1 ruby_smb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ PATH
       rinda
       ruby-macho
       ruby-mysql
-      ruby_smb (~> 3.3.17)
+      ruby_smb (~> 3.3.19)
       rubyntlm
       rubyzip
       sinatra (~> 3.2)
@@ -603,7 +603,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.17)
+    ruby_smb (3.3.19)
       bindata (= 2.4.15)
       openssl-ccm
       openssl-cmac

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -151,7 +151,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb', '~> 3.3.17'
+  spec.add_runtime_dependency 'ruby_smb', '~> 3.3.19'
   spec.add_runtime_dependency 'net-imap' # Used in Postgres auth for its SASL stringprep implementation
   spec.add_runtime_dependency 'date', '3.4.1' # Temporarily pinned until 3.5 can be tested
   spec.add_runtime_dependency 'net-ldap'

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -298,18 +298,17 @@ class MetasploitModule < Msf::Auxiliary
       self.simple = session.simple_client
       enum_shares(session.address)
     else
-      [{ port: SMB1_PORT }, { port: SMB2_3_PORT } ].each do |info|
-        vprint_status("Connecting to the server...")
+      [
+        { port: SMB1_PORT, versions: [1], backend: :ruby_smb, label: 'SMB over NetBIOS' },
+        { port: SMB2_3_PORT, versions: [1, 2, 3], backend: :ruby_smb, label: 'SMB' }
+      ].each do |info|
+        # Update line prefix, as port changes
+        remove_instance_variable(:@print_prefix) if instance_variable_defined?(:@print_prefix)
         # Assign @rport so that it is accessible via the rport method in this module,
         # as well as making it accessible to the module mixins
         @rport = info[:port]
-        if rport == SMB1_PORT
-          # force library in smb1 mode otherwise simple.client is a
-          # `Rex::Proto::SMB::Client` that does not supply `net_share_enum_all`
-          connect(versions: [1], backend: :ruby_smb)
-        else
-          connect(versions: [1, 2, 3])
-        end
+        vprint_status("Connecting using #{info[:label]} via #{info[:backend]}")
+        connect(versions: info[:versions], backend: info[:backend])
         smb_login
         shares = enum_shares(ip)
         next if shares.nil? || shares.empty?
@@ -345,19 +344,17 @@ class MetasploitModule < Msf::Auxiliary
       # Return all shares if `Shares` option has not been set
       if datastore['Share'].nil?
         shares = simple.client.net_share_enum_all(ip)
+      # Return specific share if the `Share` option has been set
       else
-        # Return specific share if the `Share` option has been set
         simple.client.net_share_enum_all(ip).each { |share| shares = [share] if share[:name] == datastore['Share'] }
-        # Return an error if `Share` option has been set but no matches were found
-        if shares.empty?
-          print_error("No shares match #{datastore['Share']}")
-        end
       end
+      # Return an error if `Share` option has been set but no matches were found
+      print_error("No shares match #{datastore['Share']}") if shares.empty?
     rescue RubySMB::Error::UnexpectedStatusCode => e
       print_error("Error when trying to enumerate shares - #{e.status_code.name}")
       return
     rescue RubySMB::Error::InvalidPacket => e
-      print_error("Invalid packet received when trying to enumerate shares - #{e}")
+      vprint_error("Invalid packet received when trying to enumerate shares - #{e}")
       return
     end
 
@@ -382,9 +379,7 @@ class MetasploitModule < Msf::Auxiliary
         update: :unique_data
       )
 
-      if datastore['SpiderShares']
-        get_files_info(ip, shares)
-      end
+      get_files_info(ip, shares) if datastore['SpiderShares']
     end
 
     shares


### PR DESCRIPTION
Target is metasploitable 2 VM.

This PR covers:

- SMB1_PORT (139/TCP) - Default to using RubySMB, then fall back to Rex
  - Work was done on RubySMB, but isn't fully there to remove Rex completely
- Disable Rex doing SMB2_3_PORT (445/TCP), as its not supported (@smcintyre-r7 request)
- Be more verbose
- Add Rex logic support

## Before

```console
msf auxiliary(scanner/smb/smb_enumshares) > options

Module options (auxiliary/scanner/smb/smb_enumshares):

   Name                    Current Setting                         Required  Description
   ----                    ---------------                         --------  -----------
   HIGHLIGHT_NAME_PATTERN  username|password|user|pass|Groups.xml  yes       PCRE regex of resource names to highlight
   LogSpider               3                                       no        0 = disabled, 1 = CSV, 2 = table (txt), 3 = one liner (txt) (Accepted: 0, 1, 2, 3)
   MaxDepth                999                                     yes       Max number of subdirectories to spider
   Share                                                           no        Show only the specified share
   ShowFiles               false                                   yes       Show detailed information when spidering
   SpiderProfiles          true                                    no        Spider only user profiles when share is a disk share
   SpiderShares            true                                    no        Spider shares recursively


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     10.0.0.10        no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/smb/smb_enumshares) >
msf auxiliary(scanner/smb/smb_enumshares) > run
[*] 10.0.0.10: - Connecting to the server...
[-] 10.0.0.10: - Invalid packet received when trying to enumerate shares - The response seems to be an SMB1 NtCreateAndxResponse but an error occurs while parsing it. It is probably missing the required extended information.
[-] 10.0.0.10: - Error: '10.0.0.10' 'NoMethodError' 'undefined method `empty?' for nil'
[*] 10.0.0.10: - Connecting to the server...
[-] 10.0.0.10: - Invalid packet received when trying to enumerate shares - The response seems to be an SMB1 NtCreateAndxResponse but an error occurs while parsing it. It is probably missing the required extended information.
[-] 10.0.0.10: - Error: '10.0.0.10' 'NoMethodError' 'undefined method `empty?' for nil'
[*] 10.0.0.10: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_enumshares) >
```

## After

```console
msf auxiliary(scanner/smb/smb_enumshares) > reload
[*] Reloading module...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
msf auxiliary(scanner/smb/smb_enumshares) >
msf auxiliary(scanner/smb/smb_enumshares) > run
[*] 10.0.0.10:139 - Connecting using SMB v1 via ruby_smb
[-] 10.0.0.10:139 - Invalid packet received when trying to enumerate shares - The response seems to be an SMB1 NtCreateAndxResponse but an error occurs while parsing it. It is probably missing the required extended information.
[*] 10.0.0.10:445 - Connecting using SMB v1/2/3 via rex
[+] 10.0.0.10:445 - print$ - (DISK) Printer Drivers
[+] 10.0.0.10:445 - tmp - (DISK) oh noes!
[+] 10.0.0.10:445 - opt - (DISK)
[+] 10.0.0.10:445 - IPC$ - (IPC) IPC Service (metasploitable server (Samba 3.0.20-Debian))
[+] 10.0.0.10:445 - ADMIN$ - (IPC) IPC Service (metasploitable server (Samba 3.0.20-Debian))
[!] 10.0.0.10:445 - This is not available for this server (unable to use RubySMB)
[*] 10.0.0.10: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_enumshares) >
```