### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/windows/antivirus/symantec_endpoint_manager_rce.rb
+++ b/modules/exploits/windows/antivirus/symantec_endpoint_manager_rce.rb
@@ -70,10 +70,10 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200 && res.body =~ /Symantec Endpoint Protection Manager/ && res.body =~ /1995 - 2013 Symantec Corporation/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Symantec Endpoint Protection Manager detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Symantec Endpoint Protection Manager not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/antivirus/symantec_workspace_streaming_exec.rb
+++ b/modules/exploits/windows/antivirus/symantec_workspace_streaming_exec.rb
@@ -222,17 +222,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    check_result = Exploit::CheckCode::Safe
+    check_result = Exploit::CheckCode::Safe('Symantec Workspace Streaming not detected')
 
     if jboss_deploy_path.nil?
       xml = build_soap_check_put
       res = send_xml_rpc_request(xml)
 
       if res && res.code == 200 && res.body && res.body.to_s =~ /No method matching arguments/
-        check_result = Exploit::CheckCode::Detected
+        check_result = Exploit::CheckCode::Detected('Symantec Workspace Streaming SOAP endpoint detected')
       end
     else
-      check_result = Exploit::CheckCode::Appears
+      check_result = Exploit::CheckCode::Appears('Symantec Workspace Streaming JBoss deployment path found')
     end
 
     check_result

--- a/modules/exploits/windows/arkeia/type77.rb
+++ b/modules/exploits/windows/arkeia/type77.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = arkeia_info
     if !(info and info['Version'])
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Could not retrieve Arkeia server version')
     end
 
     vprint_status('Arkeia Server Information:')
@@ -73,14 +73,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (info['System'] !~ /Windows/)
       vprint_status('This module only supports Windows targets')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Arkeia detected on #{info['System']} but this module only supports Windows")
     end
 
     if (info['Version'] =~ /Backup (4\.|5\.([012]\.|3\.[0123]$))/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Arkeia #{info['Version']} appears vulnerable")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Arkeia #{info['Version']} does not appear to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/backupexec/remote_agent.rb
+++ b/modules/exploits/windows/backupexec/remote_agent.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Version: #{info['Version']}")
 
       if (info['Vendor'] =~ /VERITAS/i and info['Version'] =~ /^(4\.2|5\.1)$/)
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("VERITAS Backup Exec version #{info['Version']} detected")
       end
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('VERITAS Backup Exec vulnerable version not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/backupexec/ssl_uaf.rb
+++ b/modules/exploits/windows/backupexec/ssl_uaf.rb
@@ -126,10 +126,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     s = NDMP::Socket.new(connect)
-    return CheckCode::Unknown unless connect_ndmp(s, 2)
+    return CheckCode::Unknown('No response from NDMP service') unless connect_ndmp(s, 2)
 
     resp = s.do_request_response(NDMP::Message.new_request(NDMP::Message::CONFIG_GET_HOST_INFO))
-    return CheckCode::Unknown unless resp
+    return CheckCode::Unknown('No response to host info request') unless resp
 
     info = HostInfoResponse.from_xdr(resp.body)
     print_line('Hostname: ' + info.hostname)
@@ -139,10 +139,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     disconnect
     s = NDMP::Socket.new(connect)
-    return CheckCode::Unknown unless connect_ndmp(s, 3)
+    return CheckCode::Unknown('No response from NDMP v3 service') unless connect_ndmp(s, 3)
 
     resp = s.do_request_response(NDMP::Message.new_request(NDMP::Message::CONFIG_GET_SERVER_INFO))
-    return CheckCode::Unknown unless resp
+    return CheckCode::Unknown('No response to server info request') unless resp
 
     info = ServiceInfoResponse.from_xdr(resp.body)
     print_line('Vendor: ' + info.vendor_name)
@@ -151,9 +151,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     ver = info.revision_number.split('.')
     if ver[0].to_i < 9 || (ver[0].to_i == 9 && ver[1].to_i <= 2)
-      CheckCode::Appears
+      CheckCode::Appears("Backup Exec revision #{info.revision_number} appears to be vulnerable")
     else
-      CheckCode::Detected
+      CheckCode::Detected("Backup Exec revision #{info.revision_number} detected but may not be vulnerable")
     end
   end
 

--- a/modules/exploits/windows/brightstor/discovery_tcp.rb
+++ b/modules/exploits/windows/brightstor/discovery_tcp.rb
@@ -113,10 +113,10 @@ class MetasploitModule < Msf::Exploit::Remote
     csock.close
 
     if (y and !x)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('BrightStor Discovery Service responded on TCP')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('BrightStor Discovery Service not detected on TCP')
   end
 
   def exploit

--- a/modules/exploits/windows/brightstor/discovery_udp.rb
+++ b/modules/exploits/windows/brightstor/discovery_udp.rb
@@ -101,10 +101,10 @@ class MetasploitModule < Msf::Exploit::Remote
     csock.close
 
     if (y and !x)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('BrightStor Discovery Service responded on UDP')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('BrightStor Discovery Service not detected on UDP')
   end
 
   def exploit

--- a/modules/exploits/windows/brightstor/lgserver_multi.rb
+++ b/modules/exploits/windows/brightstor/lgserver_multi.rb
@@ -61,10 +61,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (ver and ver =~ /11\.1\.742/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('BrightStor ARCserve version 11.1.742 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('BrightStor ARCserve version 11.1.742 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
@@ -62,10 +62,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (ver and ver =~ /11\.1\.742/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('BrightStor ARCserve version 11.1.742 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('BrightStor ARCserve version 11.1.742 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (ver and ver =~ /11\.1\.742/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('BrightStor ARCserve version 11.1.742 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('BrightStor ARCserve version 11.1.742 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
@@ -61,10 +61,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (ver and ver =~ /11\.1\.742/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('BrightStor ARCserve version 11.1.742 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('BrightStor ARCserve version 11.1.742 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
+++ b/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe("SMB error: #{e.message}")
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('DCOM service detected via DCE/RPC bind')
   end
 
   def exploit

--- a/modules/exploits/windows/emc/alphastor_device_manager_exec.rb
+++ b/modules/exploits/windows/emc/alphastor_device_manager_exec.rb
@@ -63,10 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
     packet = "\x75~ mminfo & #{rand_text_alpha(512)}"
     res = send_packet(packet)
     if res && res =~ /Could not fork command/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('AlphaStor Device Manager detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not conclusively detect AlphaStor Device Manager')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
+++ b/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /3Com 3CDaemon FTP Server Version 2\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates 3Com 3CDaemon FTP Server Version 2.0')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match 3Com 3CDaemon')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/ability_server_stor.rb
+++ b/modules/exploits/windows/ftp/ability_server_stor.rb
@@ -81,14 +81,14 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if banner =~ /Ability Server 2\.34/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates Ability Server 2.34')
     else
       if banner =~ /Ability Server/
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('FTP banner indicates Ability Server')
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match Ability Server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
     connect_login
     disconnect
     if /BisonWare BisonFTP server product V3\.5/i === banner
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates BisonWare BisonFTP server V3.5')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match BisonWare BisonFTP')
     end
   end
 

--- a/modules/exploits/windows/ftp/cesarftp_mkd.rb
+++ b/modules/exploits/windows/ftp/cesarftp_mkd.rb
@@ -65,10 +65,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /CesarFTP 0\.99g/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates CesarFTP 0.99g')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match CesarFTP 0.99g')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
+++ b/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
@@ -93,10 +93,10 @@ class MetasploitModule < Msf::Exploit::Remote
     validate << "\xf1\xc6\xf7\x21\x0d\x0a"
 
     if banner.to_s == validate
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('FTP banner matches known vulnerable ComSndFTP signature')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match ComSndFTP')
   end
 
   def junk(n = 4)

--- a/modules/exploits/windows/ftp/dreamftp_format.rb
+++ b/modules/exploits/windows/ftp/dreamftp_format.rb
@@ -64,10 +64,10 @@ class MetasploitModule < Msf::Exploit::Remote
     banner = sock.get_once
     disconnect
     if (banner.to_s =~ /Dream FTP Server/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates Dream FTP Server')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match Dream FTP Server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/easyfilesharing_pass.rb
+++ b/modules/exploits/windows/ftp/easyfilesharing_pass.rb
@@ -55,10 +55,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /Easy File Sharing FTP Server/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates Easy File Sharing FTP Server')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match Easy File Sharing FTP Server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /BigFoolCat/) # EasyFTP Server has undergone several name changes
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates BigFoolCat EasyFTP Server')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match BigFoolCat EasyFTP Server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/easyftp_list_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_list_fixret.rb
@@ -70,10 +70,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /BigFoolCat/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates BigFoolCat EasyFTP Server')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('FTP banner does not match BigFoolCat EasyFTP Server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
@@ -76,10 +76,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /BigFoolCat/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates BigFoolCat EasyFTP Server')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match BigFoolCat EasyFTP Server')
   end
 
   def make_nops(num)

--- a/modules/exploits/windows/ftp/freefloatftp_user.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_user.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     if (banner =~ /FreeFloat/)
       # Software is never updated, so if you run this you're f*cked.
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('FTP banner indicates FreeFloat FTP Server')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match FreeFloat FTP Server')
     end
   end
 

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner =~ /FreeFloat/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates FreeFloat FTP Server')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match FreeFloat FTP Server')
     end
   end
 

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # All versions including and above version 1.0 report "220 Hello, I'm freeFTPd 1.0"
     # when banner grabbing.
     if banner =~ /freeFTPd 1\.0/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates freeFTPd 1.0')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match freeFTPd 1.0')
 
     end
   end

--- a/modules/exploits/windows/ftp/freeftpd_user.rb
+++ b/modules/exploits/windows/ftp/freeftpd_user.rb
@@ -76,10 +76,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /freeFTPd 1\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates freeFTPd 1.0')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match freeFTPd 1.0')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
+++ b/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
@@ -60,9 +60,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     vprint_status("FTP Banner: #{banner}".strip)
     if banner =~ /Golden FTP Server ready v(4\.\d{2})/ and $1 == "4.70"
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates Golden FTP Server v4.70')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match Golden FTP Server v4.70')
     end
   end
 

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -134,10 +134,10 @@ For now, that will have to be done manually.
     disconnect
     vprint_status("FTP Banner: #{banner}".strip)
     if banner =~ /httpdx.*\(Win32\)/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates httpdx on Win32')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match httpdx')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner =~ /FTP Utility FTP server \(Version 1\.00\)/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates FTP Utility FTP server Version 1.00')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match FTP Utility FTP server')
     end
   end
 

--- a/modules/exploits/windows/ftp/netterm_netftpd_user.rb
+++ b/modules/exploits/windows/ftp/netterm_netftpd_user.rb
@@ -80,10 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /NetTerm FTP server/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates NetTerm FTP server')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match NetTerm FTP server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -71,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner =~ /\*\*        Welcome on       \*\*/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates Open-FTPD')
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not confirm Open-FTPD from the FTP banner')
     end
   end
 

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
@@ -65,10 +65,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /9\.2\.0\.1\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates Oracle 9i version 9.2.0.1.0')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match Oracle 9i XDB')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
@@ -71,10 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /9\.2\.0\.1\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates Oracle 9i version 9.2.0.1.0')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match Oracle 9i XDB')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/pcman_put.rb
+++ b/modules/exploits/windows/ftp/pcman_put.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if /220 PCMan's FTP Server 2\.0/ === banner
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears('FTP banner indicates PCMan FTP Server 2.0')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('FTP banner does not match PCMan FTP Server 2.0')
     end
   end
 

--- a/modules/exploits/windows/ftp/pcman_stor.rb
+++ b/modules/exploits/windows/ftp/pcman_stor.rb
@@ -69,14 +69,14 @@ class MetasploitModule < Msf::Exploit::Remote
     if c and banner =~ /220 PCMan's FTP Server 2\.0/
       # Auth is required to exploit
       vprint_status("Able to authenticate, and banner shows the vulnerable version")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Authenticated and banner shows PCMan FTP Server 2.0')
     elsif not c and banner =~ /220 PCMan's FTP Server 2\.0/
       vprint_status("Unable to authenticate, but banner shows the vulnerable version")
       # Auth failed, but based on version maybe the target is vulnerable
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Banner shows PCMan FTP Server 2.0 but authentication failed')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match PCMan FTP Server 2.0')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner =~ /quickshare ftpd/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates QuickShare File Server')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match QuickShare File Server')
     end
   end
 

--- a/modules/exploits/windows/ftp/ricoh_dl_bof.rb
+++ b/modules/exploits/windows/ftp/ricoh_dl_bof.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if banner =~ /220 DSC ftpd 1\.0 FTP Server/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates Ricoh DSC ftpd 1.0')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match Ricoh DSC ftpd')
     end
   end
 

--- a/modules/exploits/windows/ftp/sami_ftpd_user.rb
+++ b/modules/exploits/windows/ftp/sami_ftpd_user.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears('Sami FTP Server version 2.0.2.')
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('Target is running Sami FTP Server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/servu_chmod.rb
+++ b/modules/exploits/windows/ftp/servu_chmod.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /Serv-U FTP Server v((4.(0|1))|3.\d)/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates vulnerable Serv-U FTP Server version')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match vulnerable Serv-U FTP Server version')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -100,11 +100,11 @@ class MetasploitModule < Msf::Exploit::Remote
     case banner
     when /Serv-U FTP Server v4\.1/
       vprint_status('Found version 4.1.0.3, exploitable')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates Serv-U FTP Server v4.1')
 
     when /Serv-U FTP Server v5\.0/
       vprint_status('Found version 5! 5.0.0.0 may be exploitable, but not 5.0.0.4')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates Serv-U FTP Server v5.0')
 
     when /Serv-U FTP Server v4\.0/
       vprint_status('Found version 4.0.0.4 or 4.1.0.0, additional check.')
@@ -112,22 +112,22 @@ class MetasploitModule < Msf::Exploit::Remote
       send_pass(datastore['PASS'])
       if (double_ff?)
         vprint_status('Found version 4.0.0.4, exploitable')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('FTP banner indicates Serv-U FTP Server v4.0.0.4')
       else
         vprint_status('Found version 4.1.0.0, exploitable')
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('FTP banner indicates Serv-U FTP Server v4.1.0.0')
       end
 
     when /Serv-U FTP Server/
       vprint_status('Found an unknown version, try it!')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates Serv-U FTP Server of unknown version')
 
     else
       vprint_status('We could not recognize the server banner')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('FTP banner does not match Serv-U FTP Server')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match Serv-U FTP Server')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/turboftp_port.rb
+++ b/modules/exploits/windows/ftp/turboftp_port.rb
@@ -69,12 +69,12 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /1\.30\.823/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates TurboFTP version 1.30.823')
     elsif (banner =~ /1\.30\.826/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates TurboFTP version 1.30.826')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match vulnerable TurboFTP version')
   end
 
   def create_rop_chain(ver)

--- a/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
@@ -103,10 +103,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     vprint_status("FTP Banner: #{banner}".strip)
     if banner =~ /\(vftpd .*\)/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates Vermillion FTP daemon')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match Vermillion FTP daemon')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     @session_cookie = authenticate(datastore['USERNAME'], datastore['PASSWORD'])
     if @session_cookie.nil?
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Authentication failed')
     end
 
     ver = send_request_cgi(
@@ -81,11 +81,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless ver
       vprint_error("Connection failed!")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     unless ver.code == 200 && ver.body.include?('Wing FTP Server')
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not Wing FTP Server')
     end
 
     @version = Rex::Version.new(ver.body.scan(/Wing FTP Server ([\d\.]+)/).flatten.first)
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Lua capabilities and administrator console were added in version 3.0.0, so everything above that is (probably) vulnerable
     unless @version >= Rex::Version.new('3.0.0')
       @vuln_check = false
-      return CheckCode::Safe
+      return CheckCode::Safe("Wing FTP Server #{@version} is below 3.0.0")
     end
 
     @vuln_check = true
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless winenv_path
       vprint_error("Connection failed!")
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed while executing command')
     end
 
     if winenv_path.code == 200
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @vuln_check = false
-    return CheckCode::Vulnerable
+    return CheckCode::Vulnerable("Wing FTP Server #{@version} allows Lua script execution")
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
@@ -58,10 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /5\.0\.3/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates WS_FTP Server version 5.0.3')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match WS_FTP Server 5.0.3')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
@@ -52,10 +52,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /WS_FTP Server 5\.0\.5/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('FTP banner indicates WS_FTP Server 5.0.5')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match WS_FTP Server 5.0.5')
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/xlink_server.rb
+++ b/modules/exploits/windows/ftp/xlink_server.rb
@@ -58,10 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /XLINK FTP Server/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FTP banner indicates XLINK FTP Server')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FTP banner does not match XLINK FTP Server')
   end
 
   def exploit

--- a/modules/exploits/windows/games/ut2004_secure.rb
+++ b/modules/exploits/windows/games/ut2004_secure.rb
@@ -100,15 +100,15 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Detected Unreal Tournament Server Version: #{vers}")
     if (vers =~ /^(3120|3186|3204)$/)
       vprint_status("This system appears to be exploitable")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Unreal Tournament Server version #{vers} appears vulnerable")
     end
 
     if (vers =~ /^(2...)$/)
       vprint_status("This system appears to be running UT2003")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Unreal Tournament 2003 detected, version #{vers}")
     end
 
     vprint_status("This system appears to be patched")
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Unreal Tournament Server version #{vers} appears patched")
   end
 end

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -113,19 +113,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     end
 
     unless supports_webdav? res.headers
       vprint_status 'Server does not support WebDAV'
-      return CheckCode::Safe
+      return CheckCode::Safe('Server does not support WebDAV')
     end
 
     if res.headers['Server'].to_s.include? 'IIS/6.0'
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('IIS/6.0 with WebDAV enabled detected')
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('WebDAV enabled but IIS version is not 6.0')
   end
 
   # corelan.be

--- a/modules/exploits/windows/iis/ms01_023_printer.rb
+++ b/modules/exploits/windows/iis/ms01_023_printer.rb
@@ -87,9 +87,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     return CheckCode::Unknown('Connection failed') unless res
-    return CheckCode::Safe unless res.code == 500
+    return CheckCode::Safe('Server did not return expected error code') unless res.code == 500
     # Error response is language dependent: "<b>Error in web printer install.</b>"
-    return CheckCode::Safe unless res.body.to_s.starts_with?('<b>') && res.body.to_s.ends_with?('</b>')
+    return CheckCode::Safe('Server response does not match expected format') unless res.body.to_s.starts_with?('<b>') && res.body.to_s.ends_with?('</b>')
 
     res = send_request_cgi({
       'uri' => '/NULL.printer',
@@ -99,10 +99,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
     return CheckCode::Detected("The IUSER account is locked out, we can't check") if res.body.to_s.include?('locked out')
-    return CheckCode::Safe unless res.code == 500
-    return CheckCode::Safe unless res.body.to_s.starts_with?('<b>') && res.body.to_s.ends_with?('</b>')
+    return CheckCode::Safe('Server did not return expected error code for overflow test') unless res.code == 500
+    return CheckCode::Safe('Server response does not match expected format for overflow test') unless res.body.to_s.starts_with?('<b>') && res.body.to_s.ends_with?('</b>')
 
-    CheckCode::Appears
+    CheckCode::Appears('IIS .printer ISAPI extension appears vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     win_dir = detect_windows_directory
-    win_dir ? CheckCode::Vulnerable("Found Windows directory name: #{win_dir}") : CheckCode::Safe
+    win_dir ? CheckCode::Vulnerable("Found Windows directory name: #{win_dir}") : CheckCode::Safe('Could not detect Windows directory via double decode')
   end
 
   def execute_command(cmd, opts = {})

--- a/modules/exploits/windows/iis/ms02_065_msadc.rb
+++ b/modules/exploits/windows/iis/ms02_065_msadc.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected("#{target_uri.path} content type matches fingerprint application/x-varg")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('MSADC interface not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
+++ b/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears('The server stopped accepting requests') unless res
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Target does not appear to be vulnerable to WebDAV NTDLL overflow')
   end
 
   def exploit

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Server responded with HTTP #{res.code} OK")
       if (res.body =~ /Content-Type: application\/x-varg/)
         print_good("#{datastore['PATH']} matches fingerprint application\/x-varg")
-        Exploit::CheckCode::Detected
+        Exploit::CheckCode::Detected('MSADC RDS DataFactory interface detected')
       end
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('MSADC RDS DataFactory interface not detected')
     end
   end
 

--- a/modules/exploits/windows/imap/eudora_list.rb
+++ b/modules/exploits/windows/imap/eudora_list.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Exploit::Remote
     targ = auto_target
     disconnect
 
-    return Exploit::CheckCode::Appears if (targ)
+    return Exploit::CheckCode::Appears('Vulnerable Eudora WorldMail IMAP server detected') if (targ)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Eudora WorldMail IMAP server not detected')
   end
 
   def auto_target

--- a/modules/exploits/windows/imap/mailenable_w3c_select.rb
+++ b/modules/exploits/windows/imap/mailenable_w3c_select.rb
@@ -58,10 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner and banner =~ /MailEnable Service, Version: 0-1\.54/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('MailEnable IMAP version 0-1.54 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('MailEnable IMAP version 0-1.54 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/imap/mdaemon_fetch.rb
+++ b/modules/exploits/windows/imap/mdaemon_fetch.rb
@@ -55,10 +55,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner and banner =~ /IMAP4rev1 MDaemon 9\.6\.4 ready/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('MDaemon 9.6.4 IMAP server detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('MDaemon 9.6.4 IMAP server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -68,9 +68,9 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     resp = sock.get_once
     disconnect
-    return CheckCode::Vulnerable if resp =~ %r{Mercury/32 v4\.01[ab]}
+    return CheckCode::Vulnerable('Mercury/32 v4.01a or v4.01b IMAP server detected') if resp =~ %r{Mercury/32 v4\.01[ab]}
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Mercury/32 v4.01a or v4.01b IMAP server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/imap/mercury_rename.rb
+++ b/modules/exploits/windows/imap/mercury_rename.rb
@@ -56,10 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (resp =~ /Mercury\/32 v4\.01a/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Mercury/32 v4.01a IMAP server detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Mercury/32 v4.01a IMAP server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/isapi/ms00_094_pbserver.rb
+++ b/modules/exploits/windows/isapi/ms00_094_pbserver.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 5)
 
     if (res and res.code == 400)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Phone Book Server ISAPI extension detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Phone Book Server ISAPI extension not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
+++ b/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
@@ -73,10 +73,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, -1)
 
     if (res and res.body =~ /NetShow ISAPI/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('NetShow ISAPI extension detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('NetShow ISAPI extension not detected')
   end
 
   def exploit_target(target)

--- a/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
+++ b/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
@@ -115,9 +115,9 @@ class MetasploitModule < Msf::Exploit::Remote
     }, -1)
 
     if (r and r.code == 501)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('FrontPage fp30reg.dll ISAPI extension detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('FrontPage fp30reg.dll ISAPI extension not detected')
   end
 end

--- a/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
+++ b/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
@@ -76,10 +76,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, -1)
 
     if (r and r.body and r.body =~ /RSA Web Access Authentication/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('RSA Web Access Authentication agent detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('RSA Web Access Authentication agent not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/isapi/w3who_query.rb
+++ b/modules/exploits/windows/isapi/w3who_query.rb
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if auto_target
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Vulnerable w3who.dll ISAPI extension detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('w3who.dll ISAPI extension not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/license/calicserv_getconfig.rb
+++ b/modules/exploits/windows/license/calicserv_getconfig.rb
@@ -77,9 +77,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     if (res =~ /OS\<([^\>]+)/)
       vprint_status("CA License Server reports OS: #{$1}")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("CA License Server detected, OS: #{$1}")
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('CA License Server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/license/sentinel_lm7_udp.rb
+++ b/modules/exploits/windows/license/sentinel_lm7_udp.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect_udp
 
     if (res and res[0] == 0x7a)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Sentinel License Manager detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Sentinel License Manager not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
+++ b/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
@@ -98,9 +98,9 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner =~ /Lotus Domino Release 8\.5/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Lotus Domino Release 8.5 detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Lotus Domino Release 8.5 not detected')
     end
   end
 

--- a/modules/exploits/windows/lotus/domino_sametime_stmux.rb
+++ b/modules/exploits/windows/lotus/domino_sametime_stmux.rb
@@ -88,11 +88,11 @@ class MetasploitModule < Msf::Exploit::Remote
       disconnect
 
       if (res.to_s =~ /200 OK/)
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('Lotus Domino Sametime stmux service detected')
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Lotus Domino Sametime stmux service not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -347,7 +347,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if cookie_res and cookie_res.code == 200
       cookie = cookie_res.get_cookies.split()[0]
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Failed to retrieve initial cookie from target')
     end
 
     if defined?(cookie)
@@ -378,23 +378,23 @@ class MetasploitModule < Msf::Exploit::Remote
                   number = l.split("=")[1].split('"')[1]
                   if number.match /(\d+\.)?(\d+\.)?(\d+\.)?(\*|\d+)$/
                     if number <= '8.1.1.50' and not number < '7'
-                      return Exploit::CheckCode::Appears
+                      return Exploit::CheckCode::Appears("Ahsay Backup version #{number} appears vulnerable")
                     else
-                      return Exploit::CheckCode::Safe
+                      return Exploit::CheckCode::Safe("Ahsay Backup version #{number} is not vulnerable")
                     end
                   end
                 end
               end
             else
-              return Exploit::CheckCode::Unknown
+              return Exploit::CheckCode::Unknown('Could not determine the target state')
             end
           end
         end
       else
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine the target state')
       end
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Could not determine the target state')
     end
   end
 end

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -117,10 +117,10 @@ class MetasploitModule < Msf::Exploit::Remote
     int = rand(1..1_000)
     response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR #{int}=#{int}--"), false)
     if response_bypass.include? 'Zugangsdaten OK'
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('SQL injection authentication bypass successful')
     else
       print_status("Response was: #{response_bypass}")
-      CheckCode::Safe
+      CheckCode::Safe('SQL injection authentication bypass failed')
     end
   end
 

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -141,13 +141,13 @@ Processor-Speed=#{processor_speed}
     res = send_update_computer("2659")
 
     unless res and res =~ /Result=Success/ and res =~ /DSVersion=(.*)/
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Target did not return a successful response')
     end
 
     version = $1
 
     unless version =~ /^6\.(\d+)\.(\d+)$/
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("Altiris DS version #{version} is not vulnerable")
     end
 
     vprint_status "#{rhost}:#{rport} - Altiris DS Version '#{version}'"
@@ -157,17 +157,17 @@ Processor-Speed=#{processor_speed}
 
     if minor == 8
       if build == 206 || build == 282 || build == 378
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Altiris DS version #{version} appears vulnerable")
       elsif build < 390
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Altiris DS version #{version} appears vulnerable")
       end
     elsif minor == 9 and build < 176
       # The existence of versions matching this profile is a possibility... none were observed in the wild though
       # as such, we're basing confidence off of Symantec's vulnerability bulletin.
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Altiris DS version #{version} appears vulnerable")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Altiris DS version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/misc/bakbone_netvault_heap.rb
+++ b/modules/exploits/windows/misc/bakbone_netvault_heap.rb
@@ -76,11 +76,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if ver > 0
         print_status("Detected NetVault Build #{ver}")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Detected NetVault Build #{ver}")
       end
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
+++ b/modules/exploits/windows/misc/delta_electronics_infrasuite_deserialization.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'login.html')
     )
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response received from target') unless res
 
     unless res.body.include?('InfraSuite Manager Login')
       return CheckCode::Safe('Target does not appear to be InfraSuite Device Master.')
@@ -104,9 +104,9 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Found version '#{version}' of InfraSuite Device Master")
     r_vers = Rex::Version.new(version)
 
-    return CheckCode::Appears if r_vers < Rex::Version.new('1.0.5')
+    return CheckCode::Appears("InfraSuite Device Master version #{version} is vulnerable") if r_vers < Rex::Version.new('1.0.5')
 
-    CheckCode::Safe
+    CheckCode::Safe("InfraSuite Device Master version #{version} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       connect
     rescue
       vprint_error("Unable to get a connection")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to connect to target')
     end
 
     filename = "C:\\#{rand_text_alpha(12)}.fdb"
@@ -90,10 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     opcode = data.unpack("N*")[0]
     if opcode == 3 # Accept
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def stack_pivot_rop_chain

--- a/modules/exploits/windows/misc/gh0st.rb
+++ b/modules/exploits/windows/misc/gh0st.rb
@@ -94,10 +94,10 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     sock.put(make_packet(101, "\x00")) # heartbeat
     if validate_response(sock.get_once || '')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Gh0st RAT C&C server detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/hp_dataprotector_cmd_exec.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_cmd_exec.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fingerprint = get_fingerprint
 
     if fingerprint.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to fingerprint target')
     end
 
     print_status("HP Data Protector version #{fingerprint}")
@@ -82,14 +82,14 @@ class MetasploitModule < Msf::Exploit::Remote
     if fingerprint =~ /HP Data Protector A\.08\.(\d+)/
       minor = $1.to_i
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("#{fingerprint} is not a vulnerable version")
     end
 
     if minor < 11
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("HP Data Protector A.08.#{minor} appears vulnerable")
     end
 
-    Exploit::CheckCode::Detected
+    Exploit::CheckCode::Detected("HP Data Protector A.08.#{minor} detected")
   end
 
   def get_fingerprint

--- a/modules/exploits/windows/misc/hp_dataprotector_crs.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_crs.rb
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if fingerprint.nil?
       vprint_error("Unable to fingerprint")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to fingerprint target')
     end
 
     port = get_crs_port
@@ -156,21 +156,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if fingerprint =~ /HP Data Protector A\.06\.20: INET, internal build 370/
       # More likely to be exploitable
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("#{fingerprint} appears vulnerable")
     elsif fingerprint =~ /HP Data Protector A\.07\.00: INET, internal build 72/
       # More likely to be exploitable
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("#{fingerprint} appears vulnerable")
     elsif fingerprint =~ /HP Data Protector A\.07\.00/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("#{fingerprint} appears vulnerable")
     elsif fingerprint =~ /HP Data Protector A\.07\.01/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("#{fingerprint} appears vulnerable")
     elsif fingerprint =~ /HP Data Protector A\.06\.20/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("#{fingerprint} appears vulnerable")
     elsif fingerprint =~ /HP Data Protector A\.06\.21/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("#{fingerprint} appears vulnerable")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("#{fingerprint} is not vulnerable")
   end
 
   def get_target

--- a/modules/exploits/windows/misc/hp_dataprotector_dtbclslogin.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_dtbclslogin.rb
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if hello_response and hello_response =~ /Dtb: Context/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('HP Data Protector DtbClsLogin service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/hp_dataprotector_encrypted_comms.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_encrypted_comms.rb
@@ -65,17 +65,17 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if response.nil?
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target did not respond to probe')
     end
 
     service_version = Rex::Text.to_ascii(response).chop.chomp
 
     if service_version =~ /HP Data Protector/
       vprint_status(service_version)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def generate_dp_payload

--- a/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fingerprint = get_fingerprint
 
     if fingerprint.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to fingerprint target')
     end
 
     print_status("HP Data Protector version #{fingerprint}")
@@ -75,15 +75,15 @@ class MetasploitModule < Msf::Exploit::Remote
     if fingerprint =~ /HP Data Protector A\.06\.(\d+)/
       minor = $1.to_i
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("#{fingerprint} is not a vulnerable version")
     end
 
     if minor < 21
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("HP Data Protector A.06.#{minor} appears vulnerable")
     elsif minor == 21
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("HP Data Protector A.06.#{minor} detected")
     else
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("HP Data Protector A.06.#{minor} detected")
     end
   end
 

--- a/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
@@ -74,18 +74,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if fingerprint.nil?
       vprint_status('Unable to fingerprint because no response.')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to fingerprint target')
     end
 
     vprint_status("#{peer} - #{fingerprint}")
 
     if fingerprint =~ /HP Data Protector A\.06\.(\d+)/i
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("#{fingerprint} appears vulnerable")
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("#{fingerprint} is not vulnerable")
     end
-
-    Exploit::CheckCode::Detected
   end
 
   def get_fingerprint

--- a/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fingerprint = get_fingerprint
 
     if fingerprint.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to fingerprint target')
     end
 
     print_status("HP Data Protector version #{fingerprint}")
@@ -70,15 +70,15 @@ class MetasploitModule < Msf::Exploit::Remote
     if fingerprint =~ /HP Data Protector A\.06\.(\d+)/
       minor = $1.to_i
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("#{fingerprint} is not a vulnerable version")
     end
 
     if minor < 21
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable("HP Data Protector A.06.#{minor} is vulnerable")
     elsif minor == 21
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("HP Data Protector A.06.#{minor} detected")
     else
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("HP Data Protector A.06.#{minor} detected")
     end
   end
 

--- a/modules/exploits/windows/misc/hp_imc_dbman_restartdb_unauth_rce.rb
+++ b/modules/exploits/windows/misc/hp_imc_dbman_restartdb_unauth_rce.rb
@@ -69,9 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Expected reply:
     # "\x00\x00\x00\x01\x00\x00\x00:08\x02\x01\xFF\x043Dbman deal msg error, please to see dbman_debug.log"
-    return CheckCode::Detected if res =~ /dbman/i
+    return CheckCode::Detected('HP IMC dbman service detected') if res =~ /dbman/i
 
-    CheckCode::Safe
+    CheckCode::Safe('HP IMC dbman service not detected')
   end
 
   def dbman_msg(db_instance)

--- a/modules/exploits/windows/misc/hp_imc_dbman_restoredbase_unauth_rce.rb
+++ b/modules/exploits/windows/misc/hp_imc_dbman_restoredbase_unauth_rce.rb
@@ -69,9 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Expected reply:
     # "\x00\x00\x00\x01\x00\x00\x00:08\x02\x01\xFF\x043Dbman deal msg error, please to see dbman_debug.log"
-    return CheckCode::Detected if res =~ /dbman/i
+    return CheckCode::Detected('HP IMC dbman service detected') if res =~ /dbman/i
 
-    CheckCode::Safe
+    CheckCode::Safe('HP IMC dbman service not detected')
   end
 
   def dbman_msg(database_user)

--- a/modules/exploits/windows/misc/hp_omniinet_1.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_1.rb
@@ -112,22 +112,22 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif (resp =~ /HP StorageWorks Application Recovery Manager/)
         version = resp.split[5]
       else
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('HP Data Protector service detected but version could not be extracted')
       end
 
       version = version.split('.')
       major = version[1].to_i
       minor = version[2].to_i
       if ((major < 6) or (major == 6 and minor < 11))
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("HP Data Protector version #{version.join('.')} appears vulnerable")
       end
 
       if ((major > 6) or (major == 6 and minor >= 11))
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("HP Data Protector version #{version.join('.')} is not vulnerable")
       end
 
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/hp_omniinet_2.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_2.rb
@@ -112,22 +112,22 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif (resp =~ /HP StorageWorks Application Recovery Manager/)
         version = resp.split[5]
       else
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('HP Data Protector service detected but version could not be extracted')
       end
 
       version = version.split('.')
       major = version[1].to_i
       minor = version[2].to_i
       if ((major < 6) or (major == 6 and minor < 11))
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("HP Data Protector version #{version.join('.')} appears vulnerable")
       end
 
       if ((major > 6) or (major == 6 and minor >= 11))
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("HP Data Protector version #{version.join('.')} is not vulnerable")
       end
 
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/hp_omniinet_3.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_3.rb
@@ -76,22 +76,22 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif (resp =~ /HP StorageWorks Application Recovery Manager/)
         version = resp.split[5]
       else
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('HP Data Protector service detected but version could not be extracted')
       end
 
       version = version.split('.')
       major = version[1].to_i
       minor = version[2].to_i
       if ((major < 6) or (major == 6 and minor < 11))
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("HP Data Protector version #{version.join('.')} appears vulnerable")
       end
 
       if ((major > 6) or (major == 6 and minor >= 11))
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("HP Data Protector version #{version.join('.')} is not vulnerable")
       end
 
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
@@ -78,25 +78,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if not res
       vprint_error("No response from target")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response from target')
     end
 
     if res !~ /HTTP\/1\.1 200 OK/
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Failed to determine the target state')
     end
 
     if res =~ /server:.*coda 11.(\d+)/
       minor = $1.to_i
       if minor < 2
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("HP Operations Agent CODA 11.#{minor} appears vulnerable")
       end
     end
 
     if res =~ /server:.*coda/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def ping

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
@@ -78,27 +78,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if not res
       vprint_error("No response from target")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('No response from target')
     end
 
     if res !~ /HTTP\/1\.1 200 OK/
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Failed to determine the target state')
     end
 
     if res =~ /server:.*coda 11.(\d+)/
       minor = $1.to_i
       if minor < 2
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("HP Operations Agent CODA 11.#{minor} appears vulnerable")
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("HP Operations Agent CODA 11.#{minor} is not vulnerable")
       end
     end
 
     if res =~ /server:.*coda/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def ping

--- a/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
+++ b/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
@@ -252,10 +252,10 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 1)
 
     if res and res.code == 200 and res.body =~ /CIMVERSION/
-      return CheckCode::Appears
+      return CheckCode::Appears('IBM Director CIM listener detected')
     end
 
-    return CheckCode::Safe
+    return CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
+++ b/modules/exploits/windows/misc/ivanti_avalanche_mdm_bof.rb
@@ -65,14 +65,14 @@ class MetasploitModule < Msf::Exploit::Remote
       connect
     rescue StandardError
       print_error('Could not connect to target!')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Could not connect to target')
     end
     res = sock.get_once
 
     if res =~ /p\.guid/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('The target appears to be vulnerable')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('The target is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -60,14 +60,14 @@ class MetasploitModule < Msf::Exploit::Remote
       connect
     rescue
       vprint_error("Unable to connect")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to connect to target')
     end
     sock.put("db_net")
     if sock.recv(4) =~ /\d{1,5}/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('The target service was detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/manageengine_eventlog_analyzer_rce.rb
+++ b/modules/exploits/windows/misc/manageengine_eventlog_analyzer_rce.rb
@@ -72,9 +72,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body && res.body.include?('ManageEngine EventLog Analyzer')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('ManageEngine EventLog Analyzer detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('ManageEngine EventLog Analyzer not detected')
     end
   end
 

--- a/modules/exploits/windows/misc/ms10_104_sharepoint.rb
+++ b/modules/exploits/windows/misc/ms10_104_sharepoint.rb
@@ -106,9 +106,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = upload_file(filename, contents)
 
     if res and res.code == 200 and res.body =~ /ConvertFileResponse/ and res.body =~ /<m_ce>CE_OTHER<\/m_ce>/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('SharePoint accepted the ConvertFile request')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('SharePoint did not accept the ConvertFile request')
     end
   end
 

--- a/modules/exploits/windows/misc/plugx.rb
+++ b/modules/exploits/windows/misc/plugx.rb
@@ -137,10 +137,10 @@ class MetasploitModule < Msf::Exploit::Remote
     hdr = xor_wrap(key, hh)
     sock.put([key].pack('I<') + hdr[4..-1])
     if validate_response(sock.get_once || '')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('PlugX C&C server detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('No valid PlugX response detected')
   end
 
   def decode_packet(data)

--- a/modules/exploits/windows/misc/poisonivy_21x_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_21x_bof.rb
@@ -92,13 +92,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (response == "\x89\xFF\x90\x0B\x00\x00")
       vprint_status("Poison Ivy C&C version 2.1.4 detected.")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Poison Ivy C&C version 2.1.4 detected')
     elsif (response == "\x89\xFF\x38\xE0\x00\x00")
       vprint_status("Poison Ivy C&C version 2.0.0 detected.")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Poison Ivy C&C version 2.0.0 detected, not vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('The target is not running a vulnerable version')
   end
 
   # Load known plaintext chunk

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
       (1..15).each do |index|
         unless response[index * 16, 16] == first_block
           vprint_status("Response doesn't match Poison Ivy Challenge-Response format.")
-          return Exploit::CheckCode::Safe
+          return Exploit::CheckCode::Safe('Response does not match Poison Ivy challenge-response format')
         end
       end
 
@@ -136,12 +136,12 @@ class MetasploitModule < Msf::Exploit::Remote
       if indicator.key?(response)
         version = indicator[response]
         vprint_status("Poison Ivy C&C version #{version} detected.")
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Poison Ivy C&C version #{version} detected")
       end
     end
 
     vprint_status("Response doesn't match Poison Ivy Challenge-Response protocol.")
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('The target does not appear to be Poison Ivy')
   end
 
   def exploit

--- a/modules/exploits/windows/misc/remote_control_collection_rce.rb
+++ b/modules/exploits/windows/misc/remote_control_collection_rce.rb
@@ -102,9 +102,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @check_run = true
     @check_success = false
     upload_file
-    return Exploit::CheckCode::Vulnerable if @check_success
+    return Exploit::CheckCode::Vulnerable('Target connected back to our server') if @check_success
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target did not connect back')
   end
 
   def on_request_uri(cli, _req)

--- a/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
+++ b/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
@@ -85,13 +85,13 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     if !res
       vprint_error "Connection failed"
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Unknown('Connection failed')
     elsif res == "\x00\x00\x00\x00"
       vprint_status "Received reply (#{res.length} bytes)"
-      Exploit::CheckCode::Detected
+      Exploit::CheckCode::Detected('SolidWorks Workgroup PDM service detected')
     else
       vprint_warning "Unexpected reply (#{res.length} bytes)"
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Unexpected reply from target')
     end
   end
 

--- a/modules/exploits/windows/mssql/ms02_039_slammer.rb
+++ b/modules/exploits/windows/mssql/ms02_039_slammer.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
       info.each_pair { |k, v|
         print_status("   #{k + (" " * (15 - k.length))} = #{v}")
       }
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('MSSQL Server detected via ping')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('MSSQL Server not detected via ping')
   end
 
   def exploit

--- a/modules/exploits/windows/mssql/ms02_056_hello.rb
+++ b/modules/exploits/windows/mssql/ms02_056_hello.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
       info.each_pair { |k, v|
         print_status("   #{k + (" " * (15 - k.length))} = #{v}")
       }
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('MSSQL Server detected via ping')
     end
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('MSSQL Server not detected via ping')
   end
 
   def exploit

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
@@ -257,22 +257,22 @@ class MetasploitModule < Msf::Exploit::Remote
     # since we need to have credentials for this vuln, we just login and run a query
     # to get the version information
     if not (version = mssql_query_version())
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Could not retrieve SQL Server version')
     end
 
     print_status("@@version returned:\n\t" + version)
 
     # Any others?
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.194/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.384/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.534/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.760/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.2039/)
-    return Exploit::CheckCode::Appears if (version =~ /9\.00\.1399\.06/)
-    return Exploit::CheckCode::Appears if (version =~ /9\.00\.2047\.00/)
-    return Exploit::CheckCode::Appears if (version =~ /9\.00\.3042\.00/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.194/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.384/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.534/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.760/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.2039/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /9\.00\.1399\.06/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /9\.00\.2047\.00/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /9\.00\.3042\.00/)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("SQL Server version #{version.strip} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
@@ -259,22 +259,22 @@ class MetasploitModule < Msf::Exploit::Remote
     # to get the version information
     version = mssql_query_version
     unless version
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Could not retrieve SQL Server version')
     end
 
     print_status("@@version returned:\n\t" + version)
 
     # Any others?
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.194/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.384/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.534/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.760/)
-    return Exploit::CheckCode::Appears if (version =~ /8\.00\.2039/)
-    return Exploit::CheckCode::Appears if (version =~ /9\.00\.1399\.06/)
-    return Exploit::CheckCode::Appears if (version =~ /9\.00\.2047\.00/)
-    return Exploit::CheckCode::Appears if (version =~ /9\.00\.3042\.00/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.194/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.384/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.534/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.760/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /8\.00\.2039/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /9\.00\.1399\.06/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /9\.00\.2047\.00/)
+    return Exploit::CheckCode::Appears("SQL Server version #{version.strip} appears vulnerable") if (version =~ /9\.00\.3042\.00/)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("SQL Server version #{version.strip} is not vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/mssql/mssql_clr_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_clr_payload.rb
@@ -61,21 +61,21 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     unless mssql_login_datastore(datastore['DATABASE'])
       vprint_status('Invalid SQL Server credentials')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Connected to SQL Server but credentials may be invalid')
     end
 
     version = get_sql_version_string
 
     unless version =~ /Server 20(05|08|12|14|16)/
       vprint_status('Unsupported version of SQL Server')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("SQL Server version #{version} is not supported")
     end
 
     if mssql_is_sysadmin
       vprint_good "User #{datastore['USERNAME']} is a sysadmin"
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable("User #{datastore['USERNAME']} is a sysadmin on #{version}")
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe("User #{datastore['USERNAME']} is not a sysadmin")
     end
   ensure
     disconnect

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -81,15 +81,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless session || mssql_login_datastore
       vprint_status("Invalid SQL Server credentials")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Connected to SQL Server but credentials may be invalid')
     end
 
     mssql_query("select @@version", true)
     if mssql_is_sysadmin
       vprint_good "User #{datastore['USERNAME']} is a sysadmin"
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable("User #{datastore['USERNAME']} is a sysadmin")
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe("User #{datastore['USERNAME']} is not a sysadmin")
     end
   ensure
     disconnect

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -62,11 +62,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
-    return Exploit::CheckCode::Safe if not m
+    return Exploit::CheckCode::Safe('MySQL login failed') if not m
 
-    return Exploit::CheckCode::Appears if is_windows?
+    return Exploit::CheckCode::Appears('Target is running MySQL on Windows') if is_windows?
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target is not running Windows')
   end
 
   def query(q)

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -62,11 +62,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
-    return Exploit::CheckCode::Safe unless m
+    return Exploit::CheckCode::Safe('MySQL login failed') unless m
 
-    return Exploit::CheckCode::Appears if is_windows?
+    return Exploit::CheckCode::Appears('Target is running MySQL on Windows') if is_windows?
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target is not running Windows')
   end
 
   def query(q)

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['RPORT'] = tmp_rport
     if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
        res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-2]\<\/div\>/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Vulnerable Scrutinizer version detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Vulnerable Scrutinizer version not detected')
   end
 
   def get_php_payload(fname)

--- a/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
+++ b/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
@@ -97,9 +97,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if list_check == 0
-      return CheckCode::Appears
+      return CheckCode::Appears('Nimsoft NimController directory listing detected')
     else
-      return CheckCode::Safe
+      return CheckCode::Safe('Nimsoft NimController directory listing not detected')
     end
   end
 

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -90,12 +90,12 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/ and res.body =~ /2\.3\.1/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('NetIQ Privileged User Manager version 2.3.1 detected')
     elsif res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('NetIQ Privileged User Manager detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('NetIQ Privileged User Manager not detected')
   end
 
   def on_new_session(session)

--- a/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
+++ b/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
@@ -126,17 +126,17 @@ class MetasploitModule < Msf::Exploit::Remote
     res = upload_file(data)
     if not res or res.code != 200 or (res.body !~ /posted data was written to placeholder file/ and res.body !~ /csaPostStatus=0/)
       vprint_error("The test file could not be uploaded")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Test file could not be uploaded')
     end
 
     print_status("Checking uploaded contents...")
     res = send_request_raw({ 'uri' => "/em/CSA#{file_name}.txt" })
 
     if res and res.code == 200 and res.body =~ /#{file_contents}/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully uploaded and verified test file')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('File upload succeeded but content verification failed')
   end
 
   def exploit

--- a/modules/exploits/windows/oracle/extjob.rb
+++ b/modules/exploits/windows/oracle/extjob.rb
@@ -85,14 +85,14 @@ class MetasploitModule < Msf::Exploit::Remote
       pipe.close
       disconnect
     rescue
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Could not connect to the named pipe')
     end
 
     if result == "1" # Exit Code should be 1
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Successfully executed command via extjob named pipe')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Command execution via extjob named pipe failed')
   end
 end
 

--- a/modules/exploits/windows/oracle/tns_arguments.rb
+++ b/modules/exploits/windows/oracle/tns_arguments.rb
@@ -63,10 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (res and res =~ /32-bit Windows: Version 8\.1\.7\.0\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Oracle TNS Listener version 8.1.7.0.0 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Oracle TNS Listener version 8.1.7.0.0 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/oracle/tns_auth_sesskey.rb
+++ b/modules/exploits/windows/oracle/tns_auth_sesskey.rb
@@ -79,13 +79,13 @@ class MetasploitModule < Msf::Exploit::Remote
     version = tns_version
     if (not version)
       vprint_error("Unable to detect the Oracle version!")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unable to detect the Oracle version')
     end
     vprint_status("Oracle version reply: " + version)
-    return Exploit::CheckCode::Appears if (version =~ /32-bit Windows: Version 10\.2\.0\.1\.0/)
-    return Exploit::CheckCode::Appears if (version =~ /32-bit Windows: Version 10\.2\.0\.4\.0/)
+    return Exploit::CheckCode::Appears("Oracle version #{version} may be vulnerable") if (version =~ /32-bit Windows: Version 10\.2\.0\.1\.0/)
+    return Exploit::CheckCode::Appears("Oracle version #{version} may be vulnerable") if (version =~ /32-bit Windows: Version 10\.2\.0\.4\.0/)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Oracle version is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/windows/oracle/tns_service_name.rb
+++ b/modules/exploits/windows/oracle/tns_service_name.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (res and res =~ /32-bit Windows: Version 8\.1\.7\.0\.0/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Oracle TNS Listener version 8.1.7.0.0 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Oracle TNS Listener version 8.1.7.0.0 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -77,10 +77,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if version[:auth]
       print_good "Authentication successful. Version: #{version}"
-      return CheckCode::Appears # WRITE permission needs to be proven to get CheckCode::Vulnerable
+      return CheckCode::Appears("Authenticated successfully; PostgreSQL version: #{version[:auth]}") # WRITE permission needs to be proven to get Vulnerable
     else
       print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
-      return CheckCode::Safe
+      return CheckCode::Safe('PostgreSQL authentication failed')
     end
   end
 

--- a/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
+++ b/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
@@ -66,10 +66,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner.to_s =~ /CCProxy Telnet Service Ready/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('CCProxy Telnet Service detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('CCProxy Telnet Service not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
+++ b/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
@@ -63,10 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put("GET /\r\n\r\n") # Malformed request to get proxy info
     banner = sock.get_once || ''
     if (banner =~ /Server:\sWinGate\s6.1.1\s\(Build 1077\)/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('WinGate 6.1.1 Build 1077 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('WinGate 6.1.1 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -148,12 +148,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless (info = parse_doublepulsar_ping(res))
       print_error('DOUBLEPULSAR not detected or disabled')
-      return CheckCode::Safe
+      return CheckCode::Safe('DOUBLEPULSAR not detected or disabled')
     end
 
     print_warning('DOUBLEPULSAR RDP IMPLANT DETECTED!!!')
     print_good("Target is #{info}")
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable("DOUBLEPULSAR RDP implant detected, target is #{info}")
   end
 
   def exploit

--- a/modules/exploits/windows/sage/x3_adxsrv_auth_bypass_cmd_exec.rb
+++ b/modules/exploits/windows/sage/x3_adxsrv_auth_bypass_cmd_exec.rb
@@ -98,12 +98,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.nil? || res.length != 4
       print_bad('ADXDIR authentication failed')
-      return CheckCode::Safe
+      return CheckCode::Safe('ADXDIR authentication failed, no response')
     end
 
     if res.chars == ["\xFF", "\xFF", "\xFF", "\xFF"]
       print_bad('ADXDIR authentication failed')
-      return CheckCode::Safe
+      return CheckCode::Safe('ADXDIR authentication failed')
     end
 
     print_good('ADXDIR authentication successful.')
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     s.write(adx_dir_msg)
     directory = s.read(1024)
 
-    return CheckCode::Safe if directory.nil?
+    return CheckCode::Safe('No directory information received from ADXDIR') if directory.nil?
 
     sagedir = directory[4..-2]
     print_good(format('Received directory info from host: %s', sagedir))
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     CheckCode::Vulnerable(details: { sagedir: sagedir })
   rescue Rex::ConnectionError
-    CheckCode::Unknown
+    CheckCode::Unknown('Connection to target failed')
   end
 
   def build_buffer(head, sage_payload, tail)

--- a/modules/exploits/windows/scada/abb_wserver_exec.rb
+++ b/modules/exploits/windows/scada/abb_wserver_exec.rb
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if res and res.length == 6 and res[0, 2].unpack("v")[0] == 6 and res[2, 4].unpack("V")[0] == 0xe10001
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('ABB WServer command execution confirmed')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('ABB WServer not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -87,9 +87,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if vuln_version?
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable('Advantech WebAccess Dashboard vulnerable version detected')
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe('Advantech WebAccess Dashboard version is not vulnerable')
     end
   end
 

--- a/modules/exploits/windows/scada/codesys_web_server.rb
+++ b/modules/exploits/windows/scada/codesys_web_server.rb
@@ -88,9 +88,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # give us a version
     vprint_line(res.to_s)
     if res.to_s =~ /3S_WebServer/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('3S CoDeSys web server detected')
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('3S CoDeSys web server not detected')
     end
   end
 

--- a/modules/exploits/windows/scada/diaenergie_sqli.rb
+++ b/modules/exploits/windows/scada/diaenergie_sqli.rb
@@ -62,31 +62,31 @@ class MetasploitModule < Msf::Exploit::Remote
       res = sock.get || ''
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
       vprint_error(e.message)
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection failed')
     ensure
       disconnect
     end
 
     if res.empty?
       vprint_status('Received an empty response.')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Received an empty response')
     end
 
     vprint_status('Who is it response: ' + res.to_s)
     version_pattern = /\b\d+\.\d+\.\d+\.\d+\b/
     version = res.match(version_pattern)
 
-    if version[0].nil?
-      return Exploit::CheckCode::Detected
+    if version.nil?
+      return Exploit::CheckCode::Detected('DIAEnergie service detected but could not determine version')
     end
 
     vprint_status('Version retrieved: ' + version[0])
 
-    unless Rex::Version.new(version) <= Rex::Version.new('1.10.1.8610')
-      return CheckCode::Safe
+    unless Rex::Version.new(version[0]) <= Rex::Version.new('1.10.1.8610')
+      return CheckCode::Safe("Version #{version[0]} is not vulnerable")
     end
 
-    return CheckCode::Appears
+    return CheckCode::Appears("Version #{version[0]} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -168,10 +168,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # res.to_s is used because the CIMPLICITY embedded web server
     # doesn't send HTTP compatible responses.
     if res and res.code == 200 and res.to_s =~ /Usage.*gefebt\.exe/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('GE Proficy CIMPLICITY gefebt.exe detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not confirm the presence of the target service')
   end
 
   def exploit

--- a/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
+++ b/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
@@ -67,12 +67,12 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if app_info =~ /InduSoft Web Studio v6\.1/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('InduSoft Web Studio v6.1 detected')
     elsif app_info =~ /InduSoft Web Studio/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('InduSoft Web Studio detected but version not confirmed vulnerable')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('InduSoft Web Studio not detected')
   end
 
   def upload_file(filename, my_payload)

--- a/modules/exploits/windows/scada/mypro_cmdexe.rb
+++ b/modules/exploits/windows/scada/mypro_cmdexe.rb
@@ -70,25 +70,25 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     if res && res.code == 200
       data = res.get_json_document
       version = data['V']
       if version.nil?
-        return CheckCode::Unknown
+        return CheckCode::Unknown('Version field not found in response')
       else
         vprint_status('Version retrieved: ' + version)
       end
 
       if Rex::Version.new(version) <= Rex::Version.new('8.28')
-        return CheckCode::Appears
+        return CheckCode::Appears("Version #{version} appears vulnerable")
       else
-        return CheckCode::Safe
+        return CheckCode::Safe("Version #{version} is not vulnerable")
       end
     else
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Unexpected response from target')
     end
   end
 

--- a/modules/exploits/windows/scada/mypro_mgr_cmd.rb
+++ b/modules/exploits/windows/scada/mypro_mgr_cmd.rb
@@ -62,19 +62,19 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, 'assets/index-Aup6jYxO.js')
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     if res.to_s =~ /const v="([^"]+)"/
       version = ::Regexp.last_match(1)
       vprint_status('Version retrieved: ' + version)
       if Rex::Version.new(version) <= Rex::Version.new('1.2')
-        return CheckCode::Appears
+        return CheckCode::Appears("Version #{version} appears vulnerable")
       end
 
-      return CheckCode::Safe
+      return CheckCode::Safe("Version #{version} is not vulnerable")
     end
-    return CheckCode::Unknown
+    return CheckCode::Unknown('Could not determine version')
   end
 
   def exploit

--- a/modules/exploits/windows/scada/procyon_core_server.rb
+++ b/modules/exploits/windows/scada/procyon_core_server.rb
@@ -76,10 +76,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if res =~ /Core Command Interface V1\.(.*)2/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Procyon Core Server detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Procyon Core Server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
+++ b/modules/exploits/windows/scada/rockwell_factorytalk_rce.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_to_factory('/hmi_isapi.dll')
-    return Exploit::CheckCode::Safe unless res && res.code == 200
+    return Exploit::CheckCode::Safe('Target did not return HTTP 200') unless res && res.code == 200
 
     # Parse version from response body
     # Example: Version 11.00.00.230
@@ -96,19 +96,19 @@ class MetasploitModule < Msf::Exploit::Remote
     # Is returned version sound?
     unless version.empty?
       if version.length != 4
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Detected('Rockwell FactoryTalk detected but version format is unexpected')
       end
 
       print_status("#{peer} - Detected Rockwell FactoryTalk View SE SCADA version #{version[0..3].join('.')}")
       if version[0].to_i == 11 && version[1].to_i == 0 && version[2].to_i == 0 && version[3].to_i == 230
         # we know this exact version is vulnerable (11.00.00.230)
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears("Rockwell FactoryTalk version #{version[0..3].join('.')} appears vulnerable")
       end
 
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Rockwell FactoryTalk version #{version[0..3].join('.')} detected but not confirmed vulnerable")
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('Could not determine Rockwell FactoryTalk version')
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt = build_probe
     res = send_pkt(pkt)
     if valid_response?(res)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Yokogawa BKBCopyD service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Yokogawa BKBCopyD service not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/scada/yokogawa_bkesimmgr_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkesimmgr_bof.rb
@@ -72,12 +72,12 @@ class MetasploitModule < Msf::Exploit::Remote
       simmgr_res = parse_response(res)
 
       if valid_response?(simmgr_res)
-        check_code = Exploit::CheckCode::Appears
+        check_code = Exploit::CheckCode::Appears('Yokogawa BKESimmgr service appears vulnerable')
       else
-        check_code = Exploit::CheckCode::Safe
+        check_code = Exploit::CheckCode::Safe('Yokogawa BKESimmgr response indicates not vulnerable')
       end
     else
-      check_code = Exploit::CheckCode::Safe
+      check_code = Exploit::CheckCode::Safe('Yokogawa BKESimmgr service not detected')
     end
 
     check_code

--- a/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt = build_pkt(0xffffffff)
     res = send_pkt(pkt)
     if valid_response?(res)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Yokogawa BKHOdeq service detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Yokogawa BKHOdeq service not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb
@@ -104,21 +104,21 @@ class MetasploitModule < Msf::Exploit::Remote
       protocol = client.negotiate
       client.disconnect!
     rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('SMB negotiation failed')
     rescue Errno::ECONNRESET
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection reset during SMB negotiation')
     rescue ::Exception => e # rubocop:disable Lint/RescueException
       vprint_error("#{rhost}: #{e.class} #{e}")
-      return CheckCode::Unknown
+      return CheckCode::Unknown("Unexpected error during SMB negotiation: #{e.class}")
     end
 
-    return CheckCode::Safe unless protocol == 'SMB3'
-    return CheckCode::Safe unless client.dialect == '0x0311'
+    return CheckCode::Safe('Target does not support SMB3') unless protocol == 'SMB3'
+    return CheckCode::Safe("Target SMB dialect #{client.dialect} is not 0x0311") unless client.dialect == '0x0311'
 
     lznt1_algorithm = RubySMB::SMB2::CompressionCapabilities::COMPRESSION_ALGORITHM_MAP.key('LZNT1')
-    return CheckCode::Safe unless client.server_compression_algorithms.include?(lznt1_algorithm)
+    return CheckCode::Safe('Target does not support LZNT1 compression') unless client.server_compression_algorithms.include?(lznt1_algorithm)
 
-    CheckCode::Detected
+    CheckCode::Detected('Target supports SMB 3.1.1 with LZNT1 compression')
   end
 
   def smb_negotiate

--- a/modules/exploits/windows/smb/ipass_pipe_exec.rb
+++ b/modules/exploits/windows/smb/ipass_pipe_exec.rb
@@ -70,19 +70,19 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       response = send_command("System.Echo #{echo_value}")
       if response =~ Regexp.new(echo_value)
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Vulnerable('iPass pipe command execution confirmed')
       else
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('iPass pipe responded but echo test failed')
       end
     rescue Rex::ConnectionError => e
       vprint_error("Connection failed: #{e.class}: #{e}")
-      return Msf::Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
       vprint_error("Error during login: #{e}")
-      return Msf::Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Unknown('Login failed')
     rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
       vprint_error(e.to_s)
-      return Msf::Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Unknown('SMB error occurred')
     end
   end
 

--- a/modules/exploits/windows/smb/ms05_039_pnp.rb
+++ b/modules/exploits/windows/smb/ms05_039_pnp.rb
@@ -396,10 +396,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if (pnp_probe('A'))
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Target is vulnerable to MS05-039 PnP overflow')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target does not appear vulnerable to MS05-039')
   end
 
   def exploit

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -1279,12 +1279,12 @@ class MetasploitModule < Msf::Exploit::Remote
       smb_login
     rescue Rex::ConnectionError => e
       vprint_error("Connection failed: #{e.class}: #{e}")
-      return Msf::Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
       if e.message =~ /Connection reset/
         vprint_error('Connection reset during login')
         vprint_error('This most likely means a previous exploit attempt caused the service to crash')
-        return Msf::Exploit::CheckCode::Unknown
+        return Msf::Exploit::CheckCode::Unknown('Connection reset during login, service may have crashed')
       else
         raise e
       end
@@ -1312,7 +1312,7 @@ class MetasploitModule < Msf::Exploit::Remote
       dcerpc_bind(handle)
     rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
       vprint_error("SMB error: #{e.message}")
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('SMB service does not appear to be vulnerable')
     end
 
     vprint_status('Verifying vulnerable status... (path: 0x%08x)' % path.length)
@@ -1334,10 +1334,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (error == 0x0052005c) # \R :)
-      return Msf::Exploit::CheckCode::Vulnerable
+      return Msf::Exploit::CheckCode::Vulnerable('Target is vulnerable to MS08-067')
     else
       vprint_error('System is not vulnerable (status: 0x%08x)' % error) if error
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Safe('Target is not vulnerable to MS08-067')
     end
   end
 

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -161,13 +161,13 @@ class MetasploitModule < Msf::Exploit::Remote
         end
 
       print_warning("#{msg} - Arch: #{arch_str}, XOR Key: 0x#{@xor_key.to_s(16).upcase}")
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('DOUBLEPULSAR implant detected')
     when :not_detected
       print_error('DOUBLEPULSAR not detected or disabled')
-      CheckCode::Safe
+      CheckCode::Safe('DOUBLEPULSAR not detected or disabled')
     else
       print_error('An unknown error occurred')
-      CheckCode::Unknown
+      CheckCode::Unknown('An unknown error occurred during DOUBLEPULSAR detection')
     end
   end
 

--- a/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
+++ b/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
@@ -65,10 +65,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if banner.to_s =~ /ESMTP TABS Mail Server for Windows NT/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('MailCarrier SMTP server detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('MailCarrier SMTP server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
+++ b/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
@@ -71,14 +71,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (banner !~ /Microsoft/)
       print_status("Target does not appear to be an Exchange server.")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target does not appear to be an Exchange server')
     end
 
     sock.put("EHLO #{Rex::Text.rand_text_alpha(1)}\r\n")
     res = sock.get_once || ''
     if (res !~ /XEXCH50/)
       print_status("Target does not appear to be an Exchange server.")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Target does not support XEXCH50 command')
     end
     sock.put("MAIL FROM: #{datastore['MAILFROM']}\r\n")
     res = sock.get_once || ''
@@ -91,9 +91,9 @@ class MetasploitModule < Msf::Exploit::Remote
         res = sock.get_once || ''
         if (res !~ /Send binary data/)
           print_error("Target has been patched!")
-          return Exploit::CheckCode::Detected
+          return Exploit::CheckCode::Detected('Exchange server detected but has been patched')
         else
-          return Exploit::CheckCode::Appears
+          return Exploit::CheckCode::Appears('Exchange server appears vulnerable to XEXCH50 overflow')
         end
       end
     end

--- a/modules/exploits/windows/smtp/njstar_smtp_bof.rb
+++ b/modules/exploits/windows/smtp/njstar_smtp_bof.rb
@@ -97,10 +97,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # I can only flag it as "Detected" because it doesn't return a version
     if res =~ /Windows E-mail Server From NJStar Software/i
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('NJStar SMTP server detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('NJStar SMTP server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/smtp/ypops_overflow1.rb
+++ b/modules/exploits/windows/smtp/ypops_overflow1.rb
@@ -67,11 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if banner =~ /YahooPOPs! Simple Mail Transfer Service Ready/
       vprint_status("Vulnerable SMTP server: #{banner}")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('YahooPOPs SMTP server detected')
     end
 
     vprint_status("Unknown SMTP server: #{banner}")
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('YahooPOPs SMTP server not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -73,11 +73,11 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
     if banner.match?(/SSH\-2\.0\-WeOnlyDo/)
       version = banner.split(" ")[1]
-      return Exploit::CheckCode::Vulnerable if version.match?(/(2\.1\.3|2\.0\.6)/)
+      return Exploit::CheckCode::Vulnerable("Vulnerable freeSSHd version #{version} detected") if version.match?(/(2\.1\.3|2\.0\.6)/)
 
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("freeSSHd detected but version #{version} may not be vulnerable")
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('freeSSHd not detected')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -80,14 +80,14 @@ class MetasploitModule < Msf::Exploit::Remote
       disconnect
       vprint_status("Banner: #{banner}")
       if banner.match?(/SSH-2\.0-SysaxSSH_1\.0/)
-        return Exploit::CheckCode::Appears
+        return Exploit::CheckCode::Appears('Sysax SSH 1.0 detected')
       end
     rescue StandardError
       vprint_error('An error has occurred while trying to read a response from target')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Error reading response from target')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Sysax SSH 1.0 not detected')
   end
 
   def generate_regular_exploit

--- a/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
+++ b/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
@@ -95,10 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Banner: #{banner}")
 
     if banner.to_s =~ /TelSrv 1\.5/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('TelSrv 1.5 detected')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('TelSrv 1.5 not detected')
   end
 
   def exploit

--- a/modules/exploits/windows/unicenter/cam_log_security.rb
+++ b/modules/exploits/windows/unicenter/cam_log_security.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ack = sock.get_once || ''
     disconnect
 
-    (ack == "ACK\x00") ? Exploit::CheckCode::Detected : Exploit::CheckCode::Safe
+    (ack == "ACK\x00") ? Exploit::CheckCode::Detected('Unicenter CAM service detected') : Exploit::CheckCode::Safe('Unicenter CAM service not detected')
   end
 
   def exploit


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical