### PR TITLE
FTP mixin: Add report_service

### DIFF
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -69,6 +69,7 @@ module Exploit::Remote::Ftp
 
     # Only record the service and banner when the greeting looks like FTP (RFC 959)
     if self.banner&.match?(/^(120|220)[\s-]/)
+      # Cleaned up FTP banner
       report_service(
         host: rhost,
         port: rport,
@@ -81,6 +82,16 @@ module Exploit::Remote::Ftp
           proto: 'tcp',
           name: 'tcp'
         }
+      )
+
+      # Raw FTP banner
+      report_note(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        sname: 'ftp',
+        type: 'ftp.banner',
+        data: { banner: Rex::Text.to_hex_ascii(self.banner.strip) }
       )
     end
 

--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -47,8 +47,7 @@ module Exploit::Remote::Ftp
   # message is read in and stored in the 'banner' attribute.
   #
   def connect(global = true, verbose = nil)
-    verbose ||= datastore['FTPDEBUG']
-    verbose ||= datastore['VERBOSE']
+    verbose = datastore['FTPDEBUG'] || datastore['VERBOSE'] if verbose.nil?
 
     print_status("Connecting to FTP server...") if verbose
 
@@ -133,8 +132,8 @@ module Exploit::Remote::Ftp
   # that have been supplied in the exploit options.
   #
   def connect_login(global = true, verbose = nil)
-    verbose ||= datastore['FTPDEBUG']
-    verbose ||= datastore['VERBOSE']
+    verbose = datastore['FTPDEBUG'] || datastore['VERBOSE'] if verbose.nil?
+
     ftpsock = ftp_connect(global, verbose)
 
     if !(user and pass)

--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -52,7 +52,12 @@ module Exploit::Remote::Ftp
 
     print_status("Connecting to FTP server...") if verbose
 
-    fd = super(global)
+    begin
+      fd = super(global)
+    rescue ::Rex::ConnectionRefused
+      report_host(host: rhost)
+      raise
+    end
 
     # Wait for a banner to arrive...
     self.banner = recv_ftp_resp(fd)

--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -50,7 +50,7 @@ module Exploit::Remote::Ftp
     verbose ||= datastore['FTPDEBUG']
     verbose ||= datastore['VERBOSE']
 
-    print_status("Connecting to FTP server #{rhost}:#{rport}...") if verbose
+    print_status("Connecting to FTP server...") if verbose
 
     fd = super(global)
 

--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -56,7 +56,15 @@ module Exploit::Remote::Ftp
     # Wait for a banner to arrive...
     self.banner = recv_ftp_resp(fd)
 
-    print_status("Connected to target FTP server.") if verbose
+    # 220 (vsFTPd 2.3.4)\x0d\x0a                                   -> vsFTPd 2.3.4
+    # 220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\x0d\x0a -> ProFTPD 1.3.1 Server (Debian)
+    @banner_version = self.banner.to_s
+                      .gsub(/^\d{3}[\s-]/, '')
+                      .strip
+                      .gsub(/\A\(|\)\z/, '')
+                      .gsub(/\s*\[(?:(?:\d{1,3}\.){3}\d{1,3}|[0-9A-Fa-f:]*:[0-9A-Fa-f:.]+)\]/, '')
+
+    print_status('Connected to target FTP server') if verbose
 
     # Return the file descriptor to the caller
     fd

--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -11,6 +11,7 @@ module Msf
 module Exploit::Remote::Ftp
 
   include Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
 
   #
   # Creates an instance of an FTP exploit module.
@@ -65,6 +66,23 @@ module Exploit::Remote::Ftp
                       .gsub(/\s*\[(?:(?:\d{1,3}\.){3}\d{1,3}|[0-9A-Fa-f:]*:[0-9A-Fa-f:.]+)\]/, '')
 
     print_status('Connected to target FTP server') if verbose
+
+    # Only record the service and banner when the greeting looks like FTP (RFC 959)
+    if self.banner&.match?(/^(120|220)[\s-]/)
+      report_service(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        name: 'ftp',
+        info: Rex::Text.to_hex_ascii(@banner_version),
+        parents: {
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          name: 'tcp'
+        }
+      )
+    end
 
     # Return the file descriptor to the caller
     fd


### PR DESCRIPTION
The idea here is to always add FTP service information, when a module connects, without having to add to each module.

## Setup

Looking for a module without any reporting:

```console
$ find modules/auxiliary -name '*ftp*.rb' -exec grep -L report_service {} \;
[...]
modules/auxiliary/dos/ftp/vsftpd_232.rb
[...]
$
$ grep report_ modules/auxiliary/dos/ftp/vsftpd_232.rb
$
```

## Before

```console
[*] Connected to the database specified in the YAML file
[*] Connected to msf. Connection type: postgresql. Connection name: OYGIkFxA.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > git checkout master
[*] exec: git checkout master

Already on 'master'
Your branch is up to date with 'origin/master'.
msf > use vsftpd_232

Matching Modules
================

   #  Name                          Disclosure Date  Rank    Check  Description
   -  ----                          ---------------  ----    -----  -----------
   0  auxiliary/dos/ftp/vsftpd_232  2011-02-03       normal  Yes    VSFTPD 2.3.2 Denial of Service


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/dos/ftp/vsftpd_232

[*] Using auxiliary/dos/ftp/vsftpd_232
msf auxiliary(dos/ftp/vsftpd_232) > options

Module options (auxiliary/dos/ftp/vsftpd_232):

   Name     Current Setting      Required  Description
   ----     ---------------      --------  -----------
   FTPPASS  mozilla@example.com  no        The password for the specified username
   FTPUSER  anonymous            no        The username to authenticate as
   RHOSTS   10.0.0.10            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    21                   yes       The target port (TCP)


View the full module info with the info, or info -d command.

msf auxiliary(dos/ftp/vsftpd_232) > run
[*] Running module against 10.0.0.10
[*] 10.0.0.10:21 - Connecting to FTP server 10.0.0.10:21...
[*] 10.0.0.10:21 - Connected to target FTP server.
[*] 10.0.0.10:21 - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:21 - Sending password...
[-] 10.0.0.10:21 - Auxiliary aborted due to failure: not-vulnerable: Target is not vulnerable.
[*] Auxiliary module execution completed
msf auxiliary(dos/ftp/vsftpd_232) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(dos/ftp/vsftpd_232) >
```

## After

```console
[*] Connected to the database specified in the YAML file
[*] Connected to msf. Connection type: postgresql. Connection name: OYGIkFxA.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > git checkout ftp_mixin
[*] exec: git checkout ftp_mixin

Already on 'ftp_mixin'
Your branch is up to date with 'origin/ftp_mixin'.
msf > use vsftpd_232

Matching Modules
================

   #  Name                          Disclosure Date  Rank    Check  Description
   -  ----                          ---------------  ----    -----  -----------
   0  auxiliary/dos/ftp/vsftpd_232  2011-02-03       normal  Yes    VSFTPD 2.3.2 Denial of Service


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/dos/ftp/vsftpd_232

[*] Using auxiliary/dos/ftp/vsftpd_232
msf auxiliary(dos/ftp/vsftpd_232) > options

Module options (auxiliary/dos/ftp/vsftpd_232):

   Name     Current Setting      Required  Description
   ----     ---------------      --------  -----------
   FTPPASS  mozilla@example.com  no        The password for the specified username
   FTPUSER  anonymous            no        The username to authenticate as
   RHOSTS   10.0.0.10            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT    21                   yes       The target port (TCP)


View the full module info with the info, or info -d command.

msf auxiliary(dos/ftp/vsftpd_232) > run
[*] Running module against 10.0.0.10
[*] 10.0.0.10:21 - Connecting to FTP server 10.0.0.10:21...
[*] 10.0.0.10:21 - Connected to target FTP server
[*] 10.0.0.10:21 - Authenticating as anonymous with password mozilla@example.com...
[*] 10.0.0.10:21 - Sending password...
[-] 10.0.0.10:21 - Auxiliary aborted due to failure: not-vulnerable: Target is not vulnerable.
[*] Auxiliary module execution completed
msf auxiliary(dos/ftp/vsftpd_232) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         0      0      0      0

msf auxiliary(dos/ftp/vsftpd_232) >
msf auxiliary(dos/ftp/vsftpd_232) > services
Services
========

host       port  proto  name  state  info                resource  parents
----       ----  -----  ----  -----  ----                --------  -------
10.0.0.10  21    tcp    ftp   open   220 (vsFTPd 2.3.4)  {}        tcp (21/tcp)
10.0.0.10  21    tcp    tcp   open                       {}

msf auxiliary(dos/ftp/vsftpd_232) >
```