### PR TITLE
ftp_login: Various improvements

### DIFF
--- a/documentation/modules/auxiliary/scanner/ftp/ftp_login.md
+++ b/documentation/modules/auxiliary/scanner/ftp/ftp_login.md
@@ -1,63 +1,151 @@
-## Description
-
-This module will test FTP logins on a range of machines and report successful logins. If you have loaded a database plugin and connected to a database this module will record successful logins and hosts so you can track your access.
-
 ## Vulnerable Application
 
-### Install ftp server on Kali Linux:
+This module tests FTP logins on a range of machines and reports successful logins.
+If a database is connected, successful logins, hosts, and credentials are recorded.
+On successful login, the module can optionally check read/write access, store a
+directory listing as loot, and fingerprint the server via `FEAT`, `STAT`, and `SYST`.
 
-1.  ```apt-get install vsftpd```
-2. Allow local users to log in and to allow ftp uploads by editing file `/etc/vsftpd.conf` uncommenting the following:
+### Install a FTP server on Kali Linux
 
-    ```
-    local_enable=YES
-    write_enable=YES
-    chroot_list_enable=YES
-    chroot_list_file=/etc/vsftpd.chroot_list
-    ```
+1. `apt-get install vsftpd`
+2. Allow local users to log in and to allow FTP uploads by editing `/etc/vsftpd.conf`
+   and uncommenting the following:
 
-3. Create the file `/etc/vsftpd.chroot_list` and add the local users you want allow to connect to FTP server. Start service and test connections:
-4. ```service vsftpd start``` 
+```
+local_enable=YES
+write_enable=YES
+chroot_list_enable=YES
+chroot_list_file=/etc/vsftpd.chroot_list
+```
 
-### Installing FTP for IIS 7.5 in Windows:
+3. Create `/etc/vsftpd.chroot_list` and add local users to permit.
+4. Start the service: `service vsftpd start`
 
-#### IIS 7.5 for Windows Server 2008 R2:
+### Installing FTP for IIS 7.5 on Windows
+
+#### IIS 7.5 for Windows Server 2008 R2
 
 1. On the taskbar, click Start, point to Administrative Tools, and then click Server Manager.
 2. In the Server Manager hierarchy pane, expand Roles, and then click Web Server (IIS).
 3. In the Web Server (IIS) pane, scroll to the Role Services section, and then click Add Role Services.
 4. On the Select Role Services page of the Add Role Services Wizard, expand FTP Server.
-5. Select FTP Service. (Note: To support ASP.NET Membership or IIS Manager authentication for the FTP service, you will also need to select FTP Extensibility.)
+5. Select FTP Service. (Note: To support ASP.NET Membership or IIS Manager authentication
+   for the FTP service, you will also need to select FTP Extensibility.)
 6. Click Next.
 7. On the Confirm Installation Selections page, click Install.
-8. On the Results page, click Close. 
+8. On the Results page, click Close.
 
-#### IIS 7.5 for Windows 7:
+#### IIS 7.5 for Windows 7
 
 1. On the taskbar, click Start, and then click Control Panel.
 2. In Control Panel, click Programs and Features, and then click Turn Windows Features on or off.
 3. Expand Internet Information Services, then FTP Server.
-4. Select FTP Service. (Note: To support ASP.NET Membership or IIS Manager authentication for the FTP service, you will also need to select FTP Extensibility.)
-5. Click OK. 
+4. Select FTP Service. (Note: To support ASP.NET Membership or IIS Manager authentication
+   for the FTP service, you will also need to select FTP Extensibility.)
+5. Click OK.
 
 ## Verification Steps
 
-1. Do: ```use auxiliary/scanner/ftp/ftp_login```
-2. Do: ```set RHOSTS [IP]```
-3. Do: ```set RPORT [IP]```
-4. Do: ```run```
+1. Do: `use auxiliary/scanner/ftp/ftp_login`
+2. Do: `set RHOSTS [IP]`
+3. Do: `set RPORT [PORT]`
+4. Do: Either `set USERNAME <username>` and `set PASSWORD <password>`, or `set ANONYMOUS_LOGIN true`
+5. Do: `run`
+
+## Options
+
+### ANONYMOUS_LOGIN
+
+Attempt login using various anonymous FTP user accounts with browser-like passwords
+(e.g. `mozilla@example.com`). (Default: `false`)
+
+### CHECK_ACCESS
+
+After a successful login, test read/write access by attempting to create and remove a
+temporary directory via `MKD`/`RMD`. (Default: `false`)
+
+### DIRECTORY_LISTING
+
+After a successful login, retrieve and store the current directory listing as loot.
+(Default: `false`)
+
+### EXTENDED_CHECKS
+
+After a successful login, fingerprint the FTP service by issuing `FEAT`, `STAT`, and
+`SYST` commands and recording the responses. (Default: `false`)
 
 ## Scenarios
 
+### Anonymous login against Metasploitable 2
+
 ```
-msf> use auxiliary/scanner/ftp/ftp_login
-msf auxiliary(ftp_login) > set RHOSTS ftp.openbsd.org
-msf auxiliary(ftp_login) > set USERNAME ftp
-msf auxiliary(ftp_login) > set PASSWORD hello@metasploit.com
-msf auxiliary(ftp_login) > run
-[*] 129.128.5.191:21 - Starting FTP login sweep
-[+] 129.128.5.191:21 - LOGIN SUCCESSFUL: ftp:hello@metasploit.com
-[*] Scanned 1 of 1 hosts (100% complete)
+msf > use auxiliary/scanner/ftp/ftp_login
+msf auxiliary(scanner/ftp/ftp_login) > set RHOSTS 10.0.0.10
+RHOSTS => 10.0.0.10
+msf auxiliary(scanner/ftp/ftp_login) > set ANONYMOUS_LOGIN true
+ANONYMOUS_LOGIN => true
+msf auxiliary(scanner/ftp/ftp_login) > run
+
+[*] 10.0.0.10:21 - Starting FTP login sweep
+[*] 10.0.0.10:21 - Getting FTP root directory contents
+[+] 10.0.0.10:21 - Login Successful: anonymous:mozilla@example.com
+[*] 10.0.0.10:21 - Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
-msf auxiliary(ftp_login) >
+```
+
+### Credential brute-force against Metasploitable 2
+
+```
+msf > use auxiliary/scanner/ftp/ftp_login
+msf auxiliary(scanner/ftp/ftp_login) > set RHOSTS 10.0.0.10
+RHOSTS => 10.0.0.10
+msf auxiliary(scanner/ftp/ftp_login) > set USERNAME msfadmin
+USERNAME => msfadmin
+msf auxiliary(scanner/ftp/ftp_login) > set PASSWORD msfadmin
+PASSWORD => msfadmin
+msf auxiliary(scanner/ftp/ftp_login) > set STOP_ON_SUCCESS true
+STOP_ON_SUCCESS => true
+msf auxiliary(scanner/ftp/ftp_login) > set CHECK_ACCESS true
+CHECK_ACCESS => true
+msf auxiliary(scanner/ftp/ftp_login) > set EXTENDED_CHECKS true
+EXTENDED_CHECKS => true
+msf auxiliary(scanner/ftp/ftp_login) > set VERBOSE true
+VERBOSE => true
+msf auxiliary(scanner/ftp/ftp_login) > run
+
+[*] 10.0.0.10:21 - Starting FTP login sweep
+[*] 10.0.0.10:21 - FTP Banner: vsFTPd 2.3.4
+[*] 10.0.0.10:21 - Checking read/write access
+[*] 10.0.0.10:21 - Fingerprinting FTP service (as msfadmin)
+[*] 10.0.0.10:21 - Sending FTP command: FEAT
+[*] 10.0.0.10:21 - FTP FEAT: 211-Features:
+[*] 10.0.0.10:21 -   EPRT
+[*] 10.0.0.10:21 -   EPSV
+[*] 10.0.0.10:21 -   MDTM
+[*] 10.0.0.10:21 -   PASV
+[*] 10.0.0.10:21 -   REST STREAM
+[*] 10.0.0.10:21 -   SIZE
+[*] 10.0.0.10:21 -   TVFS
+[*] 10.0.0.10:21 -   UTF8
+[*] 10.0.0.10:21 -   211 End
+[*] 10.0.0.10:21 - Sending FTP command: STAT
+[*] 10.0.0.10:21 - FTP STAT: 211-FTP server status:
+[*] 10.0.0.10:21 -   Connected to 10.0.0.1
+[*] 10.0.0.10:21 -   Logged in as msfadmin
+[*] 10.0.0.10:21 -   TYPE: ASCII
+[*] 10.0.0.10:21 -   No session bandwidth limit
+[*] 10.0.0.10:21 -   Session timeout in seconds is 300
+[*] 10.0.0.10:21 -   Control connection is plain text
+[*] 10.0.0.10:21 -   Data connections will be plain text
+[*] 10.0.0.10:21 -   vsFTPd 2.3.4 - secure, fast, stable
+[*] 10.0.0.10:21 -   211 End of status
+[*] 10.0.0.10:21 - Sending FTP command: SYST
+[*] 10.0.0.10:21 - FTP SYST: 215 UNIX Type: L8
+[*] 10.0.0.10:21 - Getting FTP root directory contents
+[*] 10.0.0.10:21 - Directory listing:
+[*] 10.0.0.10:21 -   drwxr-xr-x    6 1000     1000         4096 Apr 28  2010 vulnerable
+[+] 10.0.0.10:21 - Directory listing stored to: /home/kali/.msf4/loot/20260520204112_default_10.0.0.10_ftp.dir_listing_894413.txt
+[+] 10.0.0.10:21 - Login Successful: msfadmin:msfadmin (Read/Write)
+[*] 10.0.0.10:21 - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
 ```

--- a/lib/metasploit/framework/login_scanner/ftp.rb
+++ b/lib/metasploit/framework/login_scanner/ftp.rb
@@ -40,19 +40,24 @@ module Metasploit
           }
 
           begin
-            success = connect_login(credential.public, credential.private)
+            ftpsock = connect(true)
+            res = send_user(credential.public, ftpsock)
+            res = send_pass(credential.private, ftpsock) if res =~ /^(331|2)/
+            if res.nil?
+              result_options[:proof] = 'No response to login command'
+              result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            elsif res.start_with?('2')
+              result_options[:proof] = res.strip
+              result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
+            else
+              result_options[:proof] = res.strip
+              result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
+            end
           rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error => e
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-            result_options[:proof] = e
-            success = false
+            result_options[:proof] = e.message
           ensure
             disconnect
-          end
-
-          if success
-            result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
-          elsif !(result_options.has_key? :status)
-            result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
           end
 
           result = ::Metasploit::Framework::LoginScanner::Result.new(result_options)

--- a/lib/metasploit/framework/login_scanner/ftp.rb
+++ b/lib/metasploit/framework/login_scanner/ftp.rb
@@ -20,6 +20,8 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY           = nil
 
+        public :banner
+
         # @!attribute ftp_timeout
         #   @return [Integer] The timeout in seconds to wait for a response to an FTP command
         attr_accessor :ftp_timeout

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -56,6 +56,28 @@ class MetasploitModule < Msf::Auxiliary
     @accepts_all_logins = {}
   end
 
+  def run_scanner(ip, scanner)
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      )
+
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        yield result, credential_data
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        vprint_error("#{ip}:#{rport} - Could not connect")
+        invalidate_login(credential_data)
+        report_host(host: ip)
+      else
+        vprint_error("#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})")
+        invalidate_login(credential_data)
+      end
+    end
+  end
+
   def run_host(ip)
     print_status("#{ip}:#{rport} - Starting FTP login sweep")
 
@@ -88,23 +110,13 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
-    scanner.scan! do |result|
-      credential_data = result.to_h
-      credential_data.merge!(
-        module_fullname: fullname,
-        workspace_id: myworkspace_id
-      )
-      if result.success?
-        credential_data[:private_type] = :password
-        credential_core = create_credential(credential_data)
-        credential_data[:core] = credential_core
-        create_credential_login(credential_data)
+    run_scanner(ip, scanner) do |result, credential_data|
+      credential_data[:private_type] = :password
+      credential_core = create_credential(credential_data)
+      credential_data[:core] = credential_core
+      create_credential_login(credential_data)
 
-        print_good("#{ip}:#{rport} - Login Successful: #{result.credential}")
-      else
-        invalidate_login(credential_data)
-        vprint_error("#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})")
-      end
+      print_good("#{ip}:#{rport} - Login Successful: #{result.credential}")
     end
   end
 

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -51,7 +51,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::Proxies,
         Opt::RPORT(21),
         OptBool.new('ANONYMOUS_LOGIN', [ true, 'Attempt to login using various anonymous FTP users', false ]), # Overwrite the AuthBrute mixin, as its not sending blank/empty user/pass
-        OptBool.new('CHECK_ACCESS', [ false, 'Check READ/WRITE access for successful logins', false ])
+        OptBool.new('CHECK_ACCESS', [ false, 'Check READ/WRITE access for successful logins', false ]),
+        OptBool.new('EXTENDED_CHECKS', [false, 'Gather service info via FEAT, STAT and SYST', false])
       ]
     )
 
@@ -144,13 +145,13 @@ class MetasploitModule < Msf::Auxiliary
       credential_data[:core] = credential_core
 
       access_level = nil
-      if datastore['CHECK_ACCESS']
-        print_brute level: :vstatus, ip: rhost, port: rport, msg: 'Checking read/write access'
+      if datastore['CHECK_ACCESS'] || datastore['EXTENDED_CHECKS']
         begin
           connect(true, false)
           send_user(result.credential.public)
           if send_pass(result.credential.private).to_s.start_with?('2')
-            access_level = test_ftp_access
+            access_level = test_ftp_access(ip) if datastore['CHECK_ACCESS']
+            ftp_fingerprint(logged_in_as: result.credential.public) if datastore['EXTENDED_CHECKS']
           end
         rescue ::IOError, Errno::ECONNRESET, ::Timeout::Error => e
           print_brute level: :verror, ip: ip, port: rport, msg: e.message
@@ -177,7 +178,8 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def test_ftp_access
+  def test_ftp_access(ip)
+    print_brute level: :vstatus, ip: ip, port: rport, msg: 'Checking read/write access'
     dir = Rex::Text.rand_text_alpha(8)
     write_check = send_cmd(['MKD', dir], true)
     if write_check && write_check.start_with?('2')

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -42,7 +42,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::Proxies,
         Opt::RPORT(21),
-        OptBool.new('RECORD_GUEST', [ false, 'Record anonymous/guest logins to the database', false ])
+        OptBool.new('RECORD_GUEST', [ false, 'Record anonymous/guest logins to the database', false ]),
+        OptBool.new('CHECK_ACCESS', [ false, 'Check READ/WRITE access for successful logins', true ])
       ]
     )
 
@@ -124,9 +125,28 @@ class MetasploitModule < Msf::Auxiliary
       credential_data[:private_type] = :password
       credential_core = create_credential(credential_data)
       credential_data[:core] = credential_core
+
+      access_level = nil
+      if datastore['CHECK_ACCESS']
+        begin
+          connect(true, false)
+          send_user(result.credential.public)
+          if send_pass(result.credential.private).to_s.start_with?('2')
+            access_level = test_ftp_access
+          end
+        rescue ::IOError, Errno::ECONNRESET, ::Timeout::Error => e
+          vprint_error("#{ip}:#{rport} - #{e.message}")
+        ensure
+          disconnect
+        end
+      end
+
+      credential_data[:access_level] = access_level if access_level
       create_credential_login(credential_data)
 
-      print_good("#{ip}:#{rport} - Login Successful: #{result.credential}")
+      msg = "Login Successful: #{result.credential}"
+      msg << " (#{access_level})" if access_level
+      print_good("#{ip}:#{rport} - #{msg}")
     end
   end
 
@@ -141,16 +161,14 @@ class MetasploitModule < Msf::Auxiliary
     anon_creds
   end
 
-  def test_ftp_access(user, scanner)
+  def test_ftp_access
     dir = Rex::Text.rand_text_alpha(8)
-    write_check = scanner.send_cmd(['MKD', dir], true)
-    if write_check && write_check =~ (/^2/)
-      scanner.send_cmd(['RMD', dir], true)
-      print_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' has READ/WRITE access")
-      return 'Read/Write'
+    write_check = send_cmd(['MKD', dir], true)
+    if write_check && write_check.start_with?('2')
+      send_cmd(['RMD', dir], true)
+      'Read/Write'
     else
-      print_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' has READ access")
-      return 'Read-only'
+      'Read-only'
     end
   end
 end

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -60,6 +60,22 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options('FTPUSER', 'FTPPASS') # Can use these, but should use 'username' and 'password'
   end
 
+  def check_host(ip)
+    connect
+    if banner&.match?(/^(120|220)[\s-]/)
+      report_ftp_service_and_banner(ip)
+      Exploit::CheckCode::Appears("FTP service detected: #{banner_version}")
+    else
+      Exploit::CheckCode::Unknown('No valid FTP banner received')
+    end
+  rescue Rex::ConnectionError, Errno::ECONNRESET
+    Exploit::CheckCode::Unknown('Port closed or connection refused')
+  rescue Rex::ConnectionTimeout, ::Timeout::Error, ::EOFError => e
+    Exploit::CheckCode::Unknown(e.message)
+  ensure
+    disconnect
+  end
+
   def run_scanner(ip, scanner)
     scanner.scan! do |result|
       unless @reported_banner

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -9,7 +9,6 @@ require 'metasploit/framework/login_scanner/ftp'
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Ftp
   include Msf::Auxiliary::Scanner
-  include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
 
   def proto
@@ -56,14 +55,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
 
-    register_advanced_options(
-      [
-        OptBool.new('SINGLE_SESSION', [ false, 'Disconnect after every login attempt', false ])
-      ]
-    )
-
     deregister_options('FTPUSER', 'FTPPASS') # Can use these, but should use 'username' and 'password'
-    @accepts_all_logins = {}
   end
 
   def run_scanner(ip, scanner)

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -58,6 +58,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_scanner(ip, scanner)
     scanner.scan! do |result|
+      unless @reported_banner
+        @reported_banner = true
+        if scanner.banner&.match?(/^(120|220)[\s-]/)
+          self.banner = scanner.banner
+          vprint_status("#{ip}:#{rport} - FTP Banner: #{banner_version}")
+        end
+      end
+
       credential_data = result.to_h
       credential_data.merge!(
         module_fullname: fullname,
@@ -79,6 +87,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    @reported_banner = false
+
     print_status("#{ip}:#{rport} - Starting FTP login sweep")
 
     cred_collection = build_credential_collection(

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -68,11 +68,11 @@ class MetasploitModule < Msf::Auxiliary
       when Metasploit::Model::Login::Status::SUCCESSFUL
         yield result, credential_data
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_error("#{ip}:#{rport} - Could not connect")
+        vprint_error("#{ip}:#{rport} - Could not connect: #{result.proof}")
         invalidate_login(credential_data)
-        report_host(host: ip)
+        report_host(host: ip) if result.proof
       else
-        vprint_error("#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})")
+        vprint_error("#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})")
         invalidate_login(credential_data)
       end
     end

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -42,8 +42,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::Proxies,
         Opt::RPORT(21),
-        OptBool.new('RECORD_GUEST', [ false, 'Record anonymous/guest logins to the database', false ]),
-        OptBool.new('CHECK_ACCESS', [ false, 'Check READ/WRITE access for successful logins', true ])
+        OptBool.new('ANONYMOUS_LOGIN', [ true, 'Attempt to login using various anonymous FTP users', false ]), # Overwrite the AuthBrute mixin, as its not sending blank/empty user/pass
+        OptBool.new('CHECK_ACCESS', [ false, 'Check READ/WRITE access for successful logins', false ])
       ]
     )
 
@@ -150,15 +150,13 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  # Always check for anonymous access by pretending to be a browser.
+  # Check for anonymous access by pretending to be a browser
   def anonymous_creds
-    anon_creds = [ ]
-    if datastore['RECORD_GUEST']
-      ['IEUser@', 'User@', 'mozilla@example.com', 'chrome@example.com' ].each do |password|
-        anon_creds << Metasploit::Framework::Credential.new(public: 'anonymous', private: password)
-      end
+    return [] unless datastore['ANONYMOUS_LOGIN']
+
+    ['mozilla@example.com', 'IEUser@', 'User@', 'chrome@example.com'].map do |password|
+      Metasploit::Framework::Credential.new(public: 'anonymous', private: password, private_type: :password)
     end
-    anon_creds
   end
 
   def test_ftp_access

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -16,32 +16,35 @@ class MetasploitModule < Msf::Auxiliary
     'ftp'
   end
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'FTP Authentication Scanner',
-      'Description' => %q{
-        This module tests FTP logins on a range of machines. Successful
-        logins are recorded in the database as credentials, along with
-        host information.
-      },
-      'Author' => [
-        'todb',
-        'g0tmi1k' # @g0tmi1k - additional features
-      ],
-      'References' => [
-        [ 'CVE', '1999-0502' ], # Weak password
-        [ 'ATT&CK', Mitre::Attack::Technique::T1021_REMOTE_SERVICES ],
-        [ 'ATT&CK', Mitre::Attack::Technique::T1110_001_PASSWORD_GUESSING ]
-      ],
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS, ACCOUNT_LOCKOUTS],
-        'Reliability' => []
-      },
-      'License' => MSF_LICENSE,
-      'DefaultOptions' => {
-        'ConnectTimeout' => 30
-      }
+      update_info(
+        info,
+        'Name' => 'FTP Authentication Scanner',
+        'Description' => %q{
+          This module tests FTP logins on a range of machines. Successful
+          logins are recorded in the database as credentials, along with
+          host information.
+        },
+        'Author' => [
+          'todb',
+          'g0tmi1k' # @g0tmi1k - additional features
+        ],
+        'References' => [
+          [ 'CVE', '1999-0502' ], # Weak password
+          [ 'ATT&CK', Mitre::Attack::Technique::T1021_REMOTE_SERVICES ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1110_001_PASSWORD_GUESSING ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS, ACCOUNT_LOCKOUTS],
+          'Reliability' => []
+        },
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => {
+          'ConnectTimeout' => 30
+        }
+      )
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -95,7 +95,8 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
       password: datastore['PASSWORD'],
-      prepended_creds: anonymous_creds
+      prepended_creds: anonymous_creds,
+      anonymous_login: false # Otherwise this would send blank for both user/password, so its different to anonymous_creds()
     )
 
     scanner = Metasploit::Framework::LoginScanner::FTP.new(

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -52,6 +52,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(21),
         OptBool.new('ANONYMOUS_LOGIN', [ true, 'Attempt to login using various anonymous FTP users', false ]), # Overwrite the AuthBrute mixin, as its not sending blank/empty user/pass
         OptBool.new('CHECK_ACCESS', [ false, 'Check READ/WRITE access for successful logins', false ]),
+        OptBool.new('DIRECTORY_LISTING', [false, 'List the directory and save the output in the loot', false]),
         OptBool.new('EXTENDED_CHECKS', [false, 'Gather service info via FEAT, STAT and SYST', false])
       ]
     )
@@ -145,12 +146,13 @@ class MetasploitModule < Msf::Auxiliary
       credential_data[:core] = credential_core
 
       access_level = nil
-      if datastore['CHECK_ACCESS'] || datastore['EXTENDED_CHECKS']
+      if datastore['CHECK_ACCESS'] || datastore['DIRECTORY_LISTING'] || datastore['EXTENDED_CHECKS']
         begin
           connect(true, false)
           send_user(result.credential.public)
           if send_pass(result.credential.private).to_s.start_with?('2')
             access_level = test_ftp_access(ip) if datastore['CHECK_ACCESS']
+            ftp_list_directory(logged_in_as: result.credential.public, save_loot: true) if datastore['DIRECTORY_LISTING']
             ftp_fingerprint(logged_in_as: result.credential.public) if datastore['EXTENDED_CHECKS']
           end
         rescue ::IOError, Errno::ECONNRESET, ::Timeout::Error => e

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -25,9 +25,12 @@ class MetasploitModule < Msf::Auxiliary
         and connected to a database this module will record successful
         logins and hosts so you can track your access.
       },
-      'Author' => 'todb',
+      'Author' => [
+        'todb',
+        'g0tmi1k' # @g0tmi1k - additional features
+      ],
       'References' => [
-        [ 'CVE', '1999-0502'] # Weak password
+        [ 'CVE', '1999-0502' ] # Weak password
       ],
       'License' => MSF_LICENSE,
       'DefaultOptions' => {
@@ -39,13 +42,13 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::Proxies,
         Opt::RPORT(21),
-        OptBool.new('RECORD_GUEST', [ false, "Record anonymous/guest logins to the database", false])
+        OptBool.new('RECORD_GUEST', [ false, 'Record anonymous/guest logins to the database', false ])
       ]
     )
 
     register_advanced_options(
       [
-        OptBool.new('SINGLE_SESSION', [ false, 'Disconnect after every login attempt', false]),
+        OptBool.new('SINGLE_SESSION', [ false, 'Disconnect after every login attempt', false ])
       ]
     )
 
@@ -88,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
-        module_fullname: self.fullname,
+        module_fullname: fullname,
         workspace_id: myworkspace_id
       )
       if result.success?
@@ -97,10 +100,10 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        print_good("#{ip}:#{rport} - Login Successful: #{result.credential}")
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        vprint_error("#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})")
       end
     end
   end
@@ -119,7 +122,7 @@ class MetasploitModule < Msf::Auxiliary
   def test_ftp_access(user, scanner)
     dir = Rex::Text.rand_text_alpha(8)
     write_check = scanner.send_cmd(['MKD', dir], true)
-    if write_check and write_check =~ /^2/
+    if write_check && write_check =~ (/^2/)
       scanner.send_cmd(['RMD', dir], true)
       print_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' has READ/WRITE access")
       return 'Read/Write'
@@ -128,5 +131,4 @@ class MetasploitModule < Msf::Auxiliary
       return 'Read-only'
     end
   end
-
 end

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
         @reported_banner = true
         if scanner.banner&.match?(/^(120|220)[\s-]/)
           self.banner = scanner.banner
-          vprint_status("#{ip}:#{rport} - FTP Banner: #{banner_version}")
+          print_brute level: :vstatus, ip: ip, port: rport, msg: "FTP Banner: #{banner_version}"
         end
       end
 
@@ -77,11 +77,11 @@ class MetasploitModule < Msf::Auxiliary
       when Metasploit::Model::Login::Status::SUCCESSFUL
         yield result, credential_data
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_error("#{ip}:#{rport} - Could not connect: #{result.proof}")
+        print_brute level: :verror, ip: ip, port: rport, msg: "Could not connect: #{result.proof}"
         invalidate_login(credential_data)
         report_host(host: ip) if result.proof
       else
-        vprint_error("#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})")
+        print_brute level: :verror, ip: ip, port: rport, msg: "Failed: #{result.credential} (#{result.status}: #{result.proof})"
         invalidate_login(credential_data)
       end
     end
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     @reported_banner = false
 
-    print_status("#{ip}:#{rport} - Starting FTP login sweep")
+    print_brute level: :status, ip: ip, port: rport, msg: 'Starting FTP login sweep'
 
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
             access_level = test_ftp_access
           end
         rescue ::IOError, Errno::ECONNRESET, ::Timeout::Error => e
-          vprint_error("#{ip}:#{rport} - #{e.message}")
+          print_brute level: :verror, ip: ip, port: rport, msg: e.message
         ensure
           disconnect
         end
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
 
       msg = "Login Successful: #{result.credential}"
       msg << " (#{access_level})" if access_level
-      print_good("#{ip}:#{rport} - #{msg}")
+      print_brute level: :good, ip: ip, port: rport, msg: msg
     end
   end
 

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -20,18 +20,24 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'FTP Authentication Scanner',
       'Description' => %q{
-        This module will test FTP logins on a range of machines and
-        report successful logins.  If you have loaded a database plugin
-        and connected to a database this module will record successful
-        logins and hosts so you can track your access.
+        This module tests FTP logins on a range of machines. Successful
+        logins are recorded in the database as credentials, along with
+        host information.
       },
       'Author' => [
         'todb',
         'g0tmi1k' # @g0tmi1k - additional features
       ],
       'References' => [
-        [ 'CVE', '1999-0502' ] # Weak password
+        [ 'CVE', '1999-0502' ], # Weak password
+        [ 'ATT&CK', Mitre::Attack::Technique::T1021_REMOTE_SERVICES ],
+        [ 'ATT&CK', Mitre::Attack::Technique::T1110_001_PASSWORD_GUESSING ]
       ],
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS, ACCOUNT_LOCKOUTS],
+        'Reliability' => []
+      },
       'License' => MSF_LICENSE,
       'DefaultOptions' => {
         'ConnectTimeout' => 30

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -99,6 +99,11 @@ class MetasploitModule < Msf::Auxiliary
       anonymous_login: false # Otherwise this would send blank for both user/password, so its different to anonymous_creds()
     )
 
+    if cred_collection.empty?
+      print_brute level: :error, ip: ip, port: rport, msg: 'No credentials specified. Set USERNAME/PASSWORD, USER_FILE/PASS_FILE, or ANONYMOUS_LOGIN'
+      return
+    end
+
     scanner = Metasploit::Framework::LoginScanner::FTP.new(
       configure_login_scanner(
         host: ip,
@@ -129,6 +134,7 @@ class MetasploitModule < Msf::Auxiliary
 
       access_level = nil
       if datastore['CHECK_ACCESS']
+        print_brute level: :vstatus, ip: rhost, port: rport, msg: 'Checking read/write access'
         begin
           connect(true, false)
           send_user(result.credential.public)

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -76,19 +76,29 @@ class MetasploitModule < Msf::Auxiliary
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
         yield result, credential_data
+        report_ftp_service_and_banner(ip)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         print_brute level: :verror, ip: ip, port: rport, msg: "Could not connect: #{result.proof}"
+
         invalidate_login(credential_data)
-        report_host(host: ip) if result.proof
+
+        report_host(host: ip) unless result.proof.to_s.empty?
       else
         print_brute level: :verror, ip: ip, port: rport, msg: "Failed: #{result.credential} (#{result.status}: #{result.proof})"
+
         invalidate_login(credential_data)
+
+        if !@reported_service && result.status == Metasploit::Model::Login::Status::INCORRECT
+          @reported_service = true
+          report_ftp_service_and_banner(ip)
+        end
       end
     end
   end
 
   def run_host(ip)
     @reported_banner = false
+    @reported_service = false
 
     print_brute level: :status, ip: ip, port: rport, msg: 'Starting FTP login sweep'
 
@@ -175,5 +185,32 @@ class MetasploitModule < Msf::Auxiliary
     else
       'Read-only'
     end
+  end
+
+  def report_ftp_service_and_banner(ip)
+    report_service(
+      host: ip,
+      port: rport,
+      proto: 'tcp',
+      name: 'ftp',
+      info: banner ? Rex::Text.to_hex_ascii(banner_version) : nil,
+      parents: {
+        host: ip,
+        port: rport,
+        proto: 'tcp',
+        name: 'tcp'
+      }
+    )
+
+    return unless banner
+
+    report_note(
+      host: ip,
+      port: rport,
+      proto: 'tcp',
+      sname: 'ftp',
+      type: 'ftp.banner',
+      data: { banner: Rex::Text.to_hex_ascii(banner.strip) }
+    )
   end
 end

--- a/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
@@ -100,11 +100,17 @@ RSpec.describe Metasploit::Framework::LoginScanner::FTP do
         expect(ftp_scanner.errors[:ftp_timeout]).to be_empty
       end
     end
+  end
 
-
+  describe '#banner' do
+    it 'is a public method' do
+      expect(described_class.public_method_defined?(:banner)).to be true
+    end
   end
 
   context '#attempt_login' do
+    let(:mock_socket) { double('socket') }
+
     before(:example) do
       ftp_scanner.host = '127.0.0.1'
       ftp_scanner.port = 21
@@ -114,34 +120,144 @@ RSpec.describe Metasploit::Framework::LoginScanner::FTP do
       ftp_scanner.cred_details = detail_group
     end
 
+    context 'when the connection fails' do
 
-    context 'when it fails' do
-
-      it 'returns Metasploit::Model::Login::Status::UNABLE_TO_CONNECT for a Rex::ConnectionError' do
+      it 'returns UNABLE_TO_CONNECT for a Rex::ConnectionError' do
         expect(Rex::Socket::Tcp).to receive(:create) { raise Rex::ConnectionError }
         expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
       end
 
-      it 'returns Metasploit::Model::Login::Status::UNABLE_TO_CONNECT for a Rex::AddressInUse' do
+      it 'returns UNABLE_TO_CONNECT for a Rex::AddressInUse' do
         expect(Rex::Socket::Tcp).to receive(:create) { raise Rex::AddressInUse }
         expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
       end
 
-      it 'returns :connection_disconnect for a ::EOFError' do
+      it 'returns UNABLE_TO_CONNECT for a ::EOFError' do
         expect(Rex::Socket::Tcp).to receive(:create) { raise ::EOFError }
         expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
       end
 
-      it 'returns :connection_disconnect for a ::Timeout::Error' do
+      it 'returns UNABLE_TO_CONNECT for a ::Timeout::Error' do
         expect(Rex::Socket::Tcp).to receive(:create) { raise ::Timeout::Error }
         expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
       end
 
+      it 'returns UNABLE_TO_CONNECT for a Errno::ECONNRESET' do
+        expect(Rex::Socket::Tcp).to receive(:create) { raise Errno::ECONNRESET }
+        expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+      end
+
+      it 'returns UNABLE_TO_CONNECT for a Rex::ConnectionTimeout' do
+        expect(Rex::Socket::Tcp).to receive(:create) { raise Rex::ConnectionTimeout }
+        expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+      end
+
+      it 'sets proof to the exception message' do
+        expect(Rex::Socket::Tcp).to receive(:create) { raise ::Timeout::Error, 'connection timed out' }
+        expect(ftp_scanner.attempt_login(pub_pri).proof).to eq 'connection timed out'
+      end
+
     end
 
-    context 'when it succeeds' do
+    context 'when the connection succeeds' do
+      before(:example) do
+        allow(ftp_scanner).to receive(:connect).and_return(mock_socket)
+        allow(ftp_scanner).to receive(:disconnect)
+      end
 
+      context 'and the login fails' do
 
+        it 'returns UNABLE_TO_CONNECT when send_user returns nil' do
+          allow(ftp_scanner).to receive(:send_user).and_return(nil)
+          expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        end
+
+        it 'sets proof to the expected string when the response is nil' do
+          allow(ftp_scanner).to receive(:send_user).and_return(nil)
+          expect(ftp_scanner.attempt_login(pub_pri).proof).to eq 'No response to login command'
+        end
+
+        it 'returns INCORRECT when send_user returns a non-2xx non-331 response' do
+          allow(ftp_scanner).to receive(:send_user).and_return("530 Login incorrect\r\n")
+          expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::INCORRECT
+        end
+
+        it 'sets proof to the stripped server response when INCORRECT' do
+          allow(ftp_scanner).to receive(:send_user).and_return("530 Login incorrect\r\n")
+          expect(ftp_scanner.attempt_login(pub_pri).proof).to eq '530 Login incorrect'
+        end
+
+        it 'does not call send_pass when send_user response does not match 331 or 2xx' do
+          allow(ftp_scanner).to receive(:send_user).and_return("530 Login incorrect\r\n")
+          expect(ftp_scanner).not_to receive(:send_pass)
+          ftp_scanner.attempt_login(pub_pri)
+        end
+
+        it 'returns INCORRECT when send_pass returns a non-2xx response' do
+          allow(ftp_scanner).to receive(:send_user).and_return("331 Password required\r\n")
+          allow(ftp_scanner).to receive(:send_pass).and_return("530 Login incorrect\r\n")
+          expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::INCORRECT
+        end
+
+        it 'returns INCORRECT when send_user returns 2xx and send_pass returns a non-2xx response' do
+          allow(ftp_scanner).to receive(:send_user).and_return("230 Login successful\r\n")
+          allow(ftp_scanner).to receive(:send_pass).and_return("530 Login incorrect\r\n")
+          expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::INCORRECT
+        end
+
+        it 'returns UNABLE_TO_CONNECT when send_pass returns nil' do
+          allow(ftp_scanner).to receive(:send_user).and_return("331 Password required\r\n")
+          allow(ftp_scanner).to receive(:send_pass).and_return(nil)
+          expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        end
+
+      end
+
+      context 'and the login succeeds' do
+
+        it 'returns SUCCESSFUL when send_user returns 331 and send_pass returns 2xx' do
+          allow(ftp_scanner).to receive(:send_user).and_return("331 Password required\r\n")
+          allow(ftp_scanner).to receive(:send_pass).and_return("230 Login successful\r\n")
+          expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::SUCCESSFUL
+        end
+
+        it 'returns SUCCESSFUL when send_user returns 2xx and send_pass returns 2xx' do
+          allow(ftp_scanner).to receive(:send_user).and_return("230 Login successful\r\n")
+          allow(ftp_scanner).to receive(:send_pass).and_return("230 Already logged in\r\n")
+          expect(ftp_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::SUCCESSFUL
+        end
+
+        it 'sets proof to the stripped server response' do
+          allow(ftp_scanner).to receive(:send_user).and_return("331 Password required\r\n")
+          allow(ftp_scanner).to receive(:send_pass).and_return("230 Login successful\r\n")
+          expect(ftp_scanner.attempt_login(pub_pri).proof).to eq "230 Login successful"
+        end
+
+      end
+
+      context 'result metadata' do
+        before(:example) do
+          allow(ftp_scanner).to receive(:send_user).and_return("331 Password required\r\n")
+          allow(ftp_scanner).to receive(:send_pass).and_return("230 Login successful\r\n")
+        end
+
+        it 'sets result.host to the scanner host' do
+          expect(ftp_scanner.attempt_login(pub_pri).host).to eq '127.0.0.1'
+        end
+
+        it 'sets result.port to the scanner port' do
+          expect(ftp_scanner.attempt_login(pub_pri).port).to eq 21
+        end
+
+        it 'sets result.protocol to tcp' do
+          expect(ftp_scanner.attempt_login(pub_pri).protocol).to eq 'tcp'
+        end
+
+        it 'sets result.service_name to ftp' do
+          expect(ftp_scanner.attempt_login(pub_pri).service_name).to eq 'ftp'
+        end
+
+      end
     end
   end
 

--- a/spec/modules/auxiliary/scanner/ftp/ftp_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/ftp/ftp_login_spec.rb
@@ -1,0 +1,490 @@
+require 'rspec'
+
+RSpec.describe 'FTP Login Scanner' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  subject do
+    load_and_create_module(
+      module_type: 'auxiliary',
+      reference_name: 'scanner/ftp/ftp_login'
+    )
+  end
+
+  let(:ip) { '127.0.0.1' }
+
+  describe '#check_host' do
+    before(:each) do
+      allow(subject).to receive(:connect)
+      allow(subject).to receive(:disconnect)
+      allow(subject).to receive(:report_ftp_service_and_banner)
+      allow(subject).to receive(:rport).and_return(21)
+    end
+
+    context 'when an FTP banner is present' do
+      before(:each) do
+        allow(subject).to receive(:banner).and_return('220 vsftpd 3.0.3')
+        allow(subject).to receive(:banner_version).and_return('vsftpd 3.0.3')
+      end
+
+      it 'returns CheckCode::Appears' do
+        expect(subject.check_host(ip).code).to eq 'appears'
+      end
+
+      it 'includes the banner version in the message' do
+        expect(subject.check_host(ip).reason).to include('vsftpd 3.0.3')
+      end
+
+      it 'reports the FTP service and banner' do
+        expect(subject).to receive(:report_ftp_service_and_banner).with(ip)
+        subject.check_host(ip)
+      end
+    end
+
+    context 'when a 120 banner is present' do
+      before(:each) do
+        allow(subject).to receive(:banner).and_return('120 Service ready in 2 minutes')
+        allow(subject).to receive(:banner_version).and_return('Service ready in 2 minutes')
+      end
+
+      it 'returns CheckCode::Appears' do
+        expect(subject.check_host(ip).code).to eq 'appears'
+      end
+    end
+
+    context 'when the banner is nil' do
+      before(:each) do
+        allow(subject).to receive(:banner).and_return(nil)
+      end
+
+      it 'returns CheckCode::Unknown' do
+        expect(subject.check_host(ip).code).to eq 'unknown'
+      end
+
+      it 'reports no valid banner' do
+        expect(subject.check_host(ip).reason).to include('No valid FTP banner received')
+      end
+    end
+
+    context 'when the banner does not match a valid FTP code' do
+      before(:each) do
+        allow(subject).to receive(:banner).and_return('500 Not FTP')
+      end
+
+      it 'returns CheckCode::Unknown' do
+        expect(subject.check_host(ip).code).to eq 'unknown'
+      end
+
+      it 'reports no valid banner' do
+        expect(subject.check_host(ip).reason).to include('No valid FTP banner received')
+      end
+    end
+
+    context 'when the connection fails' do
+      it 'returns CheckCode::Unknown for Rex::ConnectionError' do
+        allow(subject).to receive(:connect).and_raise(Rex::ConnectionError)
+        expect(subject.check_host(ip).code).to eq 'unknown'
+      end
+
+      it 'returns CheckCode::Unknown for Errno::ECONNRESET' do
+        allow(subject).to receive(:connect).and_raise(Errno::ECONNRESET)
+        expect(subject.check_host(ip).code).to eq 'unknown'
+      end
+
+      it 'reports port closed for Rex::ConnectionError' do
+        allow(subject).to receive(:connect).and_raise(Rex::ConnectionError)
+        expect(subject.check_host(ip).reason).to include('Port closed or connection refused')
+      end
+    end
+
+    context 'when the connection times out' do
+      it 'returns CheckCode::Unknown for Rex::ConnectionTimeout' do
+        allow(subject).to receive(:connect).and_raise(Rex::ConnectionTimeout, 'timed out')
+        expect(subject.check_host(ip).code).to eq 'unknown'
+      end
+
+      it 'returns CheckCode::Unknown for Timeout::Error' do
+        allow(subject).to receive(:connect).and_raise(::Timeout::Error, 'timed out')
+        expect(subject.check_host(ip).code).to eq 'unknown'
+      end
+
+      it 'returns CheckCode::Unknown for EOFError' do
+        allow(subject).to receive(:connect).and_raise(::EOFError, 'end of file')
+        expect(subject.check_host(ip).code).to eq 'unknown'
+      end
+
+      it 'includes the exception message' do
+        allow(subject).to receive(:connect).and_raise(::Timeout::Error, 'timed out')
+        expect(subject.check_host(ip).reason).to include('timed out')
+      end
+    end
+
+    context 'disconnect behaviour' do
+      it 'always calls disconnect on success' do
+        allow(subject).to receive(:banner).and_return('220 FTP ready')
+        allow(subject).to receive(:banner_version).and_return('FTP ready')
+        expect(subject).to receive(:disconnect)
+        subject.check_host(ip)
+      end
+
+      it 'always calls disconnect on connection failure' do
+        allow(subject).to receive(:connect).and_raise(Rex::ConnectionError)
+        expect(subject).to receive(:disconnect)
+        subject.check_host(ip)
+      end
+    end
+  end
+
+  describe '#anonymous_creds' do
+    it 'returns an empty array when ANONYMOUS_LOGIN is false' do
+      subject.datastore['ANONYMOUS_LOGIN'] = false
+
+      expect(subject.anonymous_creds).to eq([])
+    end
+
+    it 'returns the four anonymous browser credentials when ANONYMOUS_LOGIN is true' do
+      subject.datastore['ANONYMOUS_LOGIN'] = true
+
+      creds = subject.anonymous_creds
+
+      expect(creds).to all(have_attributes(public: 'anonymous'))
+      expect(creds.map(&:private)).to eq(['mozilla@example.com', 'IEUser@', 'User@', 'chrome@example.com'])
+    end
+  end
+
+  describe '#test_ftp_access' do
+    before(:each) do
+      allow(subject).to receive(:rport).and_return(21)
+    end
+
+    it 'returns Read/Write when MKD succeeds' do
+      allow(subject).to receive(:send_cmd).with(['MKD', anything], true).and_return('257 Directory created')
+      allow(subject).to receive(:send_cmd).with(['RMD', anything], true).and_return('250 Directory removed')
+
+      expect(subject.test_ftp_access(ip)).to eq('Read/Write')
+    end
+
+    it 'returns Read-only when MKD is rejected' do
+      allow(subject).to receive(:send_cmd).with(['MKD', anything], true).and_return('550 Permission denied')
+
+      expect(subject.test_ftp_access(ip)).to eq('Read-only')
+    end
+
+    it 'returns Read-only when MKD gets no response' do
+      allow(subject).to receive(:send_cmd).with(['MKD', anything], true).and_return(nil)
+
+      expect(subject.test_ftp_access(ip)).to eq('Read-only')
+    end
+  end
+
+  describe '#report_ftp_service_and_banner' do
+    before(:each) do
+      allow(subject).to receive(:rport).and_return(21)
+    end
+
+    context 'when a banner is present' do
+      before(:each) do
+        allow(subject).to receive(:banner).and_return('220 vsFTPd 3.0.3')
+        allow(subject).to receive(:banner_version).and_return('vsFTPd 3.0.3')
+      end
+
+      it 'reports the service' do
+        expect(subject).to receive(:report_service).with(hash_including(host: ip, port: 21, name: 'ftp'))
+
+        subject.report_ftp_service_and_banner(ip)
+      end
+
+      it 'reports a banner note' do
+        allow(subject).to receive(:report_service)
+
+        expect(subject).to receive(:report_note).with(hash_including(type: 'ftp.banner'))
+
+        subject.report_ftp_service_and_banner(ip)
+      end
+    end
+
+    context 'when no banner is present' do
+      before(:each) do
+        allow(subject).to receive(:banner).and_return(nil)
+      end
+
+      it 'still reports the service with nil info' do
+        expect(subject).to receive(:report_service).with(hash_including(info: nil))
+
+        subject.report_ftp_service_and_banner(ip)
+      end
+
+      it 'does not report a banner note' do
+        allow(subject).to receive(:report_service)
+
+        expect(subject).not_to receive(:report_note)
+
+        subject.report_ftp_service_and_banner(ip)
+      end
+    end
+  end
+
+  describe '#run_scanner' do
+    let(:credential) { Metasploit::Framework::Credential.new(public: 'msfadmin', private: 'wrongpass', private_type: :password) }
+
+    before(:each) do
+      allow(subject).to receive(:rport).and_return(21)
+      allow(subject).to receive(:fullname).and_return('auxiliary/scanner/ftp/ftp_login')
+      allow(subject).to receive(:myworkspace_id).and_return(1)
+      allow(subject).to receive(:invalidate_login)
+      allow(subject).to receive(:report_ftp_service_and_banner)
+      allow(subject).to receive(:report_host)
+    end
+
+    context 'on the first INCORRECT result' do
+      let(:result) do
+        Metasploit::Framework::LoginScanner::Result.new(credential: credential, status: Metasploit::Model::Login::Status::INCORRECT, proof: 'bad password')
+      end
+      let(:scanner) { instance_double(Metasploit::Framework::LoginScanner::FTP, banner: '220 vsFTPd 3.0.3') }
+
+      before(:each) do
+        allow(scanner).to receive(:scan!).and_yield(result)
+      end
+
+      it 'reports the service exactly once' do
+        expect(subject).to receive(:report_ftp_service_and_banner).once
+
+        subject.run_scanner(ip, scanner) { |*| }
+      end
+    end
+
+    context 'on repeated INCORRECT results' do
+      let(:result) do
+        Metasploit::Framework::LoginScanner::Result.new(credential: credential, status: Metasploit::Model::Login::Status::INCORRECT, proof: 'bad password')
+      end
+      let(:scanner) { instance_double(Metasploit::Framework::LoginScanner::FTP, banner: '220 vsFTPd 3.0.3') }
+
+      before(:each) do
+        allow(scanner).to receive(:scan!).and_yield(result).and_yield(result)
+      end
+
+      it 'only reports the service once across multiple failed attempts' do
+        expect(subject).to receive(:report_ftp_service_and_banner).once
+
+        subject.run_scanner(ip, scanner) { |*| }
+      end
+    end
+
+    context 'on UNABLE_TO_CONNECT with proof present' do
+      let(:result) do
+        Metasploit::Framework::LoginScanner::Result.new(credential: credential, status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'connection refused')
+      end
+      let(:scanner) { instance_double(Metasploit::Framework::LoginScanner::FTP, banner: nil) }
+
+      before(:each) do
+        allow(scanner).to receive(:scan!).and_yield(result)
+      end
+
+      it 'reports the host' do
+        expect(subject).to receive(:report_host).with(host: ip)
+
+        subject.run_scanner(ip, scanner) { |*| }
+      end
+    end
+
+    context 'on UNABLE_TO_CONNECT with no proof' do
+      let(:result) do
+        Metasploit::Framework::LoginScanner::Result.new(credential: credential, status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: nil)
+      end
+      let(:scanner) { instance_double(Metasploit::Framework::LoginScanner::FTP, banner: nil) }
+
+      before(:each) do
+        allow(scanner).to receive(:scan!).and_yield(result)
+      end
+
+      it 'does not report the host' do
+        expect(subject).not_to receive(:report_host)
+
+        subject.run_scanner(ip, scanner) { |*| }
+      end
+    end
+
+    context 'on a SUCCESSFUL result' do
+      let(:credential) { Metasploit::Framework::Credential.new(public: 'msfadmin', private: 'msfadmin', private_type: :password) }
+      let(:result) do
+        Metasploit::Framework::LoginScanner::Result.new(credential: credential, status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: 'ok')
+      end
+      let(:scanner) { instance_double(Metasploit::Framework::LoginScanner::FTP, banner: '220 vsFTPd 3.0.3') }
+
+      before(:each) do
+        allow(scanner).to receive(:scan!).and_yield(result)
+      end
+
+      it 'yields the result and credential data to the given block' do
+        expect { |b| subject.run_scanner(ip, scanner, &b) }.to yield_control
+      end
+
+      it 'reports the service' do
+        expect(subject).to receive(:report_ftp_service_and_banner).with(ip)
+
+        subject.run_scanner(ip, scanner) { |*| }
+      end
+    end
+  end
+
+  describe '#run_host' do
+    let(:credential) { Metasploit::Framework::Credential.new(public: 'msfadmin', private: 'msfadmin', private_type: :password) }
+    let(:result) do
+      Metasploit::Framework::LoginScanner::Result.new(
+        credential: credential,
+        status: Metasploit::Model::Login::Status::SUCCESSFUL,
+        proof: 'ok',
+        host: ip,
+        port: 21,
+        protocol: 'tcp',
+        service_name: 'ftp'
+      )
+    end
+    let(:scanner) { instance_double(Metasploit::Framework::LoginScanner::FTP, banner: '220 vsFTPd 3.0.3') }
+
+    before(:each) do
+      allow(subject).to receive(:rport).and_return(21)
+      allow(Metasploit::Framework::LoginScanner::FTP).to receive(:new).and_return(scanner)
+      allow(scanner).to receive(:scan!).and_yield(result)
+
+      allow(subject).to receive(:create_credential).and_return(double('credential_core'))
+      allow(subject).to receive(:create_credential_login)
+      allow(subject).to receive(:invalidate_login)
+      allow(subject).to receive(:report_ftp_service_and_banner)
+      allow(subject).to receive(:report_host)
+
+      allow(subject).to receive(:connect)
+      allow(subject).to receive(:disconnect)
+      allow(subject).to receive(:send_user)
+      allow(subject).to receive(:send_pass).and_return('230 Login successful')
+
+      subject.datastore['USERNAME'] = 'msfadmin'
+      subject.datastore['PASSWORD'] = 'msfadmin'
+    end
+
+    context 'when no credentials are specified' do
+      before(:each) do
+        subject.datastore['USERNAME'] = nil
+        subject.datastore['PASSWORD'] = nil
+        subject.datastore['ANONYMOUS_LOGIN'] = false
+      end
+
+      it 'does not instantiate a scanner' do
+        expect(Metasploit::Framework::LoginScanner::FTP).not_to receive(:new)
+
+        subject.run_host(ip)
+      end
+    end
+
+    context 'with no post-auth checks enabled' do
+      it 'creates a credential login record' do
+        expect(subject).to receive(:create_credential_login)
+
+        subject.run_host(ip)
+      end
+
+      it 'does not open a second connection' do
+        expect(subject).not_to receive(:connect)
+
+        subject.run_host(ip)
+      end
+    end
+
+    context 'when CHECK_ACCESS is enabled' do
+      before(:each) do
+        subject.datastore['CHECK_ACCESS'] = true
+        allow(subject).to receive(:send_cmd).and_return('257 Directory created')
+      end
+
+      it 'opens a second connection and authenticates as the found credential' do
+        expect(subject).to receive(:connect).with(true, false)
+        expect(subject).to receive(:send_user).with('msfadmin')
+
+        subject.run_host(ip)
+      end
+
+      it 'records the access level on the credential login' do
+        expect(subject).to receive(:create_credential_login).with(hash_including(access_level: 'Read/Write'))
+
+        subject.run_host(ip)
+      end
+
+      it 'always disconnects the second connection' do
+        expect(subject).to receive(:disconnect)
+
+        subject.run_host(ip)
+      end
+    end
+
+    context 'when DIRECTORY_LISTING is enabled' do
+      before(:each) do
+        subject.datastore['DIRECTORY_LISTING'] = true
+        allow(subject).to receive(:ftp_list_directory)
+      end
+
+      it 'calls ftp_list_directory with the authenticated username' do
+        expect(subject).to receive(:ftp_list_directory).with(logged_in_as: 'msfadmin', save_loot: true)
+
+        subject.run_host(ip)
+      end
+
+      it 'still records the credential login' do
+        expect(subject).to receive(:create_credential_login)
+
+        subject.run_host(ip)
+      end
+    end
+
+    context 'when EXTENDED_CHECKS is enabled' do
+      before(:each) do
+        subject.datastore['EXTENDED_CHECKS'] = true
+        allow(subject).to receive(:ftp_fingerprint)
+      end
+
+      it 'calls ftp_fingerprint with the authenticated username' do
+        expect(subject).to receive(:ftp_fingerprint).with(logged_in_as: 'msfadmin')
+
+        subject.run_host(ip)
+      end
+
+      it 'still records the credential login' do
+        expect(subject).to receive(:create_credential_login)
+
+        subject.run_host(ip)
+      end
+    end
+
+    context 'when CHECK_ACCESS, DIRECTORY_LISTING, and EXTENDED_CHECKS are all enabled' do
+      before(:each) do
+        subject.datastore['CHECK_ACCESS'] = true
+        subject.datastore['DIRECTORY_LISTING'] = true
+        subject.datastore['EXTENDED_CHECKS'] = true
+
+        allow(subject).to receive(:send_cmd).and_return('257 Directory created')
+        allow(subject).to receive(:ftp_list_directory)
+        allow(subject).to receive(:ftp_fingerprint)
+      end
+
+      it 'runs all three post-auth checks and still records the credential' do
+        expect(subject).to receive(:ftp_list_directory).with(logged_in_as: 'msfadmin', save_loot: true)
+        expect(subject).to receive(:ftp_fingerprint).with(logged_in_as: 'msfadmin')
+        expect(subject).to receive(:create_credential_login)
+
+        subject.run_host(ip)
+      end
+    end
+
+    context 'when a post-auth check raises a rescuable network error' do
+      before(:each) do
+        subject.datastore['DIRECTORY_LISTING'] = true
+        allow(subject).to receive(:ftp_list_directory).and_raise(Errno::ECONNRESET)
+      end
+
+      it 'still disconnects and still records the credential login' do
+        expect(subject).to receive(:disconnect)
+        expect(subject).to receive(:create_credential_login)
+
+        subject.run_host(ip)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related issue: https://github.com/rapid7/metasploit-framework/issues/21096

This PR covers (a lot!):
- Convert the module to use `run_scanner()`, and `print_brute()`
- Able to be more verbose (gives proof/reasoning of action, show FTP banner, check user input), and clean up output
- Use dead code - previously wasn't checking for FTP permission (CHECK_ACCESS/`test_ftp_access()`)
- Re-work how anonymous access is checked (as well as blank)
- Update workspace more (via `report_vuln()`/`report_service()`/`report_note()`)
- Refresh module metadata
- Able to enum the target more (EXTENDED_CHECKS/STORE_LOOT)
- Update docs & scanner specs

```
          current  name     hosts  services  vulns  creds  loots  notes
          -------  ----     -----  --------  -----  -----  -----  -----
Before -> *        default  1      1         0      1      0      0
After  -> *        default  1      2         1      2      1      2
```

Target is metasploitable 2.

## Before

- ANONYMOUS_LOGIN -> `[-] 10.0.0.10:21          - 10.0.0.10:21 - LOGIN FAILED: : (Incorrect: )` (incorrect)
- CHECK_ACCESS -> `[+] 10.0.0.10:21          - 10.0.0.10:21 - Login Successful: msfadmin:msfadmin` (doesn't say about permissions)

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true;
use auxiliary/scanner/ftp/ftp_login;
set RHOSTS 10.0.0.10;
set USERNAME msfadmin;
set PASSWORD incorrect;
set ANONYMOUS_LOGIN true;
set STOP_ON_SUCCESS false;
set USER_AS_PASS true;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
USERNAME => msfadmin
PASSWORD => incorrect
ANONYMOUS_LOGIN => true
STOP_ON_SUCCESS => false
USER_AS_PASS => true
msf auxiliary(scanner/ftp/ftp_login) > run
[*] 10.0.0.10:21          - 10.0.0.10:21 - Starting FTP login sweep
[-] 10.0.0.10:21          - 10.0.0.10:21 - LOGIN FAILED: : (Incorrect: )
[-] 10.0.0.10:21          - 10.0.0.10:21 - LOGIN FAILED: msfadmin:incorrect (Incorrect: )
[+] 10.0.0.10:21          - 10.0.0.10:21 - Login Successful: msfadmin:msfadmin
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      1      0      0

msf auxiliary(scanner/ftp/ftp_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf auxiliary(scanner/ftp/ftp_login) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  21    tcp    ftp   open         {}

msf auxiliary(scanner/ftp/ftp_login) > creds
Credentials
===========

id   host       origin     service       public    private   realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------   -----  ------------  ----------  ----------------
466  10.0.0.10  10.0.0.10  21/tcp (ftp)  msfadmin  msfadmin         Password

msf auxiliary(scanner/ftp/ftp_login) >
```

## After

- Can see FTP banner
- Enum the target more
- Much more in the workspace
- Output format is more like ssh_login
- ANONYMOUS_LOGIN -> `[+] 10.0.0.10:21          - Login Successful: anonymous:mozilla@example.com (Read-only)` (correct & permissions)
- CHECK_ACCESS -> `[+] 10.0.0.10:21          - Login Successful: msfadmin:msfadmin (Read/Write)` (says about permissions)

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true;
use auxiliary/scanner/ftp/ftp_login;
set RHOSTS 10.0.0.10;
set USERNAME msfadmin;
set PASSWORD incorrect;
set ANONYMOUS_LOGIN true;
set CHECK_ACCESS true;
set STOP_ON_SUCCESS false;
set USER_AS_PASS true;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
USERNAME => msfadmin
PASSWORD => incorrect
ANONYMOUS_LOGIN => true
CHECK_ACCESS => true
STOP_ON_SUCCESS => false
USER_AS_PASS => true
msf auxiliary(scanner/ftp/ftp_login) > run
[*] 10.0.0.10:21          - Starting FTP login sweep
[*] 10.0.0.10:21          - FTP Banner: vsFTPd 2.3.4
[*] 10.0.0.10:21          - Checking read/write access
[*] 10.0.0.10:21          - Getting FTP root directory contents
[*] 10.0.0.10:21          - Directory listing: (empty)
[+] 10.0.0.10:21          - Login Successful: anonymous:mozilla@example.com (Read-only)
[-] 10.0.0.10:21          - Failed: msfadmin:incorrect (Incorrect: 530 Login incorrect.)
[*] 10.0.0.10:21          - Checking read/write access
[*] 10.0.0.10:21          - Getting FTP root directory contents
[*] 10.0.0.10:21          - Directory listing:
[*] 10.0.0.10:21          -   drwxr-xr-x    6 1000     1000         4096 Apr 28  2010 vulnerable
[+] 10.0.0.10:21          - Directory listing stored to: /home/kali/.msf4/loot/20260521114501_default_10.0.0.10_ftp.dir_listing_343949.txt
[+] 10.0.0.10:21          - Login Successful: msfadmin:msfadmin (Read/Write)
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      2      1      2

msf auxiliary(scanner/ftp/ftp_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(scanner/ftp/ftp_login) > services
Services
========

host       port  proto  name  state  info          resource  parents
----       ----  -----  ----  -----  ----          --------  -------
10.0.0.10  21    tcp    tcp   open                 {}
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4  {}        tcp (21/tcp)

msf auxiliary(scanner/ftp/ftp_login) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                  References
---------                ----       -------       --------  ----                  ----------
2026-05-21 10:44:58 UTC  10.0.0.10  ftp (21/tcp)  {}        Weak FTP Credentials  CVE-1999-0502,ATT&CK-T1021,ATT&CK-T1110.001

msf auxiliary(scanner/ftp/ftp_login) > creds
Credentials
===========

id   host       origin     service       public     private              realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------     -------              -----  ------------  ----------  ----------------
471  10.0.0.10  10.0.0.10  21/tcp (ftp)  anonymous  mozilla@example.com         Password
472  10.0.0.10  10.0.0.10  21/tcp (ftp)  msfadmin   msfadmin                    Password

msf auxiliary(scanner/ftp/ftp_login) > loot

Loot
====

host       service  type             name              content     info                                path
----       -------  ----             ----              -------     ----                                ----
10.0.0.10           ftp.dir_listing  ftp_msfadmin.txt  text/plain  FTP directory listing for msfadmin  /home/kali/.msf4/loot/20260521114501_default_10.0.0.10_ftp.dir_listing_343949.txt

msf auxiliary(scanner/ftp/ftp_login) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-21 10:44:58 UTC  10.0.0.10  tcp      21    tcp       ftp.banner  {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-21 10:44:58 UTC  10.0.0.10  tcp      21    tcp       ftp.cpe     {:cpe=>"cpe:/a:vsftpd_project:vsftpd:2.3.4"}

msf auxiliary(scanner/ftp/ftp_login) >
```