### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/linux/http/accellion_fta_getstatus_oauth.rb
+++ b/modules/exploits/linux/http/accellion_fta_getstatus_oauth.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res && res.code == 200 && res.body.to_s =~ /"result_msg":"MD5 token is invalid"/
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     res = send_request_cgi({
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res && res.code == 200 && res.body.to_s =~ /"result_msg":"Success","transaction_id":"/
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    Msf::Exploit::CheckCode::Vulnerable
+    Msf::Exploit::CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/advantech_switch_bash_env_exec.rb
+++ b/modules/exploits/linux/http/advantech_switch_bash_env_exec.rb
@@ -75,19 +75,19 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     if !res
       vprint_error("No response from host")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     elsif res.headers['Server'] =~ /Boa\/(.*)/
       vprint_status("Found Boa version #{$1}")
     else
       print_status("Target is not a Boa web server")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     if res.body.to_s.index('127.0.0.1 ping statistics')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
       vprint_error("Target does not appear to be an Advantech switch")
-      return Expoit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/airties_login_cgi_bof.rb
+++ b/modules/exploits/linux/http/airties_login_cgi_bof.rb
@@ -69,13 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res && [200, 301, 302].include?(res.code) && res.body.to_s =~ /login.html\?ErrorCode=2/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/alienvault_exec.rb
+++ b/modules/exploits/linux/http/alienvault_exec.rb
@@ -87,9 +87,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body =~ /XPATH syntax error: ':#{r}'/
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/alienvault_sqli_exec.rb
+++ b/modules/exploits/linux/http/alienvault_sqli_exec.rb
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body =~ /#{marker}726F6F7440[0-9a-zA-Z]+#{marker}/ # 726F6F7440 = root
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
       print_status("#{res.body}")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/apache_airflow_dag_rce.rb
+++ b/modules/exploits/linux/http/apache_airflow_dag_rce.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless Rex::Version.new(version_number) < Rex::Version.new('1.10.11')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version_number} is not vulnerable")
     end
 
     vprint_status(
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
     check_task
     check_unpaused
 
-    return CheckCode::Appears
+    return CheckCode::Appears("Version #{version_number} appears to be vulnerable")
   end
 
   def check_api

--- a/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
@@ -56,11 +56,11 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body.include?('1.4.2')
-      CheckCode::Appears
+      CheckCode::Appears('The target appears to be vulnerable')
     elsif res && res.code == 200
-      CheckCode::Detected
+      CheckCode::Detected('The target service was detected')
     else
-      CheckCode::Safe
+      CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
@@ -77,16 +77,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     get_version
-    return CheckCode::Unknown if @version.nil?
+    return CheckCode::Unknown('Could not determine the target status') if @version.nil?
 
     version = Rex::Version.new(@version)
-    return CheckCode::Unknown if version.version.empty?
+    return CheckCode::Unknown('Could not determine the target status') if version.version.empty?
 
     vprint_status "Found CouchDB version #{version}"
 
-    return CheckCode::Appears if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
+    return CheckCode::Appears("Version #{version} appears to be vulnerable") if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -138,11 +138,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless res.code == 200
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     if res.body.include?(genecho)
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     end
 
     CheckCode::Unknown('Target does not seem to be running Apache Druid.')

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -93,9 +93,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     rand_string = Rex::Text.rand_text_alphanumeric(4..16)
     if execute_command("echo #{Rex::Text.encode_base64(rand_string)}|base64 -d").include?(rand_string)
-      CheckCode::Appears
+      CheckCode::Appears('The target appears to be vulnerable')
     else
-      CheckCode::Safe
+      CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
+++ b/modules/exploits/linux/http/artica_proxy_unauth_rce_cve_2024_2054.rb
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Safe("Artica version: #{version[1]}")
       end
     end
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/astium_sqli_upload.rb
+++ b/modules/exploits/linux/http/astium_sqli_upload.rb
@@ -68,9 +68,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 302 and res.body =~ /direct entry from outside/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
   end
 

--- a/modules/exploits/linux/http/atutor_filemanager_traversal.rb
+++ b/modules/exploits/linux/http/atutor_filemanager_traversal.rb
@@ -90,20 +90,20 @@ class MetasploitModule < Msf::Exploit::Remote
     # obviously not ideal, but if anyone knows better, feel free to change
     unless datastore['USERNAME'] && datastore['PASSWORD']
       # if we cant login, it may still be vuln
-      return Exploit::CheckCode::Unknown 'Check requires credentials. The target may still be vulnerable. If so, it may be possible to bypass authentication.'
+      return Exploit::CheckCode::Unknown('Check requires credentials. The target may still be vulnerable. If so, it may be possible to bypass authentication.')
     end
 
     student_cookie = login(datastore['USERNAME'], datastore['PASSWORD'], check = true)
     if !student_cookie.nil? && disclose_web_root
       begin
         if upload_shell(student_cookie, check = true) && found
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable('The target is vulnerable')
         end
       rescue Msf::Exploit::Failed => e
         vprint_error(e.message)
       end
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def create_zip_file(check = false)

--- a/modules/exploits/linux/http/axis_app_install.rb
+++ b/modules/exploits/linux/http/axis_app_install.rb
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/axis-cgi/prod_brand_info/getbrand.cgi')
     })
 
-    return CheckCode::Unknown unless res && (res.code == 200)
+    return CheckCode::Unknown('Could not determine the target status') unless res && (res.code == 200)
 
     body_json = res.get_json_document
-    return CheckCode::Unknown if body_json.empty? || body_json.dig('Brand', 'ProdShortName').nil?
+    return CheckCode::Unknown('Could not determine the target status') if body_json.empty? || body_json.dig('Brand', 'ProdShortName').nil?
 
     # The brand / model are now known
     check_comment = "The target reports itself to be a '#{body_json.dig('Brand', 'ProdShortName')}'."
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     # A strange edge case where there is no response... respond detected
-    return CheckCode::Detected unless res
+    return CheckCode::Detected('The target service was detected') unless res
     # Respond safe if credentials fail, to prevent the exploit from running
     return CheckCode::Safe('The user provided credentials did not work.') if res.code == 401
     # Assume any non-200 means the API doesn't exist

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -90,10 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 204
-      return CheckCode::Appears
+      return CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/belkin_login_bof.rb
+++ b/modules/exploits/linux/http/belkin_login_bof.rb
@@ -72,13 +72,13 @@ class MetasploitModule < Msf::Exploit::Remote
          res.headers['Server'] =~ /minhttpd/ &&
          res.body =~ /u_errpaswd/
 
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
+++ b/modules/exploits/linux/http/beyondtrust_pra_rs_unauth_rce.rb
@@ -83,14 +83,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     product_version = get_version
-    return CheckCode::Unknown unless product_version
+    return CheckCode::Unknown('Could not determine the target status') unless product_version
 
     product_version = Rex::Version.new(product_version)
     if Rex::Version.new(product_version) <= Rex::Version.new('24.3.1')
       return CheckCode::Appears("Detected version #{product_version}")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{product_version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
+++ b/modules/exploits/linux/http/bitbucket_git_cmd_injection.rb
@@ -107,33 +107,33 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Found Bitbucket version: #{matches[1]}")
 
     num_vers = Rex::Version.new(version_str)
-    return CheckCode::NotVulnerable if num_vers <= Rex::Version.new('6.10.17')
+    return CheckCode::Safe("Version #{version_str} is not vulnerable") if num_vers <= Rex::Version.new('6.10.17')
 
     major, minor, revision = version_str.split('.')
     case major
     when '6'
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version_str} appears to be vulnerable")
     when '7'
       case minor
       when '6'
-        return CheckCode::Appears if revision.to_i < 17
+        return CheckCode::Appears("Version #{version_str} appears to be vulnerable") if revision.to_i < 17
       when '17'
-        return CheckCode::Appears if revision.to_i < 10
+        return CheckCode::Appears("Version #{version_str} appears to be vulnerable") if revision.to_i < 10
       when '21'
-        return CheckCode::Appears if revision.to_i < 4
+        return CheckCode::Appears("Version #{version_str} appears to be vulnerable") if revision.to_i < 4
       end
     when '8'
       case minor
       when '0', '1'
-        return CheckCode::Appears if revision.to_i < 3
+        return CheckCode::Appears("Version #{version_str} appears to be vulnerable") if revision.to_i < 3
       when '2'
-        return CheckCode::Appears if revision.to_i < 2
+        return CheckCode::Appears("Version #{version_str} appears to be vulnerable") if revision.to_i < 2
       when '3'
-        return CheckCode::Appears if revision.to_i < 1
+        return CheckCode::Appears("Version #{version_str} appears to be vulnerable") if revision.to_i < 1
       end
     end
 
-    CheckCode::Detected
+    CheckCode::Detected("Target detected: version #{version_str}")
   end
 
   def username

--- a/modules/exploits/linux/http/bludit_upload_images_exec.rb
+++ b/modules/exploits/linux/http/bludit_upload_images_exec.rb
@@ -89,27 +89,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection timed out')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     html = res.get_html_document
     generator_tag = html.at('meta[@name="generator"]')
     unless generator_tag
       vprint_error('No generator metadata tag found in HTML')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     content_attr = generator_tag.attributes['content']
     unless content_attr
       vprint_error("No content attribute found in metadata tag")
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     if content_attr.value == 'Bludit'
-      return CheckCode::Detected
+      return CheckCode::Detected('The target service was detected')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_uuid(login_badge)

--- a/modules/exploits/linux/http/cayin_cms_ntp.rb
+++ b/modules/exploits/linux/http/cayin_cms_ntp.rb
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.body.include?('var model = "CMS') && res.body.include?('STR_CAYIN_LOGO')
       print_good('Cayin CMS install detected')
-      return CheckCode::Detected
+      return CheckCode::Detected('Cayin CMS install detected')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not a Cayin CMS install')
   rescue ::Rex::ConnectionError
     CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
   end

--- a/modules/exploits/linux/http/centreon_sqli_exec.rb
+++ b/modules/exploits/linux/http/centreon_sqli_exec.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_session_id(random_id)
 
     unless res && res.code == 200 && res.headers['Content-Type'] && res.headers['Content-Type'] == 'image/gif'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     injection = "#{random_id}' or 'a'='a"
@@ -79,13 +79,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200
       if res.body && res.body.to_s =~ /sh: graph: command not found/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable')
       elsif res.headers['Content-Type'] && res.headers['Content-Type'] == 'image/gif'
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/centreon_useralias_exec.rb
+++ b/modules/exploits/linux/http/centreon_useralias_exec.rb
@@ -60,9 +60,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if version && Rex::Version.new(version) <= Rex::Version.new('2.5.3')
         vprint_good("Version Detected: #{version}")
-        Exploit::CheckCode::Appears
+        Exploit::CheckCode::Appears('The target appears to be vulnerable')
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
+++ b/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res and res.code == 200 and res.body.to_s =~ /EVM ping response/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
+++ b/modules/exploits/linux/http/chamilo_unauth_rce_cve_2023_34960.rb
@@ -190,7 +190,7 @@ class MetasploitModule < Msf::Exploit::Remote
     marker = Rex::Text.rand_text_alphanumeric(8..16)
     res = execute_command("echo #{marker}")
     if res && res.code == 200 && res.body.include?('wsConvertPptResponse') && res.body.include?(marker)
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('The target is vulnerable')
     else
       CheckCode::Safe('No valid response received from the target.')
     end

--- a/modules/exploits/linux/http/cisco_firepower_useradd.rb
+++ b/modules/exploits/linux/http/cisco_firepower_useradd.rb
@@ -90,16 +90,16 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       rescue Timeout::Error
         vprint_error('The SSH connection timed out.')
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine the target status')
       rescue Net::SSH::AuthenticationFailed
         # Hey, it talked. So that means SSH is running.
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be vulnerable')
       rescue Net::SSH::Exception => e
         vprint_error(e.message)
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_sf_action_id(sid)

--- a/modules/exploits/linux/http/cisco_hyperflex_file_upload_rce.rb
+++ b/modules/exploits/linux/http/cisco_hyperflex_file_upload_rce.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'SSL' => true
     )
     unless res_ssl && res_ssl.body[%r{<title>(?:Hyperflex Installer|Cisco HyperFlex Connect)</title>}]
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     # The vulnerability, however, lies on the HTTP endpoint /upload.
@@ -96,12 +96,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'upload')
     )
     if res && res.code == 400 && res.body.include?('Apache Tomcat') && res.headers['Server'] && res.headers['Server'].include?('nginx')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     elsif res && res.code == 404
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   end
 
   def prepare_payload(app_base, jsp_name)

--- a/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
+++ b/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
@@ -84,11 +84,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'storfs-asup')
     )
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('Could not determine the target status') unless res
 
     unless res.code == 200 &&
            res.body.include?('Action for the servlet need be specified.')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     CheckCode::Appears('Storfs ASUP servlet detected.')

--- a/modules/exploits/linux/http/cisco_prime_inf_rce.rb
+++ b/modules/exploits/linux/http/cisco_prime_inf_rce.rb
@@ -75,17 +75,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.code == 404 && res.body.length == 0
       # at the moment this is the best way to detect
       # a 404 in swimtemp only returns the error code with a body length of 0,
       # while a 404 to another webapp or to the root returns code plus a body with content
-      return CheckCode::Detected
+      return CheckCode::Detected('The target service was detected')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def upload_payload(payload)

--- a/modules/exploits/linux/http/cisco_rv32x_rce.rb
+++ b/modules/exploits/linux/http/cisco_rv32x_rce.rb
@@ -190,18 +190,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection failed.')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.code == 200
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     unless res.body =~ /PASSWD/
-      return CheckCode::Detected
+      return CheckCode::Detected('The target service was detected')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/cisco_ucs_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_rce.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     })
     if res and res.code == 302
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/cpi_tararchive_upload.rb
+++ b/modules/exploits/linux/http/cpi_tararchive_upload.rb
@@ -105,14 +105,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('No response from the server')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.code == 200 && res.headers['Server'] && res.headers['Server'] == 'Prime'
-      return CheckCode::Detected
+      return CheckCode::Detected('The target service was detected')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_jsp_stager(out_file, bin_data)

--- a/modules/exploits/linux/http/craftcms_ftp_template.rb
+++ b/modules/exploits/linux/http/craftcms_ftp_template.rb
@@ -181,9 +181,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res&.body&.include?('mkdir()') && res.body.include?(nonce)
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('The target is vulnerable')
     else
-      CheckCode::Safe
+      CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/craftcms_unauth_rce_cve_2023_41892.rb
+++ b/modules/exploits/linux/http/craftcms_unauth_rce_cve_2023_41892.rb
@@ -244,9 +244,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     check_phpinfo
-    return CheckCode::Appears unless @config['upload_tmp_dir'].nil? || @config['document_root'].nil?
+    return CheckCode::Appears('The target appears to be vulnerable') unless @config['upload_tmp_dir'].nil? || @config['document_root'].nil?
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
+++ b/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
@@ -87,9 +87,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if bypass_login.nil?
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     else
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
+++ b/modules/exploits/linux/http/cve_2019_1663_cisco_rmi_rce.rb
@@ -343,55 +343,55 @@ class MetasploitModule < Msf::Exploit::Remote
     fingerprints = {
       '69d906ddd59eb6755a7b9c4f46ea11cdaa47c706' => {
         'version' => 'Cisco RV110W 1.1.0.9',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '8d3b677d870425198f7fae94d6cfe262551aa8bd' => {
         'version' => 'Cisco RV110W 1.2.0.9',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '134ee643ec877641030211193a43cc5e93c96a06' => {
         'version' => 'Cisco RV110W 1.2.0.10',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       'e3b2ec9d099a3e3468f8437e5247723643ff830e' => {
         'version' => 'Cisco RV110W 1.2.1.4, 1.2.1.7, 1.2.2.1 (not vulnerable), 1.2.2.4 (not vulnerable)',
-        'status' => Exploit::CheckCode::Unknown
+        'status' => Exploit::CheckCode::Unknown('Could not determine the target status')
       },
       '6b7b1e8097e8dda26db27a09b8176b9c32b349b3' => {
         'version' => 'Cisco RV130/RV130W 1.0.0.21',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '9b1a87b752d11c5ba97dd80d6bae415532615266' => {
         'version' => 'Cisco RV130/RV130W 1.0.1.3',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '9b6399842ef69cf94409b65c4c61017c862b9d09' => {
         'version' => 'Cisco RV130/RV130W 1.0.2.7',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '8680ec6df4f8937acd3505a4dd36d40cb02c2bd6' => {
         'version' => 'Cisco RV130/RV130W 1.0.3.14, 1.0.3.16',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '8c8e05de96810a02344d96588c09b21c491ede2d' => {
         'version' => 'Cisco RV130/RV130W 1.0.3.22, 1.0.3.28, 1.0.3.44, 1.0.3.45 (not vulnerable), 1.0.3.51 (not vulnerable)',
-        'status' => Exploit::CheckCode::Unknown
+        'status' => Exploit::CheckCode::Unknown('Could not determine the target status')
       },
       '2f29a0dfa78063d643eb17388e27d3f804ff6765' => {
         'version' => 'Cisco RV215W 1.1.0.5',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       'e5cc84d7c9c2d840af85d5f25cee33baffe3ca6f' => {
         'version' => 'Cisco RV215W 1.1.0.6',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '7cc8fcce5949a68c31641c38255e7f6ed31ff4db' => {
         'version' => 'Cisco RV215W 1.2.0.14 or 1.2.0.15',
-        'status' => Exploit::CheckCode::Vulnerable
+        'status' => Exploit::CheckCode::Vulnerable('The target is vulnerable')
       },
       '050d47ea944eaeadaec08945741e8e380f796741' => {
         'version' => 'Cisco RV215W 1.3.0.7 or 1.3.0.8, 1.3.1.1 (not vulnerable), 1.3.1.4 (not vulnerable)',
-        'status' => Exploit::CheckCode::Unknown
+        'status' => Exploit::CheckCode::Unknown('Could not determine the target status')
       }
     }
 
@@ -409,7 +409,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_status("Couldn't reliably fingerprint the target.")
       end
     end
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dcos_marathon.rb
+++ b/modules/exploits/linux/http/dcos_marathon.rb
@@ -148,9 +148,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return Exploit::CheckCode::Safe if get_apps.nil?
+    return Exploit::CheckCode::Safe('The target is not vulnerable') if get_apps.nil?
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/denyall_waf_exec.rb
+++ b/modules/exploits/linux/http/denyall_waf_exec.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # If we've managed to get token, that means target is most likely vulnerable.
     token = get_token
     if token.nil?
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     else
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/dlink_authentication_cgi_bof.rb
+++ b/modules/exploits/linux/http/dlink_authentication_cgi_bof.rb
@@ -70,13 +70,13 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res && [200, 301, 302].include?(res.code) && res.body.to_s =~ /status.*uid/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_dcs931l_upload.rb
+++ b/modules/exploits/linux/http/dlink_dcs931l_upload.rb
@@ -78,19 +78,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_status("The connection timed out.")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.code && res.code == 404
       vprint_status("uploadfile.htm does not exist")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     elsif res.code && res.code == 401 && res.headers['WWW-Authenticate'] =~ /realm="DCS\-931L"/
       vprint_error("Authentication failed")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     elsif res.code && res.code == 200 && res.body && res.body =~ /Upload File/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi({ 'uri' => '/comm.asp' })
     if res and res.code == 200 and res.body =~ /var modelname="DIR-605L"/ and res.headers["Server"] and res.headers["Server"] =~ /Boa\/0\.94\.14rc21/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('DIR-605L with Boa server detected, appears vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not a vulnerable DIR-605L')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_dir850l_unauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir850l_unauth_exec.rb
@@ -63,16 +63,16 @@ class MetasploitModule < Msf::Exploit::Remote
         auth = res.headers['Server']
         if auth =~ /DIR-850L/
           if auth =~ /WEBACCESS\/1\.0/
-            return Exploit::CheckCode::Safe
+            return Exploit::CheckCode::Safe('The target is not vulnerable')
           else
-            return Exploit::CheckCode::Detected
+            return Exploit::CheckCode::Detected('The target service was detected')
           end
         end
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def report_cred(opts)

--- a/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_dsl2750b_exec_noauth.rb
@@ -67,26 +67,26 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection failed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.code.to_i == 200 && res.body.include?('DSL-2750')
       vprint_status('Remote host is not a DSL-2750')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     if res.body =~ /var AYECOM_FWVER="(\d.\d+)";/
       version = Regexp.last_match[1]
       vprint_status("Remote host is a DSL-2750B with firmware version #{version}")
       if version >= "1.01" && version <= "1.03"
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
       end
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   rescue ::Rex::ConnectionError
     vprint_error('Connection failed')
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Could not determine the target status')
   end
 
   def execute_command(cmd, _opts)

--- a/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
@@ -68,13 +68,13 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res && res.headers["Server"] =~ /lighttpd\/1\.4\.34/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_dspw215_info_cgi_bof.rb
+++ b/modules/exploits/linux/http/dlink_dspw215_info_cgi_bof.rb
@@ -69,16 +69,16 @@ class MetasploitModule < Msf::Exploit::Remote
       if res && [200, 301, 302].include?(res.code)
         if res.body =~ /DSP-W215A1/ && res.body =~ /1.02/
           @my_target = targets[1] if target['auto']
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be vulnerable')
         end
 
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_hedwig_cgi_bof.rb
+++ b/modules/exploits/linux/http/dlink_hedwig_cgi_bof.rb
@@ -69,13 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res && [200, 301, 302].include?(res.code) && res.body.to_s =~ /unsupported HTTP request/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_hnap_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_bof.rb
@@ -83,22 +83,22 @@ class MetasploitModule < Msf::Exploit::Remote
       if res && [200, 301, 302].include?(res.code)
         if res.body =~ /DIR-505/ && res.body =~ /1.07/
           @my_target = targets[3] if target['auto']
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be vulnerable')
         elsif res.body =~ /DIR-505/ && res.body =~ /1.06/
           @my_target = targets[2] if target['auto']
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be vulnerable')
         elsif res.body =~ /DSP-W215/ && res.body =~ /1.00/
           @my_target = targets[1] if target['auto']
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be vulnerable')
         else
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('The target service was detected')
         end
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_hnap_header_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_hnap_header_exec_noauth.rb
@@ -76,13 +76,13 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res && [200].include?(res.code) && res.body =~ /D-Link/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dlink_hnap_login_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_login_bof.rb
@@ -115,13 +115,13 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res && res.code == 500
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def calc_encode_addr(offset, big_endian = true)

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -76,13 +76,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/InternetGatewayDevice.xml'
       })
       if res && [200, 301, 302].include?(res.code) && res.body.to_s =~ /<modelNumber>DIR-/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dnalims_admin_exec.rb
+++ b/modules/exploits/linux/http/dnalims_admin_exec.rb
@@ -73,12 +73,12 @@ class MetasploitModule < Msf::Exploit::Remote
       )
       if res && res.body
         if /Summary of/ =~ res.body
-          Exploit::CheckCode::Vulnerable
+          Exploit::CheckCode::Vulnerable('The target is vulnerable')
         else
-          Exploit::CheckCode::Safe
+          Exploit::CheckCode::Safe('The target is not vulnerable')
         end
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/linux/http/docker_daemon_tcp.rb
+++ b/modules/exploits/linux/http/docker_daemon_tcp.rb
@@ -161,14 +161,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       print_error('Failed to connect to the target')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res && res.code == 200 && res.headers['Server'].include?('Docker')
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/dolibarr_cmd_exec.rb
+++ b/modules/exploits/linux/http/dolibarr_cmd_exec.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /Dolibarr 3\.1\.1/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
+++ b/modules/exploits/linux/http/dtale_rce_cve_2025_0655.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Cookie' => "session=#{@session}" # Set the JWT token as a cookie
       }
     })
-    return Exploit::CheckCode::Unknown unless res&.code == 200
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless res&.code == 200
 
     html_document = res.get_html_document
     return Exploit::CheckCode::Unknown('Failed to get html document.') if html_document.blank?

--- a/modules/exploits/linux/http/empire_skywalker.rb
+++ b/modules/exploits/linux/http/empire_skywalker.rb
@@ -99,9 +99,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     @staging_key = get_staging_key
-    return Exploit::CheckCode::Safe if @staging_key.nil?
+    return Exploit::CheckCode::Safe('The target is not vulnerable') if @staging_key.nil?
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def aes_encrypt(key, data, include_mac: false)

--- a/modules/exploits/linux/http/eramba_rce.rb
+++ b/modules/exploits/linux/http/eramba_rce.rb
@@ -75,11 +75,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri('/login')
     })
 
-    return Exploit::CheckCode::Unknown unless res&.code == 200
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless res&.code == 200
 
     html_body = res.get_html_document
     version_html = html_body.at('//p[contains(text(), "App version")]/strong')&.text
-    return Exploit::CheckCode::Unknown unless version_html
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless version_html
 
     return Exploit::CheckCode::Safe('Debug mode not enabled.') unless html_body.at('input[@name="_Token[debug]"]')
 

--- a/modules/exploits/linux/http/esva_exec.rb
+++ b/modules/exploits/linux/http/esva_exec.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # If the server doesn't return the default redirection, probably something is wrong
     if res and res.code == 200 and res.body =~ /#{clue}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -223,12 +223,12 @@ class MetasploitModule < Msf::Exploit::Remote
     # any other response is considered not vulnerable
     res = create_script('', '')
     if res && res.code == 500 && res.body =~ /path is empty/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     elsif res && res.code == 401
       print_warning("HTTP/#{res.proto} #{res.code} #{res.message} -- incorrect USERNAME or PASSWORD?")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/f5_icontrol_exec.rb
+++ b/modules/exploits/linux/http/f5_icontrol_exec.rb
@@ -105,10 +105,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'password' => datastore['HttpPassword']
       })
 
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable("Exploitable: version #{version} is vulnerable")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def send_cmd(cmd)

--- a/modules/exploits/linux/http/f5_icontrol_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rce.rb
@@ -101,24 +101,24 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     })
 
-    return CheckCode::Unknown unless res&.code == 401
+    return CheckCode::Unknown('Could not determine the target status') unless res&.code == 401
 
     body = res.get_json_document
 
-    return CheckCode::Safe unless body.key?('message') && body['kind'] == ':resterrorresponse'
+    return CheckCode::Safe('The target is not vulnerable') unless body.key?('message') && body['kind'] == ':resterrorresponse'
 
     signature = Rex::Text.rand_text_alpha(13)
     stub = "echo #{signature}"
     res = send_command(stub)
-    return CheckCode::Safe unless res&.code == 200
+    return CheckCode::Safe('The target is not vulnerable') unless res&.code == 200
 
     body = res.get_json_document
 
-    return CheckCode::Safe unless body['kind'] == 'tm:util:bash:runstate'
+    return CheckCode::Safe('The target is not vulnerable') unless body['kind'] == 'tm:util:bash:runstate'
 
-    return CheckCode::Vulnerable if body['commandResult'].chomp == signature
+    return CheckCode::Vulnerable('The target is vulnerable') if body['commandResult'].chomp == signature
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    generate_token_ssrf ? CheckCode::Vulnerable : CheckCode::Safe
+    generate_token_ssrf ? CheckCode::Vulnerable('The target is vulnerable') : CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/fortinet_authentication_bypass_cve_2022_40684.rb
+++ b/modules/exploits/linux/http/fortinet_authentication_bypass_cve_2022_40684.rb
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/system/status')
     })
 
-    return CheckCode::Safe unless res&.code == 200
+    return CheckCode::Safe('The target is not vulnerable') unless res&.code == 200
 
     version = res.get_json_document['version']
 

--- a/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
+++ b/modules/exploits/linux/http/fortinet_fortiweb_rce.rb
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
     j = JSON.parse(res.body)
 
     # Tested against vulnerable FortiWeb versions 8.0.1, 7.4.8, 6.4.3, and 6.3.9
-    return Exploit::CheckCode::Appears if j.dig('results', 'errcode') == -56
+    return Exploit::CheckCode::Appears('The target appears to be vulnerable') if j.dig('results', 'errcode') == -56
 
     CheckCode::Unknown('Unexpected JSON results')
   rescue JSON::ParserError

--- a/modules/exploits/linux/http/fritzbox_echo_exec.rb
+++ b/modules/exploits/linux/http/fritzbox_echo_exec.rb
@@ -81,13 +81,13 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
       if res && res.body =~ /#{clue}/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def execute_command(cmd, opts)

--- a/modules/exploits/linux/http/geutebruck_cmdinject_cve_2021_335xx.rb
+++ b/modules/exploits/linux/http/geutebruck_cmdinject_cve_2021_335xx.rb
@@ -166,10 +166,10 @@ class MetasploitModule < Msf::Exploit::Remote
     rex_version = Rex::Version.new(version)
     vprint_status("Found Geutebruck version #{rex_version}")
     if rex_version <= Rex::Version.new('1.12.0.27') || rex_version == Rex::Version.new('1.12.13.2') || rex_version == Rex::Version.new('1.12.14.5')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -82,10 +82,10 @@ class MetasploitModule < Msf::Exploit::Remote
     version = Rex::Version.new(@version)
     vprint_status "Found Geutebruck version #{version}"
     if version < Rex::Version.new('1.12.0.25') || version == Rex::Version.new('1.12.13.2') || version == Rex::Version.new('1.12.14.5')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/github_enterprise_secret.rb
+++ b/modules/exploits/linux/http/github_enterprise_secret.rb
@@ -77,12 +77,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection timed out.')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.get_cookies.match(/^_gh_manage/)
       vprint_error('No _gh_manage value in cookie found')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     cookies = res.get_cookies
@@ -97,10 +97,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if expected_hmac == hmac
       vprint_status("The HMACs match, which means you can sign and tamper the cookie.")
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_ruby_code

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
     repo = get_repo
 
     if repo.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     chk = Rex::Text.encode_base64(rand_text_alpha(rand(32) + 5))
@@ -74,13 +74,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.body
       if res.body.include?(Rex::Text.decode_base64(chk))
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable')
       elsif res.body.to_s =~ /sh.*not found/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable')
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/glpi_htmlawed_php_injection.rb
+++ b/modules/exploits/linux/http/glpi_htmlawed_php_injection.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if @token.nil? || @sid.nil? || @html.nil?
       return Exploit::CheckCode::Safe('Failed to retrieve htmLawed page')
     end
-    return Exploit::CheckCode::Appears if @html.to_s.include?('htmLawed')
+    return Exploit::CheckCode::Appears('The target appears to be vulnerable') if @html.to_s.include?('htmLawed')
 
     return Exploit::CheckCode::Safe('Unable to determine htmLawed status')
   end

--- a/modules/exploits/linux/http/goahead_ldpreload.rb
+++ b/modules/exploits/linux/http/goahead_ldpreload.rb
@@ -251,10 +251,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Find a valid CGI target
     target_uri = find_target_cgi
     unless target_uri
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    return Exploit::CheckCode::Vulnerable
+    return Exploit::CheckCode::Vulnerable('The target is vulnerable')
   end
 
   # Upload and LD_PRELOAD execute the shared library payload

--- a/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
+++ b/modules/exploits/linux/http/goautodial_3_rce_command_injection.rb
@@ -60,18 +60,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error "#{peer} Connection failed"
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.code == 200 && res.body =~ /goautodial/
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     unless res.body =~ /1421902800/
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def check_version

--- a/modules/exploits/linux/http/grandstream_gxv31xx_settimezone_unauth_cmd_exec.rb
+++ b/modules/exploits/linux/http/grandstream_gxv31xx_settimezone_unauth_cmd_exec.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('phonecookie authentication bypassed successfully.')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/gravcms_exec.rb
+++ b/modules/exploits/linux/http/gravcms_exec.rb
@@ -69,9 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.get_hidden_inputs.first&.fetch('admin-nonce')
-      CheckCode::Appears
+      CheckCode::Appears('The target appears to be vulnerable')
     else
-      CheckCode::Safe
+      CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
+++ b/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
@@ -76,11 +76,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /GroundWork.*6\.7\.0/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     elsif res and res.body =~ /GroundWork/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -59,14 +59,14 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     rescue Rex::ConnectionError
       vprint_error("#{peer} - Connection failed")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res && res.code == 200 && res.body.include?('application-id')
-      return CheckCode::Appears
+      return CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/hp_system_management.rb
+++ b/modules/exploits/linux/http/hp_system_management.rb
@@ -79,13 +79,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error("Connection timed out")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     elsif res.code == 200 and res.body =~ /"HP System Management Homepage v(.*)"/
       version = $1
-      return Exploit::CheckCode::Appears if version <= "7.1.1.1"
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable") if version <= "7.1.1.1"
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe(version ? "Version #{version} is not vulnerable" : 'The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    checkcode = CheckCode::Safe
+    checkcode = CheckCode::Safe('The target is not vulnerable')
 
     res = send_request_cgi(
       'method' => 'POST',
@@ -105,11 +105,11 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res.nil?
-      checkcode = CheckCode::Unknown
+      checkcode = CheckCode::Unknown('Could not determine the target status')
     elsif res && res.code == 400 && res.body.include?('Missing field: name')
-      checkcode = CheckCode::Appears
+      checkcode = CheckCode::Appears('The target appears to be vulnerable')
     elsif res && res.code == 401 && res.body =~ /Missing|Invalid token/
-      checkcode = CheckCode::Safe
+      checkcode = CheckCode::Safe('The target is not vulnerable')
     end
 
     checkcode

--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -104,14 +104,14 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     rescue ::Rex::ConnectionError
       print_error("#{rhost}:#{rport} - Could not connect to device")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res && res.code == 200 && res.to_s =~ httpd_fingerprint
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   #

--- a/modules/exploits/linux/http/ibm_drm_rce.rb
+++ b/modules/exploits/linux/http/ibm_drm_rce.rb
@@ -86,10 +86,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && (res.code == 302) &&
        res.headers['Location'].include?('localhost:8765') &&
        res.headers['Location'].include?('saml/idpSelection')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   # post-exploitation:

--- a/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
+++ b/modules/exploits/linux/http/ibm_qradar_unauth_rce.rb
@@ -90,17 +90,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.code == 403
-      return CheckCode::Detected
+      return CheckCode::Detected('The target service was detected')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   rescue ::Rex::ConnectionError
     vprint_error 'Connection failed'
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Could not determine the target status')
   end
 
   # Handle incoming requests from QRadar

--- a/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
+++ b/modules/exploits/linux/http/ictbroadcast_unauth_cookie.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res&.code == 200 && res.body.include?('ICT Innovations')
     end
 
-    return CheckCode::Safe unless fingerprint_found
+    return CheckCode::Safe('The target is not vulnerable') unless fingerprint_found
 
     print_good('JS fingerprint found; performing timing tests')
 

--- a/modules/exploits/linux/http/imperva_securesphere_exec.rb
+++ b/modules/exploits/linux/http/imperva_securesphere_exec.rb
@@ -70,14 +70,14 @@ class MetasploitModule < Msf::Exploit::Remote
       res = execute_command('id')
     rescue => e
       vprint_error("#{e}")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.body =~ /uid=\d+/
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/invokeai_rce_cve_2024_12029.rb
+++ b/modules/exploits/linux/http/invokeai_rce_cve_2024_12029.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api/v1/app/version')
     })
-    return Exploit::CheckCode::Unknown unless res&.code == 200
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless res&.code == 200
 
     json_version = res&.get_json_document&.fetch('version', nil)
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless json_version

--- a/modules/exploits/linux/http/ipfire_bashbug_exec.rb
+++ b/modules/exploits/linux/http/ipfire_bashbug_exec.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
       /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
 
       if version && update && version == "2.15" && update.to_i < 83
-        Exploit::CheckCode::Appears
+        Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
       end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -74,16 +74,16 @@ class MetasploitModule < Msf::Exploit::Remote
       end
       if version.nil? || update.nil? || !Rex::Version.correct?(version)
         vprint_error('No Recognizable Version Found')
-        CheckCode::Safe
+        CheckCode::Safe('The target is not vulnerable')
       elsif Rex::Version.new(version) <= Rex::Version.new('2.19') && update.to_i <= 110
-        CheckCode::Appears
+        CheckCode::Appears('The target appears to be vulnerable')
       else
         vprint_error('Version and/or Update Not Supported')
-        CheckCode::Safe
+        CheckCode::Safe('The target is not vulnerable')
       end
     rescue ::Rex::ConnectionError
       print_error("Connection Failed")
-      CheckCode::Safe
+      CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/ipfire_proxy_exec.rb
+++ b/modules/exploits/linux/http/ipfire_proxy_exec.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
       /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
 
       if version && update && version == "2.19" && update.to_i < 101
-        Exploit::CheckCode::Appears
+        Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
       end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
+++ b/modules/exploits/linux/http/ispconfig_lang_edit_php_code_injection.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       end
     end
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def authenticate

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2023_46805.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Connection failed') unless res
 
     # If the vendor mitigation has been applied, the request will return 403 Forbidden.
-    return CheckCode::Safe if res.code != 200
+    return CheckCode::Safe('The target is not vulnerable') if res.code != 200
 
     # By here we know the target is vulnerable, we can pull out the exact version information from the expected JSON
     # response, this is only for display purposes, we don't need to test the version information.

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_21893.rb
@@ -81,13 +81,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
 
-    return CheckCode::Safe if res.code != 200
+    return CheckCode::Safe('The target is not vulnerable') if res.code != 200
 
     if res.body.include? 'Pulse Secure'
-      return CheckCode::Detected
+      return CheckCode::Detected('The target service was detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_37404.rb
+++ b/modules/exploits/linux/http/ivanti_connect_secure_rce_cve_2024_37404.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe("Version number: #{version}")
     end
 
-    return CheckCode::Appears
+    return CheckCode::Appears("Version #{version} appears to be vulnerable")
   end
 
   def confirm_login_user(uri)

--- a/modules/exploits/linux/http/ivanti_csa_unauth_rce_cve_2021_44529.rb
+++ b/modules/exploits/linux/http/ivanti_csa_unauth_rce_cve_2021_44529.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Checking if #{peer} can be exploited.")
     res = check_vuln
     return CheckCode::Unknown('No response received from the target.') unless res
-    return CheckCode::Safe unless res.code == 200 && !res.body.blank? && res.body =~ /<c123>/
+    return CheckCode::Safe('The target is not vulnerable') unless res.code == 200 && !res.body.blank? && res.body =~ /<c123>/
 
     begin
       parsed_html = Nokogiri::HTML.parse(res.body)

--- a/modules/exploits/linux/http/ivanti_sentry_misc_log_service.rb
+++ b/modules/exploits/linux/http/ivanti_sentry_misc_log_service.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('The target did not respond to the vulnerable endpoint') unless res
     return Exploit::CheckCode::Safe("A vulnerable instance should respond with an HTTP 405 with the string: 'HessianServiceExporter only supports POST requests' in the response body") unless res.code == 405 && res.body.include?('HessianServiceExporter only supports POST requests')
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/jenkins_cli_deserialization.rb
+++ b/modules/exploits/linux/http/jenkins_cli_deserialization.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vers_no = Rex::Version.new(version)
     return Exploit::CheckCode::Appears("Jenkins version #{version} detected") if vers_no < Rex::Version.new('2.54')
 
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected("Target detected: version #{vers_no}")
   end
 
   def exploit

--- a/modules/exploits/linux/http/judge0_sandbox_escape_cve_2024_28189.rb
+++ b/modules/exploits/linux/http/judge0_sandbox_escape_cve_2024_28189.rb
@@ -99,16 +99,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'version')
     })
-    return Exploit::CheckCode::Unknown unless res&.code == 200
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless res&.code == 200
 
     version = Rex::Version.new(res.body)
     return Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable") unless version <= Rex::Version.new('1.13.0')
 
     print_status("Version #{version} detected, which is vulnerable")
 
-    return Exploit::CheckCode::Appears if compile_language_ids
+    return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable") if compile_language_ids
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/kafka_ui_unauth_rce_cve_2023_52251.rb
+++ b/modules/exploits/linux/http/kafka_ui_unauth_rce_cve_2023_52251.rb
@@ -205,7 +205,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Detected("Kafka-ui unknown version: #{@version}")
       end
     end
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/kaltura_unserialize_cookie_rce.rb
+++ b/modules/exploits/linux/http/kaltura_unserialize_cookie_rce.rb
@@ -90,14 +90,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.redirect?
       print_error("Got a redirect, maybe you are not using https? #{res.headers['Location']}")
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     elsif res && res.body.include?(r)
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('The target is vulnerable')
     elsif !check_entryid
       print_error("Invalid ENTRYID")
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/kaltura_unserialize_rce.rb
+++ b/modules/exploits/linux/http/kaltura_unserialize_rce.rb
@@ -79,9 +79,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body.include?(r)
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/kloxo_sqli.rb
+++ b/modules/exploits/linux/http/kloxo_sqli.rb
@@ -80,11 +80,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return Exploit::CheckCode::Safe unless webcommand_exists?
-    return Exploit::CheckCode::Safe if exploit_sqli(1, bad_char(0))
-    return Exploit::CheckCode::Safe unless pefix_found?
+    return Exploit::CheckCode::Safe('The target is not vulnerable') unless webcommand_exists?
+    return Exploit::CheckCode::Safe('The target is not vulnerable') if exploit_sqli(1, bad_char(0))
+    return Exploit::CheckCode::Safe('The target is not vulnerable') unless pefix_found?
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/librenms_collectd_cmd_inject.rb
+++ b/modules/exploits/linux/http/librenms_collectd_cmd_inject.rb
@@ -64,22 +64,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi!('method' => 'GET', 'uri' => target_uri.path)
-    return Exploit::CheckCode::Safe unless res && res.body.downcase.include?('librenms')
+    return Exploit::CheckCode::Safe('The target is not vulnerable') unless res && res.body.downcase.include?('librenms')
 
     about_res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'pages', 'about.inc.php')
     )
 
-    return Exploit::CheckCode::Detected unless about_res && about_res.code == 200
+    return Exploit::CheckCode::Detected('The target service was detected') unless about_res && about_res.code == 200
 
     version = about_res.body.match(/version\s+to\s+(\d+\.\d+\.?\d*)/)
-    return Exploit::CheckCode::Detected unless version && version.length > 1
+    return Exploit::CheckCode::Detected('LibreNMS detected but version could not be determined') unless version && version.length > 1
 
     vprint_status("LibreNMS version #{version[1]} detected")
     version = Rex::Version.new(version[1])
 
-    return Exploit::CheckCode::Appears if version <= Rex::Version.new('1.50')
+    return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable") if version <= Rex::Version.new('1.50')
+
+    Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def login

--- a/modules/exploits/linux/http/linksys_themoon_exec.rb
+++ b/modules/exploits/linux/http/linksys_themoon_exec.rb
@@ -101,13 +101,13 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res && [200, 301, 302].include?(res.code)
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -61,14 +61,14 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue ::Rex::ConnectionError
       vprint_error("A connection error has occurred")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res and res.code == 200 and res.body =~ /<ModelName>WRT110<\/ModelName>/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/linksys_wvbr0_user_agent_exec_noauth.rb
+++ b/modules/exploits/linux/http/linksys_wvbr0_user_agent_exec_noauth.rb
@@ -61,13 +61,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'agent' => "\"; printf \"#{check_str}"
       })
       if res && res.code == 200 && res.body.to_s.include?(Rex::Text.md5(check_str))
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -96,10 +96,10 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
     if (res.code == 200) && res.body.include?(findstr)
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/exploits/linux/http/logsign_exec.rb
+++ b/modules/exploits/linux/http/logsign_exec.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body.include?('{"message": "success", "success": true}')
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/lucee_admin_imgprocess_file_write.rb
+++ b/modules/exploits/linux/http/lucee_admin_imgprocess_file_write.rb
@@ -92,10 +92,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # NOTE: This doesn't actually write a file
     res = write_file(rand_text_alphanumeric(8..16), nil)
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('Could not determine the target status') unless res
 
     unless res.code == 500 && res.body.include?("key [IMGSRC] doesn't exist")
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     CheckCode::Appears('Lucee Administrator imgProcess.cfm detected.')

--- a/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
+++ b/modules/exploits/linux/http/magento_xxe_to_glibc_buf_overflow.rb
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return libc_version_checkcode unless libc_version_checkcode.code == 'appears'
 
     print_good(libc_version_checkcode.reason)
-    CheckCode::Appears
+    CheckCode::Appears("#{libc_version_checkcode.reason}")
   end
 
   def download_file(file)

--- a/modules/exploits/linux/http/microfocus_obr_cmd_injection.rb
+++ b/modules/exploits/linux/http/microfocus_obr_cmd_injection.rb
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
       # should return a stack trace like
       # Unrecognized token '#{data}': was expecting ('true', 'false' or 'null')
       #  at [Source: org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnC (...)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/microfocus_secure_messaging_gateway.rb
+++ b/modules/exploits/linux/http/microfocus_secure_messaging_gateway.rb
@@ -95,13 +95,13 @@ class MetasploitModule < Msf::Exploit::Remote
     res = execute_query("SELECT #{r}")
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
     unless res.code == 200 && res.body.include?(r)
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def implant_payload(cookie)

--- a/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
+++ b/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Target is not vulnerable')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def execute_command(cmd, _opts = {})


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical