### PR TITLE
skip Windows-specific tests on non-Windows platforms

### DIFF
--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Post
     end
   
     it 'should deal with weird windows edge cases' do
-      skip 'Windows-specific edge cases only apply to Windows sessions' unless session.platform == 'windows'
+      skip 'Windows-specific edge cases only apply to Windows sessions' unless ['windows', 'win'].include?(session.platform)
       output = create_process(show_args_binary[:cmd], args: ['"test"', 'test\\"', 'test\\\\"', 'test words\\\\\\\\', 'test words\\\\\\', '\\\\'])
       valid_show_args_response?(output, expected: [show_args_binary[:upload_path], '"test"', 'test\\"', 'test\\\\"', 'test words\\\\\\\\', 'test words\\\\\\', '\\\\'])
     end

--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -241,6 +241,7 @@ class MetasploitModule < Msf::Post
     end
   
     it 'should deal with weird windows edge cases' do
+      skip 'Windows-specific edge cases only apply to Windows sessions' unless session.platform == 'windows'
       output = create_process(show_args_binary[:cmd], args: ['"test"', 'test\\"', 'test\\\\"', 'test words\\\\\\\\', 'test words\\\\\\', '\\\\'])
       valid_show_args_response?(output, expected: [show_args_binary[:upload_path], '"test"', 'test\\"', 'test\\\\"', 'test words\\\\\\\\', 'test words\\\\\\', '\\\\'])
     end


### PR DESCRIPTION
The test was failing on OSX builds but it's a windows specific test so I think we should be good to skip it anyway

# Verification
- [x] CI passes
