### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -63,13 +63,16 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless res && (html = res.get_html_document)
 
     if (version = html.at('//input[@name = "version"]/@value'))
+      version = version.value
       vprint_status("Nagios XI version: #{version}")
       if Rex::Version.new(version) <= target[:version]
         return CheckCode::Appears("Version #{version} appears to be vulnerable")
       end
     end
 
-    CheckCode::Safe("Version #{version} is not vulnerable")
+    return CheckCode::Safe("Version #{version} is not vulnerable") if version
+
+    CheckCode::Unknown('Could not determine Nagios XI version')
   end
 
   def exploit

--- a/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
+++ b/modules/exploits/linux/http/netgear_dnslookup_cmd_exec.rb
@@ -73,6 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
       marker_one = "Basic realm=\"NETGEAR "
       marker_two = "\""
       model = data[/#{marker_one}(.*?)#{marker_two}/m, 1]
+      return CheckCode::Unknown('Could not determine NETGEAR model') if model.nil?
+
       vprint_status("Router is a NETGEAR router (#{model})")
       model_numbers = ['DGN2200v1', 'DGN2200v2', 'DGN2200v3', 'DGN2200v4']
       if model_numbers.include?(model)
@@ -83,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     else
       print_error('Router is not a NETGEAR router')
-      return CheckCode::Safe('Router is not a NETGEAR router')
+      return CheckCode::Safe('NETGEAR router not detected')
     end
   end
 

--- a/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
+++ b/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
@@ -71,6 +71,8 @@ class MetasploitModule < Msf::Exploit::Remote
       marker_one = "Basic realm=\"NETGEAR "
       marker_two = "\""
       model = scrape(data, marker_one, marker_two)
+      return CheckCode::Unknown('Could not determine NETGEAR model') if model.nil?
+
       vprint_status("Router is a NETGEAR router (#{model})")
       if model == 'R7000' || model == 'R6400'
         print_good("Router may be vulnerable (NETGEAR #{model})")

--- a/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
+++ b/modules/exploits/linux/http/oracle_ebs_rce_cve_2022_21587.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe("Oracle EBS version #{version} detected.")
     end
 
-    CheckCode::Detected('Oracle EBS detected, but the version could not be determined from the response.')
+    CheckCode::Unknown('Oracle EBS detected, but the version could not be determined')
   end
 
   def exploit

--- a/modules/exploits/linux/http/pretalx_rce_cve_2023_28458.rb
+++ b/modules/exploits/linux/http/pretalx_rce_cve_2023_28458.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown('Login failed, please check credentials') unless login(datastore['EMAIL'], datastore['PASSWORD'])
+    return Exploit::CheckCode::Unknown('Login failed, please check credentials') unless login(datastore['EMAIL'], datastore['PASSWORD'])
 
     @logged_in = true
 
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
   rescue SessionCookieError
     return Exploit::CheckCode::Detected('Pretalx detected, failed to get session cookie - check your credentials')
   rescue DebugError
-    return Exploit::Checkcode::Detected('Failed to check if debug mode is enabled')
+    return Exploit::CheckCode::Detected('Failed to check if debug mode is enabled')
   end
 
   def exploit

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -76,16 +76,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/login.php'
     )
     if !res || !res.get_html_document
-      return Exploit::CheckCode::Unknown('Could not check rConfig version')
-    end
-    if res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig Version 3.9'
-      print_good('rConfig version 3.9 detected')
-      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
-    elsif res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig'
-      print_status('rConfig detected, but not version 3.9')
-      return Exploit::CheckCode::Detected('The target service was detected')
+      return Exploit::CheckCode::Unknown('Could not retrieve the rConfig login page')
     end
 
+    footer = res.get_html_document.at('div[@id="footer-copyright"]')
+    return Exploit::CheckCode::Unknown('Could not find version information on the login page') unless footer
+
+    if footer.text.include? 'rConfig Version 3.9'
+      print_good('rConfig version 3.9 detected')
+      return Exploit::CheckCode::Appears('rConfig version 3.9 was detected')
+    elsif footer.text.include? 'rConfig'
+      print_status('rConfig detected, but not version 3.9')
+      return Exploit::CheckCode::Detected('rConfig was detected but not version 3.9')
+    end
     Exploit::CheckCode::Safe('rConfig was not detected')
   end
 

--- a/modules/exploits/linux/http/samsung_srv_1670d_upload_exec.rb
+++ b/modules/exploits/linux/http/samsung_srv_1670d_upload_exec.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Could not determine the target version')
     end
 
-    CheckCode::Safe('The target is not vulnerable')
+    CheckCode::Safe('Samsung NVR not detected')
   end
 
   def exploit

--- a/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    leak_admin_creds ? CheckCode::Vulnerable('The target is vulnerable') : CheckCode::Safe('The target is not vulnerable')
+    leak_admin_creds ? CheckCode::Vulnerable('Successfully leaked admin credentials via SSRF') : CheckCode::Safe('Could not leak admin credentials via SSRF')
   end
 
   def exploit

--- a/modules/exploits/linux/http/webmin_packageup_rce.rb
+++ b/modules/exploits/linux/http/webmin_packageup_rce.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     print_error("#{datastore['USERNAME']} doesn't have the right to >>Package Update<<")
     print_status("Please try with another user account!")
-    CheckCode::Safe('The target is not vulnerable')
+    CheckCode::Detected("Version #{version} may be vulnerable, but user '#{datastore['USERNAME']}' lacks Package Updates permissions")
   end
 
   def exploit

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -71,6 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => "GET",
         'uri' => "/zport/acl_users/cookieAuthHelper/login_form"
       })
+      return Exploit::CheckCode::Unknown('No response received from the target') unless res
       return Exploit::CheckCode::Appears('The target appears to be vulnerable') if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\./
       return Exploit::CheckCode::Detected('The target service was detected') if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
 

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -415,7 +415,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # @config = { 'hardware' => nil, 'software' => nil, 'serial' => nil, 'ssh_user' => nil, 'ssh_port' => nil, 'ssh_wan_access' => nil, 'ssh_service_enabled' => nil }
 
     res = get_configuration
-    return CheckCode::Unknown('Could not retrieve the target configuration') if res.nil? || res.code != 200
+    return CheckCode::Unknown('No response received from the target') if res.nil?
+    return CheckCode::Unknown('Could not retrieve the target configuration') if res.code != 200
 
     begin
       process_configuration(res)

--- a/modules/exploits/linux/ids/alienvault_centerd_soap_exec.rb
+++ b/modules/exploits/linux/ids/alienvault_centerd_soap_exec.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
       version = ::Regexp.last_match(1)
     end
 
-    return CheckCode::Safe if version.blank?
+    return CheckCode::Unknown('Could not determine AlienVault version') if version.blank?
 
     if version >= '4.7.0'
       return CheckCode::Safe("AlienVault version #{version} is not vulnerable")

--- a/modules/exploits/linux/misc/hid_discoveryd_command_blink_on_unauth_rce.rb
+++ b/modules/exploits/linux/misc/hid_discoveryd_command_blink_on_unauth_rce.rb
@@ -70,9 +70,14 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     hid_res = parse_discovered_response res
+    unless hid_res
+      vprint_error 'Unexpected response from target'
+      return CheckCode::Unknown('Unexpected response from target')
+    end
+
     if hid_res[:mac].eql? ''
       vprint_error 'Malformed response'
-      return CheckCode::Safe
+      return CheckCode::Unknown('Received malformed response from target')
     end
 
     @mac = hid_res[:mac]

--- a/modules/exploits/linux/misc/qnap_transcode_server.rb
+++ b/modules/exploits/linux/misc/qnap_transcode_server.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.blank?
       vprint_status 'No reply from server'
-      return CheckCode::Safe
+      return CheckCode::Unknown('No reply received from the transcode server')
     end
 
     vprint_status "Received response: #{res}"

--- a/modules/exploits/linux/misc/ueb9_bpserverd.rb
+++ b/modules/exploits/linux/misc/ueb9_bpserverd.rb
@@ -64,10 +64,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # check if it's a valid port number (1-65534)
     if bpd_port && bpd_port >= 1 && bpd_port <= 65535
-      Exploit::CheckCode::Detected
+      Exploit::CheckCode::Detected('Target service detected on expected port')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Target did not return a valid port number')
     end
+  ensure
+    disconnect(s1) if s1
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/linux/misc/zabbix_server_exec.rb
+++ b/modules/exploits/linux/misc/zabbix_server_exec.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return Exploit::CheckCode::Safe
       end
     else # No response
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown('No response received from the target')
     end
 
     # Retry with the good node_id

--- a/modules/exploits/linux/samba/lsa_transnames_heap.rb
+++ b/modules/exploits/linux/samba/lsa_transnames_heap.rb
@@ -224,8 +224,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     CheckCode::Safe
-  rescue StandardError
-    return CheckCode::Safe
+  rescue StandardError => e
+    return CheckCode::Unknown("Unable to determine: #{e.class} - #{e.message}")
   end
 
   def brute_exploit(target_addrs)

--- a/modules/exploits/linux/snmp/awind_snmp_exec.rb
+++ b/modules/exploits/linux/snmp/awind_snmp_exec.rb
@@ -87,7 +87,9 @@ class MetasploitModule < Msf::Exploit::Remote
       model = sys_description.scan(/Crestron Electronics (AM-100|AM-101)/).flatten.first
       case model
       when 'AM-100', 'AM-101'
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable("Detected vulnerable #{model} device")
+      when nil
+        return CheckCode::Unknown("SNMP sysDescr did not match a known vulnerable model: #{sys_description}")
       else
         # TODO: insert description check for other vulnerable models (that I don't have)
         # In the meantime, we return 'safe'.

--- a/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
+++ b/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
@@ -95,15 +95,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ssh = Net::SSH.start(rhost, username, opts)
       end
     rescue Rex::ConnectionError
-      return CheckCode::Safe
+      return CheckCode::Unknown('Connection failed')
     rescue Net::SSH::Disconnect, ::EOFError
-      return CheckCode::Safe
+      return CheckCode::Unknown('Disconnected during SSH negotiation')
     rescue Timeout::Error
-      return CheckCode::Safe
+      return CheckCode::Unknown('Connection timed out')
     rescue Net::SSH::AuthenticationFailed
-      return CheckCode::Safe
+      return CheckCode::Detected('SSH service detected but authentication failed')
     rescue Net::SSH::Exception
-      return CheckCode::Safe
+      return CheckCode::Unknown('SSH error occurred')
     end
 
     CheckCode::Detected('SSH service detected.')

--- a/modules/exploits/linux/upnp/miniupnpd_soap_bof.rb
+++ b/modules/exploits/linux/upnp/miniupnpd_soap_bof.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/'
       })
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     fingerprints = targets.collect { |t| t['Fingerprint'] }


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical