### PR TITLE
Strip out same address in msg

### DIFF
--- a/lib/msf/core/module/ui/message.rb
+++ b/lib/msf/core/module/ui/message.rb
@@ -6,14 +6,14 @@ module Msf::Module::UI::Message
 
   def print_error(msg='', prefix: nil)
     msg_prefix = prefix.nil? ? print_prefix : prefix
-    super(msg_prefix + msg)
+    super(msg_prefix + strip_peer_prefix(msg_prefix, msg))
   end
 
   alias_method :print_bad, :print_error
 
   def print_good(msg='', prefix: nil)
     msg_prefix = prefix.nil? ? print_prefix : prefix
-    super(msg_prefix + msg)
+    super(msg_prefix + strip_peer_prefix(msg_prefix, msg))
   end
 
   def print_prefix
@@ -38,11 +38,27 @@ module Msf::Module::UI::Message
 
   def print_status(msg='', prefix: nil)
     msg_prefix = prefix.nil? ? print_prefix : prefix
-    super(msg_prefix + msg)
+    super(msg_prefix + strip_peer_prefix(msg_prefix, msg))
   end
 
   def print_warning(msg='', prefix: nil)
     msg_prefix = prefix.nil? ? print_prefix : prefix
-    super(msg_prefix + msg)
+    super(msg_prefix + strip_peer_prefix(msg_prefix, msg))
+  end
+
+  private
+
+  # When print_prefix already contains a peer address (e.g. injected by Msf::Exploit::Remote::Tcp),
+  # strip that same address from the start of msg to avoid it appearing twice in the output
+  def strip_peer_prefix(msg_prefix, msg)
+    # IPv4 address (e.g. 127.0.0.1:yy)
+    if (m = msg_prefix.match(/(\d+\.\d+\.\d+\.\d+:\d+)/))
+      msg.to_s.sub(/\A#{Regexp.escape(m[1])}\s*-\s*/, '')
+    # IPv6 address (e.g. [::1]:yy    ::1:yy)
+    elsif (m = msg_prefix.match(/\[([\da-fA-F:]+)\]:(\d+)/))
+      msg.to_s.sub(/\A(?:\[#{Regexp.escape(m[1])}\]|#{Regexp.escape(m[1])}):#{m[2]}\s*-\s*/, '')
+    else
+      msg
+    end
   end
 end


### PR DESCRIPTION
I've open up a few PRs recently, and a common item has been the "duplicatd IP:PORT" in output.

Example:

```console
msf auxiliary(scanner/ftp/ftp_login) > run
[*] 10.0.0.10:21          - 10.0.0.10:21 - Starting FTP login sweep
[-] 10.0.0.10:21          - 10.0.0.10:21 - LOGIN FAILED: : (Incorrect: )
[-] 10.0.0.10:21          - 10.0.0.10:21 - LOGIN FAILED: msfadmin:incorrect (Incorrect: )
[+] 10.0.0.10:21          - 10.0.0.10:21 - Login Successful: msfadmin:msfadmin
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_login) >
```


The workaround I had been doing was using `if datastore['VERBOSE']`, as seen below:

```console
$ git diff
diff --git a/modules/auxiliary/scanner/ftp/ftp_login.rb b/modules/auxiliary/scanner/ftp/ftp_login.rb
index 093eb163a5..1c41754a30 100644
--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -100,7 +100,8 @@ class MetasploitModule < Msf::Auxiliary
         print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        vprint_error "LOGIN FAILED (#1): #{result.credential} (#{result.status}: #{result.proof})"
+        print_error "LOGIN FAILED (#2): #{result.credential} (#{result.status}: #{result.proof})" if datastore['VERBOSE']
       end
     end
   end
$



msf auxiliary(scanner/ftp/ftp_login) > reload
[*] Reloading module...
msf auxiliary(scanner/ftp/ftp_login) > run
[*] 10.0.0.10:21          - 10.0.0.10:21 - Starting FTP login sweep
[-] 10.0.0.10:21          - 10.0.0.10:21          - LOGIN FAILED (#1): : (Incorrect: )
[-] 10.0.0.10:21          - LOGIN FAILED (#2): : (Incorrect: )
[-] 10.0.0.10:21          - 10.0.0.10:21          - LOGIN FAILED (#1): msfadmin:incorrect (Incorrect: )
[-] 10.0.0.10:21          - LOGIN FAILED (#2): msfadmin:incorrect (Incorrect: )
[+] 10.0.0.10:21          - 10.0.0.10:21 - Login Successful: msfadmin:msfadmin
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_login) >
```

However, after doing it on a few modules, figured I would try and address the problem.


- - - 

## Before

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; setg USERNAME msfadmin; setg PASSWORD incorrect; setg USER_AS_PASS true; setg ANONYMOUS_LOGIN true; setg BLANK_PASSWORDS true; setg RECORD_GUEST false; set STOP_ON_SUCCESS false;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
USERNAME => msfadmin
PASSWORD => incorrect
USER_AS_PASS => true
ANONYMOUS_LOGIN => true
BLANK_PASSWORDS => true
RECORD_GUEST => false
STOP_ON_SUCCESS => false
msf > use ftp_login

Matching Modules
================

   #  Name                             Disclosure Date  Rank    Check  Description
   -  ----                             ---------------  ----    -----  -----------
   0  auxiliary/scanner/ftp/ftp_login  .                normal  No     FTP Authentication Scanner


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/ftp/ftp_login

[*] Using auxiliary/scanner/ftp/ftp_login
msf auxiliary(scanner/ftp/ftp_login) > run
[*] 10.0.0.10:21          - 10.0.0.10:21 - Starting FTP login sweep
[-] 10.0.0.10:21          - 10.0.0.10:21 - LOGIN FAILED: : (Incorrect: )
[-] 10.0.0.10:21          - 10.0.0.10:21 - LOGIN FAILED: msfadmin:incorrect (Incorrect: )
[+] 10.0.0.10:21          - 10.0.0.10:21 - Login Successful: msfadmin:msfadmin
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_login) >
```

## After

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; setg USERNAME msfadmin; setg PASSWORD incorrect; setg USER_AS_PASS true; setg ANONYMOUS_LOGIN true; setg BLANK_PASSWORDS true; setg RECORD_GUEST false; set STOP_ON_SUCCESS false;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
USERNAME => msfadmin
PASSWORD => incorrect
USER_AS_PASS => true
ANONYMOUS_LOGIN => true
BLANK_PASSWORDS => true
RECORD_GUEST => false
STOP_ON_SUCCESS => false
msf > use ftp_login

Matching Modules
================

   #  Name                             Disclosure Date  Rank    Check  Description
   -  ----                             ---------------  ----    -----  -----------
   0  auxiliary/scanner/ftp/ftp_login  .                normal  No     FTP Authentication Scanner


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/ftp/ftp_login

[*] Using auxiliary/scanner/ftp/ftp_login
msf auxiliary(scanner/ftp/ftp_login) > run
[*] 10.0.0.10:21          - Starting FTP login sweep
[-] 10.0.0.10:21          - LOGIN FAILED: : (Incorrect: )
[-] 10.0.0.10:21          - LOGIN FAILED: msfadmin:incorrect (Incorrect: )
[+] 10.0.0.10:21          - Login Successful: msfadmin:msfadmin
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_login) >
```