### PR TITLE
Fix scanner/http/trace to handle missing database gracefully

### DIFF
--- a/modules/auxiliary/scanner/http/trace.rb
+++ b/modules/auxiliary/scanner/http/trace.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
           :proto => 'tcp',
           :sname => (ssl ? 'https' : 'http'),
           :info => "Vulnerable to Cross-Site Tracing"
-        )
+        ) if active_db?
       else
         vprint_error("#{rhost}:#{rport} returned #{res.code} #{res.message}")
       end


### PR DESCRIPTION
## Description

The scanner/http/trace module was failing with `Msf::ValidationError` when trying to report a vulnerability to the database when no database connection was available. This fix adds an `active_db?` check before calling `report_vuln`.

### Changes

- **modules/auxiliary/scanner/http/trace.rb**: Added `active_db?` check before `report_vuln` call to gracefully handle missing database connection.

Fixes #21296