### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/auxiliary/admin/http/atlassian_confluence_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/atlassian_confluence_auth_bypass.rb
@@ -53,11 +53,11 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/login.action')
     )
-    return Exploit::CheckCode::Unknown unless res
-    return Exploit::CheckCode::Safe unless res.code == 200
+    return Exploit::CheckCode::Unknown('No response received from target') unless res
+    return Exploit::CheckCode::Safe('Target did not return HTTP 200 on login page') unless res.code == 200
 
     poweredby = res.get_xml_document.xpath('//ul[@id="poweredby"]/li[@class="print-only"]/text()').first&.text
-    return Exploit::CheckCode::Safe unless poweredby =~ /Confluence (\d+(\.\d+)*)/
+    return Exploit::CheckCode::Safe('Could not detect Confluence version from page') unless poweredby =~ /Confluence (\d+(\.\d+)*)/
 
     confluence_version = Rex::Version.new(Regexp.last_match(1))
 

--- a/modules/auxiliary/admin/http/wp_google_maps_sqli.rb
+++ b/modules/auxiliary/admin/http/wp_google_maps_sqli.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
     mynum = Rex::Text.rand_text_numeric(8..20).to_s
     body = send_sql_request(mynum)
     return Exploit::CheckCode::Unknown('No response from target') if body.nil?
-    return Exploit::CheckCode::Vulnerable if body.include?(mynum)
+    return Exploit::CheckCode::Vulnerable('SQL injection returned expected test value') if body.include?(mynum)
 
     Exploit::CheckCode::Unknown('SQL injection test did not return expected result')
   end

--- a/modules/auxiliary/gather/camaleon_download_private_file.rb
+++ b/modules/auxiliary/gather/camaleon_download_private_file.rb
@@ -224,16 +224,16 @@ class MetasploitModule < Msf::Auxiliary
     if version.nil?
       return Exploit::CheckCode::Unknown('Failed to get build version')
     elsif vuln_version?(version) != true
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Camaleon CMS version is not vulnerable')
     end
 
     res = get_file(datastore['FILEPATH'])
 
     if res.nil? || res == false || !res.is_a?(String)
       print_error('Failed to obtain file')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Camaleon CMS version appears vulnerable but file download failed')
     end
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('Successfully downloaded private file from Camaleon CMS')
   end
 end

--- a/modules/auxiliary/gather/doliwamp_traversal_creds.rb
+++ b/modules/auxiliary/gather/doliwamp_traversal_creds.rb
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Auxiliary
   # Check for session tokens in 'tmp'
   #
   def check
-    get_session_tokens ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+    get_session_tokens ? Exploit::CheckCode::Vulnerable('Session tokens found in tmp directory') : Exploit::CheckCode::Safe('No session tokens found in tmp directory')
   end
 
   def report_cred(opts)

--- a/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
+++ b/modules/auxiliary/gather/jetty_web_inf_disclosure.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
       return Exploit::CheckCode::Appears("Jetty #{version} vulnerable to CVE-2021-34429")
     end
 
-    Exploit::CheckCode::Safe('Server not vulnerable')
+    Exploit::CheckCode::Safe("Jetty #{version} is not vulnerable")
   end
 
   def pick_payload

--- a/modules/auxiliary/gather/joomla_com_realestatemanager_sqli.rb
+++ b/modules/auxiliary/gather/joomla_com_realestatemanager_sqli.rb
@@ -87,9 +87,9 @@ class MetasploitModule < Msf::Auxiliary
 
     data = sqli(payload)
     if data && data.include?(flag)
-      Msf::Exploit::CheckCode::Vulnerable
+      Msf::Exploit::CheckCode::Vulnerable('SQL injection confirmed in com_realestatemanager')
     else
-      Msf::Exploit::CheckCode::Safe
+      Msf::Exploit::CheckCode::Safe('SQL injection test payload was not reflected in response')
     end
   end
 

--- a/modules/auxiliary/gather/suite_crm_export_sqli.rb
+++ b/modules/auxiliary/gather/suite_crm_export_sqli.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status "Version detected: #{version}"
 
-    return Exploit::CheckCode::Vulnerable if version <= Rex::Version.new('7.12.5')
+    return Exploit::CheckCode::Vulnerable("SuiteCRM version #{version} is vulnerable") if version <= Rex::Version.new('7.12.5')
 
     Exploit::CheckCode::Safe("SuiteCRM version #{version} is not vulnerable")
   end

--- a/modules/auxiliary/gather/thinmanager_traversal_download.rb
+++ b/modules/auxiliary/gather/thinmanager_traversal_download.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
       connect
     rescue Rex::ConnectionTimeout
       print_error("Connection to #{datastore['RHOSTS']}:#{datastore['RPORT']} failed.")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to target timed out')
     end
 
     vprint_status('Sending handshake...')

--- a/modules/auxiliary/gather/tplink_archer_c7_traversal.rb
+++ b/modules/auxiliary/gather/tplink_archer_c7_traversal.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => '/'
     })
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('No response received from target') unless res
 
     device_title = res.get_html_document&.at('//title')&.text
     if device_title =~ /Archer C\d/

--- a/modules/auxiliary/gather/wp_bookingpress_category_services_sqli.rb
+++ b/modules/auxiliary/gather/wp_bookingpress_category_services_sqli.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
 
     @sqli = get_sqli_object
     return Exploit::CheckCode::Unknown(GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
-    return Exploit::CheckCode::Vulnerable if @sqli.test_vulnerable
+    return Exploit::CheckCode::Vulnerable('SQL injection test succeeded') if @sqli.test_vulnerable
 
     Exploit::CheckCode::Safe('SQL injection test did not succeed')
   end

--- a/modules/auxiliary/gather/wp_depicter_sqli_cve_2025_2011.rb
+++ b/modules/auxiliary/gather/wp_depicter_sqli_cve_2025_2011.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
   def check
     @sqli = get_sqli_object
     return Exploit::CheckCode::Unknown(GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
-    return Exploit::CheckCode::Vulnerable if @sqli.test_vulnerable
+    return Exploit::CheckCode::Vulnerable('SQL injection test succeeded') if @sqli.test_vulnerable
 
     Exploit::CheckCode::Safe('SQL injection test did not succeed')
   end

--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -93,16 +93,16 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check
-    return Exploit::CheckCode::Unknown unless get_version
+    return Exploit::CheckCode::Unknown('Failed to retrieve CouchDB version') unless get_version
 
     version = Rex::Version.new(@version)
-    return Exploit::CheckCode::Unknown if version.version.empty?
+    return Exploit::CheckCode::Unknown('CouchDB version string is empty') if version.version.empty?
 
     vprint_good("#{peer} - Found CouchDB version #{version}")
 
-    return Exploit::CheckCode::Appears if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
+    return Exploit::CheckCode::Appears("CouchDB version #{version} is in the vulnerable range") if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('CouchDB version is not in the vulnerable range')
   end
 
   def get_dbs(auth)

--- a/modules/auxiliary/scanner/dlsw/dlsw_leak_capture.rb
+++ b/modules/auxiliary/scanner/dlsw/dlsw_leak_capture.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if response.blank?
       vprint_status("No response")
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('No response received from DLSw service')
     elsif response[0..1] == "\x31\x48" || response[0..1] == "\x32\x48"
       vprint_good("Detected DLSw protocol")
       report_service(
@@ -75,11 +75,11 @@ class MetasploitModule < Msf::Auxiliary
           refs: references,
           info: "Module #{fullname} collected #{response.length} bytes"
         )
-        Exploit::CheckCode::Vulnerable
+        Exploit::CheckCode::Vulnerable('DLSw information disclosure detected; leaked data found in response')
       end
     else
       vprint_status("#{response.size}-byte response didn't contain any leaked data")
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Response did not contain any leaked data')
     end
   end
 

--- a/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
@@ -50,13 +50,13 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
       if /BisonWare BisonFTP server product V3\.5/i === banner
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('BisonWare BisonFTP server V3.5 detected')
       end
     ensure
       disconnect
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not running BisonWare BisonFTP server V3.5')
   end
 
   def run_host(target_host)

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -55,13 +55,13 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
       if /Welcome to ColoradoFTP - the open source FTP server \(www\.coldcore\.com\)/i === banner
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('ColoradoFTP server detected')
       end
     ensure
       disconnect
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not running ColoradoFTP')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/ftp/easy_file_sharing_ftp.rb
+++ b/modules/auxiliary/scanner/ftp/easy_file_sharing_ftp.rb
@@ -47,13 +47,13 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
       if /Easy File Sharing FTP Server/i === banner
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('Easy File Sharing FTP Server detected')
       end
     ensure
       disconnect
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not running Easy File Sharing FTP Server')
   end
 
   def run_host(target_host)

--- a/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
@@ -52,13 +52,13 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
       if /FTP Utility FTP server \(Version 1\.00\)/i === banner
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('Konica FTP Utility server Version 1.00 detected')
       end
     ensure
       disconnect
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not running Konica FTP Utility server')
   end
 
   def run_host(target_host)

--- a/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
@@ -50,13 +50,13 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
       if /220 PCMan's FTP Server 2\.0/i === banner
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('PCMan FTP Server 2.0 detected')
       end
     ensure
       disconnect
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not running PCMan FTP Server 2.0')
   end
 
   def run_host(target_host)

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -76,11 +76,11 @@ class MetasploitModule < Msf::Auxiliary
         :name => self.name,
         :refs => self.references
       )
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Bash environment variable injection via mod_cgi confirmed')
     elsif res && res.code == 500
       injected_res_code = res.code
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target does not appear to be vulnerable to Shellshock via mod_cgi')
     end
 
     res = send_request_cgi({
@@ -89,12 +89,12 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     if res && injected_res_code == res.code
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Injected and normal responses returned the same status code')
     elsif res && injected_res_code != res.code
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target returned a different status code for the injected request')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Unable to determine if the target is vulnerable')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/bmc_trackit_passwd_reset.rb
+++ b/modules/auxiliary/scanner/http/bmc_trackit_passwd_reset.rb
@@ -81,18 +81,18 @@ class MetasploitModule < Msf::Auxiliary
             refs: references
           )
           vprint_status("#{peer}: Track-It! version #{version} is less than #{fix_version}")
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable("Track-It! version #{version} is vulnerable to password reset")
         else
           vprint_status("#{peer}: Track-It! version #{version} is not less than #{fix_version}")
-          return Exploit::CheckCode::Safe
+          return Exploit::CheckCode::Safe("Track-It! version #{version} is not vulnerable")
         end
       else
         vprint_error("#{peer}: unable to get Track-It! version")
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Unable to determine Track-It! version')
       end
     else
       vprint_status("#{peer}: does not appear to be running Track-It!")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target does not appear to be running Track-It!')
     end
   end
 

--- a/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_16_contact_dump.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path)
     })
     return Exploit::CheckCode::Unknown('Connection failed') unless res
-    return Exploit::CheckCode::Safe unless res.code == 200
+    return Exploit::CheckCode::Safe('Target did not return HTTP 200') unless res.code == 200
 
     version = res.body.scan(/Dolibarr ([\d.]+-*[a-zA-Z0-9]*)/).flatten.first
 

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -58,17 +58,17 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     unless res
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from target')
     end
 
     if res.body.include?('Access denied')
       # This probably means the Views Module actually isn't installed
       print_error("Access denied")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Drupal Views module does not appear to be installed')
     elsif res.message != 'OK' || res.body != '[  ]'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Drupal Views user autocomplete endpoint not accessible')
     else
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Drupal Views user enumeration endpoint is accessible')
     end
   end
 

--- a/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
+++ b/modules/auxiliary/scanner/http/grafana_plugin_traversal.rb
@@ -61,12 +61,12 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path)
     })
-    return Exploit::CheckCode::Unknown unless res && res.code == 200
+    return Exploit::CheckCode::Unknown('No response or unexpected status code from target') unless res && res.code == 200
 
     # We need to take into account beta versions, which end with -beta<digit>. See: https://grafana.com/docs/grafana/latest/release-notes/
     # Also take into account preview versions, which end with -preview. See https://grafana.com/grafana/download/10.0.0-preview?edition=oss for more info.
     /"subTitle":"Grafana v(?<full_version>\d{1,2}\.\d{1,2}\.\d{1,2}(?:(?:-beta\d)?|(?:-preview)?)) \([0-9a-f]{10}\)",/ =~ res.body
-    return Exploit::CheckCode::Safe unless full_version
+    return Exploit::CheckCode::Safe('Could not detect Grafana version in response') unless full_version
 
     # However, since 8.3.1 does not have a beta, we can safely ignore the -beta suffix when comparing versions
     # In fact, this is necessary because Rex::Version doesn't correctly handle versions ending with -beta when comparing
@@ -83,10 +83,10 @@ class MetasploitModule < Msf::Auxiliary
        version.between?(Rex::Version.new('8.2.0'), Rex::Version.new('8.2.7')) ||
        version.between?(Rex::Version.new('8.3.0'), Rex::Version.new('8.3.1'))
       print_good("Detected vulnerable Grafana: #{full_version}")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Detected vulnerable Grafana version: #{full_version}")
     end
     print_bad("Detected non-vulnerable Grafana: #{full_version}")
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Grafana version #{full_version} is not in the vulnerable range")
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
+++ b/modules/auxiliary/scanner/http/iis_shortname_scanner.rb
@@ -59,9 +59,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check
-    is_vul ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+    is_vul ? Exploit::CheckCode::Vulnerable('Target is vulnerable to IIS shortname scanning') : Exploit::CheckCode::Safe('Target is not vulnerable to IIS shortname scanning')
   rescue Rex::ConnectionError
     print_bad("Failed to connect to target")
+    Exploit::CheckCode::Unknown('Failed to connect to target')
   end
 
   def is_vul

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check
-    get_users ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+    get_users ? Exploit::CheckCode::Vulnerable('Successfully retrieved user credentials') : Exploit::CheckCode::Safe('Could not retrieve user credentials')
   end
 
   def get_users

--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -99,13 +99,13 @@ class MetasploitModule < Msf::Auxiliary
         # Save the file that we want to use for the information leak
         target_uri.path = uri
 
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable("#{uri} returned 'Requested Range Not Satisfiable', indicating HTTP.SYS is vulnerable to MS15-034.")
       elsif res && res.body.include?('The request has an invalid header name')
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('Server rejected the crafted Range header, indicating it is not vulnerable to MS15-034.')
       end
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine vulnerability status. No static file returned a definitive response.')
   end
 
   def dump(data)

--- a/modules/auxiliary/scanner/http/netalertx_file_read.rb
+++ b/modules/auxiliary/scanner/http/netalertx_file_read.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'maintenance.php')
     })
-    return Exploit::CheckCode::Unknown unless res&.code == 200
+    return Exploit::CheckCode::Unknown('No response or unexpected status code from target') unless res&.code == 200
 
     html_document = res.get_html_document
     return Exploit::CheckCode::Unknown('Failed to get html document.') if html_document.blank?

--- a/modules/auxiliary/scanner/http/pretalx_file_read_cve_2023_28459.rb
+++ b/modules/auxiliary/scanner/http/pretalx_file_read_cve_2023_28459.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
 
     version = get_version
 
-    return Exploit::CheckCode::Detected unless version
+    return Exploit::CheckCode::Detected('Pretalx detected but unable to determine version') unless version
 
     return Exploit::CheckCode::Appears("Detected vulnerable version #{version}") if version <= Rex::Version.new('2.3.1')
 

--- a/modules/auxiliary/scanner/http/strapi_3_password_reset.rb
+++ b/modules/auxiliary/scanner/http/strapi_3_password_reset.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
       return Exploit::CheckCode::Vulnerable("Vulnerable version detected: #{version.dig('data', 'strapiVersion')}")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Strapi version is not vulnerable to password reset')
   end
 
   def run

--- a/modules/auxiliary/scanner/http/surgenews_user_creds.rb
+++ b/modules/auxiliary/scanner/http/surgenews_user_creds.rb
@@ -52,10 +52,10 @@ class MetasploitModule < Msf::Auxiliary
     @tries = 0
     res = read_file 'install.log'
     if res =~ /SurgeNews/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('SurgeNews installation detected via file disclosure')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target does not appear to be running SurgeNews')
   end
 
   def read_file(file)

--- a/modules/auxiliary/scanner/http/syncovery_linux_token_cve_2022_36536.rb
+++ b/modules/auxiliary/scanner/http/syncovery_linux_token_cve_2022_36536.rb
@@ -77,19 +77,19 @@ class MetasploitModule < Msf::Auxiliary
         version = json_res['SyncoveryTitle']&.scan(/Syncovery\s([A-Za-z0-9.]+)/)&.flatten&.first || ''
         if version.empty?
           vprint_warning("#{peer} - Could not identify version")
-          Exploit::CheckCode::Detected
+          Exploit::CheckCode::Detected('Syncovery Linux detected but version could not be determined')
         elsif Rex::Version.new(version) < Rex::Version.new('9.48j') || Rex::Version.new(version) == Rex::Version.new('9.48')
           vprint_good("#{peer} - Syncovery #{version}")
-          Exploit::CheckCode::Appears
+          Exploit::CheckCode::Appears("Syncovery Linux #{version} appears to be vulnerable")
         else
           vprint_status("#{peer} - Syncovery #{version}")
-          Exploit::CheckCode::Safe
+          Exploit::CheckCode::Safe("Syncovery Linux #{version} is not vulnerable")
         end
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('Target is running Syncovery on Windows, not Linux')
       end
     else
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Unknown('Failed to retrieve Syncovery global variables')
     end
   end
 

--- a/modules/auxiliary/scanner/http/totaljs_traversal.rb
+++ b/modules/auxiliary/scanner/http/totaljs_traversal.rb
@@ -80,21 +80,21 @@ class MetasploitModule < Msf::Auxiliary
     if res && res.code == 200
       json = res.get_json_document
       if json.empty? || !json['dependencies']['total.js']
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('Total.js dependency not found in package.json')
       else
         print_status("Total.js version is: #{json['dependencies']['total.js']}")
         print_status("App name: #{json['name']}")
         print_status("App description: #{json['description']}")
         print_status("App version: #{json['version']}")
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Successfully retrieved package.json via path traversal')
       end
     elsif res && res.headers['X-Powered-By'].to_s.downcase.include?('total.js')
       print_status('Target appear to be vulnerable!')
       print_status("X-Powered-By: #{res.headers['X-Powered-By']}")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Total.js detected via X-Powered-By header')
     else
       vprint_warning('No response')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from target')
     end
   end
 

--- a/modules/auxiliary/scanner/http/wordpress_content_injection.rb
+++ b/modules/auxiliary/scanner/http/wordpress_content_injection.rb
@@ -60,15 +60,15 @@ class MetasploitModule < Msf::Auxiliary
     if (version = wordpress_version)
       version = Rex::Version.new(version)
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('WordPress version not detected')
     end
 
     vprint_status("WordPress #{version}: #{full_uri}")
 
     if version.between?(Rex::Version.new('4.7'), Rex::Version.new('4.7.1'))
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('WordPress version is in the vulnerable range 4.7 - 4.7.1')
     else
-      Exploit::CheckCode::Detected
+      Exploit::CheckCode::Detected('WordPress detected but version is outside the vulnerable range')
     end
   end
 

--- a/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
@@ -58,10 +58,10 @@ class MetasploitModule < Msf::Auxiliary
       v = Rex::Version.new(Regexp.last_match(1))
       print_status "Version detected: #{v}"
       if v <= Rex::Version.new('3.4')
-        return Msf::Exploit::CheckCode::Appears
+        return Msf::Exploit::CheckCode::Appears("ChopSlider version #{v} appears to be vulnerable")
       end
     end
-    Msf::Exploit::CheckCode::Unknown
+    Msf::Exploit::CheckCode::Unknown('ChopSlider plugin not detected')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/wp_perfect_survey_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_perfect_survey_sqli.rb
@@ -84,9 +84,9 @@ class MetasploitModule < Msf::Auxiliary
   def check
     @sqli = get_sqli_object
     return Exploit::CheckCode::Unknown(GET_SQLI_OBJECT_FAILED_ERROR_MSG) if @sqli == GET_SQLI_OBJECT_FAILED_ERROR_MSG
-    return Exploit::CheckCode::Vulnerable if @sqli.test_vulnerable
+    return Exploit::CheckCode::Vulnerable('SQL injection test succeeded') if @sqli.test_vulnerable
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Perfect Survey plugin is not vulnerable to SQL injection')
   end
 
   # Run method

--- a/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
+++ b/modules/auxiliary/scanner/misc/freeswitch_event_socket_login.rb
@@ -114,6 +114,6 @@ class MetasploitModule < Msf::Auxiliary
       return Exploit::CheckCode::Unknown('Unable to determine the service fingerprint')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('FreeSWITCH event socket is accepting authentication requests')
   end
 end

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -90,11 +90,11 @@ class MetasploitModule < Msf::Auxiliary
           info: 'Accepted an NTP symmetric active association by replying with a symmetric passive request',
           refs: references
         )
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('NTP service accepted a symmetric active association')
       end
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('NTP service did not respond to symmetric active request')
   end
 
   def run_host(_ip)

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def check_host(_ip)
     # The check command will call this method instead of run_host
-    status = Exploit::CheckCode::Unknown
+    status = Exploit::CheckCode::Unknown('Unable to determine BlueKeep vulnerability status')
 
     begin
       begin
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Auxiliary
       elog(e)
     rescue RdpCommunicationError
       vprint_error('Error communicating RDP protocol.')
-      status = Exploit::CheckCode::Unknown
+      status = Exploit::CheckCode::Unknown('Error communicating RDP protocol')
     rescue Errno::ECONNRESET
       vprint_error('Connection reset')
     rescue StandardError => e

--- a/modules/auxiliary/scanner/rdp/ms12_020_check.rb
+++ b/modules/auxiliary/scanner/rdp/ms12_020_check.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Auxiliary
   def check_host(ip)
     # The check command will call this method instead of run_host
 
-    status = Exploit::CheckCode::Unknown
+    status = Exploit::CheckCode::Unknown('Unable to determine MS12-020 vulnerability status')
 
     begin
       connect

--- a/modules/auxiliary/scanner/redis/file_upload.rb
+++ b/modules/auxiliary/scanner/redis/file_upload.rb
@@ -125,13 +125,13 @@ class MetasploitModule < Msf::Auxiliary
   def check
     connect
     # they are only vulnerable if we can run the CONFIG command, so try that
-    return Exploit::CheckCode::Safe unless (config_data = redis_command('CONFIG', 'GET', '*')) && config_data =~ /dbfilename/
+    return Exploit::CheckCode::Safe('Redis CONFIG command is not accessible') unless (config_data = redis_command('CONFIG', 'GET', '*')) && config_data =~ /dbfilename/
 
     if (info_data = redis_command('INFO')) && /redis_version:(?<redis_version>\S+)/ =~ info_data
       report_redis(redis_version)
     end
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('Redis CONFIG command is accessible and can be used for file upload')
   ensure
     disconnect
   end

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -118,7 +118,8 @@ class MetasploitModule < Msf::Auxiliary
           port: rport, # A service is necessary for the analyze command
           name: self.name,
           refs: self.references,
-          info: "STATUS_INSUFF_SERVER_RESOURCES for FID 0 against IPC$ - #{os}"
+          info: "STATUS_INSUFF_SERVER_RESOURCES for FID 0 against IPC$ - #{os}",
+          check_code: checkcode
         )
 
         # vulnerable to MS17-010, check for DoublePulsar infection

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -213,26 +213,26 @@ class MetasploitModule < Msf::Auxiliary
 
       if samba_info !~ /^samba/i
         vprint_status("Target isn't Samba, no check will run.")
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('Target is not running Samba')
       end
 
       if datastore['PASSIVE']
         if maybe_vulnerable?(samba_info)
           flag_vuln_host(ip, samba_info)
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('Samba version appears to be vulnerable based on version check')
         end
       else
         # Explicit: Actually triggers the bug
         if is_vulnerable?(ip)
           flag_vuln_host(ip, samba_info)
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable('Samba uninitialized credential vulnerability confirmed')
         end
       end
     end
 
-    return Exploit::CheckCode::Detected if samba_info =~ /^samba/i
+    return Exploit::CheckCode::Detected('Samba detected but vulnerability could not be confirmed') if samba_info =~ /^samba/i
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target does not appear to be running Samba')
   end
 
   # Reports to the database about a possible vulnerable host

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -37,7 +37,11 @@ class MetasploitModule < Msf::Auxiliary
         negotiation is only present in version 3.1.1.
       },
       'Author' => ['hdm', 'Spencer McIntyre', 'Christophe De La Fuente'],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'https://support.microsoft.com/en-us/help/161372/how-to-enable-smb-signing-in-windows-nt'],
+        ['URL', 'https://support.microsoft.com/en-us/help/887429/overview-of-server-message-block-signing'],
+      ]
     )
 
     register_options([
@@ -300,15 +304,15 @@ class MetasploitModule < Msf::Auxiliary
           lines << { type: :good, message: "  #{os_desc}" }
 
           unless info[:signing_required]
+            lines << { type: :status, message: '  SMB signing is not required' }
             report_vuln({
               host: ip,
               port: rport,
               proto: 'tcp',
               name: 'SMB Signing Is Not Required',
-              refs: [
-                SiteReference.new('URL', 'https://support.microsoft.com/en-us/help/161372/how-to-enable-smb-signing-in-windows-nt'),
-                SiteReference.new('URL', 'https://support.microsoft.com/en-us/help/887429/overview-of-server-message-block-signing'),
-              ]
+              info: 'Disabling SMB signing allows attackers to intercept and tamper with file-sharing traffic via man-in-the-middle attacks',
+              refs: self.references,
+              check_code: Msf::Exploit::CheckCode.Appears('SMB signing is not required')
             })
           end
 

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -92,7 +92,8 @@ class MetasploitModule < Msf::Auxiliary
             proto: 'tcp',
             name: name,
             info: "Module #{fullname} confirmed SSH Host Key Encryption #{host_key} is available, but should be deprecated",
-            refs: refs
+            refs: refs,
+            check_code: Msf::Exploit::CheckCode.Appears("SSH Host Key Encryption #{host_key} is available, but should be deprecated")
           )
           note = 'Weak elliptic curve'
         end
@@ -138,7 +139,8 @@ class MetasploitModule < Msf::Auxiliary
           proto: 'tcp',
           name: name,
           info: "Module #{fullname} confirmed SSH Encryption #{encryption} is available, but should be deprecated",
-          refs: refs
+          refs: refs,
+          check_code: Msf::Exploit::CheckCode.Appears("SSH Encryption #{encryption} is available, but should be deprecated")
         )
         note = 'Deprecated'
       end
@@ -175,8 +177,9 @@ class MetasploitModule < Msf::Auxiliary
           port: rport,
           proto: 'tcp',
           name: name,
-          info: "Module #{fullname} confirmed SSH Encryption #{kex} is available, but should be deprecated",
-          refs: refs
+          info: "Module #{fullname} confirmed SSH Key Exchange #{kex} is available, but should be deprecated",
+          refs: refs,
+          check_code: Msf::Exploit::CheckCode.Appears("SSH Key Exchange #{kex} is available, but should be deprecated")
         )
         note = 'Deprecated'
       end
@@ -210,7 +213,8 @@ class MetasploitModule < Msf::Auxiliary
           proto: 'tcp',
           name: name,
           info: "Module #{fullname} confirmed SSH HMAC #{hmac} is available, but should be deprecated",
-          refs: refs
+          refs: refs,
+          check_code: Msf::Exploit::CheckCode.Appears("SSH HMAC #{hmac} is available, but should be deprecated")
         )
         note = 'Deprecated'
       end

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -186,9 +186,9 @@ class MetasploitModule < Msf::Auxiliary
     @check_only = true
     vprint_status "Checking for Heartbleed exposure"
     if bleed
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('Target returned extra data in heartbeat response, likely vulnerable to Heartbleed')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Target did not return extra data in heartbeat response')
     end
   end
 

--- a/modules/auxiliary/server/relay/esc8.rb
+++ b/modules/auxiliary/server/relay/esc8.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     disconnect
 
-    return Exploit::CheckCode::Unknown if res.nil?
+    return Exploit::CheckCode::Unknown('No response received from target') if res.nil?
     unless res.code == 401
       return Exploit::CheckCode::Safe('The target does not require authentication.')
     end

--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -48,16 +48,16 @@ class MetasploitModule < Msf::Post
   def check
     system_version = get_system_version
     unless system_version
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine macOS version')
     end
 
     version = Rex::Version.new(system_version)
     if version >= Rex::Version.new('10.15.6')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("macOS #{system_version} is patched")
     elsif version < Rex::Version.new('10.15.0')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown("macOS #{system_version} is not in the affected range")
     else
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("macOS #{system_version} appears vulnerable to TCC bypass")
     end
   end
 

--- a/modules/post/osx/gather/apfs_encrypted_volume_passwd.rb
+++ b/modules/post/osx/gather/apfs_encrypted_volume_passwd.rb
@@ -45,9 +45,9 @@ class MetasploitModule < Msf::Post
 
   def check
     osx_version = cmd_exec('sw_vers -productVersion')
-    return Exploit::CheckCode::Vulnerable if osx_version =~ /^10\.13[.[0-3]]?$/
+    return Exploit::CheckCode::Vulnerable('macOS 10.13.0-10.13.3 is vulnerable to APFS password disclosure') if osx_version =~ /^10\.13[.[0-3]]?$/
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('macOS version is not vulnerable to APFS password disclosure')
   end
 
   def run

--- a/modules/post/windows/gather/credentials/pulse_secure.rb
+++ b/modules/post/windows/gather/credentials/pulse_secure.rb
@@ -370,7 +370,7 @@ class MetasploitModule < Msf::Post
     begin
       if !session.fs.file.exist?(version_path)
         print_error('Pulse Secure Connect client is not installed on this system')
-        return Msf::Exploit::CheckCode::Safe
+        return Msf::Exploit::CheckCode::Safe('Pulse Secure Connect client is not installed on this system')
       end
       version_file = begin
         session.fs.file.open(version_path)
@@ -379,7 +379,7 @@ class MetasploitModule < Msf::Post
       end
       if version_file.nil?
         print_error('Cannot open Pulse Secure Connect version file.')
-        return Msf::Exploit::CheckCode::Unknown
+        return Msf::Exploit::CheckCode::Unknown('Cannot open Pulse Secure Connect version file')
       end
       version_data = version_file.read.to_s
       version_file.close
@@ -388,18 +388,18 @@ class MetasploitModule < Msf::Post
       print_status("Target is running Pulse Secure Connect build #{build}.")
       if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
         print_good('This version is considered vulnerable.')
-        return Msf::Exploit::CheckCode::Vulnerable
+        return Msf::Exploit::CheckCode::Vulnerable("Pulse Secure Connect build #{build} is vulnerable")
       end
 
       if is_system?
         print_good("You're executing from a privileged process so this version is considered vulnerable.")
-        return Msf::Exploit::CheckCode::Vulnerable
+        return Msf::Exploit::CheckCode::Vulnerable('Running as SYSTEM with Pulse Secure Connect installed')
       end
 
       print_warning("You're executing from an unprivileged process so this version is considered safe.")
       print_warning('However, there might be leftovers from previous versions in the registry.')
       print_warning('We recommend running this script in elevated mode to obtain credentials saved by recent versions.')
-      return Msf::Exploit::CheckCode::Appears
+      return Msf::Exploit::CheckCode::Appears("Pulse Secure Connect build #{build} may have leftover credentials")
     rescue Rex::Post::Meterpreter::RequestError => e
       vprint_error(e.message)
     end


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical