### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/multi/elasticsearch/script_mvel_rce.rb
+++ b/modules/exploits/multi/elasticsearch/script_mvel_rce.rb
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    result = Exploit::CheckCode::Safe
+    result = Exploit::CheckCode::Safe('Elasticsearch does not appear to be vulnerable')
 
     if vulnerable?
-      result = Exploit::CheckCode::Vulnerable
+      result = Exploit::CheckCode::Vulnerable('Arbitrary Java execution confirmed via MVEL scripting')
     end
 
     result

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -58,10 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    result = Exploit::CheckCode::Safe
+    result = Exploit::CheckCode::Safe('Elasticsearch does not appear to be vulnerable')
 
     if vulnerable?
-      result = Exploit::CheckCode::Vulnerable
+      result = Exploit::CheckCode::Vulnerable('Arbitrary Java execution confirmed via Groovy scripting')
     end
 
     result

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -85,17 +85,17 @@ class MetasploitModule < Msf::Exploit::Remote
     command = "echo auth_ok:1; echo uid:#{random_id}; echo gid:#{random_id}; echo dir:/tmp; echo end"
     if send_command(username, command) =~ /^2\d\d ok./i
       disconnect
-      return CheckCode::Safe if banner !~ /pure-ftpd/i
+      return CheckCode::Safe('Target does not appear to be running Pure-FTPd') if banner !~ /pure-ftpd/i
 
       command = "echo auth_ok:0; echo end"
       if send_command(username, command) =~ /^5\d\d login authentication failed/i
         disconnect
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable('Pure-FTPd bash environment variable injection confirmed')
       end
     end
     disconnect
 
-    CheckCode::Safe
+    CheckCode::Safe('Pure-FTPd not vulnerable to bash environment variable injection')
   end
 
   def execute_command(cmd, _opts)

--- a/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
+++ b/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
@@ -120,21 +120,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # We just want the banner to check against our targets..
     vprint_status("FTP Banner: #{banner.strip}")
-    status = Exploit::CheckCode::Safe
+    status = Exploit::CheckCode::Safe('WU-FTPD not detected or version is not vulnerable')
     if banner =~ /Version wu-2\.(4|5)/
-      status = Exploit::CheckCode::Appears
+      status = Exploit::CheckCode::Appears('WU-FTPD 2.x version detected')
     elsif banner =~ /Version wu-2\.6\.0/
-      status = Exploit::CheckCode::Appears
+      status = Exploit::CheckCode::Appears('WU-FTPD 2.6.0 detected')
     end
 
     # If we've made it this far, we care if login succeeded.
     if (ret)
       # NOTE: vulnerable and exploitable might not mean the same thing here :)
       if not fmtstr_detect_vulnerable
-        status = Exploit::CheckCode::Safe
+        status = Exploit::CheckCode::Safe('Format string vulnerability not detected')
       end
       if not fmtstr_detect_exploitable
-        status = Exploit::CheckCode::Safe
+        status = Exploit::CheckCode::Safe('Format string vulnerability not exploitable')
       end
     end
 

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -118,14 +118,12 @@ class MetasploitModule < Msf::Exploit::Local
         user = cmd_exec('id -un')
         unless exist?("/var/run/console/#{user}")
           vprint_error("No console lock for #{user}")
-          return CheckCode::Safe
+          return CheckCode::Safe("No console lock for #{user}")
         end
         vprint_good("Console lock for #{user}")
       end
 
       return CheckCode::Safe('SELinux is enforcing') if selinux_installed? && selinux_enforcing?
-
-      vprint_good('SELinux is not an issue')
     end
 
     # suid program check
@@ -148,16 +146,16 @@ class MetasploitModule < Msf::Exploit::Local
       v = Rex::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
       unless v.between?(Rex::Version.new('1.19.0'), Rex::Version.new('1.20.2'))
         vprint_error "Xorg version #{v} not supported"
-        return CheckCode::Safe
+        return CheckCode::Safe("Xorg version #{v} is not in the vulnerable range")
       end
     elsif x_version.include?('Fatal server error')
       vprint_error 'User probably does not have console auth'
       vprint_error 'Below is Xorg -version output'
       vprint_error x_version
-      return CheckCode::Safe
+      return CheckCode::Safe('User does not have console auth')
     else
       vprint_warning('Could not parse Xorg -version output')
-      return CheckCode::Appears
+      return CheckCode::Appears('Could not parse Xorg version, but Xorg is SUID')
     end
     vprint_good("Xorg version #{v} is vulnerable")
 
@@ -165,10 +163,10 @@ class MetasploitModule < Msf::Exploit::Local
     proc_list = cmd_exec 'ps ax'
     if proc_list.include?('/X ')
       vprint_warning('Xorg in process list')
-      return CheckCode::Appears
+      return CheckCode::Appears("Xorg version #{v} is vulnerable but Xorg is already running")
     end
     vprint_good('Xorg does not appear running')
-    return CheckCode::Vulnerable
+    return CheckCode::Vulnerable("Xorg version #{v} is vulnerable and not currently running")
   end
 
   def on_new_session(session)

--- a/modules/exploits/multi/local/xorg_x11_suid_server_modulepath.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server_modulepath.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Local
         user = cmd_exec('id -un')
         unless exist?("/var/run/console/#{user}")
           vprint_error("No console lock for #{user}")
-          return CheckCode::Safe
+          return CheckCode::Safe("No console lock for #{user}")
         end
         vprint_good("Console lock for #{user}")
       end
@@ -132,10 +132,10 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_error 'User probably does not have console auth'
       vprint_error 'Below is Xorg -version output'
       vprint_error x_version
-      return CheckCode::Safe
+      return CheckCode::Safe('User does not have console auth')
     else
       vprint_warning('Could not parse Xorg -version output')
-      return CheckCode::Appears
+      return CheckCode::Appears('Could not parse Xorg version, but Xorg is SUID')
     end
     vprint_good("Xorg version #{v} is vulnerable")
 
@@ -143,10 +143,10 @@ class MetasploitModule < Msf::Exploit::Local
     proc_list = cmd_exec 'ps ax'
     if proc_list.include?('/X ')
       vprint_warning('Xorg in process list')
-      return CheckCode::Appears
+      return CheckCode::Appears("Xorg version #{v} is vulnerable but Xorg is already running")
     end
     vprint_good('Xorg does not appear to be running')
-    return CheckCode::Vulnerable
+    return CheckCode::Vulnerable("Xorg version #{v} is vulnerable and not currently running")
   end
 
   def check_arch_and_compile(path, data)

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -81,21 +81,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     len = sock.timed_read(4)&.unpack1('N')
 
-    return CheckCode::Unknown if len.nil? || len > 0x2000 # upper limit in case the service isn't ActiveMQ
+    return CheckCode::Unknown('Invalid or unexpected response length') if len.nil? || len > 0x2000 # upper limit in case the service isn't ActiveMQ
 
     res = sock.timed_read(len)
 
     disconnect
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response received from target') unless res
 
     _, magic = res.unpack('CZ*')
 
-    return CheckCode::Unknown unless res.length == len
+    return CheckCode::Unknown('Response length mismatch') unless res.length == len
 
-    return CheckCode::Unknown unless magic == 'ActiveMQ'
+    return CheckCode::Unknown('Target is not an ActiveMQ service') unless magic == 'ActiveMQ'
 
-    return CheckCode::Detected unless res =~ /ProviderVersion...(\d+\.\d+\.\d+)/
+    return CheckCode::Detected('ActiveMQ detected but version could not be determined') unless res =~ /ProviderVersion...(\d+\.\d+\.\d+)/
 
     version = Rex::Version.new(::Regexp.last_match(1))
 
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     Exploit::CheckCode::Safe("Apache ActiveMQ #{version}")
   rescue ::Timeout::Error
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine vulnerability status')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/arkeia_agent_exec.rb
+++ b/modules/exploits/multi/misc/arkeia_agent_exec.rb
@@ -106,14 +106,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x60\x00\x04"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unexpected response from Arkeia agent')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     req = "\x00\x73"
@@ -133,14 +133,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x60\x00\x04"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     req = "\x00\x61\x00\x04\x00\x01\x00\x11\x00\x00\x31\x00"
@@ -160,21 +160,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless header && header.length == 6 && header[0, 4] == "\x00\x43\x00\x00"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
 
     unless data_length == 0
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     # ARKADMIN_GET_CLIENT_INFO
@@ -190,20 +190,20 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x43\x00\x00"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
     unless data_length == 0
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     req = "\x00\x63\x00\x04\x00\x00\x00\x12\x30\x00\x31\x00\x32\x38"
@@ -216,14 +216,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x63\x00\x04"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
@@ -231,7 +231,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     # 2nd packet
@@ -239,14 +239,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x68\x00\x04"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
@@ -254,7 +254,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     # 3rd packet
@@ -262,14 +262,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x65\x00\x04"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
@@ -277,7 +277,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length && data.include?('You have successfully retrieved client information')
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     # 4th packet
@@ -285,14 +285,14 @@ class MetasploitModule < Msf::Exploit::Remote
     header = sock.get_once(6)
     unless header && header.length == 6 && header[0, 4] == "\x00\x69\x00\x04"
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = sock.get_once(2)
 
     unless data_length && data_length.length == 2
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     data_length = data_length.unpack('n')[0]
@@ -300,20 +300,20 @@ class MetasploitModule < Msf::Exploit::Remote
     data = sock.get_once(data_length)
     unless data && data.length == data_length
       disconnect
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     if data =~ /VERSION.*WD Arkeia ([0-9]+\.[0-9]+\.[0-9]+)/
       version = $1
       vprint_status("#{rhost}:#{rport} - Arkeia version detected: #{version}")
       if Rex::Version.new(version) <= Rex::Version.new('11.0.12')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Arkeia version #{version} is vulnerable")
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Arkeia version #{version} is not vulnerable")
       end
     else
       vprint_status("#{rhost}:#{rport} - Arkeia version not detected")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the version')
     end
   end
 

--- a/modules/exploits/multi/misc/bmc_server_automation_rscd_nsh_rce.rb
+++ b/modules/exploits/multi/misc/bmc_server_automation_rscd_nsh_rce.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Check for successful platform detection
     if res[0] == 1
       vprint_good('BMC RSCD agent detected, platform appears to be ' + res[1])
-      return CheckCode::Detected
+      return CheckCode::Detected('BMC RSCD agent detected')
     end
 
     # Get first four bytes of the packet which should hold the content length
@@ -99,13 +99,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_warning('Target appears to be BMC, however an unexpected ' \
                      'agentinfo response was returned.')
       vprint_warning('Response: ' + res[1])
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target state')
     end
 
     # Invalid response, probably not a BMC RSCD target
     vprint_error('The target does not appear to be a BMC RSCD agent.')
     vprint_error('Response: ' + res[1]) if res[1]
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/calibre_exec.rb
+++ b/modules/exploits/multi/misc/calibre_exec.rb
@@ -76,28 +76,29 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path)
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     if res && res.code == 200
       data = res.body.to_s
       pattern = /CALIBRE_VERSION\s*=\s*"([^"]+)"/
 
-      version = data.match(pattern)
+      match = data.match(pattern)
 
-      if version[1].nil?
-        return CheckCode::Unknown
-      else
-        vprint_status('Version retrieved: ' + version[1].to_s)
+      unless match
+        return CheckCode::Unknown('Could not determine the Calibre version')
       end
 
-      if Rex::Version.new(version[1]).between?(Rex::Version.new('6.9.0'), Rex::Version.new('7.15.0'))
-        return CheckCode::Appears
+      version = match[1]
+      vprint_status("Version retrieved: #{version}")
+
+      if Rex::Version.new(version).between?(Rex::Version.new('6.9.0'), Rex::Version.new('7.15.0'))
+        return CheckCode::Appears("Calibre version #{version} is vulnerable")
       else
-        return CheckCode::Safe
+        return CheckCode::Safe("Calibre version #{version} is not vulnerable")
       end
     else
-      return CheckCode::Unknown
+      return CheckCode::Unknown(res ? "Unexpected HTTP status code: #{res.code}" : 'No response received from target')
     end
   end
 

--- a/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
+++ b/modules/exploits/multi/misc/claymore_dual_miner_remote_manager_rce.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     target = select_target
     if target.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Unable to detect Claymore Dual Miner')
     end
 
     data = {
@@ -117,13 +117,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     str = Rex::Text.hex_to_raw(hex)
     if str.include?('WARNING')
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Response contains WARNING marker indicating command execution')
     else
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
   rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
     vprint_error(e.message)
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Connection failed')
   ensure
     disconnect
   end

--- a/modules/exploits/multi/misc/consul_rexec_exec.rb
+++ b/modules/exploits/multi/misc/consul_rexec_exec.rb
@@ -64,18 +64,18 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
     begin
       agent_info = JSON.parse(res.body)
       if agent_info["Config"]["DisableRemoteExec"] == false || agent_info["DebugConfig"]["DisableRemoteExec"] == false
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable('DisableRemoteExec is false')
       else
-        return CheckCode::Safe
+        return CheckCode::Safe('The target is not vulnerable')
       end
     rescue JSON::ParserError
       vprint_error 'Failed to parse JSON output.'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Failed to parse response')
     end
   end
 

--- a/modules/exploits/multi/misc/consul_service_exec.rb
+++ b/modules/exploits/multi/misc/consul_service_exec.rb
@@ -79,24 +79,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     unless res.code == 200
       vprint_error 'Unexpected reply'
-      return CheckCode::Safe
+      return CheckCode::Unknown('Unexpected HTTP reply')
     end
 
     agent_info = JSON.parse(res.body)
 
     if agent_info['Config']['EnableScriptChecks'] == true || agent_info['DebugConfig']['EnableScriptChecks'] == true || agent_info['DebugConfig']['EnableRemoteScriptChecks'] == true
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('EnableScriptChecks or EnableRemoteScriptChecks is true')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   rescue JSON::ParserError
     vprint_error 'Failed to parse JSON output.'
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Failed to parse response')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/multi/misc/freeswitch_event_socket_cmd_exec.rb
+++ b/modules/exploits/multi/misc/freeswitch_event_socket_cmd_exec.rb
@@ -108,14 +108,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if banner.include?('Access Denied, go away.') || banner.include?('text/rude-rejection')
       vprint_error 'Access denied by network ACL'
-      return CheckCode::Safe
+      return CheckCode::Safe('Access denied by network ACL')
     end
 
     unless banner.include?('Content-Type: auth/request')
-      return CheckCode::Safe
+      return CheckCode::Safe('The target is not vulnerable')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('FreeSWITCH Event Socket responded to auth request')
   end
 
   def auth(password)

--- a/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
+++ b/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fingerprint = get_fingerprint
 
     if fingerprint.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to fingerprint target')
     end
 
     if fingerprint =~ /Data Protector A\.(\d+\.\d+)/
@@ -96,16 +96,16 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Windows / HP Data Protector version #{version} found")
     elsif fingerprint =~ / INET/
       vprint_status("Linux / HP Data Protector found")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target does not appear to be HP Data Protector')
     end
 
     if Rex::Version.new(version) <= Rex::Version.new('9')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("HP Data Protector version #{version} is vulnerable")
     end
 
-    Exploit::CheckCode::Detected # there is no patch at the time of module writing
+    Exploit::CheckCode::Detected('There is no patch at the time of module writing')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/indesign_server_soap.rb
+++ b/modules/exploits/multi/misc/indesign_server_soap.rb
@@ -92,9 +92,9 @@ xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:IDSP="http://ns
 
     res = send_soap_request(checkscript, 'javascript')
 
-    return Exploit::CheckCode::Vulnerable if res.body.include?('<data xsi:type="xsd:string">' + check_var + '</data>')
+    return Exploit::CheckCode::Vulnerable('InDesign Server executed the test script successfully') if res.body.include?('<data xsi:type="xsd:string">' + check_var + '</data>')
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('InDesign Server SOAP endpoint did not return expected response')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -127,12 +127,12 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if res.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('JDWP handshake returned nil')
     elsif res == HANDSHAKE
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('JDWP handshake successful')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def default_timeout

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -114,27 +114,28 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
 
     unless is_rmi?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not an RMI endpoint')
     end
 
     mbean_server = discover_endpoint
     disconnect
     if mbean_server.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
     unless is_rmi?
-      return Exploit::CheckCode::Unknown
+      disconnect
+      return Exploit::CheckCode::Unknown('RMI endpoint not found on discovered MBean server')
     end
 
     jmx_endpoint = handshake(mbean_server)
     disconnect
     if jmx_endpoint.nil?
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('JMX endpoint discovered on target')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/jboss_remoting_unified_invoker_rce.rb
+++ b/modules/exploits/multi/misc/jboss_remoting_unified_invoker_rce.rb
@@ -82,12 +82,12 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put(handshake_data)
     data = sock.get_once(16)
     disconnect
-    return Exploit::CheckCode::Appears if data == handshake_data
+    return Exploit::CheckCode::Appears('Target responded with Java serialization handshake') if data == handshake_data
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target did not respond with expected Java serialization handshake')
   rescue Rex::ConnectionError, Errno::ECONNRESET, ::EOFError => e
     print_error("Error to connect #{rhost}:#{rport} : '#{e.class}' '#{e}'")
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Connection error')
   end
 
   # def exploit

--- a/modules/exploits/multi/misc/legend_bot_exec.rb
+++ b/modules/exploits/multi/misc/legend_bot_exec.rb
@@ -78,22 +78,22 @@ class MetasploitModule < Msf::Exploit::Remote
     res = register(sock)
     if res =~ /463/ || res =~ /464/
       vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
-    if !res =~ /353/ && !res =~ /366/
+    if res !~ /353/ && res !~ /366/
       vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     quit(sock)
     disconnect
 
     if res =~ /auth/ && res =~ /logged in/
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Bot responded with auth and logged in confirmation')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
-    if !res =~ /353/ && !res =~ /366/
+    if res !~ /353/ && res !~ /366/
       print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end

--- a/modules/exploits/multi/misc/msfd_rce_remote.rb
+++ b/modules/exploits/multi/misc/msfd_rce_remote.rb
@@ -57,12 +57,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect
     data = sock.get_once
+    if data.nil?
+      disconnect
+      return Exploit::CheckCode::Unknown('No response received from target')
+    end
     if data.include?("msf")
       disconnect
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be running msfd')
     end
     disconnect
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('msfd service not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/nodejs_v8_debugger.rb
+++ b/modules/exploits/multi/misc/nodejs_v8_debugger.rb
@@ -69,12 +69,14 @@ class MetasploitModule < Msf::Exploit::Remote
     res = sock.get_once
     disconnect
 
+    return Exploit::CheckCode::Unknown('V8 debugger protocol not detected') unless res
+
     if res.include? "V8-Version" and res.include? "Protocol-Version: 1"
       vprint_status("Got debugger handshake:\n#{res}")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Node.js V8 debugger protocol detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('V8 debugger protocol not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/nomad_exec.rb
+++ b/modules/exploits/multi/misc/nomad_exec.rb
@@ -81,12 +81,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     unless res.code == 200
       vprint_error 'Unexpected reply'
-      return CheckCode::Safe
+      return CheckCode::Unknown('Unexpected HTTP reply')
     end
 
     agent_info = JSON.parse(res.body)
@@ -94,26 +94,26 @@ class MetasploitModule < Msf::Exploit::Remote
     if agent_info['config']['Plugins']
       agent_info['config']['Plugins'].each do |plugin|
         if plugin['Name'] == 'raw_exec' && plugin['Config']['enabled'] == true
-          return CheckCode::Vulnerable
+          return CheckCode::Vulnerable('raw_exec plugin is enabled')
         end
       end
     end
 
     if agent_info['config']['Client']['Options']['driver.raw_exec.enable'] == 'true' || agent_info['config']['Client']['Options']['driver.raw_exec.enable'] == '1'
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('driver.raw_exec.enable is set to true')
     end
 
     if datastore['JOB_TYPE'] == 'raw_exec' && agent_info['config']['Client']['DisableRemoteExec'] == false
       print_status 'raw_exec doesn\'t appear to be supported. Try setting JOB_TYPE to exec instead.'
-      return CheckCode::Appears
+      return CheckCode::Appears('DisableRemoteExec is false but raw_exec may not be supported')
     elsif datastore['JOB_TYPE'] == 'exec' && agent_info['config']['Client']['DisableRemoteExec'] == false
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('DisableRemoteExec is false and exec driver is available')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('The target is not vulnerable')
   rescue JSON::ParserError
     vprint_error 'Failed to parse JSON output.'
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Failed to parse response')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/multi/misc/openview_omniback_exec.rb
+++ b/modules/exploits/multi/misc/openview_omniback_exec.rb
@@ -88,15 +88,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if !(res and res.length > 0)
         vprint_status("The remote service did not reply to our request")
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Unknown('Target did not reply to our request')
       end
 
       if (res =~ /passwd|group|resolv/)
         vprint_status("The remote service is exploitable")
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Response contains Unix path markers (passwd, group, or resolv)')
       end
 
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
 
     if (target.name =~ /Windows/)
@@ -123,15 +123,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if !(res and res.length > 0)
         print_status("The remote service did not reply to our request")
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Unknown('No reply received from target')
       end
 
       if (res =~ /V.o.l.u.m.e/) # Unicode
         print_status("The remote service is exploitable")
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Received expected V.o.l.u.m.e marker response')
       end
 
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -64,10 +64,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     disconnect
     if res && res == 'osgi> '
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('OSGi console prompt detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -79,22 +79,22 @@ class MetasploitModule < Msf::Exploit::Remote
     response = register(sock)
     if response =~ /463/ or response =~ /464/
       vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     response = join(sock)
     if not response =~ /353/ and not response =~ /366/
       vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
     response = pbot_login(sock)
     quit(sock)
     disconnect
 
     if response =~ /auth/ and response =~ /logged in/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Bot responded with auth and logged in confirmation')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
+++ b/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
@@ -93,10 +93,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if res && res.unpack('C')[0] == 0
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('HPCA Radexec service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     response = register(sock)
     if response =~ /463/ or response =~ /464/
       vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     confirm_string = rand_text_alpha(8)
@@ -104,9 +104,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if response =~ /#{confirm_string}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Bot echoed back confirmation string via PRIVMSG')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/multi/misc/teamcity_agent_xmlrpc_exec.rb
+++ b/modules/exploits/multi/misc/teamcity_agent_xmlrpc_exec.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     version = determine_version
     if !version.nil? && version >= 15772
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears("TeamCity agent version #{version} appears vulnerable")
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe("TeamCity agent does not appear vulnerable")
     end
   end
 

--- a/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
+++ b/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner.to_s.index(sploit)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target executed the echo command successfully')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/multi/misc/w3tw0rk_exec.rb
+++ b/modules/exploits/multi/misc/w3tw0rk_exec.rb
@@ -68,22 +68,22 @@ class MetasploitModule < Msf::Exploit::Remote
     res = register(sock)
     if res =~ /463/ || res =~ /464/
       vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
-    if !res =~ /353/ && !res =~ /366/
+    if res !~ /353/ && res !~ /366/
       vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     quit(sock)
     disconnect
 
     if res =~ /auth/ && res =~ /logged in/
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Bot responded with auth and logged in confirmation')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
-    if !res =~ /353/ && !res =~ /366/
+    if res !~ /353/ && res !~ /366/
       print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end

--- a/modules/exploits/multi/misc/weblogic_deserialize.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = sock.get_once
     disconnect
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response received from target') unless res
 
     /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.*\d*)/ =~ res
     if version
@@ -80,19 +80,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
       case
       when version.to_s.start_with?('10.3')
-        return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
+        return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('10.3.6.0')
       when version.to_s.start_with?('12.1')
-        return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
+        return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.1.3.0')
       when version.to_s.start_with?('12.2')
-        return CheckCode::Appears unless version > Rex::Version.new('12.2.1.3')
+        return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.2.1.3')
       end
     end
 
     if res.include?('Oracle WebLogic Server Administration Console')
-      return CheckCode::Detected
+      return CheckCode::Detected('Oracle WebLogic Server Administration Console detected')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Target does not appear to be Oracle WebLogic Server')
   end
 
   def gen_resp

--- a/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_asyncresponseservice.rb
@@ -97,17 +97,17 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 500 && res.body.include?('<faultcode>env:Client</faultcode>')
       vprint_status("The target returned a vulnerable HTTP code: /#{res.code}")
       vprint_status("The target returned a vulnerable HTTP error: /#{res.body.split("\n")[0]}")
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Target returned a vulnerable SOAP fault response')
     elsif res && res.code != 202
       vprint_status('The target returned a non-vulnerable HTTP code')
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Target returned a non-vulnerable HTTP response')
     elsif res.nil?
       vprint_status('The target did not respond in an expected way')
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Unknown('Target did not respond in an expected way')
     else
       vprint_status("The target returned HTTP code: #{res.code}")
       vprint_status("The target returned HTTP body: #{res.body.split("\n")[0]} [...]")
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Unknown('Unable to determine vulnerability status')
     end
   end
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
@@ -99,9 +99,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @version_no = Rex::Version.new(version)
     print_status("WebLogic version detected: #{@version_no}")
 
-    return CheckCode::Appears if versions.include?(@version_no)
+    return CheckCode::Appears("WebLogic version #{@version_no} appears vulnerable") if versions.include?(@version_no)
 
-    CheckCode::Detected('Version of WebLogic is not vulnerable')
+    CheckCode::Safe('Version of WebLogic is not vulnerable')
   ensure
     disconnect
   end

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -93,9 +93,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @version_no = Rex::Version.new(version)
     print_status("WebLogic version detected: #{@version_no}")
 
-    return CheckCode::Appears if versions.include?(@version_no)
+    return CheckCode::Appears("WebLogic version #{@version_no} appears vulnerable") if versions.include?(@version_no)
 
-    CheckCode::Detected('Version of WebLogic is not vulnerable')
+    CheckCode::Safe('Version of WebLogic is not vulnerable')
   ensure
     disconnect
   end

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -95,31 +95,31 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => '/console/login/LoginForm.jsp'
     )
 
-    return CheckCode::Unknown unless resp && resp.code == 200
+    return CheckCode::Unknown('No valid response from target') unless resp && resp.code == 200
 
     unless resp.body.include?('Oracle WebLogic Server Administration Console')
       vprint_warning("Oracle WebLogic Server banner cannot be found")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Oracle WebLogic Server banner not found')
     end
 
     /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.\d*)/ =~ resp.body
     unless version
       vprint_warning("Oracle WebLogic Server version cannot be found")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine WebLogic version from response')
     end
 
     version = Rex::Version.new(version)
     vprint_good("Detected Oracle WebLogic Server Version: #{version}")
     case
     when version.to_s.start_with?('10.3')
-      return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('10.3.6.0')
     when version.to_s.start_with?('12.1.3')
-      return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.1.3.0')
     when version.to_s.start_with?('12.2')
-      return CheckCode::Appears unless version > Rex::Version.new('12.2.1.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.2.1.0')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("WebLogic version #{version} is not vulnerable")
   end
 =end
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_rawobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_rawobject.rb
@@ -94,33 +94,33 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => '/console/login/LoginForm.jsp'
     )
 
-    return CheckCode::Unknown unless resp && resp.code == 200
+    return CheckCode::Unknown('No valid response from target') unless resp && resp.code == 200
 
     unless resp.body.include?('Oracle WebLogic Server Administration Console')
       vprint_warning("Oracle WebLogic Server banner cannot be found")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Oracle WebLogic Server banner not found')
     end
 
     /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.\d*)/ =~ resp.body
     unless version
       vprint_warning("Oracle WebLogic Server version cannot be found")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine WebLogic version from response')
     end
 
     version = Rex::Version.new(version)
     vprint_good("Detected Oracle WebLogic Server Version: #{version}")
     case
     when version.to_s.start_with?('10.3')
-      return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('10.3.6.0')
     when version.to_s.start_with?('12.1.2')
-      return CheckCode::Appears unless version > Rex::Version.new('12.1.2.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.1.2.0')
     when version.to_s.start_with?('12.1.3')
-      return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.1.3.0')
     when version.to_s.start_with?('12.2')
-      return CheckCode::Appears unless version > Rex::Version.new('12.2.1.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.2.1.0')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("WebLogic version #{version} is not vulnerable")
   end
 =end
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_unicastref.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_unicastref.rb
@@ -94,31 +94,31 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => '/console/login/LoginForm.jsp'
     )
 
-    return CheckCode::Unknown unless resp && resp.code == 200
+    return CheckCode::Unknown('No valid response from target') unless resp && resp.code == 200
 
     unless resp.body.include?('Oracle WebLogic Server Administration Console')
       vprint_warning("Oracle WebLogic Server banner cannot be found")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Oracle WebLogic Server banner not found')
     end
 
     /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.\d*)/ =~ resp.body
     unless version
       vprint_warning("Oracle WebLogic Server version cannot be found")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine WebLogic version from response')
     end
 
     version = Rex::Version.new(version)
     vprint_good("Detected Oracle WebLogic Server Version: #{version}")
     case
     when version.to_s.start_with?('10.3')
-      return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('10.3.6.0')
     when version.to_s.start_with?('12.1.3')
-      return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.1.3.0')
     when version.to_s.start_with?('12.2')
-      return CheckCode::Appears unless version > Rex::Version.new('12.2.1.1')
+      return CheckCode::Appears("WebLogic version #{version} appears vulnerable") unless version > Rex::Version.new('12.2.1.1')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("WebLogic version #{version} is not vulnerable")
   end
 =end
 

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -80,22 +80,22 @@ class MetasploitModule < Msf::Exploit::Remote
     res = register(sock)
     if res =~ /463/ || res =~ /464/
       vprint_error("#{rhost}:#{rport}  - Connection to the IRC Server not allowed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to the IRC server not allowed')
     end
 
     res = join(sock)
-    if !res =~ /353/ && !res =~ /366/
+    if res !~ /353/ && res !~ /366/
       vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     quit(sock)
     disconnect
 
     if res =~ /auth/ && res =~ /logged in/
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Bot responded with auth and logged in confirmation')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
     res = join(sock)
-    if !res =~ /353/ && !res =~ /366/
+    if res !~ /353/ && res !~ /366/
       print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
       return
     end

--- a/modules/exploits/multi/persistence/periodic_script.rb
+++ b/modules/exploits/multi/persistence/periodic_script.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     periodic = "/etc/periodic/#{datastore['PERIODIC_DIR']}/"
 
-    return CheckCode::Vulnerable "#{periodic} is writable" if writable? periodic
+    return CheckCode::Vulnerable("#{periodic} is writable") if writable? periodic
 
-    CheckCode::Safe "Unable to write to #{periodic}"
+    CheckCode::Safe("Unable to write to #{periodic}")
   end
 
   def write_periodic_script(payload_content)

--- a/modules/exploits/multi/php/ignition_laravel_debug_rce.rb
+++ b/modules/exploits/multi/php/ignition_laravel_debug_rce.rb
@@ -85,9 +85,9 @@ class MetasploitModule < Msf::Exploit::Remote
       # to be sure that it is vulnerable we could try to cleanup the log files (invalid and valid)
       # but it is way more intrusive than just checking the version moreover we would need to call
       # the find_log_file method before, meaning four requests more.
-      return Exploit::CheckCode::Appears if version <= Rex::Version.new('8.26.1')
+      return Exploit::CheckCode::Appears("Laravel #{version} with Ignition appears vulnerable") if version <= Rex::Version.new('8.26.1')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target does not appear to be running Laravel with Ignition')
   end
 
   def exploit

--- a/modules/exploits/multi/php/jorani_path_trav.rb
+++ b/modules/exploits/multi/php/jorani_path_trav.rb
@@ -95,19 +95,19 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe('There was a problem accessing the login page')
     end
 
-    return Exploit::CheckCode::Safe unless service_running(res)
+    return Exploit::CheckCode::Safe('Target service is not running') unless service_running(res)
 
     print_good('Jorani seems to be running on the target!')
 
     current_version = get_version(res)
-    return Exploit::CheckCode::Detected if current_version.nil?
+    return Exploit::CheckCode::Detected('Jorani detected but could not determine version') if current_version.nil?
 
     print_good("Found version: #{current_version}")
     current_version = Rex::Version.new(current_version)
 
-    return Exploit::CheckCode::Appears if current_version < Rex::Version.new('1.0.2')
+    return Exploit::CheckCode::Appears("Jorani version #{current_version} is vulnerable") if current_version < Rex::Version.new('1.0.2')
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Jorani version #{current_version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
+++ b/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
@@ -238,14 +238,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (!res)
       vprint_status('No response from the server')
-      return Exploit::CheckCode::Unknown # User should try again
+      return Exploit::CheckCode::Unknown('No response from target, user should try again')
     end
 
     http_fingerprint({ response: res }) # check method
 
     if (res.code != 200)
       vprint_status("The server returned #{res.code} #{res.message}")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Server returned non-200 response')
     end
 
     if (
@@ -261,7 +261,7 @@ class MetasploitModule < Msf::Exploit::Remote
         php_bug = true
       else
         vprint_status("The server runs a non-vulnerable version of PHP (#{php_raw})")
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Non-vulnerable PHP version #{php_raw} detected")
       end
     end
 
@@ -279,7 +279,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     end
 
-    return php_bug ? Exploit::CheckCode::Appears : Exploit::CheckCode::Detected
+    return php_bug ? Exploit::CheckCode::Appears('Vulnerable PHP version detected') : Exploit::CheckCode::Detected('PHP detected but version may not be vulnerable')
   end
 
   def brute_exploit(target_addrs)

--- a/modules/exploits/multi/php/wp_duplicator_code_inject.rb
+++ b/modules/exploits/multi/php/wp_duplicator_code_inject.rb
@@ -74,20 +74,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless response
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     unless response.code == 200
       vprint_error("Server responded with #{response.code}")
-      return CheckCode::Safe
+      return CheckCode::Safe("Server responded with #{response.code}")
     end
 
     # check_plugin_version_from_readme('duplicator', '1.2.42')
-    version = response.body.to_s.scan(/version: ([^<]*)</).last.first
+    matches = response.body.to_s.scan(/version: ([^<]*)</)
+    if matches.empty?
+      return CheckCode::Unknown('Could not determine Duplicator version')
+    end
+
+    version = matches.last.first
     if Rex::Version.new(version) <= Rex::Version.new("1.2.40")
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable("Duplicator version #{version} is vulnerable")
     else
-      return CheckCode::Detected
+      return CheckCode::Detected("Duplicator version #{version} detected")
     end
   end
 

--- a/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
+++ b/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    vuln_version? ? CheckCode::Appears : CheckCode::Safe
+    vuln_version? ? CheckCode::Appears('PostgreSQL version appears vulnerable') : CheckCode::Safe('PostgreSQL version does not appear to be vulnerable')
   end
 
   def vuln_version?

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    vuln_version? ? CheckCode::Appears : CheckCode::Safe
+    vuln_version? ? CheckCode::Appears('PostgreSQL version appears vulnerable') : CheckCode::Safe('PostgreSQL version does not appear to be vulnerable')
   end
 
   def vuln_version?

--- a/modules/exploits/multi/realserver/describe.rb
+++ b/modules/exploits/multi/realserver/describe.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Exploit::Remote
     http_fingerprint({ response: res }) # check method / Custom server check
     if res and res['Server']
       vprint_status("Found RTSP: #{res['Server']}")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('RealServer RTSP service detected')
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('RealServer RTSP service not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/sap/cve_2020_6207_solman_rs.rb
+++ b/modules/exploits/multi/sap/cve_2020_6207_solman_rs.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       agents = make_agents_array
     rescue RuntimeError
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown('Could not retrieve agent list from Solution Manager')
     end
     if agents.empty?
       print_status("Solution Manager server: #{@host}:#{@port} is vulnerable but no agents are connected!")
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good("Successfully retrieved agent list:\n#{pretty_agents_table(agents)}")
     end
     report_service_and_vuln
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('SAP Solution Manager is vulnerable to CVE-2020-6207')
   end
 
   def exploit

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -93,18 +93,18 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       res = send_soap_request('')
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     if res and res.code == 200 and res.headers['Server'] =~ /gSOAP/ and res.body =~ /OSExecuteResponse/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('SAP Management Console OS command execution available')
     elsif res and res.code == 500 and (res.body =~ /Invalid Credentials/ or res.body =~ /Permission denied/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('SAP Management Console detected but credentials are invalid')
     elsif res and res.headers['Server'] =~ /gSOAP/
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('SAP Management Console gSOAP detected but could not confirm vulnerability')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('SAP Management Console not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -128,10 +128,10 @@ class MetasploitModule < Msf::Exploit::Remote
     data = rand_text_alphanumeric(rand(4..7))
     res = send_soap_request(data)
     if res and res.code == 500 and res.body =~ /faultstring/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('SAP SOAP RFC SXPG service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('SAP SOAP RFC SXPG service not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -130,10 +130,10 @@ class MetasploitModule < Msf::Exploit::Remote
     data = rand_text_alphanumeric(rand(4..7))
     res = send_soap_request(data)
     if res and res.code == 500 and res.body =~ /faultstring/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('SAP SOAP RFC SXPG service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('SAP SOAP RFC SXPG service not detected')
   end
 
   def exploit

--- a/modules/exploits/multi/scada/inductive_ignition_rce.rb
+++ b/modules/exploits/multi/scada/inductive_ignition_rce.rb
@@ -131,9 +131,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     print_status("#{peer} - Detected version #{version}")
     if version >= Rex::Version.new('8.0.0') && version <= Rex::Version.new('8.0.7')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Inductive Automation Ignition version #{version} appears vulnerable")
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Inductive Automation Ignition version #{version} is not vulnerable")
     end
   end
 


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical