### PR TITLE
Fix get_os_architecture for Linux/BSD shell sessions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,7 +499,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rex-arch (0.1.19)
+    rex-arch (0.1.20)
       rex-text
     rex-bin_tools (0.1.16)
       metasm

--- a/lib/msf/core/post/architecture.rb
+++ b/lib/msf/core/post/architecture.rb
@@ -4,6 +4,7 @@ module Msf::Post::Architecture
 
   # Get the architecture of the target's operating system.
   # @return [String, Nil] Returns a string containing the target OS architecture if known, or Nil if its not known.
+  #
   def get_os_architecture
     if session.type == 'meterpreter'
       os_architecture = sysinfo['Architecture']
@@ -31,6 +32,9 @@ module Msf::Post::Architecture
           print_error('Target is running Windows on an unsupported architecture!')
           return nil
         end
+      when 'linux', 'bsd', 'osx'
+        uname_m = cmd_exec('uname -m').to_s.strip
+        Rex::Arch.from_uname(uname_m)
       end
     end
   end


### PR DESCRIPTION
## What this does

Extends `get_os_architecture` in `Msf::Post::Architecture` to support
non-meterpreter Linux and BSD shell sessions. Previously the method only
handled meterpreter sessions and Windows shell sessions, leaving Linux/BSD
shell sessions returning nil.

The fix calls `uname -m` on the remote host and passes the output to
`Rex::Arch.from_uname` (added in rapid7/rex-arch#13) which normalizes it
to the correct ARCH_ constant.

Fixes #21403
References rapid7/rex-arch#13

## Verification

- [ ] Start `msfconsole`
- [ ] Obtain a shell session on a Linux target (e.g. via any linux exploit or ssh session)
- [ ] Run a post module that calls `get_os_architecture`, or test directly:
```
irb
session = framework.sessions[1]
include Msf::Post::Architecture
puts get_os_architecture

```

- [ ] **Verify** it returns the correct ARCH_ constant (e.g. `x64` for a 64-bit Linux host)
- [ ] **Verify** it still works correctly for meterpreter sessions
- [ ] **Verify** it still works correctly for Windows shell sessions
- [ ] **Verify** it returns `nil` gracefully for unsupported platforms