### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
+++ b/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
@@ -317,11 +317,11 @@ class MetasploitModule < Msf::Exploit::Local
     acrord32 = session.railgun.kernel32.GetModuleHandleA("AcroRd32.exe")
     @addresses['AcroRd32.exe'] = acrord32["return"]
     if @addresses['AcroRd32.exe'] == 0
-      return Msf::Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Unknown('Unable to determine target state')
     elsif check_trigger
-      return Msf::Exploit::CheckCode::Vulnerable
+      return Msf::Exploit::CheckCode::Vulnerable('Target is vulnerable')
     else
-      return Msf::Exploit::CheckCode::Detected
+      return Msf::Exploit::CheckCode::Detected('AcroRd32.exe process found, but target does not match the expected vulnerable build')
     end
   end
 

--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -123,11 +123,11 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     handle = open_named_pipe("\\\\.\\pipe\\acsipc_server")
     if handle.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     session.railgun.kernel32.CloseHandle(handle)
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Detected('Target service detected')
   end
 
   def exploit

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -73,10 +73,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     if local_machine_value.nil?
       vprint_error("#{hklm}\\#{install_elevated} does not exist or is not accessible.")
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('Target is not vulnerable')
     elsif local_machine_value == 0
       vprint_error("#{hklm}\\#{install_elevated} is #{local_machine_value}.")
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('Target is not vulnerable')
     else
       vprint_good("#{hklm}\\#{install_elevated} is #{local_machine_value}.")
       current_user_value = registry_getvaldata(hkcu, install_elevated)
@@ -84,13 +84,13 @@ class MetasploitModule < Msf::Exploit::Local
 
     if current_user_value.nil?
       vprint_error("#{hkcu}\\#{install_elevated} does not exist or is not accessible.")
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('Target is not vulnerable')
     elsif current_user_value == 0
       vprint_error("#{hkcu}\\#{install_elevated} is #{current_user_value}.")
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('Target is not vulnerable')
     else
       vprint_good("#{hkcu}\\#{install_elevated} is #{current_user_value}.")
-      return Msf::Exploit::CheckCode::Vulnerable
+      return Msf::Exploit::CheckCode::Vulnerable('Target is vulnerable')
     end
   end
 

--- a/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
+++ b/modules/exploits/windows/local/appxsvc_hard_link_privesc.rb
@@ -60,12 +60,12 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1803)
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears vulnerable")
     elsif version.build_number >= Msf::WindowsVersion::Win10_InitialRelease
-      return CheckCode::Detected
+      return CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
     end
 
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Unable to determine target state')
   end
 
   def upload_file(file_name, file_path)

--- a/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
+++ b/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
@@ -157,18 +157,18 @@ class MetasploitModule < Msf::Exploit::Local
     if version.build_number < Msf::WindowsVersion::Win8 && !version.windows_server?
       print_bad("Operating system: #{version.product_name}")
       print_bad('BITS behavior on Windows 7 and previous has not been shown vulnerable.')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     unless privs.include?('SeImpersonatePrivilege') || privs.include?('SeAssignPrimaryTokenPrivilege')
       print_bad('Target session is missing both SeImpersonatePrivilege and SeAssignPrimaryTokenPrivilege.')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Session lacks required SeImpersonatePrivilege or SeAssignPrimaryTokenPrivilege')
     end
     vprint_good('Target session has either SeImpersonatePrivilege or SeAssignPrimaryTokenPrivilege.')
 
     running_services_code = check_bits_and_winrm
     if running_services_code < 0
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown("Could not determine BITS/WinRM service state for version #{version}")
     end
 
     should_services_be_shutdown = datastore['SHUTDOWN_SERVICES']
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
       if [WINRM, WINRM + BITS].include?(running_services_code)
         print_bad('WinRM is running. Target is not exploitable.')
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('WinRM is running, target is not exploitable')
       elsif running_services_code == BITS
         if should_services_be_shutdown
           print_warning('Failed to shutdown BITS.')
@@ -191,11 +191,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     if is_system?
       print_bad('Session is already elevated.')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Session is already elevated')
     end
 
     vprint_good('Session is not (yet) System.')
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
   end
 
   #

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -138,18 +138,18 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # covers both native x64 and WOW64
     if sysinfo['Architecture'] == ARCH_X64
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     version = get_version_info
-    return Exploit::CheckCode::Safe unless version.build_number == Msf::WindowsVersion::XP_SP3
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable") unless version.build_number == Msf::WindowsVersion::XP_SP3
 
     handle = open_device('\\\\.\\bthpan', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
-    return Exploit::CheckCode::Safe unless handle
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable") unless handle
 
     session.railgun.kernel32.CloseHandle(handle)
 
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("System OS Detected: #{version_info.product_name}")
     # return CheckCode::Safe('UAC is not enabled') unless is_uac_enabled?
     if version_info.build_number.between?(::Msf::WindowsVersion::Win7_SP0, ::Msf::WindowsVersion::Win10_1903)
-      return CheckCode::Appears
+      return CheckCode::Appears("#{version_info.product_name} appears vulnerable")
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe("#{version_info.product_name} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if is_uac_enabled?
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('Target appears vulnerable')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -75,9 +75,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win10_1607)
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number >= Msf::WindowsVersion::Win10_InitialRelease && !version.windows_server? && is_uac_enabled?
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/bypassuac_sdclt.rb
+++ b/modules/exploits/windows/local/bypassuac_sdclt.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number >= Msf::WindowsVersion::Vista_SP0 && is_uac_enabled?
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -75,9 +75,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number.between?(Msf::WindowsVersion::Win8, Msf::WindowsVersion::Win10_1909)
-      CheckCode::Appears
+      CheckCode::Appears("Version #{version} appears vulnerable")
     else
-      CheckCode::Safe
+      CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
@@ -63,10 +63,10 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number > Msf::WindowsVersion::Win10_InitialRelease && !version.windows_server? && exists?('C:\\Windows\\System32\\WSReset.exe')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears vulnerable")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
@@ -65,10 +65,10 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number >= Msf::WindowsVersion::Win10_InitialRelease && !version.windows_server? && is_uac_enabled? && exists?('C:\\Windows\\System32\\WSReset.exe')
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears vulnerable")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -66,11 +66,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return Exploit::CheckCode::Unknown unless session.platform == 'windows'
+    return Exploit::CheckCode::Unknown('Unable to determine target state') unless session.platform == 'windows'
 
     version = get_version_info
     if version.build_number < Msf::WindowsVersion::Win7_SP0 || version.windows_server?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     # These versions of Windows 11 come built in with a driver block list preventing loading of capcom.sys
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if sysinfo['Architecture'] != ARCH_X64
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("System architecture #{sysinfo['Architecture']} is not supported; only x64 targets are vulnerable to this exploit")
     end
 
     # Validate that the driver has been loaded and that
@@ -91,11 +91,11 @@ class MetasploitModule < Msf::Exploit::Local
       target_checksum = client.fs.file.md5(d[:filename])
 
       if expected_checksum == Rex::Text.to_hex(target_checksum, '')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
+++ b/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
@@ -93,10 +93,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if session.sys.process['SearchIndexer.exe']
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Search Indexer process detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def get_name(option, default_ext)

--- a/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
+++ b/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     file_path = expand_path('%WINDIR%\\system32\\win32k.sys')
@@ -76,21 +76,21 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2019-12-10/microsoft/
     if (build_num_gemversion >= Rex::Version.new('6.0.6000.0')) && (build_num_gemversion < Rex::Version.new('6.0.6003.20692')) # Windows Vista and Windows Server 2008
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     elsif (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24540')) # Windows 7 and Windows Server 2008 R2
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     elsif (build_num_gemversion >= Rex::Version.new('6.2.9200.0')) && (build_num_gemversion < Rex::Version.new('6.2.9200.22932')) # Windows 8 and Windows Server 2012
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     elsif (build_num_gemversion >= Rex::Version.new('6.3.9600.0')) && (build_num_gemversion < Rex::Version.new('6.3.9600.19574')) # Windows 8.1 and Windows Server 2012 R2
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     elsif (build_num_gemversion >= Rex::Version.new('10.0.10240.0')) && (build_num_gemversion < Rex::Version.new('10.0.10240.18427')) # Windows 10 v1507
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     elsif (build_num_gemversion >= Rex::Version.new('10.0.10586.0')) && (build_num_gemversion < Rex::Version.new('10.0.10586.99999')) # Windows 10 v1511
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     elsif (build_num_gemversion >= Rex::Version.new('10.0.14393.0')) && (build_num_gemversion < Rex::Version.new('10.0.14393.3383')) # Windows 10 v1607
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     else
-      return CheckCode::Safe
+      return CheckCode::Safe("Revision #{revision} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     version = get_version_info
@@ -71,16 +71,16 @@ class MetasploitModule < Msf::Exploit::Local
     # see https://docs.microsoft.com/en-us/windows/release-information/
     unless version.build_number.between?(Msf::WindowsVersion::Win10_1903, Msf::WindowsVersion::Win10_1909)
       print_error('The exploit only supports Windows 10 versions 1903 - 1909')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     disable_compression = registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters', 'DisableCompression')
     if !disable_compression.nil? && disable_compression != 0
       print_error('The exploit requires compression to be enabled')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("Version #{version} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -176,9 +176,9 @@ class MetasploitModule < Msf::Exploit::Local
     version = get_version_info
 
     vprint_status("OS version: #{version}")
-    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909)
+    return Exploit::CheckCode::Appears("Version #{version} appears vulnerable") if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def ensure_clean_destination(path)

--- a/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
+++ b/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     file_path = expand_path('%WINDIR%\\system32\\win32k.sys')
@@ -84,11 +84,11 @@ class MetasploitModule < Msf::Exploit::Local
     if (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24542')) # Windows 7 SP1
       @xleft_offset = 0x900
       @oob_offset = 0x238
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     elsif (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24553')) # Windows 7 SP1 with patches
       @xleft_offset = 0x8c0
       @oob_offset = 0x240
-      return CheckCode::Appears
+      return CheckCode::Appears("Revision #{revision} appears vulnerable")
     else
       return CheckCode::Safe("No target for win32k.sys version #{build_num_gemversion}")
     end

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -153,9 +153,9 @@ class MetasploitModule < Msf::Exploit::Local
     version = get_version_info
     vprint_status("OS version: #{version}")
     if version.build_number.between?(Msf::WindowsVersion::Win10_1903, Msf::WindowsVersion::Win10_2004)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -177,8 +177,8 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     vprint_status("OS version: #{version}")
-    return Exploit::CheckCode::Appears if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909)
+    return Exploit::CheckCode::Appears("Version #{version} appears vulnerable") if version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_1909)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 end

--- a/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
+++ b/modules/exploits/windows/local/cve_2021_21551_dbutil_memmove.rb
@@ -67,16 +67,16 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     handle = open_device('\\\\.\\dbutil_2_3', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     if handle.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     session.railgun.kernel32.CloseHandle(handle)
-    CheckCode::Appears
+    CheckCode::Appears('Target appears vulnerable')
   end
 
   def target_compatible?

--- a/modules/exploits/windows/local/cve_2022_21882_win32k.rb
+++ b/modules/exploits/windows/local/cve_2022_21882_win32k.rb
@@ -90,18 +90,18 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     version = get_version_info
     vprint_status("Windows Build Number = #{version.product_name}")
     if version.build_number.between?(Msf::WindowsVersion::Win10_1803, Msf::WindowsVersion::Win10_21H2)
-      CheckCode::Appears
+      CheckCode::Appears("Version #{version} appears vulnerable")
     elsif version.build_number == Msf::WindowsVersion::Server2022 || version.build_number == Msf::WindowsVersion::Win11_21H2
       CheckCode::Detected("May be vulnerable, but exploit not tested on #{version.product_name}")
     else
       print_error('Vulnerability only present on Windows 10 versions 1803 - 21H2, Windows 11 21H2, Server 2019 and Server 2022')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/cve_2022_21999_spoolfool_privesc.rb
+++ b/modules/exploits/windows/local/cve_2022_21999_spoolfool_privesc.rb
@@ -99,10 +99,10 @@ class MetasploitModule < Msf::Exploit::Local
     elsif version.build_number.between?(Msf::WindowsVersion::Win10_InitialRelease, Msf::WindowsVersion::Win10_21H2) ||
           version.build_number == Msf::WindowsVersion::Server2022 ||
           version.build_number == Msf::WindowsVersion::Win11_21H2
-      return CheckCode::Appears
+      return CheckCode::Appears("Version #{version} appears vulnerable")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def winspool

--- a/modules/exploits/windows/local/cve_2022_3699_lenovo_diagnostics_driver.rb
+++ b/modules/exploits/windows/local/cve_2022_3699_lenovo_diagnostics_driver.rb
@@ -62,16 +62,16 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless session.platform == 'windows'
       # Non-Windows systems are definitely not affected.
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     handle = open_device('\\\\.\\LenovoDiagnosticsDriver', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     if handle.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     session.railgun.kernel32.CloseHandle(handle)
-    CheckCode::Appears
+    CheckCode::Appears('Target appears vulnerable')
   end
 
   def target_compatible?

--- a/modules/exploits/windows/local/cve_2023_21768_afd_lpe.rb
+++ b/modules/exploits/windows/local/cve_2023_21768_afd_lpe.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("This Windows host seems to be patched (build 22621.#{revision})")
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("Revision #{revision} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/cve_2023_28252_clfs_driver.rb
+++ b/modules/exploits/windows/local/cve_2023_28252_clfs_driver.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless session.platform == 'windows'
       # Non-Windows systems are definitely not affected.
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     file_path = get_env('WINDIR') + '\\system32\\drivers\\clfs.sys'
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Appears("The target is running windows version: #{version.build_number} which has a vulnerable version of clfs.sys installed by default")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/cve_2024_30085_cloud_files.rb
+++ b/modules/exploits/windows/local/cve_2024_30085_cloud_files.rb
@@ -97,9 +97,9 @@ class MetasploitModule < Msf::Exploit::Local
     version = get_version_info
     vprint_status("OS version: #{version}")
     vprint_status("OS revision: #{version.revision_number}")
-    return Exploit::CheckCode::Appears if target_compatible?(version)
+    return Exploit::CheckCode::Appears("Version #{version} appears vulnerable") if target_compatible?(version)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
 end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_good('OS seems vulnerable.')
     else
       vprint_error('OS is not vulnerable!')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     username = client.sys.config.getuid
@@ -101,18 +101,18 @@ class MetasploitModule < Msf::Exploit::Local
     srv_info = service_info('DNS')
     if srv_info.nil?
       vprint_error('Unable to enumerate the DNS service!')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     if srv_info && srv_info[:display].empty?
       vprint_error('The DNS service does not exist on this host!')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     # for use during permission check
     if srv_info[:dacl].nil?
       vprint_error('Unable to determine permissions on the DNS service!')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
     dacl_items = srv_info[:dacl].split('D:')[1].scan(/\((.+?)\)/)
 
@@ -122,12 +122,12 @@ class MetasploitModule < Msf::Exploit::Local
     group_membership = get_whoami
     unless group_membership
       vprint_error('Unable to enumerate group membership!')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     unless group_membership.include? 'DnsAdmins'
       vprint_error("User #{username} is not part of the DnsAdmins group!")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("User #{username} is not a member of the DnsAdmins group")
     end
 
     # find the DnsAdmins group SID
@@ -163,10 +163,10 @@ class MetasploitModule < Msf::Exploit::Local
       end
     else
       vprint_error("User #{username} does not have permissions to start/stop the DNS service!")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("User #{username} lacks start/stop permissions on the DNS service")
     end
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable("Version #{version} is vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if docker_version <= Rex::Version.new('18.09.0')
-      return CheckCode::Appears
+      return CheckCode::Appears('Target appears vulnerable')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if !service_exists?(@service_name)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     srv_info = service_info(@service_name)
@@ -83,19 +83,19 @@ class MetasploitModule < Msf::Exploit::Local
     case START_TYPE[srv_info[:starttype]]
     when 'Disabled'
       vprint_error("Service startup is Disabled, so will be unable to exploit unless account has correct permissions...")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     when 'Manual'
       vprint_error("Service startup is Manual, so will be unable to exploit unless account has correct permissions...")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     when 'Auto'
       vprint_good("Service is set to Automatically start...")
     end
 
     if check_search_path
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('Target appears vulnerable')
   end
 
   def check_search_path

--- a/modules/exploits/windows/local/ipass_launch_app.rb
+++ b/modules/exploits/windows/local/ipass_launch_app.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless session.platform == 'windows'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     svc = service_info('iPlatformService')
@@ -87,15 +87,15 @@ class MetasploitModule < Msf::Exploit::Local
 
       if handle.nil?
         vprint_error('\\\\.\\pipe\\IPEFSYSPCPIPE named pipe not found')
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('Target is not vulnerable')
       else
         vprint_good('\\\\.\\pipe\\IPEFSYSPCPIPE found!')
         session.railgun.kernel32.CloseHandle(handle)
       end
 
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target is vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/local/lenovo_systemupdate.rb
+++ b/modules/exploits/windows/local/lenovo_systemupdate.rb
@@ -76,15 +76,15 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless session.platform == 'windows'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     svc = service_info('SUService')
     if svc && svc[:display] =~ /System Update/
       vprint_good("Found service '#{svc[:display]}'")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Target service detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -95,18 +95,18 @@ class MetasploitModule < Msf::Exploit::Local
     handle = open_device('\\\\.\\MQAC', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     if handle.nil?
       print_error('MSMQ installation not found')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
     session.railgun.kernel32.CloseHandle(handle)
 
     version = get_version_info
     if version.build_number == Msf::WindowsVersion::XP_SP3
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     elsif version.xp_or_2003? && !version.windows_server?
       vprint_error('Unsupported version of Windows XP detected')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -54,16 +54,16 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Validate platform architecture
     if sysinfo['Architecture'] == ARCH_X64
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     # Validate OS version
     version = get_version_info
     unless version.build_number.between?(Msf::WindowsVersion::Win2000, Msf::WindowsVersion::Win7_SP1)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Local
     return CheckCode::Unknown('Could not retrieve OS system information.') unless system_info
 
     [ 'Windows Vista', 'Windows 7', 'Windows 2008' ].each do |v|
-      return CheckCode::Detected if system_info['OS'].include?(v)
+      return CheckCode::Detected("Target OS #{system_info['OS']} matches a vulnerable version") if system_info['OS'].include?(v)
     end
 
     CheckCode::Safe("#{system_info['OS']} is not vulnerable")

--- a/modules/exploits/windows/local/ms13_053_schlamperei.rb
+++ b/modules/exploits/windows/local/ms13_053_schlamperei.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless session.platform == 'windows'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
@@ -83,15 +83,15 @@ class MetasploitModule < Msf::Exploit::Local
 
     case build
     when 7600
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
     when 7601
       if branch == 18
-        return Exploit::CheckCode::Appears if revision < 18176
+        return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if revision < 18176
       elsif revision < 22348
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
       end
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Revision #{revision} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if session.platform != 'windows'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
@@ -75,13 +75,13 @@ class MetasploitModule < Msf::Exploit::Local
 
     case build
     when 7600
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
     when 7601
-      return Exploit::CheckCode::Appears if revision <= 18126
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if revision <= 18126
     when 9200
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Revision #{revision} is not vulnerable")
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Unable to determine target state')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
+++ b/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
@@ -73,26 +73,26 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless file_exist?("#{get_env("windir")}\\Microsoft.NET\\Framework\\v4.0.30319\\dfsvc.exe")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     net_version = get_net_version
 
     if net_version.empty?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     unless file_exist?("#{get_env("windir")}\\Microsoft.NET\\Framework\\v4.0.30319\\mscorlib.dll")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('mscorlib.dll not found, unable to verify patch status')
     end
 
     mscorlib_version = get_mscorlib_version
 
     if Rex::Version.new(mscorlib_version) >= Rex::Version.new(NET_VERSIONS[net_version]["mscorlib"])
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Mscorlib version #{mscorlib_version} is not vulnerable")
     end
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears("Mscorlib version #{mscorlib_version} appears vulnerable")
   end
 
   def get_net_version

--- a/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
@@ -84,12 +84,12 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
     # Neither target suports Windows 8 or 8.1
-    return Exploit::CheckCode::Safe if build == 9200
-    return Exploit::CheckCode::Safe if build == 9600
+    return Exploit::CheckCode::Safe("Build #{build} is not vulnerable") if build == 9200
+    return Exploit::CheckCode::Safe("Build #{build} is not vulnerable") if build == 9600
 
-    return Exploit::CheckCode::Appears if [2600, 3790, 7600, 7601].include?(build)
+    return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if [2600, 3790, 7600, 7601].include?(build)
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Unable to determine target state')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -76,27 +76,27 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if sysinfo["Architecture"] == ARCH_X64
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     handle = open_device('\\\\.\\tcp', 0, 'FILE_SHARE_READ', 'OPEN_EXISTING')
-    return Exploit::CheckCode::Safe unless handle
+    return Exploit::CheckCode::Safe('Target is not vulnerable') unless handle
 
     session.railgun.kernel32.CloseHandle(handle)
 
     file_path = get_env('WINDIR') << "\\system32\\drivers\\tcpip.sys"
     unless file?(file_path)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("tcpip.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
     if ("#{major}.#{minor}.#{build}" == "5.2.3790" && revision < 5440)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Revision #{revision} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms15_004_tswbproxy.rb
+++ b/modules/exploits/windows/local/ms15_004_tswbproxy.rb
@@ -83,14 +83,14 @@ class MetasploitModule < Msf::Exploit::Local
     version = get_version_info
 
     unless version.build_number.between?(Msf::WindowsVersion::Vista_SP0, Msf::WindowsVersion::Server2012_R2)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     unless file_exist?(dll_path)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -74,16 +74,16 @@ class MetasploitModule < Msf::Exploit::Local
     # Windows Server 2008 R2 (64-bit) SP1          6.1.7601.18105 (Works)
 
     unless session.platform == 'windows'
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
-    return Exploit::CheckCode::Safe if build > 7601
+    return Exploit::CheckCode::Safe("Build #{build} is not vulnerable") if build > 7601
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -311,35 +311,35 @@ class MetasploitModule < Msf::Exploit::Local
     # We have tested only windows 8.1
     version = get_version_info
     unless version.build_number != Msf::WindowsVersion::Win81 && !version.windows_server?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     # We have tested only 64 bits
     if sysinfo['Architecture'] != ARCH_X64
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     atmfd = atmfd_version
     # atmfd 5.1.2.238 => Works
     unless atmfd && Rex::Version.new(atmfd) <= Rex::Version.new('5.1.2.243')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     # win32k.sys 6.3.9600.17393 => Works
     @win32k = win32k_version
 
     unless @win32k && WIN32K_VERSIONS.include?(@win32k)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
     end
 
     # ntoskrnl.exe 6.3.9600.17415 => Works
     @ntoskrnl = ntoskrnl_version
 
     unless @ntoskrnl && NT_VERSIONS.include?(@ntoskrnl)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb
+++ b/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb
@@ -61,15 +61,15 @@ class MetasploitModule < Msf::Exploit::Local
     # Windows 7 SP0/SP1 (64-bit)
 
     unless session.platform == 'windows'
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     version = get_version_info
     vprint_status("OS Version: #{version.product_name}")
 
-    return Exploit::CheckCode::Safe unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable") unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms16_016_webdav.rb
+++ b/modules/exploits/windows/local/ms16_016_webdav.rb
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if sysinfo["Architecture"] == ARCH_X64
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected('32-bit target detected')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -83,16 +83,16 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless session.platform == 'windows'
       # Non-Windows systems are definitely not affected.
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     res = psh_exec 'if($([System.Environment]::ProcessorCount) -gt 1) { echo("true") }'
     unless res.include? 'true'
       vprint_error 'Target system has an insufficient number of processor cores'
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected('Windows session with multiple CPU cores detected')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms16_075_reflection.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection.rb
@@ -104,10 +104,10 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     privs = client.sys.config.getprivs
     if privs.include?('SeImpersonatePrivilege')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Target appears vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -132,15 +132,15 @@ class MetasploitModule < Msf::Exploit::Local
     # Fast fails
     if !privs.include?('SeImpersonatePrivilege')
       print_bad('Target session is missing the SeImpersonatePrivilege.')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
     version = get_version_info
     unless version.build_number.between?(Msf::WindowsVersion::Server2008_R2_SP0, Msf::WindowsVersion::Win10_1803)
       print_bad("System not vulnerable (#{version.product_name})")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
     print_good("Target appears to be vulnerable (#{version.product_name})")
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -174,22 +174,22 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if sysinfo['Architecture'] == ARCH_X64
       vprint_error 'Running against 64-bit systems is not supported'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     handle = open_device('\\\\.\\NDProxy', 0x0, 0x0, 0x3)
-    return Exploit::CheckCode::Safe if handle.nil?
+    return Exploit::CheckCode::Safe('Target is not vulnerable') if handle.nil?
 
     session.railgun.kernel32.CloseHandle(handle)
 
     version = get_version_info
     if version.build_number == Msf::WindowsVersion::XP_SP3 ||
        version.build_number == Msf::WindowsVersion::Server2003_SP2
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     elsif version.xp_or_2003?
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
   end
 

--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -143,11 +143,11 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     handle = open_device('\\\\.\\nicm')
     if handle.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     session.railgun.kernel32.CloseHandle(handle)
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Detected('Target service detected')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ntapphelpcachecontrol.rb
+++ b/modules/exploits/windows/local/ntapphelpcachecontrol.rb
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = get_version_info
     if version.build_number.between?(Msf::WindowsVersion::Win8, Msf::WindowsVersion::Win81)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Version #{version} detected but not confirmed vulnerable")
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/ntusermndragover.rb
+++ b/modules/exploits/windows/local/ntusermndragover.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if session.platform != 'windows'
       # Non-Windows systems are definitely not affected.
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     version = get_version_info
@@ -73,14 +73,14 @@ class MetasploitModule < Msf::Exploit::Local
     # see https://docs.microsoft.com/en-us/windows/release-information/
     unless version.build_number.between?(Msf::WindowsVersion::Win7_SP0, Msf::WindowsVersion::Win7_SP1) && version.workstation?
       print_error('The exploit only supports Windows 7 versions 7600 and 7601')
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     path = expand_path('%WINDIR%\\system32\\win32k.sys')
     _major, _minor, _build, revision, _brand = file_version(path)
-    return CheckCode::Safe if revision >= 24387
+    return CheckCode::Safe("Revision #{revision} is not vulnerable") if revision >= 24387
 
-    CheckCode::Appears
+    CheckCode::Appears("Revision #{revision} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
           end
         rescue RuntimeError
           vprint_error('Unable to retrieve service status')
-          return Exploit::CheckCode::Unknown
+          return Exploit::CheckCode::Unknown('Unable to determine target state')
         end
 
         path = svc[:path].gsub('"', '').strip
@@ -102,18 +102,18 @@ class MetasploitModule < Msf::Exploit::Local
           hash = client.fs.file.md5(path).unpack('H*').first
         rescue Rex::Post::Meterpreter::RequestError => e
           print_error("Error checking file hash: #{e}")
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected("Unable to verify file hash: #{e}")
         end
 
         if vuln_hashes.include?(hash)
           vprint_good("Hash '#{hash}' is listed as vulnerable")
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable('Target is vulnerable')
         else
           vprint_status("Hash '#{hash}' is not recorded as vulnerable")
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('Target service detected')
         end
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe('Target is not vulnerable')
       end
     end
   end

--- a/modules/exploits/windows/local/panda_psevents.rb
+++ b/modules/exploits/windows/local/panda_psevents.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if directory?(get_path)
       print_good('Vuln path exists')
-      CheckCode::Appears
+      CheckCode::Appears('Target appears vulnerable')
     else
       vprint_error("#{get_path} doesn't exist on target")
-      CheckCode::Safe
+      CheckCode::Safe('Target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("Directory '#{path}' does not exist")
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('Target service detected')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -87,37 +87,37 @@ class MetasploitModule < Msf::Exploit::Local
       # Win8/2012 - 6.2.9200.16627 / 6.2.9200.20732
       case build
       when 2600
-        return Exploit::CheckCode::Appears if revision < 6404
+        return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if revision < 6404
       when 3790
-        return Exploit::CheckCode::Appears if revision < 5174
+        return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if revision < 5174
       when 6000
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
       when 6001
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
       when 6002
         if branch == 18
-          return Exploit::CheckCode::Appears if revision < 18861
+          return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if revision < 18861
         elsif revision < 23132
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
         end
       when 7600
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
       when 7601
         if branch == 18
-          return Exploit::CheckCode::Appears if revision < 18176
+          return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if revision < 18176
         elsif revision < 22348
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
         end
       when 9200
         if branch == 16
-          return Exploit::CheckCode::Appears if revision < 16627
+          return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if revision < 16627
         elsif revision < 20732
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable")
         end
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Revision #{revision} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/razer_zwopenprocess.rb
+++ b/modules/exploits/windows/local/razer_zwopenprocess.rb
@@ -98,14 +98,14 @@ class MetasploitModule < Msf::Exploit::Remote
         target_checksum = client.fs.file.md5(d[:filename])
 
         if expected_checksum == Rex::Text.to_hex(target_checksum, '')
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('Target appears vulnerable')
         else
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('Target service detected')
         end
       end
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -287,7 +287,7 @@ class MetasploitModule < Msf::Exploit::Local
       print_good("#{current_user} has write permissions to #{provided_path_dir}")
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -181,13 +181,13 @@ minutes to trigger and recieve a shell.")
     # Service method has been tested on Windows 7, 8 and 10 (1803 and ealier)
     vulnerable_to_service = version.build_number.between?(Msf::WindowsVersion::Win7_SP1, Msf::WindowsVersion::Win10_1803)
     if datastore['METHOD'] =~ /service/i
-      return Exploit::CheckCode::Appears if vulnerable_to_service
+      return Exploit::CheckCode::Appears("Version #{version} appears vulnerable") if vulnerable_to_service
     elsif version.build_number.between?(Msf::WindowsVersion::Win10_1703, Msf::WindowsVersion::Win10_1803)
       # DLL method has been tested on Windows 10 (1703 to 1803)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     elsif datastore['METHOD'] =~ /dll/i && vulnerable_to_service
       print_error("The current target is not vulnerable to the DLL hijacking technique. Please try setting METHOD to 'SERVICE' and then try again!")
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 end

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     services = enum_vuln_services.map { |srv| srv['name'] }
     if services.empty?
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not vulnerable')
     end
 
     CheckCode::Vulnerable("Vulnerable services: #{services.join(', ')}")

--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -97,45 +97,45 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if sysinfo['Architecture'] == ARCH_X64
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     handle = open_device('\\\\.\\vboxguest', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     if handle.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     session.railgun.kernel32.CloseHandle(handle)
 
     version = get_version_info
     if version != Msf::WindowsVersion::XP_SP3
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
     end
 
     file_path = get_env('WINDIR') << '\\system32\\drivers\\vboxguest.sys'
     unless file?(file_path)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to determine target state')
     end
 
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("vboxguest.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
     unless (major == 4)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Revision #{revision} is not vulnerable")
     end
 
     case minor
     when 0
-      return Exploit::CheckCode::Appears if build < 26
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if build < 26
     when 1
-      return Exploit::CheckCode::Appears if build < 34
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if build < 34
     when 2
-      return Exploit::CheckCode::Appears if build < 26
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if build < 26
     when 3
-      return Exploit::CheckCode::Appears if build < 12
+      return Exploit::CheckCode::Appears("Revision #{revision} appears vulnerable") if build < 12
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Revision #{revision} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -290,12 +290,12 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     handle = open_device
     if handle.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     session.railgun.kernel32.CloseHandle(handle)
 
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected('Target service detected')
   end
 
   def exploit

--- a/modules/exploits/windows/local/webexec.rb
+++ b/modules/exploits/windows/local/webexec.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless service_exists?(@service_name)
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
     srv_info = service_info(@service_name)
@@ -85,19 +85,19 @@ class MetasploitModule < Msf::Exploit::Local
     case START_TYPE[srv_info[:starttype]]
     when 'Disabled'
       vprint_error("Service startup is Disabled, so will be unable to exploit unless account has correct permissions...")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     when 'Manual'
       vprint_error("Service startup is Manual, so will be unable to exploit unless account has correct permissions...")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     when 'Auto'
       vprint_good("Service is set to Automatically start...")
     end
 
     if check_search_path
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target is not vulnerable')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('Target appears vulnerable')
   end
 
   def check_write_access(path)

--- a/modules/exploits/windows/local/win_error_cve_2023_36874.rb
+++ b/modules/exploits/windows/local/win_error_cve_2023_36874.rb
@@ -151,9 +151,9 @@ class MetasploitModule < Msf::Exploit::Local
     # This only appears to work on 22H2, but likely will work elsewhere if we figure out the function pointers.
     version = get_version_info
     vprint_status("OS version: #{version}")
-    return Exploit::CheckCode::Appears if version.build_number == Msf::WindowsVersion::Win10_22H2
+    return Exploit::CheckCode::Appears("Version #{version} appears vulnerable") if version.build_number == Msf::WindowsVersion::Win10_22H2
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
+++ b/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("Service '#{service}' does not exist")
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('Target service detected')
   end
 
   def exploit


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical