### PR TITLE
Add string comparison scenario to AGENTS.md file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 - Multiline block comments are acceptable for embedded code snippets/payloads
 - Don't use `get_`/`set_` prefixes for accessor methods in new code
 - Method parameter names must be at least 2 characters (exception for well-known crypto abbreviations)
+- When wanting to compare string values, prefer using either frozen constants (`EXAMPLE = "hello world".freeze`) or symbols to ensure consistency.
 
 ### Module Development
 


### PR DESCRIPTION
Follow-on from previous PRs and R7 reviews.

We would prefer symbols or constants be used when doing comparison/equality checks, as opposed to raw strings. For example:
```ruby
# Old, not preferred
case user_input.downcase
when "x"
  ...
when "exaple" # typo'd on purpose
  ... 

# Preferred
OPT_1 = "example".freeze

case user_input.downcase
when OPT_1 # Code auto-completion, ensured correctness
  ...
```