### PR TITLE
ftp_anonymous: Report service/vuln, store loot & update metadata

### DIFF
--- a/documentation/modules/auxiliary/scanner/ftp/ftp_anonymous.md
+++ b/documentation/modules/auxiliary/scanner/ftp/ftp_anonymous.md
@@ -52,7 +52,7 @@ This module allows us to scan through a series of IP Addresses and provide detai
 
 ## Verification Steps
 
-1. Do: ```use auxiliary/scanner/ftp/anonymous```
+1. Do: ```use auxiliary/scanner/ftp/ftp_anonymous```
 2. Do: ```set RHOSTS [IP]```
 3. Do: ```set RPORT [IP]```
 4. Do: ```run```
@@ -62,17 +62,17 @@ This module allows us to scan through a series of IP Addresses and provide detai
 ### vsFTPd 3.0.3 on Kali
 
 ```
-msf > use auxiliary/scanner/ftp/anonymous
-msf auxiliary(anonymous) > set RHOSTS 127.0.0.1
+msf > use auxiliary/scanner/ftp/ftp_anonymous
+msf auxiliary(ftp_anonymous) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1
-msf auxiliary(anonymous) > set RPORT 21
+msf auxiliary(ftp_anonymous) > set RPORT 21
 RPORT => 21
-msf auxiliary(anonymous) > exploit
+msf auxiliary(ftp_anonymous) > exploit
 
 [+] 127.0.0.1:21          - 127.0.0.1:21 - Anonymous READ (220 (vsFTPd 3.0.3))
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
-msf auxiliary(anonymous) > 
+msf auxiliary(ftp_anonymous) >
 ```
 
 ## Confirming using NMAP

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(21),
+        OptBool.new('STORE_LOOT', [false, 'Store the directory listing as loot', true])
       ]
     )
   end
@@ -50,6 +51,20 @@ class MetasploitModule < Msf::Auxiliary
         end
         version = banner.gsub(/^\d{3}[\s-]/, '').gsub(/\A\(|\)\z/, '').strip
         print_good("Anonymous #{access_type} access (#{version})")
+
+        if datastore['STORE_LOOT']
+          vprint_status("Listing directory contents")
+          listing = send_cmd_data(['LS'], nil)
+          if listing.nil?
+            print_warning('Could not retrieve directory listing (data connection failed)')
+          elsif listing[1].nil? || listing[1].empty?
+            vprint_status('Directory listing: (empty)')
+          else
+            vprint_status("Directory listing:\n#{listing[1]}")
+            path = store_loot('ftp.anonymous', 'text/plain', rhost, listing[1], 'ftp_anonymous.txt', 'Anonymous FTP directory listing')
+            print_good("Directory listing stored to: #{path}")
+          end
+        end
 
         report_ftp_service(banner)
         report_vuln(

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -18,11 +18,10 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
         ['CVE', '1999-0497'],
       ],
-      'Author' =>
-        [
-          'Matteo Cantoni <goony[at]nothink.org>',
-          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
-       ],
+      'Author' => [
+        'Matteo Cantoni <goony[at]nothink.org>',
+        'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+      ],
       'License' => MSF_LICENSE,
       'Notes' => {
         'Stability' => [CRASH_SAFE],
@@ -40,62 +39,62 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(target_host)
-    begin
-      res = connect_login(true, false)
+    res = connect_login(true, false)
 
-      banner.strip! if banner
+    banner.strip! if banner
 
-      if res
-        dir = Rex::Text.rand_text_alpha(8)
-        vprint_status("Testing write access, Creating directory: #{dir}")
-        write_check = send_cmd(['MKD', dir], true)
+    if res
+      dir = Rex::Text.rand_text_alpha(8)
+      vprint_status("Testing write access, Creating directory: #{dir}")
+      # Alt would be to use STOR
+      write_check = send_cmd(['MKD', dir], true)
 
-        if write_check && write_check =~ /^2/
-          access_type = 'Read/Write'
+      if write_check && write_check =~ /^2/
+        access_type = 'Read/Write'
 
-          vprint_status("Deleting directory: #{dir}")
-          send_cmd(['RMD', dir], true)
+        vprint_status("Deleting directory: #{dir}")
+        send_cmd(['RMD', dir], true)
+      else
+        access_type = 'Read-only'
+      end
+      version = banner.gsub(/^\d{3}[\s-]/, '').gsub(/\A\(|\)\z/, '').strip
+      print_good("Anonymous #{access_type} access (#{version})")
+
+      if datastore['STORE_LOOT']
+        vprint_status('Listing directory contents')
+        listing = send_cmd_data(['LS'], nil)
+        if listing.nil?
+          print_warning('Could not retrieve directory listing (data connection failed)')
+        elsif listing[1].nil? || listing[1].empty?
+          vprint_status('Directory listing: (empty)')
         else
-          access_type = 'Read-only'
+          vprint_status("Directory listing:\n#{listing[1]}")
+          path = store_loot('ftp.anonymous', 'text/plain', rhost, listing[1], 'ftp_anonymous.txt', 'Anonymous FTP directory listing')
+          print_good("Directory listing stored to: #{path}")
         end
-        version = banner.gsub(/^\d{3}[\s-]/, '').gsub(/\A\(|\)\z/, '').strip
-        print_good("Anonymous #{access_type} access (#{version})")
-
-        if datastore['STORE_LOOT']
-          vprint_status("Listing directory contents")
-          listing = send_cmd_data(['LS'], nil)
-          if listing.nil?
-            print_warning('Could not retrieve directory listing (data connection failed)')
-          elsif listing[1].nil? || listing[1].empty?
-            vprint_status('Directory listing: (empty)')
-          else
-            vprint_status("Directory listing:\n#{listing[1]}")
-            path = store_loot('ftp.anonymous', 'text/plain', rhost, listing[1], 'ftp_anonymous.txt', 'Anonymous FTP directory listing')
-            print_good("Directory listing stored to: #{path}")
-          end
-        end
-
-        report_ftp_service(banner)
-        report_vuln(
-          host: rhost,
-          port: rport,
-          proto: 'tcp',
-          sname: 'ftp',
-          name: 'Anonymous FTP Access',
-          info: "Anonymous FTP login accepted with #{access_type} access",
-          refs: references
-        )
-        register_creds(target_host, access_type)
-      elsif banner
-        print_warning("FTP service, but no Anonymous access  (#{banner_version})")
-        report_ftp_service(banner)
       end
 
-      disconnect
-    rescue ::Interrupt
-      raise $ERROR_INFO
-    rescue ::Rex::ConnectionError, ::IOError
+      report_ftp_service(banner)
+      report_vuln(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        sname: 'ftp',
+        name: 'Anonymous FTP Access',
+        info: "Anonymous FTP login accepted with #{access_type} access",
+        refs: references
+      )
+      register_creds(target_host, access_type)
+    elsif banner
+      print_warning("FTP service, but no Anonymous access  (#{banner_version})")
+      report_ftp_service(banner)
     end
+
+    disconnect
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  rescue ::Rex::ConnectionError, ::IOError => e
+    vprint_error(e.message)
   end
 
   def report_ftp_service(banner)

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -90,10 +90,11 @@ class MetasploitModule < Msf::Auxiliary
       print_warning("FTP service, but no Anonymous access (#{sanitize_ftp_response(banner)})")
       report_ftp_service
     end
+  rescue ::Rex::TimeoutError, ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNREFUSED => e
+    vprint_error(e.message)
+    report_host(host: rhost)
   rescue ::Interrupt
     raise $ERROR_INFO
-  rescue ::Rex::ConnectionError, ::IOError => e
-    vprint_error(e.message)
   ensure
     disconnect
   end

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -48,15 +48,10 @@ class MetasploitModule < Msf::Auxiliary
           print_good("Anonymous READ (#{banner})")
           access_type = 'Read-only'
         end
+        report_ftp_service(banner)
         register_creds(target_host, access_type)
       elsif banner
-        report_service(
-          host: rhost,
-          port: rport,
-          proto: 'tcp',
-          name: 'ftp',
-          info: banner
-        )
+        report_ftp_service(banner)
       end
 
       disconnect
@@ -64,6 +59,16 @@ class MetasploitModule < Msf::Auxiliary
       raise $ERROR_INFO
     rescue ::Rex::ConnectionError, ::IOError
     end
+  end
+
+  def report_ftp_service(banner)
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'ftp',
+      info: banner
+    )
   end
 
   def register_creds(target_host, access_type)

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -75,7 +75,6 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      report_ftp_service
       report_vuln(
         host: rhost,
         port: rport,
@@ -88,8 +87,11 @@ class MetasploitModule < Msf::Auxiliary
       register_creds(target_host, access_type)
     elsif banner
       print_warning("FTP service, but no Anonymous access (#{sanitize_ftp_response(banner)})")
-      report_ftp_service
+    else
+      vprint_warning('No FTP banner received')
     end
+
+    report_ftp_service
   rescue ::Rex::TimeoutError, ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNREFUSED => e
     vprint_error(e.message)
     report_host(host: rhost)

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -90,12 +90,12 @@ class MetasploitModule < Msf::Auxiliary
       print_warning("FTP service, but no Anonymous access (#{sanitize_ftp_response(banner)})")
       report_ftp_service
     end
-
-    disconnect
   rescue ::Interrupt
     raise $ERROR_INFO
   rescue ::Rex::ConnectionError, ::IOError => e
     vprint_error(e.message)
+  ensure
+    disconnect
   end
 
   def report_ftp_service

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -18,8 +18,17 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
         ['CVE', '1999-0497'],
       ],
-      'Author' => 'Matteo Cantoni <goony[at]nothink.org>',
-      'License' => MSF_LICENSE
+      'Author' =>
+        [
+          'Matteo Cantoni <goony[at]nothink.org>',
+          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+       ],
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -16,6 +16,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => 'Detect anonymous (read/write) FTP server access.',
       'References' => [
         ['URL', 'https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
+        ['CVE', '1999-0497'],
       ],
       'Author' => 'Matteo Cantoni <goony[at]nothink.org>',
       'License' => MSF_LICENSE

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Ftp
   include Msf::Auxiliary::Scanner
-  include Msf::Auxiliary::Report
   include Msf::Module::Deprecated
   moved_from 'auxiliary/scanner/ftp/anonymous'
 
@@ -38,10 +37,6 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def sanitize_ftp_response(str)
-    Rex::Text.to_hex_ascii(str.to_s.gsub(/^\d{3}[\s-]/, '').strip.gsub(/\A\(|\)\z/, ''))
-  end
-
   def run_host(target_host)
     res = connect_login(true, false)
 
@@ -59,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
         access_type = 'Read-only'
       end
 
-      print_good("Anonymous #{access_type} access (#{sanitize_ftp_response(banner)})")
+      print_good("Anonymous #{access_type} access (#{@banner_version})")
 
       if datastore['STORE_LOOT']
         vprint_status('Listing directory contents')
@@ -86,12 +81,10 @@ class MetasploitModule < Msf::Auxiliary
       )
       register_creds(target_host, access_type)
     elsif banner
-      print_warning("FTP service, but no Anonymous access (#{sanitize_ftp_response(banner)})")
+      print_warning("FTP service, but no anonymous access (#{@banner_version})")
     else
       vprint_warning('No FTP banner received')
     end
-
-    report_ftp_service
   rescue ::Rex::TimeoutError, ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNREFUSED => e
     vprint_error(e.message)
     report_host(host: rhost)
@@ -99,16 +92,6 @@ class MetasploitModule < Msf::Auxiliary
     raise $ERROR_INFO
   ensure
     disconnect
-  end
-
-  def report_ftp_service
-    report_service(
-      host: rhost,
-      port: rport,
-      proto: 'tcp',
-      name: 'ftp',
-      info: sanitize_ftp_response(banner)
-    )
   end
 
   def register_creds(target_host, access_type)

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -38,27 +38,28 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
+  def sanitize_ftp_response(str)
+    Rex::Text.to_hex_ascii(str.to_s.gsub(/^\d{3}[\s-]/, '').strip.gsub(/\A\(|\)\z/, ''))
+  end
+
   def run_host(target_host)
     res = connect_login(true, false)
 
-    banner.strip! if banner
-
     if res
       dir = Rex::Text.rand_text_alpha(8)
-      vprint_status("Testing write access, Creating directory: #{dir}")
+      vprint_status("Testing write access, creating test directory: #{dir}")
       # Alt would be to use STOR
       write_check = send_cmd(['MKD', dir], true)
 
       if write_check && write_check =~ /^2/
         access_type = 'Read/Write'
-
-        vprint_status("Deleting directory: #{dir}")
+        vprint_status("Removing test directory: #{dir}")
         send_cmd(['RMD', dir], true)
       else
         access_type = 'Read-only'
       end
-      version = banner.gsub(/^\d{3}[\s-]/, '').gsub(/\A\(|\)\z/, '').strip
-      print_good("Anonymous #{access_type} access (#{version})")
+
+      print_good("Anonymous #{access_type} access (#{sanitize_ftp_response(banner)})")
 
       if datastore['STORE_LOOT']
         vprint_status('Listing directory contents')
@@ -74,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      report_ftp_service(banner)
+      report_ftp_service
       report_vuln(
         host: rhost,
         port: rport,
@@ -86,8 +87,8 @@ class MetasploitModule < Msf::Auxiliary
       )
       register_creds(target_host, access_type)
     elsif banner
-      print_warning("FTP service, but no Anonymous access  (#{banner_version})")
-      report_ftp_service(banner)
+      print_warning("FTP service, but no Anonymous access (#{sanitize_ftp_response(banner)})")
+      report_ftp_service
     end
 
     disconnect
@@ -97,13 +98,13 @@ class MetasploitModule < Msf::Auxiliary
     vprint_error(e.message)
   end
 
-  def report_ftp_service(banner)
+  def report_ftp_service
     report_service(
       host: rhost,
       port: rport,
       proto: 'tcp',
       name: 'ftp',
-      info: banner
+      info: sanitize_ftp_response(banner)
     )
   end
 

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -7,6 +7,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Ftp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Module::Deprecated
+  moved_from 'auxiliary/scanner/ftp/anonymous'
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -42,10 +42,10 @@ class MetasploitModule < Msf::Auxiliary
         if write_check && write_check =~ /^2/
           send_cmd(['RMD', dir], true)
 
-          print_good("#{target_host}:#{rport} - Anonymous READ/WRITE (#{banner})")
+          print_good("Anonymous READ/WRITE (#{banner})")
           access_type = 'Read/Write'
         else
-          print_good("#{target_host}:#{rport} - Anonymous READ (#{banner})")
+          print_good("Anonymous READ (#{banner})")
           access_type = 'Read-only'
         end
         register_creds(target_host, access_type)

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -49,6 +49,15 @@ class MetasploitModule < Msf::Auxiliary
           access_type = 'Read-only'
         end
         report_ftp_service(banner)
+        report_vuln(
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          sname: 'ftp',
+          name: 'Anonymous FTP Access',
+          info: "Anonymous FTP login accepted with #{access_type} access",
+          refs: references
+        )
         register_creds(target_host, access_type)
       elsif banner
         report_ftp_service(banner)

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name' => 'Anonymous FTP Access Detection',
-      'Description' => 'Detect anonymous (read/write) FTP server access.',
+      'Description' => 'Detect anonymous (read/write) FTP service access.',
       'References' => [
         ['URL', 'https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
         ['CVE', '1999-0497'],
@@ -35,19 +35,22 @@ class MetasploitModule < Msf::Auxiliary
 
       banner.strip! if banner
 
-      dir = Rex::Text.rand_text_alpha(8)
       if res
+        dir = Rex::Text.rand_text_alpha(8)
+        vprint_status("Testing write access, Creating directory: #{dir}")
         write_check = send_cmd(['MKD', dir], true)
 
         if write_check && write_check =~ /^2/
-          send_cmd(['RMD', dir], true)
-
-          print_good("Anonymous READ/WRITE (#{banner})")
           access_type = 'Read/Write'
+
+          vprint_status("Deleting directory: #{dir}")
+          send_cmd(['RMD', dir], true)
         else
-          print_good("Anonymous READ (#{banner})")
           access_type = 'Read-only'
         end
+        version = banner.gsub(/^\d{3}[\s-]/, '').gsub(/\A\(|\)\z/, '').strip
+        print_good("Anonymous #{access_type} access (#{version})")
+
         report_ftp_service(banner)
         report_vuln(
           host: rhost,
@@ -60,6 +63,7 @@ class MetasploitModule < Msf::Auxiliary
         )
         register_creds(target_host, access_type)
       elsif banner
+        print_warning("FTP service, but no Anonymous access  (#{banner_version})")
         report_ftp_service(banner)
       end
 

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -19,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'Author' => [
         'Matteo Cantoni <goony[at]nothink.org>',
-        'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+        'g0tmi1k' # @g0tmi1k - additional features
       ],
       'License' => MSF_LICENSE,
       'Notes' => {

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Auxiliary
     # Build service information
     service_data = {
       address: target_host,
-      port: datastore['RPORT'],
+      port: rport,
       service_name: 'ftp',
       protocol: 'tcp',
       workspace_id: myworkspace_id
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
     # Build credential information
     credential_data = {
       origin_type: :service,
-      module_fullname: self.fullname,
+      module_fullname: fullname,
       private_data: datastore['FTPPASS'],
       private_type: :password,
       username: datastore['FTPUSER'],


### PR DESCRIPTION
This PR is for:

- Move module to match other generic FTP modules
- Add/Update metasploit (including CVE & notes)
- Clean up output and be more verbose
- Add report_service and report_vuln
- Able to store "loot" if successfully exploited as proof

## Before

```console
[*] Connected to the database specified in the YAML file
[*] Connected to msf. Connection type: postgresql. Connection name: OYGIkFxA.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf >
msf > use scanner anonymous ftp

Matching Modules
================

   #  Name                             Disclosure Date  Rank    Check  Description
   -  ----                             ---------------  ----    -----  -----------
   0  auxiliary/scanner/ftp/anonymous  .                normal  No     Anonymous FTP Access Detection


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/ftp/anonymous

[*] Using auxiliary/scanner/ftp/anonymous
msf auxiliary(scanner/ftp/anonymous) >
msf auxiliary(scanner/ftp/anonymous) > options

Module options (auxiliary/scanner/ftp/anonymous):

   Name     Current Setting      Required  Description
   ----     ---------------      --------  -----------
   FTPPASS  mozilla@example.com  no        The password for the specified username
   FTPUSER  anonymous            no        The username to authenticate as
   RHOSTS   10.0.0.10            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    21                   yes       The target port (TCP)
   THREADS  1                    yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ftp/anonymous) >
msf auxiliary(scanner/ftp/anonymous) > run
[*] 10.0.0.10:21          - Connecting to FTP server 10.0.0.10:21...
[*] 10.0.0.10:21          - Connected to target FTP server.
[*] 10.0.0.10:21          - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:21          - Sending password...
[+] 10.0.0.10:21          - 10.0.0.10:21 - Anonymous READ (220 (vsFTPd 2.3.4))
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/anonymous) >
msf auxiliary(scanner/ftp/anonymous) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      1      0      0

msf auxiliary(scanner/ftp/anonymous) > services -v
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  21    tcp    ftp   open         {}

msf auxiliary(scanner/ftp/anonymous) >
msf auxiliary(scanner/ftp/anonymous) > creds
Credentials
===========

id  host       origin     service       public     private              realm  private_type  JtR Format  cracked_password
--  ----       ------     -------       ------     -------              -----  ------------  ----------  ----------------
63  10.0.0.10  10.0.0.10  21/tcp (ftp)  anonymous  mozilla@example.com         Password

msf auxiliary(scanner/ftp/anonymous) >
msf auxiliary(scanner/ftp/anonymous) >
```

## After

```console
msf > use scanner anonymous ftp

Matching Modules
================

   #  Name                                 Disclosure Date  Rank    Check  Description
   -  ----                                 ---------------  ----    -----  -----------
   0  auxiliary/scanner/ftp/ftp_anonymous  .                normal  No     Anonymous FTP Access Detection
   1  auxiliary/scanner/ftp/ftp_login      .                normal  No     FTP Authentication Scanner


Interact with a module by name or index. For example info 1, use 1 or use auxiliary/scanner/ftp/ftp_login

msf > use 0
msf auxiliary(scanner/ftp/ftp_anonymous) >
msf auxiliary(scanner/ftp/ftp_anonymous) > options

Module options (auxiliary/scanner/ftp/ftp_anonymous):

   Name        Current Setting      Required  Description
   ----        ---------------      --------  -----------
   FTPPASS     mozilla@example.com  no        The password for the specified username
   FTPUSER     anonymous            no        The username to authenticate as
   RHOSTS      10.0.0.10            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT       21                   yes       The target port (TCP)
   STORE_LOOT  true                 no        Store the directory listing as loot
   THREADS     1                    yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ftp/ftp_anonymous) >
msf auxiliary(scanner/ftp/ftp_anonymous) > run
[*] 10.0.0.10:21          - Connecting to FTP server 10.0.0.10:21...
[*] 10.0.0.10:21          - Connected to target FTP server.
[*] 10.0.0.10:21          - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:21          - Sending password...
[*] 10.0.0.10:21          - Testing write access, Creating directory: wSSePVqs
[+] 10.0.0.10:21          - Anonymous Read-only access (vsFTPd 2.3.4)
[*] 10.0.0.10:21          - Listing directory contents
[*] 10.0.0.10:21          - Directory listing:
-rw-r--r--    1 0        0               0 Apr 24 19:25 test

[+] 10.0.0.10:21          - Directory listing stored to: /home/kali/.msf4/loot/20260424203150_default_10.0.0.10_ftp.anonymous_727755.txt
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_anonymous) >
msf auxiliary(scanner/ftp/ftp_anonymous) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      1      1      0

msf auxiliary(scanner/ftp/ftp_anonymous) >
msf auxiliary(scanner/ftp/ftp_anonymous) > services
Services
========

host       port  proto  name  state  info                resource  parents
----       ----  -----  ----  -----  ----                --------  -------
10.0.0.10  21    tcp    ftp   open   220 (vsFTPd 2.3.4)  {}

msf auxiliary(scanner/ftp/ftp_anonymous) >
msf auxiliary(scanner/ftp/ftp_anonymous) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                  References
---------                ----       -------       --------  ----                  ----------
2026-04-24 19:31:51 UTC  10.0.0.10  ftp (21/tcp)  {}        Anonymous FTP Access  URL-https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP,CVE-1999-0497

msf auxiliary(scanner/ftp/ftp_anonymous) >
```
