### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/multi/http/activecollab_chat.rb
+++ b/modules/exploits/multi/http/activecollab_chat.rb
@@ -73,10 +73,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if (cms and cms.body =~ /powered by activeCollab/)
       # detect the chat module
       if (chat and chat.code == 200)
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
+++ b/modules/exploits/multi/http/adobe_coldfusion_rce_cve_2023_26360.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('ColdFusion detected but version number is unknown.')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not connect to the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -163,16 +163,16 @@ class MetasploitModule < Msf::Exploit::Remote
     if response
       if response.redirect? && response.headers['location'] =~ /login.php/ && !(datastore['USERNAME'] && datastore['PASSWORD'])
         print_warning('Unauthenticated RCE can\'t be exploited, retry if you gain CnC credentials.')
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Target requires authentication; unauthenticated exploitation is not possible without valid CnC credentials')
       end
 
       rand_str = Rex::Text.rand_text_alpha(8..16)
       cmd_output = parse_response(execute_command("echo #{rand_str}"))
 
-      return Exploit::CheckCode::Vulnerable if cmd_output.include?(rand_str)
+      return Exploit::CheckCode::Vulnerable('Successfully executed a command on the target') if cmd_output.include?(rand_str)
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # If the server doesn't return the default redirection, probably something is wrong
     if res and res.code == 200 and res.body =~ /#{clue}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified remote command execution')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
+++ b/modules/exploits/multi/http/apache_apisix_api_default_token_rce.rb
@@ -100,9 +100,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if server && server.match(/APISIX/)
       vprint_status("Found an #{server} #{version} http server header")
-      return Exploit::CheckCode::Appears if version > Rex::Version.new('2')
+      return Exploit::CheckCode::Appears('The target is running a vulnerable version') if version > Rex::Version.new('2')
     end
-    return Exploit::CheckCode::Safe('A vulnerable version if APISIX server is not running')
+    return Exploit::CheckCode::Safe('APISIX not detected in Server header')
   end
 
   def exploit

--- a/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
+++ b/modules/exploits/multi/http/apache_druid_cve_2023_25194.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       info: "Module #{fullname} found vulnerable host."
     })
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
   ensure
     cleanup_service
   end

--- a/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
+++ b/modules/exploits/multi/http/apache_flink_jar_upload_exec.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("Apache Flink version #{version}.")
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def delete_jar(filename)

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -84,11 +84,11 @@ class MetasploitModule < Msf::Exploit::Remote
     res = req("echo #{marker}", datastore['CVE'])
 
     if res && res.body.include?(marker * 3)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     elsif res && res.code == 500
       injected_res_code = res.code
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     res = send_request_cgi({
@@ -97,12 +97,12 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && injected_res_code == res.code
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Received an unexpected response from the target')
     elsif res && injected_res_code != res.code
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('No response received from the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/apache_roller_ognl_injection.rb
+++ b/modules/exploits/multi/http/apache_roller_ognl_injection.rb
@@ -132,9 +132,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /#{sum}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified OGNL injection vulnerability')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 end

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -69,9 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body.empty?
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/atlassian_confluence_rce_cve_2023_22515.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_rce_cve_2023_22515.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # By here we have identified a Confluence server, but could not get the version number to determine if it is
     # vulnerable of not.
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/atlassian_confluence_webwork_ognl_injection.rb
+++ b/modules/exploits/multi/http/atlassian_confluence_webwork_ognl_injection.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = inject_ognl("#{token1}'+'#{token2}'+'#{token3}")
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response received from the target') unless res
 
     unless res.code == 200 && res.body.include?("#{token1}#{token2}#{token3}")
       return CheckCode::Safe('Failed to test OGNL injection.')

--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -67,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     # the only way to test if the target is vuln
     if test_injection
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('SQL injection confirmed')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri("#{base}/admin/sitebanners/upload_banners.php")
     })
     if res and res.body =~ %r{<title>Pet Rate Admin - Banner Manager</title>}
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if select_target
       Exploit::CheckCode::Appears("Baldr Version: #{select_target.name}")
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target version is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -80,14 +80,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # default example app
     if res and res.code == 200 and res.body =~ /#{rando}/
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('Successfully verified JavaScript injection leading to code execution')
 
     # non-default app
     elsif res and res.code == 500 and res.body =~ /#{rando}/
-      return CheckCode::Appears
+      return CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/multi/http/bitbucket_env_var_rce.rb
+++ b/modules/exploits/multi/http/bitbucket_env_var_rce.rb
@@ -125,35 +125,35 @@ class MetasploitModule < Msf::Exploit::Remote
     when '7'
       case minor
       when '0', '1', '2', '3', '4', '5'
-        return CheckCode::Appears
+        return CheckCode::Appears('The target appears to be a vulnerable version')
       when '6'
-        return CheckCode::Appears if rev_num >= 0 && rev_num <= 18
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num >= 0 && rev_num <= 18
       when '7', '8', '9', '10', '11', '12', '13', '14', '15', '16'
-        return CheckCode::Appears
+        return CheckCode::Appears('The target appears to be a vulnerable version')
       when '17'
-        return CheckCode::Appears if rev_num >= 0 && rev_num <= 11
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num >= 0 && rev_num <= 11
       when '18', '19', '20'
-        return CheckCode::Appears
+        return CheckCode::Appears('The target appears to be a vulnerable version')
       when '21'
-        return CheckCode::Appears if rev_num >= 0 && rev_num <= 5
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num >= 0 && rev_num <= 5
       end
     when '8'
       print_status('Versions 8.* are vulnerable only if the mesh setting is disabled')
       case minor
       when '0'
-        return CheckCode::Appears if rev_num >= 0 && rev_num <= 4
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num >= 0 && rev_num <= 4
       when '1'
-        return CheckCode::Appears if rev_num >= 0 && rev_num <= 4
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num >= 0 && rev_num <= 4
       when '2'
-        return CheckCode::Appears if rev_num >= 0 && rev_num <= 3
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num >= 0 && rev_num <= 3
       when '3'
-        return CheckCode::Appears if rev_num >= 0 && rev_num <= 2
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num >= 0 && rev_num <= 2
       when '4'
-        return CheckCode::Appears if rev_num == 0 || rev_num == 1
+        return CheckCode::Appears('The target appears to be a vulnerable version') if rev_num == 0 || rev_num == 1
       end
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   end
 
   def default_branch

--- a/modules/exploits/multi/http/bolt_file_upload.rb
+++ b/modules/exploits/multi/http/bolt_file_upload.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     cookie = bolt_login(username, password)
-    return Exploit::CheckCode::Detected unless cookie
+    return Exploit::CheckCode::Detected('The target application was detected but requires authentication') unless cookie
 
     res = send_request_cgi(
       'method' => 'GET',
@@ -62,10 +62,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.body.include?('Bolt 2.2.4</b>: Sophisticated, lightweight & simple CMS')
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified file upload vulnerability')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def username

--- a/modules/exploits/multi/http/builderengine_upload_exec.rb
+++ b/modules/exploits/multi/http/builderengine_upload_exec.rb
@@ -68,9 +68,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && !res.body.blank?
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/cacti_graph_template_rce.rb
+++ b/modules/exploits/multi/http/cacti_graph_template_rce.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @logged_in = true
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Successfully verified code execution on the target')
   end
 
   def csrf_magic_token

--- a/modules/exploits/multi/http/cacti_package_import_rce.rb
+++ b/modules/exploits/multi/http/cacti_package_import_rce.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Could not access `package_import.php` - insufficient permissions')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("Cacti version #{cacti_version} appears to be vulnerable")
   end
 
   def generate_package

--- a/modules/exploits/multi/http/cacti_pollers_sqli_rce.rb
+++ b/modules/exploits/multi/http/cacti_pollers_sqli_rce.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Attempting SQLi to check if the target is vulnerable')
     return CheckCode::Safe('Blind SQL injection test failed') unless sqli.test_vulnerable
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Blind SQL injection confirmed')
   end
 
   def get_ext_link_id

--- a/modules/exploits/multi/http/caidao_php_backdoor_exec.rb
+++ b/modules/exploits/multi/http/caidao_php_backdoor_exec.rb
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Exploit::Remote
     flag = Rex::Text.rand_text_alpha(16)
     res = http_send_command("printf(\"#{flag}\");")
     if res && res.body =~ /#{flag}/m
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Successfully executed the injected code')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error("Connection timed out")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.code == 200 and
@@ -105,16 +105,16 @@ class MetasploitModule < Msf::Exploit::Remote
       version = $1
       vprint_status("Cisco Primer Data Center Network Manager version #{version} found")
       if version =~ /6\.1/
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
       else
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
 
     elsif res.code == 200 and res.body.to_s =~ /Data Center Network Manager/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/cisco_dcnm_upload_2019.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload_2019.rb
@@ -93,11 +93,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET'
       )
       if res && res.code == 500
-        return CheckCode::Detected
+        return CheckCode::Detected('The target service was detected')
       end
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Received an unexpected response from the target')
   end
 
   def target_select

--- a/modules/exploits/multi/http/cleo_rce_cve_2024_55956.rb
+++ b/modules/exploits/multi/http/cleo_rce_cve_2024_55956.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe(res.headers['Server'])
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not connect to the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/clinic_pms_fileupload_rce.rb
+++ b/modules/exploits/multi/http/clinic_pms_fileupload_rce.rb
@@ -65,13 +65,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res_session && res_session.code == 302 && res_session.respond_to?(:get_cookies)
       print_error('Server connect error. Couldn\'t connect or get necessary information - try to check your options.')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     phpsessid = res_session.get_cookies.match(/PHPSESSID=([^;]+)/)
     if phpsessid.nil?
       print_error('Failed to retrieve PHPSESSID. Target may not be vulnerable.')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Failed to retrieve PHPSESSID from the target response')
     else
       phpsessid = phpsessid[1]
       vprint_good("Obtained PHPSESSID: #{phpsessid}")
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res_upload && res_upload.code == 302
       print_error('File upload attempt failed. Target may not be vulnerable.')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
     vprint_good('Dummy file uploaded successfully.')
 
@@ -113,10 +113,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res_listing && res_listing.code == 200 && !res_listing.body.nil? && res_listing.body&.include?(dummy_filename)
       vprint_good("File #{dummy_filename} found in /pms/user_images. Target is vulnerable!")
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('Successfully verified the upload vulnerability')
     else
       vprint_error("File #{dummy_filename} not found in /pms/user_images. Target may not be vulnerable.")
-      CheckCode::Unknown
+      CheckCode::Unknown('Uploaded file not found in directory listing')
     end
   end
 

--- a/modules/exploits/multi/http/clipbucket_fileupload_exec.rb
+++ b/modules/exploits/multi/http/clipbucket_fileupload_exec.rb
@@ -72,12 +72,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection failed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     unless res.code == 200 && res.body.include?('ClipBucket')
       vprint_error('Could not find readme')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     # check for beats_uploader.php file
@@ -88,15 +88,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection failed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     unless res.code == 200
       vprint_error('Could not find beats_uploader.php')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
+++ b/modules/exploits/multi/http/cmsms_file_manager_auth_rce.rb
@@ -77,19 +77,19 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     unless res && res.code == 200
       vprint_error('Connection Failed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     set_cookie = res.get_cookies
-    return CheckCode::Safe unless set_cookie&.match?(/^CMSSESSID/)
+    return CheckCode::Safe('The target is not vulnerable') unless set_cookie&.match?(/^CMSSESSID/)
 
     html = res.get_html_document
     version = Rex::Version.new(html.at('p.copyright-info').text.scan(/\d+\.\d+\.\d+/).first)
     vprint_status("#{peer} - CMS Made Simple Version: #{version}")
 
-    return CheckCode::Appears if version <= Rex::Version.new('2.2.21')
+    return CheckCode::Appears('The target is running a vulnerable version') if version <= Rex::Version.new('2.2.21')
 
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   end
 
   def login

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -86,21 +86,21 @@ class MetasploitModule < Msf::Exploit::Remote
     res = get('', 'index.php')
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     unless res.body.match?(/CMS Made Simple/i)
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     version = Rex::Version.new(res.body.scan(/CMS Made Simple<\/a> version (\d+\.\d+\.\d+)/).flatten.first)
     vprint_status("#{peer} - CMS Made Simple Version: #{version}")
 
     if version <= Rex::Version.new('2.2.9.1')
-      return CheckCode::Appears
+      return CheckCode::Appears('The target is running a vulnerable version')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def login

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.code == 200
@@ -131,11 +131,11 @@ class MetasploitModule < Msf::Exploit::Remote
       if module_version < Rex::Version.new('3.6.3')
         # Showtime2 module is uploaded and present on "Module Manager" section but it could be NOT installed.
         vprint_status("Showtime2 version: #{module_version}")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target is running a vulnerable version')
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target version is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -67,11 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     unless res.body =~ /CMS Made Simple/i
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     if res.body =~ %r{CMS Made Simple</a> version (\d+\.\d+\.\d+)}i
@@ -79,11 +79,11 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("#{peer} - CMS Made Simple Version: #{version}")
 
       if version == Rex::Version.new('2.2.5')
-        return CheckCode::Appears
+        return CheckCode::Appears('The target is running a vulnerable version')
       end
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -229,11 +229,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     begin
-      return Exploit::CheckCode::Appears unless get_users(check: true)
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response') unless get_users(check: true)
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
+++ b/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200 && res.body.include?('ColdFusion Administrator Login')
       vprint_good 'Administrator access available'
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     # is it cf9?
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if img == imghash
       vprint_good 'ColdFusion 9 Detected'
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     # can we access the RDS component?
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body.include?('true')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/confluence_widget_connector.rb
+++ b/modules/exploits/multi/http/confluence_widget_connector.rb
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   # @return [Array] Check code
   def check
-    checkcode = Exploit::CheckCode::Safe
+    checkcode = Exploit::CheckCode::Safe('The target is not vulnerable')
     begin
       # Start the FTP service
       print_status('Starting the FTP server.')
@@ -182,11 +182,11 @@ class MetasploitModule < Msf::Exploit::Remote
       @check_text = Rex::Text.rand_text_alpha(5..10)
       res = inject_template("ftp://#{srvhost}:#{srvport}/#{Rex::Text.rand_text_alpha(5)}check.vm")
       if res && res.body && res.body.include?(@check_text)
-        checkcode = Exploit::CheckCode::Vulnerable
+        checkcode = Exploit::CheckCode::Vulnerable('Successfully executed the injected code')
       end
     rescue Msf::Exploit::Failed => e
       vprint_error(e.message)
-      checkcode = Exploit::CheckCode::Unknown
+      checkcode = Exploit::CheckCode::Unknown('An error occurred while checking the target')
     end
     checkcode
   end

--- a/modules/exploits/multi/http/connectwise_screenconnect_rce_cve_2024_1709.rb
+++ b/modules/exploits/multi/http/connectwise_screenconnect_rce_cve_2024_1709.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe(detected)
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not connect to the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/crushftp_rce_cve_2023_43177.rb
+++ b/modules/exploits/multi/http/crushftp_rce_cve_2023_43177.rb
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     do_logout(cookie)
 
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be vulnerable based on the response')
   rescue CrushFtpError => e
     CheckCode::Unknown("#{e.class} - #{e.message}")
   end

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -95,12 +95,12 @@ class MetasploitModule < Msf::Exploit::Remote
     res = add_printer(printer_name, '')
     if !res
       vprint_error("No response from host")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from the target')
     elsif res.headers['Server'] =~ /CUPS\/([\d\.]+)/
       vprint_status("Found CUPS version #{$1}")
     else
       print_status("Target is not a CUPS web server")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target version is not vulnerable')
     end
     if res.body =~ /Set Default Options for #{printer_name}/
       vprint_good("Added printer successfully")
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
     elsif res.code == 426
       vprint_error("SSL required - set SSL true")
     end
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   end
 
   #

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -67,11 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res.body =~ /\<strong style\=\"font\-size\:8pt\;font\-weight\:normal\"\>Version 2\.11\.2\<\/strong\>\<br\>/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
     elsif res.body =~ /\<a href\=\"http\:\/\/cuteflow\.org" target\=\"\_blank\"\>/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -85,9 +85,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.nil?
       CheckCode::Unknown("The target server didn't respond!")
     elsif res.code == 302 && res.headers['Location']&.end_with?('/base/AMInvalidURL')
-      CheckCode::Appears
+      CheckCode::Appears('The target appears to be a vulnerable version')
     else
-      CheckCode::Safe
+      CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/dexter_casinoloader_exec.rb
+++ b/modules/exploits/multi/http/dexter_casinoloader_exec.rb
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res and !res.get_cookies.empty? and res.get_cookies.start_with?('response=') and
        Rex::Text.decode_base64(URI.decode_uri_component(res.get_cookies['response='.length..-1])) == '$' + testvalue + ';#' and database_get_field('users', 'name', 0) != false
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/dotcms_file_upload_rce.rb
+++ b/modules/exploits/multi/http/dotcms_file_upload_rce.rb
@@ -108,10 +108,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body.include?(uuid)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified arbitrary file upload vulnerability')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def write_jsp_payload

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -65,12 +65,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if !res or res.code != 200
       vprint_error('Failed: Error requesting page')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
-    return CheckCode::Vulnerable if (res.body =~ /This program makes use of the Zend/)
+    return CheckCode::Vulnerable('The target is vulnerable') if (res.body =~ /This program makes use of the Zend/)
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   def execute_php_code(code, _opts = {})

--- a/modules/exploits/multi/http/eventlog_file_upload.rb
+++ b/modules/exploits/multi/http/eventlog_file_upload.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET'
       })
       if res and res.code == 405
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
       end
 
       # version 8.1+ detection
@@ -112,14 +112,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET'
       })
       if res and res.code == 405 and version == 8
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
       else
         # We can't be sure that it is vulnerable in version 9
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
 
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/extplorer_upload_exec.rb
+++ b/modules/exploits/multi/http/extplorer_upload_exec.rb
@@ -79,21 +79,21 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if !res or res.code != 200
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
       end
 
       if res.body =~ /<version>2\.1\.(0RC\d|0|1|2)<\/version>/
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
       end
 
       if res.body =~ /eXtplorer/
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def on_new_session(client)

--- a/modules/exploits/multi/http/familycms_less_exec.rb
+++ b/modules/exploits/multi/http/familycms_less_exec.rb
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
 
     if res and res.code == 200 and res.body =~ /#{mark}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/gambio_unauth_rce_cve_2024_23759.rb
+++ b/modules/exploits/multi/http/gambio_unauth_rce_cve_2024_23759.rb
@@ -214,7 +214,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Check if target is running a Gambio webshop
     # Search for "Gambio" on the login page
-    return CheckCode::Safe unless res.body.include?('gambio')
+    return CheckCode::Safe('Target does not appear to be running Gambio') unless res.body.include?('gambio')
 
     CheckCode::Detected('It looks like Gambio Webshop is running.')
   end

--- a/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
+++ b/modules/exploits/multi/http/getsimplecms_unauth_code_exec.rb
@@ -143,15 +143,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     version = gscms_version
     unless version
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not running a vulnerable version')
     end
 
     vprint_status "GetSimpleCMS version #{version}"
     unless vulnerable
-      return CheckCode::Detected
+      return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Successfully verified unauthenticated code execution')
   end
 
   def vulnerable

--- a/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
+++ b/modules/exploits/multi/http/gibbon_auth_rce_cve_2024_24725.rb
@@ -227,7 +227,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Safe("Gibbon v#{version_number[1]}")
       end
     end
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/gitlab_exif_rce.rb
+++ b/modules/exploits/multi/http/gitlab_exif_rce.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    return CheckCode::Detected
+    return CheckCode::Detected('The target application was detected')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/multi/http/gitlab_shell_exec.rb
+++ b/modules/exploits/multi/http/gitlab_shell_exec.rb
@@ -115,9 +115,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi('uri' => normalize_uri(target_uri.path.to_s, 'users', 'sign_in'))
     if res && res.body && res.body.include?('GitLab')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
+    elsif res
+      return Exploit::CheckCode::Safe('GitLab not detected in the response')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from the target')
     end
   end
 

--- a/modules/exploits/multi/http/gitlist_arg_injection.rb
+++ b/modules/exploits/multi/http/gitlist_arg_injection.rb
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && /Powered by .*GitList 0\.6\.0/.match(res.body)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_repo

--- a/modules/exploits/multi/http/glossword_upload_exec.rb
+++ b/modules/exploits/multi/http/glossword_upload_exec.rb
@@ -75,16 +75,16 @@ class MetasploitModule < Msf::Exploit::Remote
       if res
         if res.code == 200
           vprint_error("Authentication failed")
-          return Exploit::CheckCode::Unknown
+          return Exploit::CheckCode::Unknown('Could not authenticate to the target')
         elsif res.code == 301 and res.get_cookies =~ /sid([\da-f]+)=([\da-f]{32})/
           vprint_good("Authenticated successfully")
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be vulnerable')
         end
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def on_new_session(client)

--- a/modules/exploits/multi/http/glpi_install_rce.rb
+++ b/modules/exploits/multi/http/glpi_install_rce.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if not res or res.code != 200
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     re = '(version)(\\s+)(.*)(\\s+)(Copyright)'
@@ -75,11 +75,11 @@ class MetasploitModule < Msf::Exploit::Remote
     matched = m.match(res.body)
     if matched and matched[3] =~ /0.(8[0-4].[0-1])|([0-7][0-9].[0-9])/
       vprint_good("Detected Version : #{matched[3]}")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
     elsif matched
       vprint_error("Version #{matched[3]} is not vulnerable")
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
+++ b/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
@@ -89,10 +89,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_soap_request(value)
 
     if res and res.code == 500 and res.body.to_s =~ /Cmd Error: User and Password must be specified/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
@@ -96,15 +96,15 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_command(cmd)
     if !res
       vprint_error('Connection timed out')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.code == 200 && res.body =~ /#{sig}/
       vprint_good("Running with user '#{res.body.split(sig)[1].strip}'")
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def login

--- a/modules/exploits/multi/http/hyperic_hq_script_console.rb
+++ b/modules/exploits/multi/http/hyperic_hq_script_console.rb
@@ -126,15 +126,15 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Checking access to the script console")
       get_nonce
       if @nonce.nil?
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
       else
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
       end
     elsif res.headers.include?('X-Jenkins') or res.headers['location'] =~ /authfailed/
       vprint_error("Authentication failed")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.rb
+++ b/modules/exploits/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.rb
@@ -87,14 +87,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_status "#{peer} Connection failed"
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.code == 200 && res.body =~ %r{<ns1:saveHomePageResponse><return xsi:type="xsd:string">";##{fingerprint}</return>}
-      return CheckCode::Detected
+      return CheckCode::Detected('The target service was detected')
     end
 
-    Msf::Exploit::CheckCode::Safe
+    Msf::Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -98,23 +98,23 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_serialized_request('version')
     if res.nil?
       vprint_error('Connection timed out')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     elsif res.code != 200
       vprint_error("Unable to request version, returned http code is: #{res.code}")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown("Unexpected HTTP status code: #{res.code}")
     end
 
     # Check if the version is supported by this exploit
-    return Exploit::CheckCode::Appears if res.body =~ /CVSTag=Branch_4_/
-    return Exploit::CheckCode::Appears if res.body =~ /SVNTag=JBoss_4_/
-    return Exploit::CheckCode::Appears if res.body =~ /SVNTag=JBoss_5_/
+    return Exploit::CheckCode::Appears('The target appears to be a vulnerable version') if res.body =~ /CVSTag=Branch_4_/
+    return Exploit::CheckCode::Appears('The target appears to be a vulnerable version') if res.body =~ /SVNTag=JBoss_4_/
+    return Exploit::CheckCode::Appears('The target appears to be a vulnerable version') if res.body =~ /SVNTag=JBoss_5_/
 
     if res.body =~ /ServletException/ # Simple check, if we caused an exception.
       vprint_status('Target seems vulnerable, but the used JBoss version is not supported by this exploit')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target version is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/jboss_seam_upload_exec.rb
+++ b/modules/exploits/multi/http/jboss_seam_upload_exec.rb
@@ -92,16 +92,13 @@ class MetasploitModule < Msf::Exploit::Remote
           refs: references,
           info: "Module #{fullname} found vulnerable JBoss Seam 2 resource."
         })
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Successfully verified remote code execution')
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Received an unexpected response from the target')
     end
-
-    # If we reach this point, we didn't find the service
-    return Exploit::CheckCode::Unknown
   end
 
   def execute_cmd(cmd)

--- a/modules/exploits/multi/http/jenkins_metaprogramming.rb
+++ b/modules/exploits/multi/http/jenkins_metaprogramming.rb
@@ -110,25 +110,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res && (version = res.headers['X-Jenkins'])
       vprint_error('Jenkins version not detected')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
     vprint_status("Jenkins #{version} detected")
 
     if Rex::Version.new(version) > target['Version']
       vprint_error("Jenkins #{version} is not a supported target")
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not running a vulnerable version')
     end
 
     vprint_good("Jenkins #{version} is a supported target")
-    checkcode = CheckCode::Appears
+    checkcode = CheckCode::Appears('The target is running a vulnerable version')
 
     if res.body.include?('Administrator')
       vprint_good('ACL bypass successful')
-      checkcode = CheckCode::Vulnerable
+      checkcode = CheckCode::Vulnerable('Successfully verified the authentication bypass')
     else
       vprint_error('ACL bypass unsuccessful')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not running a vulnerable version')
     end
 
     checkcode

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -75,9 +75,9 @@ class MetasploitModule < Msf::Exploit::Remote
     uri.path << '/' if uri.path[-1, 1] != '/'
     res = send_request_cgi({ 'uri' => "#{uri.path}login" })
     if res && res.headers.include?('X-Jenkins')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/jenkins_xstream_deserialize.rb
+++ b/modules/exploits/multi/http/jenkins_xstream_deserialize.rb
@@ -111,9 +111,9 @@ class MetasploitModule < Msf::Exploit::Remote
     http_headers = res.headers
 
     if http_headers['X-Jenkins'] && http_headers['X-Jenkins'].to_f < 1.650
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/jetbrains_teamcity_rce_cve_2023_42793.rb
+++ b/modules/exploits/multi/http/jetbrains_teamcity_rce_cve_2023_42793.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe(detected)
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not connect to the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/jetbrains_teamcity_rce_cve_2024_27198.rb
+++ b/modules/exploits/multi/http/jetbrains_teamcity_rce_cve_2024_27198.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Connection failed') unless server_res
 
     # A patched TeamCity, e.g. 2023.11.4, reports 403 (Forbidden)
-    return CheckCode::Safe if server_res.code == 403
+    return CheckCode::Safe('The target appears to be patched') if server_res.code == 403
 
     return CheckCode::Unknown("Received unexpected HTTP status code: #{server_res.code}.") unless server_res.code == 200
 

--- a/modules/exploits/multi/http/jira_hipchat_template.rb
+++ b/modules/exploits/multi/http/jira_hipchat_template.rb
@@ -102,14 +102,14 @@ class MetasploitModule < Msf::Exploit::Remote
       res = inject_template(c, cookie)
       json = res.get_json_document
       if json['message'] && json['message'] == '0'
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Successfully executed code on the target')
       end
     rescue Msf::Exploit::Failed => e
       vprint_error(e.message)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('An error occurred while checking the target')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   # Returns the Jira version
@@ -154,12 +154,12 @@ class MetasploitModule < Msf::Exploit::Remote
     jira_version = get_jira_version
     vprint_status("Found Jira version: #{jira_version}")
     if jira_version && jira_version >= '6.3.5' && jira_version < '6.4.11'
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The Jira version is in the vulnerable range')
     else
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Jira was detected but the version is not in the vulnerable range')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   # Checks the vulnerability. Username and password are required to be able to accurately verify
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   # @return [Array] Check code
   def check
-    checkcode = Exploit::CheckCode::Safe
+    checkcode = Exploit::CheckCode::Safe('The target is not vulnerable')
 
     if jira_cred_empty?
       vprint_status("No username and password supplied, so we can only do a passive check.")

--- a/modules/exploits/multi/http/jira_plugin_upload.rb
+++ b/modules/exploits/multi/http/jira_plugin_upload.rb
@@ -62,13 +62,13 @@ class MetasploitModule < Msf::Exploit::Remote
     login_res = query_login
     if login_res.nil?
       vprint_error('Unable to access the web application!')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('No response received from the target')
     end
-    return CheckCode::Unknown unless login_res.code == 200
+    return CheckCode::Unknown('Unexpected HTTP status from the target') unless login_res.code == 200
 
     @session_id = get_sid(login_res)
     @xsrf_token = login_res.get_html_document.at('meta[@id="atlassian-token"]')
-    return CheckCode::Unknown if @xsrf_token.nil? || @xsrf_token['content'].nil?
+    return CheckCode::Unknown('Missing XSRF token in response') if @xsrf_token.nil? || @xsrf_token['content'].nil?
 
     @xsrf_token = @xsrf_token['content']
 
@@ -78,13 +78,13 @@ class MetasploitModule < Msf::Exploit::Remote
     res = query_upm(good_cookie)
     if res.nil?
       vprint_error('Unable to access the web application!')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('No response received from the target')
     elsif res.code == 200
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     else
       vprint_status('Something went wrong, make sure host is up and options are correct!')
       vprint_status("HTTP Response Code: #{res.code}")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unexpected HTTP status from the UPM endpoint')
     end
   end
 

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -71,18 +71,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error("Connection timed out")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     unless res.headers['X-Powered-By']
       vprint_error("Unable to determine the PHP version.")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('X-Powered-By header is missing, unable to determine PHP version')
     end
 
     online = joomla_and_online?
     unless online
       vprint_error("Unable to detect joomla on #{target_uri.path}")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
 
     php_version, rest = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)(?:-(.+))?/i).flatten || ''
@@ -130,18 +130,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless vulnerable
       vprint_error('This module currently does not work against this PHP version')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target version is not vulnerable')
     end
 
     j_version = joomla_version
     unless j_version.nil?
       vprint_status("Detected Joomla version #{j_version}")
-      return Exploit::CheckCode::Appears if Rex::Version.new(j_version) < Rex::Version.new('3.4.6')
+      return Exploit::CheckCode::Appears('The target is running a vulnerable version') if Rex::Version.new(j_version) < Rex::Version.new('3.4.6')
     end
 
-    return Exploit::CheckCode::Detected if online
+    return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable') if online
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def get_payload(header_name)

--- a/modules/exploits/multi/http/kong_gateway_admin_api_rce.rb
+++ b/modules/exploits/multi/http/kong_gateway_admin_api_rce.rb
@@ -122,18 +122,18 @@ class MetasploitModule < Msf::Exploit::Remote
     @route_cleanup_required = false
     # Check admin API
     response = send_request_cgi
-    return CheckCode::Unknown unless response
-    return CheckCode::Safe unless response.get_json_document['tagline'] == 'Welcome to kong'
+    return CheckCode::Unknown('No response received from the target') unless response
+    return CheckCode::Safe('The target endpoint was not found') unless response.get_json_document['tagline'] == 'Welcome to kong'
 
     # Check public API
     rhost = datastore['PUBLIC-API-RHOST'] if datastore['PUBLIC-API-RHOST']
     rport = datastore['PUBLIC-API-RPORT'] if datastore['PUBLIC-API-RPORT']
     path = normalize_uri(target_uri.path, @rand_name)
     response = send_request_cgi({ 'rport' => rport, 'rhost' => rhost, 'uri' => path })
-    return CheckCode::Unknown unless response
-    return CheckCode::Safe unless response.get_json_document['message'] == 'no Route matched with those values'
+    return CheckCode::Unknown('No response received from the target') unless response
+    return CheckCode::Safe('The target application was not detected') unless response.get_json_document['message'] == 'no Route matched with those values'
 
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/kordil_edms_upload_exec.rb
+++ b/modules/exploits/multi/http/kordil_edms_upload_exec.rb
@@ -71,17 +71,17 @@ class MetasploitModule < Msf::Exploit::Remote
       })
       if res and res.code == 200
         if res.body =~ /<center><font face="Arial" size="2">Kordil EDMS v2\.2\.60/
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
         elsif res.body =~ /Kordil EDMS v/
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
         end
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def upload(base, file)

--- a/modules/exploits/multi/http/lcms_php_exec.rb
+++ b/modules/exploits/multi/http/lcms_php_exec.rb
@@ -117,10 +117,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if response and response.body =~ /#{signature}/
       vprint_status("Signature: #{signature}")
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     else
       vprint_error("Signature was not detected")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target application was not detected')
     end
   end
 

--- a/modules/exploits/multi/http/lighthouse_studio_unauth_rce_cve_2025_34300.rb
+++ b/modules/exploits/multi/http/lighthouse_studio_unauth_rce_cve_2025_34300.rb
@@ -109,17 +109,17 @@ class MetasploitModule < Msf::Exploit::Remote
       version = Rex::Version.new(version_match.gsub('_', '.'))
       print_status("Extracted version: #{version}")
 
-      return CheckCode::Appears if version < Rex::Version.new('9.16.14')
+      return CheckCode::Appears('The target is running a vulnerable version') if version < Rex::Version.new('9.16.14')
     else
       print_error("#{peer} - Unable to extract version number")
     end
 
     html = res.get_html_document
     if html&.text&.include?('Lighthouse Studio')
-      return CheckCode::Detected
+      return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
+++ b/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/magento_unserialize.rb
+++ b/modules/exploits/multi/http/magento_unserialize.rb
@@ -302,18 +302,18 @@ class MetasploitModule < Msf::Exploit::Remote
             res = do_check
           end
           if (res && res.body.include?('phpinfo()'))
-            return Exploit::CheckCode::Appears
+            return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
           else
-            return Exploit::CheckCode::Safe
+            return Exploit::CheckCode::Safe('The target is not vulnerable')
           end
         end
       end
     rescue ::Rex::ConnectionError => e
       vprint_error(e.message)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_webroot

--- a/modules/exploits/multi/http/makoserver_cmd_exec.rb
+++ b/modules/exploits/multi/http/makoserver_cmd_exec.rb
@@ -64,9 +64,11 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 20)
 
     # If response does not include "MakoServer.net", target is not viable.
+    return CheckCode::Unknown('No response received from the target') unless res
+
     if res.headers['Server'] !~ /MakoServer\.net/
       vprint_warning('Target is not a Mako Server.')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
     if res.body
@@ -74,20 +76,18 @@ class MetasploitModule < Msf::Exploit::Remote
         # We are able to determine that the server has a save.lsp page and
         # returns the correct output.
         vprint_status('Mako Server save.lsp returns correct ouput.')
-        return CheckCode::Appears
+        return CheckCode::Appears('The target appears vulnerable based on response body')
       else
         # The page exists, but is not returning the expected output.
         # May be a different version?
         vprint_warning('Mako Server save.lsp did not return expected output.')
-        return CheckCode::Detected
+        return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
     else
       # The above checks failed and exploitability could not be determined.
       vprint_error('Unable to determine exploitability, save.lsp not found.')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
-
-    CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -541,7 +541,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('Detected Desktop Central v8 (MySQL)')
     end
     # DC v8 < 80200 uses the MySQL database
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('Detected Desktop Central v8')
   end
 
   def check_desktop_central_9(body)
@@ -549,9 +549,9 @@ class MetasploitModule < Msf::Exploit::Remote
       build = ::Regexp.last_match(1)
       print_status("Detected Desktop Central v9 #{build}")
       if ver_lt(build, '90039')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('Desktop Central v9 is running a vulnerable build')
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('Desktop Central v9 build is not vulnerable')
       end
     end
   end
@@ -564,14 +564,14 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res && res.code == 200
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to Desktop Central')
     end
 
     if res.body.to_s =~ /ManageEngine Desktop Central 7/ ||
        res.body.to_s =~ /ManageEngine Desktop Central MSP 7/
       # DC v7 uses the MySQL database
       print_status('Detected Desktop Central v7 (MySQL)')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Detected Desktop Central v7')
     elsif res.body.to_s =~ /ManageEngine Desktop Central 8/ ||
           res.body.to_s =~ /ManageEngine Desktop Central MSP 8/
       return check_desktop_central_8(res.body.to_s)
@@ -580,7 +580,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return check_desktop_central_9(res.body.to_s)
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Desktop Central was not detected')
   end
 
   # Test for Password Manager Pro
@@ -599,23 +599,23 @@ class MetasploitModule < Msf::Exploit::Remote
        )
       build = ::Regexp.last_match(1)
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not detect Password Manager Pro')
     end
 
     if ver_lt_eq(build, '6500')
       # if it's a build below 6500, it will only work if we have a JSP compiler
       print_status("Detected Password Manager Pro v6 #{build} (needs a JSP compiler)")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Password Manager Pro detected but requires a JSP compiler')
     elsif ver_lt(build, '6800')
       # PMP v6 < 6800 uses the MySQL database
       print_status("Detected Password Manager Pro v6 #{build} (MySQL)")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Password Manager Pro v6 is running a vulnerable build')
     elsif ver_lt(build, '7003')
       print_status("Detected Password Manager Pro v6 / v7 #{build}")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Password Manager Pro is running a vulnerable build')
     else
       print_status("Detected Password Manager Pro v6 / v7 #{build}")
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Password Manager Pro build is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/manageengine_adselfservice_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_adselfservice_plus_saml_rce_cve_2022_47966.rb
@@ -88,16 +88,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(datastore['TARGETURI'], datastore['GUID'])
     )
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response received from the target') unless res
 
-    return CheckCode::Safe unless res.code == 200
+    return CheckCode::Safe('The target is not vulnerable') unless res.code == 200
 
     product = res.get_html_document.xpath('//title').first&.text
     unless product == 'ADSelfService Plus'
       return CheckCode::Safe("This is not ManageEngine ADSelfService Plus (#{product})")
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected but requires authentication')
   end
 
   def encode_begin(real_payload, reqs)

--- a/modules/exploits/multi/http/manageengine_auth_upload.rb
+++ b/modules/exploits/multi/http/manageengine_auth_upload.rb
@@ -143,16 +143,16 @@ class MetasploitModule < Msf::Exploit::Remote
     if (version[0] <= 9 && version[0] > 4 && version[2] < 9031 && version[3] == 'sd') ||
        (version[0] <= 6 && version[2] < 99999 && version[3] == 'ae') ||
        (version[3] == 'sc' && version[2] < 99999)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
     end
 
     if (version[2] > 9030 && version[3] == 'sd') ||
        (version[2] > 99999 && version[3] == 'ae') ||
        (version[2] > 99999 && version[3] == 'sc')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     else
       # An IT360 check always lands here, there is no way to get the version easily
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the vulnerability status')
     end
   end
 

--- a/modules/exploits/multi/http/manageengine_sd_uploader.rb
+++ b/modules/exploits/multi/http/manageengine_sd_uploader.rb
@@ -65,11 +65,11 @@ class MetasploitModule < Msf::Exploit::Remote
        res.body.to_s =~ /src='\/scripts\/Login\.js\?([0-9]+)'><\/script>/
       build = $1
       if build < "9103" && build > "9000"
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Build #{build} appears to be vulnerable")
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/manageengine_search_sqli.rb
+++ b/modules/exploits/multi/http/manageengine_search_sqli.rb
@@ -59,9 +59,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = sqli_exec(Rex::Text.rand_text_alpha(1))
 
     if res and res.body =~ /Error during search/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('SQL injection condition detected in search response')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/multi/http/manageengine_servicedesk_plus_saml_rce_cve_2022_47966.rb
@@ -115,14 +115,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(datastore['TARGETURI'])
     )
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response received from the target') unless res
 
     # vulnerable servers respond with 400 and a HTML body
-    return CheckCode::Safe unless res.code == 400
+    return CheckCode::Safe('The target is not vulnerable') unless res.code == 400
 
     script = res.get_html_document.xpath('//script[contains(text(), "BUILD_NUMBER")]')
     info = script.text.match(/PRODUCT_NAME\\x22\\x3A\\x22(?<product>.+?)\\x22,.*BUILD_NUMBER\\x22\\x3A\\x22(?<build>[0-9]+?)\\x22,/)
-    return CheckCode::Unknown unless info
+    return CheckCode::Unknown('Unable to extract product and build information from response') unless info
     unless info[:product] == 'ManageEngine\\x20ServiceDesk\\x20Plus'
       return CheckCode::Safe("This is not ManageEngine ServiceDesk Plus (#{info[:product]})")
     end
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe("Target build is #{info[:build]}")
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('The target is running a vulnerable version')
   end
 
   def encode_begin(real_payload, reqs)

--- a/modules/exploits/multi/http/mantisbt_manage_proj_page_rce.rb
+++ b/modules/exploits/multi/http/mantisbt_manage_proj_page_rce.rb
@@ -60,12 +60,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection to host failed!')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     unless res.body =~ /Mantis ([0-9]+\.[0-9]+\.[0-9]+)/
       vprint_error('Cannot determine Mantis version!')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Unable to determine Mantis version from the response')
     end
 
     version = Rex::Version.new(Regexp.last_match[1])
@@ -73,10 +73,10 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Mantis version #{version} detected")
 
     if res.code == 200 && version <= Rex::Version.new('1.1.3')
-      return CheckCode::Appears
+      return CheckCode::Appears('The target is running a vulnerable version')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target version is not vulnerable')
   end
 
   def login

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -95,16 +95,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     version = get_mantis_version
 
-    return Exploit::CheckCode::Unknown if version.nil?
+    return Exploit::CheckCode::Unknown('Unable to detect Mantis version') if version.nil?
 
     gem_version = Rex::Version.new(version)
     gem_version_introduced = Rex::Version.new('1.2.0a3')
     gem_version_fixed = Rex::Version.new('1.2.18')
 
     if gem_version < gem_version_fixed && gem_version >= gem_version_introduced
-      return Msf::Exploit::CheckCode::Appears
+      return Msf::Exploit::CheckCode::Appears('The target is running a vulnerable version')
     else
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/mediawiki_syntaxhighlight.rb
+++ b/modules/exploits/multi/http/mediawiki_syntaxhighlight.rb
@@ -76,15 +76,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (res && res.headers.key?('MediaWiki-API-Error'))
       if (res.headers['MediaWiki-API-Error'] == 'internal_api_error_MWException')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
       elsif (res.headers['MediaWiki-API-Error'] == 'readapidenied')
         print_error("Login is required")
       end
 
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown("MediaWiki API returned an error: #{res.headers['MediaWiki-API-Error']}")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   # use deprecated interface

--- a/modules/exploits/multi/http/mediawiki_thumb.rb
+++ b/modules/exploits/multi/http/mediawiki_thumb.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless response
       vprint_status("No response from #{full_uri}.")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('No response received from the target')
     end
 
     # Mediawiki will give a 404 for unknown pages but still have a body
@@ -146,26 +146,26 @@ class MetasploitModule < Msf::Exploit::Remote
       major, minor, patch = get_version(response.body)
 
       unless major
-        return CheckCode::Unknown
+        return CheckCode::Unknown('Unable to extract MediaWiki version from response')
       end
 
       if major == 1 && (minor < 8 || minor > 22)
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not running a vulnerable version')
       elsif major == 1 && (minor == 22 && patch > 1)
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not running a vulnerable version')
       elsif major == 1 && (minor == 21 && patch > 4)
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not running a vulnerable version')
       elsif major == 1 && (minor == 19 && patch > 10)
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not running a vulnerable version')
       elsif major == 1
-        return CheckCode::Appears
+        return CheckCode::Appears('The target appears to be a vulnerable version')
       else
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not running a vulnerable version')
       end
     end
 
     vprint_status("Received response code #{response.code} from #{full_uri}")
-    CheckCode::Unknown
+    CheckCode::Unknown('Received an unexpected response from the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/metasploit_static_secret_key_base.rb
+++ b/modules/exploits/multi/http/metasploit_static_secret_key_base.rb
@@ -222,17 +222,17 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
 
     unless res
-      return Exploit::CheckCode::Unknown   # Target didn't respond
+      return Exploit::CheckCode::Unknown('No response received from the target')   # Target didn't respond
     end
 
     if res.get_cookies.empty?
-      return Exploit::CheckCode::Unknown   # Target didn't send us any cookies. We can't continue.
+      return Exploit::CheckCode::Unknown('No cookies received from the target')   # Target didn't send us any cookies. We can't continue.
     end
 
     match = res.get_cookies.match(/([_A-Za-z0-9]+)=([A-Za-z0-9%]*)--([0-9A-Fa-f]+);/)
 
     unless match
-      return Exploit::CheckCode::Unknown   # Target didn't send us a session cookie. We can't continue.
+      return Exploit::CheckCode::Unknown('No session cookie found in the response')   # Target didn't send us a session cookie. We can't continue.
     end
 
     if match[1] == cookie_name
@@ -248,9 +248,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if secret
       vprint_status("Found secret, detected version #{version}")
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target version is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/microfocus_obm_auth_rce.rb
+++ b/modules/exploits/multi/http/microfocus_obm_auth_rce.rb
@@ -71,10 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # unfortunately could not find an easy way to detect the version running, even when auth
     if res && res.code == 200 && res.body.include?('Login - Operations Bridge Manager')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Operations Bridge Manager not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
+++ b/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
@@ -85,16 +85,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'ucmdb-api', 'connect'),
       'method' => 'GET'
     })
-    if res && res.code == 200 && res.body.include?('HttpUcmdbServiceProviderFactoryImpl')
-      if res.body.include?('ServerVersion=11.6.0')
-        # 100% sure this version is vulnerable
-        return Exploit::CheckCode::Appears
-      end
-
-      return Exploit::CheckCode::Detected
+    unless res
+      return Exploit::CheckCode::Unknown('No response received from the target')
     end
 
-    return Exploit::CheckCode::Unknown
+    if res.code == 200 && res.body.include?('HttpUcmdbServiceProviderFactoryImpl')
+      if res.body.include?('ServerVersion=11.6.0')
+        # 100% sure this version is vulnerable
+        return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
+      end
+
+      return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
+    end
+
+    return Exploit::CheckCode::Safe('UCMDB service not detected in the response')
   end
 
   def exploit

--- a/modules/exploits/multi/http/mma_backdoor_upload.rb
+++ b/modules/exploits/multi/http/mma_backdoor_upload.rb
@@ -71,11 +71,11 @@ class MetasploitModule < Msf::Exploit::Remote
       form = n.at('form[@id="uploader"]')
       inputs = form.search('input')
       if has_input_name?(inputs, 'file') && has_input_name?(inputs, '_upl')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -67,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_raw({ 'uri' => normalize_uri(uri, '/index.php') })
     if res and res.body =~ /MobileCartly/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
+++ b/modules/exploits/multi/http/monitorr_webshell_rce_cve_2020_28871.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
       version = Rex::Version.new(res.body)
       return CheckCode::Vulnerable("Monitorr version: #{version}") if version.between?(Rex::Version.new('0.8.6'), Rex::Version.new('1.7.7'))
     end
-    CheckCode::Unknown
+    CheckCode::Unknown('Received an unexpected response from the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -66,12 +66,12 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, 'admin', 'index.php') })
     rescue
       vprint_error("Unable to access the index.php file")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Failed to connect to the target')
     end
 
     if res and res.code != 200
       vprint_error("Error accessing the index.php file")
-      return CheckCode::Unknown
+      return CheckCode::Unknown("Unexpected HTTP status code: #{res.code}")
     end
 
     if res.body =~ /<\/a>.*?Version (\d+\.\d+\.\d+)/i
@@ -80,11 +80,11 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Monstra CMS: #{version}")
 
       if version > vulnVersion
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not running a vulnerable version')
       elsif version == vulnVersion
-        return CheckCode::Appears
+        return CheckCode::Appears('The target is running a vulnerable version')
       elsif version < vulnVersion
-        return CheckCode::Detected
+        return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
     end
   end

--- a/modules/exploits/multi/http/movabletype_upgrade_exec.rb
+++ b/modules/exploits/multi/http/movabletype_upgrade_exec.rb
@@ -78,18 +78,18 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       res = http_send_raw(fingerprint)
     rescue Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
     if (res)
       if (res.code == 200 and res.body =~ /Can't locate object method \\"dbi_driver\\" via package \\"#{fingerprint}\\" at/)
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Successfully verified Perl code injection vulnerability')
       elsif (res.code != 200)
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown("Unexpected HTTP status code: #{res.code}")
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
   end
 

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -167,10 +167,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /: Mutiny : Login @ mutiny/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/mybb_rce_cve_2022_24734.rb
+++ b/modules/exploits/multi/http/mybb_rce_cve_2022_24734.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good("MyBB forum found running at #{target_uri.path}")
 
-    return CheckCode::Detected
+    return CheckCode::Detected('The target application was detected')
   end
 
   def login

--- a/modules/exploits/multi/http/navigate_cms_rce.rb
+++ b/modules/exploits/multi/http/navigate_cms_rce.rb
@@ -78,9 +78,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Vulnerable if login_bypass
+    return CheckCode::Vulnerable('Successfully verified the authentication bypass') if login_bypass
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -54,9 +54,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_raw({ 'uri' => '/cgi/surgeftpmgr.cgi' })
     if res and res.body =~ /surgeftp\x20\x0d\x0a\x20\x20Manager CGI/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/nibbleblog_file_upload.rb
+++ b/modules/exploits/multi/http/nibbleblog_file_upload.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     cookie = do_login(username, password)
-    return Exploit::CheckCode::Detected unless cookie
+    return Exploit::CheckCode::Detected('The target application was detected but requires authentication') unless cookie
 
     res = send_request_cgi(
       'method' => 'GET',
@@ -73,10 +73,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.body.include?('Nibbleblog 4.0.3 "Coffee"')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def do_login(user, pass)

--- a/modules/exploits/multi/http/nostromo_code_exec.rb
+++ b/modules/exploits/multi/http/nostromo_code_exec.rb
@@ -70,17 +70,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection failed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.code == 200 and res.headers['Server'] =~ /nostromo [\d.]{5}/
       /nostromo (?<version>[\d.]{5})/ =~ res.headers['Server']
       if Rex::Version.new(version) <= Rex::Version.new('1.9.6')
-        return CheckCode::Appears
+        return CheckCode::Appears('The target is running a vulnerable version')
       end
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/multi/http/novell_servicedesk_rce.rb
+++ b/modules/exploits/multi/http/novell_servicedesk_rce.rb
@@ -92,11 +92,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     version = get_version
     if version <= 7.1 && version >= 6.5
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
     elsif version > 7.1
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Detected version is outside the known vulnerable range')
     end
   end
 

--- a/modules/exploits/multi/http/nuuo_nvrmini_upgrade_rce.rb
+++ b/modules/exploits/multi/http/nuuo_nvrmini_upgrade_rce.rb
@@ -58,14 +58,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.code == 200 && res.body =~ /upload_tmp_dir/
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('Successfully verified the upload vulnerability')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(cmd)

--- a/modules/exploits/multi/http/october_upload_bypass_exec.rb
+++ b/modules/exploits/multi/http/october_upload_bypass_exec.rb
@@ -75,14 +75,14 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue
       vprint_error('Unable to access the /assets/js/framework.js file')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if res && res.code == 200
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   def login

--- a/modules/exploits/multi/http/op5_license.rb
+++ b/modules/exploits/multi/http/op5_license.rb
@@ -77,10 +77,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
     elapsed = Time.now - start
     if elapsed >= 5
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -77,10 +77,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
     elapsed = Time.now - start
     if elapsed >= 5
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/open_web_analytics_rce.rb
+++ b/modules/exploits/multi/http/open_web_analytics_rce.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = check_connection
     return CheckCode::Unknown('Connection failed') unless res
-    return CheckCode::Safe if !res.body.include?('Open Web Analytics')
+    return CheckCode::Safe('Target is not running Open Web Analytics') if !res.body.include?('Open Web Analytics')
 
     version = Rex::Version.new(res.body.scan(/version=([\d.]+)/).flatten.first)
     return CheckCode::Detected("Open Web Analytics #{version} detected") unless version < Rex::Version.new('1.7.4')

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -110,20 +110,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (!res) or (res.code != 200)
       vprint_error("Unable to make a request to: #{path}")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Failed to fetch the login page')
     end
 
     versioncheck = res.body =~ %r{Openfire, \D*: (\d)\.(\d).(\d)\s*</div>}
 
     if versioncheck.nil?
       vprint_error('Unable to detect Openfire version')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine Openfire version from response')
     end
 
     vprint_status("Detected version: #{::Regexp.last_match(1)}.#{::Regexp.last_match(2)}.#{::Regexp.last_match(3)}")
     version = "#{::Regexp.last_match(1)}#{::Regexp.last_match(2)}#{::Regexp.last_match(3)}".to_i
 
-    return Exploit::CheckCode::Safe if version > 360
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version') if version > 360
 
     # Just to be sure, try to access the log page
     path = "#{base}setup/setup-/../../log.jsp"
@@ -135,10 +135,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (!res) or (res.code != 200)
       print_error("Failed: Error requesting #{path}")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('An error occurred while checking the target')
     end
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def get_plugin_jar(plugin_name)

--- a/modules/exploits/multi/http/openfire_auth_bypass_rce_cve_2023_32315.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass_rce_cve_2023_32315.rb
@@ -230,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     openfire_version = get_version
-    return CheckCode::Safe if openfire_version.nil?
+    return CheckCode::Unknown('Unable to determine Openfire version') if openfire_version.nil?
     # check first for patched versions
     return CheckCode::Safe("Openfire version is #{openfire_version}") if openfire_version == Rex::Version.new('4.6.8')
     return CheckCode::Safe("Openfire version is #{openfire_version}") if openfire_version == Rex::Version.new('4.7.5')

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("OpenMRS platform version: #{version_no}")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target version is not vulnerable')
   end
 
   def format_payload

--- a/modules/exploits/multi/http/openx_backdoor_php.rb
+++ b/modules/exploits/multi/http/openx_backdoor_php.rb
@@ -60,12 +60,12 @@ class MetasploitModule < Msf::Exploit::Remote
     response = execute_php("echo '#{token} '.phpversion();die();")
 
     if response.nil?
-      CheckCode::Unknown
+      return CheckCode::Unknown('No response received from the target')
     elsif response.body =~ /#{token} ((:?\d\.?)+)/
       vprint_status("PHP Version #{$1}")
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
-    return CheckCode::Safe
+    return CheckCode::Safe('The target version is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/opmanager_socialit_file_upload.rb
+++ b/modules/exploits/multi/http/opmanager_socialit_file_upload.rb
@@ -62,10 +62,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # A GET request on this servlet returns "405 Method not allowed"
     if res and res.code == 405
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def upload_war_and_exec(try_again, app_base)

--- a/modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb
+++ b/modules/exploits/multi/http/opmanager_sumpdu_deserialization.rb
@@ -135,11 +135,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/servlets/com.adventnet.tools.sum.transport.SUMHandShakeServlet'),
       'data' => build_java_serialized_int(1002)
     })
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('No response received from the target') unless res
     # the patched version will respond back with 200 OK and no data in the response body
-    return Exploit::CheckCode::Safe unless res.code == 200 && res.body.start_with?("\xac\xed\x00\x05".b)
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version') unless res.code == 200 && res.body.start_with?("\xac\xed\x00\x05".b)
 
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/oracle_access_manager_rce_cve_2021_35587.rb
+++ b/modules/exploits/multi/http/oracle_access_manager_rce_cve_2021_35587.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # By here we think the target is OAM, but we did not get a version number from the response body, so
     # we cannot do a version based check to determine if vulnerable or safe.
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
   rescue Msf::Exploit::Failed => e
     return Exploit::CheckCode::Unknown(e.message)
   end

--- a/modules/exploits/multi/http/oracle_ats_file_upload.rb
+++ b/modules/exploits/multi/http/oracle_ats_file_upload.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body.include?('12.4.0.2.0')
-      CheckCode::Appears
+      CheckCode::Appears('The target appears to be vulnerable based on the response')
     else
-      CheckCode::Safe
+      CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
+++ b/modules/exploits/multi/http/oracle_ebs_cve_2025_61882_exploit_rce.rb
@@ -88,14 +88,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     vprint_status('Checking if target is vulnerable...')
 
-    return CheckCode::Safe unless oracle_ebs_detected?
+    return CheckCode::Safe('Oracle E-Business Suite not detected') unless oracle_ebs_detected?
 
     csrf_token = retrieve_csrf_token
-    return CheckCode::Unknown unless csrf_token
+    return CheckCode::Unknown('Failed to retrieve CSRF token') unless csrf_token
 
-    return CheckCode::Appears if vulnerable_servlet_accessible?(csrf_token)
+    return CheckCode::Appears('The target appears to be vulnerable') if vulnerable_servlet_accessible?(csrf_token)
 
-    CheckCode::Safe
+    CheckCode::Safe('Vulnerable servlet is not accessible')
   end
 
   # Serve malicious XSLT file

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
         vprint_good 'Linux install detected'
         vprint_status "Path:  #{::Regexp.last_match(1)}"
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     end
 
@@ -110,13 +110,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res and res.code == 200 and res.body.downcase.exclude?('<html>')
       vprint_good 'URLPARAMETER is vulnerable'
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified path traversal vulnerability')
     else
       vprint_status 'URLPARAMETER is not vulnerable'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
-
-    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/multi/http/orientdb_exec.rb
+++ b/modules/exploits/multi/http/orientdb_exec.rb
@@ -62,12 +62,14 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = target_uri
     uri.path = normalize_uri(uri.path)
     res = send_request_raw({ 'uri' => "#{uri.path}listDatabases" })
-    if res and res.code == 200 and res.headers['Server'] =~ /OrientDB Server v\.2\.2\./
+    return Exploit::CheckCode::Unknown('No response received from the target') unless res
+
+    if res.code == 200 and res.headers['Server'] =~ /OrientDB Server v\.2\.2\./
       print_good("Version: #{res.headers['Server']}")
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears('OrientDB 2.2.x detected via Server header')
     else
       print_status("Version: #{res.headers['Server']}")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/os_cmd_exec.rb
+++ b/modules/exploits/multi/http/os_cmd_exec.rb
@@ -130,12 +130,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     response = send_request(method, uri, data)
 
-    return Exploit::CheckCode::Unknown unless response
-    return Exploit::CheckCode::Appears if response.code == 200 && response.body.match(content)
-    return Exploit::CheckCode::Detected if response.code == 200
+    return Exploit::CheckCode::Unknown('Could not connect to the target') unless response
+    return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response') if response.code == 200 && response.body.match(content)
+    return Exploit::CheckCode::Detected('The target service was detected') if response.code == 200
 
     vprint_error("Server responded with: HTTP #{response.code}")
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Unexpected HTTP status code received')
   end
 
   def exploit


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical