### PR TITLE
ftp_version: Use FTP mixin

### DIFF
--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -34,10 +34,12 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_warning('No FTP banner received')
     end
+  rescue ::Rex::ConnectionRefused
+    vprint_error('Connection refused')
+  rescue ::Rex::TimeoutError, ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNREFUSED => e
+    vprint_error(e.message)
   rescue ::Interrupt
     raise $ERROR_INFO
-  rescue ::Rex::ConnectionError, ::IOError => e
-    vprint_error(e.message)
   ensure
     disconnect
   end

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -34,11 +34,11 @@ class MetasploitModule < Msf::Auxiliary
     else
       print_warning('No FTP banner received')
     end
-
-    disconnect
   rescue ::Interrupt
     raise $ERROR_INFO
   rescue ::Rex::ConnectionError, ::IOError => e
     vprint_error(e.message)
+  ensure
+    disconnect
   end
 end

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -20,6 +20,10 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(21),
       ]
     )
+
+    # TODO: One day, might be nice to enum via doing: `send_cmd(['xxx'])` {STAT,SYST,FEAT}
+    #       May need to be auth for these to work
+    deregister_options('FTPUSER', 'FTPPASS')
   end
 
   def run_host(_target_host)

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -11,8 +11,19 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'FTP Version Scanner',
       'Description' => 'Detect FTP Version.',
-      'Author' => 'hdm',
-      'License' => MSF_LICENSE
+      'Author' => [
+        'hdm',
+        'g0tmi1k' # @g0tmi1k - additional features
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'https://www.ietf.org/rfc/rfc959']
+      ],
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'Reliability' => [],
+        'SideEffects' => [IOC_IN_LOGS]
+      }
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -23,20 +23,19 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def run_host(target_host)
-    begin
-      res = connect(true, false)
+  def run_host(_target_host)
+    connect(true, false)
 
-      if (banner)
-        banner_sanitized = Rex::Text.to_hex_ascii(self.banner.to_s)
-        print_good("FTP Banner: '#{banner_sanitized}'")
-        report_service(:host => rhost, :port => rport, :name => "ftp", :info => banner_sanitized)
-      end
-
-      disconnect
-    rescue ::Interrupt
-      raise $!
-    rescue ::Rex::ConnectionError, ::IOError
+    if (banner)
+      banner_sanitized = Rex::Text.to_hex_ascii(banner.to_s)
+      print_good("FTP Banner: '#{banner_sanitized}'")
+      report_service(host: rhost, port: rport, name: 'ftp', info: banner_sanitized)
     end
+
+    disconnect
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  rescue ::Rex::ConnectionError, ::IOError => e
+    vprint_error(e.message)
   end
 end

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -7,23 +7,28 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Ftp
   include Msf::Auxiliary::Scanner
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'FTP Version Scanner',
-      'Description' => 'Detect FTP Version.',
-      'Author' => [
-        'hdm',
-        'g0tmi1k' # @g0tmi1k - additional features
-      ],
-      'License' => MSF_LICENSE,
-      'References' => [
-        ['URL', 'https://www.ietf.org/rfc/rfc959']
-      ],
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'Reliability' => [],
-        'SideEffects' => [IOC_IN_LOGS]
-      }
+      update_info(
+        info,
+        'Name' => 'FTP Version Scanner',
+        'Description' => %q{
+          This module tries to identify the version of an FTP service by reading its banner.
+        },
+        'Author' => [
+          'hdm',
+          'g0tmi1k' # @g0tmi1k - additional features
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://www.ietf.org/rfc/rfc959']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Ftp
   include Msf::Auxiliary::Scanner
-  include Msf::Auxiliary::Report
 
   def initialize
     super(
@@ -26,10 +25,10 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(_target_host)
     connect(true, false)
 
-    if (banner)
-      banner_sanitized = Rex::Text.to_hex_ascii(banner.to_s)
-      print_good("FTP Banner: '#{banner_sanitized}'")
-      report_service(host: rhost, port: rport, name: 'ftp', info: banner_sanitized)
+    if banner
+      print_good("FTP Banner: #{Rex::Text.to_hex_ascii(banner_version)}")
+    else
+      print_warning('No FTP banner received')
     end
 
     disconnect


### PR DESCRIPTION
This PR covers:

- Move functions into FTP mixin
- Add more metadata (Notes & references)
- Remove un-used variables/options/settings (FTPUSER/FTPPASS)
- ...and Get rubocop happy


```
          current  name     hosts  services  vulns  creds  loots  notes
          -------  ----     -----  --------  -----  -----  -----  -----
Before -> *        default  2      4         0      0      0      2
After  -> *        default  2      4         0      0      0      5
```

```
[+] 10.0.0.10:21          - FTP Banner: '220 (vsFTPd 2.3.4)\x0d\x0a'
[...]
[+] 10.0.0.10:21          - FTP Banner: vsFTPd 2.3.4
```

Target is Metasploitable 2.

## Before

- FTP banner needs trimming
- Host/service metadata isn't "rich"

```console
$ ./msfconsole -q -x 'workspace -D;
setg RHOSTS 10.0.0.10;
use auxiliary/scanner/ftp/ftp_version;
run;
set RPORT 2121;
run;
set RHOST 10.0.0.1;
set RPORT 21;
run;'
[*] Deleted workspace: default
[*] Recreated the default workspace
RHOSTS => 10.0.0.10
[+] 10.0.0.10:21          - FTP Banner: '220 (vsFTPd 2.3.4)\x0d\x0a'
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RPORT => 2121
[+] 10.0.0.10:2121        - FTP Banner: '220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\x0d\x0a'
[*] 10.0.0.10:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RHOST => 10.0.0.1
RPORT => 21
[*] 10.0.0.1:21           - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  2      4         0      0      0      2

msf auxiliary(scanner/ftp/ftp_version) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.1
10.0.0.10             Unknown                    device

msf auxiliary(scanner/ftp/ftp_version) > services
Services
========

host       port  proto  name  state  info                                                          resource  parents
----       ----  -----  ----  -----  ----                                                          --------  -------
10.0.0.10  21    tcp    tcp   open                                                                 {}
10.0.0.10  21    tcp    ftp   open   220 (vsFTPd 2.3.4)\x0d\x0a                                    {}        tcp (21/tcp)
10.0.0.10  2121  tcp    tcp   open                                                                 {}
10.0.0.10  2121  tcp    ftp   open   220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\x0d\x0a  {}        tcp (2121/tcp)

msf auxiliary(scanner/ftp/ftp_version) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-20 09:37:56 UTC  10.0.0.10  ftp      21    tcp       ftp.banner  {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-20 09:37:56 UTC  10.0.0.10  ftp      2121  tcp       ftp.banner  {:banner=>"220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]"}

msf auxiliary(scanner/ftp/ftp_version) >
```

## After

```console
$ ./msfconsole -q -x 'workspace -D;
setg RHOSTS 10.0.0.10;
use auxiliary/scanner/ftp/ftp_version;
run;
set RPORT 2121;
run;
set RHOST 10.0.0.1;
set RPORT 21;
run;'
[*] Deleted workspace: default
[*] Recreated the default workspace
RHOSTS => 10.0.0.10
[+] 10.0.0.10:21          - FTP Banner: vsFTPd 2.3.4
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RPORT => 2121
[+] 10.0.0.10:2121        - FTP Banner: ProFTPD 1.3.1
[*] 10.0.0.10:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RHOST => 10.0.0.1
RPORT => 21
[*] 10.0.0.1:21           - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  2      4         0      0      0      5

msf auxiliary(scanner/ftp/ftp_version) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.1
10.0.0.10             Linux    Debian            device

msf auxiliary(scanner/ftp/ftp_version) > services
Services
========

host       port  proto  name  state  info           resource  parents
----       ----  -----  ----  -----  ----           --------  -------
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4   {}        tcp (21/tcp)
10.0.0.10  21    tcp    tcp   open                  {}
10.0.0.10  2121  tcp    ftp   open   ProFTPD 1.3.1  {}        tcp (2121/tcp)
10.0.0.10  2121  tcp    tcp   open                  {}

msf auxiliary(scanner/ftp/ftp_version) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-20 09:36:19 UTC  10.0.0.10  ftp      21    tcp       ftp.banner  {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-20 09:36:19 UTC  10.0.0.10  ftp      21    tcp       ftp.cpe     {:cpe=>"cpe:/a:vsftpd_project:vsftpd:2.3.4"}
 2026-05-20 09:36:19 UTC  10.0.0.10  ftp      2121  tcp       ftp.banner  {:banner=>"220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]"}
 2026-05-20 09:36:19 UTC  10.0.0.10  ftp      2121  tcp       ftp.cpe     {:cpe=>"cpe:/a:proftpd:proftpd:1.3.1"}
 2026-05-20 09:36:19 UTC  10.0.0.10  ftp      2121  tcp       ftp.cpe     {:cpe=>"cpe:/o:debian:debian_linux:-"}

msf auxiliary(scanner/ftp/ftp_version) >
```