### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
+++ b/modules/exploits/windows/http/advantech_iview_networkservlet_cmd_inject.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('Vulnerability is present, though authentication is required.')
     end
 
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def send_db_backup_request(filename)

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -97,16 +97,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'page' => 'version.frag'
       }
     )
-    return CheckCode::Unknown unless res&.code == 200
+    return CheckCode::Unknown('Target did not return HTTP 200') unless res&.code == 200
 
     version = res.get_html_document.xpath('string(//input[starts-with(@value, "Version")]/@value)')
-    return CheckCode::Unknown unless version =~ /Version (\d+\.\d+) \(Build ([\d.]+)\)/
+    return CheckCode::Unknown('Could not extract version information') unless version =~ /Version (\d+\.\d+) \(Build ([\d.]+)\)/
 
     version = "#{Regexp.last_match(1)}.#{Regexp.last_match(2)}"
     vprint_status("Identified the version as #{version}")
-    return CheckCode::Safe if Rex::Version.new(version) >= Rex::Version.new('5.7.03.6112')
+    return CheckCode::Safe("Version #{version} is not vulnerable") if Rex::Version.new(version) >= Rex::Version.new('5.7.03.6112')
 
-    CheckCode::Appears
+    CheckCode::Appears("Detected vulnerable version: #{version}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/altn_securitygateway.rb
+++ b/modules/exploits/windows/http/altn_securitygateway.rb
@@ -86,9 +86,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if auto_target
-      Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
+++ b/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
@@ -78,10 +78,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (res.to_s =~ /<H1>BAD REQUEST<\/H1><P>Your client sent a request that this server didn't understand.<br>Request:\s(\w+)/)
       if ($1 == rand)
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Target is vulnerable')
       end
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -98,10 +98,10 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         1
       )
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target is vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/apache_chunked.rb
+++ b/modules/exploits/windows/http/apache_chunked.rb
@@ -171,12 +171,12 @@ class MetasploitModule < Msf::Exploit::Remote
     response = send_request_raw({ 'uri' => '/' }, 5)
     if response.nil?
       vprint_status("No response to request")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     http_fingerprint({ :response => response })  # Custom Server header matching
 
-    code = Exploit::CheckCode::Appears
+    code = Exploit::CheckCode::Appears('Target appears to be vulnerable')
 
     case response['Server']
     when "Oracle HTTP Server Powered by Apache/1.3.12 (Win32) ApacheJServ/1.1 mod_ssl/2.6.4 OpenSSL/0.9.5a mod_perl/1.22"
@@ -187,10 +187,10 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("This looks like an Oracle 9.2.0 Apache service (multiple tries allowed)")
     when /IBM_HTTP_SERVER\/1\.3\.(19\.[3-9]|2[0-9]\.)/
       vprint_status("IBM backported the patch, this system is not vulnerable")
-      code = Exploit::CheckCode::Safe
+      code = Exploit::CheckCode::Safe('Target is not vulnerable')
     when /Apache(-AdvancedExtranetServer)?\/(1\.([0-2]\.[0-9]|3\.([0-9][^0-9]|[0-1][0-9]|2[0-5]))|2\.0.([0-9][^0-9]|[0-2][0-9]|3[0-8]))/
     else
-      code = Exploit::CheckCode::Safe
+      code = Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     vprint_status("Server: #{response['Server']}")

--- a/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
+++ b/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 2)
 
     if (res.to_s =~ /Apache/) # This could be smarter.
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/apache_modjk_overflow.rb
+++ b/modules/exploits/windows/http/apache_modjk_overflow.rb
@@ -66,9 +66,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (resp and (m = resp.match(/Server: Apache\/(.*) \(Win32\)(.*) mod_jk\/1\.2\.20/))) then
       vprint_status("Apache version detected : #{m[1]}")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -76,20 +76,20 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     if res.nil?
       vprint_error('No server response, check configuration')
-      return CheckCode::Safe
+      return CheckCode::Safe('No server response')
     elsif res.code != 200
       vprint_error('No server response, check configuration')
-      return CheckCode::Safe
+      return CheckCode::Safe('Unexpected response code from target')
     end
 
     if res.body =~ /Apache Tika (\d.[\d]+)/
       version = Rex::Version.new($1)
       vprint_status("Apache Tika Version Detected: #{version}")
       if version.between?(Rex::Version.new('1.15'), Rex::Version.new('1.17'))
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable("Target is vulnerable based on version: #{version}")
       end
     end
-    CheckCode::Safe
+    CheckCode::Safe('Target is not vulnerable')
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/windows/http/badblue_ext_overflow.rb
+++ b/modules/exploits/windows/http/badblue_ext_overflow.rb
@@ -55,10 +55,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = http_fingerprint # check method
     if (info =~ /BadBlue\/2\.5/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -92,13 +92,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case fingerprint
     when /Version found/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     when /BEA WebLogic connector vulnerable/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     when /BEA WebLogic connector undefined/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     when /BEA WebLogic connector no vulnerable/, /BEA WebLogic connector not found/
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/ca_igateway_debug.rb
+++ b/modules/exploits/windows/http/ca_igateway_debug.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
     banner = sock.get_once
 
     if (banner.to_s =~ /GET and POST methods are the only methods supported at this time/) # Unique?
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
+++ b/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if version && Rex::Version.new(version) <= Rex::Version.new('2.5')
       print_good("Version Detected: #{version}")
-      return CheckCode::Appears
+      return CheckCode::Appears("Detected vulnerable version: #{version}")
     end
 
     # try a backup plan, at least verify the title
@@ -95,9 +95,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.body =~ %r{<title>xPost</title>}
       vprint_good('HTML Title includes xPost')
-      return CheckCode::Detected
+      return CheckCode::Detected('Target service detected as xPost')
     end
-    CheckCode::Safe
+    CheckCode::Safe('Target is not vulnerable')
   rescue ::Rex::ConnectionError
     CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
   end

--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -357,10 +357,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body =~ /PermissionRecord/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def send_injection(dll)

--- a/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
+++ b/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /<title>DataHub - Web Data Browser<\/title>/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -67,14 +67,15 @@ class MetasploitModule < Msf::Exploit::Remote
     b64_version = get_version(path)
     if b64_version.empty?
       vprint_error("Unable to determine the version number")
+      return Exploit::CheckCode::Unknown('Could not determine the target version')
     else
       b64_version = Rex::Text.decode_base64(b64_version)
       if b64_version =~ /^[0-6]\.1/
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Detected vulnerable version: #{b64_version}")
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{b64_version}")
   end
 
   def get_version(path)

--- a/modules/exploits/windows/http/desktopcentral_file_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_file_upload.rb
@@ -99,15 +99,15 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       if build.nil?
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine the target status')
       elsif Rex::Version.new(build) < Rex::Version.new("80293")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Detected vulnerable version: #{build}")
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{build}")
       end
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
@@ -78,15 +78,15 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       if build.nil?
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine the target status')
       elsif Rex::Version.new(build) < Rex::Version.new("90055")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Detected vulnerable version: #{build}")
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{build}")
       end
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/windows/http/disk_pulse_enterprise_bof.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_bof.rb
@@ -68,10 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /Disk Pulse Enterprise v9\.0\.34/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_get.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.body =~ /Disk Pulse Enterprise v9\.9\.16/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/diskboss_get_bof.rb
+++ b/modules/exploits/windows/http/diskboss_get_bof.rb
@@ -90,16 +90,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200
       if res.body =~ /DiskBoss Enterprise v(7\.4\.28|7\.5\.12|8\.2\.14)/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('Target is vulnerable')
       elsif res.body =~ /DiskBoss Enterprise/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('Target service detected')
       end
     else
       vprint_error('Unable to determine due to a HTTP connection timeout')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/disksavvy_get_bof.rb
+++ b/modules/exploits/windows/http/disksavvy_get_bof.rb
@@ -84,17 +84,17 @@ class MetasploitModule < Msf::Exploit::Remote
       if version
         vprint_status("Version detected: #{version}")
         if version =~ /9\.(1|3)\.14/
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
         end
 
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected("Target detected with version: #{version}")
       end
     else
       vprint_error('Unable to determine due to a HTTP connection timeout')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Disk Savvy Enterprise not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/http/disksorter_bof.rb
+++ b/modules/exploits/windows/http/disksorter_bof.rb
@@ -69,17 +69,17 @@ class MetasploitModule < Msf::Exploit::Remote
       if version
         vprint_status("Version detected: #{version}")
         if version =~ /9\.5\.12/
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
         end
 
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected("Target detected with version: #{version}")
       end
     else
       vprint_error('Unable to determine due to a HTTP connection timeout')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Disk Sorter Enterprise not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
+++ b/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     rand_text = Rex::Text.rand_text_alphanumeric(rand(4..10))
     if inject_php("echo \"#{rand_text}\"")&.chomp == rand_text
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target is vulnerable')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -345,9 +345,9 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good('Custom error page detected.')
     else
       print_error('IIS Error Page detected.')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('Target appears to be vulnerable')
   end
 
   # ===========================

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -82,10 +82,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = http_fingerprint # check method
     if info and (info =~ /Easy\-Web Server\//)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/efs_easychatserver_username.rb
+++ b/modules/exploits/windows/http/efs_easychatserver_username.rb
@@ -67,21 +67,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     version = get_version
     if not version
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('EFS Easy Chat Server not detected')
     end
 
     vprint_status "Found version: #{version}"
     if version !~ /^(2\.\d|3\.0|3\.1)$/
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
     end
 
     path = get_install_path
     if not path
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Target detected with version: #{version}")
     end
 
     vprint_status "Found path: #{path}"
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
   end
 
   #

--- a/modules/exploits/windows/http/efs_fmws_userid_bof.rb
+++ b/modules/exploits/windows/http/efs_fmws_userid_bof.rb
@@ -97,14 +97,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    code = Exploit::CheckCode::Safe
     version = get_version
+    code = Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     if version.nil?
-      code = Exploit::CheckCode::Unknown
+      code = Exploit::CheckCode::Unknown('Could not determine the target status')
     elsif version == "5.3"
-      code = Exploit::CheckCode::Appears
+      code = Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
     elsif version == "4.0"
-      code = Exploit::CheckCode::Appears
+      code = Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
     end
 
     code

--- a/modules/exploits/windows/http/ektron_xslt_exec.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec.rb
@@ -99,10 +99,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully executed XSLT code on target')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target does not appear to be vulnerable')
   end
 
   def uri_path

--- a/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
@@ -141,10 +141,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target is vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def uri_path

--- a/modules/exploits/windows/http/ericom_access_now_bof.rb
+++ b/modules/exploits/windows/http/ericom_access_now_bof.rb
@@ -68,16 +68,16 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res && res.code == 200 && res.headers['Server']
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     if res.headers['Server'] =~ /Ericom AccessNow Server/
-      return Exploit::CheckCode::Appears # Ericom AccessNow 2.4
+      return Exploit::CheckCode::Appears('Ericom AccessNow 2.4 detected')
     elsif res && res.code == 200 && res.headers['Server'] && res.headers['Server'] =~ /Ericom Access Server/
-      return Exploit::CheckCode::Detected # Ericom AccessNow 3
+      return Exploit::CheckCode::Detected('Ericom AccessNow 3 detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit_uri

--- a/modules/exploits/windows/http/exchange_ecp_viewstate.rb
+++ b/modules/exploits/windows/http/exchange_ecp_viewstate.rb
@@ -71,19 +71,19 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     state = get_request_setup
     viewstate = state[:viewstate]
-    return CheckCode::Unknown if viewstate.nil?
+    return CheckCode::Unknown('Could not retrieve ViewState') if viewstate.nil?
 
     viewstate = Rex::Text.decode_base64(viewstate)
     body = viewstate[0...-20]
     signature = viewstate[-20..-1]
 
     unless generate_viewstate_signature(state[:viewstate_generator], state[:session_id], body) == signature
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     # we've validated the signature matches based on the data we have and thus
     # proven that we are capable of signing a viewstate ourselves
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Target is vulnerable')
   end
 
   def generate_viewstate(generator, session_id, cmd)

--- a/modules/exploits/windows/http/exchange_proxynotshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxynotshell_rce.rb
@@ -91,16 +91,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     @ssrf_email ||= Faker::Internet.email
     res = send_http('GET', '/mapi/nspi/')
-    return CheckCode::Unknown if res.nil?
+    return CheckCode::Unknown('No response received from target') if res.nil?
     return CheckCode::Unknown('Server responded with 401 Unauthorized.') if res.code == 401
-    return CheckCode::Safe unless res.code == 200 && res.get_html_document.xpath('//head/title').text == 'Exchange MAPI/HTTP Connectivity Endpoint'
+    return CheckCode::Safe('Exchange MAPI/HTTP endpoint not detected') unless res.code == 200 && res.get_html_document.xpath('//head/title').text == 'Exchange MAPI/HTTP Connectivity Endpoint'
 
     # actually run the powershell cmdlet and see if it works, this will fail if:
     #   * the credentials are incorrect (USERNAME, PASSWORD, DOMAIN)
     #   * the exchange emergency mitigation service M1 rule is in place
-    return CheckCode::Safe unless execute_powershell('Get-Mailbox')
+    return CheckCode::Safe('PowerShell Get-Mailbox cmdlet failed') unless execute_powershell('Get-Mailbox')
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Target is vulnerable')
   rescue Msf::Exploit::Failed => e
     CheckCode::Safe(e.to_s)
   end

--- a/modules/exploits/windows/http/exchange_proxyshell_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxyshell_rce.rb
@@ -125,10 +125,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     @ssrf_email ||= Faker::Internet.email
     res = send_http('GET', '/mapi/nspi/')
-    return CheckCode::Unknown if res.nil?
-    return CheckCode::Safe unless res.code == 200 && res.get_html_document.xpath('//head/title').text == 'Exchange MAPI/HTTP Connectivity Endpoint'
+    return CheckCode::Unknown('No response received from target') if res.nil?
+    return CheckCode::Safe('Exchange MAPI/HTTP endpoint not detected') unless res.code == 200 && res.get_html_document.xpath('//head/title').text == 'Exchange MAPI/HTTP Connectivity Endpoint'
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Target is vulnerable')
   end
 
   def cmd_windows_generic?

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     # Checks for the `WWW-Authenticate` header in the response
     if res.code && res.code == 401 && res.headers['WWW-Authenticate'].include?('Basic realm="File Sharing Wizard"')
-      CheckCode::Detected
+      CheckCode::Detected('Target service detected')
     else
-      CheckCode::Safe
+      CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/hp_autopass_license_traversal.rb
+++ b/modules/exploits/windows/http/hp_autopass_license_traversal.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    check_code = Exploit::CheckCode::Safe
+    check_code = Exploit::CheckCode::Safe('Target is not vulnerable')
 
     res = send_request_cgi(
       {
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      check_code = Exploit::CheckCode::Unknown
+      check_code = Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res && res.code == 500 &&
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
        res.body.to_s.include?("java.lang.NullPointerException") &&
        res.body.to_s.include?("com.hp.autopass")
 
-      check_code = Exploit::CheckCode::Detected
+      check_code = Exploit::CheckCode::Detected('Target service detected')
     end
 
     check_code

--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -70,17 +70,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error("Unable to determine, because the request timed out.")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.code == 200 and res.headers['Content-Type'] =~ /application\/doc/ and res.body =~ /com\.h3c\.imc\.bims\.acs\.server\.UploadServlet/
       vprint_status("Upload interface found. Must be tested to verify vulnerable state.")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     elsif res.code == 405 and res.message =~ /Method Not Allowed/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/hp_imc_java_deserialize.rb
+++ b/modules/exploits/windows/http/hp_imc_java_deserialize.rb
@@ -66,11 +66,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     unless res.code == 200 && res.body.include?('login_logo_hp.png')
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     # Java serialized ysoserial JSON1 synchronous sleep command, from https://github.com/federicodotta/Java-Deserialization-Scanner/blob/43653733ae58f63a9a4ef257ac2f276d1ca3c0a8/src/burp/BurpExtender.java
@@ -87,15 +87,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Detected
+      return CheckCode::Unknown('Connection failed')
     end
 
     diff = t2 - t1
     if res.code == 500 && res.body.include?('HPE Intelligent Management Center') && diff >= 10
       print_good("Response received after #{diff} seconds.")
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('Target is vulnerable')
     else
-      return CheckCode::Appears
+      return CheckCode::Appears('Target appears to be vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/hp_imc_mibfileupload.rb
+++ b/modules/exploits/windows/http/hp_imc_mibfileupload.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /HP Intelligent Management Center/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/hp_loadrunner_copyfiletoserver.rb
+++ b/modules/exploits/windows/http/hp_loadrunner_copyfiletoserver.rb
@@ -130,10 +130,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if res and res.code == 200 and res.body.to_s =~ /HP Service Emulation/
         vprint_good("Traversal exists and parameters are correct...")
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable("Target is vulnerable with Tomcat version #{tomcat_version}")
       elsif res and res.code == 500 and res.body.to_s =~ /FileNotFoundException/
         vprint_warning("Traversal appears to exist, try adjusting parameters DEPTH and INSTALLPATH...")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Detected vulnerable version: #{tomcat_version}")
       else
         vprint_error("Failed to verify the directory traversal...")
       end
@@ -148,10 +148,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body.to_s =~ /wsdl.*EmulationAdmin/ and res.body.to_s =~ /copyFileToServerRequest/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Vulnerable web service and method detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/hp_mpa_job_acct.rb
+++ b/modules/exploits/windows/http/hp_mpa_job_acct.rb
@@ -178,16 +178,16 @@ class MetasploitModule < Msf::Exploit::Remote
     if res and res.code == 200 and res.body =~ /HP Managed Printing Administration/ and res.body =~ /<dd>v(.*)<\/dd>/
       version = $1
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('HP Managed Printing Administration not detected')
     end
 
     vprint_status("HP MPA Version Detected: #{version}")
 
     if version <= "2.6.3"
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/hp_nnm_ovas.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovas.rb
@@ -186,13 +186,13 @@ class MetasploitModule < Msf::Exploit::Remote
     resp = send_request_raw({ 'uri' => '/topology/home' }, 5)
     if resp.nil?
       vprint_status("No response to request")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if (resp.body =~ /NNM Release B\.07\.53/ || resp.body =~ /NNM Release B\.07\.52/ || resp.body =~ /NNM Release B\.07\.51/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 end

--- a/modules/exploits/windows/http/hp_pcm_snac_update_certificates.rb
+++ b/modules/exploits/windows/http/hp_pcm_snac_update_certificates.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     session = get_session
     if session.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     res = send_request_cgi({
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /"success":"true"/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def get_session

--- a/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
+++ b/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     session = get_session
     if session.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     res = send_request_cgi({
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /domainName/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def get_session

--- a/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
+++ b/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_soap_request(op, key, value)
 
     if res and res.code == 200 and res.body =~ /runOMAgentCommandResponse/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/httpdx_handlepeer.rb
+++ b/modules/exploits/windows/http/httpdx_handlepeer.rb
@@ -90,10 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = http_fingerprint # check method
     if info and (info =~ /httpdx\/(.*) \(Win32\)/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/http/httpdx_tolog_format.rb
@@ -144,10 +144,10 @@ For now, that will have to be done manually.
     if version
       print_status("HTTPDX version detected : #{version}")
       if (version =~ /1\.4/) or (version == "1.5")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
       end
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Target is not vulnerable#{version ? " based on version: #{version}" : ''}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -73,15 +73,15 @@ class MetasploitModule < Msf::Exploit::Remote
       connect
     rescue
       print_error("Could not connect to target!")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
     sock.put("GET / HTTP/1.0\r\n\r\n")
     res = sock.get_once
 
     if res =~ /intrasrv 1\.0/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/jira_collector_traversal.rb
+++ b/modules/exploits/windows/http/jira_collector_traversal.rb
@@ -149,14 +149,14 @@ class MetasploitModule < Msf::Exploit::Remote
     if res and res.code == 200 and res.body =~ /<meta name="application-name" content="JIRA" data-name="jira" data-version="([0-9\.]*)">/
       version = $1
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if version <= "6.0.3"
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Target detected with version: #{version}")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/kaseya_uploader.rb
+++ b/modules/exploits/windows/http/kaseya_uploader.rb
@@ -55,9 +55,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 302 && res.body && res.body.to_s =~ /mainLogon\.asp\?logout=([0-9]*)/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
   end
 

--- a/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
+++ b/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
@@ -56,10 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # the vuln was patched by removing uploadImage.asp. if the page is there, calling it without params will return 500, else 404
     unless res and res.code == 500
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/kentico_staging_syncserver.rb
+++ b/modules/exploits/windows/http/kentico_staging_syncserver.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.body =~ /SyncServer Web Service/i # SOAP endpoint disco / WSDL
-      return CheckCode::Detected
+      return CheckCode::Detected('Target service detected')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/kolibri_http.rb
+++ b/modules/exploits/windows/http/kolibri_http.rb
@@ -55,10 +55,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = http_fingerprint
     if info and (info =~ /kolibri-2\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
+++ b/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
@@ -63,14 +63,14 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200 && res.body && res.body.to_s =~ /MarkVision Enterprise ([\d\.]+)/
       version = $1
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if Rex::Version.new(version) <= Rex::Version.new('2.0.0')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/lg_simple_editor_rce.rb
+++ b/modules/exploits/windows/http/lg_simple_editor_rce.rb
@@ -69,13 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
 
     version_text = res.get_html_document.xpath('//h2')[0]&.text&.gsub('v', '')
-    return Exploit::CheckCode::Unknown if version_text.blank? || version_text == 'Unknown'
+    return Exploit::CheckCode::Unknown('Could not determine version') if version_text.blank? || version_text == 'Unknown'
 
     version = Rex::Version.new(version_text)
-    return Exploit::CheckCode::Unknown if version == Rex::Version.new('0')
+    return Exploit::CheckCode::Unknown('Could not parse version') if version == Rex::Version.new('0')
     return Exploit::CheckCode::Appears("Version: #{version}") if version <= Rex::Version.new('3.21.0')
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
   end
 
   def generate_jsp_payload

--- a/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
+++ b/modules/exploits/windows/http/lg_simple_editor_rce_uploadvideo.rb
@@ -68,13 +68,13 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
 
     version_text = res.get_html_document.xpath('//h2')[0]&.text&.gsub('v', '')
-    return Exploit::CheckCode::Unknown if version_text.blank? || version_text == 'Unknown'
+    return Exploit::CheckCode::Unknown('Could not determine version') if version_text.blank? || version_text == 'Unknown'
 
     version = Rex::Version.new(version_text)
-    return Exploit::CheckCode::Unknown if version == Rex::Version.new('0')
+    return Exploit::CheckCode::Unknown('Could not parse version') if version == Rex::Version.new('0')
     return Exploit::CheckCode::Appears("Version: #{version}") if version <= Rex::Version.new('3.21.0')
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/magicinfo_traversal.rb
+++ b/modules/exploits/windows/http/magicinfo_traversal.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'config.js')
     })
 
-    return CheckCode::Unknown unless res&.code == 200
+    return CheckCode::Unknown('Target did not return HTTP 200') unless res&.code == 200
 
     js_object = res.body.to_s[/window\.globalConfig = (\{.+\})/m, 1]
 
@@ -74,14 +74,14 @@ class MetasploitModule < Msf::Exploit::Remote
     full_version = data.fetch('magicInfoFrontEndVersion', nil)
     version = full_version[/Server\s+([\d.]+)/, 1]
 
-    return CheckCode::Unknown unless version
+    return CheckCode::Unknown('Could not extract version from response') unless version
 
     unless Rex::Version.new(version) > Rex::Version.new('21.1050.0')
       vprint_status("MagicINFO version detected: #{full_version}")
-      return CheckCode::Appears
+      return CheckCode::Appears("Detected vulnerable version: #{version}")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("Target is not vulnerable based on version: #{version}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/mailenable_auth_header.rb
+++ b/modules/exploits/windows/http/mailenable_auth_header.rb
@@ -52,10 +52,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = http_fingerprint # check method
     if (info =~ /MailEnable/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -65,21 +65,21 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res && res.code == 200
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target did not respond as expected')
     end
 
     if res.body =~ /OpManager.*v\.([0-9]+\.[0-9]+)<\/span>/
       version = $1
       if Rex::Version.new(version) <= Rex::Version.new('11.6')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
       else
         # Patch unknown
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected("Target detected with version: #{version}")
       end
     elsif res.body =~ /OpManager/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('OpManager detected but version not identified')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target does not appear to be OpManager')
     end
   end
 

--- a/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
+++ b/modules/exploits/windows/http/manageengine_adshacluster_rce.rb
@@ -59,12 +59,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     unless res.code == 200
       vprint_status 'Target is not ManageEngine Exchange Reporter Plus'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     begin
@@ -72,16 +72,16 @@ class MetasploitModule < Msf::Exploit::Remote
       raise if json.empty? || !json['BUILD_NUMBER']
     rescue
       vprint_status 'Target is not ManageEngine Exchange Reporter Plus'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     vprint_status "Version: #{json['BUILD_NUMBER']}"
 
     if json['BUILD_NUMBER'].to_i <= 5310
-      return CheckCode::Appears
+      return CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/manageengine_appmanager_exec.rb
+++ b/modules/exploits/windows/http/manageengine_appmanager_exec.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = trigger_endpoint(Rex::Text.rand_text_alpha(3))
     if res && res.body.include?('Kindly check the credentials and try again')
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Target is vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/manageengine_connectionid_write.rb
+++ b/modules/exploits/windows/http/manageengine_connectionid_write.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error("Connection timed out")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     build_number = get_build_number(res)
@@ -144,12 +144,12 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Found title: #{html_title}")
 
     if build_number <= '91084'
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Detected vulnerable version: #{build_number}")
     elsif /ManageEngine Desktop Central/ === html_title
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Target detected with version: #{build_number}")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{build_number}")
   end
 
   def upload_jsp(stager_info)

--- a/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
+++ b/modules/exploits/windows/http/manageengine_endpoint_central_saml_rce_cve_2022_47966.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     # check if SAML-based SSO is enabled otherwise exploit will fail
     # No additional fingerprint / banner information available to collect and determine version
-    return Exploit::CheckCode::Safe unless check_saml_enabled
+    return Exploit::CheckCode::Safe('SAML-based SSO is not enabled') unless check_saml_enabled
 
     CheckCode::Detected('SAML-based SSO is enabled.')
   end

--- a/modules/exploits/windows/http/mcafee_epolicy_source.rb
+++ b/modules/exploits/windows/http/mcafee_epolicy_source.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
     banner = sock.get_once
 
     if banner.to_s =~ /Spipe\/1\.0/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
+++ b/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner.to_s =~ /WDaemon\/6\.8\.[0-5]/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/miniweb_upload_wbem.rb
+++ b/modules/exploits/windows/http/miniweb_upload_wbem.rb
@@ -74,16 +74,16 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
       vprint_error("Connection failed")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
     if !res or res.headers['Server'].empty?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     elsif res.headers['Server'] =~ /^MiniWeb$/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def upload(filename, filedata)

--- a/modules/exploits/windows/http/moveit_cve_2023_34362.rb
+++ b/modules/exploits/windows/http/moveit_cve_2023_34362.rb
@@ -112,21 +112,21 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200 && res.headers.key?('X-MOVEitISAPI-Version')
       version = Rex::Version.new(res.headers['X-MOVEitISAPI-Version'])
       # 2020.1.x AKA 12.1.x
-      return Exploit::CheckCode::Appears if version >= Rex::Version.new('12.1.0') && version < Rex::Version.new('12.1.10')
+      return Exploit::CheckCode::Appears("MOVEit Transfer version #{version} is vulnerable") if version >= Rex::Version.new('12.1.0') && version < Rex::Version.new('12.1.10')
       # 2021.0.x AKA 13.0.x
-      return Exploit::CheckCode::Appears if version >= Rex::Version.new('13.0.0') && version < Rex::Version.new('13.0.8')
+      return Exploit::CheckCode::Appears("MOVEit Transfer version #{version} is vulnerable") if version >= Rex::Version.new('13.0.0') && version < Rex::Version.new('13.0.8')
       # 2021.1.x AKA 13.1.x
-      return Exploit::CheckCode::Appears if version >= Rex::Version.new('13.1.0') && version < Rex::Version.new('13.1.6')
+      return Exploit::CheckCode::Appears("MOVEit Transfer version #{version} is vulnerable") if version >= Rex::Version.new('13.1.0') && version < Rex::Version.new('13.1.6')
       # 2022.0.x AKA 14.0.x
-      return Exploit::CheckCode::Appears if version >= Rex::Version.new('14.0.0') && version < Rex::Version.new('14.0.6')
+      return Exploit::CheckCode::Appears("MOVEit Transfer version #{version} is vulnerable") if version >= Rex::Version.new('14.0.0') && version < Rex::Version.new('14.0.6')
       # 2022.1.x AKA 14.1.x
-      return Exploit::CheckCode::Appears if version >= Rex::Version.new('14.1.0') && version < Rex::Version.new('14.1.7')
+      return Exploit::CheckCode::Appears("MOVEit Transfer version #{version} is vulnerable") if version >= Rex::Version.new('14.1.0') && version < Rex::Version.new('14.1.7')
       # 2023.0.x AKA 15.0.x
-      return Exploit::CheckCode::Appears if version >= Rex::Version.new('15.0.0') && version < Rex::Version.new('15.0.3')
+      return Exploit::CheckCode::Appears("MOVEit Transfer version #{version} is vulnerable") if version >= Rex::Version.new('15.0.0') && version < Rex::Version.new('15.0.3')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('MOVEit Transfer not detected')
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def cleanup

--- a/modules/exploits/windows/http/navicopa_get_overflow.rb
+++ b/modules/exploits/windows/http/navicopa_get_overflow.rb
@@ -65,10 +65,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (resp =~ /2\.01 11th September/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/netdecision_http_bof.rb
+++ b/modules/exploits/windows/http/netdecision_http_bof.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({ 'uri' => '/' })
     banner = res.headers['Server']
     if banner =~ /NetDecision\-HTTP\-Server\/1\.0/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/netgear_nms_rce.rb
+++ b/modules/exploits/windows/http/netgear_nms_rce.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => { 'method' => 'loginHtml' } # This is required for auth bypass above v1.5.0.11
     })
     if res && res.code == 200 # if this endpoint returns 200 than we can exploit all targets
-      Exploit::CheckCode::Detected
+      Exploit::CheckCode::Detected('Target service detected')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/novell_mdm_lfi.rb
+++ b/modules/exploits/windows/http/novell_mdm_lfi.rb
@@ -67,13 +67,13 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Detected version: #{v || 'Unknown'}")
 
     if v.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     elsif v =~ /^2\.6\.[01]/ or v =~ /^2\.7\.0/
       # Conditions based on OSVDB info
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def setup_session()

--- a/modules/exploits/windows/http/oats_weblogic_console.rb
+++ b/modules/exploits/windows/http/oats_weblogic_console.rb
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.body.include?('Oracle WebLogic Server Administration Console')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def set_admin_console_session(res)

--- a/modules/exploits/windows/http/octopusdeploy_deploy.rb
+++ b/modules/exploits/windows/http/octopusdeploy_deploy.rb
@@ -72,17 +72,17 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::BadConfig, 'Need username and password or API key')
       rescue Msf::Exploit::Failed => e
         vprint_error(e.message)
-        return CheckCode::Unknown
+        return CheckCode::Unknown('Could not determine the target status')
       end
     end
     disconnect
-    return CheckCode::Unknown if res.nil?
+    return CheckCode::Unknown('No response received from target') if res.nil?
 
     if res.code.between?(400, 499)
       vprint_error("Server rejected the credentials")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
-    CheckCode::Appears
+    CheckCode::Appears('Target appears to be vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/oracle9i_xdb_pass.rb
+++ b/modules/exploits/windows/http/oracle9i_xdb_pass.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (resp =~ /9\.2\.0\.1\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/oracle_beehive_evaluation.rb
+++ b/modules/exploits/windows/http/oracle_beehive_evaluation.rb
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'voice-servlet', 'prompt-qa', 'showRecxml.jsp'))
 
     if res && /RECXML Prompt Tester/ === res.body
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
+++ b/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
@@ -60,12 +60,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error("Connection timed out.")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     elsif res && (res.code == 403 || res.code == 200)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -84,13 +84,13 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_soap(version_soap)
 
     if res.nil? or res.code != 200 or res.body !~ /versionResponse/
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target did not return a valid version response')
     end
 
     version_match = res.body.match(/<serverVersion>Oracle Endeca Server ([0-9\.]*) /)
 
     if version_match.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Could not extract version from response')
     else
       version = version_match[1]
     end
@@ -98,10 +98,10 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Version found: Oracle Endeca Server #{version}")
 
     if version =~ /7\.4\.0/ and version <= "7.4.0.787"
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
   end
 
   def send_request_soap(data)

--- a/modules/exploits/windows/http/oracle_event_processing_upload.rb
+++ b/modules/exploits/windows/http/oracle_event_processing_upload.rb
@@ -123,12 +123,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200
       if res.body.to_s.include?("Oracle Event Processing 11g Release 1 (11.1.1.7.0)")
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('Target service detected')
       elsif res.body.to_s.include?("Oracle Event Processing 12")
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('Target is not vulnerable')
       end
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 end

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -238,7 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Camera Upload not enabled')
     end
     print_good("Camera Upload: #{server['MediaContainer']['allowCameraUpload']}")
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable("Version #{v} is vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/http/prtg_authenticated_rce.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce.rb
@@ -233,7 +233,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(datastore['URI'], '/index.htm')
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     ensure
       disconnect
     end
@@ -255,16 +255,16 @@ class MetasploitModule < Msf::Exploit::Remote
       if prtg_version
         vprint_status("Identified PRTG Network Monitor Version #{prtg_version}")
         if Rex::Version.new(prtg_version) < Rex::Version.new('18.2.39')
-          return CheckCode::Appears
+          return CheckCode::Appears("Detected vulnerable version: #{prtg_version}")
         else
-          return CheckCode::Safe
+          return CheckCode::Safe("Target is not vulnerable based on version: #{prtg_version}")
         end
       elsif (prtg_server_header.include? 'PRTG') || (html.to_s.include? 'PRTG')
-        return CheckCode::Detected
+        return CheckCode::Detected('PRTG Network Monitor detected but version not identified')
       end
     end
 
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
@@ -76,20 +76,19 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(datastore['URI'], '/index.htm')
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     ensure
       disconnect
     end
 
     if res && res.code == 200
       prtg_server_header = res.headers['Server']
-
-      if (prtg_server_header.include? 'PRTG') || (html.to_s.include? 'PRTG')
-        return CheckCode::Detected
+      if (prtg_server_header&.include? 'PRTG') || (res.body.to_s.include? 'PRTG')
+        return CheckCode::Detected("Target detected: #{prtg_server_header || 'PRTG detected in response body'}")
       end
     end
 
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/windows/http/psoproxy91_overflow.rb
+++ b/modules/exploits/windows/http/psoproxy91_overflow.rb
@@ -64,10 +64,10 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put("GET / HTTP/1.0\r\n\r\n")
     banner = sock.get_once
     if (banner.to_s =~ /PSO Proxy 0\.9/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/rabidhamster_r4_log.rb
+++ b/modules/exploits/windows/http/rabidhamster_r4_log.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.headers['Server'] == 'R4 Embedded Server'
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     else
-      return Exploit::CheckCoded::Safe
+      return Exploit::CheckCode::Safe('Target service was not detected')
     end
   end
 

--- a/modules/exploits/windows/http/rejetto_hfs_exec.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_exec.rb
@@ -67,12 +67,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.headers['Server'] && res.headers['Server'] =~ /HFS ([\d.]+)/
       version = $1
       if Rex::Version.new(version) <= Rex::Version.new("2.3")
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected("Target detected with version: #{version}")
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version}")
       end
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('HFS not detected')
     end
   end
 

--- a/modules/exploits/windows/http/rejetto_hfs_rce_cve_2024_23692.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_rce_cve_2024_23692.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Vulnerable("Rejetto HFS version #{version[1]}") if version
 
-    CheckCode::Safe
+    CheckCode::Safe('Rejetto HFS not detected or not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/sambar6_search_results.rb
+++ b/modules/exploits/windows/http/sambar6_search_results.rb
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /Server:\sSAMBAR/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -71,15 +71,15 @@ class MetasploitModule < Msf::Exploit
       res = send_evil_request(uri, "whoami", 20)
     rescue
       vprint_error("An error has occurred while sending the malicious request")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
     if !res
       vprint_error("Connection timed out")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     elsif res.body.include?("Process created")
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target is vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -391,9 +391,9 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 10)
 
     if (res and res.code == 500 and res.body =~ /Generic error/)
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('Target is vulnerable')
     else
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/savant_31_overflow.rb
+++ b/modules/exploits/windows/http/savant_31_overflow.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = http_fingerprint # check method
     if info and (info =~ /Savant\/3\.1/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def safe_nops(count)

--- a/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
+++ b/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
@@ -65,30 +65,30 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.headers['Server'] !~ /Serviio/
       vprint_status 'Target is not a Serviio Media Server'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     if res.headers['Server'] !~ /Windows/
       vprint_status 'Target operating system is not vulnerable'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     if res.code != 200 || res.body !~ %r{<errorCode>603</errorCode>}
       vprint_status 'Unexpected reply'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     if res.headers['Server'] =~ %r{Serviio/(1\.[4-8])}
       vprint_status "#{peer} Serviio Media Server version #{$1}"
-      return CheckCode::Appears
+      return CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Target is not vulnerable')
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/windows/http/servu_session_cookie.rb
+++ b/modules/exploits/windows/http/servu_session_cookie.rb
@@ -81,12 +81,12 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (res.to_s =~ /Server: Serv-U\/9\.0\.0\.5/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     elsif (res.to_s =~ /Server: Serv-U/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/sharepoint_data_deserialization.rb
+++ b/modules/exploits/windows/http/sharepoint_data_deserialization.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe('Failed to identify that SharePoint is running.') unless res&.code == 200 && res.headers['MicrosoftSharePointTeamServices']
 
     html = res.get_html_document
-    return CheckCode::Safe if html.xpath('//html/body/form[@action]').select do |node|
+    return CheckCode::Safe('Quicklinks form not found in response') if html.xpath('//html/body/form[@action]').select do |node|
       node['action'] =~ /quicklinks.aspx\?Mode=Suggestion/i
     end.empty?
 

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -72,9 +72,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('No compiler errors were reported') unless compiler_errors&.length&.> 0
 
     # once patched you get a specific compiler error message about the type name
-    return CheckCode::Safe if compiler_errors[0].to_s =~ /is not a valid language-independent type name/
+    return CheckCode::Safe('Target appears to be patched') if compiler_errors[0].to_s =~ /is not a valid language-independent type name/
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Target is vulnerable')
   end
 
   def extract_compiler_errors(res)

--- a/modules/exploits/windows/http/shoutcast_format.rb
+++ b/modules/exploits/windows/http/shoutcast_format.rb
@@ -64,23 +64,23 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => uri
     }, 5)
 
-    return Exploit::CheckCode::Safe if not r
+    return Exploit::CheckCode::Safe('No response from target') if not r
 
     m = r.body.match(/Network Audio Server\/([^\s]+)\s+([^<]+)<BR/)
-    return Exploit::CheckCode::Safe if not m
+    return Exploit::CheckCode::Safe('Could not identify SHOUTcast version') if not m
 
     vprint_status("This system is running SHOUTcast #{m[1]} on #{m[2]}")
 
     # SHOUTcast Distributed Network Audio Server/win32 v1.9.2<BR>
     if (m[1] =~ /v1\.([0-8]\.|9\.[0-3])$/)
       if (m[2] == "win32")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('Target appears to be vulnerable')
       else
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('Target service detected')
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/smartermail_rce.rb
+++ b/modules/exploits/windows/http/smartermail_rce.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if product_build && Rex::Version.new(build_number) < Rex::Version.new('6985')
-      return CheckCode::Appears
+      return CheckCode::Appears("Detected vulnerable version: #{build_number}")
     end
 
     print_status('Checking SmarterMail product version...')
@@ -145,10 +145,10 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Target is running SmarterMail Version #{version_number}.")
 
     if Rex::Version.new(version_number) <= Rex::Version.new('16.3.6989.16341')
-      return CheckCode::Appears
+      return CheckCode::Appears("Detected vulnerable version: #{version_number}")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("Target is not vulnerable based on version: #{version_number}")
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/windows/http/softing_sis_rce.rb
+++ b/modules/exploits/windows/http/softing_sis_rce.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # check the Softing SIS version
     softing_version_res = checker_instance.check_setup
     unless softing_version_res
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     softing_version = Rex::Version.new(softing_version_res)
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # the vulnerabilities are to be fixed in version 1.30 according to the Softing advisory
     # so we will not continue if the version is not vulnerable
     unless softing_version < Rex::Version.new('1.30')
-      return CheckCode::Safe
+      return CheckCode::Safe("Target is not vulnerable based on version: #{softing_version_res}")
     end
 
     # if the operator provides a signature, then use that instead of the username and password
@@ -171,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # if the version is less than 1.30 it's supposedly vulnerable
     # but there is no way to confirm vulnerability existence without actually exploiting
     # so instead of "Vulnerable", return "Appears"
-    CheckCode::Appears
+    CheckCode::Appears("Detected vulnerable version: #{softing_version_res}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
+++ b/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'fsm', 'login.jsp'))
 
     if res && res.body =~ /SolarWinds FSM Change Advisor/i
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   # Exploit/run command

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -75,9 +75,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res and res.body =~ /\<title>\SolarWinds \- Storage Manager\<\/title\>/ and
        res.body =~ /\<img style="padding\-top:30px;" src="\/images\/logo_solarwinds_login\.png" width="163" height="70" alt="SolarWinds Storage Manager"\>/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
+++ b/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_raw({ 'uri' => '/' }) # Check the base path for version regex
     if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
        res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-1]\<\/div\>/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
+++ b/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     json_response = send_api_request('ReportServerInfo', 'Model.SiteName')
-    return CheckCode::Unknown unless json_response && json_response['value'] == 'SQL Server Reporting Services'
+    return CheckCode::Unknown('SQL Server Reporting Services not detected') unless json_response && json_response['value'] == 'SQL Server Reporting Services'
 
-    CheckCode::Detected
+    CheckCode::Detected('Target service detected')
   end
 
   def exploit

--- a/modules/exploits/windows/http/steamcast_useragent.rb
+++ b/modules/exploits/windows/http/steamcast_useragent.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (res.to_s =~ /Steamcast\/0\.9\.75/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/sws_connection_bof.rb
+++ b/modules/exploits/windows/http/sws_connection_bof.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_raw({ 'uri' => '/' })
     if res and res.headers['Server'] =~ /PMSoftware\-SWS\/2\.[0-2]/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/syncbreeze_bof.rb
+++ b/modules/exploits/windows/http/syncbreeze_bof.rb
@@ -94,15 +94,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     product_name = get_product_name
-    return Exploit::CheckCode::Unknown unless product_name
+    return Exploit::CheckCode::Unknown('Could not determine product name') unless product_name
 
     if product_name =~ /9\.4\.28/ || product_name =~ /10\.0\.28/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears to be vulnerable')
     elsif product_name =~ /Sync Breeze Enterprise/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def get_target_name

--- a/modules/exploits/windows/http/telerik_rau_deserialization.rb
+++ b/modules/exploits/windows/http/telerik_rau_deserialization.rb
@@ -92,8 +92,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'Telerik.Web.UI.WebResource.axd'),
       'vars_get' => { 'type' => 'rau' }
     })
-    return CheckCode::Safe unless res&.code == 200
-    return CheckCode::Safe unless res.get_json_document&.dig('message') =~ /RadAsyncUpload handler is registered succesfully/
+    return CheckCode::Safe('Target did not return HTTP 200') unless res&.code == 200
+    return CheckCode::Safe('RadAsyncUpload handler not detected') unless res.get_json_document&.dig('message') =~ /RadAsyncUpload handler is registered succesfully/
 
     if datastore['VERSION'].blank?
       @version = enumerate_version
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         upload_file('', datastore['VERSION'])
       rescue Msf::Exploit::Failed
-        return CheckCode::Safe
+        return CheckCode::Safe("Target is not vulnerable based on version: #{datastore['VERSION']}")
       end
 
       @version = datastore['VERSION']
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # with custom errors enabled (which is the default), it's not possible to test for the serialization flaw without triggering it
-    CheckCode::Detected
+    CheckCode::Detected("Target detected with version: #{@version}")
   end
 
   def exploit

--- a/modules/exploits/windows/http/tomcat_cgi_cmdlineargs.rb
+++ b/modules/exploits/windows/http/tomcat_cgi_cmdlineargs.rb
@@ -73,14 +73,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error('No Response from server')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine the target status')
     end
 
     if res.body.include?(sig)
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('Target is vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Target is not vulnerable')
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/windows/http/trackercam_phparg_overflow.rb
+++ b/modules/exploits/windows/http/trackercam_phparg_overflow.rb
@@ -78,9 +78,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if (res and res.body =~ /fsockopen/)
       fp = fingerprint()
       vprint_status("Detected a vulnerable TrackerCam installation on #{fp}")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/trackit_file_upload.rb
+++ b/modules/exploits/windows/http/trackit_file_upload.rb
@@ -88,16 +88,16 @@ class MetasploitModule < Msf::Exploit::Remote
           sock.write(rand_text_alpha(rand(200) + 100))
           res = sock.recv(1024)
           if res =~ /Tcp channel protocol violation: expecting preamble/
-            return Exploit::CheckCode::Appears
+            return Exploit::CheckCode::Appears("Detected vulnerable version: #{version.join('.')}")
           end
 
           sock.close
         end
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Target is not vulnerable based on version: #{version.join('.')}")
       end
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not determine the target status')
   end
 
   def longest_common_substr(strings)

--- a/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
+++ b/modules/exploits/windows/http/trendmicro_officescan_widget_exec.rb
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
     token = auth(my_target)
     # If we dont have a cookie that means authentication bypass issue has been patched on target system.
     if token.nil?
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Target is not vulnerable')
     else
       # Authentication bypass does not mean that we have a command injection.
       # Accessing to the widget framework without having command injection means literally nothing.
@@ -171,9 +171,9 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
       if res && res.code == 200 && res.body.include?('Proxy execution failed: exec report.php failed')
-        Exploit::CheckCode::Vulnerable
+        Exploit::CheckCode::Vulnerable('Target is vulnerable')
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('Target is not vulnerable')
       end
     end
   end

--- a/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
+++ b/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
@@ -126,10 +126,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /vCenter Chargeback Manager/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/http/vxsrchs_bof.rb
+++ b/modules/exploits/windows/http/vxsrchs_bof.rb
@@ -69,17 +69,17 @@ class MetasploitModule < Msf::Exploit::Remote
       if version
         vprint_status("Version detected: #{version}")
         if version =~ /9\.5\.12/
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears("Detected vulnerable version: #{version}")
         end
 
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected("Target detected with version: #{version}")
       end
     else
       vprint_error('Unable to determine due to a HTTP connection timeout')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target status')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('VX Search Enterprise not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/http/ws_ftp_rce_cve_2023_40044.rb
+++ b/modules/exploits/windows/http/ws_ftp_rce_cve_2023_40044.rb
@@ -105,10 +105,10 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # If we couldn't get the JS build date, we at least know the target is WS_FTP with the Ad Hoc Transfer module.
-      return CheckCode::Detected
+      return CheckCode::Detected('Target service detected')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine the target status')
   end
 
   def exploit

--- a/modules/exploits/windows/http/xitami_if_mod_since.rb
+++ b/modules/exploits/windows/http/xitami_if_mod_since.rb
@@ -69,10 +69,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (banner.to_s =~ /Xitami/)
       vprint_status("Banner: #{banner}")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical