### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/multi/http/pandora_upload_exec.rb
+++ b/modules/exploits/multi/http/pandora_upload_exec.rb
@@ -72,16 +72,16 @@ class MetasploitModule < Msf::Exploit::Remote
       if res and res.code == 200
         # Tested on v3.1 Build PC100609 and PC100608
         if res.body.include?("v3.1 Build PC10060")
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
         elsif res.body.include?("Pandora")
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
         end
       end
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     rescue ::Rex::ConnectionError
       vprint_error("Connection failed")
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not connect to the target')
   end
 
   # upload a payload using the pandora built-in file upload

--- a/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
+++ b/modules/exploits/multi/http/papercut_ng_auth_bypass.rb
@@ -202,10 +202,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # For the check command
     bypass_success = bypass_auth
     if bypass_success.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    return Exploit::CheckCode::Vulnerable
+    return Exploit::CheckCode::Vulnerable('Successfully verified the authentication bypass')
   end
 
   def exploit

--- a/modules/exploits/multi/http/pentaho_business_server_authbypass_and_ssti.rb
+++ b/modules/exploits/multi/http/pentaho_business_server_authbypass_and_ssti.rb
@@ -124,12 +124,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'api', 'ldap', 'config', 'ldapTreeNodeChildren', "require#{post_require_mixup}#{period_mixup}js")
     )
 
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('Could not authenticate to the target') unless res
 
     if res.code == 200 && res.body == '{}'
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -56,10 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
     test = Rex::Text.rand_text_alpha(8)
     res = http_send_command("echo \"#{test}\";")
     if res && res.body.include?(test)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified remote code execution')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('Connection failed.') unless response
 
     if response.code == 200 && response.body.to_s.lstrip =~ /^<code><span style/i
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('The target is vulnerable')
     end
 
     if datastore['PLESK'] && response.code == 500

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -379,7 +379,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good("Parameters found: QSL=#{@params[:qsl]}, customh_length=#{@params[:customh_length]}")
     print_good('Target is vulnerable!')
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('The target is vulnerable')
   ensure
     disconnect(client) if client&.conn?
   end

--- a/modules/exploits/multi/http/php_utility_belt_rce.rb
+++ b/modules/exploits/multi/http/php_utility_belt_rce.rb
@@ -60,9 +60,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = http_send_command("echo #{txt};")
 
     if res && res.body.include?(txt)
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Successfully verified arbitrary PHP code execution')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = http_send_command("echo #{txt}")
 
     if res && res.body =~ /#{txt}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified remote command execution vulnerability')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if (res and res.body =~ /phpLDAPadmin \(1\.2\.[0|1]\.\d/i)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_session

--- a/modules/exploits/multi/http/phpmoadmin_exec.rb
+++ b/modules/exploits/multi/http/phpmoadmin_exec.rb
@@ -63,10 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body.include?(testrun)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/phpmyadmin_lfi_rce.rb
+++ b/modules/exploits/multi/http/phpmyadmin_lfi_rce.rb
@@ -64,12 +64,12 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path) })
     rescue
       vprint_error("#{peer} - Unable to connect to server")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.nil? || res.code != 200
       vprint_error("#{peer} - Unable to query /js/messages.php")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     # v4.8.0 || 4.8.1 phpMyAdmin
@@ -78,13 +78,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("#{peer} - phpMyAdmin version: #{version}")
 
       if version == Rex::Version.new('4.8.0') || version == Rex::Version.new('4.8.1')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target is running a vulnerable version')
       end
 
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target version is not vulnerable')
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not connect to the target')
   end
 
   def query(uri, qstring, cookies, token)

--- a/modules/exploits/multi/http/phpmyadmin_null_termination_exec.rb
+++ b/modules/exploits/multi/http/phpmyadmin_null_termination_exec.rb
@@ -67,12 +67,12 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, '/js/messages.php') })
     rescue
       print_error("#{peer} - Unable to connect to server")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     if res.nil? || res.code != 200
       print_error("#{peer} - Unable to query /js/messages.php")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     # PHP 4.3.0-5.4.6
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
         version = Rex::Version.new($1)
         vprint_status("#{peer} - PHP version: #{version.to_s}")
         if version > Rex::Version.new('5.4.6')
-          return Exploit::CheckCode::Safe
+          return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
         end
       end
     else
@@ -98,15 +98,15 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("#{peer} - phpMyAdmin version: #{version.to_s}")
 
       if version >= Rex::Version.new('4.3.0') and version <= Rex::Version.new('4.6.2')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target is running a vulnerable version')
       elsif version < Rex::Version.new('4.3.0')
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
 
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not authenticate to the target')
   end
 
   def exploit

--- a/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
+++ b/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -67,12 +68,14 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, '/js/messages.php') })
     rescue
       vprint_error("Unable to connect to server.")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Failed to connect to the target.')
     end
+
+    return CheckCode::Unknown('No response received from the target') unless res
 
     if res.code != 200
       vprint_error("Unable to query /js/messages.php")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Unable to query /js/messages.php to determine version.')
     end
 
     php_version = res['X-Powered-By']
@@ -80,13 +83,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("PHP Version: #{php_version}")
       if php_version =~ /PHP\/(\d)\.(\d)\.(\d)/
         if $1.to_i > 5
-          return CheckCode::Safe
+          return CheckCode::Safe("PHP version #{php_version} is not vulnerable. Only PHP <= 5.4.6 supports preg_replace /e modifier.")
         else
           if $1.to_i == 5 and $2.to_i > 4
-            return CheckCode::Safe
+            return CheckCode::Safe("PHP version #{php_version} is not vulnerable. Only PHP <= 5.4.6 supports preg_replace /e modifier.")
           else
             if $1.to_i == 5 and $2.to_i == 4 and $3.to_i > 6
-              return CheckCode::Safe
+              return CheckCode::Safe("PHP version #{php_version} is not vulnerable. Only PHP <= 5.4.6 supports preg_replace /e modifier.")
             end
           end
         end
@@ -99,19 +102,19 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("phpMyAdmin version: #{$1}")
       case $1.downcase
       when '3.5.8.1', '4.0.0-rc3'
-        return CheckCode::Safe
+        return CheckCode::Safe("phpMyAdmin version #{$1} is patched.")
       when '4.0.0-alpha1', '4.0.0-alpha2', '4.0.0-beta1', '4.0.0-beta2', '4.0.0-beta3', '4.0.0-rc1', '4.0.0-rc2'
-        return CheckCode::Appears
+        return CheckCode::Appears("phpMyAdmin version #{$1} is vulnerable.")
       else
         if $1.starts_with? '3.5.'
-          return CheckCode::Appears
+          return CheckCode::Appears("phpMyAdmin version #{$1} appears vulnerable (3.5.x < 3.5.8.1).")
         end
 
-        return CheckCode::Detected
+        return CheckCode::Detected("phpMyAdmin detected but version #{$1} is not a known vulnerable version.")
       end
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Could not determine phpMyAdmin version.')
   end
 
   def exploit

--- a/modules/exploits/multi/http/phpscheduleit_start_date.rb
+++ b/modules/exploits/multi/http/phpscheduleit_start_date.rb
@@ -80,10 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
 
     if response.code == 200 and response.body =~ /#{signature}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body.to_s.include?(fingerprint)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -67,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
     uri << '/' if uri[-1, 1] != '/'
     res = send_request_raw({ 'uri' => uri })
     if res and res.body =~ /PHPTAX by William L\. Berggren/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/pimcore_unserialize_rce.rb
+++ b/modules/exploits/multi/http/pimcore_unserialize_rce.rb
@@ -201,14 +201,14 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from the target')
     end
 
     if res.code == 200 && res.headers =~ /pimcore/i || res.body =~ /pimcore/i
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe('Target does not appear to be Pimcore')
   end
 
   def exploit

--- a/modules/exploits/multi/http/playsms_filename_exec.rb
+++ b/modules/exploits/multi/http/playsms_filename_exec.rb
@@ -73,14 +73,14 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue
       vprint_error('Unable to access the index.php file')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if res.code == 302 && res.headers['Location'].include?('index.php?app=main&inc=core_auth&route=login')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def login

--- a/modules/exploits/multi/http/playsms_template_injection.rb
+++ b/modules/exploits/multi/http/playsms_template_injection.rb
@@ -73,14 +73,14 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue StandardError
       vprint_error('Unable to access the index.php file')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if res.code == 302 && res.headers['Location'].include?('index.php?app=main&inc=core_auth&route=login')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   # Send Payload in Login Request

--- a/modules/exploits/multi/http/playsms_uploadcsv_exec.rb
+++ b/modules/exploits/multi/http/playsms_uploadcsv_exec.rb
@@ -72,14 +72,14 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue
       vprint_error('Unable to access the index.php file')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if res.code == 302 && res.headers['Location'].include?('index.php?app=main&inc=core_auth&route=login')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   def login

--- a/modules/exploits/multi/http/plone_popen2.rb
+++ b/modules/exploits/multi/http/plone_popen2.rb
@@ -70,11 +70,11 @@ class MetasploitModule < Msf::Exploit::Remote
       }, 25
     )
     if (res.headers['Bobo-Exception-Type'].to_s =~ /zExceptions.BadRequest/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
     end
 
     # patched == zExceptions.NotFound
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target application was not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/http/pmwiki_pagelist.rb
+++ b/modules/exploits/multi/http/pmwiki_pagelist.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if (res and res.body =~ /pmwiki-2.[0.00-2.34]/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/polarcms_upload_exec.rb
+++ b/modules/exploits/multi/http/polarcms_upload_exec.rb
@@ -62,10 +62,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if !res or res.code != 200
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/processmaker_exec.rb
+++ b/modules/exploits/multi/http/processmaker_exec.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # login
     @cookie = "PHPSESSID=#{rand_text_alphanumeric(rand(10) + 10)};"
     unless login(datastore['USERNAME'], datastore['PASSWORD'])
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not authenticate to the target')
     end
 
     # send check
@@ -140,15 +140,15 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       res = execute_command("echo #{fingerprint}")
       if res and res.body =~ /#{fingerprint}/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('The target is vulnerable')
       elsif res
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   #

--- a/modules/exploits/multi/http/qdpm_authenticated_rce.rb
+++ b/modules/exploits/multi/http/qdpm_authenticated_rce.rb
@@ -71,20 +71,20 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = normalize_uri(uri, '/index.php')
     res = send_request_raw({ 'uri' => uri })
     if res.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from the target')
     end
 
     login_page = res.get_html_document
     begin
       version_num = login_page.at('div[@class="copyright"]').at('a').text.tr('qdPM ', '').to_f
     rescue StandardError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from the target')
     end
     version = Rex::Version.new(version_num)
     if version <= Rex::Version.new('9.1')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target is running a vulnerable version')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     if res and res.body =~ %r{<div id="footer">.+qdPM (\d)\.(\d).+</div>}m
       major = ::Regexp.last_match(1)
       minor = ::Regexp.last_match(2)
-      return Exploit::CheckCode::Appears if (major + minor).to_i <= 70
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response') if (major + minor).to_i <= 70
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def get_write_exec_payload(fname, _data)

--- a/modules/exploits/multi/http/rails_double_tap.rb
+++ b/modules/exploits/multi/http/rails_double_tap.rb
@@ -128,19 +128,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    check_code = CheckCode::Safe
+    check_code = CheckCode::Safe('The target is not vulnerable')
     app_name = get_application_name
-    check_code = CheckCode::Appears unless app_name.blank?
+    check_code = CheckCode::Appears('The target appears to be vulnerable') unless app_name.blank?
     test_payload = %Q|puts 1|
     rails_payload = generate_rails_payload(app_name, test_payload)
     result = send_serialized_payload(rails_payload)
-    check_code = CheckCode::Vulnerable if result
+    check_code = CheckCode::Vulnerable('The target is vulnerable') if result
     check_code
   rescue Msf::Exploit::Failed => e
     vprint_error(e.message)
     return check_code if e.message.to_s.include? NO_RAILS_ROOT_MSG
 
-    CheckCode::Unknown
+    CheckCode::Unknown('An error occurred while checking the target')
   end
 
   # Returns information about Rails.root if we retrieve an invalid path under rails.

--- a/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
+++ b/modules/exploits/multi/http/rails_dynamic_render_code_exec.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # if the page controller is dynamically rendering, its for sure vuln
     if res and res.body =~ /render params/
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('Successfully verified Rails dynamic render remote code execution condition')
     end
 
     # this is the check for the prod environment
@@ -92,10 +92,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # if we can read files, its likley we can execute code
     if res and res.body =~ /ruby/
-      return CheckCode::Appears
+      return CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/multi/http/rocket_servergraph_file_requestor_rce.rb
+++ b/modules/exploits/multi/http/rocket_servergraph_file_requestor_rce.rb
@@ -99,10 +99,10 @@ class MetasploitModule < Msf::Exploit::Remote
     os = get_os
 
     if os.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('The target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/roundcube_auth_rce_cve_2025_49113.rb
+++ b/modules/exploits/multi/http/roundcube_auth_rce_cve_2025_49113.rb
@@ -108,12 +108,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Extracted version: #{version}")
 
     if version.between?(Rex::Version.new(10100), Rex::Version.new(10509))
-      return CheckCode::Appears
+      return CheckCode::Appears('The target is running a vulnerable version')
     elsif version.between?(Rex::Version.new(10600), Rex::Version.new(10610))
-      return CheckCode::Appears
+      return CheckCode::Appears('The target is running a vulnerable version')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target version is not vulnerable')
   end
 
   def build_serialized_payload

--- a/modules/exploits/multi/http/rudder_server_sqli_rce.rb
+++ b/modules/exploits/multi/http/rudder_server_sqli_rce.rb
@@ -82,13 +82,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     version = get_version
-    return Exploit::CheckCode::Unknown if version.nil? || version == 'Unknown'
+    return Exploit::CheckCode::Unknown('No response received from the target') if version.nil? || version == 'Unknown'
 
     if Rex::Version.new('1.3.0-rc.1') > Rex::Version.new(version.gsub('v', ''))
       return Exploit::CheckCode::Appears("Rudder Version: #{version}")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def get_version

--- a/modules/exploits/multi/http/sflog_upload_exec.rb
+++ b/modules/exploits/multi/http/sflog_upload_exec.rb
@@ -66,11 +66,11 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_raw({ 'uri' => "#{base}/index.php" })
 
     if !res
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from the target')
     elsif res and res.body =~ %r{<input type="hidden" name="sitesearch" value="www\.thebonnotgang\.com/sflog}
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
+++ b/modules/exploits/multi/http/shopware_createinstancefromnamedarguments_rce.rb
@@ -234,12 +234,12 @@ class MetasploitModule < Msf::Exploit::Remote
     cookie = do_login
     if cookie.nil?
       vprint_error "Authentication was unsuccessful"
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
     csrf_token = leak_csrf(cookie)
     if csrf_token.nil?
       vprint_error "Unable to leak the CSRF token"
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
     res = send_request_cgi(
       'method' => 'GET',
@@ -248,10 +248,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => { 'X-CSRF-Token' => csrf_token }
     )
     if res.code == 200 && res.body =~ /Shop not found/i
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target application was not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -63,12 +63,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     test = Rex::Text.rand_text_alpha(8)
-    http_send_command(test)
+    res = http_send_command(test)
     if res && res.body =~ /#{test}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Backdoor command execution confirmed')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(cmd)

--- a/modules/exploits/multi/http/sit_file_upload.rb
+++ b/modules/exploits/multi/http/sit_file_upload.rb
@@ -77,13 +77,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("SiT! #{ver[0]}.#{ver[1]}")
 
       if (ver[0] == 3 and ver[1] == 65)
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("SiT! version #{ver[0]}.#{ver[1]} appears to be vulnerable")
       elsif (ver[0] == 3 and ver[1] < 65)
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("SiT! version #{ver[0]}.#{ver[1]} appears to be vulnerable")
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def retrieve_session(user, pass)

--- a/modules/exploits/multi/http/solarwinds_store_manager_auth_filter.rb
+++ b/modules/exploits/multi/http/solarwinds_store_manager_auth_filter.rb
@@ -62,10 +62,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body && res.body.to_s =~ /Upload Successful!!/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified the upload vulnerability')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -290,7 +290,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if @vuln_core.to_s == ''
         @vuln_core = possibly_vulnerable_cores.first
       end
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('Successfully verified remote code execution')
     end
   end
 

--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if install_path.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     if install_path.include?('\\')
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       vprint_status('Target looks like Linux')
     end
-    return Exploit::CheckCode::Vulnerable
+    return Exploit::CheckCode::Vulnerable('Successfully verified auth bypass and file upload vulnerability')
   end
 
   def exploit

--- a/modules/exploits/multi/http/sonicwall_scrutinizer_methoddetail_sqli.rb
+++ b/modules/exploits/multi/http/sonicwall_scrutinizer_methoddetail_sqli.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res = do_login
     rescue Msf::Exploit::Failed => e
       vprint_error(e.message)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not authenticate to the target')
     end
 
     uid = res['userid']
@@ -122,9 +122,9 @@ class MetasploitModule < Msf::Exploit::Remote
     pattern = Rex::Text.rand_text_alpha(10)
     sqli_str = "-6045 UNION ALL SELECT '#{pattern}',#{pad_null(19)}"
     res = do_sqli(sqli_str, sid, uid).get_json_document
-    return Exploit::CheckCode::Vulnerable if res['id'].to_s == pattern
+    return Exploit::CheckCode::Vulnerable('Successfully exploited SQL injection') if res['id'].to_s == pattern
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   # Returns the OS information by using @@version_compile_os.

--- a/modules/exploits/multi/http/spip_connect_exec.rb
+++ b/modules/exploits/multi/http/spip_connect_exec.rb
@@ -89,11 +89,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vulnerable_ranges.each do |range|
       if rversion.between?(Rex::Version.new(range[:start]), Rex::Version.new(range[:end]))
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The SPIP version is in the vulnerable range')
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The SPIP version is not in the vulnerable range')
   end
 
   def exploit

--- a/modules/exploits/multi/http/splunk_mappy_exec.rb
+++ b/modules/exploits/multi/http/splunk_mappy_exec.rb
@@ -110,9 +110,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res and res.body =~ /Splunk Inc\. Splunk 4\.[0-2]\.[0-4] build [\d+]/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -272,9 +272,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body =~ /Splunk Inc\. Splunk/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/spring_cloud_function_spel_injection.rb
+++ b/modules/exploits/multi/http/spring_cloud_function_spel_injection.rb
@@ -78,14 +78,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(datastore['TARGETURI'])
     )
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response received from the target, the service may be unavailable') unless res
 
     # both vulnerable and patched servers respond with 500 and a JSON body with these keys
-    return CheckCode::Safe unless res.code == 500
-    return CheckCode::Safe unless %w[timestamp path status error message].to_set.subset?(res.get_json_document&.keys&.to_set)
+    return CheckCode::Safe('The target appears to be patched') unless res.code == 500
+    return CheckCode::Safe('The target appears to be patched') unless %w[timestamp path status error message].to_set.subset?(res.get_json_document&.keys&.to_set)
 
     # best we can do is detect that the service is running
-    CheckCode::Detected
+    CheckCode::Detected('The target application was detected')
   end
 
   def exploit

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Appears(details: { method: method }) if res.code == 400
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target does not appear to be vulnerable to Spring4Shell')
   end
 
   def exploit

--- a/modules/exploits/multi/http/struts2_code_exec_showcase.rb
+++ b/modules/exploits/multi/http/struts2_code_exec_showcase.rb
@@ -86,13 +86,13 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       resp = send_struts_request(ognl)
     rescue Msf::Exploit::Failed
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if resp && resp.code == 200 && resp.body.include?("#{var_a}#{var_b}")
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Successfully executed the injected code')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/struts2_content_type_ognl.rb
+++ b/modules/exploits/multi/http/struts2_content_type_ognl.rb
@@ -78,14 +78,14 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       resp = send_struts_request(ognl)
     rescue Msf::Exploit::Failed
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if resp && resp.headers && resp.headers[var_a]
       vprint_good("Victim operating system: #{resp.headers[var_a]}")
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Successfully executed the injected code')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target appears to be patched')
     end
   end
 

--- a/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
@@ -89,12 +89,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(build_http_request(datastore['CVE'], "#{num1}*#{num2}"))
     if res.nil?
-      return CheckCode::Unknown
+      return CheckCode::Unknown('No response received from the target')
     elsif res.body.scan(/(["'])\s*#{(num1 * num2)}\s*\1/).empty?
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
-    return CheckCode::Appears
+    return CheckCode::Appears('The target appears to be vulnerable based on the response')
   end
 
   def exploit

--- a/modules/exploits/multi/http/struts2_namespace_ognl.rb
+++ b/modules/exploits/multi/http/struts2_namespace_ognl.rb
@@ -108,13 +108,13 @@ class MetasploitModule < Msf::Exploit::Remote
       if (output.include? '/true/')
         print_status("Target does *not* require enabling 'allowStaticMethodAccess'.  Setting ENABLE_STATIC to 'false'")
         datastore['ENABLE_STATIC'] = false
-        CheckCode::Vulnerable
+        CheckCode::Vulnerable('Successfully executed the injected code')
       elsif (output.include? '/false/')
         print_status("Target requires enabling 'allowStaticMethodAccess'.  Setting ENABLE_STATIC to 'true'")
         datastore['ENABLE_STATIC'] = true
-        CheckCode::Vulnerable
+        CheckCode::Vulnerable('Successfully executed the injected code')
       else
-        CheckCode::Safe
+        CheckCode::Safe('The target is not vulnerable')
       end
     elsif resp && resp.code == 400
       # METHOD 2: Generate two random numbers, ask the target to add them together.
@@ -131,9 +131,9 @@ class MetasploitModule < Msf::Exploit::Remote
         vprint_status("Redirected to:  #{resp.headers['Location']}")
         print_status("Target does *not* require enabling 'allowStaticMethodAccess'.  Setting ENABLE_STATIC to 'false'")
         datastore['ENABLE_STATIC'] = false
-        CheckCode::Vulnerable
+        CheckCode::Vulnerable('Successfully executed the injected code')
       else
-        CheckCode::Safe
+        CheckCode::Safe('The target is not vulnerable')
       end
     elsif resp.nil?
       fail_with(Failure::Unreachable, "Target did not respond.  Please double check RHOSTS and RPORT")

--- a/modules/exploits/multi/http/struts2_rest_xstream.rb
+++ b/modules/exploits/multi/http/struts2_rest_xstream.rb
@@ -100,9 +100,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Appears if execute_command(rand_str)
+    return CheckCode::Appears('The target appears to be vulnerable') if execute_command(rand_str)
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -196,11 +196,11 @@ class MetasploitModule < Msf::Exploit::Remote
     delta = t2 - t1
 
     if response.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     elsif delta < sleep_time
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     else
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     end
   end
 end

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil? or res.code != 200
       vprint_error("#{rhost}:#{rport} - Check needs a valid action, returning 200, as TARGETURI")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response received from the target')
     end
 
     proof = rand_text_alpha(rand(6..9))
@@ -153,10 +153,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 302 and res.headers['Location'] =~ /#{proof}/ and res.headers['Location'] !~ /String/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def auto_target

--- a/modules/exploits/multi/http/struts_dev_mode.rb
+++ b/modules/exploits/multi/http/struts_dev_mode.rb
@@ -67,16 +67,16 @@ class MetasploitModule < Msf::Exploit::Remote
     res = execute_command("new java.lang.Integer(#{addend_one}+#{addend_two})")
 
     if res and res.code == 200 and res.body.to_i == sum
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully executed the injected code')
     end
 
     if res and res.code == 200 and res.body.to_s =~ /#{sum}/
       vprint_status("Code got evaluated. Target seems vulnerable, but the response contains something else:")
       vprint_line(res.body.to_s)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/struts_dmi_exec.rb
+++ b/modules/exploits/multi/http/struts_dmi_exec.rb
@@ -168,13 +168,13 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       resp = send_http_request(payload, params_hash)
     rescue Msf::Exploit::Failed
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if resp && resp.code == 200 && resp.body.include?("#{flag}#{sum}#{flag}")
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Successfully verified remote code execution')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/struts_dmi_rest_exec.rb
+++ b/modules/exploits/multi/http/struts_dmi_rest_exec.rb
@@ -169,13 +169,13 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       resp = send_http_request(payload, params_hash)
     rescue Msf::Exploit::Failed
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if resp && resp.code == 200 && resp.body.include?("#{flag}#{sum}#{flag}")
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Successfully verified remote code execution')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/struts_include_params.rb
+++ b/modules/exploits/multi/http/struts_include_params.rb
@@ -193,11 +193,11 @@ class MetasploitModule < Msf::Exploit::Remote
     delta = t2 - t1
 
     if response.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     elsif delta < sleep_time
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     else
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully executed the injected code')
     end
   end
 end

--- a/modules/exploits/multi/http/stunshell_eval.rb
+++ b/modules/exploits/multi/http/stunshell_eval.rb
@@ -68,10 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     shell = send_request_cgi(request_parameters)
     if (shell and shell.body =~ /andalas_oku test parameter/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully executed the injected code')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(cmd)

--- a/modules/exploits/multi/http/stunshell_exec.rb
+++ b/modules/exploits/multi/http/stunshell_exec.rb
@@ -71,10 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     shell = send_request_cgi(request_parameters)
     if (shell and shell.body =~ /andalas_oku test parameter/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified webshell command execution')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(cmd)

--- a/modules/exploits/multi/http/subrion_cms_file_upload_rce.rb
+++ b/modules/exploits/multi/http/subrion_cms_file_upload_rce.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def login_and_get_csrf_token(username, password)

--- a/modules/exploits/multi/http/sun_jsws_dav_options.rb
+++ b/modules/exploits/multi/http/sun_jsws_dav_options.rb
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
     info = http_fingerprint({ response: res }) # check method
     if (info =~ /Sun/)
       print_status("Found server: #{info}")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/sysaid_auth_file_upload.rb
+++ b/modules/exploits/multi/http/sysaid_auth_file_upload.rb
@@ -79,13 +79,13 @@ class MetasploitModule < Msf::Exploit::Remote
       major = ::Regexp.last_match(1).to_i
       minor = ::Regexp.last_match(2).to_i
       if major == 14 && minor == 4
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
       elsif major > 14
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     end
     # Haven't tested in versions < 14.4, so we don't know if they are vulnerable or not
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('An error occurred while checking the target')
   end
 
   def authenticate

--- a/modules/exploits/multi/http/sysaid_rdslogs_file_upload.rb
+++ b/modules/exploits/multi/http/sysaid_rdslogs_file_upload.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Received an unexpected response from the target')
   end
 
   def send_payload(war_payload, tomcat_path, app_base)

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -80,24 +80,24 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(base, "login.php")
       })
 
-      return Exploit::CheckCode::Unknown if res.nil?
+      return Exploit::CheckCode::Unknown('No response received from the target') if res.nil?
 
       if res
         if res.code == 200
           if res.body =~ /<p><img alt="Company logo" title="logo" style="width: 115px; height: 53px;"\s+src="[^"]+" \/>\s+<br \/>TestLink 1\.9\.3/
-            return Exploit::CheckCode::Appears
+            return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
           end
         end
       end
 
-      return Exploit::CheckCode::Detected if res and res.body =~ /TestLink project <a href="http:\/\/testlink\.sourceforge\.net\/docs\/testLink\.php">Home<\/a><br \/>/
+      return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable') if res and res.body =~ /TestLink project <a href="http:\/\/testlink\.sourceforge\.net\/docs\/testLink\.php">Home<\/a><br \/>/
 
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def upload(base, fname, file)

--- a/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
+++ b/modules/exploits/multi/http/tomcat_jsp_upload_bypass.rb
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, "#{testurl}.jsp/"),
         'method' => 'DELETE'
       )
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified JSP upload bypass vulnerability')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -127,17 +127,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = query_serverinfo
     disconnect
-    return CheckCode::Unknown if res.nil?
+    return CheckCode::Unknown('Could not connect to the target') if res.nil?
 
     if (res.code.between?(400, 499))
       vprint_error("Server rejected the credentials")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Server rejected the provided credentials')
     end
 
     store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
 
     vprint_status("Target is #{detect_platform(res.body)} #{detect_arch(res.body)}")
-    return CheckCode::Appears
+    return CheckCode::Appears('The target appears to be vulnerable based on the response')
   end
 
   def auto_target

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -120,29 +120,29 @@ class MetasploitModule < Msf::Exploit::Remote
     res = query_manager
     disconnect
 
-    return CheckCode::Unknown if res.nil?
+    return CheckCode::Unknown('Could not connect to the target') if res.nil?
 
     if res.code.between?(400, 499)
       vprint_error("Server rejected the credentials")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Server rejected the provided credentials')
     end
 
-    return CheckCode::Safe unless res.code == 200
+    return CheckCode::Safe('The target is not vulnerable') unless res.code == 200
 
     # if res.code == 200
     #   there should be access to the Tomcat Manager and to the status page
     res = query_status
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('Could not connect to the target') unless res
 
     plat = detect_platform(res.body)
     arch = detect_arch(res.body)
-    return CheckCode::Unknown unless plat and arch
+    return CheckCode::Unknown('Could not determine platform or architecture from target') unless plat and arch
 
     vprint_status("Tomcat Manager found running on #{plat} platform and #{arch} architecture")
 
     store_valid_credential(user: datastore['HttpUsername'], private: datastore['HttpPassword'])
 
-    return CheckCode::Appears
+    return CheckCode::Appears('The target appears to be vulnerable based on the response')
   end
 
   def exploit

--- a/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
+++ b/modules/exploits/multi/http/tomcat_partial_put_deserialization.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       upload_session_id = upload_payload('')
       unless upload_session_id
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     rescue Msf::Exploit::Failed => e
       return CheckCode::Safe(e)
@@ -95,10 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     trigger_res = trigger_payload(upload_session_id)
     if trigger_res&.code != 500
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('Successfully verified the upload vulnerability')
   end
 
   def exploit

--- a/modules/exploits/multi/http/torchserver_cve_2023_43654.rb
+++ b/modules/exploits/multi/http/torchserver_cve_2023_43654.rb
@@ -63,14 +63,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'api-description'))
-    return Exploit::CheckCode::Unknown unless res
-    return Exploit::CheckCode::Safe unless res.code == 200
+    return Exploit::CheckCode::Unknown('No response received from the target') unless res
+    return Exploit::CheckCode::Safe('The target is not vulnerable') unless res.code == 200
     unless res.get_json_document.dig('info', 'title') == 'TorchServe APIs'
       return Exploit::CheckCode::Safe('The TorchServe API was not detected on the target.')
     end
 
     version = res.get_json_document.dig('info', 'version')
-    return Exploit::CheckCode::Detected unless version.present?
+    return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable') unless version.present?
 
     unless Rex::Version.new(version) < Rex::Version.new('8.0.2')
       return Exploit::CheckCode::Safe("Version #{version} is patched.")

--- a/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
+++ b/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    code = CheckCode::Safe
+    code = CheckCode::Safe('The target is not vulnerable')
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -99,14 +99,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('Connection timed out')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
 
     # If the admin's login page is visited too many times, we will start getting
     # a 401 (unauthorized response). In that case, we only have a header to work
     # with.
     if res.headers['X-Powered-By'].to_s == 'Total.js'
-      code = CheckCode::Detected
+      code = CheckCode::Detected('The target application was detected but requires authentication')
     end
 
     # If we are here, then that means we can still see the login page.
@@ -124,10 +124,10 @@ class MetasploitModule < Msf::Exploit::Remote
       # If we are able to check the version, we could try the default cred and attempt
       # to execute malicious code and see how the application responds. However, this
       # seems to a bit too aggressive so I'll leave that to the exploit part.
-      return CheckCode::Appears
+      return CheckCode::Appears('The target is running a vulnerable version')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target version is not vulnerable')
   end
 
   def auth(user, pass)

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -70,10 +70,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if (res and res.body =~ /Powered by Traq 2.[0-3]/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
+++ b/modules/exploits/multi/http/trendmicro_threat_discovery_admin_sys_time_cmdi.rb
@@ -85,11 +85,11 @@ class MetasploitModule < Msf::Exploit::Remote
         version = "#{$1}" if res.body =~ /var ver_str = new String\("(.*)"\)/
         case version
         when /2.6.1062/
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable('Successfully verified command injection vulnerability')
         end
       end
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
+++ b/modules/exploits/multi/http/ubiquiti_unifi_log4shell.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('No HTTP response was received.') if res.nil?
 
     wait_until { @search_received }
-    @search_received ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Unknown('No LDAP search query was received.')
+    @search_received ? Exploit::CheckCode::Vulnerable('The target is running a vulnerable version') : Exploit::CheckCode::Unknown('No LDAP search query was received.')
   ensure
     cleanup_service
   end

--- a/modules/exploits/multi/http/uptime_file_upload_1.rb
+++ b/modules/exploits/multi/http/uptime_file_upload_1.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 500 and res.body.to_s =~ /<title><\/title>/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/uptime_file_upload_2.rb
+++ b/modules/exploits/multi/http/uptime_file_upload_2.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error("Connection timed out.")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not connect to the target')
     end
 
     n = Nokogiri::HTML(res.body)
@@ -102,11 +102,11 @@ class MetasploitModule < Msf::Exploit::Remote
       version = uptime_text.text.scan(/up\.time ([\d\.]+)/i).flatten.first
       vprint_status("Found version: #{version}")
       if version >= '7.4.0' && version <= '7.5.0'
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def create_exec_service(*args)

--- a/modules/exploits/multi/http/v0pcr3w_exec.rb
+++ b/modules/exploits/multi/http/v0pcr3w_exec.rb
@@ -68,10 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     if (shell and shell.body =~ /v0pCr3w<br>/ and shell.body =~ /<br>nob0dyCr3w/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified webshell command execution')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(cmd)

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if response.code == 200 and response.body =~ /#{flag}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -477,21 +477,21 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'js', 'login.js')
     })
 
-    return CheckCode::Unknown unless res && res.code == 200
+    return CheckCode::Unknown('No response received from the target') unless res && res.code == 200
 
-    return CheckCode::Safe if res.body.to_s =~ /vBulletin 5\.6\.1 Patch Level 1/
+    return CheckCode::Safe('The target appears to be patched') if res.body.to_s =~ /vBulletin 5\.6\.1 Patch Level 1/
 
     if res.body.to_s =~ /vBulletin ([.0-9]+)/
       if Rex::Version.new(Regexp.last_match(1)) > Rex::Version.new('5.6.1')
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not running a vulnerable version')
       elsif Rex::Version.new(Regexp.last_match(1)) > Rex::Version.new('5.0.0')
-        return CheckCode::Appears
+        return CheckCode::Appears('The target is running a vulnerable version')
       end
 
-      return CheckCode::Detected
+      return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   # Performs all exploit functionality

--- a/modules/exploits/multi/http/vbulletin_replace_ad_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_replace_ad_template_rce.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     vprint_status("Starting vulnerability check on #{rhost}:#{rport}#{target_uri.path}")
-    inject_and_trigger(:check) ? CheckCode::Vulnerable : CheckCode::Safe
+    inject_and_trigger(:check) ? CheckCode::Vulnerable('Successfully executed the injected code') : CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/vbulletin_unserialize.rb
+++ b/modules/exploits/multi/http/vbulletin_unserialize.rb
@@ -61,16 +61,16 @@ class MetasploitModule < Msf::Exploit::Remote
       if (res && res.body.include?('vBulletin Solutions, Inc.'))
         if res.body.include?("Version 5.0")
           @my_target = targets[1] if target['auto']
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
         elsif res.body.include?("Version 5.1")
           @my_target = targets[2] if target['auto']
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('The target appears to be a vulnerable version')
         else
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
         end
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
     end
   end
 

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -113,10 +113,10 @@ class MetasploitModule < Msf::Exploit::Remote
     rand_str = Rex::Text.rand_text_alpha(8)
     received = execute_command(cmd_payload("echo #{rand_str}"))
     if received && received.body.include?(rand_str)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/vbulletin_widgetconfig_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widgetconfig_rce.rb
@@ -111,10 +111,10 @@ class MetasploitModule < Msf::Exploit::Remote
     rand_str = Rex::Text.rand_text_alpha(8)
     received = execute_command(cmd_payload("echo #{rand_str}"))
     if received && received.body.include?(rand_str)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
+++ b/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
@@ -76,9 +76,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body && res.body.to_s.include?(SIGNATURE)
-      Exploit::CheckCode::Detected
+      Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/vmware_vcenter_log4shell.rb
+++ b/modules/exploits/multi/http/vmware_vcenter_log4shell.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     validate_configuration!
 
-    return Exploit::CheckCode::Unknown if tenant.nil?
+    return Exploit::CheckCode::Unknown('Could not determine tenant from the target; the target may have returned an unexpected redirect') if tenant.nil?
 
     super
   end

--- a/modules/exploits/multi/http/vtiger_logo_upload_exec.rb
+++ b/modules/exploits/multi/http/vtiger_logo_upload_exec.rb
@@ -72,24 +72,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error("Unable to access the index.php file")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
     unless res.code == 200
       vprint_error("Error accessing the index.php file")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('An error occurred while checking the target')
     end
 
     if res.body =~ /<small> Powered by vtiger CRM (.*.0)<\/small>/i
       vprint_status("vTiger CRM version: #{$1}")
       if $1 == '6.3.0'
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable('The target is running a vulnerable version')
       else
-        return CheckCode::Detected
+        return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   # Login Function.

--- a/modules/exploits/multi/http/vtiger_php_exec.rb
+++ b/modules/exploits/multi/http/vtiger_php_exec.rb
@@ -62,25 +62,25 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, '/index.php') })
     rescue
       vprint_error("Unable to access the index.php file")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('No response received from the target')
     end
 
     if res and res.code != 200
       vprint_error("Error accessing the index.php file")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Unexpected HTTP response status from the target')
     end
 
     if res.body =~ /<div class="poweredBy">Powered by vtiger CRM - (.*)<\/div>/i
       vprint_status("vTiger CRM version: " + $1)
       case $1
       when '5.4.0', '5.3.0'
-        return CheckCode::Appears
+        return CheckCode::Appears('The target appears to be a vulnerable version')
       else
-        return CheckCode::Detected
+        return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable')
       end
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/vtiger_soap_upload.rb
+++ b/modules/exploits/multi/http/vtiger_soap_upload.rb
@@ -74,17 +74,17 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_soap_request(test_one)
 
     unless res and res.code == 200 and res.body.to_s =~ /<return xsi:nil="true" xsi:type="xsd:string"\/>/
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unexpected SOAP response from the target')
     end
 
     test_two = check_email_soap("admin")
     res = send_soap_request(test_two)
 
     if res and res.code == 200 and (res.body.blank? or res.body.to_s =~ /<return xsi:type="xsd:string">.*<\/return>/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('The target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -155,12 +155,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(datastore['URI']),
       'method' => 'OPTIONS'
     }.merge(res_creds), 10)
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('No response received from the target') unless res
 
     unless res.code == 200
       print_error "Target responded: HTTP #{res.code}, should be 200"
       print_res_code(res, res_creds)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown("Target responded with unexpected HTTP status #{res.code}")
     end
 
     # Record results!
@@ -171,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_raw({
       'uri' => test_url
     }.merge(res_creds), 10)
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('No response received from the target') unless res
     return Exploit::CheckCode::Unknown("The test file may already exists (HTTP #{res.code})") unless res.code == 404 # Need to try again with a different file
 
     # Try to create it
@@ -181,13 +181,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'PUT',
       'data' => payload
     }.merge(res_creds), 10)
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('No response received from the target') unless res
 
     ## Often its HTTP 201
     unless res.code.to_i.between?(200, 299)
       print_error "Error with upload request (HTTP #{res.code}, should be 2xx)"
       print_res_code(res, res_creds)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown("Upload request failed with HTTP status #{res.code}")
     end
 
     # Record results!
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => test_url
     }.merge(res_creds))
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('An error occurred while checking the target') unless res
     return Exploit::CheckCode::Safe("Error with exploit request (HTTP #{res.code}, should be 2xx)") unless res.code.to_i.between?(200, 299)
     return Exploit::CheckCode::Safe("Error with exploit request (Response doesn't match payload) - Missing PHP?") unless res.body.to_s.include?(payload)
 
@@ -208,13 +208,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => test_url,
       'method' => 'DELETE'
     }.merge(res_creds), 10)
-    return Exploit::CheckCode::Unknown unless res
+    return Exploit::CheckCode::Unknown('An error occurred while checking the target') unless res
 
     # Exploit uses cmd to delete via file system, not HTTP DELETE request
     print_warning "Error with delete request (HTTP #{res.code}, should be 204) - Can't clean up" unless res.code == 204
 
     # Done
-    return Exploit::CheckCode::Vulnerable
+    return Exploit::CheckCode::Vulnerable('The target is vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/webnms_file_upload.rb
+++ b/modules/exploits/multi/http/webnms_file_upload.rb
@@ -78,9 +78,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     )
     if res && res.code == 405
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Received an unexpected response from the target')
     end
   end
 

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -71,10 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res1 and res1.body =~ /WebPagetest \- Website Performance and Optimization Test/ and
        res2 and res2.code == 200
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable based on the response')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def on_new_session(cli)

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -73,9 +73,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.body =~ /Powered by WikkaWiki/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/http/wp_acf_extended_rce.rb
+++ b/modules/exploits/multi/http/wp_acf_extended_rce.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     plugin_check = check_plugin_version_from_readme('acf-extended', '0.9.2', '0.9.0.5')
     return plugin_check if plugin_check == CheckCode::Safe
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @nonce = find_nonce
     return CheckCode::Unknown('Could not find nonce on specified page') unless @nonce
 
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_ai_engine_mcp_rce.rb
+++ b/modules/exploits/multi/http/wp_ai_engine_mcp_rce.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     plugin_check = check_plugin_version_from_readme('ai-engine', '3.1.4')
     return plugin_check if plugin_check == CheckCode::Safe
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @token = find_token
     return CheckCode::Safe('MCP token not found. Plugin may be patched or not configured.') unless @token
 
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_ait_csv_rce.rb
+++ b/modules/exploits/multi/http/wp_ait_csv_rce.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     # no readme file, just a changelog so we need the version from there
     changelog = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'ait-csv-import-export', 'changelog.txt')

--- a/modules/exploits/multi/http/wp_automatic_sqli_to_rce.rb
+++ b/modules/exploits/multi/http/wp_automatic_sqli_to_rce.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('Target does not appear to be running WordPress') unless wordpress_and_online?
 
     print_status('Attempting SQLi test to verify vulnerability...')
 

--- a/modules/exploits/multi/http/wp_backup_migration_php_filter.rb
+++ b/modules/exploits/multi/http/wp_backup_migration_php_filter.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     wp_version = wordpress_version
     print_status("WordPress Version: #{wp_version}") if wp_version
@@ -85,12 +85,12 @@ class MetasploitModule < Msf::Exploit::Remote
     check_code = check_plugin_version_from_readme('backup-backup', '1.3.8')
 
     if check_code.code != 'appears'
-      return CheckCode::Safe
+      return CheckCode::Safe('The target version is not vulnerable')
     end
 
     plugin_version = check_code.details[:version]
     print_good("Detected Backup Migration Plugin version: #{plugin_version}")
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_bricks_builder_rce.rb
+++ b/modules/exploits/multi/http/wp_bricks_builder_rce.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     theme_version = theme_check_code.details[:version]
     print_good("Detected Bricks Builder theme version: #{theme_version}")
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
 end

--- a/modules/exploits/multi/http/wp_crop_rce.rb
+++ b/modules/exploits/multi/http/wp_crop_rce.rb
@@ -60,11 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     cookie = wordpress_login(username, password)
     if cookie.nil?
-      store_valid_credential(user: username, private: password, proof: cookie)
-      return CheckCode::Safe
+      return CheckCode::Unknown('Failed to authenticate with the provided credentials')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be running a vulnerable version of the plugin')
   end
 
   def username

--- a/modules/exploits/multi/http/wp_db_backup_rce.rb
+++ b/modules/exploits/multi/http/wp_db_backup_rce.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     changelog_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-database-backup', 'readme.txt')
     res = send_request_cgi(
@@ -85,12 +85,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200
       version = res.body.match(/=+\s(\d+\.\d+)\.?\d*\s=/)
-      return CheckCode::Detected unless version && version.length > 1
+      return CheckCode::Detected('The target application was detected but the version could not be confirmed as vulnerable') unless version && version.length > 1
 
       vprint_status("Version of wp-database-backup detected: #{version[1]}")
-      return CheckCode::Appears if Rex::Version.new(version[1]) < Rex::Version.new('5.2')
+      return CheckCode::Appears('The target is running a vulnerable version') if Rex::Version.new(version[1]) < Rex::Version.new('5.2')
     end
-    CheckCode::Safe
+    CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_dnd_mul_file_rce.rb
+++ b/modules/exploits/multi/http/wp_dnd_mul_file_rce.rb
@@ -88,9 +88,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return check_plugin_version_from_readme('drag-and-drop-multiple-file-upload-contact-form-7', '1.3.4', '1')
     rescue ::Rex::ConnectionError
       vprint_error('Could not connect to the web service')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not connect to the target')
     end
-    CheckCode::Safe
+    CheckCode::Safe('The target version is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     # check the plugin version from readme
     check_plugin_version_from_readme('wp-file-manager', '6.9', '6.0')

--- a/modules/exploits/multi/http/wp_givewp_rce.rb
+++ b/modules/exploits/multi/http/wp_givewp_rce.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     print_status("WordPress Version: #{wordpress_version}") if wordpress_version
 
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if detected_version.nil?
       print_warning('Unable to determine the GiveWP plugin version.')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('No response received from the target')
     end
 
     detected_version = Rex::Version.new(detected_version)
@@ -87,16 +87,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if detected_version < Rex::Version.new('3.14.2')
       print_good('Vulnerable to both CVE-2024-5932 and CVE-2024-8353 (bypass).')
-      return CheckCode::Appears
+      return CheckCode::Appears('The target is running a vulnerable version')
     end
 
     if detected_version < Rex::Version.new('3.16.2')
       print_good('Vulnerable to CVE-2024-8353 (bypass).')
-      return CheckCode::Appears
+      return CheckCode::Appears('The target is running a vulnerable version')
     end
 
     print_status("GiveWP Plugin version #{detected_version} is not vulnerable.")
-    CheckCode::Safe
+    CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_hash_form_rce.rb
+++ b/modules/exploits/multi/http/wp_hash_form_rce.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe("Hash Form plugin is version: #{plugin_version}, which is not vulnerable.") unless plugin_check_code.code == CheckCode::Appears.code
 
     print_good("Detected Hash Form plugin version: #{plugin_version}")
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_king_addons_privilege_escalation.rb
+++ b/modules/exploits/multi/http/wp_king_addons_privilege_escalation.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('Target does not appear to be running WordPress') unless wordpress_and_online?
 
     plugin_check = check_plugin_version_from_readme('king-addons', '51.1.35', '24.12.92')
     return plugin_check if plugin_check == CheckCode::Safe
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @nonce = find_nonce
     return CheckCode::Detected('Could not find nonce on specified page') unless @nonce
 
-    CheckCode::Appears
+    CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if check_code
       return check_code
     else
-      return CheckCode::Safe
+      return CheckCode::Safe('The target version is not vulnerable')
     end
   end
 
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       version = Rex::Version.new($1)
       if version <= Rex::Version.new('1.0')
         vprint_status("Plugin version found: #{version}")
-        return CheckCode::Appears
+        return CheckCode::Appears('The plugin version is vulnerable')
       end
     end
 
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200
       vprint_status('Upload folder for wp-responsive-images-thumbnail-slider detected')
-      return CheckCode::Detected
+      return CheckCode::Detected('The plugin upload folder was detected')
     end
 
     nil

--- a/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
+++ b/modules/exploits/multi/http/wp_royal_elementor_addons_rce.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('The target does not appear to be running WordPress') unless wordpress_and_online?
 
     wp_version = wordpress_version
     print_status("WordPress Version: #{wp_version}") if wp_version
@@ -56,12 +56,12 @@ class MetasploitModule < Msf::Exploit::Remote
     check_code = check_plugin_version_from_readme('royal-elementor-addons', '1.3.79')
 
     if check_code.code != 'appears'
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not running a vulnerable version')
     end
 
     plugin_version = check_code.details[:version]
     print_good("Detected Royal Elementor Addons version: #{plugin_version}")
-    return CheckCode::Appears
+    return CheckCode::Appears('The target appears to be a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wp_simple_file_list_rce.rb
+++ b/modules/exploits/multi/http/wp_simple_file_list_rce.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown('Could not connect to the target') unless wordpress_and_online?
 
     # check the plugin version from readme
     check_plugin_version_from_readme('simple-file-list', '4.2.3', '1.0.1')

--- a/modules/exploits/multi/http/wp_user_registration_membership_escalation.rb
+++ b/modules/exploits/multi/http/wp_user_registration_membership_escalation.rb
@@ -97,14 +97,14 @@ class MetasploitModule < Msf::Exploit::Remote
       if version
         detected = Rex::Version.new(version)
         print_good("Detected #{slug} version #{detected}")
-        return CheckCode::Appears if detected < Rex::Version.new(fixed_version)
+        return CheckCode::Appears('The target is running a vulnerable version') if detected < Rex::Version.new(fixed_version)
       else
         print_warning("Unable to determine #{slug} version")
       end
     end
 
     print_status('No vulnerable plugin versions detected')
-    CheckCode::Safe
+    CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/multi/http/wso2_api_manager_file_upload_rce.rb
+++ b/modules/exploits/multi/http/wso2_api_manager_file_upload_rce.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
       authenticate
     rescue Msf::Exploit::Failed => e
       vprint_error(e.message)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not authenticate to the target')
     end
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'services', 'Version'),
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    return CheckCode::Unknown unless res&.code == 200 && res&.headers&.[]('Server') =~ /WSO2/
+    return CheckCode::Unknown('Target did not respond as expected; it may not be running WSO2 API Manager') unless res&.code == 200 && res&.headers&.[]('Server') =~ /WSO2/
 
     xml = res.get_xml_document
     xml.at_xpath('//return').text.match(/WSO2 API Manager-((?:\d\.){2}(?:\d))$/)

--- a/modules/exploits/multi/http/wso2_file_upload_rce.rb
+++ b/modules/exploits/multi/http/wso2_file_upload_rce.rb
@@ -79,9 +79,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.headers['Server'] && res.headers['Server'] =~ /WSO2/
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('The target appears vulnerable based on response headers')
     else
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Unknown('Received an unexpected response from the target')
     end
   end
 

--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = exec_php('phpinfo(); die();', true)
 
     if res && res.body =~ /This program makes use of the Zend/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('PHP code execution confirmed via preg_replace')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not verify PHP code execution on the target')
     end
   end
 

--- a/modules/exploits/multi/http/xerte_authenticated_rce_uploadimage.rb
+++ b/modules/exploits/multi/http/xerte_authenticated_rce_uploadimage.rb
@@ -84,12 +84,12 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     if res&.code == 200
       if res.body.include?('No valid language definition found in the file!')
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Successfully verified authenticated file upload RCE vulnerability')
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def trigger_payload

--- a/modules/exploits/multi/http/xerte_unauthenticated_importlanguage.rb
+++ b/modules/exploits/multi/http/xerte_unauthenticated_importlanguage.rb
@@ -61,12 +61,12 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     if res&.code == 200
       if res.body.include?('No valid language definition found in the file!')
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Successfully verified unauthenticated file upload vulnerability')
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(_cmd)

--- a/modules/exploits/multi/http/xerte_unauthenticated_template_import_rce.rb
+++ b/modules/exploits/multi/http/xerte_unauthenticated_template_import_rce.rb
@@ -66,12 +66,12 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     if res&.code == 200
       if res.body.include?('No valid language definition found in the file!')
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Successfully verified arbitrary file upload vulnerability')
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('The target is not vulnerable')
       end
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(_cmd)

--- a/modules/exploits/multi/http/zabbix_script_exec.rb
+++ b/modules/exploits/multi/http/zabbix_script_exec.rb
@@ -94,10 +94,10 @@ class MetasploitModule < Msf::Exploit::Remote
     resp = execute_script(auth_token, host_id, script_id)
 
     if resp.get_json_document.dig('result', 'value').gsub("\n", '') == str
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified code execution on the target')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target version is not vulnerable')
   end
 
   def send_json_api_request(method, auth_token = nil, params = {})

--- a/modules/exploits/multi/http/zemra_panel_rce.rb
+++ b/modules/exploits/multi/http/zemra_panel_rce.rb
@@ -62,12 +62,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     txt = Rex::Text.rand_text_alpha(8)
-    http_send_command(txt)
+    res = http_send_command(txt)
     if res && res.body =~ /cmd/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully verified remote command execution vulnerability')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def http_send_command(cmd)

--- a/modules/exploits/multi/http/zenworks_configuration_management_upload.rb
+++ b/modules/exploits/multi/http/zenworks_configuration_management_upload.rb
@@ -70,10 +70,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body.to_s =~ /ZENworks File Upload Servlet/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def upload_war_and_exec(tomcat_path)

--- a/modules/exploits/multi/http/zenworks_control_center_upload.rb
+++ b/modules/exploits/multi/http/zenworks_control_center_upload.rb
@@ -80,11 +80,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/zenworks/jsp/fw/internal/Login.jsp'
     })
 
-    if res and res.code == 200 and res.body =~ /Novell ZENworks Control Center/
-      return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Unknown('No response received from the target') unless res
+
+    if res.code == 200 and res.body =~ /Novell ZENworks Control Center/
+      return Exploit::CheckCode::Detected('The target application was detected but requires authentication')
     end
 
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Safe('The target does not appear to be running ZENworks Control Center')
   end
 
   def exploit


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical