### PR TITLE
FTP mixin: Fixes & improvements

### DIFF
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -61,6 +61,7 @@ module Exploit::Remote::Ftp
 
     # Wait for a banner to arrive...
     self.banner = recv_ftp_resp(fd)
+    remove_instance_variable(:@recog_banner) if instance_variable_defined?(:@recog_banner)
 
     print_status('Connected to target FTP server') if verbose
 
@@ -90,16 +91,68 @@ module Exploit::Remote::Ftp
         type: 'ftp.banner',
         data: { banner: Rex::Text.to_hex_ascii(self.banner.strip) }
       )
+
+      # Lookup FTP banner
+      info = recog_banner
+      if info
+        os_info = {}
+        info.each_pair do |k, v|
+          case k
+          when 'os.product' then os_info[:os_name] = v
+          when 'os.vendor' then os_info[:os_flavor] = v
+          when 'os.version' then os_info[:os_sp] = v
+          when 'os.cpe23', 'service.cpe23'
+            report_note(
+              host: rhost,
+              port: rport,
+              proto: 'tcp',
+              sname: 'ftp',
+              type: 'ftp.cpe',
+              data: { cpe: v },
+              update: :unique_data
+            )
+          end
+        end
+
+        report_host({ host: rhost }.merge(os_info)) unless os_info.empty?
+      end
     end
 
     # Return the file descriptor to the caller
     fd
   end
 
-  # Extracts a normalized version string from the FTP banner
-  # 220 (vsFTPd 2.3.4)\x0d\x0a                                   -> vsFTPd 2.3.4
-  # 220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\x0d\x0a -> ProFTPD 1.3.1 Server (Debian)
+  #
+  # Matches the FTP banner against the Recog ftp.banner fingerprint set
+  # Tests each line of a multi-line banner after stripping the reply code prefix
+  # Result is memoised
+  #
+  # @return [Hash, nil] Recog match, or nil if no fingerprint matched
+  def recog_banner
+    return nil unless banner
+    return @recog_banner if instance_variable_defined?(:@recog_banner)
+
+    @recog_banner = nil
+    banner.to_s.each_line do |line|
+      text = line.sub(/^\d{3}[\s-]/, '').strip
+      next if text.empty?
+      match = Recog::Nizer.match('ftp.banner', text)
+      @recog_banner = match and break if match
+    end
+    @recog_banner
+  end
+
+  #
+  # Returns a normalised version string from the FTP banner
+  # Uses Recog - falls back to regex if no match
+  #
+  # @return [String, nil] version string, or nil if no banner
   def banner_version
+    info = recog_banner
+    return [info['service.product'], info['service.version']].compact.join(' ') if info
+
+    # 220 (vsFTPd 2.3.4)\x0d\x0a                                    -> vsFTPd 2.3.4
+    # 220 ProFTPD 1.3.1 Server (Debian) [::ffff:192.0.2.10]\x0d\x0a -> ProFTPD 1.3.1 Server (Debian)
     banner.to_s
           .sub(/^\d{3}[\s-]/, '')
           .strip

--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -161,6 +161,96 @@ module Exploit::Remote::Ftp
   end
 
   #
+  # Sends FEAT, STAT, and SYST and records the output as workspace notes
+  # Skips SYST-based OS detection if Recog already identified os.product
+  #
+  # @param logged_in_as [String] current FTP session user, recorded in notes
+  # @raise [Rex::ConnectionError] if the server closes the connection mid-fingerprint
+  # @return [void]
+  def ftp_fingerprint(logged_in_as: 'anonymous')
+    print_status("Fingerprinting FTP service (as #{logged_in_as})")
+
+    [
+      ['FEAT', 'ftp.cmd.feat'], # server-level
+      ['STAT', 'ftp.cmd.stat'], # user-level
+      ['SYST', 'ftp.cmd.syst'] # server-level
+    ].each do |cmd, note_type|
+      vprint_status("Sending FTP command: #{cmd}")
+      response = send_cmd([cmd], true)
+      raise Rex::ConnectionError.new(rhost, rport) unless response
+      next if response.empty?
+
+      response.strip.each_line.with_index do |line, i|
+        prefix = i == 0 ? "FTP #{cmd}: " : '  '
+        vprint_status("#{prefix}#{line.strip}")
+      end
+
+      # Examples:
+      #   215 UNIX Type: L8
+      #   215 Windows_NT
+      #   215 UNIX emulated by FileZilla     (Windows host but looks like *nix service)
+      if cmd == 'SYST'
+        os_name = if response.match?(/emulated/i) then nil
+                  elsif response.match?(/Windows_NT/i) then 'Windows'
+                  elsif response.match?(/UNIX/i) then '*nix'
+                  else nil
+                  end
+        report_host(host: rhost, os_name: os_name) if os_name && !recog_banner&.key?('os.product')
+      end
+
+      report_note(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        sname: 'ftp',
+        type: note_type,
+        data: {
+          username: logged_in_as,
+          output: response.strip
+        }
+      )
+    end
+  end
+
+  #
+  # Lists the current remote directory and optionally stores the result as loot
+  #
+  # @param logged_in_as [String] current FTP session user, used to label the loot file
+  # @param save_loot [Boolean] store the directory listing as loot
+  # @return [String, nil] directory listing content, or nil on failure
+  def ftp_list_directory(logged_in_as: 'anonymous', save_loot: false)
+    print_status('Getting FTP root directory contents')
+
+    listing = send_cmd_data(['LS'], nil)
+    if listing.nil?
+      print_warning('Could not retrieve directory listing (data connection failed)')
+      return nil
+    elsif listing[1].blank?
+      vprint_status('Directory listing: (empty)')
+      return nil
+    end
+
+    vprint_status('Directory listing:')
+    listing[1].strip.each_line do |line|
+      vprint_status("  #{line.strip}")
+    end
+
+    return listing[1] unless save_loot
+
+    path = store_loot(
+      'ftp.dir_listing',
+      'text/plain',
+      rhost,
+      listing[1],
+      "ftp_#{logged_in_as.to_s.downcase}.txt",
+      "FTP directory listing for #{logged_in_as}"
+    )
+    print_good("Directory listing stored to: #{path}")
+
+    listing[1]
+  end
+
+  #
   # This method handles establishing datasocket for data channel
   #
   def data_connect(mode = nil, nsock = self.sock)

--- a/spec/lib/msf/core/exploit/remote/ftp_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ftp_spec.rb
@@ -1,0 +1,354 @@
+require 'spec_helper'
+require 'msf/core/exploit/remote/ftp'
+
+RSpec.describe Msf::Exploit::Remote::Ftp do
+  subject(:instance) do
+    mod = Msf::Exploit::Remote.allocate
+    mod.extend described_class
+    mod
+  end
+
+  let(:socket) { double('socket') }
+
+  before do
+    allow(instance).to receive(:datastore).and_return('FTPDEBUG' => false)
+    allow(instance).to receive(:ftp_timeout).and_return(1)
+    instance.instance_variable_set(:@ftpbuff, '')
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '#recv_ftp_resp' do
+    context 'when @ftpbuff holds a partial response and the socket completes it' do
+      before do
+        instance.instance_variable_set(:@ftpbuff, "220-Welcome to vsftpd\r\n")
+        allow(socket).to receive(:get_once).and_return("220 Ready.\r\n", nil)
+      end
+
+      it 'combines the buffered and socket data into one response' do
+        response = instance.recv_ftp_resp(socket)
+        expect(response).to include("220-Welcome to vsftpd\r\n")
+        expect(response).to include("220 Ready.\r\n")
+      end
+    end
+
+    context 'when @ftpbuff is empty and a single response arrives from the socket' do
+      before do
+        allow(socket).to receive(:get_once).and_return("220 (vsFTPd 2.3.4)\r\n", nil)
+      end
+
+      it 'returns the response from the socket' do
+        expect(instance.recv_ftp_resp(socket)).to eq("220 (vsFTPd 2.3.4)\r\n")
+      end
+    end
+
+    context 'when FTPDEBUG is enabled' do
+      before do
+        allow(instance).to receive(:datastore).and_return('FTPDEBUG' => true)
+        allow(instance).to receive(:print_status)
+        allow(socket).to receive(:get_once).and_return("220 (vsFTPd 2.3.4)\r\n", nil)
+      end
+
+      it 'prints FTP recv: for a response read from the socket' do
+        instance.recv_ftp_resp(socket)
+        expect(instance).to have_received(:print_status).with('FTP recv: "220 (vsFTPd 2.3.4)\r\n"')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '#recog_banner' do
+    context 'when banner is nil' do
+      before { allow(instance).to receive(:banner).and_return(nil) }
+
+      it 'returns nil' do
+        expect(instance.recog_banner).to be_nil
+      end
+    end
+
+    context 'when the banner has no recog match' do
+      before do
+        allow(instance).to receive(:banner).and_return("220 Custom FTP Server\r\n")
+        allow(Recog::Nizer).to receive(:match).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(instance.recog_banner).to be_nil
+      end
+    end
+
+    context 'when the banner matches recog on a single line' do
+      let(:recog_match) { { 'matched' => 'vsftpd', 'service.version' => '2.3.4' } }
+
+      before do
+        allow(instance).to receive(:banner).and_return("220 (vsFTPd 2.3.4)\r\n")
+        allow(Recog::Nizer).to receive(:match).with('ftp.banner', '(vsFTPd 2.3.4)').and_return(recog_match)
+      end
+
+      it 'returns the recog match' do
+        expect(instance.recog_banner).to eq(recog_match)
+      end
+
+      it 'strips the reply code prefix before matching' do
+        instance.recog_banner
+        expect(Recog::Nizer).to have_received(:match).with('ftp.banner', '(vsFTPd 2.3.4)')
+      end
+    end
+
+    context 'when the banner is multi-line and the match is on a later line' do
+      let(:recog_match) { { 'matched' => 'vsftpd', 'service.version' => '2.3.4' } }
+
+      before do
+        allow(instance).to receive(:banner).and_return("220-Welcome to FTP\r\n220 (vsFTPd 2.3.4)\r\n")
+        allow(Recog::Nizer).to receive(:match).with('ftp.banner', 'Welcome to FTP').and_return(nil)
+        allow(Recog::Nizer).to receive(:match).with('ftp.banner', '(vsFTPd 2.3.4)').and_return(recog_match)
+      end
+
+      it 'returns the match found on the later line' do
+        expect(instance.recog_banner).to eq(recog_match)
+      end
+
+      it 'tests each line independently' do
+        instance.recog_banner
+        expect(Recog::Nizer).to have_received(:match).with('ftp.banner', 'Welcome to FTP')
+        expect(Recog::Nizer).to have_received(:match).with('ftp.banner', '(vsFTPd 2.3.4)')
+      end
+    end
+
+    context 'memoisation when a match is found' do
+      let(:recog_match) { { 'matched' => 'vsftpd' } }
+
+      before do
+        allow(instance).to receive(:banner).and_return("220 (vsFTPd 2.3.4)\r\n")
+        allow(Recog::Nizer).to receive(:match).and_return(recog_match)
+      end
+
+      it 'calls Recog only once across multiple invocations' do
+        instance.recog_banner
+        instance.recog_banner
+        expect(Recog::Nizer).to have_received(:match).once
+      end
+
+      it 'returns the same result on repeated calls' do
+        expect(instance.recog_banner).to eq(instance.recog_banner)
+      end
+    end
+
+    context 'memoisation when no match is found' do
+      before do
+        allow(instance).to receive(:banner).and_return("220 Unknown FTP Server\r\n")
+        allow(Recog::Nizer).to receive(:match).and_return(nil)
+      end
+
+      it 'does not re-run Recog on a cached nil result' do
+        instance.recog_banner
+        instance.recog_banner
+        expect(Recog::Nizer).to have_received(:match).once
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '#banner_version' do
+    before { allow(instance).to receive(:recog_banner).and_return(recog_result) }
+
+    context 'when recog returns a full match' do
+      let(:recog_result) { { 'service.product' => 'vsftpd', 'service.version' => '2.3.4' } }
+
+      it 'returns service.product and service.version joined by a space' do
+        expect(instance.banner_version).to eq('vsftpd 2.3.4')
+      end
+    end
+
+    context 'when recog matches but has no service.version' do
+      let(:recog_result) { { 'service.product' => 'vsftpd' } }
+
+      it 'returns just service.product' do
+        expect(instance.banner_version).to eq('vsftpd')
+      end
+    end
+
+    context 'when recog returns nil (regex fallback)' do
+      let(:recog_result) { nil }
+
+      {
+        "220 (vsFTPd 2.3.4)\r\n"                                    => 'vsFTPd 2.3.4',
+        "220 ProFTPD 1.3.1 Server (Debian) [::ffff:192.0.2.10]\r\n" => 'ProFTPD 1.3.1 Server (Debian)',
+        "220 Pure-FTPd\r\n"                                         => 'Pure-FTPd'
+      }.each do |input, expected|
+        context "with banner #{input.inspect}" do
+          before { allow(instance).to receive(:banner).and_return(input) }
+
+          it "returns #{expected.inspect}" do
+            expect(instance.banner_version).to eq(expected)
+          end
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '#ftp_fingerprint' do
+    let(:feat_response) { "211-Features:\r\n211 End\r\n" }
+    let(:stat_response) { "211 FTP server status\r\n" }
+    let(:syst_response) { "215 UNIX Type: L8\r\n" }
+
+    before do
+      allow(instance).to receive(:rhost).and_return('192.0.2.1')
+      allow(instance).to receive(:rport).and_return(21)
+      allow(instance).to receive(:print_status)
+      allow(instance).to receive(:vprint_status)
+      allow(instance).to receive(:report_note)
+      allow(instance).to receive(:report_host)
+      allow(instance).to receive(:recog_banner).and_return(nil)
+      allow(instance).to receive(:send_cmd) do |args, _|
+        case args[0]
+        when 'FEAT' then feat_response
+        when 'STAT' then stat_response
+        when 'SYST' then syst_response
+        end
+      end
+    end
+
+    it 'sends FEAT, STAT, and SYST' do
+      instance.ftp_fingerprint
+      expect(instance).to have_received(:send_cmd).with(['FEAT'], true)
+      expect(instance).to have_received(:send_cmd).with(['STAT'], true)
+      expect(instance).to have_received(:send_cmd).with(['SYST'], true)
+    end
+
+    it 'stores a note for each command' do
+      instance.ftp_fingerprint
+      expect(instance).to have_received(:report_note).exactly(3).times
+    end
+
+    it 'records logged_in_as in the note data' do
+      instance.ftp_fingerprint(logged_in_as: 'msfadmin')
+      expect(instance).to have_received(:report_note).with(
+        hash_including(data: hash_including(username: 'msfadmin'))
+      ).at_least(:once)
+    end
+
+    context 'SYST OS detection' do
+      context 'when recog found no OS' do
+        before { allow(instance).to receive(:recog_banner).and_return(nil) }
+
+        it 'reports *nix for a UNIX SYST response' do
+          instance.ftp_fingerprint
+          expect(instance).to have_received(:report_host).with(hash_including(os_name: '*nix'))
+        end
+
+        context 'when SYST returns Windows_NT' do
+          let(:syst_response) { "215 Windows_NT\r\n" }
+
+          it 'reports Windows' do
+            instance.ftp_fingerprint
+            expect(instance).to have_received(:report_host).with(hash_including(os_name: 'Windows'))
+          end
+        end
+
+        context 'when SYST returns emulated (FileZilla on Windows)' do
+          let(:syst_response) { "215 UNIX emulated by FileZilla\r\n" }
+
+          it 'does not report any OS' do
+            instance.ftp_fingerprint
+            expect(instance).not_to have_received(:report_host)
+          end
+        end
+      end
+
+      context 'when recog already identified os.product' do
+        before do
+          allow(instance).to receive(:recog_banner).and_return(
+            'os.product' => 'Linux', 'service.version' => '2.3.4'
+          )
+        end
+
+        it 'does not overwrite the recog OS with the coarser SYST value' do
+          instance.ftp_fingerprint
+          expect(instance).not_to have_received(:report_host)
+        end
+      end
+
+      context 'when recog matched but found no os.product' do
+        before do
+          allow(instance).to receive(:recog_banner).and_return(
+            'service.product' => 'vsftpd', 'service.version' => '2.3.4'
+          )
+        end
+
+        it 'still reports OS from SYST' do
+          instance.ftp_fingerprint
+          expect(instance).to have_received(:report_host).with(hash_including(os_name: '*nix'))
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  describe '#ftp_list_directory' do
+    before do
+      allow(instance).to receive(:rhost).and_return('192.0.2.1')
+      allow(instance).to receive(:rport).and_return(21)
+      allow(instance).to receive(:print_status)
+      allow(instance).to receive(:print_warning)
+      allow(instance).to receive(:print_good)
+      allow(instance).to receive(:vprint_status)
+      allow(instance).to receive(:store_loot).and_return('/tmp/loot.txt')
+      allow(instance).to receive(:send_cmd_data).and_return(listing)
+    end
+
+    context 'when the data connection fails' do
+      let(:listing) { nil }
+
+      it 'returns nil' do
+        expect(instance.ftp_list_directory).to be_nil
+      end
+    end
+
+    context 'when the directory listing is empty' do
+      let(:listing) { [nil, ''] }
+
+      it 'returns nil' do
+        expect(instance.ftp_list_directory).to be_nil
+      end
+    end
+
+    context 'when listing succeeds' do
+      let(:listing) { [nil, "drwxr-xr-x 2 root root 4096 Jan  1 00:00 pub\n"] }
+
+      it 'returns the listing content when save_loot is false (default)' do
+        expect(instance.ftp_list_directory).to eq("drwxr-xr-x 2 root root 4096 Jan  1 00:00 pub\n")
+      end
+
+      it 'does not call store_loot when save_loot is false' do
+        instance.ftp_list_directory
+        expect(instance).not_to have_received(:store_loot)
+      end
+
+      context 'when save_loot: true' do
+        it 'calls store_loot' do
+          instance.ftp_list_directory(save_loot: true)
+          expect(instance).to have_received(:store_loot)
+        end
+
+        it 'uses logged_in_as in the loot filename' do
+          instance.ftp_list_directory(logged_in_as: 'msfadmin', save_loot: true)
+          expect(instance).to have_received(:store_loot).with(
+            anything, anything, anything, anything, 'ftp_msfadmin.txt', anything
+          )
+        end
+
+        it 'lowercases logged_in_as in the loot filename' do
+          instance.ftp_list_directory(logged_in_as: 'ADMIN', save_loot: true)
+          expect(instance).to have_received(:store_loot).with(
+            anything, anything, anything, anything, 'ftp_admin.txt', anything
+          )
+        end
+
+        it 'returns the listing content' do
+          expect(instance.ftp_list_directory(save_loot: true)).to eq("drwxr-xr-x 2 root root 4096 Jan  1 00:00 pub\n")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This started from @cdelafuente-r7's feedback in https://github.com/rapid7/metasploit-framework/pull/21380#discussion_r3196232990

This PR fixes a few things:

- Use recog (fall back to regex) with `banner_version`
- If pointed at a non-ftp service, but one which is up, record
- Check for complete response (e.g. two responses in one TCP burst - issue found when using STAT/FEAT with `ftp_fingerprint`)
- Add ftp_fingerprint() & ftp_list_directory() to help enum targets.

- - -

# Use recog

Target is Metasploitable 2.

## After

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
LHOST => tap0
msf > use ftp_anonymous

Matching Modules
================

   #  Name                                 Disclosure Date  Rank    Check  Description
   -  ----                                 ---------------  ----    -----  -----------
   0  auxiliary/scanner/ftp/ftp_anonymous  .                normal  No     Anonymous FTP Access Detection


Interact with a module by name or index. For example info 0, use 0 or use auxiliary/scanner/ftp/ftp_anonymous

[*] Using auxiliary/scanner/ftp/ftp_anonymous
msf auxiliary(scanner/ftp/ftp_anonymous) > run
[*] 10.0.0.10:21          - Testing write access, creating test directory: fzgzOlMG
[+] 10.0.0.10:21          - Anonymous Read-only access (vsFTPd 2.3.4)
[*] 10.0.0.10:21          - Listing directory contents
[*] 10.0.0.10:21          - Directory listing: (empty)
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_anonymous) >
```

- - - 

### Proof

```console
$ git diff ./lib/msf/core/exploit/remote/ftp.rb
diff --git a/lib/msf/core/exploit/remote/ftp.rb b/lib/msf/core/exploit/remote/ftp.rb
index a2a8855f6d..15a2ca2da9 100644
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -119,7 +119,7 @@ module Exploit::Remote::Ftp
   #
   def banner_version
    info = recog_banner
-   return [info['service.product'], info['service.version']].compact.join(' ') if info
+   return [info['service.product'], info['service.product'], info['service.version']].compact.join(' ') if info

     # 220 (vsFTPd 2.3.4)\x0d\x0a                                   -> vsFTPd 2.3.4
     # 220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\x0d\x0a -> ProFTPD 1.3.1 Server (Debian)
$ ./msfconsole -q -x 'db_status; workspace -D;
setg VERBOSE true; setg RHOSTS 10.0.0.10; setg LHOST tap0; use ftp_anonymous; run'
[...]
[+] 10.0.0.10:21          - Anonymous Read-only access (vsFTPd vsFTPd 2.3.4)
[...]
msf auxiliary(scanner/ftp/ftp_anonymous) >
```