### PR TITLE
ftp_bounce: Various improvements

### DIFF
--- a/documentation/modules/auxiliary/scanner/portscan/ftp_bounce.md
+++ b/documentation/modules/auxiliary/scanner/portscan/ftp_bounce.md
@@ -5,7 +5,7 @@ Enumerate TCP services via the FTP bounce PORT/LIST method
 ## Verification Steps
 
 1. Start msfconsole
-2. Do: `use modules/auxiliary/scanner/portscan/ftpbounce`
+2. Do: `use modules/auxiliary/scanner/portscan/ftp_bounce`
 3. Do: `set BOUNCEHOST [ip]`
 4. Do: `set PORTS [number(s)]`
 5. Do: `set RHOSTS [ip]`
@@ -20,18 +20,18 @@ Docker Usage:  `docker run -e "ADDED_FLAGS=-w -W -d -d" -e FTP_USER_NAME=bob -e 
 ### PureFTPd and Kali Linux 2019.3
 
   ```
-  msf > use modules/auxiliary/scanner/portscan/ftpbounce
-  msf auxiliary(scanner/portscan/ftpbounce) > set BOUNCEHOST 172.17.0.2
+  msf > use modules/auxiliary/scanner/portscan/ftp_bounce
+  msf auxiliary(scanner/portscan/ftp_bounce) > set BOUNCEHOST 172.17.0.2
     BOUNCEHOST => 172.17.0.2
-  msf auxiliary(scanner/portscan/ftpbounce) > set PORTS 8080
+  msf auxiliary(scanner/portscan/ftp_bounce) > set PORTS 8080
     BOUNCEPORT => 8080
-  msf auxiliary(scanner/portscan/ftpbounce) > set RHOSTS 172.17.0.4
+  msf auxiliary(scanner/portscan/ftp_bounce) > set RHOSTS 172.17.0.4
     RHOSTS => 172.17.0.4
-  msf auxiliary(scanner/portscan/ftpbounce) > set FTPUSER bob
+  msf auxiliary(scanner/portscan/ftp_bounce) > set FTPUSER bob
     FTPUSER => bob
-  msf auxiliary(scanner/portscan/ftpbounce) > set FTPPASS 12345
+  msf auxiliary(scanner/portscan/ftp_bounce) > set FTPPASS 12345
     FTPPASS => 12345
-  msf auxiliary(scanner/portscan/ftpbounce) > run
+  msf auxiliary(scanner/portscan/ftp_bounce) > run
 
     [+] 172.17.0.2:21 -  TCP OPEN 172.17.0.4:8080
     [*] 172.17.0.2:21 - Scanned 1 of 1 hosts (100% complete)

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -50,6 +50,46 @@ class MetasploitModule < Msf::Auxiliary
     datastore['BOUNCEPORT']
   end
 
+  def register_ftp_creds(ip)
+    report_note(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      type: 'ftp.bounce',
+      data: { info: 'Attempted to use machine for FTP bounce attack', target: ip }
+    )
+
+    service_data = {
+      address: rhost,
+      port: rport,
+      service_name: 'ftp',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      private_data: datastore['FTPPASS'],
+      private_type: :password,
+      username: datastore['FTPUSER'],
+      workspace_id: myworkspace_id
+    }
+
+    credential_data.merge!(service_data)
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      workspace_id: myworkspace_id
+    }
+
+    login_data.merge!(service_data)
+    create_credential_login(login_data)
+  end
+
   def run_host(ip)
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
     raise Msf::OptionValidateError, ['PORTS'] if ports.empty?
@@ -68,6 +108,10 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Could not authenticate to relay #{rhost}:#{rport} (check FTPUSER/FTPPASS)")
       return
     end
+
+    # This is for the FTP relay host (BOUNCEHOST/BOUNCEPORT), not the target(s) (RHOSTS)
+    # Msf::Exploit::Remote::Ftp should handle that
+    register_ftp_creds(ip)
 
     open_ports = []
     host_up = false

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptAddressRange.new('RHOSTS', [true, 'The host(s) to scan via BOUNCEHOST (FTP relay)']), # Overwrite the mixin default value
-      OptString.new('PORTS', [true, 'Ports to scan (e.g. 22-25,80,110-900)', '1-10000']),
+      OptString.new('PORTS', [true, 'Ports to scan (e.g. 22-25,80,110-900)', '1024-10000']),
       OptAddress.new('BOUNCEHOST', [true, 'FTP relay host']),
       OptPort.new('BOUNCEPORT', [true, 'FTP relay port', 21]),
       OptString.new('FTPUSER', [false, 'Username for the FTP relay (BOUNCEHOST)', 'anonymous']), # Already defined in Msf::Exploit::Remote::Ftp, but in advanced section
@@ -60,7 +60,14 @@ class MetasploitModule < Msf::Auxiliary
     delay_value = datastore['DELAY'].to_i
     raise Msf::OptionValidateError, ['DELAY'] if delay_value < 0
 
-    return if !connect_login
+    vprint_warning("Scanning relay host (#{rhost}) via itself") if rhost == ip
+
+    connected = connect_login
+
+    unless connected
+      print_error("Could not authenticate to relay #{rhost}:#{rport} (check FTPUSER/FTPPASS)")
+      return
+    end
 
     ports.each do |port|
       # Clear out the receive buffer since we're heavily dependent
@@ -78,10 +85,15 @@ class MetasploitModule < Msf::Auxiliary
         host = (ip.split('.') + [port / 256, port % 256]).join(',')
         resp = send_cmd(['PORT', host])
 
-        if resp =~ /^5/
-          # print_error("Got error from PORT to #{ip}:#{port}")
+        # RFC 2577
+        if resp =~ /^5/ && port < 1024
+          vprint_warning("#{rhost}:#{rport} -> #{ip}:#{port}: PORT rejected (port <= 1023/TCP blocked by server, which is expected) -- #{resp.strip}")
+          next
+        elsif resp =~ /^5/
+          vprint_warning("#{rhost}:#{rport} -> #{ip}:#{port}: PORT rejected -- #{resp.strip}")
           next
         elsif !resp
+          print_error("#{rhost}:#{rport} -> #{ip}:#{port}: No response!")
           next
         end
 
@@ -89,7 +101,9 @@ class MetasploitModule < Msf::Auxiliary
 
         if resp =~ /^[12]/
           print_good(" TCP OPEN #{ip}:#{port}")
-          report_service(host: ip, port: port)
+          report_service(host: ip, port: port, info: "Discovered via FTP bounce from #{rhost}:#{rport}")
+        else
+          vprint_warning("#{rhost}:#{rport} -> #{ip}:#{port}: LIST -- #{resp.strip}")
         end
       rescue ::StandardError
         print_error("Unknown error: #{$ERROR_INFO}")

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -16,11 +16,26 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'FTP Bounce Port Scanner',
       'Description' => %q{
-        Enumerate TCP services via the FTP bounce PORT/LIST
-        method.
+        This module performs the FTP bounce attack by using FTP's PORT/LIST commands to
+        proxy a port scan through a "FTP relay host" (BOUNCEHOST/BOUNCEPORT) to
+        enumerate TCP services (RHOSTS/PORTS).
+
+        NOTE: Per RFC 2577, a compliant FTP server should refuse PORT commands that
+        target privileged ports (<= 1023/TCP), so those ports may not be scannable
+        via FTP bounce even on an otherwise vulnerable relay.
+
+        NOTE: IPv6 targets are not supported.
       },
       'Author' => 'kris katterjohn',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'References' => [
+        [ 'CVE', '1999-0017' ]
+      ],
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'SideEffects' => [IOC_IN_LOGS],
+        'Reliability' => []
+      }
     )
 
     register_options([

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -24,11 +24,11 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
-      OptString.new('PORTS', [true, "Ports to scan (e.g. 22-25,80,110-900)", "1-10000"]),
-      OptAddress.new('BOUNCEHOST', [true, "FTP relay host"]),
-      OptPort.new('BOUNCEPORT', [true, "FTP relay port", 21]),
-      OptInt.new('DELAY', [true, "The delay between connections, per thread, in milliseconds", 0]),
-      OptInt.new('JITTER', [true, "The delay jitter factor (maximum value by which to +/- DELAY) in milliseconds.", 0])
+      OptString.new('PORTS', [true, 'Ports to scan (e.g. 22-25,80,110-900)', '1-10000']),
+      OptAddress.new('BOUNCEHOST', [true, 'FTP relay host']),
+      OptPort.new('BOUNCEPORT', [true, 'FTP relay port', 21]),
+      OptInt.new('DELAY', [true, 'The delay between connections, per thread, in milliseconds', 0]),
+      OptInt.new('JITTER', [true, 'The delay jitter factor (maximum value by which to +/- DELAY) in milliseconds.', 0])
     ])
 
     deregister_options('RPORT')
@@ -50,28 +50,28 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
     if ports.empty?
-      raise Msf::OptionValidateError.new(['PORTS'])
+      raise Msf::OptionValidateError, ['PORTS']
     end
 
     jitter_value = datastore['JITTER'].to_i
     if jitter_value < 0
-      raise Msf::OptionValidateError.new(['JITTER'])
+      raise Msf::OptionValidateError, ['JITTER']
     end
 
     delay_value = datastore['DELAY'].to_i
     if delay_value < 0
-      raise Msf::OptionValidateError.new(['DELAY'])
+      raise Msf::OptionValidateError, ['DELAY']
     end
 
-    return if not connect_login
+    return if !connect_login
 
     ports.each do |port|
       # Clear out the receive buffer since we're heavily dependent
       # on the response codes.  We need to do this between every
       # port scan attempt unfortunately.
-      while true
+      loop do
         r = sock.get_once(-1, 0.25)
-        break if not r or r.empty?
+        break if (!r) || r.empty?
       end
 
       begin
@@ -79,23 +79,23 @@ class MetasploitModule < Msf::Auxiliary
         add_delay_jitter(delay_value, jitter_value)
 
         host = (ip.split('.') + [port / 256, port % 256]).join(',')
-        resp = send_cmd(["PORT", host])
+        resp = send_cmd(['PORT', host])
 
         if resp =~ /^5/
           # print_error("Got error from PORT to #{ip}:#{port}")
           next
-        elsif not resp
+        elsif !resp
           next
         end
 
-        resp = send_cmd(["LIST"])
+        resp = send_cmd(['LIST'])
 
         if resp =~ /^[12]/
           print_good(" TCP OPEN #{ip}:#{port}")
-          report_service(:host => ip, :port => port)
+          report_service(host: ip, port: port)
         end
-      rescue ::Exception
-        print_error("Unknown error: #{$!}")
+      rescue ::StandardError
+        print_error("Unknown error: #{$ERROR_INFO}")
       end
     end
   end

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -12,30 +12,33 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Module::Deprecated
   moved_from 'auxiliary/scanner/portscan/ftpbounce'
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'FTP Bounce Port Scanner',
-      'Description' => %q{
-        This module performs the FTP bounce attack by using FTP's PORT/LIST commands to
-        proxy a port scan through a "FTP relay host" (BOUNCEHOST/BOUNCEPORT) to
-        enumerate TCP services (RHOSTS/PORTS).
+      update_info(
+        info,
+        'Name' => 'FTP Bounce Port Scanner',
+        'Description' => %q{
+          This module performs the FTP bounce attack by using FTP's PORT/LIST commands to
+          proxy a port scan through a "FTP relay host" (BOUNCEHOST/BOUNCEPORT) to
+          enumerate TCP services (RHOSTS/PORTS).
 
-        NOTE: Per RFC 2577, a compliant FTP server should refuse PORT commands that
-        target privileged ports (<= 1023/TCP), so those ports may not be scannable
-        via FTP bounce even on an otherwise vulnerable relay.
+          NOTE: Per RFC 2577, a compliant FTP server should refuse PORT commands that
+          target privileged ports (<= 1023/TCP), so those ports may not be scannable
+          via FTP bounce even on an otherwise vulnerable relay.
 
-        NOTE: IPv6 targets are not supported.
-      },
-      'Author' => 'kris katterjohn',
-      'License' => MSF_LICENSE,
-      'References' => [
-        [ 'CVE', '1999-0017' ]
-      ],
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [IOC_IN_LOGS],
-        'Reliability' => []
-      }
+          NOTE: IPv6 targets are not supported.
+        },
+        'Author' => 'kris katterjohn',
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'CVE', '1999-0017' ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
     )
 
     register_options([

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -24,9 +24,12 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
+      OptAddressRange.new('RHOSTS', [true, 'The host(s) to scan via BOUNCEHOST (FTP relay)']), # Overwrite the mixin default value
       OptString.new('PORTS', [true, 'Ports to scan (e.g. 22-25,80,110-900)', '1-10000']),
       OptAddress.new('BOUNCEHOST', [true, 'FTP relay host']),
       OptPort.new('BOUNCEPORT', [true, 'FTP relay port', 21]),
+      OptString.new('FTPUSER', [false, 'Username for the FTP relay (BOUNCEHOST)', 'anonymous']), # Already defined in Msf::Exploit::Remote::Ftp, but in advanced section
+      OptString.new('FTPPASS', [false, 'Password for the FTP relay (BOUNCEHOST)', 'mozilla@example.com']), # Already defined in Msf::Exploit::Remote::Ftp, but in advanced section
       OptInt.new('DELAY', [true, 'The delay between connections, per thread, in milliseconds', 0]),
       OptInt.new('JITTER', [true, 'The delay jitter factor (maximum value by which to +/- DELAY) in milliseconds.', 0])
     ])
@@ -49,19 +52,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
-    if ports.empty?
-      raise Msf::OptionValidateError, ['PORTS']
-    end
+    raise Msf::OptionValidateError, ['PORTS'] if ports.empty?
 
     jitter_value = datastore['JITTER'].to_i
-    if jitter_value < 0
-      raise Msf::OptionValidateError, ['JITTER']
-    end
+    raise Msf::OptionValidateError, ['JITTER'] if jitter_value < 0
 
     delay_value = datastore['DELAY'].to_i
-    if delay_value < 0
-      raise Msf::OptionValidateError, ['DELAY']
-    end
+    raise Msf::OptionValidateError, ['DELAY'] if delay_value < 0
 
     return if !connect_login
 
@@ -98,5 +95,9 @@ class MetasploitModule < Msf::Auxiliary
         print_error("Unknown error: #{$ERROR_INFO}")
       end
     end
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  ensure
+    disconnect
   end
 end

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -9,6 +9,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::Ftp
+  include Msf::Module::Deprecated
+  moved_from 'auxiliary/scanner/portscan/ftpbounce'
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/portscan/ftp_bounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftp_bounce.rb
@@ -69,6 +69,10 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
+    open_ports = []
+    host_up = false
+    port_accepted = false
+
     ports.each do |port|
       # Clear out the receive buffer since we're heavily dependent
       # on the response codes.  We need to do this between every
@@ -97,17 +101,47 @@ class MetasploitModule < Msf::Auxiliary
           next
         end
 
+        port_accepted = true
         resp = send_cmd(['LIST'])
 
         if resp =~ /^[12]/
-          print_good(" TCP OPEN #{ip}:#{port}")
-          report_service(host: ip, port: port, info: "Discovered via FTP bounce from #{rhost}:#{rport}")
+          print_good("#{rhost}:#{rport} -> #{ip}:#{port}: LIST -- TCP OPEN")
+
+          report_service(
+            host: ip,
+            port: port,
+            proto: 'tcp',
+            info: "Discovered via FTP bounce from #{rhost}:#{rport}"
+          )
+
+          open_ports << port
         else
           vprint_warning("#{rhost}:#{rport} -> #{ip}:#{port}: LIST -- #{resp.strip}")
+
+          host_up = true if resp.to_s =~ /connection refused/i
         end
       rescue ::StandardError
         print_error("Unknown error: #{$ERROR_INFO}")
       end
+    end
+
+    report_host(host: ip) if host_up
+
+    if open_ports.empty?
+      msg = "#{ports.length} port(s) scanned via #{rhost}:#{rport}, none open"
+      msg << ' (relay may block FTP bounce)' unless port_accepted
+      print_status(msg)
+    else
+      print_good("#{ports.length} port(s) scanned via #{rhost}:#{rport}, #{open_ports.length} port(s) open: #{open_ports.join(', ')}")
+
+      report_vuln(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        name: 'FTP Bounce Attack',
+        info: "FTP Relay accepted PORT/LIST to #{ip}:#{open_ports.join(',')}",
+        refs: references
+      )
     end
   rescue ::Interrupt
     raise $ERROR_INFO


### PR DESCRIPTION
This PR refreshes this module by:

- Moves the module to be more like other generic FTP service modules filenames
- Able to be more verbose
- Updating metadata
- Update workspace (`report_note()`/`report_service()`/`report_vuln()`/`report_host()`)
- Tweaked settings/options descriptions

```
         current  name     hosts  services  vulns  creds  loots  notes
         -------  ----     -----  --------  -----  -----  -----  -----
Before -> *        default  2      3         0      0      0      1
AFter  -> *        default  2      3         1      1      0      3
```

Target is Metasploitable 2 & a container which is vulnerable to the attack.

## Setup

Skipping over Metasploitable 2, but looking at the container: 

```console
$ docker run --rm -p 2121:21 -p 40000-40100:40000-40100 --name proftpd registry.gitlab.com/g0tmi1k/proftpd-docker:1.3.3c
787c7350dc34 - ProFTPD 1.3.3c (maint) (built Mon Apr 27 2026 16:28:37 UTC) standalone mode STARTUP
```

## Before

- Only see open ports

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/portscan/ftpbounce;
set RHOSTS 10.0.0.10;
set BOUNCEHOST 127.0.0.1;
set BOUNCEPORT 2121;
set PORTS 80,6667;
options;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
BOUNCEHOST => 127.0.0.1
BOUNCEPORT => 2121
PORTS => 80,6667

Module options (auxiliary/scanner/portscan/ftpbounce):

   Name        Current Setting      Required  Description
   ----        ---------------      --------  -----------
   BOUNCEHOST  127.0.0.1            yes       FTP relay host
   BOUNCEPORT  2121                 yes       FTP relay port
   DELAY       0                    yes       The delay between connections, per thread, in milliseconds
   FTPPASS     mozilla@example.com  no        The password for the specified username
   FTPUSER     anonymous            no        The username to authenticate as
   JITTER      0                    yes       The delay jitter factor (maximum value by which to +/- DELAY) in milliseconds.
   PORTS       80,6667              yes       Ports to scan (e.g. 22-25,80,110-900)
   RHOSTS      10.0.0.10            yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   THREADS     1                    yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/portscan/ftpbounce) > run
[*] 127.0.0.1:2121        - Connecting to FTP server...
[*] 127.0.0.1:2121        - Connected to target FTP server
[*] 127.0.0.1:2121        - Authenticating as anonymous with password mozilla@example.com...
[*] 127.0.0.1:2121        - Sending password...
[+] 127.0.0.1:2121        -  TCP OPEN 10.0.0.10:6667
[*] 127.0.0.1:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/portscan/ftpbounce) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  2      3         0      0      0      1

msf auxiliary(scanner/portscan/ftpbounce) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device
127.0.0.1             Unknown                    device

msf auxiliary(scanner/portscan/ftpbounce) > services
Services
========

host       port  proto  name  state  info                                                 resource  parents
----       ----  -----  ----  -----  ----                                                 --------  -------
10.0.0.10  6667  tcp          open                                                        {}
127.0.0.1  2121  tcp    ftp   open   ProFTPD 1.3.3c Server (ProFTPD Docker Installation)  {}        tcp (2121/tcp)
127.0.0.1  2121  tcp    tcp   open                                                        {}

msf auxiliary(scanner/portscan/ftpbounce) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-21 09:03:19 UTC  127.0.0.1  ftp      2121  tcp       ftp.banner  {:banner=>"220 ProFTPD 1.3.3c Server (ProFTPD Docker Installation) [172.17.0.2]"}

msf auxiliary(scanner/portscan/ftpbounce) >
```

## After

- Can see open and closed ports (and reason)

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/portscan/ftp_bounce;
set RHOSTS 10.0.0.10;
set BOUNCEHOST 127.0.0.1;
set BOUNCEPORT 2121;
set PORTS 80,6667;
options;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
BOUNCEHOST => 127.0.0.1
BOUNCEPORT => 2121
PORTS => 80,6667

Module options (auxiliary/scanner/portscan/ftp_bounce):

   Name        Current Setting      Required  Description
   ----        ---------------      --------  -----------
   BOUNCEHOST  127.0.0.1            yes       FTP relay host
   BOUNCEPORT  2121                 yes       FTP relay port
   DELAY       0                    yes       The delay between connections, per thread, in milliseconds
   FTPPASS     mozilla@example.com  no        Password for the FTP relay (BOUNCEHOST)
   FTPUSER     anonymous            no        Username for the FTP relay (BOUNCEHOST)
   JITTER      0                    yes       The delay jitter factor (maximum value by which to +/- DELAY) in milliseconds.
   PORTS       80,6667              yes       Ports to scan (e.g. 22-25,80,110-900)
   RHOSTS      10.0.0.10            yes       The host(s) to scan via BOUNCEHOST (FTP relay)
   THREADS     1                    yes       The number of concurrent threads (max one per host)


View the full module info with the info, or info -d command.

msf auxiliary(scanner/portscan/ftp_bounce) > run
[*] 127.0.0.1:2121        - Connecting to FTP server...
[*] 127.0.0.1:2121        - Connected to target FTP server
[*] 127.0.0.1:2121        - Authenticating as anonymous with password mozilla@example.com...
[*] 127.0.0.1:2121        - Sending password...
[!] 127.0.0.1:2121        - 127.0.0.1:2121 -> 10.0.0.10:80: PORT rejected (port <= 1023/TCP blocked by server, which is expected) -- 500 Illegal PORT command
[+] 127.0.0.1:2121        - 127.0.0.1:2121 -> 10.0.0.10:6667: LIST -- TCP OPEN
[+] 127.0.0.1:2121        - 2 port(s) scanned via 127.0.0.1:2121, 1 port(s) open: 6667
[*] 127.0.0.1:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/portscan/ftp_bounce) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  2      3         1      1      0      3

msf auxiliary(scanner/portscan/ftp_bounce) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device
127.0.0.1             Unknown                    device

msf auxiliary(scanner/portscan/ftp_bounce) > services
Services
========

host       port  proto  name  state  info                                           resource  parents
----       ----  -----  ----  -----  ----                                           --------  -------
10.0.0.10  6667  tcp          open   Discovered via FTP bounce from 127.0.0.1:2121  {}
127.0.0.1  2121  tcp    ftp   open   ProFTPD 1.3.3c                                 {}        tcp (2121/tcp)
127.0.0.1  2121  tcp    tcp   open                                                  {}

msf auxiliary(scanner/portscan/ftp_bounce) > vulns

Vulnerabilities
===============

Timestamp                Host       Service         Resource  Name               References
---------                ----       -------         --------  ----               ----------
2026-05-21 09:06:05 UTC  127.0.0.1  ftp (2121/tcp)  {}        FTP Bounce Attack  CVE-1999-0017

msf auxiliary(scanner/portscan/ftp_bounce) > creds
Credentials
===========

id   host       origin     service         public     private              realm  private_type  JtR Format  cracked_password
--   ----       ------     -------         ------     -------              -----  ------------  ----------  ----------------
465  127.0.0.1  127.0.0.1  2121/tcp (ftp)  anonymous  mozilla@example.com         Password

msf auxiliary(scanner/portscan/ftp_bounce) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-21 09:06:04 UTC  127.0.0.1  ftp      2121  tcp       ftp.banner  {:banner=>"220 ProFTPD 1.3.3c Server (ProFTPD Docker Installation) [172.17.0.2]"}
 2026-05-21 09:06:04 UTC  127.0.0.1  ftp      2121  tcp       ftp.cpe     {:cpe=>"cpe:/a:proftpd:proftpd:1.3.3c"}
 2026-05-21 09:06:04 UTC  127.0.0.1  ftp      2121  tcp       ftp.bounce  {:info=>"Attempted to use machine for FTP bounce attack", :target=>"10.0.0.10"}

msf auxiliary(scanner/portscan/ftp_bounce) >
```