### PR TITLE
Auth_Brute mixin: Add report_host/report_service & remove dup IP:PORT

### DIFF
--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -204,6 +204,7 @@ module Metasploit
             successful_users = Set.new
             ignored_users = Set.new
             first_attempt = true
+            service_reported = false
 
             each_credential do |credential|
               # Skip users for whom we've have already found a password
@@ -235,6 +236,34 @@ module Metasploit
               result.freeze
 
               yield result if block_given?
+
+              # Any non-UNABLE_TO_CONNECT status means the service is reachable.
+              # A connection-refused proof means the host is up but service not listening.
+              unless service_reported
+                if result.status != Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+                  framework_module.report_host(
+                    host: host,
+                    workspace_id: framework_module.myworkspace_id
+                  ) if framework_module&.respond_to?(:report_host)
+
+                  framework_module.report_service({
+                      host: host,
+                      port: port,
+                      proto: 'tcp',
+                      workspace_id: framework_module.myworkspace_id
+                    }.tap { |h| h[:name] = result.service_name if result.service_name.present? }
+                  ) if framework_module&.respond_to?(:report_service)
+
+                  service_reported = true
+                elsif connection_refused_proof?(result.proof)
+                  framework_module.report_host(
+                    host: host,
+                    workspace_id: framework_module.myworkspace_id
+                  ) if framework_module&.respond_to?(:report_host)
+
+                  service_reported = true
+                end
+              end
 
               if result.success?
                 consecutive_error_count = 0
@@ -310,6 +339,15 @@ module Metasploit
           # @return [void]
           def set_sane_defaults
             self.connection_timeout = 30 if self.connection_timeout.nil?
+          end
+
+          # Returns true when the proof from an UNABLE_TO_CONNECT result
+          # indicates the remote port actively refused the connection.
+          # e.g. The host is up but the service is not listening.
+          def connection_refused_proof?(proof)
+            return false if proof.nil?
+            return true if proof.is_a?(::Rex::ConnectionRefused) || proof.is_a?(::Errno::ECONNREFUSED)
+            proof.to_s =~ /\bconnection\s+refused\b|\bECONNREFUSED\b/i ? true : false
           end
 
           # This method validates that the credentials supplied

--- a/lib/metasploit/framework/login_scanner/ftp.rb
+++ b/lib/metasploit/framework/login_scanner/ftp.rb
@@ -41,8 +41,9 @@ module Metasploit
 
           begin
             success = connect_login(credential.public, credential.private)
-          rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error
+          rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error => e
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            result_options[:proof] = e
             success = false
           ensure
             disconnect

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -825,7 +825,11 @@ module Auxiliary::AuthBrute
     msg = opts[:msg] || opts[:message]
     proto = opts[:proto] || opts[:protocol] || proto_from_fullname
 
-    complete_message = build_brute_message(host_ip,host_port,proto,msg)
+    complete_message = if is_a?(Msf::Auxiliary::Scanner)
+      msg.to_s
+    else
+      build_brute_message(host_ip, host_port, proto, msg)
+    end
 
     print_method = "print_#{level}"
     if self.respond_to? print_method

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -318,7 +318,11 @@ module Auxiliary::AuthBrute
         prev_iterator = datastore['PASSWORD_SPRAY'] ? p : u # Update the iterator
       end
 
-      ret = block.call(u, p)
+      ret = begin
+        block.call(u, p)
+      rescue ::Rex::ConnectionRefused, ::Errno::ECONNREFUSED
+        :connection_refused
+      end
 
       case ret
       when :abort # Skip the current host entirely.
@@ -334,6 +338,15 @@ module Auxiliary::AuthBrute
         print_brute abort_msg
         break
 
+      when :connection_refused # Host is up, but service not listening. Record and stop.
+        print_brute(
+          :level => :verror,
+          :ip => datastore['RHOST'],
+          :port => datastore['RPORT'],
+          :msg => "Connection refused")
+        report_host(host: datastore['RHOST']) if framework.db.active
+        break
+
       when :next_user # This means success for that user.
         @@credentials_skipped[fq_user] = p
         if datastore['STOP_ON_SUCCESS'] # See?
@@ -343,7 +356,7 @@ module Auxiliary::AuthBrute
       when :skip_user # Skip the user in non-success cases.
         @@credentials_skipped[fq_user] = p
 
-      when :connection_error # Report an error, skip this cred, but don't neccisarily abort.
+      when :connection_error # Report an error, skip this cred, but don't necessarily abort.
         print_brute(
           :level => :verror,
           :ip => datastore['RHOST'],


### PR DESCRIPTION
The idea of this PR to update the authbrute force mixin, so each module doesn't need to be udpated to support being able to detect if a host is up, but the service attacking isn't on the target.

Example:

- 10.0.0.1 is attacker, without service.
- 10.0.0.10 is target, with service.

Both now are in `hosts`, without having to update any modules. Doing it via mixin.

## Before

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > git checkout
[*] exec: git checkout

Your branch is up to date with 'origin/master'.
msf > use exec_login

Matching Modules
================

   #  Name                                     Disclosure Date  Rank    Check  Description
   -  ----                                     ---------------  ----    -----  -----------
   0  auxiliary/scanner/rservices/rexec_login  .                normal  No     rexec Authentication Scanner


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/rservices/rexec_login

[*] Using auxiliary/scanner/rservices/rexec_login
msf auxiliary(scanner/rservices/rexec_login) > options

Module options (auxiliary/scanner/rservices/rexec_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
   BLANK_PASSWORDS   false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   CreateSession     true             no        Create a new session for every successful login
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   ENABLE_STDERR     false            yes       Enables connecting the stderr port
   PASSWORD                           no        A specific password to authenticate with
   PASS_FILE                          no        File containing passwords, one per line
   RHOSTS            10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             512              yes       The target port (TCP)
   STDERR_PORT                        no        The port to listen on for stderr
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   USERNAME                           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false            no        Try the username as the password for all users
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/rservices/rexec_login) > set RHOST 10.0.0.1 10.0.0.10
RHOST => 10.0.0.1 10.0.0.10
msf auxiliary(scanner/rservices/rexec_login) > set USERNAME foo
USERNAME => foo
msf auxiliary(scanner/rservices/rexec_login) > set PASSWORD bar
PASSWORD => bar
msf auxiliary(scanner/rservices/rexec_login) > run
[*] 10.0.0.1:512          - 10.0.0.1:512 - Starting rexec sweep
[*] 10.0.0.1:512          - 10.0.0.1:512 - Attempting rexec with username:password 'foo':'bar'
[*] Scanned 1 of 2 hosts (50% complete)
[*] 10.0.0.10:512         - 10.0.0.10:512 - Starting rexec sweep
[*] 10.0.0.10:512         - 10.0.0.10:512 - Attempting rexec with username:password 'foo':'bar'
[-] 10.0.0.10:512         - 10.0.0.10:512         - [1/1] - Result: Where are you?
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/rservices/rexec_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      0      0      0

msf auxiliary(scanner/rservices/rexec_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(scanner/rservices/rexec_login) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  512   tcp    exec  open         {}

msf auxiliary(scanner/rservices/rexec_login) >
```

## After

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > git checkout
[*] exec: git checkout

Your branch is up to date with 'origin/auth_brute_mixin'.
msf > use exec_login

Matching Modules
================

   #  Name                                     Disclosure Date  Rank    Check  Description
   -  ----                                     ---------------  ----    -----  -----------
   0  auxiliary/scanner/rservices/rexec_login  .                normal  No     rexec Authentication Scanner


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/rservices/rexec_login

[*] Using auxiliary/scanner/rservices/rexec_login
msf auxiliary(scanner/rservices/rexec_login) > set RHOST 10.0.0.1 10.0.0.10
RHOST => 10.0.0.1 10.0.0.10
msf auxiliary(scanner/rservices/rexec_login) > set USERNAME foo
USERNAME => foo
msf auxiliary(scanner/rservices/rexec_login) > set PASSWORD bar
PASSWORD => bar
msf auxiliary(scanner/rservices/rexec_login) > options

Module options (auxiliary/scanner/rservices/rexec_login):

   Name              Current Setting     Required  Description
   ----              ---------------     --------  -----------
   ANONYMOUS_LOGIN   false               yes       Attempt to login with a blank username and password
   BLANK_PASSWORDS   false               no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                   yes       How fast to bruteforce, from 0 to 5
   CreateSession     true                no        Create a new session for every successful login
   DB_ALL_CREDS      false               no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false               no        Add all passwords in the current database to the list
   DB_ALL_USERS      false               no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none                no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   ENABLE_STDERR     false               yes       Enables connecting the stderr port
   PASSWORD          bar                 no        A specific password to authenticate with
   PASS_FILE                             no        File containing passwords, one per line
   RHOSTS            10.0.0.1 10.0.0.10  yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             512                 yes       The target port (TCP)
   STDERR_PORT                           no        The port to listen on for stderr
   STOP_ON_SUCCESS   false               yes       Stop guessing when a credential works for a host
   THREADS           1                   yes       The number of concurrent threads (max one per host)
   USERNAME          foo                 no        A specific username to authenticate as
   USERPASS_FILE                         no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false               no        Try the username as the password for all users
   USER_FILE                             no        File containing usernames, one per line
   VERBOSE           true                yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/rservices/rexec_login) > run
[*] 10.0.0.1:512          - 10.0.0.1:512 - Starting rexec sweep
[*] 10.0.0.1:512          - 10.0.0.1:512 - Attempting rexec with username:password 'foo':'bar'
[-] 10.0.0.1:512          - 10.0.0.1:512          - [1/1] - Connection refused
[*] Scanned 1 of 2 hosts (50% complete)
[*] 10.0.0.10:512         - 10.0.0.10:512 - Starting rexec sweep
[*] 10.0.0.10:512         - 10.0.0.10:512 - Attempting rexec with username:password 'foo':'bar'
[-] 10.0.0.10:512         - 10.0.0.10:512         - [1/1] - Result: Where are you?
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/rservices/rexec_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  2      1         0      0      0      0

msf auxiliary(scanner/rservices/rexec_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.1
10.0.0.10             Unknown                    device

msf auxiliary(scanner/rservices/rexec_login) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  512   tcp    exec  open         {}

msf auxiliary(scanner/rservices/rexec_login) >
```