### PR TITLE
ssh_version: Various improvements

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -299,6 +299,16 @@ class MetasploitModule < Msf::Auxiliary
 
       print_status("#{target_host} - #{table}")
 
+      report_note(
+        host: target_host,
+        port: rport,
+        proto: 'tcp',
+        sname: 'ssh',
+        type: 'ssh.algorithms',
+        data: { algorithms: table.rows.map { |r| { type: r[0], value: r[1], note: r[2] } } },
+        update: :unique_data
+      )
+
       flagged_rows = table.rows.reject { |r| r[2].to_s.empty? }
       if flagged_rows.any?
         category_labels = {
@@ -317,5 +327,6 @@ class MetasploitModule < Msf::Auxiliary
     vprint_error("#{target_host} - #{e.message}") # This may be a little noisy, but it is consistent
   rescue Timeout::Error
     vprint_warning("#{target_host} - Timed out after #{timeout} seconds. Skipping.")
+    report_host(host: target_host)
   end
 end

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -94,6 +94,7 @@ class MetasploitModule < Msf::Auxiliary
       'ecdsa-sha2-nistp521' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys'] },
       'ecdsa-sha2-nistp384' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys'] },
       'ecdsa-sha2-nistp256' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys'] },
+      'ssh-dss' => { note: 'Deprecated SHA-1', refs: ['https://www.openssh.com/legacy.html'] }
     }
 
     server_data[:host_key].each do |host_key|
@@ -117,29 +118,29 @@ class MetasploitModule < Msf::Auxiliary
     deprecated = []
 
     encryption_checks = {
-      'arcfour' => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
-      'arcfour128' => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
-      'arcfour256' => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
-      'aes256-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'aes192-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'aes128-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'rijndael-cbc@lysator.liu.se' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'blowfish-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'cast128-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      '3des-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'idea-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'twofish-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'twofish128-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'twofish256-cbc' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'],
-      'blowfish-ctr' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'],
-      'cast128-ctr' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'],
-      '3des-ctr' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'],
-      'none' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers']
+      'arcfour' => { note: 'RC4 stream cipher', refs: ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'] },
+      'arcfour128' => { note: 'RC4 stream cipher', refs: ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'] },
+      'arcfour256' => { note: 'RC4 stream cipher', refs: ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'] },
+      'aes256-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'aes192-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'aes128-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'rijndael-cbc@lysator.liu.se' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'blowfish-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'cast128-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      '3des-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'idea-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'twofish-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'twofish128-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'twofish256-cbc' => { note: 'CBC padding oracle', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers', 'CVE-2008-5161'] },
+      'blowfish-ctr' => { note: 'Removed from spec', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'] },
+      'cast128-ctr' => { note: 'Removed from spec', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'] },
+      '3des-ctr' => { note: 'Removed from spec', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'] },
+      'none' => { note: 'No encryption', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers'] }
     }
 
     server_data[:encryption_server].each do |encryption|
       note = ''
-      encryption_checks.each do |bad_enc, refs|
+      encryption_checks.each do |bad_enc, data|
         next unless encryption.downcase == bad_enc
 
         vprint_good("#{target_host} - Encryption #{encryption} is deprecated and should not be used")
@@ -158,20 +159,20 @@ class MetasploitModule < Msf::Auxiliary
     deprecated = []
 
     kex_checks = {
-      'gss-group1-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
-      'gss-group14-sha1-gss-gex-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
-      'gss-gex-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
-      'ecdsa-sha2-nistp521' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'],
-      'ecdsa-sha2-nistp384' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'],
-      'ecdsa-sha2-nistp256' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'],
-      'diffie-hellman-group-exchange-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'],
-      'diffie-hellman-group1-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'],
-      'rsa1024-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16']
+      'gss-group1-sha1-*' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'] },
+      'gss-group14-sha1-gss-gex-sha1-*' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'] },
+      'gss-gex-sha1-*' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'] },
+      'ecdsa-sha2-nistp521' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'] },
+      'ecdsa-sha2-nistp384' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'] },
+      'ecdsa-sha2-nistp256' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'] },
+      'diffie-hellman-group-exchange-sha1' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'] },
+      'diffie-hellman-group1-sha1' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'] },
+      'rsa1024-sha1' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'] }
     }
 
     server_data[:kex].each do |kex|
       note = ''
-      kex_checks.each do |bad_kex, refs|
+      kex_checks.each do |bad_kex, data|
         if bad_kex.ends_with? '*'
           next unless kex.downcase.start_with? bad_kex[0..-2]
         else
@@ -194,18 +195,18 @@ class MetasploitModule < Msf::Auxiliary
     deprecated = []
 
     hmac_checks = {
-      'hmac-sha2-512-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
-      'hmac-sha2-256-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
-      'hmac-sha1-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
-      'hmac-ripemd160' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
-      'hmac-md5' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
-      'hmac-md5-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
-      'none' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms']
+      'hmac-sha2-512-96' => { note: 'Truncated HMAC', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'] },
+      'hmac-sha2-256-96' => { note: 'Truncated HMAC', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'] },
+      'hmac-sha1-96' => { note: 'Truncated HMAC', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'] },
+      'hmac-ripemd160' => { note: 'RIPEMD-160 weakness', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'] },
+      'hmac-md5' => { note: 'MD5 collision', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'] },
+      'hmac-md5-96' => { note: 'MD5 collision', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'] },
+      'none' => { note: 'No authentication', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'] }
     }
 
     server_data[:hmac_server].each do |hmac|
       note = ''
-      hmac_checks.each do |bad_hmac, refs|
+      hmac_checks.each do |bad_hmac, data|
         next unless hmac.downcase == bad_hmac
 
         vprint_good("#{target_host} - HMAC #{hmac} is deprecated and should not be used")

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -8,7 +8,7 @@ require 'net/ssh/transport/session'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
-  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SSH
 
   def initialize
     super(
@@ -254,7 +254,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(target_host)
     ::Timeout.timeout(timeout) do
-      transport = Net::SSH::Transport::Session.new(target_host, { port: rport })
+      transport = connect_ssh_transport(target_host, ssh_client_defaults.merge(port: rport))
 
       server_data = transport.algorithms.instance_variable_get(:@server_data)
       host_keys = transport.algorithms.session.instance_variable_get(:@host_keys).instance_variable_get(:@host_keys)
@@ -265,8 +265,6 @@ class MetasploitModule < Msf::Auxiliary
       ident = transport.server_version.version
 
       print_status("#{target_host} - SSH banner: #{ident}")
-
-      report_service(host: target_host, port: rport, name: 'ssh', proto: 'tcp', info: ident)
 
       return unless datastore['EXTENDED_CHECKS']
 

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -229,14 +229,14 @@ class MetasploitModule < Msf::Auxiliary
 
       ident = transport.server_version.version
 
-      print_status("#{target_host} - SSH server version: #{ident}")
+      print_status("#{target_host} - SSH banner: #{ident}")
 
       report_service(host: target_host, port: rport, name: 'ssh', proto: 'tcp', info: ident)
 
       return unless datastore['EXTENDED_CHECKS']
 
       table = Rex::Text::Table.new(
-        'Header' => 'Server Information and Encryption',
+        'Header' => 'SSH Server Details',
         'Indent' => 2,
         'SortIndex' => 0,
         'Columns' => %w[Type Value Note]

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -160,11 +160,8 @@ class MetasploitModule < Msf::Auxiliary
 
     kex_checks = {
       'gss-group1-sha1-*' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'] },
-      'gss-group14-sha1-gss-gex-sha1-*' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'] },
+      'gss-group14-sha1-*' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'] },
       'gss-gex-sha1-*' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'] },
-      'ecdsa-sha2-nistp521' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'] },
-      'ecdsa-sha2-nistp384' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'] },
-      'ecdsa-sha2-nistp256' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#key-exchange'] },
       'diffie-hellman-group-exchange-sha1' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'] },
       'diffie-hellman-group1-sha1' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'] },
       'rsa1024-sha1' => { note: 'SHA-1 weakness', refs: ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'] }

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -12,8 +12,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name' => 'SSH Version Scanner',
-      'Description' => 'Detect SSH Version, and the server encryption',
+      'Name' => 'SSH Version and Algorithm Scanner',
+      'Description' => %q{
+        This module detects the SSH version, cryptographic algorithm support,
+        as well as the host key fingerprint. It will flag deprecated/weak ciphers,
+        HMAC algorithms, key exchange methods, and host key types.
+      },
       'References' => [
         ['URL', 'https://en.wikipedia.org/wiki/SecureShell'], # general info
         ['URL', 'https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'], # deprecation of kex gss-sha1 stuff
@@ -24,9 +28,15 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'Author' => [
         'Daniel van Eeden <metasploit[at]myname.nl>', # original author
-        'h00die' # algorithms enhancements
+        'h00die', # algorithms enhancements
+        'g0tmi1k' # @g0tmi1k - additional features
       ],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'Reliability' => [],
+        'SideEffects' => [IOC_IN_LOGS]
+      }
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -50,6 +50,7 @@ class MetasploitModule < Msf::Auxiliary
   def perform_recog(ident)
     table = []
     recog_info = []
+
     if /^SSH-\d+\.\d+-(.*)$/ =~ ident
       recog_match = Recog::Nizer.match('ssh.banner', ::Regexp.last_match(1))
       if recog_match
@@ -70,8 +71,24 @@ class MetasploitModule < Msf::Auxiliary
     table
   end
 
+  def report_weak_algo_vuln(vuln_name, algo_label, deprecated)
+    return if deprecated.empty?
+
+    report_vuln(
+      host: target_host,
+      port: rport,
+      proto: 'tcp',
+      sname: 'ssh',
+      name: vuln_name,
+      info: "Module #{fullname} confirmed deprecated SSH #{algo_label} algorithms: #{deprecated.map { |d| d[:name] }.join(', ')}",
+      refs: deprecated.flat_map { |d| d[:refs] }.uniq,
+      check_code: Msf::Exploit::CheckCode.Appears("Deprecated SSH #{algo_label} algorithms detected")
+    )
+  end
+
   def check_host_key(server_data)
     table = []
+    deprecated = []
 
     host_key_checks = {
       %w[
@@ -79,32 +96,27 @@ class MetasploitModule < Msf::Auxiliary
         ecdsa-sha2-nistp256
       ] => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys']
     }
+
     server_data[:host_key].each do |host_key|
       note = ''
       host_key_checks.each do |host_key_check, refs|
         host_key_check.each do |bad_key|
           next unless host_key.downcase == bad_key
 
-          vprint_good("#{target_host} - Host Key Encryption #{host_key} uses a weak elliptic curve and should not be used.")
-          report_vuln(
-            host: target_host,
-            port: rport,
-            proto: 'tcp',
-            name: 'SSH Weak Host Key Algorithm',
-            info: "Module #{fullname} confirmed SSH Host Key Encryption #{host_key} is available, but should be deprecated",
-            refs: refs,
-            check_code: Msf::Exploit::CheckCode.Appears("SSH Host Key Encryption #{host_key} is available, but should be deprecated")
-          )
-          note = 'Weak elliptic curve'
-        end
+        vprint_good("#{target_host} - Host Key #{host_key} is deprecated and should not be used")
+        deprecated << { name: host_key, refs: data[:refs] }
+        note = data[:note].presence || 'Deprecated'
       end
       table << ['encryption.host_key', host_key, note]
     end
+
+    report_weak_algo_vuln('SSH Weak Host Key Algorithm', 'Host Key', deprecated)
     table
   end
 
   def check_encryption(server_data)
     table = []
+    deprecated = []
 
     encryption_checks = {
       'arcfour' => ['https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'],
@@ -132,25 +144,21 @@ class MetasploitModule < Msf::Auxiliary
       encryption_checks.each do |bad_enc, refs|
         next unless encryption.downcase == bad_enc
 
-        vprint_good("#{target_host} - Encryption #{encryption} is deprecated and should not be used.")
-        report_vuln(
-          host: target_host,
-          port: rport,
-          proto: 'tcp',
-          name: 'SSH Weak Encryption Cipher',
-          info: "Module #{fullname} confirmed SSH Encryption #{encryption} is available, but should be deprecated",
-          refs: refs,
-          check_code: Msf::Exploit::CheckCode.Appears("SSH Encryption #{encryption} is available, but should be deprecated")
-        )
-        note = 'Deprecated'
+        vprint_good("#{target_host} - Encryption #{encryption} is deprecated and should not be used")
+        deprecated << { name: encryption, refs: data[:refs] }
+        note = data[:note].presence || 'Deprecated'
       end
       table << ['encryption.encryption', encryption, note]
     end
+
+    report_weak_algo_vuln('SSH Weak Encryption Cipher', 'Encryption', deprecated)
     table
   end
 
   def check_kex(server_data)
     table = []
+    deprecated = []
+
     kex_checks = {
       'gss-group1-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
       'gss-group14-sha1-gss-gex-sha1-*' => ['https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'],
@@ -162,6 +170,7 @@ class MetasploitModule < Msf::Auxiliary
       'diffie-hellman-group1-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'],
       'rsa1024-sha1' => ['https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16']
     }
+
     server_data[:kex].each do |kex|
       note = ''
       kex_checks.each do |bad_kex, refs|
@@ -171,25 +180,20 @@ class MetasploitModule < Msf::Auxiliary
           next unless kex.downcase == bad_kex
         end
 
-        vprint_good("#{target_host} - Key Exchange (kex) #{kex} is deprecated and should not be used.")
-        report_vuln(
-          host: target_host,
-          port: rport,
-          proto: 'tcp',
-          name: 'SSH Weak Key Exchange Algorithm',
-          info: "Module #{fullname} confirmed SSH Key Exchange #{kex} is available, but should be deprecated",
-          refs: refs,
-          check_code: Msf::Exploit::CheckCode.Appears("SSH Key Exchange #{kex} is available, but should be deprecated")
-        )
-        note = 'Deprecated'
+        vprint_good("#{target_host} - Key Exchange (kex) #{kex} is deprecated and should not be used")
+        deprecated << { name: kex, refs: data[:refs] }
+        note = data[:note].presence || 'Deprecated'
       end
       table << ['encryption.key_exchange', kex, note]
     end
+
+    report_weak_algo_vuln('SSH Weak Key Exchange Algorithm', 'Key Exchange', deprecated)
     table
   end
 
   def check_hmac(server_data)
     table = []
+    deprecated = []
 
     hmac_checks = {
       'hmac-sha2-512-96' => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms'],
@@ -206,20 +210,14 @@ class MetasploitModule < Msf::Auxiliary
       hmac_checks.each do |bad_hmac, refs|
         next unless hmac.downcase == bad_hmac
 
-        vprint_good("#{target_host} - HMAC #{hmac} is deprecated and should not be used.")
-        report_vuln(
-          host: target_host,
-          port: rport,
-          proto: 'tcp',
-          name: 'SSH Weak HMAC Algorithm',
-          info: "Module #{fullname} confirmed SSH HMAC #{hmac} is available, but should be deprecated",
-          refs: refs,
-          check_code: Msf::Exploit::CheckCode.Appears("SSH HMAC #{hmac} is available, but should be deprecated")
-        )
-        note = 'Deprecated'
+        vprint_good("#{target_host} - HMAC #{hmac} is deprecated and should not be used")
+        deprecated << { name: hmac, refs: data[:refs] }
+        note = data[:note].presence || 'Deprecated'
       end
       table << ['encryption.hmac', hmac, note]
     end
+
+    report_weak_algo_vuln('SSH Weak HMAC Algorithm', 'HMAC', deprecated)
     table
   end
 

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -86,6 +86,41 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
+  def check_host_key_size(host_keys)
+    table = []
+    deprecated = []
+
+    key_size_checks = {
+      'ssh-rsa' => {
+        min_bits: 2048,
+        bits: ->(k) { k.n.num_bits },
+        standard: 'NIST SP 800-131A',
+        refs: ['https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final']
+      },
+      'ssh-dss' => {
+        min_bits: 2048,
+        bits: ->(k) { k.p.num_bits },
+        standard: 'NIST SP 800-131A',
+        refs: ['https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final']
+      }
+    }
+
+    host_keys.each do |host_key|
+      check = key_size_checks[host_key.ssh_type]
+      next unless check
+
+      bits = check[:bits].call(host_key)
+      next if bits >= check[:min_bits]
+
+      vprint_good("#{target_host} - #{host_key.ssh_type} host key is #{bits}-bit (weak, minimum #{check[:min_bits]}-bit per #{check[:standard]})")
+      deprecated << { name: "#{host_key.ssh_type} (#{bits}-bit)", refs: check[:refs] }
+      table << ['encryption.host_key', "#{host_key.ssh_type} (#{bits}-bit)", "Weak key size (min #{check[:min_bits]}-bit)"]
+    end
+
+    report_weak_algo_vuln('SSH Weak Host Key Size', 'Host Key Size', deprecated)
+    table
+  end
+
   def check_host_key(server_data)
     table = []
     deprecated = []
@@ -256,15 +291,13 @@ class MetasploitModule < Msf::Auxiliary
 
       table.rows.concat check_host_key(server_data)
 
+      table.rows.concat check_host_key_size(host_keys)
+
       table.rows.concat check_hmac(server_data)
 
       table.rows.concat check_encryption(server_data)
 
       table.rows.concat perform_recog(ident)
-
-      # XXX check for host key size?
-      # h00die - not sure how to get that info from the library.
-      # https://www.tenable.com/plugins/nessus/153954
 
       print_status("#{target_host} - #{table}")
 

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Auxiliary
           next unless kex.downcase == bad_kex
         end
 
-        vprint_good("#{target_host} - Key Exchange (kex) #{kex} is deprecated and should not be used")
+        vprint_good("#{target_host} - Key EXchange (KEX) #{kex} is deprecated and should not be used")
         deprecated << { name: kex, refs: data[:refs] }
         note = data[:note].presence || 'Deprecated'
       end
@@ -267,6 +267,20 @@ class MetasploitModule < Msf::Auxiliary
       # https://www.tenable.com/plugins/nessus/153954
 
       print_status("#{target_host} - #{table}")
+
+      flagged_rows = table.rows.reject { |r| r[2].to_s.empty? }
+      if flagged_rows.any?
+        category_labels = {
+          'encryption.key_exchange' => 'KEX',
+          'encryption.host_key' => 'Host Key',
+          'encryption.hmac' => 'HMAC',
+          'encryption.encryption' => 'Encryption'
+        }
+        breakdown = flagged_rows.group_by { |r| r[0] }.map do |type, rows|
+          "#{rows.count} #{category_labels[type] || type}"
+        end.join(', ')
+        print_warning("#{target_host} - Found #{flagged_rows.count} deprecated/weak algorithm(s): #{breakdown}")
+      end
     end
   rescue EOFError, Rex::ConnectionError => e
     vprint_error("#{target_host} - #{e.message}") # This may be a little noisy, but it is consistent

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(22),
         OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', 30]),
         OptBool.new('EXTENDED_CHECKS', [true, 'Check for cryptographic issues', true])
       ],
@@ -41,10 +40,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def timeout
     datastore['TIMEOUT']
-  end
-
-  def rport
-    datastore['RPORT']
   end
 
   def perform_recog(ident)
@@ -324,9 +319,11 @@ class MetasploitModule < Msf::Auxiliary
         print_warning("#{target_host} - Found #{flagged_rows.count} deprecated/weak algorithm(s): #{breakdown}")
       end
     end
-  rescue EOFError, Rex::ConnectionError => e
+  rescue EOFError, Rex::ConnectionRefused, Errno::ECONNREFUSED => e
+    vprint_error("#{target_host} - #{e.message}")
+  rescue Rex::ConnectionError, Errno::EHOSTUNREACH => e
     vprint_error("#{target_host} - #{e.message}") # This may be a little noisy, but it is consistent
-  rescue Timeout::Error
+  rescue ::Timeout::Error
     vprint_warning("#{target_host} - Timed out after #{timeout} seconds. Skipping.")
     report_host(host: target_host)
   end

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -91,17 +91,15 @@ class MetasploitModule < Msf::Auxiliary
     deprecated = []
 
     host_key_checks = {
-      %w[
-        ecdsa-sha2-nistp521 ecdsa-sha2-nistp384
-        ecdsa-sha2-nistp256
-      ] => ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys']
+      'ecdsa-sha2-nistp521' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys'] },
+      'ecdsa-sha2-nistp384' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys'] },
+      'ecdsa-sha2-nistp256' => { note: 'Weak elliptic curve', refs: ['https://github.com/net-ssh/net-ssh?tab=readme-ov-file#host-keys'] },
     }
 
     server_data[:host_key].each do |host_key|
       note = ''
-      host_key_checks.each do |host_key_check, refs|
-        host_key_check.each do |bad_key|
-          next unless host_key.downcase == bad_key
+      host_key_checks.each do |bad_key, data|
+        next unless host_key.downcase == bad_key
 
         vprint_good("#{target_host} - Host Key #{host_key} is deprecated and should not be used")
         deprecated << { name: host_key, refs: data[:refs] }

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
             host: target_host,
             port: rport,
             proto: 'tcp',
-            name: name,
+            name: 'SSH Weak Host Key Algorithm',
             info: "Module #{fullname} confirmed SSH Host Key Encryption #{host_key} is available, but should be deprecated",
             refs: refs,
             check_code: Msf::Exploit::CheckCode.Appears("SSH Host Key Encryption #{host_key} is available, but should be deprecated")
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
           host: target_host,
           port: rport,
           proto: 'tcp',
-          name: name,
+          name: 'SSH Weak Encryption Cipher',
           info: "Module #{fullname} confirmed SSH Encryption #{encryption} is available, but should be deprecated",
           refs: refs,
           check_code: Msf::Exploit::CheckCode.Appears("SSH Encryption #{encryption} is available, but should be deprecated")
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Auxiliary
           host: target_host,
           port: rport,
           proto: 'tcp',
-          name: name,
+          name: 'SSH Weak Key Exchange Algorithm',
           info: "Module #{fullname} confirmed SSH Key Exchange #{kex} is available, but should be deprecated",
           refs: refs,
           check_code: Msf::Exploit::CheckCode.Appears("SSH Key Exchange #{kex} is available, but should be deprecated")
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Auxiliary
           host: target_host,
           port: rport,
           proto: 'tcp',
-          name: name,
+          name: 'SSH Weak HMAC Algorithm',
           info: "Module #{fullname} confirmed SSH HMAC #{hmac} is available, but should be deprecated",
           refs: refs,
           check_code: Msf::Exploit::CheckCode.Appears("SSH HMAC #{hmac} is available, but should be deprecated")

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -259,7 +259,8 @@ class MetasploitModule < Msf::Auxiliary
       server_data = transport.algorithms.instance_variable_get(:@server_data)
       host_keys = transport.algorithms.session.instance_variable_get(:@host_keys).instance_variable_get(:@host_keys)
       host_keys.each do |host_key|
-        print_status("#{target_host} - Key Fingerprint: #{host_key.ssh_type} #{Base64.strict_encode64(host_key.to_blob)}")
+        fingerprint = 'SHA256:' + Base64.strict_encode64(OpenSSL::Digest::SHA256.digest(host_key.to_blob)).chomp('=')
+        print_status("#{target_host} - Key Fingerprint: #{host_key.ssh_type} #{fingerprint}")
       end
 
       ident = transport.server_version.version

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -10,33 +10,36 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::SSH
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'SSH Version and Algorithm Scanner',
-      'Description' => %q{
-        This module detects the SSH version, cryptographic algorithm support,
-        as well as the host key fingerprint. It will flag deprecated/weak ciphers,
-        HMAC algorithms, key exchange methods, and host key types.
-      },
-      'References' => [
-        ['URL', 'https://en.wikipedia.org/wiki/SecureShell'], # general info
-        ['URL', 'https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'], # deprecation of kex gss-sha1 stuff
-        ['URL', 'https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'], # diffie-hellman-group-exchange-sha1, diffie-hellman-group1-sha1, rsa1024-sha1
-        ['URL', 'https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'], # arc4 deprecation
-        ['URL', 'https://github.com/net-ssh/net-ssh?tab=readme-ov-file#supported-algorithms'], # a bunch of diff removed things from the ruby lib
-        ['CVE', '2008-5161'] # CBC modes
-      ],
-      'Author' => [
-        'Daniel van Eeden <metasploit[at]myname.nl>', # original author
-        'h00die', # algorithms enhancements
-        'g0tmi1k' # @g0tmi1k - additional features
-      ],
-      'License' => MSF_LICENSE,
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'Reliability' => [],
-        'SideEffects' => [IOC_IN_LOGS]
-      }
+      update_info(
+        info,
+        'Name' => 'SSH Version and Algorithm Scanner',
+        'Description' => %q{
+          This module detects the SSH version, cryptographic algorithm support,
+          as well as the host key fingerprint. It will flag deprecated/weak ciphers,
+          HMAC algorithms, key exchange methods, and host key types.
+        },
+        'References' => [
+          ['URL', 'https://en.wikipedia.org/wiki/SecureShell'], # general info
+          ['URL', 'https://datatracker.ietf.org/doc/html/rfc8732#name-deprecated-algorithms'], # deprecation of kex gss-sha1 stuff
+          ['URL', 'https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16'], # diffie-hellman-group-exchange-sha1, diffie-hellman-group1-sha1, rsa1024-sha1
+          ['URL', 'https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations'], # arc4 deprecation
+          ['URL', 'https://github.com/net-ssh/net-ssh?tab=readme-ov-file#supported-algorithms'], # a bunch of diff removed things from the ruby lib
+          ['CVE', '2008-5161'] # CBC modes
+        ],
+        'Author' => [
+          'Daniel van Eeden <metasploit[at]myname.nl>', # original author
+          'h00die', # algorithms enhancements
+          'g0tmi1k' # @g0tmi1k - additional features
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
     )
 
     register_options(


### PR DESCRIPTION
This PR does a few things:

- Split up report_vulns, as they were overwriting each other 
- Switch to use the SSH mixin 
- Switch to SHA256 fingerprints
- Adds a summary at the end of the scan
- Add specific deprecation reason 
  - include ssh-dss
  - Fix a few other incorrect values too
- Add a host key size check (was in the module's comments as a TODO item)

Target is Metasploitable 2.

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      1         1      0      0      0
After : *        default  1      2         4      0      0      3
```

## Before

- Scanning a valid host, but closed port: 0
- Scanning a valid host, open port, but incorrect: 0
- All testing was done using master branch

```console
	$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
	use auxiliary/scanner/ssh/ssh_version;
	setg RHOSTS 10.0.0.10;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
msf auxiliary(scanner/ssh/ssh_version) >
```

```console
msf auxiliary(scanner/ssh/ssh_version) > run RPORT=9999
[*] Error: 10.0.0.10: Errno::ECONNREFUSED Connection refused - connect(2) for 10.0.0.10:9999
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_version) >
```

```console
msf auxiliary(scanner/ssh/ssh_version) > run RPORT=21
[!] 10.0.0.10 - Timed out after 30 seconds. Skipping.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_version) >
```

```console
msf auxiliary(scanner/ssh/ssh_version) > run
[*] 10.0.0.10 - Key Fingerprint: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAstqnuFMBOZvO3WTEjP4TUdjgWkIVNdTq6kboEDjteOfc65TlI7sRvQBwqAhQjeeyyIk8T55gMDkOD0akSlSXvLDcmcdYfxeIF0ZSuT+nkRhij7XSSA/Oc5QSk3sJ/SInfb78e3anbRHpmkJcVgETJ5WhKObUNf1AKZW++4Xlc63M4KI5cjvMMIPEVOyR3AKmI78Fo3HJjYucg87JjLeC66I7+dlEYX6zT8i1XYwa/L1vZ3qSJISGVu8kRPikMv/cNSvki4j+qDYyZ2E5497W87+Ed46/8P42LNGoOV8OcX/ro6pAcbEPUdUEfkJrqi2YXbhvwIJ0gFMb6wfe5cnQew==
[*] 10.0.0.10 - SSH server version: SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1
[+] 10.0.0.10 - Key Exchange (kex) diffie-hellman-group-exchange-sha1 is deprecated and should not be used.
[+] 10.0.0.10 - Key Exchange (kex) diffie-hellman-group1-sha1 is deprecated and should not be used.
[+] 10.0.0.10 - HMAC hmac-md5 is deprecated and should not be used.
[+] 10.0.0.10 - HMAC hmac-ripemd160 is deprecated and should not be used.
[+] 10.0.0.10 - HMAC hmac-sha1-96 is deprecated and should not be used.
[+] 10.0.0.10 - HMAC hmac-md5-96 is deprecated and should not be used.
[+] 10.0.0.10 - Encryption aes128-cbc is deprecated and should not be used.
[+] 10.0.0.10 - Encryption 3des-cbc is deprecated and should not be used.
[+] 10.0.0.10 - Encryption blowfish-cbc is deprecated and should not be used.
[+] 10.0.0.10 - Encryption cast128-cbc is deprecated and should not be used.
[+] 10.0.0.10 - Encryption arcfour128 is deprecated and should not be used.
[+] 10.0.0.10 - Encryption arcfour256 is deprecated and should not be used.
[+] 10.0.0.10 - Encryption arcfour is deprecated and should not be used.
[+] 10.0.0.10 - Encryption aes192-cbc is deprecated and should not be used.
[+] 10.0.0.10 - Encryption aes256-cbc is deprecated and should not be used.
[+] 10.0.0.10 - Encryption rijndael-cbc@lysator.liu.se is deprecated and should not be used.
[*] 10.0.0.10 - Server Information and Encryption
=================================

  Type                     Value                                 Note
  ----                     -----                                 ----
  encryption.compression   none
  encryption.compression   zlib@openssh.com
  encryption.encryption    aes128-cbc                            Deprecated
  encryption.encryption    3des-cbc                              Deprecated
  encryption.encryption    blowfish-cbc                          Deprecated
  encryption.encryption    cast128-cbc                           Deprecated
  encryption.encryption    arcfour128                            Deprecated
  encryption.encryption    arcfour256                            Deprecated
  encryption.encryption    arcfour                               Deprecated
  encryption.encryption    aes192-cbc                            Deprecated
  encryption.encryption    aes256-cbc                            Deprecated
  encryption.encryption    rijndael-cbc@lysator.liu.se           Deprecated
  encryption.encryption    aes128-ctr
  encryption.encryption    aes192-ctr
  encryption.encryption    aes256-ctr
  encryption.hmac          hmac-md5                              Deprecated
  encryption.hmac          hmac-sha1
  encryption.hmac          umac-64@openssh.com
  encryption.hmac          hmac-ripemd160                        Deprecated
  encryption.hmac          hmac-ripemd160@openssh.com
  encryption.hmac          hmac-sha1-96                          Deprecated
  encryption.hmac          hmac-md5-96                           Deprecated
  encryption.host_key      ssh-rsa
  encryption.host_key      ssh-dss
  encryption.key_exchange  diffie-hellman-group-exchange-sha256
  encryption.key_exchange  diffie-hellman-group-exchange-sha1    Deprecated
  encryption.key_exchange  diffie-hellman-group14-sha1
  encryption.key_exchange  diffie-hellman-group1-sha1            Deprecated
  fingerprint_db           ssh.banner
  openssh.comment          Debian-8ubuntu1
  os.cpe23                 cpe:/o:canonical:ubuntu_linux:8.04
  os.family                Linux
  os.product               Linux
  os.vendor                Ubuntu
  os.version               8.04
  service.cpe23            cpe:/a:openbsd:openssh:4.7p1
  service.family           OpenSSH
  service.product          OpenSSH
  service.protocol         ssh
  service.vendor           OpenBSD
  service.version          4.7p1

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_version) >
msf auxiliary(scanner/ssh/ssh_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      0      0      0

msf auxiliary(scanner/ssh/ssh_version) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux               8.04   server

msf auxiliary(scanner/ssh/ssh_version) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}

msf auxiliary(scanner/ssh/ssh_version) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                 References
---------                ----       -------       --------  ----                 ----------
2026-05-26 15:59:03 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Version Scanner  https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16,https://github.com/net-ssh/net-ssh?tab=readme
                                                                                 -ov-file#message-authentication-code-algorithms,https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-c
                                                                                 iphers,CVE-2008-5161,https://datatracker.ietf.org/doc/html/rfc8758#name-iana-considerations

msf auxiliary(scanner/ssh/ssh_version) >
```

## After

- Scanning a valid host, but closed port: 1 host
- Scanning a valid host, open port, but incorrect: 1 host, 1 service
- Summary output at the end
- All testing was done on this branch, with SSH mixin (https://github.com/rapid7/metasploit-framework/pull/21479) and auth_brute_mixin applied (https://github.com/rapid7/metasploit-framework/pull/21396)

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ssh/ssh_version;
setg RHOSTS 10.0.0.10;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
msf auxiliary(scanner/ssh/ssh_version) > run RPORT=9999
[-] 10.0.0.10 - The connection was refused by the remote host (10.0.0.10:9999).
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_version) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf auxiliary(scanner/ssh/ssh_version) >
```

```console
msf auxiliary(scanner/ssh/ssh_version) > run RPORT=21
[!] 10.0.0.10 - Timed out after 30 seconds. Skipping.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      0      0      0

msf auxiliary(scanner/ssh/ssh_version) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  21    tcp          open         {}

msf auxiliary(scanner/ssh/ssh_version) >
```

```console
msf auxiliary(scanner/ssh/ssh_version) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/ssh/ssh_version) > run
[*] 10.0.0.10 - Key Fingerprint: ssh-rsa SHA256:BQHm5EoHX9GCiOLuVscegPXLQOsuPs+E9d/rrJB84rk
[*] 10.0.0.10 - SSH banner: SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1
[+] 10.0.0.10 - Key EXchange (KEX) diffie-hellman-group-exchange-sha1 is deprecated and should not be used
[+] 10.0.0.10 - Key EXchange (KEX) diffie-hellman-group1-sha1 is deprecated and should not be used
[+] 10.0.0.10 - Host Key ssh-dss is deprecated and should not be used
Calling Net::SSH::Buffer methods on HostKeyEntries PubKey is deprecated
[+] 10.0.0.10 - HMAC hmac-md5 is deprecated and should not be used
[+] 10.0.0.10 - HMAC hmac-ripemd160 is deprecated and should not be used
[+] 10.0.0.10 - HMAC hmac-sha1-96 is deprecated and should not be used
[+] 10.0.0.10 - HMAC hmac-md5-96 is deprecated and should not be used
[+] 10.0.0.10 - Encryption aes128-cbc is deprecated and should not be used
[+] 10.0.0.10 - Encryption 3des-cbc is deprecated and should not be used
[+] 10.0.0.10 - Encryption blowfish-cbc is deprecated and should not be used
[+] 10.0.0.10 - Encryption cast128-cbc is deprecated and should not be used
[+] 10.0.0.10 - Encryption arcfour128 is deprecated and should not be used
[+] 10.0.0.10 - Encryption arcfour256 is deprecated and should not be used
[+] 10.0.0.10 - Encryption arcfour is deprecated and should not be used
[+] 10.0.0.10 - Encryption aes192-cbc is deprecated and should not be used
[+] 10.0.0.10 - Encryption aes256-cbc is deprecated and should not be used
[+] 10.0.0.10 - Encryption rijndael-cbc@lysator.liu.se is deprecated and should not be used
[*] 10.0.0.10 - SSH Server Details
==================

  Type                     Value                                 Note
  ----                     -----                                 ----
  encryption.compression   none
  encryption.compression   zlib@openssh.com
  encryption.encryption    aes128-cbc                            CBC padding oracle
  encryption.encryption    3des-cbc                              CBC padding oracle
  encryption.encryption    blowfish-cbc                          CBC padding oracle
  encryption.encryption    cast128-cbc                           CBC padding oracle
  encryption.encryption    arcfour128                            RC4 stream cipher
  encryption.encryption    arcfour256                            RC4 stream cipher
  encryption.encryption    arcfour                               RC4 stream cipher
  encryption.encryption    aes192-cbc                            CBC padding oracle
  encryption.encryption    aes256-cbc                            CBC padding oracle
  encryption.encryption    rijndael-cbc@lysator.liu.se           CBC padding oracle
  encryption.encryption    aes128-ctr
  encryption.encryption    aes192-ctr
  encryption.encryption    aes256-ctr
  encryption.hmac          hmac-md5                              MD5 collision
  encryption.hmac          hmac-sha1
  encryption.hmac          umac-64@openssh.com
  encryption.hmac          hmac-ripemd160                        RIPEMD-160 weakness
  encryption.hmac          hmac-ripemd160@openssh.com
  encryption.hmac          hmac-sha1-96                          Truncated HMAC
  encryption.hmac          hmac-md5-96                           MD5 collision
  encryption.host_key      ssh-rsa
  encryption.host_key      ssh-dss                               Deprecated SHA-1
  encryption.key_exchange  diffie-hellman-group-exchange-sha256
  encryption.key_exchange  diffie-hellman-group-exchange-sha1    SHA-1 weakness
  encryption.key_exchange  diffie-hellman-group14-sha1
  encryption.key_exchange  diffie-hellman-group1-sha1            SHA-1 weakness
  fingerprint_db           ssh.banner
  openssh.comment          Debian-8ubuntu1
  os.cpe23                 cpe:/o:canonical:ubuntu_linux:8.04
  os.family                Linux
  os.product               Linux
  os.vendor                Ubuntu
  os.version               8.04
  service.cpe23            cpe:/a:openbsd:openssh:4.7p1
  service.family           OpenSSH
  service.product          OpenSSH
  service.protocol         ssh
  service.vendor           OpenBSD
  service.version          4.7p1

[!] 10.0.0.10 - Found 17 deprecated/weak algorithm(s): 10 Encryption, 4 HMAC, 1 Host Key, 2 KEX
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         4      0      0      3

msf auxiliary(scanner/ssh/ssh_version) >
msf auxiliary(scanner/ssh/ssh_version) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    tcp   open                                          {}
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)

msf auxiliary(scanner/ssh/ssh_version) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                             References
---------                ----       -------       --------  ----                             ----------
2026-05-26 16:02:49 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Weak Key Exchange Algorithm  https://datatracker.ietf.org/doc/html/draft-ietf-curdle-ssh-kex-sha2-20#page-16
2026-05-26 16:02:49 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Weak Host Key Algorithm      https://www.openssh.com/legacy.html
2026-05-26 16:02:49 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Weak HMAC Algorithm          https://github.com/net-ssh/net-ssh?tab=readme-ov-file#message-authentication-code-algorithms
2026-05-26 16:02:49 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Weak Encryption Cipher       https://github.com/net-ssh/net-ssh?tab=readme-ov-file#encryption-algorithms-ciphers,CVE-2008-5161,https://datatra
                                                                                             cker.ietf.org/doc/html/rfc8758#name-iana-considerations

msf auxiliary(scanner/ssh/ssh_version) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type            Data
 ----                     ----       -------  ----  --------  ----            ----
 2026-05-26 16:02:49 UTC  10.0.0.10  ssh      22    tcp       ssh.cpe         {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}
 2026-05-26 16:02:49 UTC  10.0.0.10  ssh      22    tcp       ssh.hostkey     {:type=>"ssh-rsa", :fingerprint=>"SHA256:BQHm5EoHX9GCiOLuVscegPXLQOsuPs+E9d/rrJB84rk"}
 2026-05-26 16:02:49 UTC  10.0.0.10  tcp      22    tcp       ssh.algorithms  {:algorithms=>[{:type=>"encryption.compression", :value=>"none", :note=>""}, {:type=>"encryption.compression", :value=>"zlib@ope
                                                                              nssh.com", :note=>""}, {:type=>"encryption.encryption", :value=>"aes128-cbc", :note=>"CBC padding oracle"}, {:type=>"encryption.
                                                                              encryption", :value=>"3des-cbc", :note=>"CBC padding oracle"}, {:type=>"encryption.encryption", :value=>"blowfish-cbc", :note=>"
                                                                              CBC padding oracle"}, {:type=>"encryption.encryption", :value=>"cast128-cbc", :note=>"CBC padding oracle"}, {:type=>"encryption.
                                                                              encryption", :value=>"arcfour128", :note=>"RC4 stream cipher"}, {:type=>"encryption.encryption", :value=>"arcfour256", :note=>"R
                                                                              C4 stream cipher"}, {:type=>"encryption.encryption", :value=>"arcfour", :note=>"RC4 stream cipher"}, {:type=>"encryption.encrypt
                                                                              ion", :value=>"aes192-cbc", :note=>"CBC padding oracle"}, {:type=>"encryption.encryption", :value=>"aes256-cbc", :note=>"CBC pad
                                                                              ding oracle"}, {:type=>"encryption.encryption", :value=>"rijndael-cbc@lysator.liu.se", :note=>"CBC padding oracle"}, {:type=>"en
                                                                              cryption.encryption", :value=>"aes128-ctr", :note=>""}, {:type=>"encryption.encryption", :value=>"aes192-ctr", :note=>""}, {:typ
                                                                              e=>"encryption.encryption", :value=>"aes256-ctr", :note=>""}, {:type=>"encryption.hmac", :value=>"hmac-md5", :note=>"MD5 collisi
                                                                              on"}, {:type=>"encryption.hmac", :value=>"hmac-sha1", :note=>""}, {:type=>"encryption.hmac", :value=>"umac-64@openssh.com", :not
                                                                              e=>""}, {:type=>"encryption.hmac", :value=>"hmac-ripemd160", :note=>"RIPEMD-160 weakness"}, {:type=>"encryption.hmac", :value=>"
                                                                              hmac-ripemd160@openssh.com", :note=>""}, {:type=>"encryption.hmac", :value=>"hmac-sha1-96", :note=>"Truncated HMAC"}, {:type=>"e
                                                                              ncryption.hmac", :value=>"hmac-md5-96", :note=>"MD5 collision"}, {:type=>"encryption.host_key", :value=>"ssh-rsa", :note=>""}, {
                                                                              :type=>"encryption.host_key", :value=>"ssh-dss", :note=>"Deprecated SHA-1"}, {:type=>"encryption.key_exchange", :value=>"diffie-
                                                                              hellman-group-exchange-sha256", :note=>""}, {:type=>"encryption.key_exchange", :value=>"diffie-hellman-group-exchange-sha1", :no
                                                                              te=>"SHA-1 weakness"}, {:type=>"encryption.key_exchange", :value=>"diffie-hellman-group14-sha1", :note=>""}, {:type=>"encryption
                                                                              .key_exchange", :value=>"diffie-hellman-group1-sha1", :note=>"SHA-1 weakness"}, {:type=>"fingerprint_db", :value=>"ssh.banner",
                                                                              :note=>nil}, {:type=>"openssh.comment", :value=>"Debian-8ubuntu1", :note=>nil}, {:type=>"os.cpe23", :value=>"cpe:/o:canonical:ub
                                                                              untu_linux:8.04", :note=>nil}, {:type=>"os.family", :value=>"Linux", :note=>nil}, {:type=>"os.product", :value=>"Linux", :note=>
                                                                              nil}, {:type=>"os.vendor", :value=>"Ubuntu", :note=>nil}, {:type=>"os.version", :value=>"8.04", :note=>nil}, {:type=>"service.cp
                                                                              e23", :value=>"cpe:/a:openbsd:openssh:4.7p1", :note=>nil}, {:type=>"service.family", :value=>"OpenSSH", :note=>nil}, {:type=>"se
                                                                              rvice.product", :value=>"OpenSSH", :note=>nil}, {:type=>"service.protocol", :value=>"ssh", :note=>nil}, {:type=>"service.vendor"
                                                                              , :value=>"OpenBSD", :note=>nil}, {:type=>"service.version", :value=>"4.7p1", :note=>nil}]}

msf auxiliary(scanner/ssh/ssh_version) >
```