### PR TITLE
Update validation for report_vuln

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -101,9 +101,10 @@ module Msf::DBManager::Vuln
   #
   def report_vuln(opts)
     return if not active
-    raise ArgumentError.new("Missing required option :host") if opts[:host].nil?
-    raise ArgumentError.new("Deprecated data column for vuln, use .info instead") if opts[:data]
-    name = opts[:name] || return
+    raise ArgumentError.new("report_vuln Missing required option :host") if opts[:host].nil?
+    raise ArgumentError.new("report_vuln Deprecated data column for vuln, use .info instead") if opts[:data]
+    raise ArgumentError.new("report_vuln Missing required option :name") if opts[:name].nil?
+    name = opts[:name]
     info = opts[:info]
 
   ::ApplicationRecord.connection_pool.with_connection {
@@ -333,7 +334,7 @@ module Msf::DBManager::Vuln
   # @param opts[:ids] [Array] Array containing Integers corresponding to the IDs of the Vuln entries to delete.
   # @return [Array] Array containing the Mdm::Vuln objects that were successfully deleted.
   def delete_vuln(opts)
-    raise ArgumentError.new("The following options are required: :ids") if opts[:ids].nil?
+    raise ArgumentError.new("delete_vuln The following options are required: :ids") if opts[:ids].nil?
 
   ::ApplicationRecord.connection_pool.with_connection {
     deleted = []

--- a/modules/auxiliary/scanner/dns/dns_amp.rb
+++ b/modules/auxiliary/scanner/dns/dns_amp.rb
@@ -126,7 +126,8 @@ class MetasploitModule < Msf::Auxiliary
         report_vuln(
           :host => shost,
           :port => datastore['RPORT'],
-          :proto => 'udp', :name => "DNS",
+          :proto => 'udp',
+          :name => "DNS",
           :info => "DNS amplification -  #{data.length} bytes [#{amp.round(2)}x Amplification]",
           :refs => self.references
         )


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/21314

## Verification

### Before

When `report_vuln` is called without a `name` option:

```
[-] Auxiliary failed: Msf::ValidationError Failed to report vuln for 10.0.0.10:80 to the database
```

### After

Now:

```
[-] Auxiliary failed: ArgumentError report_vuln Missing required option :name
```