### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/linux/http/mobileiron_core_log4shell.rb
+++ b/modules/exploits/linux/http/mobileiron_core_log4shell.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('No HTTP response was received.') if res.nil?
 
     wait_until { @search_received }
-    @search_received ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Unknown('No LDAP search query was received.')
+    @search_received ? Exploit::CheckCode::Vulnerable('The target is vulnerable') : Exploit::CheckCode::Unknown('No LDAP search query was received.')
   ensure
     cleanup_service
   end

--- a/modules/exploits/linux/http/multi_ncc_ping_exec.rb
+++ b/modules/exploits/linux/http/multi_ncc_ping_exec.rb
@@ -86,13 +86,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # unknown if other devices also using mini_httpd
       if res && [500].include?(res.code) && res.headers['Server'] && res.headers['Server'] =~ /mini_httpd/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exec_command(cmd, timeout = 20)

--- a/modules/exploits/linux/http/mutiny_frontend_upload.rb
+++ b/modules/exploits/linux/http/mutiny_frontend_upload.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error("Connection timed out")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.body =~ /var currentMutinyVersion = "Version ([0-9\.-]*)/
@@ -144,10 +144,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if version and version >= "5" and version <= "5.0-1.07"
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/mutiny_frontend_upload.rb
+++ b/modules/exploits/linux/http/mutiny_frontend_upload.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
+    return Exploit::CheckCode::Safe(version ? "Version #{version} is not vulnerable" : 'The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
+++ b/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
@@ -72,12 +72,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'headers' => { 'Connection' => 'Keep-Alive' }
       )
       if res && res.body.include?(fingerprint)
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable('The target is vulnerable')
       end
     rescue ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def execute_command(cmd, opts)

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -65,11 +65,11 @@ class MetasploitModule < Msf::Exploit::Remote
     if (version = html.at('//input[@name = "version"]/@value'))
       vprint_status("Nagios XI version: #{version}")
       if Rex::Version.new(version) <= target[:version]
-        return CheckCode::Appears
+        return CheckCode::Appears("Version #{version} appears to be vulnerable")
       end
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
       if @version < target[:lower_version]
         vprint_bad('Try nagios_xi_chained for this version.')
       elsif (@version <= target[:upper_version] && @version >= target[:lower_version])
-        return CheckCode::Appears("Version #{version} appears to be vulnerable")
+        return CheckCode::Appears("Version #{@version} appears to be vulnerable")
       end
     end
-    CheckCode::Safe("Version #{version} is not vulnerable")
+    CheckCode::Safe("Version #{@version} is not vulnerable")
   end
 
   def set_db_user(usr, passwd)

--- a/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
       if @version < target[:lower_version]
         vprint_bad('Try nagios_xi_chained for this version.')
       elsif (@version <= target[:upper_version] && @version >= target[:lower_version])
-        return CheckCode::Appears
+        return CheckCode::Appears("Version #{version} appears to be vulnerable")
       end
     end
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def set_db_user(usr, passwd)

--- a/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_configwizards_authenticated_rce.rb
@@ -100,10 +100,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @version >= Rex::Version.new('5.5.6') && @version <= Rex::Version.new('5.7.5')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{@version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("Version #{@version} is not vulnerable")
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
+++ b/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears('Found MagpieRSS.')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -96,10 +96,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @version >= Rex::Version.new('5.6.0') && @version <= Rex::Version.new('5.7.3')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -96,10 +96,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @version >= Rex::Version.new('5.6.0') && @version <= Rex::Version.new('5.7.3')
-      return CheckCode::Appears("Version #{version} appears to be vulnerable")
+      return CheckCode::Appears("Version #{@version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe("Version #{version} is not vulnerable")
+    return CheckCode::Safe("Version #{@version} is not vulnerable")
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -130,10 +130,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @version < Rex::Version.new('5.6.6')
-      return CheckCode::Appears("Version #{version} appears to be vulnerable")
+      return CheckCode::Appears("Version #{@version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe("Version #{version} is not vulnerable")
+    return CheckCode::Safe("Version #{@version} is not vulnerable")
   end
 
   def grab_plugins_nsp

--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -130,10 +130,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @version < Rex::Version.new('5.6.6')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def grab_plugins_nsp

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -97,10 +97,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @version < Rex::Version.new('5.8.0')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -97,10 +97,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @version < Rex::Version.new('5.8.0')
-      return CheckCode::Appears("Version #{version} appears to be vulnerable")
+      return CheckCode::Appears("Version #{@version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe("Version #{version} is not vulnerable")
+    return CheckCode::Safe("Version #{@version} is not vulnerable")
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
@@ -143,10 +143,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # check if the target is actually vulnerable
     version = Rex::Version.new(nagios_version)
     if version >= Rex::Version.new('5.5.0') && version <= Rex::Version.new('5.7.3')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def alert_exploit_attempt(payload_string)

--- a/modules/exploits/linux/http/netalertx_rce_cve_2024_46506.rb
+++ b/modules/exploits/linux/http/netalertx_rce_cve_2024_46506.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'maintenance.php')
     })
-    return Exploit::CheckCode::Unknown unless res&.code == 200
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless res&.code == 200
 
     html_document = res&.get_html_document
     return Exploit::CheckCode::Unknown('Failed to get html document.') if html_document.blank?

--- a/modules/exploits/linux/http/netgear_dgn1000_setup_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000_setup_unauth_exec.rb
@@ -58,13 +58,13 @@ class MetasploitModule < Msf::Exploit::Remote
       if res && res.headers['WWW-Authenticate']
         auth = res.headers['WWW-Authenticate']
         if auth =~ /DGN1000/
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('The target service was detected')
         end
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
+++ b/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
@@ -77,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
       model_numbers = ['DGN2200v1', 'DGN2200v2', 'DGN2200v3', 'DGN2200v4']
       if model_numbers.include?(model)
         print_good("Router may be vulnerable (NETGEAR #{model})")
-        return CheckCode::Detected("Target detected: version #{model}")
+        return CheckCode::Detected("Target detected: model #{model}")
       else
-        return CheckCode::Safe("Version #{model} is not vulnerable")
+        return CheckCode::Safe("Model #{model} is not vulnerable")
       end
     else
       print_error('Router is not a NETGEAR router')
-      return CheckCode::Safe("Version #{model} is not vulnerable")
+      return CheckCode::Safe('Router is not a NETGEAR router')
     end
   end
 

--- a/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
+++ b/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
@@ -77,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
       model_numbers = ['DGN2200v1', 'DGN2200v2', 'DGN2200v3', 'DGN2200v4']
       if model_numbers.include?(model)
         print_good("Router may be vulnerable (NETGEAR #{model})")
-        return CheckCode::Detected
+        return CheckCode::Detected("Target detected: version #{model}")
       else
-        return CheckCode::Safe
+        return CheckCode::Safe("Version #{model} is not vulnerable")
       end
     else
       print_error('Router is not a NETGEAR router')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{model} is not vulnerable")
     end
   end
 

--- a/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
+++ b/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
@@ -74,13 +74,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Router is a NETGEAR router (#{model})")
       if model == 'R7000' || model == 'R6400'
         print_good("Router may be vulnerable (NETGEAR #{model})")
-        return CheckCode::Detected
+        return CheckCode::Detected("Target detected: version #{model}")
       else
-        return CheckCode::Safe
+        return CheckCode::Safe("Version #{model} is not vulnerable")
       end
     else
       print_error('Router is not a NETGEAR router')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{model} is not vulnerable")
     end
   end
 

--- a/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
+++ b/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
@@ -74,13 +74,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Router is a NETGEAR router (#{model})")
       if model == 'R7000' || model == 'R6400'
         print_good("Router may be vulnerable (NETGEAR #{model})")
-        return CheckCode::Detected("Target detected: version #{model}")
+        return CheckCode::Detected("Target detected: model #{model}")
       else
-        return CheckCode::Safe("Version #{model} is not vulnerable")
+        return CheckCode::Safe("Model #{model} is not vulnerable")
       end
     else
       print_error('Router is not a NETGEAR router')
-      return CheckCode::Safe("Version #{model} is not vulnerable")
+      return CheckCode::Safe('NETGEAR router not detected')
     end
   end
 

--- a/modules/exploits/linux/http/netgear_readynas_exec.rb
+++ b/modules/exploits/linux/http/netgear_readynas_exec.rb
@@ -83,10 +83,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_payload(")")
     if res and res.code == 200 and res.body =~ /syntax error at \(eval/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/netgear_unauth_exec.rb
+++ b/modules/exploits/linux/http/netgear_unauth_exec.rb
@@ -67,18 +67,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.code == 200
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     unless res.get_html_document.at('input').to_s.include? fingerprint
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('The target is vulnerable')
   end
 
   # execute a command, or simply send a POST request

--- a/modules/exploits/linux/http/netgear_wnr2000_rce.rb
+++ b/modules/exploits/linux/http/netgear_wnr2000_rce.rb
@@ -97,12 +97,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.headers['WWW-Authenticate']
       auth = res.headers['WWW-Authenticate']
       if auth =~ /WNR2000v5/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       elsif auth =~ /WNR2000v4/ || auth =~ /WNR2000v3/
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine the target status')
       end
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def uri_encode(str)

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_22729.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_22729.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       return CheckCode::Safe(version[2].chop.to_s)
     end
-    CheckCode::Safe("Version #{version} is not vulnerable")
+    CheckCode::Unknown('Unable to parse target version from response')
   end
 
   def exploit

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_22729.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_22729.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       return CheckCode::Safe(version[2].chop.to_s)
     end
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Safe(version[1].to_s)
       end
     end
-    CheckCode::Safe("Version #{version} is not vulnerable")
+    CheckCode::Unknown('Unable to parse target version from response')
   end
 
   def exploit

--- a/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
+++ b/modules/exploits/linux/http/netis_unauth_rce_cve_2024_48456_and_48457.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Safe(version[1].to_s)
       end
     end
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -84,16 +84,16 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_fixed(nil)
 
       if res =~ /^Server: nginx\/(1\.3\.(9|10|11|12|13|14|15|16)|1\.4\.0)/m
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be vulnerable')
       elsif res =~ /^Server: nginx/m
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   #

--- a/modules/exploits/linux/http/nuuo_nvrmini_unauth_rce.rb
+++ b/modules/exploits/linux/http/nuuo_nvrmini_unauth_rce.rb
@@ -81,9 +81,9 @@ class MetasploitModule < Msf::Exploit::Remote
     echo = rand_text_alpha(9 + rand(9))
     res = send_payload("echo #{echo}", 20)
     if res && res.body.to_s =~ /([#{echo}]{2})/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/op5_config_exec.rb
+++ b/modules/exploits/linux/http/op5_config_exec.rb
@@ -66,9 +66,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if version && Rex::Version.new(version) <= Rex::Version.new('7.1.9')
         vprint_good("Version Detected: #{version}")
-        Exploit::CheckCode::Appears
+        Exploit::CheckCode::Appears('The target appears to be vulnerable')
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -81,15 +81,15 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res and res.code == 200 and res.body =~ /<strong>Distro Release:&nbsp;<\/strong>Openfiler [NE]SA 2\./
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be vulnerable')
       elsif res and res.code == 200 and res.body =~ /<title>Openfiler Storage Control Center<\/title>/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def on_new_session(client)

--- a/modules/exploits/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.rb
+++ b/modules/exploits/linux/http/optergy_bms_backdoor_rce_cve_2019_7276.rb
@@ -142,9 +142,9 @@ class MetasploitModule < Msf::Exploit::Remote
   # Checking if the target is vulnerable by executing the whoami command via the backdoor
   def check
     res = execute_command('whoami')
-    return Exploit::CheckCode::Safe unless res && (res.chomp == 'root' || res.chomp == 'optergy')
+    return Exploit::CheckCode::Safe('The target is not vulnerable') unless res && (res.chomp == 'root' || res.chomp == 'optergy')
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
 
-    return CheckCode::Unknown unless res.code == 200
+    return CheckCode::Unknown('Could not determine the target status') unless res.code == 200
 
     match = res.body.match(%r{jsLibs/Common(\d+_\d+_\d+)})
 
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe("Oracle EBS version #{version} detected.")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe("Oracle EBS version #{version} detected.")
     end
 
-    CheckCode::Safe("Version #{version} is not vulnerable")
+    CheckCode::Detected('Oracle EBS detected, but the version could not be determined from the response.')
   end
 
   def exploit

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless datastore['USERNAME'] && datastore['PASSWORD']
       unless datastore['RESET_ADMIN_PASSWD']
         print_bad('No USERNAME and PASSWORD set. If you are sure you want to reset the admin password, set RESET_ADMIN_PASSWD to true and run the module again.')
-        return CheckCode::Unknown
+        return CheckCode::Unknown('Could not determine the target status')
       end
 
       res = send_request_cgi(
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Failed to receive a reply from the server.') unless res
 
       if res.code == 403
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not vulnerable')
       end
 
       return CheckCode::Safe("Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.body.include?('Admin password restored to')
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       @xsrf_token_value = xsrf_token_value
     rescue XsrfException::Error
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     res = send_request_cgi(
@@ -155,16 +155,16 @@ class MetasploitModule < Msf::Exploit::Remote
     version = data.dig('msg', 'Expedition')
 
     if version.nil?
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     print_status('Version retrieved: ' + version)
 
     if Rex::Version.new(version) > Rex::Version.new('1.2.91')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
-    return CheckCode::Appears
+    return CheckCode::Appears("Version #{version} appears to be vulnerable")
   end
 
   def execute_command(cmd, check_res)

--- a/modules/exploits/linux/http/pandora_fms_exec.rb
+++ b/modules/exploits/linux/http/pandora_fms_exec.rb
@@ -93,10 +93,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200 && res.body.include?("Pandora FMS Remote Gateway")
       print_good("Pandora FMS Remote Gateway Detected!")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/pandora_fms_sqli.rb
+++ b/modules/exploits/linux/http/pandora_fms_sqli.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.body =~ /<div id="ver_num">v(.*?)<\/div>/
         version = $1
       else
-        return Exploit::CheckCode::Detected("Target detected: version #{version}")
+        return Exploit::CheckCode::Detected('Pandora FMS detected, but the version could not be determined')
       end
     end
 
@@ -97,6 +97,8 @@ class MetasploitModule < Msf::Exploit::Remote
         return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
       end
     end
+
+    return Exploit::CheckCode::Safe('Pandora FMS was not detected') if version.nil?
 
     Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end

--- a/modules/exploits/linux/http/pandora_fms_sqli.rb
+++ b/modules/exploits/linux/http/pandora_fms_sqli.rb
@@ -87,18 +87,18 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.body =~ /<div id="ver_num">v(.*?)<\/div>/
         version = $1
       else
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected("Target detected: version #{version}")
       end
     end
 
     unless version.nil?
       vprint_status("Pandora FMS #{version} found")
       if Rex::Version.new(version) <= Rex::Version.new('5.0SP2')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   # Attempt to login with credentials (default admin:pandora)

--- a/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
+++ b/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
@@ -60,11 +60,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.body =~ /Pandora/i
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     pandora_version = res.body.scan(%r{<div id="ver_num">v(.*?)</div>}).flatten.first
@@ -73,10 +73,10 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Pandora FMS version #{version}") if version
 
     if Rex::Version.new(version) <= Rex::Version.new('7.0NG')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    CheckCode::Detected
+    CheckCode::Detected("Target detected: version #{version}")
   end
 
   def authenticate

--- a/modules/exploits/linux/http/panos_management_unauth_rce.rb
+++ b/modules/exploits/linux/http/panos_management_unauth_rce.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # NOTE: We set dontfail to true, as a check routine cannot fail_with().
 
     # return Safe if we fail to trigger the vulnerability and execute a command.
-    return CheckCode::Safe unless execute_cmd(
+    return CheckCode::Safe('The target is not vulnerable') unless execute_cmd(
       "echo #{check_file_name} > /var/appweb/htdocs/unauth/#{check_file_name}",
       dontfail: true
     )
@@ -105,15 +105,15 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.code == 200 && res.body.include?(check_file_name)
 
       # return Unknown if we fail to trigger the vulnerability a second time.
-      return CheckCode::Unknown unless execute_cmd(
+      return CheckCode::Unknown('Could not determine the target status') unless execute_cmd(
         "rm -f /var/appweb/htdocs/unauth/#{check_file_name}",
         dontfail: true
       )
 
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   # We can only execute a short command upon each invocation of the command injection vulnerability. To execute

--- a/modules/exploits/linux/http/panos_op_cmd_exec.rb
+++ b/modules/exploits/linux/http/panos_op_cmd_exec.rb
@@ -111,10 +111,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if version >= Rex::Version.new('9.0.0') && version < Rex::Version.new('9.0.10') ||
        version >= Rex::Version.new('9.1.0') && version < Rex::Version.new('9.1.4') ||
        version >= Rex::Version.new('10.0.0') && version < Rex::Version.new('10.0.1')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def api_key

--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return
       end
 
-      if res.code = 200
+      if res.code == 200
         return CheckCode::Detected('The target service was detected')
       end
     elsif target.name =~ /Horde IMP H3/
@@ -246,7 +246,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return
       end
 
-      if res.code = 200
+      if res.code == 200
         cookie = res.get_cookies
       else
         print_error("HTTP code #{res.code} found, check options.")
@@ -280,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return
       end
 
-      if res.code = 302
+      if res.code == 302
         cookie = res.get_cookies
         print_good('Login Success')
       else

--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
       uri = normalize_uri(target_uri.path)
       res = send_request_cgi({ 'uri' => uri })
       if res && (res.code == 301 || res.code == 302)
-        return CheckCode::Detected
+        return CheckCode::Detected('The target service was detected')
       end
     elsif target.name =~ /suitecrm/
       # login page GET /index.php?action=Login&module=Users
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       if res.code = 200
-        return CheckCode::Detected
+        return CheckCode::Detected('The target service was detected')
       end
     elsif target.name =~ /Horde IMP H3/
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, 'imp', 'test.php') })
@@ -111,13 +111,13 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.code == 200 && res.body =~ /PHP Mail Server Support Test/ && phpversion != '.'
         if Rex::Version.new(phpversion) < Rex::Version.new('5.6.39')
           vprint_good("PHP Version #{phpversion} is vulnerable")
-          return CheckCode::Appears
+          return CheckCode::Appears("Version #{phpversion} appears to be vulnerable")
         else
           vprint_bad("PHP Version #{phpversion} is NOT vulnerable, patched in 5.6.39.")
         end
       end
     end
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def command(spaces = '$IFS$()')

--- a/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
+++ b/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
@@ -78,10 +78,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     if res and res.code == 200 and res.body =~ /window\.setTimeout\('loaded\(\)', 2500\);/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/pineapp_livelog_exec.rb
+++ b/modules/exploits/linux/http/pineapp_livelog_exec.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     if res and res.code == 200 and res.body =~ /NS Query result for 127\.0\.0\.1/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
+++ b/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
@@ -90,10 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # checking for the vulnerable component should be a reliable test.
     cookies = get_cookies
     if cookies.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -100,10 +100,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = cmd_inject("echo")
     if res && res.code == 200 && res.body =~ /Executing/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -241,15 +241,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET',
         'uri' => brute_uri
       )
-      return Exploit::CheckCode::Safe if !brutecheck || !brutecheck.code == 200 || brutecheck.body !~ /own this pineapple/
+      return Exploit::CheckCode::Safe('The target is not vulnerable') if !brutecheck || !brutecheck.code == 200 || brutecheck.body !~ /own this pineapple/
 
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
     cmd_success = cmd_inject("echo")
-    return Exploit::CheckCode::Vulnerable if cmd_success && cmdSuccess.code == 200 && cmd_success.body =~ /Executing/
+    return Exploit::CheckCode::Vulnerable('The target is vulnerable') if cmd_success && cmdSuccess.code == 200 && cmd_success.body =~ /Executing/
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -241,13 +241,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET',
         'uri' => brute_uri
       )
-      return Exploit::CheckCode::Safe('The target is not vulnerable') if !brutecheck || !brutecheck.code == 200 || brutecheck.body !~ /own this pineapple/
+      return Exploit::CheckCode::Safe('The target is not vulnerable') if !brutecheck || brutecheck.code != 200 || brutecheck.body !~ /own this pineapple/
 
       return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
     cmd_success = cmd_inject("echo")
-    return Exploit::CheckCode::Vulnerable('The target is vulnerable') if cmd_success && cmdSuccess.code == 200 && cmd_success.body =~ /Executing/
+    return Exploit::CheckCode::Vulnerable('The target is vulnerable') if cmd_success && cmd_success.code == 200 && cmd_success.body =~ /Executing/
 
     Exploit::CheckCode::Safe('The target is not vulnerable')
   end

--- a/modules/exploits/linux/http/pretalx_rce_cve_2023_28458.rb
+++ b/modules/exploits/linux/http/pretalx_rce_cve_2023_28458.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return Exploit::CheckCode::Unknown, 'Login failed, please check credentials' unless login(datastore['EMAIL'], datastore['PASSWORD'])
+    return Exploit::CheckCode::Unknown('Could not determine the target status'), 'Login failed, please check credentials' unless login(datastore['EMAIL'], datastore['PASSWORD'])
 
     @logged_in = true
 

--- a/modules/exploits/linux/http/pretalx_rce_cve_2023_28458.rb
+++ b/modules/exploits/linux/http/pretalx_rce_cve_2023_28458.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return Exploit::CheckCode::Unknown('Could not determine the target status'), 'Login failed, please check credentials' unless login(datastore['EMAIL'], datastore['PASSWORD'])
+    return CheckCode::Unknown('Login failed, please check credentials') unless login(datastore['EMAIL'], datastore['PASSWORD'])
 
     @logged_in = true
 

--- a/modules/exploits/linux/http/progress_kemp_loadmaster_unauth_cmd_injection.rb
+++ b/modules/exploits/linux/http/progress_kemp_loadmaster_unauth_cmd_injection.rb
@@ -119,14 +119,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # No response from server
     unless res
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     # Check for specific error pattern in headers or body to confirm vulnerability
     if res.headers.to_s.include?('unexpected EOF while looking for matching') || res.body.include?('unexpected EOF while looking for matching')
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     else
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/projectsend_unauth_rce.rb
+++ b/modules/exploits/linux/http/projectsend_unauth_rce.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     updated_title = res.body[title_regex, 1]
 
     if updated_title != random_new_title
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     # If the title was changed, it is vulnerable and we should restore the original title
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => params
     })
 
-    return CheckCode::Appears
+    return CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def get_csrf_token

--- a/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
+++ b/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
@@ -89,15 +89,15 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve the version information') unless version
     version, build = version
 
-    return CheckCode::Unknown unless version.include?('R')
+    return CheckCode::Unknown('Could not determine the target status') unless version.include?('R')
 
     version, revision = version.split('R', 2)
     print_status("Version #{version.strip}, revision #{revision.strip}, build #{build.strip} found")
-    return CheckCode::Appears if version.to_f <= 9.1 && revision.to_f < 9
+    return CheckCode::Appears("Version #{version} appears to be vulnerable") if version.to_f <= 9.1 && revision.to_f < 9
 
-    CheckCode::Detected
+    CheckCode::Detected("Target detected: version #{version}")
   rescue Msf::Exploit::Failed
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   ensure
     logout unless exploiting
   end

--- a/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
+++ b/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version = res.body.scan(/\.js\?_v=([\d\.]+)/).flatten.first
     if version.to_s.eql? ''
       vprint_error "Could not determine QNAP Q'Center appliance version"
-      return CheckCode::Detected("Target detected: version #{version}")
+      return CheckCode::Detected("QNAP Q'Center detected, but the version could not be determined")
     end
 
     version = Rex::Version.new version

--- a/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
+++ b/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
@@ -72,28 +72,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.code == 200 && res.body.include?("<title>Q'center</title>")
       vprint_error "Target is not a QNAP Q'Center appliance"
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     version = res.body.scan(/\.js\?_v=([\d\.]+)/).flatten.first
     if version.to_s.eql? ''
       vprint_error "Could not determine QNAP Q'Center appliance version"
-      return CheckCode::Detected
+      return CheckCode::Detected("Target detected: version #{version}")
     end
 
     version = Rex::Version.new version
     vprint_status "Target is QNAP Q'Center appliance version #{version}"
 
     if version >= Rex::Version.new('1.7.1083')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("Version #{version} appears to be vulnerable")
   end
 
   def login(user, pass)

--- a/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
+++ b/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # </Errmsg>
     # </Storage>
 
-    return Exploit::CheckCode::Detected("Target detected: version #{version}") if res.body.include? '<Result>failure</Result>'
+    return Exploit::CheckCode::Detected('QNAP QTS target detected') if res.body.include? '<Result>failure</Result>'
 
     CheckCode::Unknown('Could not determine the target status')
   end

--- a/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
+++ b/modules/exploits/linux/http/qnap_qts_rce_cve_2023_47218.rb
@@ -85,9 +85,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # </Errmsg>
     # </Storage>
 
-    return Exploit::CheckCode::Detected if res.body.include? '<Result>failure</Result>'
+    return Exploit::CheckCode::Detected("Target detected: version #{version}") if res.body.include? '<Result>failure</Result>'
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -84,9 +84,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     new_md5 = Rex::Text.md5(res.body)
 
-    return Exploit::CheckCode::Appears if new_md5 == md5
+    return Exploit::CheckCode::Appears('The target appears to be vulnerable') if new_md5 == md5
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/rancher_server.rb
+++ b/modules/exploits/linux/http/rancher_server.rb
@@ -126,12 +126,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       print_error('Failed to connect to the target')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.code == 401 && res.headers.to_json.include?('X-Rancher-Version')
       print_error('Authorization is required. Provide valid Rancher API Keys.')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
     if res.code == 200 && res.headers.to_json.include?('X-Rancher-Version')
@@ -164,21 +164,21 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       if target_found
-        return Exploit::CheckCode::Vulnerable if target_selected
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable') if target_selected
 
         print_bad("Your TARGETENV \"#{datastore['TARGETENV']}\" or/and TARGETHOST \"#{datastore['TARGETHOST']}\" is not available")
         if datastore['VERBOSE'] == false
           print_bad('Try verbose mode to know what happened.')
         end
         vprint_bad('Choose a TARGETHOST and TARGETENV from the results above')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be vulnerable')
       else
         print_bad('No TARGETHOST available')
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/ray_agent_job_rce.rb
+++ b/modules/exploits/linux/http/ray_agent_job_rce.rb
@@ -90,18 +90,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api/version')
     })
-    return Exploit::CheckCode::Unknown unless res && res.code == 200
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless res && res.code == 200
 
     ray_version = res.get_json_document['ray_version']
 
-    return Exploit::CheckCode::Unknown unless ray_version
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless ray_version
 
-    return Exploit::CheckCode::Safe unless Rex::Version.new(ray_version) <= Rex::Version.new('2.6.3')
+    return Exploit::CheckCode::Safe("Version #{ray_version} is not vulnerable") unless Rex::Version.new(ray_version) <= Rex::Version.new('2.6.3')
 
     @job_data = get_job_data('ls')
-    return Exploit::CheckCode::Vulnerable unless @job_data.nil?
+    return Exploit::CheckCode::Vulnerable("Exploitable: version #{ray_version} is vulnerable") unless @job_data.nil?
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears("Version #{ray_version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/ray_cpu_profile_cmd_injection_cve_2023_6019.rb
+++ b/modules/exploits/linux/http/ray_cpu_profile_cmd_injection_cve_2023_6019.rb
@@ -78,19 +78,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api/version')
     })
-    return Exploit::CheckCode::Unknown unless res && res.code == 200
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless res && res.code == 200
 
     ray_version = res.get_json_document['ray_version']
 
-    return Exploit::CheckCode::Unknown unless ray_version
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless ray_version
 
     ray_version = Rex::Version.new(ray_version)
-    return Exploit::CheckCode::Safe unless Rex::Version.new('2.2.0') <= ray_version && ray_version <= Rex::Version.new('2.6.3')
+    return Exploit::CheckCode::Safe("Version #{ray_version} is not vulnerable") unless Rex::Version.new('2.2.0') <= ray_version && ray_version <= Rex::Version.new('2.6.3')
 
     @nodes = get_nodes
-    return Exploit::CheckCode::Vulnerable unless @nodes.nil?
+    return Exploit::CheckCode::Vulnerable("Exploitable: version #{ray_version} is vulnerable") unless @nodes.nil?
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears("Version #{ray_version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     if res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig Version 3.9'
       print_good('rConfig version 3.9 detected')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     elsif res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig'
       print_status('rConfig detected, but not version 3.9')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
   end
 

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -75,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/login.php'
     )
     if !res || !res.get_html_document
-      fail_with(Failure::Unknown, 'Could not check rConfig version')
+      return Exploit::CheckCode::Unknown('Could not check rConfig version')
     end
     if res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig Version 3.9'
       print_good('rConfig version 3.9 detected')
@@ -84,6 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('rConfig detected, but not version 3.9')
       return Exploit::CheckCode::Detected('The target service was detected')
     end
+
+    Exploit::CheckCode::Safe('rConfig was not detected')
   end
 
   # CREATE AN ADMIN USER IN RCONFIG
@@ -193,7 +196,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    check
     @username = rand_text_alphanumeric(8..12)
     @password = 'admin'
     _cres_res = create_rconfig_user @username, @password

--- a/modules/exploits/linux/http/realtek_miniigd_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/realtek_miniigd_upnp_exec_noauth.rb
@@ -77,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/picsdesc.xml'
       })
       if res && [200, 301, 302].include?(res.code) && res.headers['Server'] =~ /miniupnpd\/1.0 UPnP\/1.0/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/riverbed_netprofiler_netexpress_exec.rb
+++ b/modules/exploits/linux/http/riverbed_netprofiler_netexpress_exec.rb
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.body && res.body.include?('AUTH_DISABLED_ACCOUNT')
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/samsung_srv_1670d_upload_exec.rb
+++ b/modules/exploits/linux/http/samsung_srv_1670d_upload_exec.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless resp
       vprint_error('Connection timed out.')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     # File Version 1.0.0.193
@@ -78,12 +78,12 @@ class MetasploitModule < Msf::Exploit::Remote
         version = $1
         if version == '1.0.0.193'
           vprint_good "Found vesrion: #{version}"
-          return CheckCode::Appears
+          return CheckCode::Appears("Version #{version} appears to be vulnerable")
         end
       end
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/samsung_srv_1670d_upload_exec.rb
+++ b/modules/exploits/linux/http/samsung_srv_1670d_upload_exec.rb
@@ -77,13 +77,17 @@ class MetasploitModule < Msf::Exploit::Remote
       if resp.body =~ /File Version (\d+\.\d+\.\d+\.\d+)/
         version = $1
         if version == '1.0.0.193'
-          vprint_good "Found vesrion: #{version}"
+          vprint_good "Found version: #{version}"
           return CheckCode::Appears("Version #{version} appears to be vulnerable")
         end
+
+        return CheckCode::Safe("Version #{version} is not vulnerable")
       end
+
+      return CheckCode::Unknown('Could not determine the target version')
     end
 
-    CheckCode::Safe("Version #{version} is not vulnerable")
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/seagate_nas_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/seagate_nas_php_exec_noauth.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
         if headers.include?('X-Powered-By: PHP/5.2.13') && headers.include?('Server: lighttpd/1.4.28')
           # and make sure that the body contains the title we'd expect
           if res.body.include?('Login to BlackArmor')
-            return Exploit::CheckCode::Appears
+            return Exploit::CheckCode::Appears('The target appears to be vulnerable')
           end
         end
       end
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # something went wrong, assume safe.
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   #

--- a/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
+++ b/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
@@ -82,16 +82,16 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_close_window_request(safe_check)
 
     unless res and res.code == 200 and res.body.to_s =~ /Can't find action/
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     res = send_close_window_request(trigger_check)
 
     unless res and res.code == 500
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def target_smt_x9_214

--- a/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
+++ b/modules/exploits/linux/http/sonicwall_cve_2021_20039.rb
@@ -96,20 +96,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case major
     when '9'
-      return CheckCode::Safe unless minor.to_i == 0 && revision.to_i == 0 && build.to_i <= 11 && point.to_i <= 31
+      return CheckCode::Safe("Version #{version} is not vulnerable") unless minor.to_i == 0 && revision.to_i == 0 && build.to_i <= 11 && point.to_i <= 31
     when '10'
-      return CheckCode::Safe unless minor.to_i == 2
+      return CheckCode::Safe("Version #{version} is not vulnerable") unless minor.to_i == 2
 
       case revision
       when '0'
-        return CheckCode::Safe unless build.to_i <= 8 && point.to_i <= 37
+        return CheckCode::Safe("Version #{version} is not vulnerable") unless build.to_i <= 8 && point.to_i <= 37
       when '1'
-        return CheckCode::Safe unless build.to_i <= 2 && point.to_i <= 24
+        return CheckCode::Safe("Version #{version} is not vulnerable") unless build.to_i <= 2 && point.to_i <= 24
       else
-        return CheckCode::Safe
+        return CheckCode::Safe("Version #{version} is not vulnerable")
       end
     else
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
     CheckCode::Appears('Based on the discovered version.')
   end

--- a/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
+++ b/modules/exploits/linux/http/sophos_utm_webadmin_sid_cmd_injection.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       inject_cmd("sleep #{sleep_time}", timeout: sleep_time * 1.5)
     end
 
-    return CheckCode::Unknown if injected.nil?
+    return CheckCode::Unknown('Could not determine the target status') if injected.nil?
 
     vprint_status("Elapsed time: #{elapsed_time} seconds")
 

--- a/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_exploit_query(url, domain)
 
     if res and res.code == 302 and res.headers.include?('Location') and res.headers['Location'] =~ /#{url}/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
+++ b/modules/exploits/linux/http/sourcegraph_gitserver_sshcmd.rb
@@ -74,20 +74,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_exec(Rex::Text.rand_text_alphanumeric(4..11), ['config', '--default', '', 'core.sshCommand'])
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('Could not determine the target status') unless res
 
     if res.code == 200 && res.body =~ /^X-Exec-Exit-Status: 0/
       # this is the response if the target repo does exist, highly unlikely since it's randomized
       return CheckCode::Vulnerable('Successfully set core.sshCommand.')
     elsif res.code == 404 && res.body =~ /"cloneInProgress"/
       # this is the response if the target repo does not exist
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     elsif res.code == 400 && res.body =~ /^invalid command/
       # this is the response when the server is patched, regardless of if there are cloned repos
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/linux/http/spark_unauth_rce.rb
+++ b/modules/exploits/linux/http/spark_unauth_rce.rb
@@ -53,9 +53,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Detected if get_version
+    return CheckCode::Detected('The target service was detected') if get_version
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   end
 
   def primer

--- a/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
+++ b/modules/exploits/linux/http/spring_cloud_gateway_rce.rb
@@ -135,9 +135,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = execute_command('whoami')
 
     if res
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     authenticate unless @authenticated
-    return Exploit::CheckCode::Unknown unless @authenticated
+    return Exploit::CheckCode::Unknown('Could not determine the target status') unless @authenticated
 
     version_check_request = send_request_cgi(
       {

--- a/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
+++ b/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       elsif res.code == 401
         print_bad("Authentication failed: #{res.code} response")
-        return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
+        return Exploit::CheckCode::Detected('Authentication required (HTTP 401)')
       else
         print_bad("Unexpected HTTP code: #{res.code} response")
         return Exploit::CheckCode::Unknown('Could not determine the target status')

--- a/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
+++ b/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
@@ -94,25 +94,25 @@ class MetasploitModule < Msf::Exploit::Remote
           version = Rex::Version.new(match[1])
           if check_version(version)
             print_good("Vulnerable version found: #{version}")
-            return Exploit::CheckCode::Appears
+            return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
           else
             print_bad("Version #{version} is not vulnerable")
-            return Exploit::CheckCode::Safe
+            return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
           end
         else
           print_bad('Could not extract version number from web interface')
-          return Exploit::CheckCode::Unknown
+          return Exploit::CheckCode::Unknown('Could not determine the target status')
         end
       elsif res.code == 401
         print_bad("Authentication failed: #{res.code} response")
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
       else
         print_bad("Unexpected HTTP code: #{res.code} response")
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine the target status')
       end
     else
       print_bad('Error connecting to web interface')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
   end
 

--- a/modules/exploits/linux/http/symantec_web_gateway_exec.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_exec.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /\<title\>Symantec Web Gateway\<\/title\>/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /\<title\>Symantec Web Gateway\<\/title\>/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /\<title\>Symantec Web Gateway\<\/title\>/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/symantec_web_gateway_pbcontrol.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_pbcontrol.rb
@@ -71,11 +71,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res1 and res2
       if res1.body =~ /\<title\>Symantec Web Gateway\<\/title\>/ and res2.body =~ /^0$/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target service was detected')
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({ 'uri' => normalize_uri(uri, 'spywall/login.php') })
 
     if res && res.body.include?('Symantec Web Gateway')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_sid

--- a/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
+++ b/modules/exploits/linux/http/symmetricom_syncserver_rce.rb
@@ -85,9 +85,9 @@ class MetasploitModule < Msf::Exploit
           }
     })
     if res && res.body.to_s =~ /uid=0/
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/synology_dsm_sliceupload_exec_noauth.rb
+++ b/modules/exploits/linux/http/synology_dsm_sliceupload_exec_noauth.rb
@@ -84,24 +84,24 @@ class MetasploitModule < Msf::Exploit::Remote
       model = "DS#{model}" unless model =~ /^[A-Z]/
     else
       vprint_error("Detection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     vprint_status("Model #{model} with version #{version}-#{build} detected")
 
     case version
     when '4.0'
-      return Exploit::CheckCode::Appears if build < '2259'
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable") if build < '2259'
     when '4.1'
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
     when '4.2'
-      return Exploit::CheckCode::Appears if build < '3243'
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable") if build < '3243'
     when '4.3'
-      return Exploit::CheckCode::Appears if build < '3810'
-      return Exploit::CheckCode::Detected if build == '3810'
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable") if build < '3810'
+      return Exploit::CheckCode::Detected("Target detected: version #{version}") if build == '3810'
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -90,19 +90,19 @@ class MetasploitModule < Msf::Exploit::Remote
       model = "DS#{model}" unless model =~ /^[A-Z]/
     else
       vprint_error('Detection failed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     vprint_status("Model #{model} with version #{version}-#{build} detected")
 
     case version
     when '3.0', '4.0', '4.1', '4.2', '4.3', '5.0', '5.1'
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     when '5.2'
-      return CheckCode::Appears if build < '5967-5'
+      return CheckCode::Appears("Version #{version} appears to be vulnerable") if build < '5967-5'
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def on_request_uri(cli, _request, cookie, token)

--- a/modules/exploits/linux/http/terramaster_unauth_rce_cve_2020_35665.rb
+++ b/modules/exploits/linux/http/terramaster_unauth_rce_cve_2020_35665.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     get_terramaster_info
-    return CheckCode::Safe if @terramaster.empty?
+    return CheckCode::Safe('The target is not vulnerable') if @terramaster.empty?
 
     if Rex::Version.new(@terramaster['tos_version']) <= Rex::Version.new('4.2.06')
       return CheckCode::Vulnerable("TOS version is #{@terramaster['tos_version']} and CPU architecture is #{@terramaster['cpu_arch']}.")

--- a/modules/exploits/linux/http/terramaster_unauth_rce_cve_2021_45837.rb
+++ b/modules/exploits/linux/http/terramaster_unauth_rce_cve_2021_45837.rb
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     get_terramaster_info
-    return CheckCode::Safe if @terramaster.empty?
+    return CheckCode::Safe('The target is not vulnerable') if @terramaster.empty?
 
     if Rex::Version.new(@terramaster['tos_version']) <= Rex::Version.new('4.2.15')
       return CheckCode::Vulnerable("TOS version is #{@terramaster['tos_version']} and CPU architecture is #{@terramaster['cpu_arch']}.")

--- a/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
+++ b/modules/exploits/linux/http/terramaster_unauth_rce_cve_2022_24990.rb
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     get_terramaster_info
-    return CheckCode::Safe if @terramaster.empty?
+    return CheckCode::Safe('The target is not vulnerable') if @terramaster.empty?
 
     if Rex::Version.new(@terramaster['tos_version']) <= Rex::Version.new('4.2.29')
       return CheckCode::Vulnerable("TOS version is #{@terramaster['tos_version']} and CPU architecture is #{@terramaster['cpu_arch']}.")

--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -134,9 +134,9 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.body =~ /You do not have permission to view the calendar/i
         fail_with(Failure::NoAccess, "#{peer} - Additional Permissions Required")
       elsif res.body =~ />#{flag}</
-        Exploit::CheckCode::Vulnerable
+        Exploit::CheckCode::Vulnerable('The target is vulnerable')
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     end
   end

--- a/modules/exploits/linux/http/tr064_ntpserver_cmdinject.rb
+++ b/modules/exploits/linux/http/tr064_ntpserver_cmdinject.rb
@@ -120,14 +120,14 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue ::Rex::ConnectionError
       vprint_error("#{peer} - A connection error has occurred")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res and res.code == 404 and res.body =~ /home_wan\.htm/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def inject_staged_data

--- a/modules/exploits/linux/http/traccar_rce_upload.rb
+++ b/modules/exploits/linux/http/traccar_rce_upload.rb
@@ -72,21 +72,21 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'api/server')
     })
 
-    return CheckCode::Unknown unless res && res.code == 200
+    return CheckCode::Unknown('Could not determine the target status') unless res && res.code == 200
 
     data = res.get_json_document
     version = data['version']
     if version.nil?
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     else
       vprint_status('Version retrieved: ' + version)
     end
 
     unless Rex::Version.new(version).between?(Rex::Version.new('5.1'), Rex::Version.new('5.12'))
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
-    return CheckCode::Appears
+    return CheckCode::Appears("Version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_imsva_widget_exec.rb
@@ -95,14 +95,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # If we've managed to bypass authentication, that means target is most likely vulnerable.
     jsessionid = extract_jsessionid
     if jsessionid.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     auth = widget_auth(jsessionid)
     if auth.nil?
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     else
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/trendmicro_sps_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_sps_exec.rb
@@ -81,13 +81,13 @@ class MetasploitModule < Msf::Exploit::Remote
         if (version == 3.0 and build < 1330) or
            (version == 2.6 and build < 2106) or
            (version == 2.5 and build < 2200)
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable("Exploitable: version #{version} is vulnerable")
         else
-          return Exploit::CheckCode::Safe
+          return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
         end
       end
     end
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/linux/http/trendmicro_websecurity_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_websecurity_exec.rb
@@ -182,9 +182,9 @@ class MetasploitModule < Msf::Exploit::Remote
     hijack_cookie
 
     if @jsessionid == -1
-      CheckCode::Safe
+      CheckCode::Safe('The target is not vulnerable')
     else
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('The target is vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/trueonline_p660hn_v1_rce.rb
+++ b/modules/exploits/linux/http/trueonline_p660hn_v1_rce.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     })
     if res && res.body =~ /ZyXEL P-660HN-T1A/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
   end
 

--- a/modules/exploits/linux/http/trueonline_p660hn_v2_rce.rb
+++ b/modules/exploits/linux/http/trueonline_p660hn_v2_rce.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     })
     if res && res.body =~ /P-660HN-T1A_IPv6/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
   end
 

--- a/modules/exploits/linux/http/ueb_api_rce.rb
+++ b/modules/exploits/linux/http/ueb_api_rce.rb
@@ -82,11 +82,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     if res && res.code == 200
       print_good("Good news, looks like a vulnerable version of UEB.")
-      return CheckCode::Appears
+      return CheckCode::Appears('The target appears to be vulnerable')
     else
       print_bad('Host does not appear to be vulnerable.')
     end
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   # substitue some charactes

--- a/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
+++ b/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("Unraid version #{version} appears to be vulnerable")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/vap2500_tools_command_exec.rb
+++ b/modules/exploits/linux/http/vap2500_tools_command_exec.rb
@@ -64,13 +64,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'cookie' => "p=#{Rex::Text.md5('super')}"
       })
       if res && res.code == 200 && res.body.to_s =~ /TOOLS - COMMAND/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable')
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/vcms_upload.rb
+++ b/modules/exploits/linux/http/vcms_upload.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /V-CMS v1\.[0-1]/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
+++ b/modules/exploits/linux/http/vinchin_backup_recovery_cmd_inject.rb
@@ -101,9 +101,9 @@ class MetasploitModule < Msf::Exploit::Remote
        (version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')) ||
        (version >= Rex::Version.new('6.7.0') && version < Rex::Version.new('6.8.0')) ||
        (version >= Rex::Version.new('7.0.0') && version < Rex::Version.new('7.0.2'))
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears to be vulnerable")
     else
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 end

--- a/modules/exploits/linux/http/vmware_vcenter_analytics_file_upload.rb
+++ b/modules/exploits/linux/http/vmware_vcenter_analytics_file_upload.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('Could not determine the target status') unless res
 
     unless res.code == 200 && res.body == '"FULL"'
       return CheckCode::Safe('CEIP is not fully enabled.')

--- a/modules/exploits/linux/http/vmware_vcenter_vsan_health_rce.rb
+++ b/modules/exploits/linux/http/vmware_vcenter_vsan_health_rce.rb
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }.to_json
     )
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('Could not determine the target status') unless res
 
     unless res.code == 200 && res.get_json_document['result'] == 'vsphere-ui'
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     CheckCode::Vulnerable('System property user.name is vsphere-ui.')

--- a/modules/exploits/linux/http/vmware_vrli_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrli_rce.rb
@@ -104,14 +104,14 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response (response code: #{res.code})") unless res.code == 200
     translation = JSON.parse(res.body.gsub(/^.+= /, '').gsub(/;/, ''))
-    return Exploit::CheckCode::Unknown if translation.nil? || !translation.key?('version')
+    return Exploit::CheckCode::Unknown('Could not determine the target status') if translation.nil? || !translation.key?('version')
 
     version = Rex::Version.new(translation['version'])
     if version <= Rex::Version.new('8.10') && version >= Rex::Version.new('8.0') # This is not exactly the product version but we can use it
       return Exploit::CheckCode::Appears("VMware XRLI Version: #{translation['version']}")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def generate_malicious_tar

--- a/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    leak_admin_creds ? CheckCode::Vulnerable : CheckCode::Safe
+    leak_admin_creds ? CheckCode::Vulnerable('The target is vulnerable') : CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
+++ b/modules/exploits/linux/http/vmware_workspace_one_access_cve_2022_22954.rb
@@ -88,10 +88,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     ret = execute_command("echo #{token = rand_text_alphanumeric(8..16)}")
 
-    return CheckCode::Unknown unless ret
-    return CheckCode::Safe unless ret.match?(/device (?:id|type): #{token}/)
+    return CheckCode::Unknown('Could not determine the target status') unless ret
+    return CheckCode::Safe('The target is not vulnerable') unless ret.match?(/device (?:id|type): #{token}/)
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -80,13 +80,13 @@ class MetasploitModule < Msf::Exploit::Remote
       }, 25)
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res and res.code == 200 and res.body =~ /#{fingerprint}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
+++ b/modules/exploits/linux/http/watchguard_firebox_unauth_rce_cve_2022_26318.rb
@@ -125,9 +125,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     print_status("Checking if #{peer} can be exploited.")
-    return CheckCode::Detected if check_watchguard_firebox?
+    return CheckCode::Detected('The target service was detected') if check_watchguard_firebox?
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/wd_mycloud_multiupload_upload.rb
+++ b/modules/exploits/linux/http/wd_mycloud_multiupload_upload.rb
@@ -55,14 +55,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error('Connection failed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.code == 302 && res.headers['Location'] =~ /\?status=1/
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def upload(web_folder, fname, file)

--- a/modules/exploits/linux/http/webcalendar_settings_exec.rb
+++ b/modules/exploits/linux/http/webcalendar_settings_exec.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /WebCalendar v1\.2\.\d/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /1\.0\.2 \- 17\/01\/11/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
     res = send_request_cgi({
@@ -88,10 +88,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /WeBId.*CURRENCY CONVERTER/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def on_new_session(client)

--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -95,12 +95,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Server did not respond')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.body.include?('This web server is running in SSL mode.')
       print_error('Please enable the SSL option to proceed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     version =
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless version
       vprint_error('Webmin version not detected')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     version = Rex::Version.new(version)
@@ -117,11 +117,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless version.between?(*target['Version'])
       vprint_error("Webmin #{version} is not a supported target")
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     vprint_good("Webmin #{version} is a supported target")
-    checkcode = CheckCode::Appears
+    checkcode = CheckCode::Appears("Version #{version} appears to be vulnerable")
 
     res = execute_command("echo #{token}")
 
@@ -132,15 +132,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.body.include?('Password changing is not enabled!')
       vprint_error('Expired password changing disabled')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     if res.body.include?(token)
       vprint_good('Webmin executed a benign check command')
-      checkcode = CheckCode::Vulnerable
+      checkcode = CheckCode::Vulnerable("Exploitable: version #{version} is vulnerable")
     else
       vprint_error('Webmin did not execute our check command')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     checkcode

--- a/modules/exploits/linux/http/webmin_package_updates_rce.rb
+++ b/modules/exploits/linux/http/webmin_package_updates_rce.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_good("Webmin #{version} is a supported target")
 
-    CheckCode::Appears
+    CheckCode::Appears("Version #{version} appears to be vulnerable")
   rescue ::Rex::ConnectionError
     return CheckCode::Unknown("#{peer} - Could not connect to web service")
   end

--- a/modules/exploits/linux/http/webmin_packageup_rce.rb
+++ b/modules/exploits/linux/http/webmin_packageup_rce.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 302 && res.body
       version = res.body.split("- Webmin 1.")[1]
-      return CheckCode::Detected("Target detected: version #{version}") if version.nil?
+      return CheckCode::Detected('Webmin detected but version could not be determined') if version.nil?
 
       version = version.split(" ")[0]
       if version <= "910"

--- a/modules/exploits/linux/http/webmin_packageup_rce.rb
+++ b/modules/exploits/linux/http/webmin_packageup_rce.rb
@@ -86,8 +86,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     cookie = login
-    return CheckCode::Detected if cookie == ''
-    return CheckCode::Unknown if cookie.nil?
+    return CheckCode::Detected('The target service was detected') if cookie == ''
+    return CheckCode::Unknown('Could not determine the target status') if cookie.nil?
 
     vprint_status('Attempting to execute...')
     # check version
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 302 && res.body
       version = res.body.split("- Webmin 1.")[1]
-      return CheckCode::Detected if version.nil?
+      return CheckCode::Detected("Target detected: version #{version}") if version.nil?
 
       version = version.split(" ")[0]
       if version <= "910"
@@ -112,13 +112,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
         if res && res.code == 200 && res.body =~ /Software Package Update/
           print_status("NICE! #{datastore['USERNAME']} has the right to >>Package Update<<")
-          return CheckCode::Vulnerable
+          return CheckCode::Vulnerable("Exploitable: version #{version} is vulnerable")
         end
       end
     end
     print_error("#{datastore['USERNAME']} doesn't have the right to >>Package Update<<")
     print_status("Please try with another user account!")
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/wepresent_cmd_injection.rb
+++ b/modules/exploits/linux/http/wepresent_cmd_injection.rb
@@ -97,11 +97,11 @@ class MetasploitModule < Msf::Exploit::Remote
     if check_resp.code == 200
       check_resp.body.gsub!(/[\r\n]/, '')
       if check_resp.body == 'root'
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable('The target is vulnerable')
       end
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/linux/http/wipg1000_cmd_injection.rb
+++ b/modules/exploits/linux/http/wipg1000_cmd_injection.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/cgi-bin/rdfs.cgi'
     })
     if res && res.body.include?("Follow administrator instructions to enter the complete path")
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('The target appears to be vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/http/xplico_exec.rb
+++ b/modules/exploits/linux/http/xplico_exec.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'users', 'register')
     )
     if res && res.code == 302
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     else
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Unknown('Could not determine the target status')
     end
   end
 

--- a/modules/exploits/linux/http/zabbix_sqli.rb
+++ b/modules/exploits/linux/http/zabbix_sqli.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    if version and version <= "2.0.8"
+    if version and Rex::Version.new(version) <= Rex::Version.new("2.0.8")
       return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
     else
       return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")

--- a/modules/exploits/linux/http/zabbix_sqli.rb
+++ b/modules/exploits/linux/http/zabbix_sqli.rb
@@ -80,13 +80,13 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       # If this fails, guest access may not be enabled
       vprint_status("Unable to access httpmon.php")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if version and version <= "2.0.8"
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -77,15 +77,15 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res and res.code == 200 and res.body =~ /#version ZEN\s+\$version=\"(2|3\.0\-rc1)/
-        return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
+        return Exploit::CheckCode::Appears("Version #{$1} appears to be vulnerable")
       elsif res and res.code == 200 and res.body =~ /zenloadbalancer/
-        return Exploit::CheckCode::Detected("Target detected: version #{version}")
+        return Exploit::CheckCode::Detected('Zen Load Balancer detected')
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
       return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
-    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -77,15 +77,15 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res and res.code == 200 and res.body =~ /#version ZEN\s+\$version=\"(2|3\.0\-rc1)/
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Version #{version} appears to be vulnerable")
       elsif res and res.code == 200 and res.body =~ /zenloadbalancer/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected("Target detected: version #{version}")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -75,11 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected('The target service was detected') if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
 
       return Exploit::CheckCode::Safe('The target is not vulnerable')
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeoutp
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
       return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
-    return Exploit::CheckCode::Save('Target status check completed')
   end
 
   def exploit

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -71,15 +71,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => "GET",
         'uri' => "/zport/acl_users/cookieAuthHelper/login_form"
       })
-      return Exploit::CheckCode::Appears if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\./
-      return Exploit::CheckCode::Detected if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable') if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\./
+      return Exploit::CheckCode::Detected('The target service was detected') if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
 
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeoutp
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
-    return Exploit::CheckCode::Save
+    return Exploit::CheckCode::Save('Target status check completed')
   end
 
   def exploit

--- a/modules/exploits/linux/http/zimbra_xxe_rce.rb
+++ b/modules/exploits/linux/http/zimbra_xxe_rce.rb
@@ -188,14 +188,14 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       res = xxe_req(soap_discover(true))
     rescue Msf::Exploit::Failed
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.body.include?('zimbra')
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   end
 
   def on_request_uri(cli, req)

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -415,7 +415,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
 
     res = get_configuration
-    return CheckCode::Safe if res.nil? || res.code != 200
+    return CheckCode::Safe('The target is not vulnerable') if res.nil? || res.code != 200
 
     begin
       process_configuration(res)
@@ -427,7 +427,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Unknown(e.message)
       end
     end
-    return CheckCode::Vulnerable
+    return CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -415,7 +415,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
 
     res = get_configuration
-    return CheckCode::Safe('The target is not vulnerable') if res.nil? || res.code != 200
+    return CheckCode::Unknown('Could not retrieve the target configuration') if res.nil? || res.code != 200
 
     begin
       process_configuration(res)


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical