### PR TITLE
Don't report anonymous as a  success when relaying

### DIFF
--- a/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
+++ b/lib/msf/core/exploit/remote/smb/relay/ntlm/server_client.rb
@@ -242,7 +242,6 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
         @relay_targets.on_relay_end(relayed_connection.target, identity: session.metadata[:identity], is_success: is_success)
 
         if is_success
-          logger.print_good("Identity: #{session.metadata[:identity]} - Successfully authenticated against relay target #{relayed_connection.target}")
           session.metadata[:incoming_challenge_response] = ntlm_message
 
           @listener.on_ntlm_type3(
@@ -251,8 +250,14 @@ module Msf::Exploit::Remote::SMB::Relay::NTLM
             ntlm_type2: session.metadata[:relay_target_server_challenge],
             ntlm_type3: session.metadata[:incoming_challenge_response],
             service_name: 'SMB'
-          )
-          @listener.on_relay_success(relay_connection: relayed_connection, relay_identity: session.metadata[:identity])
+         )
+          if session.metadata[:identity].blank?
+            logger.print_status("Anonymous Identity - Successfully authenticated against relay target #{relayed_connection.target}")
+            relayed_connection.disconnect!
+          else
+            logger.print_good("Identity: #{session.metadata[:identity]} - Successfully authenticated against relay target #{relayed_connection.target}")
+            @listener.on_relay_success(relay_connection: relayed_connection, relay_identity: session.metadata[:identity])
+          end
         else
           @listener.on_relay_failure(relay_connection: relayed_connection)
           relayed_connection.disconnect!


### PR DESCRIPTION
When running a relay attack, the point is to obtain an authenticated session as an identity that would not otherwise be available to us. With that in mind, it's not a true success to report that relaying anonymous authentication was able to establish and authenticated session. The changes in this PR tweak the reporting slightly to demote the message from print_good to print_status when the relayed identity is anonymous. It also skips the `#on_relay_success` callback because the module doesn't need to be notified of an authenticated session which likely lacks any real privileges or access that we couldn't obtain ourselves by simply logging in anonymously.

## Verification

- [x] Setup the `smb_to_ldap` relay to a domain controller. DCs respond to a bind request with a blank username and password with a success.
- [x] Use the `smb_to_ldap` relay module
- [x] Trigger authentication to the SMB server with no credentials (pro-tip use rapid7/ruby_smb#298 and `examples/authenticate.rb`)
- [x] See that it no longer reports an anonymous session and the session object isn't created

## Demo (After)
```
msf auxiliary(server/relay/smb_to_ldap) > 
[*] SMB Server is running. Listening on 0.0.0.0:445
[*] Server started.
[*] New request from 192.168.159.128
[*] Relaying to next target ldap://192.168.159.10:389
[*] Anonymous Identity - Successfully authenticated against relay target ldap://192.168.159.10:389
[*] New request from 192.168.159.128
[*] Relaying to next target ldap://192.168.159.10:389
[*] Anonymous Identity - Successfully authenticated against relay target ldap://192.168.159.10:389
```

## Demo (Before)

```
msf auxiliary(server/relay/smb_to_ldap) > 
[*] SMB Server is running. Listening on 0.0.0.0:445
[*] Server started.
[*] New request from 192.168.159.128
[*] Relaying to next target ldap://192.168.159.10:389
[+] Identity:  - Successfully authenticated against relay target ldap://192.168.159.10:389
[+] Relay succeeded
[*] New request from 192.168.159.128
[*] Relaying to next target ldap://192.168.159.10:389
[+] Identity:  - Successfully authenticated against relay target ldap://192.168.159.10:389
[+] Relay succeeded

msf auxiliary(server/relay/smb_to_ldap) > sessions -i -1
[-] Invalid session identifier: -1
```