### PR TITLE
Default to the most recent session

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -21,7 +21,7 @@ module Msf::PostMixin
     )
 
     register_options( [
-      Msf::OptInt.new('SESSION', [ true, 'The session to run this module on' ])
+      Msf::OptInt.new('SESSION', [ true, 'The session to run this module on', -1 ])
     ] , Msf::Post)
   end
 end


### PR DESCRIPTION
Metasploit has supported referencing the most recent session as -1 for quite some time now. This updates post and local exploits to default to the most recent session by setting SESSION to -1 by default. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Use any post module
- [ ] See the session defaults to -1, the most recent session now
