### PR TITLE
Comment out payload size cache tests

### DIFF
--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -110,7 +110,7 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
 
     next if reference_name =~ /generic|peinject/
 
-    it 'has a valid cached_size' do
+    it 'has a valid cached_size', skip: 'Migrated to Jenkins' do
       pinst = load_and_create_module(
             ancestor_reference_names: ancestor_reference_names,
             module_type: module_type,


### PR DESCRIPTION
This PR comments out (can remove) the specs related to payload cache size validation.
This caused us some woes in the past, and we are looking for an alternative approach with the Jenkins commits instead.

## Verification

List the steps needed to make sure this thing works

- [ ] Passing CI
- [ ] Modify the CachedSize constant of any payload
- [ ] Run `bundle exec rspec spec/modules/payloads_spec.rb`
- [ ] Verify the tests do not fail.