### PR TITLE
Improve failure condition checks

### DIFF
--- a/modules/exploits/linux/http/projectsend_unauth_rce.rb
+++ b/modules/exploits/linux/http/projectsend_unauth_rce.rb
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => params
     })
 
-    fail_with(Failure::Unknown, 'Could not create a new user') unless res&.code != 403
+    fail_with(Failure::Unknown, 'Could not create a new user') if res.nil? || res.code == 403
     print_good("User #{username} created with password #{password}")
   end
 


### PR DESCRIPTION
Module: `modules/exploits/linux/http/projectsend_unauth_rce.rb`

### Description
In the function `register_new_user`, the prior check silently passes when res is nil (e.g. request timeout / host unreachable), because nil != 403 evaluates to true.

Prior code:
```ruby
fail_with(Failure::Unknown, 'Could not create a new user') unless res&.code != 403
```

When `res` equals `nil`, `res&.code` = `nil`, and `nil` != 403, so this `fail_with` wouldn't be triggered, the module would continue, causing confusing downstream errors instead of failing fast. (In that case, `print_good` would print `"User #{username} created..."`, then proceed to the next function.)

### Fix
Add a nil check for the response. Besides, convert the double-negative condition to a positive one, in order to make it more readable.
```ruby
fail_with(Failure::Unknown, 'Could not create a new user') if res.nil? || res.code == 403
```