### PR TITLE
Fix false positive on couchdb enum check

### DIFF
--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -71,24 +71,29 @@ class MetasploitModule < Msf::Auxiliary
       return false
     end
 
-    if res && res.code == 401
+    if res.code == 401
       print_bad("#{peer} - Authentication required.")
       return false
     end
 
-    if res && res.code == 200
-      res_json = res.get_json_document
-
-      if res_json.empty?
-        vprint_bad("#{peer} - Cannot parse the response, seems like it's not CouchDB.")
-        return false
-      end
-
-      @version = res_json['version'] if res_json['version']
-      return true
+    unless res.code == 200
+      vprint_bad("#{peer} - Unexpected HTTP status #{res.code}, does not appear to be CouchDB.")
+      return false
     end
 
-    vprint_warning("#{peer} - Version not found")
+    res_json = res.get_json_document
+
+    unless res_json.is_a?(Hash) && res_json.key?('couchdb')
+      vprint_bad("#{peer} - Response does not appear to be from CouchDB.")
+      return false
+    end
+
+    @version = res_json['version']
+    unless @version
+      vprint_warning("#{peer} - CouchDB detected but version not found in response.")
+      return false
+    end
+
     true
   end
 


### PR DESCRIPTION
Fix false positive on couchdb enum check

```
msf auxiliary(scanner/couchdb/couchdb_enum) > check 10.140.106.183 rport=8080 httptrace=true
####################
# Request:
####################
GET / HTTP/1.1
Host: 10.140.106.183:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0
####################
# Response:
####################
HTTP/1.1 404 Not Found
Date: Tue, 21 Apr 2026 15:24:18 GMT
Content-Type: text/html
Content-Length: 795
Server: Jetty(8.1.7.v20120910)
<HTML>
<HEAD>
<TITLE>Error 404 - Not Found</TITLE>
<BODY>
<H2>Error 404 - Not Found.</H2>
No context on this server matched or handled this request.<BR>Contexts known to this server are: <ul><li><a href="/continuum">/continuum&nbsp;--->&nbsp;o.e.j.w.WebAppContext{/continuum,file:/opt/apache_continuum/apache-continuum-1.4.2/apps/continuum/},./apps/continuum</a></li>
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
<!-- Padding for IE                  -->
</BODY>
</HTML>
[+] 10.140.106.183:8080 - The target appears to be vulnerable.
msf auxiliary(scanner/couchdb/couchdb_enum) > 
```

## Verification

Against not vulnerable, working as expected:
```
msf auxiliary(scanner/couchdb/couchdb_enum) > check 10.140.106.183 rport=8080
[*] 10.140.106.183:8080 - Cannot reliably check exploitability.

```

Against vulnerable (`docker run -p 5984:5984 couchdb:1.6.1`) - working as expected:

```
msf auxiliary(scanner/couchdb/couchdb_enum) > check 127.0.0.1 httptrace=true
####################
# Request:
####################
GET / HTTP/1.1
Host: 127.0.0.1:5984
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0
####################
# Response:
####################
HTTP/1.1 200 OK
Server: CouchDB/1.6.1 (Erlang OTP/17)
Date: Tue, 21 Apr 2026 15:31:35 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 151
Cache-Control: must-revalidate
{"couchdb":"Welcome","uuid":"a7e82208122cb03efb9a1c5812bb97ba","version":"1.6.1","vendor":{"version":"1.6.1","name":"The Apache Software Foundation"}}
[+] 127.0.0.1:5984 - The target appears to be vulnerable.
msf auxiliary(scanner/couchdb/couchdb_enum) > run 127.0.0.1 httptrace=true
[*] Running module against 127.0.0.1
####################
# Request:
####################
GET /_all_dbs HTTP/1.1
Host: 127.0.0.1:5984
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0
####################
# Response:
####################
HTTP/1.1 200 OK
Server: CouchDB/1.6.1 (Erlang OTP/17)
Date: Tue, 21 Apr 2026 15:31:37 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 25
Cache-Control: must-revalidate
["_replicator","_users"]
[*] 127.0.0.1:5984 - Enumerating Databases...
[+] 127.0.0.1:5984 - Databases:
[
  "_replicator",
  "_users"
]
[+] 127.0.0.1:5984 - File saved in: /Users/adfoster/.msf4/loot/20260421163137_default_127.0.0.1_couchdb.enum_522335.bin
####################
# Request:
####################
GET /_all_dbs/_replicator/_all_docs?include_docs=true&attachments=true HTTP/1.1
Host: 127.0.0.1:5984
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0
Authorization: Basic d0RrTHJKdGFPZWRxOnFHVHJMTnVRelFoTg==
####################
# Response:
####################
HTTP/1.1 401 Unauthorized
Server: CouchDB/1.6.1 (Erlang OTP/17)
Date: Tue, 21 Apr 2026 15:31:37 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 67
Cache-Control: must-revalidate
{"error":"unauthorized","reason":"Name or password is incorrect."}
[-] 127.0.0.1:5984 - Error retrieving database. Consider providing credentials or setting CREATEUSER and rerunning.
[*] Auxiliary module execution completed
msf auxiliary(scanner/couchdb/couchdb_enum) > 
```