### PR TITLE
Update payload cached sizes when creating new module metadata cache

### DIFF
--- a/tools/automation/cache/build_new_cache.sh
+++ b/tools/automation/cache/build_new_cache.sh
@@ -1,5 +1,7 @@
-#!/bin/sh -ex
+#!/bin/bash -exu
+set -o pipefail
 bundle install
+bundle exec ruby tools/modules/update_payload_cached_sizes.rb
 rm -f db/modules_metadata_base.json
 git ls-files modules/ -z | xargs -0 -n1 -P `nproc` -I{} -- git log -1 --format="%ai {}" {} | while read -r udate utime utz ufile ; do
   touch -d "$udate $utime" $ufile


### PR DESCRIPTION
This PR allows for modifying the payload cached sizes when the module search metadata cache is regenerated.

## Verification

List the steps needed to make sure this thing works

- [ ] `docker build -t metasploitframework/metasploit-framework:latest .`
- [ ] `IMG='metasploitframework/metasploit-framework:latest'; docker run --rm=true --tty --volume="$(pwd)":/r7-source --workdir=/r7-source ${IMG} /bin/sh -c 'time ./tools/automation/cache/build_new_cache.sh'`
- [ ] Verify it completes