### PR TITLE
smb_version: Make SMBv1 happy

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -413,7 +413,7 @@ module Msf
         # Leverage Recog for SMB native OS fingerprinting
         fp_match = Recog::Nizer.match('smb.native_os', fprint['native_os']) || { }
 
-        os = fp_match['os.product'] || 'Unknown'
+        os = fp_match['os.product'] || fp_match['os.family'] || 'Unknown'
         sp = fp_match['os.version'] || ''
 
         # Metasploit prefers 'Windows 2003' vs 'Windows Server 2003'

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -295,9 +295,11 @@ class MetasploitModule < Msf::Auxiliary
         if info[:os_name] && info[:os_name] != 'Unknown'
           smb_desc = smb_description(info)
           os_desc = "Host is running #{info[:os_name]}"
+          smb1_desc = smb1_fingerprint['native_lm'] ? "; #{smb1_fingerprint['native_lm']}" : ""
 
           lines << { type: :status, message: smb_desc }
           lines << { type: :good, message: "  #{os_desc}" }
+          lines << { type: :status, message: "  #{smb1_fingerprint['native_lm']}", verbose: true } if smb1_fingerprint['native_lm']
 
           unless info[:signing_required]
             report_vuln({
@@ -318,7 +320,7 @@ class MetasploitModule < Msf::Auxiliary
             port: rport,
             proto: 'tcp',
             name: 'smb',
-            info: "#{smb_desc}; #{os_desc}"
+            info: "#{smb_desc}; #{os_desc}#{smb1_desc}"
           )
 
           # Report a fingerprint.match hash for name, domain, and language

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -149,19 +149,19 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def smb_description(info)
-    desc = "SMB Detected (versions:#{info[:versions].join(', ')}) (preferred dialect:#{info[:preferred_dialect]})"
+    desc = "SMB Detected (versions: #{info[:versions].join(', ')}) (preferred dialect: #{info[:preferred_dialect]})"
     info[:capabilities].each do |name, values|
-      desc << " (#{name} capabilities:#{values.join(', ')})"
+      desc << " (#{name} capabilities: #{values.join(', ')})"
     end
 
     if info[:signing_required]
-      desc << ' (signatures:required)'
+      desc << ' (signatures: required)'
     else
-      desc << ' (signatures:optional)'
+      desc << ' (signatures: optional)'
     end
-    desc << " (uptime:#{info[:uptime]})" if info[:uptime]
-    desc << " (guid:#{Rex::Text.to_guid(info[:server_guid])})" if info[:server_guid]
-    desc << " (authentication domain:#{info[:auth_domain]})" if info[:auth_domain]
+    desc << " (uptime: #{info[:uptime]})" if info[:uptime]
+    desc << " (guid: #{Rex::Text.to_guid(info[:server_guid])})" if info[:server_guid]
+    desc << " (authentication domain: #{info[:auth_domain]})" if info[:auth_domain]
 
     desc
   end
@@ -209,13 +209,13 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if !res['build'].to_s.empty?
-      words << " (build:#{res['build']})"
+      words << " (build: #{res['build']})"
       nd_smb_fingerprint[:os_build] = res['build']
       nd_fingerprint_match['os.build'] = res['build']
     end
 
     if !res['lang'].to_s.empty? && res['lang'] != 'Unknown'
-      words << " (language:#{res['lang']})"
+      words << " (language: #{res['lang']})"
       nd_smb_fingerprint[:os_lang] = res['lang']
       nd_fingerprint_match['os.language'] = nd_smb_fingerprint[:os_lang]
     end


### PR DESCRIPTION
The target is metasploitable 2 VM.

## Before

```console
msf > use auxiliary/scanner/smb/smb_version
msf auxiliary(scanner/smb/smb_version) >
msf auxiliary(scanner/smb/smb_version) > options

Module options (auxiliary/scanner/smb/smb_version):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   RHOSTS   10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT                     no        The target port (TCP)
   THREADS  1                yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/smb/smb_version) >

msf auxiliary(scanner/smb/smb_version) > run
[*] 10.0.0.10:445         - Force SMB1 since SMB fingerprint needs native_lm/native_os information
[*] 10.0.0.10:445         -   Host could not be identified: Unix (Samba 3.0.20-Debian)
[*] 10.0.0.10             - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_version) >
```

## After

```console
msf auxiliary(scanner/smb/smb_version) > run
[*] 10.0.0.10:445         - Force SMB1 since SMB fingerprint needs native_lm/native_os information
[*] 10.0.0.10:445         - SMB Detected (versions: 1) (preferred dialect: ) (signatures:optional)
[+] 10.0.0.10:445         -   Host is running Unix
[*] 10.0.0.10             - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_version) >
```