### PR TITLE
ftp: replace @banner_version with banner_version helper method

### DIFF
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -62,14 +62,6 @@ module Exploit::Remote::Ftp
     # Wait for a banner to arrive...
     self.banner = recv_ftp_resp(fd)
 
-    # 220 (vsFTPd 2.3.4)\x0d\x0a                                   -> vsFTPd 2.3.4
-    # 220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\x0d\x0a -> ProFTPD 1.3.1 Server (Debian)
-    @banner_version = self.banner.to_s
-                      .gsub(/^\d{3}[\s-]/, '')
-                      .strip
-                      .gsub(/\A\(|\)\z/, '')
-                      .gsub(/\s*\[(?:(?:\d{1,3}\.){3}\d{1,3}|[0-9A-Fa-f:]*:[0-9A-Fa-f:.]+)\]/, '')
-
     print_status('Connected to target FTP server') if verbose
 
     # Only record the service and banner when the greeting looks like FTP (RFC 959)
@@ -80,7 +72,7 @@ module Exploit::Remote::Ftp
         port: rport,
         proto: 'tcp',
         name: 'ftp',
-        info: Rex::Text.to_hex_ascii(@banner_version),
+        info: Rex::Text.to_hex_ascii(banner_version),
         parents: {
           host: rhost,
           port: rport,
@@ -102,6 +94,17 @@ module Exploit::Remote::Ftp
 
     # Return the file descriptor to the caller
     fd
+  end
+
+  # Extracts a normalized version string from the FTP banner
+  # 220 (vsFTPd 2.3.4)\x0d\x0a                                   -> vsFTPd 2.3.4
+  # 220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\x0d\x0a -> ProFTPD 1.3.1 Server (Debian)
+  def banner_version
+    banner.to_s
+          .sub(/^\d{3}[\s-]/, '')
+          .strip
+          .gsub(/\A\(|\)\z/, '')
+          .gsub(/\s*\[(?:(?:\d{1,3}\.){3}\d{1,3}|[0-9A-Fa-f:]*:[0-9A-Fa-f:.]+)\]/, '')
   end
 
   #

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
       )
       register_creds(target_host, access_type)
     elsif banner
-      print_warning("FTP service, but no anonymous access (#{@banner_version})")
+      print_warning("FTP service, but no anonymous access (#{banner_version})")
     else
       vprint_warning('No FTP banner received')
     end


### PR DESCRIPTION
Follow up from https://github.com/rapid7/metasploit-framework/pull/21380

Address the feedback from @cdelafuente-r7

## After

```console
$ ././msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > use ftp_anonymous

Matching Modules
================

   #  Name                                 Disclosure Date  Rank    Check  Description
   -  ----                                 ---------------  ----    -----  -----------
   0  auxiliary/scanner/ftp/ftp_anonymous  .                normal  No     Anonymous FTP Access Detection


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/ftp/ftp_anonymous

[*] Using auxiliary/scanner/ftp/ftp_anonymous
msf auxiliary(scanner/ftp/ftp_anonymous) > run
[*] 10.0.0.10:21          - Testing write access, creating test directory: rklSSZwb
[+] 10.0.0.10:21          - Anonymous Read-only access (vsFTPd 2.3.4)
[*] 10.0.0.10:21          - Listing directory contents
[*] 10.0.0.10:21          - Directory listing: (empty)
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_anonymous) >
```