### PR TITLE
Add human-readable descriptions to CheckCode returns modules

### DIFF
--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -98,31 +98,31 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if immutable?('/etc/passwd')
       vprint_error 'File /etc/passwd is immutable'
-      return CheckCode::Safe
+      return CheckCode::Safe("'/etc/passwd' is immutable")
     end
 
     kernel_core_pattern = cmd_exec 'grep abrt-hook-ccpp /proc/sys/kernel/core_pattern'
     unless kernel_core_pattern.include? 'abrt-hook-ccpp'
       vprint_error 'System is NOT configured to use ABRT for crash reporting'
-      return CheckCode::Safe
+      return CheckCode::Safe('System is not configured to use ABRT for crash reporting')
     end
     vprint_good 'System is configured to use ABRT for crash reporting'
 
     if cmd_exec('[ -d /var/spool/abrt ] && echo true').include? 'true'
       vprint_error "Directory '/var/spool/abrt' exists. System has been patched."
-      return CheckCode::Safe
+      return CheckCode::Safe('System appears to have been patched')
     end
     vprint_good 'System does not appear to have been patched'
 
     unless cmd_exec('[ -d /var/tmp/abrt ] && echo true').include? 'true'
       vprint_error "Directory '/var/tmp/abrt' does NOT exist"
-      return CheckCode::Safe
+      return CheckCode::Safe("Directory '/var/tmp/abrt' does not exist")
     end
     vprint_good "Directory '/var/tmp/abrt' exists"
 
     if cmd_exec('systemctl status abrt-ccpp | grep Active').include? 'inactive'
       vprint_error 'abrt-ccp service NOT running'
-      return CheckCode::Safe
+      return CheckCode::Safe('abrt-ccpp service is not running')
     end
     vprint_good 'abrt-ccpp service is running'
 
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status "System is using ABRT package version #{abrt_version}"
     end
 
-    CheckCode::Detected
+    CheckCode::Detected("ABRT is installed and running")
   end
 
   def upload_and_chmodx(path, data)

--- a/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
@@ -92,13 +92,13 @@ class MetasploitModule < Msf::Exploit::Local
     kernel_core_pattern = cmd_exec 'grep abrt-hook-ccpp /proc/sys/kernel/core_pattern'
     unless kernel_core_pattern.include? 'abrt-hook-ccpp'
       vprint_error 'System is not configured to use ABRT for crash reporting'
-      return CheckCode::Safe
+      return CheckCode::Safe('System is not configured to use ABRT for crash reporting')
     end
     vprint_good 'System is configured to use ABRT for crash reporting'
 
     if cmd_exec('systemctl status abrt-ccpp | grep Active').include? 'inactive'
       vprint_error 'abrt-ccp service not running'
-      return CheckCode::Safe
+      return CheckCode::Safe('abrt-ccpp service is not running')
     end
     vprint_good 'abrt-ccpp service is running'
 
@@ -107,21 +107,21 @@ class MetasploitModule < Msf::Exploit::Local
     abrt_version = pkg_info[/^abrt.*$/].to_s.split(/\s+/)[1]
     if abrt_version.blank?
       vprint_status 'Could not retrieve ABRT package version'
-      return CheckCode::Safe
+      return CheckCode::Safe('Could not retrieve ABRT package version')
     end
     unless Rex::Version.new(abrt_version) < Rex::Version.new('2.1.11-35.el7')
       vprint_status "ABRT package version #{abrt_version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("ABRT package version #{abrt_version} is not vulnerable")
     end
     vprint_good "ABRT package version #{abrt_version} is vulnerable"
 
     unless command_exists? 'python'
       vprint_error 'python is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('Python is not installed')
     end
     vprint_good 'python is installed'
 
-    CheckCode::Appears
+    CheckCode::Appears("ABRT package version #{abrt_version} appears vulnerable")
   end
 
   def upload_and_chmodx(path, data)

--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good 'Unprivileged user namespaces are permitted'
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -138,14 +138,14 @@ class MetasploitModule < Msf::Exploit::Local
     version = kernel_release
     unless version =~ /^4\.8\.0-(34|36|39|41|42|44|45)-generic/
       vprint_error "Linux kernel version #{version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{version} is not vulnerable")
     end
     vprint_good "Linux kernel version #{version} is vulnerable"
 
     arch = kernel_hardware
     unless arch.include? 'x86_64'
       vprint_error "System architecture #{arch} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("System architecture #{arch} is not supported")
     end
     vprint_good "System architecture #{arch} is supported"
 
@@ -153,40 +153,40 @@ class MetasploitModule < Msf::Exploit::Local
     min_required_cores = 2
     unless cores >= min_required_cores
       vprint_error "System has less than #{min_required_cores} CPU cores"
-      return CheckCode::Safe
+      return CheckCode::Safe('System has insufficient CPU cores')
     end
     vprint_good "System has #{cores} CPU cores"
 
     config = kernel_config
     if config.nil?
       vprint_error 'Could not retrieve kernel config'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not retrieve kernel config')
     end
 
     unless config.include? 'CONFIG_USER_NS=y'
       vprint_error 'Kernel config does not include CONFIG_USER_NS'
-      return CheckCode::Safe
+      return CheckCode::Safe('Kernel config does not include CONFIG_USER_NS')
     end
     vprint_good 'Kernel config has CONFIG_USER_NS enabled'
 
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'
-      return CheckCode::Safe
+      return CheckCode::Safe('Unprivileged user namespaces are not permitted')
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
     if kptr_restrict? && dmesg_restrict?
       vprint_error 'Both kernel.kptr_restrict and kernel.dmesg_destrict are enabled. KASLR bypass will fail.'
-      return CheckCode::Safe
+      return CheckCode::Safe('KASLR bypass will fail due to kernel restrictions')
     end
 
     if lkrg_installed?
       vprint_error 'LKRG is installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('LKRG is installed')
     end
     vprint_good 'LKRG is not installed'
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
+++ b/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'
-      return CheckCode::Safe
+      return CheckCode::Safe('Unprivileged user namespaces are not permitted')
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     if kernel_version < Rex::Version.new('3.12')
       vprint_error "Linux kernel version #{kernel_version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{kernel_version} is not vulnerable")
     end
     vprint_good "Linux kernel version #{kernel_version} is vulnerable"
 
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Local
     #   kernel.core_pattern = |/usr/libexec/abrt-hook-ccpp %s %c %p %u %g %t e
     if kernel_core_pattern.include?('chroot') && kernel_core_pattern.include?('abrt-hook-ccpp')
       vprint_good 'System is configured to chroot ABRT for crash reporting'
-      return CheckCode::Appears
+      return CheckCode::Appears('System is configured to chroot ABRT for crash reporting')
     end
 
     # Vulnerable core_pattern (apport):
@@ -130,17 +130,17 @@ class MetasploitModule < Msf::Exploit::Local
       # apport 2.13 < 2.17.1
       if apport_version.between?(Rex::Version.new('2.13'), Rex::Version.new('2.17'))
         vprint_good "Apport version #{apport_version} is vulnerable"
-        return CheckCode::Appears
+        return CheckCode::Appears("Apport version #{apport_version} appears to be vulnerable")
       end
 
       vprint_error "Apport version #{apport_version} is not vulnerable"
 
-      return CheckCode::Safe
+      return CheckCode::Safe("Apport version #{apport_version} is not vulnerable")
     end
 
     vprint_error 'System is not configured to use Apport or chroot ABRT for crash reporting'
 
-    CheckCode::Safe
+    CheckCode::Safe('Target is not vulnerable')
   end
 
   def upload_and_chmodx(path, data)

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -151,23 +151,23 @@ class MetasploitModule < Msf::Exploit::Local
     if readable? suid_exe_path && command_exists?('ldd')
       unless cmd_exec("ldd #{suid_exe_path}").to_s.include? 'libasan.so'
         vprint_error "#{suid_exe_path} was not compiled with ASan"
-        return CheckCode::Safe
+        return CheckCode::Safe('SUID executable was not compiled with ASan')
       end
     else
       unless cmd_exec("ASAN_OPTIONS=help=1 #{suid_exe_path}").include? 'AddressSanitizer'
         vprint_error "#{suid_exe_path} was not compiled with ASan"
-        return CheckCode::Safe
+        return CheckCode::Safe('SUID executable was not compiled with ASan')
       end
     end
     vprint_good "#{suid_exe_path} was compiled with ASan"
 
     unless has_gcc?
       print_error 'gcc is not installed. Compiling will fail.'
-      return CheckCode::Safe
+      return CheckCode::Safe('gcc is not installed')
     end
     vprint_good 'gcc is installed'
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless command_exists? 'dbus-send'
       vprint_error 'dbus-send is not installed. Exploitation will fail.'
-      return CheckCode::Safe
+      return CheckCode::Safe('dbus-send is not installed')
     end
     vprint_good 'dbus-send is installed'
 
@@ -109,17 +109,17 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless res.include? 'EnableNetwork'
       vprint_error 'org.blueman.Mechanism.EnableNetwork D-Bus interface is not available'
-      return CheckCode::Safe
+      return CheckCode::Safe('org.blueman.Mechanism.EnableNetwork D-Bus interface is not available')
     end
     vprint_good 'org.blueman.Mechanism.EnableNetwork D-Bus interface is available'
 
     res = execute_python('')
     unless res.include? 'eval("nc.set_dhcp_handler(%s)" % dhcp_handler)'
       vprint_error 'Target is not vulnerable'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Target is vulnerable')
   end
 
   def execute_python(code)

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -189,26 +189,26 @@ class MetasploitModule < Msf::Exploit::Local
     if Rex::Version.new(release.split('-').first) < Rex::Version.new('4.4') ||
        Rex::Version.new(release.split('-').first) > Rex::Version.new('4.5.5')
       vprint_error "Kernel version #{release} #{version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
 
     if version.downcase.include?('ubuntu') && release =~ /^4\.4\.0-(\d+)-/ && (::Regexp.last_match(1).to_i > 21)
       vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
     vprint_good "Kernel version #{release} #{version} appears to be vulnerable"
 
     lib = cmd_exec('dpkg --get-selections | grep ^fuse').to_s
     unless lib.include?('install')
       print_error('fuse package is not installed.  Exploitation will fail.')
-      return CheckCode::Safe
+      return CheckCode::Safe('fuse package is not installed')
     end
     vprint_good('fuse package is installed')
 
     fuse_mount = "#{base_dir}/fuse_mount"
     if directory? fuse_mount
       vprint_error("#{fuse_mount} should be unmounted and deleted.  Exploitation will fail.")
-      return CheckCode::Safe
+      return CheckCode::Safe('fuse mount directory exists and should be cleaned up')
     end
     vprint_good("#{fuse_mount} doesn't exist")
 
@@ -216,22 +216,22 @@ class MetasploitModule < Msf::Exploit::Local
 
     if config.nil?
       vprint_error 'Could not retrieve kernel config'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not retrieve kernel config')
     end
 
     unless config.include? 'CONFIG_BPF_SYSCALL=y'
       vprint_error 'Kernel config does not include CONFIG_BPF_SYSCALL'
-      return CheckCode::Safe
+      return CheckCode::Safe('Kernel config does not include CONFIG_BPF_SYSCALL')
     end
     vprint_good 'Kernel config has CONFIG_BPF_SYSCALL enabled'
 
     if unprivileged_bpf_disabled?
       vprint_error 'Unprivileged BPF loading is not permitted'
-      return CheckCode::Safe
+      return CheckCode::Safe('Unprivileged BPF loading is not permitted')
     end
     vprint_good 'Unprivileged BPF loading is permitted'
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{release} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good('Kernel config has CONFIG_BPF_SYSCALL enabled')
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{release} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
+++ b/modules/exploits/linux/local/cve_2021_3490_ebpf_alu32_bounds_check_lpe.rb
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good('Kernel config has CONFIG_BPF_SYSCALL enabled')
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{release} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/cve_2021_3493_overlayfs.rb
+++ b/modules/exploits/linux/local/cve_2021_3493_overlayfs.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("The target version #{major_version} is outside the vulnerable version range #{lower_bound_version}-#{upper_bound_version}")
     end
 
-    return CheckCode::Appears
+    return CheckCode::Appears("Kernel version #{major_version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
+++ b/modules/exploits/linux/local/cve_2021_4034_pwnkit_lpe_pkexec.rb
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # run the exploit in check mode if everything looks right
     if run_exploit(true)
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable("pkexec appears to be vulnerable")
     end
 
     return CheckCode::Safe('The target does not appear vulnerable')

--- a/modules/exploits/linux/local/cve_2022_0995_watch_queue.rb
+++ b/modules/exploits/linux/local/cve_2022_0995_watch_queue.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     major_version = version_info[0]
     if major_version <= vulnerable_version
-      return CheckCode::Appears
+      return CheckCode::Appears("Kernel version #{major_version} appears to be vulnerable")
     else
       return CheckCode::Safe("The target kernel version #{major_version} is later than the last known vulnerable version aka #{vulnerable_version}")
     end

--- a/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
+++ b/modules/exploits/linux/local/cve_2022_1043_io_uring_priv_esc.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Local
     if Rex::Version.new(release.split('-').first) > Rex::Version.new('5.14-rc7') ||
        Rex::Version.new(release.split('-').first) < Rex::Version.new('5.12-rc3')
       vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
     vprint_good "Kernel version #{release} appears to be vulnerable"
 

--- a/modules/exploits/linux/local/desktop_privilege_escalation.rb
+++ b/modules/exploits/linux/local/desktop_privilege_escalation.rb
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status(output)
 
     if output['OK'] == 'OK'
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target appears to be vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -52,10 +52,10 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if cmd_exec('docker ps && echo true') =~ /true$/
       print_good("Docker daemon is accessible.")
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Docker daemon is accessible')
     else
       print_error("Failed to access Docker daemon.")
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Failed to access Docker daemon')
     end
   end
 

--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Local
       begin
         socket_subsystem, socket = open_tcp_connection
       rescue StandardError
-        return CheckCode::Safe
+        return CheckCode::Safe('Could not connect to Exim service')
       end
       res = socket.gets
       socket.close
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Local
       if res == 'false'
         vprint_error("Couldn't connect to port #{datastore['EXIMPORT']}, "\
                      'are you sure exim is listening on this port? (see EXIMPORT)')
-        return CheckCode::Safe
+        return CheckCode::Safe('Could not connect to Exim service')
       end
     end
 
@@ -220,13 +220,13 @@ class MetasploitModule < Msf::Exploit::Local
       version = Rex::Version.new(Regexp.last_match(1))
       vprint_status("Found exim version: #{version}")
       if version >= target[:lower_version] && version <= target[:upper_version]
-        return CheckCode::Appears
+        return CheckCode::Appears("Exim version #{version} appears to be vulnerable")
       else
-        return CheckCode::Safe
+        return CheckCode::Safe("Exim version #{version} is not vulnerable")
       end
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine Exim version')
   end
 
   def exploit

--- a/modules/exploits/linux/local/gameoverlay_privesc.rb
+++ b/modules/exploits/linux/local/gameoverlay_privesc.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Name' => 'GameOver(lay) Privilege Escalation and Container Escape',
         'Description' => %q{
           This module exploits the use of unsafe functions in a number of Ubuntu kernels
-          utilizing vunerable versions of overlayfs. To mitigate CVE-2021-3493 the Linux
+          utilizing vulnerable versions of overlayfs. To mitigate CVE-2021-3493 the Linux
           kernel added a call to vfs_setxattr during ovl_do_setxattr. Due to independent
           changes to the kernel by the Ubuntu development team __vfs_setxattr_noperm is
           called during ovl_do_setxattr without calling the intermediate safety function
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def vuln
-    # Keys are ubuntu versions, vals is list of vunerable kernels
+    # Keys are ubuntu versions, vals is list of vulnerable kernels
     {
       "Lunar Lobster": %w[6.2.0], # Ubuntu 23.04
       "Kinetic Kudu": %w[5.19.0], # Ubuntu 22.10
@@ -105,16 +105,16 @@ class MetasploitModule < Msf::Exploit::Local
     kernel = kernel_release
     print_status "Detected kernel version: #{kernel}"
 
-    # Make sure release is running vunerable kernel
+    # Make sure release is running vulnerable kernel
     # will this return in correct context??
     # could scan kernel to prevent looping if return below doesn't work
     vuln[codename].each do |version|
       if kernel.include? version
-        return CheckCode::Vulnerable "#{codename} with #{kernel} kernel is vunerable"
+        return CheckCode::Vulnerable("#{codename} with #{kernel} kernel is vulnerable")
       end
     end
 
-    return CheckCode::Safe('Target does not appear to be running a vunerable Ubuntu Distro or Kernel')
+    return CheckCode::Safe('Target does not appear to be running a vulnerable Ubuntu Distro or Kernel')
   end
 
   def exploit

--- a/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
@@ -107,11 +107,11 @@ class MetasploitModule < Msf::Exploit::Local
     glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d.]+)/).flatten.first
     if glibc_version.to_s.eql? ''
       vprint_error 'Could not determine the GNU C library version'
-      return CheckCode::Safe
+      return CheckCode::Safe('Could not determine GNU C Library version')
     elsif glibc_version >= Rex::Version.new('2.12.2') ||
           (glibc_version >= Rex::Version.new('2.11.3') && glibc_version < Rex::Version.new('2.12'))
       vprint_error "GNU C Library version #{glibc_version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("GNU C Library version #{glibc_version} is not vulnerable")
     end
     vprint_good "GNU C Library version #{glibc_version} is vulnerable"
 
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     if @lib_dir.nil?
       vprint_error "Could not find #{lib}"
-      return CheckCode::Safe
+      return CheckCode::Safe('Could not find libpcprofile.so')
     end
     vprint_good "Found #{lib} in #{@lib_dir}"
 
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good "#{suid_exe_path} is setuid"
 
-    CheckCode::Appears
+    CheckCode::Appears("GNU C Library version #{glibc_version} appears to be vulnerable")
   end
 
   def upload_and_chmodx(path, data)

--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good "#{suid_exe_path} is readable"
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def upload(path, data)

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -134,53 +134,53 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = kernel_release
-    if Rex::Version.new(version.split('-').first) < Rex::Version.new('2.6.36')
-      vprint_error "Linux kernel version #{version} is not vulnerable"
-      return CheckCode::Safe
+    kernel_ver = kernel_release
+    if Rex::Version.new(kernel_ver.split('-').first) < Rex::Version.new('2.6.36')
+      vprint_error "Linux kernel version #{kernel_ver} is not vulnerable"
+      return CheckCode::Safe("Kernel version #{kernel_ver} is not vulnerable")
     end
-    vprint_good "Linux kernel version #{version} is vulnerable"
+    vprint_good "Linux kernel version #{kernel_ver} is vulnerable"
 
     arch = kernel_hardware
     unless arch.include? 'x86_64'
       vprint_error "System architecture #{arch} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("System architecture #{arch} is not supported")
     end
     vprint_good "System architecture #{arch} is supported"
 
-    version = glibc_version
-    if Rex::Version.new(version.split('-').first) > Rex::Version.new('2.26')
-      vprint_error "GNU C Library version #{version} is not vulnerable"
-      return CheckCode::Safe
+    glibc_ver = glibc_version
+    if Rex::Version.new(glibc_ver.split('-').first) > Rex::Version.new('2.26')
+      vprint_error "GNU C Library version #{glibc_ver} is not vulnerable"
+      return CheckCode::Safe("GNU C Library version #{glibc_ver} is not vulnerable")
     end
-    vprint_good "GNU C Library version #{version} is vulnerable"
+    vprint_good "GNU C Library version #{glibc_ver} is vulnerable"
 
     # fuzzy match glibc 2.23-0ubuntu9 and 2.24-11+deb9u1
     glibc_banner = cmd_exec('ldd --version')
     unless glibc_banner.include?('2.23-0ubuntu') || glibc_banner.include?('2.24-11+deb9')
       vprint_error 'No offsets for this version of GNU C Library'
-      return CheckCode::Safe
+      return CheckCode::Safe('No offsets available for this GNU C Library version')
     end
 
     config = kernel_config
     if config.nil?
       vprint_error 'Could not retrieve kernel config'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not retrieve kernel config')
     end
 
     unless config.include? 'CONFIG_USER_NS=y'
       vprint_error 'Kernel config does not include CONFIG_USER_NS'
-      return CheckCode::Safe
+      return CheckCode::Safe('Kernel config does not include CONFIG_USER_NS')
     end
     vprint_good 'Kernel config has CONFIG_USER_NS enabled'
 
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'
-      return CheckCode::Safe
+      return CheckCode::Safe('Unprivileged user namespaces are not permitted')
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
-    CheckCode::Appears
+    CheckCode::Appears("GNU C Library version #{glibc_ver} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/hp_xglance_priv_esc.rb
+++ b/modules/exploits/linux/local/hp_xglance_priv_esc.rb
@@ -101,10 +101,10 @@ class MetasploitModule < Msf::Exploit::Local
     lib = find_libs
     if lib.nil?
       vprint_error 'Patched xglance-bin, not linked to -L/lib64/'
-      return CheckCode::Safe
+      return CheckCode::Safe('xglance-bin is patched')
     end
     vprint_good "xglance-bin found, and linked to vulnerable relative path -L/lib64/ through #{lib}"
-    CheckCode::Appears
+    CheckCode::Appears("xglance-bin appears to be vulnerable, linked via #{lib}")
   end
 
   def exploit

--- a/modules/exploits/linux/local/juju_run_agent_priv_esc.rb
+++ b/modules/exploits/linux/local/juju_run_agent_priv_esc.rb
@@ -64,12 +64,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     if juju_run_path.start_with? '/'
       vprint_good 'juju-run is installed'
-      return CheckCode::Detected
+      return CheckCode::Detected('juju-run is installed')
     end
 
     vprint_error 'juju-run is NOT installed'
 
-    CheckCode::Safe
+    CheckCode::Safe('juju-run is not installed')
   end
 
   def unit_names

--- a/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
@@ -112,10 +112,10 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status res
 
     unless res.include? 'uid=0'
-      return CheckCode::Safe
+      return CheckCode::Safe('ktsuss does not appear to be exploitable')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable("ktsuss is exploitable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
@@ -113,18 +113,18 @@ class MetasploitModule < Msf::Exploit::Local
     %w(lastore-daemon dpkg-deb dbus-send).each do |cmd|
       unless command_exists? cmd
         vprint_error "#{cmd} is not installed. Exploitation will fail."
-        return CheckCode::Safe
+        return CheckCode::Safe('Required command is not installed')
       end
       vprint_good "#{cmd} is installed"
     end
 
     unless dbus_priv?
       vprint_error 'User is not permitted to install packages. Exploitation will fail.'
-      return CheckCode::Safe
+      return CheckCode::Safe('User is not permitted to install packages')
     end
     vprint_good 'User is permitted to install packages'
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -139,13 +139,13 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless command_exists? 'script'
       vprint_error 'script is not installed. Exploitation will fail.'
-      return CheckCode::Safe
+      return CheckCode::Safe('script is not installed')
     end
     vprint_good 'script is installed'
 
     if immutable?('/etc/passwd')
       vprint_error 'File /etc/passwd is immutable'
-      return CheckCode::Safe
+      return CheckCode::Safe('/etc/passwd is immutable')
     end
     vprint_good 'File /etc/passwd is not immutable'
 
@@ -153,17 +153,17 @@ class MetasploitModule < Msf::Exploit::Local
     glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d.]+)/).flatten.first
     if glibc_version.to_s.eql? ''
       vprint_error 'Could not determine the GNU C library version'
-      return CheckCode::Detected
+      return CheckCode::Detected('Could not determine GNU C Library version')
     end
 
     # roothelper.c requires functions only available since glibc 2.6+
     if glibc_version < Rex::Version.new('2.6')
       vprint_error "GNU C Library version #{glibc_version} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("GNU C Library version #{glibc_version} is not supported")
     end
     vprint_good "GNU C Library version #{glibc_version} is supported"
 
-    CheckCode::Detected
+    CheckCode::Detected("GNU C Library version #{glibc_version} detected but exploitability is uncertain")
   end
 
   def exploit

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -164,29 +164,29 @@ class MetasploitModule < Msf::Exploit::Local
        v >= Rex::Version.new('4.19.2') ||
        (v >= Rex::Version.new('4.18.19') && v < Rex::Version.new('4.19'))
       vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
     vprint_good "Kernel version #{release} appears to be vulnerable"
 
     config = kernel_config
     if config.nil?
       vprint_error 'Could not retrieve kernel config'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not retrieve kernel config')
     end
 
     unless config.include? 'CONFIG_USER_NS=y'
       vprint_error 'Kernel config does not include CONFIG_USER_NS'
-      return CheckCode::Safe
+      return CheckCode::Safe('Kernel config does not include CONFIG_USER_NS')
     end
     vprint_good 'Kernel config has CONFIG_USER_NS enabled'
 
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'
-      return CheckCode::Safe
+      return CheckCode::Safe('Unprivileged user namespaces are not permitted')
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{release} appears to be vulnerable")
   end
 
   def on_new_session(session)

--- a/modules/exploits/linux/local/netfilter_nft_set_elem_init_privesc.rb
+++ b/modules/exploits/linux/local/netfilter_nft_set_elem_init_privesc.rb
@@ -197,10 +197,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     version, patchlvl = release.match(/^(\d+)\.(\d+)/)&.captures
     if version&.to_i == 5 && patchlvl && (7..19).include?(patchlvl.to_i)
-      return CheckCode::Appears # ("The kernel #{version} appears to be vulnerable, but no offsets are available for this version")
+      return CheckCode::Appears("The kernel #{version} appears to be vulnerable, but no offsets are available for this version")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Kernel release #{release} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
+++ b/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
@@ -101,27 +101,27 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    return CheckCode::Safe unless iptables_loaded?
+    return CheckCode::Safe('iptables is not loaded') unless iptables_loaded?
 
     if smep_enabled?
       print_error('SMEP enabled, system not vulnerable.')
-      return CheckCode::Safe
+      return CheckCode::Safe('SMEP is enabled')
     end
     vprint_good('SMEP is not enabled')
 
     if smap_enabled?
       print_error('SMAP enabled, system not vulnerable.')
-      return CheckCode::Safe
+      return CheckCode::Safe('SMAP is enabled')
     end
     vprint_good('SMAP is not enabled')
 
     unless userns_enabled?
       vprint_error('Unprivileged user namespaces are not permitted')
-      return CheckCode::Safe
+      return CheckCode::Safe('Unprivileged user namespaces are not permitted')
     end
     vprint_good('Unprivileged user namespaces are permitted')
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
+++ b/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
@@ -94,11 +94,11 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless command_exists? 'nmcli'
       vprint_error 'Network Manager nmcli utility is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('Network Manager nmcli utility is not installed')
     end
     vprint_good 'nmcli utility is installed'
 
-    CheckCode::Detected
+    CheckCode::Detected('Network Manager nmcli utility is installed')
   end
 
   def exploit

--- a/modules/exploits/linux/local/ntfs3g_priv_esc.rb
+++ b/modules/exploits/linux/local/ntfs3g_priv_esc.rb
@@ -75,33 +75,31 @@ class MetasploitModule < Msf::Exploit::Local
     if output
       if output.include?('1:2015.3.14AR.1-1build1') # Ubuntu 16.04 LTS
         print_good('Vulnerable Ubuntu 16.04 detected')
-        CheckCode::Appears
+        CheckCode::Appears('Vulnerable ntfs-3g version detected')
       elsif output.include?('1:2016.2.22AR.1-3') # Ubuntu 16.10
         print_good('Vulnerable Ubuntu 16.10 detected')
-        CheckCode::Appears
+        CheckCode::Appears('Vulnerable ntfs-3g version detected')
       elsif output.include?('1:2012.1.15AR.5-2.1+deb7u2') # Debian Wheezy, we also need linux-source installed
         print_good('Vulnerable Debian 7 (wheezy) detected')
         if headers_installed?
-          CheckCode::Appears
+          return CheckCode::Appears('Vulnerable ntfs-3g version detected')
         else
-          CheckCode::Safe
+          return CheckCode::Safe('Linux kernel headers are not available')
         end
-        CheckCode::Appears
       elsif output.include?('1:2014.2.15AR.2-1+deb8u2') # Debian Jessie, we also need linux-source installed
         print_good('Vulnerable Debian 8 (jessie) detected')
         if headers_installed?
-          CheckCode::Appears
+          return CheckCode::Appears('Vulnerable ntfs-3g version detected')
         else
-          CheckCode::Safe
+          return CheckCode::Safe('Linux kernel headers are not available')
         end
-        CheckCode::Appears
       else
         print_error("Version installed not vulnerable: #{output}")
-        CheckCode::Safe
+        CheckCode::Safe('Installed ntfs-3g version is not vulnerable')
       end
     else
       print_error('ntfs-3g not installed')
-      CheckCode::Safe
+      CheckCode::Safe('ntfs-3g is not installed or version not recognized')
     end
   end
 

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -98,14 +98,14 @@ class MetasploitModule < Msf::Exploit::Local
 
       unless Rex::Version.new(version) < target[:upper_version] ||
              (Rex::Version.new(version) == target[:upper_version] && build <= 118)
-        return CheckCode::Safe
+        return CheckCode::Safe("omniresolve version #{version} build #{build} is not vulnerable")
       end
 
-      return CheckCode::Appears
+      return CheckCode::Appears("omniresolve version #{version} build #{build} appears to be vulnerable")
     end
 
     vprint_error('Could not parse omniresolve -ver output')
-    CheckCode::Detected
+    CheckCode::Detected('Could not parse omniresolve version output')
   end
 
   def exploit

--- a/modules/exploits/linux/local/overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/overlayfs_priv_esc.rb
@@ -152,9 +152,9 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if mounts_exist?() && kernel_vuln?()
-      return CheckCode::Appears
+      return CheckCode::Appears('Target appears to be vulnerable')
     else
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -77,15 +77,15 @@ class MetasploitModule < Msf::Exploit::Local
     # version can be a string, so we check it
     if version.nil? || !Rex::Version.correct?(version)
       vprint_error('pkexec not found or version incorrect')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('pkexec not found or version is incorrect')
     end
 
     if Rex::Version.new(version) <= Rex::Version.new('0.101')
       vprint_good("pkexec #{version} found")
-      return CheckCode::Appears
+      return CheckCode::Appears("pkexec version #{version} appears to be vulnerable")
     end
 
-    CheckCode::Detected
+    CheckCode::Detected("pkexec version #{version} is installed but may not be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
+++ b/modules/exploits/linux/local/progress_flowmon_sudo_privesc_2024.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit::Local
     score += 1 if read_file('/var/www/shtml/ui/manifest.json')&.include?('Flowmon Web Interface')
     score += 1 if exists?('/var/www/shtml/translate.php')
     vprint_status("Found #{score} indicators this is a Progress Flowmon product")
-    return CheckCode::Detected if score > 0
+    return CheckCode::Detected('Target appears to be a Progress Flowmon product') if score > 0
 
-    return CheckCode::Safe
+    return CheckCode::Safe('Target does not appear to be a Progress Flowmon product')
   end
 
   def on_new_session(session)

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -110,31 +110,31 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if yama_enabled?
       vprint_error 'YAMA ptrace scope is restrictive'
-      return CheckCode::Safe
+      return CheckCode::Safe('YAMA ptrace scope is restrictive')
     end
     vprint_good 'YAMA ptrace scope is not restrictive'
 
     if command_exists? '/usr/sbin/getsebool'
       if cmd_exec("/usr/sbin/getsebool deny_ptrace 2>1 | /bin/grep -q on && echo true").to_s.include? 'true'
         vprint_error 'SELinux deny_ptrace is enabled'
-        return CheckCode::Safe
+        return CheckCode::Safe('SELinux deny_ptrace is enabled')
       end
       vprint_good 'SELinux deny_ptrace is disabled'
     end
 
     unless command_exists? 'sudo'
       vprint_error 'sudo is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('sudo is not installed')
     end
     vprint_good 'sudo is installed'
 
     unless command_exists? 'gdb'
       vprint_error 'gdb is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('gdb is not installed')
     end
     vprint_good 'gdb is installed'
 
-    CheckCode::Detected
+    CheckCode::Detected('Target appears to be exploitable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -77,30 +77,30 @@ class MetasploitModule < Msf::Exploit::Local
 
     if v >= Rex::Version.new('5.1.17') || v < Rex::Version.new('3')
       vprint_error "Kernel version #{release} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
     vprint_good "Kernel version #{release} appears to be vulnerable"
 
     unless command_exists? 'pkexec'
       vprint_error 'pkexec is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('pkexec is not installed')
     end
     vprint_good 'pkexec is installed'
 
     arch = kernel_hardware
     unless arch.include? 'x86_64'
       vprint_error "System architecture #{arch} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("System architecture #{arch} is not supported")
     end
     vprint_good "System architecture #{arch} is supported"
 
     loginctl_output = cmd_exec('loginctl --no-ask-password show-session "$XDG_SESSION_ID" | grep Remote')
     if loginctl_output =~ /Remote=yes/
       print_warning 'This exploit requires a valid policykit session (it cannot be executed over ssh)'
-      return CheckCode::Safe
+      return CheckCode::Safe('Exploit requires a valid policykit session')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{release} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'rds.ko kernel module is loaded'
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'RDS kernel module is loadable'
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -121,31 +121,31 @@ class MetasploitModule < Msf::Exploit::Local
     arch = kernel_hardware
     unless arch.include? 'x86_64'
       vprint_error "System architecture #{arch} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("System architecture #{arch} is not supported")
     end
     vprint_good "System architecture #{arch} is supported"
 
     version = kernel_version
     unless version.include? 'Ubuntu'
       vprint_error "System kernel #{version} is not based on Ubuntu"
-      return CheckCode::Safe
+      return CheckCode::Safe("System kernel #{version} is not based on Ubuntu")
     end
     vprint_good 'System kernel is based on Ubuntu'
 
     # Ubuntu 12.x kernels are not supported
     if version.include? 'precise'
       vprint_error "System kernel #{version} is not exploitable"
-      return CheckCode::Safe
+      return CheckCode::Safe("System kernel #{version} is not exploitable")
     end
 
     release = kernel_release
     unless release =~ /^3\.11\.0-(12|15)-generic/ || release.eql?('3.8.0-19-generic')
       vprint_error "Kernel #{release} #{version} is not exploitable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel #{release} #{version} is not exploitable")
     end
     vprint_good "Kernel #{release} #{version} is exploitable"
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel #{release} #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
+++ b/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless executable? reptile_cmd_path
       vprint_error "#{reptile_cmd_path} is not executable"
-      return CheckCode::Safe
+      return CheckCode::Safe('reptile_cmd is not executable')
     end
     vprint_good "#{reptile_cmd_path} is executable"
 
@@ -87,16 +87,16 @@ class MetasploitModule < Msf::Exploit::Local
 
     if res.include?('You have no power here!')
       vprint_error 'Reptile kernel module is not loaded'
-      return CheckCode::Safe
+      return CheckCode::Safe('Reptile kernel module is not loaded')
     end
 
     unless res.include?('root')
       vprint_error 'Reptile is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('Reptile is not installed')
     end
     vprint_good 'Reptile is installed and loaded'
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good "#{servu_path} is setuid"
 
-    CheckCode::Detected
+    CheckCode::Detected('Serv-U FTP server is installed and setuid')
   end
 
   def exploit

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     if version.to_s.eql? ''
       vprint_error 'Could not determine the kernel version'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine kernel version')
     end
 
     if version.between?(Rex::Version.new('2.4.4'), Rex::Version.new('2.4.37.4')) ||
@@ -100,17 +100,17 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_good "Kernel version #{version} appears to be vulnerable"
     else
       vprint_error "Kernel version #{version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{version} is not vulnerable")
     end
 
     arch = kernel_hardware
     unless arch.include?('x86') || arch =~ /i\d86/
       vprint_error "System architecture #{arch} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("System architecture #{arch} is not supported")
     end
     if arch.include? 'x86_64'
       vprint_error "System architecture #{arch} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("System architecture #{arch} is not supported")
     end
     vprint_good "System architecture #{arch} is supported"
 
@@ -128,10 +128,10 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_good 'vm.mmap_min_addr is zero'
     else
       vprint_error "vm.mmap_min_addr (#{mmap_min_addr}) is not zero"
-      return CheckCode::Safe
+      return CheckCode::Safe('vm.mmap_min_addr is not zero')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
+++ b/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
@@ -62,10 +62,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if file?(datastore['clear_keys'])
-      return CheckCode::Detected
+      return CheckCode::Detected('Vulnerable clear_keys.pl script found')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('clear_keys.pl script not found')
   end
 
   def exploit

--- a/modules/exploits/linux/local/su_login.rb
+++ b/modules/exploits/linux/local/su_login.rb
@@ -87,14 +87,14 @@ class MetasploitModule < Msf::Exploit::Local
     # Make sure su is installed.
     unless command_exists?('su')
       vprint_error('su not found on target machine')
-      return CheckCode::Safe
+      return CheckCode::Safe('su is not found on target')
     end
 
     # Make sure a program to run the exploit is installed.
     prorgam = find_exec_program
     unless prorgam
       vprint_error('One of the following programs must be installed on target: python, python3, script')
-      return CheckCode::Safe
+      return CheckCode::Safe('Required program is not installed on target')
     end
 
     # Make sure script requirements are met.
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
       for command in commands
         unless command_exists?(command)
           vprint_error("The '#{command}' must be installed on target")
-          return CheckCode::Safe
+          return CheckCode::Safe('Required command is not installed on target')
         end
       end
 
@@ -112,17 +112,17 @@ class MetasploitModule < Msf::Exploit::Local
       version = find_util_linux_verison
       unless version
         vprint_error("The 'script' program must be of the 'util-linux' package")
-        return CheckCode::Safe
+        return CheckCode::Safe("The 'script' program is not from the util-linux package")
       end
 
       # Check that util-linux in of a compatible version.
       unless version >= Rex::Version.new('2.25')
         vprint_error("The package 'util-linux' must be version 2.25 or higher")
-        return CheckCode::Safe
+        return CheckCode::Safe("util-linux version #{version} is not compatible")
       end
     end
 
-    return CheckCode::Appears
+    return CheckCode::Appears('Target appears to be vulnerable')
   end
 
   # Function to build and write the payload.

--- a/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
+++ b/modules/exploits/linux/local/sudo_chroot_cve_2025_32463.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     return CheckCode::Unknown('Could not identify the version of sudo.') if sudo_version.blank?
 
-    return CheckCode::Safe if !file?('/etc/nsswitch.conf')
+    return CheckCode::Safe('/etc/nsswitch.conf not found') if !file?('/etc/nsswitch.conf')
 
     return CheckCode::Appears("Running version #{sudo_version}") if Rex::Version.new(sudo_version).between?(Rex::Version.new('1.9.14'), Rex::Version.new('1.9.17'))
 

--- a/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
+++ b/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good "#{staprun_path} is setuid"
 
-    CheckCode::Detected
+    CheckCode::Detected('staprun is installed and setuid')
   end
 
   def exploit

--- a/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
+++ b/modules/exploits/linux/local/ubuntu_enlightenment_mount_priv_esc.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Local
     enlightenment_sys = find_enlightenment_sys
     return CheckCode::Safe('An exploitable enlightenment_sys was not found on the system') if enlightenment_sys.nil?
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Local
     arch = kernel_hardware
     unless arch.include? 'x86_64'
       vprint_error "System architecture #{arch} is not supported"
-      return CheckCode::Safe
+      return CheckCode::Safe("System architecture #{arch} is not supported")
     end
     vprint_good "System architecture #{arch} is supported"
 
@@ -148,42 +148,42 @@ class MetasploitModule < Msf::Exploit::Local
     unless version =~ /^4\.4\.0-(21|22|24|28|31|34|36|38|42|45|47|51|53|57|59|62|63|64|66|67|70|71|72|75|78|79|81|83|87|89|81|89)-generic/ ||
            version =~ /^4\.8\.0-(34|36|39|41|45|46|49|51|52|53|54|56|58)-generic/
       vprint_error "Linux kernel version #{version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Kernel version #{version} is not vulnerable")
     end
     vprint_good "Linux kernel version #{version} is vulnerable"
 
     vprint_status 'Checking if SMAP is enabled ...'
     if smap_enabled?
       vprint_error 'SMAP is enabled'
-      return CheckCode::Safe
+      return CheckCode::Safe('SMAP is enabled')
     end
     vprint_good 'SMAP is not enabled'
 
     config = kernel_config
     if config.nil?
       vprint_error 'Could not retrieve kernel config'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not retrieve kernel config')
     end
 
     unless config.include? 'CONFIG_USER_NS=y'
       vprint_error 'Kernel config does not include CONFIG_USER_NS'
-      return CheckCode::Safe
+      return CheckCode::Safe('Kernel config does not include CONFIG_USER_NS')
     end
     vprint_good 'Kernel config has CONFIG_USER_NS enabled'
 
     unless userns_enabled?
       vprint_error 'Unprivileged user namespaces are not permitted'
-      return CheckCode::Safe
+      return CheckCode::Safe('Unprivileged user namespaces are not permitted')
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
     if lkrg_installed?
       vprint_error 'LKRG is installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('LKRG is installed')
     end
     vprint_good 'LKRG is not installed'
 
-    CheckCode::Appears
+    CheckCode::Appears("Kernel version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -123,13 +123,13 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless command_exists? '/usr/bin/vmplayer'
       print_error 'vmplayer is not installed. Exploitation will fail.'
-      return CheckCode::Safe
+      return CheckCode::Safe('vmplayer is not installed')
     end
     vprint_good 'vmplayer is installed'
 
     unless has_gcc?
       print_error 'gcc is not installed. Compiling will fail.'
-      return CheckCode::Safe
+      return CheckCode::Safe('gcc is not installed')
     end
     vprint_good 'gcc is installed'
 
@@ -139,15 +139,15 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status "VMware is version #{version}"
     else
       vprint_error 'Could not determine VMware version.'
-      return CheckCode::Detected
+      return CheckCode::Detected('Could not determine VMware version')
     end
 
     if version >= Rex::Version.new('12.5.6')
       vprint_error 'Target version is not vulnerable'
-      return CheckCode::Safe
+      return CheckCode::Safe("VMware version #{version} is not vulnerable")
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("VMware version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Local
     return CheckCode::Safe("#{vmware_mount} file not found") unless file? vmware_mount
     return CheckCode::Safe("#{vmware_mount} is not setuid") unless setuid? vmware_mount
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_certproxy_lpe.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('Cannot write to the service file.')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
+++ b/modules/exploits/linux/local/vmware_workspace_one_access_cve_2022_22960.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     test = cmd_exec("sudo #{TARGET_FILE}")
     unless test.include? 'basename: missing operand'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target does not appear vulnerable')
     end
 
     Exploit::CheckCode::Appears('vulnerable')

--- a/modules/exploits/linux/local/zimbra_postfix_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_postfix_priv_esc.rb
@@ -67,12 +67,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless file_exist?("#{datastore['ZIMBRA_BASE']}/common/sbin/postfix")
       print_error("postfix executable not detected: #{datastore['ZIMBRA_BASE']}/common/sbin/postfix (set ZIMBRA_BASE if Zimbra is installed in an unusual location)")
-      return CheckCode::Safe
+      return CheckCode::Safe('Postfix executable not detected')
     end
 
     unless command_exists?(datastore['SUDO_PATH'])
-      print_error("Could not find sudo: #{datastore['SUDOPATH']} (set SUDO_PATH if sudo isn't in $PATH)")
-      return CheckCode::Safe
+      print_error("Could not find sudo: #{datastore['SUDO_PATH']} (set SUDO_PATH if sudo isn't in $PATH)")
+      return CheckCode::Safe('sudo not found')
     end
 
     # Run `sudo -n -l` to make sure we have access to the target command
@@ -82,15 +82,15 @@ class MetasploitModule < Msf::Exploit::Local
 
     if !output || output.start_with?('usage:') || output.include?('illegal option') || output.include?('a password is required')
       print_error('Current user could not execute sudo -l')
-      return CheckCode::Safe
+      return CheckCode::Safe('Current user could not execute sudo')
     end
 
     if !output.include?("(root) NOPASSWD: #{datastore['ZIMBRA_BASE']}/common/sbin/postfix")
       print_error('Current user does not have access to run postfix')
-      return CheckCode::Safe
+      return CheckCode::Safe('Current user does not have access to run postfix')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
+++ b/modules/exploits/linux/local/zimbra_slapper_priv_esc.rb
@@ -72,12 +72,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless file_exist?("#{datastore['ZIMBRA_BASE']}/libexec/zmslapd")
       print_error("zmslapd executable not detected: #{datastore['ZIMBRA_BASE']}/libexec/zmslapd (set ZIMBRA_BASE if Zimbra is installed in an unusual location)")
-      return CheckCode::Safe
+      return CheckCode::Safe('zmslapd executable not detected')
     end
 
     unless command_exists?(datastore['SUDO_PATH'])
-      print_error("Could not find sudo: #{datastore['SUDOPATH']} (set SUDO_PATH if sudo isn't in $PATH)")
-      return CheckCode::Safe
+      print_error("Could not find sudo: #{datastore['SUDO_PATH']} (set SUDO_PATH if sudo isn't in $PATH)")
+      return CheckCode::Safe('sudo not found')
     end
 
     # Run `sudo -n -l` to make sure we have access to the target command
@@ -87,15 +87,15 @@ class MetasploitModule < Msf::Exploit::Local
 
     if !output || output.start_with?('usage:') || output.include?('illegal option') || output.include?('a password is required')
       print_error('Current user could not execute sudo -l')
-      return CheckCode::Safe
+      return CheckCode::Safe('Current user could not execute sudo')
     end
 
     if !output.include?("(root) NOPASSWD: #{datastore['ZIMBRA_BASE']}/libexec/zmslapd")
       print_error('Current user does not have access to run zmslapd')
-      return CheckCode::Safe
+      return CheckCode::Safe('Current user does not have access to run zmslapd')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -54,10 +54,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if file?(datastore['zsudo'])
-      return CheckCode::Detected
+      return CheckCode::Detected('zsudo binary found')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('zsudo binary not found')
   end
 
   def exploit


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical