### PR TITLE
ISSUE-21328: Fix misleading `use` errors when http-cookie / `::HTTP` is missing

### DIFF
--- a/lib/msf/core/exploit/remote/http/http_cookie.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie.rb
@@ -1,5 +1,8 @@
 require 'http/cookie'
 
+require_relative 'http_cookie_dependency'
+Msf::Exploit::Remote::HTTP::HttpCookieDependency.ensure_cookie!
+
 module Msf
   class Exploit
     class Remote

--- a/lib/msf/core/exploit/remote/http/http_cookie_dependency.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_dependency.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        # Runtime checks that the +http-cookie+ Ruby gem has defined the top-level +HTTP+ namespace
+        # expected by {Msf::Exploit::Remote::HTTP::HttpCookie} and {Msf::Exploit::Remote::HTTP::HttpCookieJar}
+        # (+::HTTP::Cookie+, +::HTTP::CookieJar+).
+        #
+        # Call these immediately after +require 'http/cookie'+ (and jar requires) so broken or partial
+        # installs raise {LoadError} with actionable text instead of +NameError: uninitialized constant HTTP+.
+        #
+        # @see https://www.rubydoc.info/gems/http-cookie HTTP::Cookie API
+        module HttpCookieDependency
+          # Full error message when +http-cookie+ failed to define +::HTTP+ constants.
+          MESSAGE = 'Metasploit requires the http-cookie Ruby gem (top-level HTTP::Cookie / HTTP::CookieJar). ' \
+            'Ensure RubyGems can load it: run `bundle install` in the framework source tree, or reinstall your ' \
+            'OS metasploit / ruby-http-cookie package.'
+
+          # Verifies +::HTTP::Cookie+ exists after loading +http/cookie+.
+          #
+          # @return [void]
+          # @raise [LoadError] if +::HTTP+ or +::HTTP::Cookie+ is missing
+          def self.ensure_cookie!
+            return if defined?(::HTTP) && ::HTTP.const_defined?(:Cookie)
+
+            raise LoadError, MESSAGE
+          end
+
+          # Verifies +::HTTP::Cookie+ and +::HTTP::CookieJar+ exist after loading cookie jar support.
+          #
+          # @return [void]
+          # @raise [LoadError] if any required constant is missing
+          def self.ensure_cookie_jar!
+            return if defined?(::HTTP) && ::HTTP.const_defined?(:Cookie) && ::HTTP.const_defined?(:CookieJar)
+
+            raise LoadError, MESSAGE
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -3,6 +3,9 @@ require 'http/cookie'
 require 'http/cookie_jar'
 require 'http/cookie_jar/hash_store'
 
+require_relative 'http_cookie_dependency'
+Msf::Exploit::Remote::HTTP::HttpCookieDependency.ensure_cookie_jar!
+
 # This class is a collection of Http Cookies with some built in convenience methods.
 # Acts as a wrapper for the +::HTTP::CookieJar+ (https://www.rubydoc.info/gems/http-cookie/1.0.2/HTTP/CookieJar) class.
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -842,10 +842,15 @@ module Msf
                   return false
                 end
               end
-            rescue Rex::AmbiguousArgumentError => info
-              print_error(info.to_s)
-            rescue NameError => info
-              log_error("The supplied module name is ambiguous: #{$!}.")
+            rescue Rex::AmbiguousArgumentError => e
+              print_error(e.to_s)
+            rescue LoadError, NameError => e
+              print_error("Failed to load module #{mod_name}: #{e.message}")
+              elog("Failure while activating module #{mod_name}", 'core', 0, error: e)
+              print_warning(
+                'The http-cookie Ruby gem may be missing or broken. Reinstall framework gems (for example `bundle install` ' \
+                'in the source tree) or your OS metasploit / ruby-http-cookie package.'
+              ) if hint_http_cookie_dependency?(e)
             end
 
             return false if (mod == nil)
@@ -913,6 +918,17 @@ module Msf
             end
 
             mod.init_ui(driver.input, driver.output)
+          end
+
+          # @param err [Exception]
+          # @return [Boolean] whether to show the http-cookie reinstall hint (avoids duplicating {Msf::Exploit::Remote::HTTP::HttpCookieDependency} +LoadError+ text)
+          def hint_http_cookie_dependency?(err)
+            return false unless err.is_a?(NameError)
+
+            msg = err.message.to_s
+            msg.match?(/\Auninitialized constant (?:\:?:)?HTTP\b/o) ||
+              msg.include?('HTTP::CookieJar') ||
+              msg.include?('::HTTP::Cookie')
           end
 
           #

--- a/spec/http_cookie_dependency_standalone.rb
+++ b/spec/http_cookie_dependency_standalone.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Minimal RSpec boot for specs that only need the http-cookie wrapper (no database).
+# Usage:
+#   bundle exec rspec spec/lib/msf/core/exploit/remote/http/http_cookie_dependency_spec.rb \
+#     --options /dev/null --require spec/http_cookie_dependency_standalone
+
+require 'rspec/core'
+
+ROOT = File.expand_path('..', __dir__)
+# Match load order in lib/msf/core/exploit/remote/http/http_cookie_jar.rb so ::HTTP is defined.
+require 'http/cookie'
+require 'http/cookie_jar'
+require 'http/cookie_jar/hash_store'
+require File.join(ROOT, 'lib/msf/core/exploit/remote/http/http_cookie_dependency.rb')
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+end

--- a/spec/lib/msf/core/exploit/remote/http/http_cookie_dependency_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/http/http_cookie_dependency_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieDependency do
+  describe '.ensure_cookie!' do
+    it 'does not raise when the http-cookie gem is available' do
+      expect { described_class.ensure_cookie! }.not_to raise_error
+    end
+  end
+
+  describe '.ensure_cookie_jar!' do
+    it 'does not raise when the http-cookie gem is fully available' do
+      expect { described_class.ensure_cookie_jar! }.not_to raise_error
+    end
+  end
+
+  describe '::MESSAGE' do
+    it 'mentions the http-cookie gem' do
+      expect(described_class::MESSAGE).to include('http-cookie')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`cmd_use` treated any `NameError` as an “ambiguous module name,” which hid real failures (e.g. `uninitialized constant HTTP` when the **http-cookie** gem is broken or absent). Load/instantiation errors now surface clearly; `LoadError` from a small `HttpCookieDependency` check explains the **http-cookie** dependency.

Fixes #21328

## Verification

- [ ] `bundle exec rspec spec/lib/msf/core/exploit/remote/http/http_cookie_dependency_spec.rb --options /dev/null --require ./spec/http_cookie_dependency_standalone.rb`
- [ ] `msfconsole` → `use exploit/multi/http/<module>` succeeds on a normal install
