### PR TITLE
Add human-readable descriptions to CheckCode returns in modules

### DIFF
--- a/modules/exploits/aix/local/xorg_x11_server.rb
+++ b/modules/exploits/aix/local/xorg_x11_server.rb
@@ -83,21 +83,21 @@ class MetasploitModule < Msf::Exploit::Local
     xorg_path = cmd_exec('command -v Xorg')
     if !xorg_path.include?('Xorg')
       print_error('Could not find Xorg executable')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Xorg executable not found')
     end
 
     ksh93_path = cmd_exec('command -v ksh93')
     if !ksh93_path.include?('ksh')
       print_error('Could not find Ksh93 executable')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Ksh93 executable not found')
     end
 
     if !xorg_vulnerable?
       print_error('Xorg version is not vulnerable')
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Xorg version is not vulnerable')
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Appears('Xorg appears vulnerable')
   end
 
   def exploit

--- a/modules/exploits/android/adb/adb_server_exec.rb
+++ b/modules/exploits/android/adb/adb_server_exec.rb
@@ -48,10 +48,10 @@ class MetasploitModule < Msf::Exploit::Remote
     setup_adb_connection do
       device_info = @adb_client.connect.data
       print_good("Detected device:\n#{device_info}")
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('ADB service detected and accessible')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not connect to ADB service')
   end
 
   def execute_command(cmd, _opts)

--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -113,11 +113,11 @@ class MetasploitModule < Msf::Exploit::Local
     os = cmd_exec('getprop ro.build.version.release')
     unless Rex::Version.new(os) < Rex::Version.new('4.5.0')
       vprint_error "Android version #{os} does not appear to be vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Android version #{os} does not appear to be vulnerable")
     end
     vprint_good "Android version #{os} appears to be vulnerable"
 
-    CheckCode::Appears
+    CheckCode::Appears("Android version #{os} appears vulnerable to futex_requeue")
   end
 
   def exploit

--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -79,16 +79,16 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put("#{token}\n")
     res = sock.get_once
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response from finger service') unless res
 
     if res.include?("Login name: #{token}")
-      return CheckCode::Detected
+      return CheckCode::Detected('Finger service detected and responding')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Finger service did not respond as expected')
   rescue EOFError, Rex::ConnectionError => e
     vprint_error(e.message)
-    CheckCode::Unknown
+    CheckCode::Unknown("Connection error: #{e.message}")
   ensure
     disconnect
   end

--- a/modules/exploits/example.rb
+++ b/modules/exploits/example.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # vulnerable.
   #
   def check
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Target is always considered vulnerable')
   end
 
   #

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
       CheckCode::Appears("Version Detected: #{version}")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Target does not appear to be vulnerable')
   end
 
   #

--- a/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # We just want the banner to check against our targets..
     vprint_status("FTP Banner: #{banner.strip}")
 
-    status = CheckCode::Safe
+    status = CheckCode::Safe('ProFTPD version does not appear to be vulnerable')
     if banner =~ /ProFTPD (1\.3\.[23])/i
       banner_array = banner.split('.')
 
@@ -118,15 +118,15 @@ class MetasploitModule < Msf::Exploit::Remote
             if extra[0..1] == 'rc'
               v = extra[2..extra.length].to_i
               if v && v > 2
-                status = CheckCode::Appears
+                status = CheckCode::Appears("ProFTPD #{banner.strip} appears vulnerable")
               end
             else
-              status = CheckCode::Appears
+              status = CheckCode::Appears("ProFTPD #{banner.strip} appears vulnerable")
             end
           end
         elsif relnum == '3'
           if [ '', 'a', 'b', ].include?(extra)
-            status = CheckCode::Appears
+            status = CheckCode::Appears("ProFTPD #{banner.strip} appears vulnerable")
           end
         end
       end

--- a/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_formssso_target_rce.rb
@@ -128,29 +128,29 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => normalize_uri(datastore['TARGETURI'], 'logon', 'LogonPoint', 'index.html')
     })
-    return CheckCode::Unknown if res.nil?
+    return CheckCode::Unknown('No response received from 13.x resource path') if res.nil?
 
     if res.code == 200 && res.body =~ /<title class="_ctxstxt_NetscalerGateway">/
       mytarget = get_target
       return CheckCode::Appears("Detected #{mytarget.name}.") if mytarget
 
-      return CheckCode::Detected
+      return CheckCode::Detected('Citrix Gateway 13.x detected but could not determine specific target')
     end
 
     # version 12.x resource path
     res = send_request_cgi({
       'uri' => normalize_uri(datastore['TARGETURI'], 'vpn', 'index.html')
     })
-    return CheckCode::Unknown if res.nil?
+    return CheckCode::Unknown('No response received from 12.x resource path') if res.nil?
 
     if res.code == 200 && res.body =~ /Citrix Gateway/ && res.body =~ /AccessGateway\.ico/
       mytarget = get_target
       return CheckCode::Appears("Detected #{mytarget.name}.") if mytarget
 
-      return CheckCode::Detected
+      return CheckCode::Detected('Citrix Gateway 12.x detected but could not determine specific target')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Citrix Gateway not detected')
   end
 
   def get_target

--- a/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
+++ b/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
@@ -71,10 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.body && res.body.include?('unterminated quoted string')
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('SQL injection confirmed in borderpost')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('SQL injection not detected')
   end
 
   def exploit

--- a/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
+++ b/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good("#{hw_model} is vulnerable")
 
-    CheckCode::Appears
+    CheckCode::Appears("#{hw_model} appears vulnerable to SYSRET privilege escalation")
   end
 
   def exploit

--- a/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
+++ b/modules/exploits/freebsd/local/ip6_setpktopt_uaf_priv_esc.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good('cc is installed')
 
-    CheckCode::Appears
+    CheckCode::Appears("#{kernel_version} appears vulnerable to ip6_setpktopt use-after-free")
   end
 
   def exploit

--- a/modules/exploits/freebsd/local/mmap.rb
+++ b/modules/exploits/freebsd/local/mmap.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     res = cmd_exec('uname -a')
-    return Exploit::CheckCode::Appears if res =~ /FreeBSD 9\.[01]/
+    return Exploit::CheckCode::Appears('FreeBSD 9.0 or 9.1 detected') if res =~ /FreeBSD 9\.[01]/
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target does not appear to be FreeBSD 9.0 or 9.1')
   end
 
   def upload_payload

--- a/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
+++ b/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_good("#{suid_exe_path} is setuid")
 
-    CheckCode::Appears
+    CheckCode::Appears("FreeBSD #{kernel_release} with setuid #{suid_exe_path} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/freebsd/local/watchguard_fix_corrupt_mail.rb
+++ b/modules/exploits/freebsd/local/watchguard_fix_corrupt_mail.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Basic check to see if the device is a Watchguard XCS
     res = cmd_exec('uname -a')
-    return Exploit::CheckCode::Detected if res && res.include?('support-xcs@watchguard.com')
+    return Exploit::CheckCode::Detected('Target appears to be a WatchGuard XCS device') if res && res.include?('support-xcs@watchguard.com')
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target does not appear to be a WatchGuard XCS device')
   end
 
   def upload_payload

--- a/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
+++ b/modules/exploits/freebsd/misc/citrix_netscaler_soap_bof.rb
@@ -84,10 +84,12 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body && res.body =~ /Server Request Handler.*No body received/m
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Citrix NetScaler SOAP endpoint detected')
     end
 
-    Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Unknown('No response received from target') unless res
+
+    Exploit::CheckCode::Safe('Citrix NetScaler SOAP endpoint not detected')
   end
 
   def exploit

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears('SpamTitan vulnerable page is accessible')
   rescue ::Rex::ConnectionError => e
     vprint_error("Connection error: #{e}")
     return Exploit::CheckCode::Unknown.new(

--- a/modules/exploits/irix/lpd/tagprinter_exec.rb
+++ b/modules/exploits/irix/lpd/tagprinter_exec.rb
@@ -60,10 +60,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if resp =~ /IRIX/
       vprint_status("Response: #{resp.strip}")
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable('IRIX system detected via lpd tagprinter')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('IRIX system not detected')
   end
 
   def exploit

--- a/modules/exploits/osx/arkeia/type77.rb
+++ b/modules/exploits/osx/arkeia/type77.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     info = arkeia_info
     if !(info and info['Version'])
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Could not retrieve Arkeia server version')
     end
 
     vprint_status('Arkeia Server Information:')
@@ -70,14 +70,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (info['System'] !~ /Darwin/)
       vprint_status('This module only supports Mac OS X targets')
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected("Arkeia detected on #{info['System']} but this module only supports Mac OS X")
     end
 
     if (info['Version'] =~ /Backup (4\.|5\.([012]\.|3\.[0123]$))/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("Arkeia #{info['Version']} appears vulnerable")
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("Arkeia #{info['Version']} does not appear to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/osx/http/remote_for_mac_rce.rb
+++ b/modules/exploits/osx/http/remote_for_mac_rce.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vulnerable_version = Rex::Version.new('2025.7')
 
     if target_version <= vulnerable_version
-      return CheckCode::Appears
+      return CheckCode::Appears("Target version #{version} appears vulnerable")
     else
       return CheckCode::Safe("Target version #{version} is not vulnerable")
     end

--- a/modules/exploits/osx/local/acronis_trueimage_xpc_privesc.rb
+++ b/modules/exploits/osx/local/acronis_trueimage_xpc_privesc.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Local
     plist = '/Applications/Acronis True Image.app/Contents/Info.plist'
 
     unless helper_svc_names.any? { |svc_name| file?("#{helper_location}/#{svc_name}") }
-      return CheckCode::Safe
+      return CheckCode::Safe('Acronis True Image helper service not found')
     end
 
     return CheckCode::Detected('Service found, but cannot determine version via plist') unless file?(plist)

--- a/modules/exploits/osx/local/cfprefsd_race_condition.rb
+++ b/modules/exploits/osx/local/cfprefsd_race_condition.rb
@@ -95,11 +95,11 @@ session    optional       pam_permit.so
   def check
     version = Rex::Version.new(get_system_version)
     if version > Rex::Version.new('10.15.4')
-      CheckCode::Safe
+      CheckCode::Safe("macOS version #{version} is patched")
     elsif version < Rex::Version.new('10.15')
-      CheckCode::Safe
+      CheckCode::Safe("macOS version #{version} is not in the vulnerable range")
     else
-      CheckCode::Appears
+      CheckCode::Appears("macOS version #{version} appears vulnerable")
     end
   end
 

--- a/modules/exploits/osx/local/dyld_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dyld_print_to_file_root.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    (ver?) ? CheckCode::Appears : CheckCode::Safe
+    (ver?) ? CheckCode::Appears('Target version appears vulnerable') : CheckCode::Safe('Target version is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/osx/local/iokit_keyboard_root.rb
+++ b/modules/exploits/osx/local/iokit_keyboard_root.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if ver_lt(osx_ver, "10.10")
-      CheckCode::Appears
+      CheckCode::Appears("OS X version #{osx_ver} appears vulnerable")
     else
-      CheckCode::Safe
+      CheckCode::Safe("OS X version #{osx_ver} is not vulnerable")
     end
   end
 

--- a/modules/exploits/osx/local/libxpc_mitm_ssudo.rb
+++ b/modules/exploits/osx/local/libxpc_mitm_ssudo.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = Rex::Version.new(get_system_version)
     if version >= Rex::Version.new('10.13.4')
-      CheckCode::Safe
+      CheckCode::Safe("macOS version #{version} is patched")
     else
-      CheckCode::Appears
+      CheckCode::Appears("macOS version #{version} appears vulnerable")
     end
   end
 

--- a/modules/exploits/osx/local/mac_dirty_cow.rb
+++ b/modules/exploits/osx/local/mac_dirty_cow.rb
@@ -57,13 +57,13 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = Rex::Version.new(get_system_version)
     if version > Rex::Version.new('13.0.1')
-      CheckCode::Safe
+      CheckCode::Safe("macOS version #{version} is patched")
     elsif version < Rex::Version.new('13.0') && version > Rex::Version.new('12.6.1')
-      CheckCode::Safe
+      CheckCode::Safe("macOS version #{version} is patched")
     elsif version < Rex::Version.new('10.15')
-      CheckCode::Safe
+      CheckCode::Safe("macOS version #{version} is not in the vulnerable range")
     else
-      CheckCode::Appears
+      CheckCode::Appears("macOS version #{version} appears vulnerable")
     end
   end
 

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if ver_lt(xnu_ver, '1699.32.7') and xnu_ver.strip != '1699.24.8'
-      CheckCode::Appears
+      CheckCode::Appears("XNU version #{xnu_ver} appears vulnerable")
     else
-      CheckCode::Safe
+      CheckCode::Safe("XNU version #{xnu_ver} is not vulnerable")
     end
   end
 

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    (ver? && is_admin?) ? CheckCode::Appears : CheckCode::Safe
+    (ver? && is_admin?) ? CheckCode::Appears('Target version appears vulnerable') : CheckCode::Safe('Target is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/osx/local/rootpipe_entitlements.rb
+++ b/modules/exploits/osx/local/rootpipe_entitlements.rb
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     if ver? && is_admin?
       vprint_status("Version is between 10.9 and 10.10.3, and is admin.")
-      return CheckCode::Appears
+      return CheckCode::Appears('Version is between 10.9 and 10.10.3 and user is admin')
     else
-      return CheckCode::Safe
+      return CheckCode::Safe('Version is not vulnerable or user is not admin')
     end
   end
 

--- a/modules/exploits/osx/local/setuid_tunnelblick.rb
+++ b/modules/exploits/osx/local/setuid_tunnelblick.rb
@@ -65,16 +65,16 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless file? datastore['Tunnelblick']
       vprint_error 'openvpnstart not found'
-      return CheckCode::Safe
+      return CheckCode::Safe('openvpnstart not found')
     end
 
     check = cmd_exec("find  #{datastore['Tunnelblick']} -type f -user root -perm -4000")
 
     unless check.include? 'openvpnstart'
-      return CheckCode::Safe
+      return CheckCode::Safe('openvpnstart is not setuid root')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Setuid openvpnstart binary found')
   end
 
   def clean

--- a/modules/exploits/osx/local/setuid_viscosity.rb
+++ b/modules/exploits/osx/local/setuid_viscosity.rb
@@ -65,16 +65,16 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless file? datastore['Viscosity']
       vprint_error 'ViscosityHelper not found'
-      return CheckCode::Safe
+      return CheckCode::Safe('ViscosityHelper not found')
     end
 
     check = cmd_exec("find  #{datastore['Viscosity']} -type f -user root -perm -4000")
 
     unless check.include? 'ViscosityHelper'
-      return CheckCode::Safe
+      return CheckCode::Safe('ViscosityHelper is not setuid root')
     end
 
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable('Setuid ViscosityHelper binary found')
   end
 
   def clean

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -114,21 +114,21 @@ class MetasploitModule < Msf::Exploit::Local
       # and 1.8.0 through 1.8.6p6
       if !vn_bt(sudo_vn, VULNERABLE_VERSION_RANGES)
         vprint_error "sudo version #{sudo_vn} not vulnerable."
-        return CheckCode::Safe
+        return CheckCode::Safe("sudo version #{sudo_vn} is not vulnerable")
       end
     else
       vprint_error 'sudo not detected on the system.'
-      return CheckCode::Safe
+      return CheckCode::Safe('sudo not detected on the system')
     end
 
     # check that the user is in OSX's admin group, necessary to change sys clock
     unless is_admin?
       vprint_error 'sudo version is vulnerable, but user is not in the admin group (necessary to change the date).'
-      return CheckCode::Safe
+      return CheckCode::Safe('User is not in the admin group')
     end
 
     # one root for you sir
-    CheckCode::Vulnerable
+    CheckCode::Vulnerable("sudo version #{sudo_vn} is vulnerable and user is in admin group")
   end
 
   def exploit

--- a/modules/exploits/osx/local/timemachine_cmd_injection.rb
+++ b/modules/exploits/osx/local/timemachine_cmd_injection.rb
@@ -68,9 +68,9 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = Rex::Version.new(get_system_version)
     if version >= Rex::Version.new('10.14.4')
-      CheckCode::Safe
+      CheckCode::Safe("macOS version #{version} is patched")
     else
-      CheckCode::Appears
+      CheckCode::Appears("macOS version #{version} appears vulnerable")
     end
   end
 

--- a/modules/exploits/osx/local/tpwn.rb
+++ b/modules/exploits/osx/local/tpwn.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    ver? ? CheckCode::Appears : CheckCode::Safe
+    ver? ? CheckCode::Appears('Target version appears vulnerable') : CheckCode::Safe('Target version is not vulnerable')
   end
 
   def exploit

--- a/modules/exploits/osx/local/vmware_bash_function_root.rb
+++ b/modules/exploits/osx/local/vmware_bash_function_root.rb
@@ -80,9 +80,9 @@ class MetasploitModule < Msf::Exploit::Local
     if cmd_exec("env x='() { :;}; echo #{check_str}' bash -c echo").include?(check_str) &&
        cmd_exec("file '#{datastore['VMWARE_PATH']}'") !~ /cannot open/
 
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('Target is vulnerable to bash environment variable injection and VMware is present')
     else
-      CheckCode::Safe
+      CheckCode::Safe('Target is not vulnerable to bash env injection or VMware not found')
     end
   end
 

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -187,16 +187,16 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}"
       print_bad "'#{open_usb_service}' binary missing"
-      return CheckCode::Safe
+      return CheckCode::Safe("#{open_usb_service} binary missing")
     end
     version = get_version
     if version.between?(Rex::Version.new('10.1.3'), Rex::Version.new('11.5.3'))
       vprint_good "Vmware Fusion #{version} is exploitable"
     else
       print_bad "VMware Fusion #{version} is NOT exploitable"
-      return CheckCode::Safe
+      return CheckCode::Safe("VMware Fusion #{version} is not in the vulnerable range")
     end
-    CheckCode::Appears
+    CheckCode::Appears("VMware Fusion #{version} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/osx/mdns/upnp_location.rb
+++ b/modules/exploits/osx/mdns/upnp_location.rb
@@ -93,9 +93,9 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     upnp_port = scan_for_upnp_port()
     if (upnp_port > 0)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('UPnP service detected via mDNS')
     else
-      return Exploit::CheckCode::Unsupported
+      return Exploit::CheckCode::Unsupported('UPnP service not detected via mDNS')
     end
   end
 

--- a/modules/exploits/qnx/qconn/qconn_exec.rb
+++ b/modules/exploits/qnx/qconn/qconn_exec.rb
@@ -76,27 +76,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Unknown('Connection failed') unless res
 
-    return CheckCode::Safe unless res.include?('QCONN')
+    return CheckCode::Safe('QCONN service not detected') unless res.include?('QCONN')
 
     sock.put("service launcher\n")
     res = sock.get_once(-1, 10)
 
-    return CheckCode::Safe unless res.to_s.include?('OK')
+    return CheckCode::Safe('Launcher service not available') unless res.to_s.include?('OK')
 
     fingerprint = Rex::Text.rand_text_alphanumeric(5..10)
     sock.put("start/flags run /bin/echo /bin/echo #{fingerprint}\n")
+    res = sock.get_once(-1, 10)
 
-    return CheckCode::Safe unless res.to_s.include?('OK')
+    return CheckCode::Safe('Command execution not available') unless res.to_s.include?('OK')
 
     Rex.sleep(1)
 
     res = sock.get_once(-1, 10)
 
-    return CheckCode::Safe unless res.to_s.include?(fingerprint)
+    return CheckCode::Safe('Command execution did not return expected output') unless res.to_s.include?(fingerprint)
 
+    CheckCode::Vulnerable('Remote command execution confirmed via QCONN')
+  ensure
     disconnect
-
-    CheckCode::Vulnerable
   end
 
   def exploit

--- a/modules/exploits/solaris/dtspcd/heap_noir.rb
+++ b/modules/exploits/solaris/dtspcd/heap_noir.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     spc_write(spc_register('root', "\x00"), 4)
     host, os, ver, arch = spc_read.gsub("\x00", '').split(':')
 
-    return CheckCode::Safe unless host
+    return CheckCode::Safe('No host information received from dtspcd') unless host
 
     spc_write('', 2)
 

--- a/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
+++ b/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
@@ -137,30 +137,30 @@ class MetasploitModule < Msf::Exploit::Local
     [dtappgather_path, suid_bin_path].each do |path|
       unless setuid? path
         vprint_error "#{path} is not setuid"
-        return CheckCode::Safe
+        return CheckCode::Safe("#{path} is not setuid")
       end
       vprint_good "#{path} is setuid"
     end
 
     unless has_gcc?
       vprint_error 'gcc is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('gcc is not installed')
     end
     vprint_good 'gcc is installed'
 
     version = kernel_release
     if version.to_s.eql? ''
       vprint_error 'Could not determine Solaris version'
-      return CheckCode::Detected
+      return CheckCode::Detected('Could not determine Solaris version')
     end
 
     unless Rex::Version.new(version).between? Rex::Version.new('5.7'), Rex::Version.new('5.10')
       vprint_error "Solaris version #{version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Solaris version #{version} is not vulnerable")
     end
     vprint_good "Solaris version #{version} appears to be vulnerable"
 
-    CheckCode::Appears
+    CheckCode::Appears("Solaris version #{version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
+++ b/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
@@ -125,13 +125,13 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless setuid? suid_bin_path
       vprint_error "#{suid_bin_path} is not setuid"
-      return CheckCode::Safe
+      return CheckCode::Safe("#{suid_bin_path} is not setuid")
     end
     vprint_good "#{suid_bin_path} is setuid"
 
     unless has_gcc?
       vprint_error 'gcc is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('gcc is not installed')
     end
     vprint_good 'gcc is installed'
 
@@ -141,12 +141,12 @@ class MetasploitModule < Msf::Exploit::Local
     libnspr_pkg_version = libnspr_pkg_info.scan(/VERSION:\s+([\d.]+),/).flatten.first
     if libnspr_pkg_version.to_s.eql? ''
       vprint_error 'Could not determine libnspr version'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Could not determine libnspr version')
     end
 
     if Rex::Version.new(libnspr_pkg_version) >= Rex::Version.new('4.6.3')
       vprint_error "libnspr version #{libnspr_pkg_version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Libnspr version #{libnspr_pkg_version} is not vulnerable")
     end
     vprint_good "libnspr version #{libnspr_pkg_version} appears to be vulnerable"
 
@@ -156,12 +156,12 @@ class MetasploitModule < Msf::Exploit::Local
     version = kernel_release
     if version.to_s.eql? ''
       vprint_error 'Could not determine Solaris version'
-      return CheckCode::Detected
+      return CheckCode::Detected('Could not determine Solaris version')
     end
 
     unless Rex::Version.new(version) <= Rex::Version.new('5.10')
       vprint_error "Solaris version #{version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Solaris version #{version} is not vulnerable")
     end
     vprint_good "Solaris version #{version} appears to be vulnerable"
 
@@ -181,12 +181,12 @@ class MetasploitModule < Msf::Exploit::Local
       revision = ::Regexp.last_match(1).to_i
       if revision >= 10
         vprint_error "Solaris patch #{patch}-#{revision} has been applied"
-        return CheckCode::Safe
+        return CheckCode::Safe("Solaris patch #{patch}-#{revision} has been applied")
       end
     end
     vprint_good 'Solaris patches are not installed'
 
-    CheckCode::Appears
+    CheckCode::Appears('Vulnerable libnspr version and unpatched Solaris detected')
   end
 
   def exploit

--- a/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
+++ b/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
@@ -116,30 +116,30 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     unless setuid? xscreensaver_path
       vprint_error "#{xscreensaver_path} is not setuid"
-      return CheckCode::Safe
+      return CheckCode::Safe("#{xscreensaver_path} is not setuid")
     end
     vprint_good "#{xscreensaver_path} is setuid"
 
     unless has_gcc?
       vprint_error 'gcc is not installed'
-      return CheckCode::Safe
+      return CheckCode::Safe('gcc is not installed')
     end
     vprint_good 'gcc is installed'
 
     xscreensaver_version = cmd_exec("#{xscreensaver_path} --help").to_s.scan(/^xscreensaver ([\d.]+)/).flatten.first
     if xscreensaver_version.to_s.eql? ''
       vprint_error 'Could not determine xscreensaver version'
-      return CheckCode::Detected
+      return CheckCode::Detected('Could not determine xscreensaver version')
     end
 
     # Bug introduced in version 5.06. Patched in version <~ 5.42.
     unless Rex::Version.new(xscreensaver_version).between?(Rex::Version.new('5.06'), Rex::Version.new('5.41'))
       vprint_error "xscreensaver version #{xscreensaver_version} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("Xscreensaver version #{xscreensaver_version} is not vulnerable")
     end
     vprint_good "xscreensaver version #{xscreensaver_version} appears to be vulnerable"
 
-    CheckCode::Appears
+    CheckCode::Appears("Xscreensaver version #{xscreensaver_version} appears to be vulnerable")
   end
 
   def exploit

--- a/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     port = sunrpc_create('udp', 100232, 10)
-    port.nil? ? CheckCode::Safe : CheckCode::Detected
+    port.nil? ? CheckCode::Safe('SADMIND RPC service not found') : CheckCode::Detected('SADMIND RPC service detected')
   ensure
     sunrpc_destroy unless rpcobj.nil?
   end

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     port = sunrpc_create('udp', 100232, 10)
-    port.nil? ? CheckCode::Safe : CheckCode::Detected
+    port.nil? ? CheckCode::Safe('SADMIND RPC service not found') : CheckCode::Detected('SADMIND RPC service detected')
   ensure
     sunrpc_destroy unless rpcobj.nil?
   end

--- a/modules/exploits/unix/ftp/proftpd_modcopy_exec.rb
+++ b/modules/exploits/unix/ftp/proftpd_modcopy_exec.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("#{rhost}:#{ftp_port} - Unauthenticated SITE CPFR command was successful")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("#{rhost}:#{ftp_port} - SITE CPFR command returned unexpected response")
   ensure
     sock.close unless sock.nil?
   end

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
     nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
     if nsock
       print_error("The port used by the backdoor bind listener is already open/in-use (6200/TCP)")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Backdoor bind listener port 6200 is already open')
     end
 
     vprint_status("Connecting to FTP service")
@@ -109,16 +109,18 @@ class MetasploitModule < Msf::Exploit::Remote
     resp = sock.get_once(-1, 30).to_s
     if resp =~ /^530 /
       print_error("This server is configured for anonymous only and the backdoor code cannot be reached")
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe('Server configured for anonymous only, backdoor code unreachable')
     end
 
     if resp !~ /^331 /
       print_error("This server did not respond as expected: #{resp.strip}")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown("Unexpected FTP response: #{resp.strip}")
     end
 
-    return Exploit::CheckCode::Appears if banner.downcase.include?("vsftpd 2.3.4") and resp =~ /^331 /
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Appears('vsftpd 2.3.4 banner detected; backdoor may be present') if banner.downcase.include?("vsftpd 2.3.4") and resp =~ /^331 /
+    return Exploit::CheckCode::Unknown('Could not determine if target is vulnerable')
+  ensure
+    disconnect
   end
 
   def exploit

--- a/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
+++ b/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if version && Rex::Version.new(version) <= Rex::Version.new('1.2.12')
         vprint_good("Version Detected: #{version}")
-        return CheckCode::Appears
+        return CheckCode::Appears("Cacti version #{version} appears vulnerable")
       end
     rescue ::Rex::ConnectionError
       CheckCode::Safe("#{peer} - Could not connect to the web service") # unknown maybe?

--- a/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
+++ b/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
@@ -68,10 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /500 Internal/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('ContentKeeper mimencode CGI returned 500 Internal error')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('ContentKeeper mimencode CGI not detected')
   end
 
   def exploit

--- a/modules/exploits/unix/http/dell_kace_k1000_upload.rb
+++ b/modules/exploits/unix/http/dell_kace_k1000_upload.rb
@@ -65,24 +65,24 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi('uri' => normalize_uri('service', 'kbot_upload.php'))
     unless res
       vprint_error('Connection failed')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to Dell KACE K1000 failed')
     end
     if res.code && res.code == 500 && res.headers['X-DellKACE-Appliance'].downcase == 'k1000'
       if res.headers['X-DellKACE-Version'] =~ /\A([0-9])\.([0-9])\.([0-9]+)\z/
         vprint_status("Found Dell KACE K1000 version #{res.headers['X-DellKACE-Version']}")
         if $1.to_i == 5 && $2.to_i <= 3                         # 5.0 to 5.3
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable("Dell KACE K1000 version #{res.headers['X-DellKACE-Version']} is vulnerable")
         elsif $1.to_i == 5 && $2.to_i == 4 && $3.to_i <= 76849  # 5.4 prior to 5.4.76849
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable("Dell KACE K1000 version #{res.headers['X-DellKACE-Version']} is vulnerable")
         elsif $1.to_i == 5 && $2.to_i == 5 && $3.to_i <= 90547  # 5.5 prior to 5.5.90547
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Vulnerable("Dell KACE K1000 version #{res.headers['X-DellKACE-Version']} is vulnerable")
         end
 
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("Dell KACE K1000 version #{res.headers['X-DellKACE-Version']} is not vulnerable")
       end
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Dell KACE K1000 detected but version could not be parsed')
     end
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target does not appear to be Dell KACE K1000')
   end
 
   def exploit

--- a/modules/exploits/unix/http/epmp1000_get_chart_cmd_shell.rb
+++ b/modules/exploits/unix/http/epmp1000_get_chart_cmd_shell.rb
@@ -107,9 +107,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     success, epmp_ver = is_app_epmp1000?
     if (success != 'false' && !epmp_ver.nil? && epmp_ver >= '3.1')
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable("ePMP1000 version #{epmp_ver} is vulnerable")
     else
-      return CheckCode::Safe # Using 'Safe' here to imply this ver is not exploitable using the module'
+      return CheckCode::Safe('Target is not a vulnerable ePMP1000 version')
     end
   end
 

--- a/modules/exploits/unix/http/epmp1000_ping_cmd_shell.rb
+++ b/modules/exploits/unix/http/epmp1000_ping_cmd_shell.rb
@@ -108,9 +108,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     success, epmp_ver = is_app_epmp1000?
     if (success != 'false' && !epmp_ver.nil? && epmp_ver < '2.5')
-      return CheckCode::Vulnerable
+      return CheckCode::Vulnerable("ePMP1000 version #{epmp_ver} is vulnerable")
     else
-      return CheckCode::Safe # Using 'Safe' here to imply this ver is not exploitable using ~the module~'
+      return CheckCode::Safe('Target is not a vulnerable ePMP1000 version')
     end
   end
 

--- a/modules/exploits/unix/http/laravel_token_unserialize_exec.rb
+++ b/modules/exploits/unix/http/laravel_token_unserialize_exec.rb
@@ -64,13 +64,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Can be 'XSRF-TOKEN', 'X-XSRF-TOKEN', 'laravel_session', or $appname_session... and maybe more?
     unless res && res.headers && res.headers.to_s =~ /XSRF-TOKEN|laravel_session/i
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Target does not appear to be a Laravel application')
     end
 
     auth_token = check_appkey
     if auth_token.blank? || test_appkey(auth_token) == false
       vprint_error 'Unable to continue: the set datastore APP_KEY value or information leak is invalid.'
-      return CheckCode::Detected
+      return CheckCode::Detected('Laravel detected but APP_KEY is invalid')
     end
 
     random_string = Rex::Text.rand_text_alphanumeric(12)
@@ -87,15 +87,15 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
       if res.body.include?(random_string)
-        return CheckCode::Vulnerable
+        return CheckCode::Vulnerable('Successfully executed command via deserialization')
       # Not conclusive but witnessed in the wild
       elsif res.body.include?('Method Not Allowed')
-        return CheckCode::Safe
+        return CheckCode::Safe('Laravel responded with Method Not Allowed')
       end
     end
-    CheckCode::Detected
+    CheckCode::Detected('Laravel detected but could not confirm vulnerability')
   rescue Rex::ConnectionError
-    CheckCode::Unknown
+    CheckCode::Unknown('Connection to target failed')
   end
 
   def env_leak

--- a/modules/exploits/unix/http/pfsense_group_member_exec.rb
+++ b/modules/exploits/unix/http/pfsense_group_member_exec.rb
@@ -128,9 +128,9 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
       if /Login to pfSense/ =~ res.body
-        Exploit::CheckCode::Detected
+        Exploit::CheckCode::Detected('pfSense login page detected')
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('Target does not appear to be pfSense')
       end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
+++ b/modules/exploits/unix/http/pfsense_pfblockerng_webshell.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Host' => "' *; echo '16i #{encoded_clean_up} P' | dc | php; '"
       }
     )
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Vulnerable('Successfully uploaded and executed test webshell via pfBlockerNG')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -97,21 +97,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if version.nil?
         print_error("#{peer} - Could not connect to web service - no response or non-200 HTTP code")
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine Pi-hole version')
       end
 
       if version && Rex::Version.new(version) <= Rex::Version.new('4.4')
         vprint_good("Version Detected: #{version}")
-        return CheckCode::Appears
+        return CheckCode::Appears("Pi-hole version #{version} appears vulnerable")
       else
         vprint_bad("Version Detected: #{version}")
-        return CheckCode::Safe
+        return CheckCode::Safe("Pi-hole version #{version} is not vulnerable")
       end
     rescue ::Rex::ConnectionError
       print_error("#{peer} - Could not connect to the web service")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to Pi-hole failed')
     end
-    CheckCode::Safe
   end
 
   def add_blocklist(file, token)

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -64,21 +64,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if web_version.nil?
         print_error("#{peer} - Could not connect to web service - no response or non-200 HTTP code")
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine Pi-hole web interface version')
       end
 
       if web_version && Rex::Version.new(web_version) <= Rex::Version.new('4.3.2')
         vprint_good("Web Interface Version Detected: #{web_version}")
-        return CheckCode::Appears
+        return CheckCode::Appears("Pi-hole web interface version #{web_version} appears vulnerable")
       else
         vprint_bad("Web Interface Version Detected: #{web_version}")
-        return CheckCode::Safe
+        return CheckCode::Safe("Pi-hole web interface version #{web_version} is not vulnerable")
       end
     rescue ::Rex::ConnectionError
       print_error("#{peer} - Could not connect to the web service")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to Pi-hole failed')
     end
-    CheckCode::Safe
   end
 
   def add_static(payload, token)

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -103,21 +103,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if web_version.nil?
         print_error("#{peer} - Could not connect to web service - no response or non-200 HTTP code")
-        return Exploit::CheckCode::Unknown
+        return Exploit::CheckCode::Unknown('Could not determine Pi-hole web interface version')
       end
 
       if web_version && Rex::Version.new(web_version) < Rex::Version.new('3.3')
         vprint_good("Web Interface Version Detected: #{web_version}")
-        return CheckCode::Appears
+        return CheckCode::Appears("Pi-hole web interface version #{web_version} appears vulnerable")
       else
         vprint_bad("Web Interface Version Detected: #{web_version}")
-        return CheckCode::Safe
+        return CheckCode::Safe("Pi-hole web interface version #{web_version} is not vulnerable")
       end
     rescue ::Rex::ConnectionError
       print_error("#{peer} - Could not connect to the web service")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to Pi-hole failed')
     end
-    CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
+++ b/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
@@ -76,17 +76,17 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi('uri' => normalize_uri('common', 'download_agent_installer.php'))
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection to Quest KACE failed')
     end
 
     unless res.code == 302 && res.headers.to_s.include?('X-KACE-Appliance')
       vprint_status 'Remote host is not a Quest KACE appliance'
-      return CheckCode::Safe
+      return CheckCode::Safe('Target is not a Quest KACE appliance')
     end
 
     unless res.headers['X-KACE-Version'] =~ /\A([0-9]+)\.([0-9]+)\.([0-9]+)\z/
       vprint_error 'Could not determine KACE appliance version'
-      return CheckCode::Detected
+      return CheckCode::Detected('Quest KACE detected but version could not be determined')
     end
 
     version = Rex::Version.new res.headers['X-KACE-Version'].to_s
@@ -99,10 +99,10 @@ class MetasploitModule < Msf::Exploit::Remote
        (version >= Rex::Version.new('7.2') && version < Rex::Version.new('7.2.103')) ||
        (version >= Rex::Version.new('8.0') && version < Rex::Version.new('8.0.320')) ||
        (version >= Rex::Version.new('8.1') && version < Rex::Version.new('8.1.108'))
-      return CheckCode::Appears
+      return CheckCode::Appears("Quest KACE version #{version} appears vulnerable")
     end
 
-    CheckCode::Safe
+    CheckCode::Safe("Quest KACE version #{version} is not vulnerable")
   end
 
   def serial_number

--- a/modules/exploits/unix/http/raspap_rce.rb
+++ b/modules/exploits/unix/http/raspap_rce.rb
@@ -85,10 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown("#{peer} - Could not connect to web service - no response") if res.nil?
 
     if res.code == 200
-      return CheckCode::Appears
+      return CheckCode::Appears('RaspAP OpenVPN config deletion endpoint is accessible')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('RaspAP OpenVPN config deletion endpoint is not accessible')
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -95,10 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
     xmlResponse = resp.join(',')
     disconnect_udp
     if xmlResponse.include?('NET5501') || xmlResponse.include?('NET5501-I') || xmlResponse.include?('NET5501-XT') || xmlResponse.include?('NET5504') || xmlResponse.include?('NET5500') || xmlResponse.include?('NET5516') || xmlResponse.include?('NET5508')
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Schneider Electric NET55xx encoder detected via ONVIF discovery')
     end
 
-    CheckCode::Safe
+    CheckCode::Safe('Target does not appear to be a Schneider Electric NET55xx encoder')
   end
 
   def change_password

--- a/modules/exploits/unix/http/syncovery_linux_rce_2022_36534.rb
+++ b/modules/exploits/unix/http/syncovery_linux_rce_2022_36534.rb
@@ -76,19 +76,19 @@ class MetasploitModule < Msf::Exploit::Remote
         version = json_res['SyncoveryTitle']&.scan(/Syncovery\s([A-Za-z0-9.]+)/)&.flatten&.first || ''
         if version.empty?
           vprint_warning("#{peer} - Could not identify version")
-          Exploit::CheckCode::Detected
+          Exploit::CheckCode::Detected('Syncovery detected but version could not be identified')
         elsif Rex::Version.new(version) < Rex::Version.new('9.48j') || Rex::Version.new(version) == Rex::Version.new('9.48')
           vprint_good("#{peer} - Syncovery #{version}")
-          Exploit::CheckCode::Appears
+          Exploit::CheckCode::Appears("Syncovery version #{version} appears vulnerable")
         else
           vprint_status("#{peer} - Syncovery #{version}")
-          Exploit::CheckCode::Safe
+          Exploit::CheckCode::Safe("Syncovery version #{version} is not vulnerable")
         end
       else
-        Exploit::CheckCode::Safe
+        Exploit::CheckCode::Safe('Target is running Syncovery on Windows, not Linux')
       end
     else
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Unknown('Could not connect to Syncovery web interface')
     end
   end
 

--- a/modules/exploits/unix/http/twiki_debug_plugins.rb
+++ b/modules/exploits/unix/http/twiki_debug_plugins.rb
@@ -87,9 +87,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_code(code)
 
     if res and res.code == 200
-      return CheckCode::Vulnerable if res.body == rand_1 + rand_2
+      return CheckCode::Vulnerable('Successfully executed code via TWiki debug plugins') if res.body == rand_1 + rand_2
     end
-    CheckCode::Unknown
+    CheckCode::Unknown('Could not determine if TWiki debug plugins are exploitable')
   end
 
   def exploit

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       vprint_error('Failed to connect to the web server')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to VMTurbo failed')
     end
 
     if res and res.code == 200 and res.body =~ /vmtbuild:(\d+),vmtrelease:([\d.]+),vmtbits:\d+,osbits:\d+/
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("VMTurbo Operations Manager version #{version} build #{build} detected")
     else
       vprint_status('Unexpected vmtadmin.cgi response')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Unexpected response from vmtadmin.cgi')
     end
 
     # NOTE: (@todb): This PHP style comparison seems incorrect, since
@@ -107,9 +107,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # Also, the description says 4.5 is also vuln. This doesn't
     # appear to care.
     if version and version <= '4.6' and build < '28657'
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears("VMTurbo version #{version} build #{build} appears vulnerable")
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("VMTurbo version #{version} build #{build} is not vulnerable")
     end
   end
 

--- a/modules/exploits/unix/http/xdebug_unauth_exec.rb
+++ b/modules/exploits/unix/http/xdebug_unauth_exec.rb
@@ -70,12 +70,12 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status "Request sent\n#{res}"
       if res && res.headers.to_s =~ /XDEBUG/i
         vprint_good("Looks like remote server has xdebug enabled\n")
-        return CheckCode::Detected
+        return CheckCode::Detected('Xdebug header detected in response')
       else
-        return CheckCode::Safe
+        return CheckCode::Safe('Xdebug header not found in response')
       end
     rescue Rex::ConnectionError
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection to target failed')
     end
   end
 

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -57,13 +57,13 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi('uri' => normalize_uri('cgi-bin', 'iptest.cgi'))
     unless res
       vprint_error('Connection failed')
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown('Connection to Zivif camera failed')
     end
     unless res.code && res.code == 200
-      return CheckCode::Safe
+      return CheckCode::Safe('Zivif iptest.cgi not found')
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('Zivif iptest.cgi endpoint detected')
   end
 
   def exploit

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -101,20 +101,20 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Connected to #{rhost}:#{rport}")
 
     vprint_status("Checking IRC banner")
-    return Exploit::CheckCode::Appears if unreal_version?(send_irc_command)
+    return Exploit::CheckCode::Appears('UnrealIRCd detected in banner') if unreal_version?(send_irc_command)
 
     irc_user = Faker::Internet.username(specifier: 3..9)
     print_status("Trying to register a new IRC user: #{irc_user}")
     send_irc_command("NICK #{irc_user}")
     # Not checking for PING/PONG
     response = send_irc_command("USER #{irc_user} 0 * #{irc_user}")
-    return Exploit::CheckCode::Appears if unreal_version?(response)
+    return Exploit::CheckCode::Appears('UnrealIRCd detected after registration') if unreal_version?(response)
 
     commands = %w[VERSION INFO CREDITS MOTD BOTMOTD HELP LICENSE]
-    return Exploit::CheckCode::Appears if
+    return Exploit::CheckCode::Appears('UnrealIRCd detected via IRC commands') if
       commands.any? { |cmd| unreal_version?(send_irc_command(cmd)) }
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('UnrealIRCd 3.2.8.1 not detected')
   end
 
   def exploit

--- a/modules/exploits/unix/local/chkrootkit.rb
+++ b/modules/exploits/unix/local/chkrootkit.rb
@@ -62,9 +62,9 @@ class MetasploitModule < Msf::Exploit::Local
     version = cmd_exec("#{datastore['CHKROOTKIT']} -V 2>&1")
 
     if version =~ /chkrootkit version 0\.[1-4]/
-      CheckCode::Appears
+      CheckCode::Appears("Chkrootkit #{version.strip} appears vulnerable")
     else
-      CheckCode::Safe
+      CheckCode::Safe('Chkrootkit version does not appear to be vulnerable')
     end
   end
 

--- a/modules/exploits/unix/local/emacs_movemail.rb
+++ b/modules/exploits/unix/local/emacs_movemail.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless file?(movemail)
       vprint_bad("#{movemail} not found")
-      return CheckCode::Safe
+      return CheckCode::Safe("#{movemail} not found")
     end
 
     unless movemail.end_with?('movemail')
@@ -126,11 +126,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless setuid_root?(movemail)
       vprint_status("Non-SUID-root #{movemail} found")
-      return CheckCode::Detected
+      return CheckCode::Detected("Non-SUID-root #{movemail} found")
     end
 
     vprint_good("SUID-root #{movemail} found")
-    CheckCode::Appears
+    CheckCode::Appears("SUID-root #{movemail} found")
   end
 
   def exploit

--- a/modules/exploits/unix/local/exim_perl_startup.rb
+++ b/modules/exploits/unix/local/exim_perl_startup.rb
@@ -48,9 +48,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if exploit('whoami') == 'root'
-      CheckCode::Vulnerable
+      CheckCode::Vulnerable('Exim Perl startup exploit confirmed command execution as root')
     else
-      CheckCode::Safe
+      CheckCode::Safe('Could not confirm command execution as root')
     end
   end
 

--- a/modules/exploits/unix/misc/distcc_exec.rb
+++ b/modules/exploits/unix/misc/distcc_exec.rb
@@ -67,10 +67,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     err, out = read_output
     if out && out.index(r)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable('Remote code execution via distcc confirmed')
     end
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe('Target does not appear to be running a vulnerable distcc daemon')
+  ensure
+    disconnect
   end
 
   def exploit

--- a/modules/exploits/unix/misc/polycom_hdx_auth_bypass.rb
+++ b/modules/exploits/unix/misc/polycom_hdx_auth_bypass.rb
@@ -78,15 +78,15 @@ class MetasploitModule < Msf::Exploit::Remote
     res = sock.get_once
     disconnect
 
-    if !res && !res.empty?
-      return Exploit::CheckCode::Safe
+    if res.nil? || res.empty?
+      return Exploit::CheckCode::Unknown('No response received from target')
     end
 
     if res =~ /Welcome to ViewStation/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears('Polycom HDX ViewStation detected')
     end
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe('Target does not appear to be a Polycom HDX device')
   end
 
   def exploit

--- a/modules/exploits/unix/misc/polycom_hdx_traceroute_exec.rb
+++ b/modules/exploits/unix/misc/polycom_hdx_traceroute_exec.rb
@@ -65,13 +65,13 @@ class MetasploitModule < Msf::Exploit::Remote
     Rex.sleep(1)
     res = sock.get_once
     disconnect
-    if !res && !res.empty?
-      return Exploit::CheckCode::Unknown
+    if res.nil? || res.empty?
+      return Exploit::CheckCode::Unknown('No response received from target')
     elsif res =~ /Welcome to ViewStation/ || res =~ /Polycom/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Detected('Polycom HDX device detected')
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown('Could not determine if target is a Polycom HDX device')
   end
 
   def exploit

--- a/modules/exploits/unix/smtp/morris_sendmail_debug.rb
+++ b/modules/exploits/unix/smtp/morris_sendmail_debug.rb
@@ -65,15 +65,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    checkcode = CheckCode::Safe
+    checkcode = CheckCode::Safe('Sendmail DEBUG mode not detected')
 
     connect
     res = sock.get_once
 
-    return CheckCode::Unknown unless res
+    return CheckCode::Unknown('No response from SMTP server') unless res
 
     if res =~ /^220.*Sendmail/
-      checkcode = CheckCode::Detected
+      checkcode = CheckCode::Detected('Sendmail service detected')
     end
 
     sock.put("DEBUG\r\n")
@@ -82,13 +82,13 @@ class MetasploitModule < Msf::Exploit::Remote
     return checkcode unless res
 
     if res.start_with?('200 Debug set')
-      checkcode = CheckCode::Appears
+      checkcode = CheckCode::Appears('Sendmail DEBUG mode is enabled')
     end
 
     checkcode
   rescue EOFError, Rex::ConnectionError => e
     vprint_error(e.message)
-    CheckCode::Unknown
+    CheckCode::Unknown('Connection error')
   ensure
     disconnect
   end

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -69,13 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     res = sock.get_once
 
-    return CheckCode::Unknown unless res
-    return CheckCode::Detected if res =~ /^220.*ESMTP OpenSMTPD/
+    return CheckCode::Unknown('No response from SMTP server') unless res
+    return CheckCode::Detected('OpenSMTPD detected') if res =~ /^220.*ESMTP OpenSMTPD/
 
-    CheckCode::Safe
+    CheckCode::Safe('Target does not appear to be running OpenSMTPD')
   rescue EOFError, Rex::ConnectionError => e
     vprint_error(e.message)
-    CheckCode::Unknown
+    CheckCode::Unknown('Connection error')
   ensure
     disconnect
   end

--- a/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
+++ b/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
@@ -83,20 +83,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res
       vprint_error 'Connection failed'
-      return CheckCode::Unknown
+      return CheckCode::Unknown('Connection failed')
     end
 
     unless res.code == 200 && res.body =~ /<TITLE>.+v(\d\.\d)/
-      return CheckCode::Safe
+      return CheckCode::Safe('SonicWall XMLRPC endpoint not detected')
     end
 
     version = Rex::Version.new $1.to_s
 
     unless version <= Rex::Version.new('8.1')
-      return CheckCode::Safe
+      return CheckCode::Safe("SonicWall version #{version} is not vulnerable")
     end
 
-    CheckCode::Appears
+    CheckCode::Appears("SonicWall version #{version} appears vulnerable")
   end
 
   def exploit

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -78,18 +78,18 @@ class MetasploitModule < Msf::Exploit::Remote
         Net::SSH.start(rhost, username, opts)
       end
     rescue Rex::ConnectionError
-      return CheckCode::Safe
+      return CheckCode::Safe('Connection failed')
     rescue Net::SSH::Disconnect, ::EOFError
-      return CheckCode::Safe
+      return CheckCode::Safe('SSH connection disconnected')
     rescue Timeout::Error
-      return CheckCode::Safe
+      return CheckCode::Safe('SSH connection timed out')
     rescue Net::SSH::AuthenticationFailed
-      return CheckCode::Safe
+      return CheckCode::Safe('SSH authentication failed')
     rescue Net::SSH::Exception
-      return CheckCode::Safe
+      return CheckCode::Safe('SSH connection error')
     end
 
-    CheckCode::Detected
+    CheckCode::Detected('Successfully connected via SSH')
   end
 
   def rhost

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -85,33 +85,33 @@ class MetasploitModule < Msf::Exploit::Remote
     case version
     when /^6\.0/
       unless (4..14).include?(build) or (17..20).include?(build)
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("SSH Tectia version #{version} is not vulnerable")
       end
 
     when /^6\.1/
       unless (0..9).include?(build) or build == 12
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("SSH Tectia version #{version} is not vulnerable")
       end
 
     when /^6\.2/
       unless (0..5).include?(build)
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("SSH Tectia version #{version} is not vulnerable")
       end
 
     when /^6\.3/
       unless (0..2).include?(build)
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Safe("SSH Tectia version #{version} is not vulnerable")
       end
     else
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe("SSH Tectia version #{version} is not in the vulnerable range")
     end
 
     # The vulnerable version must use PASSWORD method
     user = Rex::Text.rand_text_alpha(4)
     transport, connection = init_ssh(user)
-    return Exploit::CheckCode::Vulnerable if is_passwd_method?(user, transport)
+    return Exploit::CheckCode::Vulnerable("SSH Tectia version #{version} uses PASSWORD authentication") if is_passwd_method?(user, transport)
 
-    return Exploit::CheckCode::Safe
+    return Exploit::CheckCode::Safe("SSH Tectia version #{version} does not use PASSWORD authentication")
   end
 
   def rhost


### PR DESCRIPTION
Improves multiple module check code messages and statuses

This metadata is currently missing in modules, which means the bubbling up of results to users is often missing

Continuation of https://github.com/rapid7/metasploit-framework/pull/21304

## Verification

- Ensure CI passes
- Ensure the updated messages are sensical