### PR TITLE
reload_lib -a: [Bug fix] Compares against default branch

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -522,7 +522,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   def modified_files
     # Using an array avoids shelling out, so we avoid escaping/quoting
     # --diff-filter=d excludes deleted files that would fail realpath resolution
-    changed_files = %w[git diff --name-only --diff-filter=d]
+    changed_files = %w[git diff --name-only --diff-filter=d git_base_ref]
 
     is_success = true
     files = []
@@ -544,5 +544,17 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       end
     end
     [files, is_success]
+  end
+
+  #
+  # Attempt to find the best git ref to diff against
+  # Prefers upstream remotes, rather than personal/forked remotes
+  #
+  def git_base_ref
+    %w[upstream/master upstream/main origin/master origin/main master main].each do |ref|
+      _, status = Open3.capture2e('git', 'rev-parse', '--verify', ref, chdir: source_directories.first)
+      return ref if status.success?
+    end
+    'master'
   end
 end


### PR DESCRIPTION
There was a bug with `reload_lib -a` not working. 

Note: `master` is the default branch for this git repo.

## Before

```
$ git checkout master
[...]
$ ./msfconsole -q
msf > reload_lib
Usage: reload_lib lib/to/reload.rb [...]

Reload Ruby library files from specified paths.

    -h, --help                       Help banner.
    -a, --all                        Reload all* changed files in your current Git working tree.
                                     *Excludes modules and non-Ruby files.
msf > reload_lib -h
Usage: reload_lib lib/to/reload.rb [...]

Reload Ruby library files from specified paths.

    -h, --help                       Help banner.
    -a, --all                        Reload all* changed files in your current Git working tree.
                                     *Excludes modules and non-Ruby files.
msf > reload_lib -a
Usage: reload_lib lib/to/reload.rb [...]

Reload Ruby library files from specified paths.

    -h, --help                       Help banner.
    -a, --all                        Reload all* changed files in your current Git working tree.
                                     *Excludes modules and non-Ruby files.
msf >
```

## After

```
$ git checkout  reload_all
[...]
$ ./msfconsole -q
msf > reload_lib -a
[*] Reloading /usr/share/metasploit-framework2/lib/msf/ui/console/command_dispatcher/developer.rb
msf >
```