### PR TITLE
ftp_anonymous: Fixes & improvements

### DIFF
--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -37,6 +37,12 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('STORE_LOOT', [false, 'Store the directory listing as loot', true])
       ]
     )
+
+    # Some servers may accept anonymous login under the username `ftp` (RFC 959)
+    # Some servers may also check the password is a valid email address
+    deregister_options('FTPUSER', 'FTPPASS')
+    datastore['FTPUSER'] = 'anonymous'
+    datastore['FTPPASS'] = 'mozilla@example.com'
   end
 
   def run_host(target_host)

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
         access_type = 'Read-only'
       end
 
-      print_good("Anonymous #{access_type} access (#{@banner_version})")
+      print_good("Anonymous #{access_type} access (#{banner_version})")
 
       if datastore['STORE_LOOT']
         vprint_status('Listing directory contents')

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -64,19 +64,7 @@ class MetasploitModule < Msf::Auxiliary
 
       print_good("Anonymous #{access_type} access (#{banner_version})")
 
-      if datastore['STORE_LOOT']
-        vprint_status('Listing directory contents')
-        listing = send_cmd_data(['LS'], nil)
-        if listing.nil?
-          print_warning('Could not retrieve directory listing (data connection failed)')
-        elsif listing[1].nil? || listing[1].empty?
-          vprint_status('Directory listing: (empty)')
-        else
-          vprint_status("Directory listing:\n#{listing[1]}")
-          path = store_loot('ftp.anonymous', 'text/plain', rhost, listing[1], 'ftp_anonymous.txt', 'Anonymous FTP directory listing')
-          print_good("Directory listing stored to: #{path}")
-        end
-      end
+      ftp_list_directory(username: datastore['FTPUSER'], save_loot: true) if datastore['STORE_LOOT']
 
       report_vuln(
         host: rhost,
@@ -95,7 +83,6 @@ class MetasploitModule < Msf::Auxiliary
     end
   rescue ::Rex::TimeoutError, ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNREFUSED => e
     vprint_error(e.message)
-    report_host(host: rhost)
   rescue ::Interrupt
     raise $ERROR_INFO
   ensure

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -83,6 +83,8 @@ class MetasploitModule < Msf::Auxiliary
     else
       vprint_warning('No FTP banner received')
     end
+  rescue ::Rex::ConnectionRefused
+    vprint_error('Connection refused')
   rescue ::Rex::TimeoutError, ::Rex::ConnectionError, ::EOFError, ::Errno::ECONNREFUSED => e
     vprint_error(e.message)
   rescue ::Interrupt

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -34,7 +34,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(21),
-        OptBool.new('STORE_LOOT', [false, 'Store the directory listing as loot', true])
+        OptBool.new('STORE_LOOT', [false, 'Store the directory listing as loot', true]),
+        OptBool.new('EXTENDED_CHECKS', [false, 'Gather service info via FEAT, STAT and SYST', true])
       ]
     )
 
@@ -65,6 +66,7 @@ class MetasploitModule < Msf::Auxiliary
       print_good("Anonymous #{access_type} access (#{banner_version})")
 
       ftp_list_directory(username: datastore['FTPUSER'], save_loot: true) if datastore['STORE_LOOT']
+      ftp_fingerprint(username: datastore['FTPUSER']) if datastore['EXTENDED_CHECKS']
 
       report_vuln(
         host: rhost,

--- a/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_anonymous.rb
@@ -11,24 +11,27 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Module::Deprecated
   moved_from 'auxiliary/scanner/ftp/anonymous'
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'Anonymous FTP Access Detection',
-      'Description' => 'Detect anonymous (read/write) FTP service access.',
-      'References' => [
-        ['URL', 'https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
-        ['CVE', '1999-0497'],
-      ],
-      'Author' => [
-        'Matteo Cantoni <goony[at]nothink.org>',
-        'g0tmi1k' # @g0tmi1k - additional features
-      ],
-      'License' => MSF_LICENSE,
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'SideEffects' => [IOC_IN_LOGS],
-        'Reliability' => []
-      }
+      update_info(
+        info,
+        'Name' => 'Anonymous FTP Access Detection',
+        'Description' => 'Detect anonymous (read/write) FTP service access.',
+        'References' => [
+          ['URL', 'https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP'],
+          ['CVE', '1999-0497'],
+        ],
+        'Author' => [
+          'Matteo Cantoni <goony[at]nothink.org>',
+          'g0tmi1k' # @g0tmi1k - additional features
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
     )
 
     register_options(


### PR DESCRIPTION
_First up: Sorry for the amount of work!_

Follow on from: https://github.com/rapid7/metasploit-framework/pull/21415

This PR fixes:

- Use FTP mixin
  - `@banner_version` -> `banner_version` (So the banner output works again)
  - Adds STORE_LOOT & EXTENDED_CHECKS - enum the target more, 
- Removed a case when duplicate IP:PORT is shown (Connection refused)
- Fix the value of `FTPUSER` & `FTPPASS`

```
          current  name     hosts  services  vulns  creds  loots  notes
          -------  ----     -----  --------  -----  -----  -----  -----
Before -> *        default  2      4         1      1      0      2
After  -> *        default  2      5         1      1      0      8
```

Target is Metasploitable 2.

## Before

- 10.0.0.1 - has 2x FTP services
- 10.0.0.1 - only has 1x SSH service

- Can see the FTP banner is incorrect: `Anonymous Read-only access ()`
- Less values in workspace

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ftp/ftp_anonymous;
set RHOSTS 10.0.0.10;
run;
set RPORT 2121;
run;
set RHOSTS 10.0.0.1;
run;
set RPORT 22;
run;
'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
[*] 10.0.0.10:21          - Testing write access, creating test directory: LieWQopm
[+] 10.0.0.10:21          - Anonymous Read-only access ()
[*] 10.0.0.10:21          - Listing directory contents
[*] 10.0.0.10:21          - Directory listing: (empty)
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RPORT => 2121
[!] 10.0.0.10:2121        - FTP service, but no anonymous access (ProFTPD 1.3.1 Server (Debian))
[*] 10.0.0.10:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RHOSTS => 10.0.0.1
[-] 10.0.0.1:2121         - The connection was refused by the remote host (10.0.0.1:2121).
[*] 10.0.0.1:2121         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RPORT => 22
[-] 10.0.0.1:22           - EOFError
[*] 10.0.0.1:22           - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_anonymous) >
msf auxiliary(scanner/ftp/ftp_anonymous) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  2      4         1      1      0      2

msf auxiliary(scanner/ftp/ftp_anonymous) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.1
10.0.0.10             Unknown                    device

msf auxiliary(scanner/ftp/ftp_anonymous) > services
Services
========

host       port  proto  name  state  info                           resource  parents
----       ----  -----  ----  -----  ----                           --------  -------
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4                   {}        tcp (21/tcp)
10.0.0.10  21    tcp    tcp   open                                  {}
10.0.0.10  2121  tcp    ftp   open   ProFTPD 1.3.1 Server (Debian)  {}        tcp (2121/tcp)
10.0.0.10  2121  tcp    tcp   open                                  {}

msf auxiliary(scanner/ftp/ftp_anonymous) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                  References
---------                ----       -------       --------  ----                  ----------
2026-05-20 10:15:28 UTC  10.0.0.10  ftp (21/tcp)  {}        Anonymous FTP Access  URL-https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP,CVE-1999-0497

msf auxiliary(scanner/ftp/ftp_anonymous) > creds
Credentials
===========

id   host       origin     service       public     private              realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------     -------              -----  ------------  ----------  ----------------
460  10.0.0.10  10.0.0.10  21/tcp (ftp)  anonymous  mozilla@example.com         Password

msf auxiliary(scanner/ftp/ftp_anonymous) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type        Data
 ----                     ----       -------  ----  --------  ----        ----
 2026-05-20 10:15:28 UTC  10.0.0.10  ftp      21    tcp       ftp.banner  {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-20 10:15:29 UTC  10.0.0.10  ftp      2121  tcp       ftp.banner  {:banner=>"220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]"}

msf auxiliary(scanner/ftp/ftp_anonymous) >
```

## After

- If there was something in the FTP root, it would of been added to "loot" (sorry, didn't have that setup in my test)!

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ftp/ftp_anonymous;
set RHOSTS 10.0.0.10;
run;
set RPORT 2121;
run;
set RHOSTS 10.0.0.1;
run;
set RPORT 22;
run;
'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10
[*] 10.0.0.10:21          - Testing write access, creating test directory: RkhFTOCt
[+] 10.0.0.10:21          - Anonymous Read-only access (vsFTPd 2.3.4)
[*] 10.0.0.10:21          - Getting FTP root directory contents
[*] 10.0.0.10:21          - Directory listing: (empty)
[*] 10.0.0.10:21          - Fingerprinting FTP service (as anonymous)
[*] 10.0.0.10:21          - Sending FTP command: FEAT
[...]
[*] 10.0.0.10:21          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RPORT => 2121
[!] 10.0.0.10:2121        - FTP service, but no anonymous access (ProFTPD 1.3.1)
[*] 10.0.0.10:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RHOSTS => 10.0.0.1
[-] 10.0.0.1:2121         - Connection refused
[*] 10.0.0.1:2121         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
RPORT => 22
[-] 10.0.0.1:22           - EOFError
[*] 10.0.0.1:22           - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_anonymous) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  2      5         1      1      0      8

msf auxiliary(scanner/ftp/ftp_anonymous) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.1              Unknown                    device
10.0.0.10             Linux    Debian            device

msf auxiliary(scanner/ftp/ftp_anonymous) > services
Services
========

host       port  proto  name  state  info             resource  parents
----       ----  -----  ----  -----  ----             --------  -------
10.0.0.1   22    tcp          open   Non-FTP service  {}
10.0.0.10  21    tcp    ftp   open   vsFTPd 2.3.4     {}        tcp (21/tcp)
10.0.0.10  21    tcp    tcp   open                    {}
10.0.0.10  2121  tcp    ftp   open   ProFTPD 1.3.1    {}        tcp (2121/tcp)
10.0.0.10  2121  tcp    tcp   open                    {}

msf auxiliary(scanner/ftp/ftp_anonymous) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                  References
---------                ----       -------       --------  ----                  ----------
2026-05-20 10:13:11 UTC  10.0.0.10  ftp (21/tcp)  {}        Anonymous FTP Access  URL-https://en.wikipedia.org/wiki/File_Transfer_Protocol#Anonymous_FTP,CVE-1999-0497

msf auxiliary(scanner/ftp/ftp_anonymous) > creds
Credentials
===========

id   host       origin     service       public     private              realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------     -------              -----  ------------  ----------  ----------------
459  10.0.0.10  10.0.0.10  21/tcp (ftp)  anonymous  mozilla@example.com         Password

msf auxiliary(scanner/ftp/ftp_anonymous) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type          Data
 ----                     ----       -------  ----  --------  ----          ----
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      21    tcp       ftp.banner    {:banner=>"220 (vsFTPd 2.3.4)"}
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      21    tcp       ftp.cpe       {:cpe=>"cpe:/a:vsftpd_project:vsftpd:2.3.4"}
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      21    tcp       ftp.cmd.feat  {:username=>"anonymous", :output=>"211-Features:\r\n EPRT\r\n EPSV\r\n MDTM\r\n PASV\r\n REST STREAM\r\n SIZE\r\n TVFS\r\n UTF8\r\
                                                                            n211 End"}
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      21    tcp       ftp.cmd.stat  {:username=>"anonymous", :output=>"211-FTP server status:\r\n     Connected to 10.0.0.1\r\n     Logged in as ftp\r\n     TYPE: ASC
                                                                            II\r\n     No session bandwidth limit\r\n     Session timeout in seconds is 300\r\n     Control connection is plain text\r\n     D
                                                                            ata connections will be plain text\r\n     vsFTPd 2.3.4 - secure, fast, stable\r\n211 End of status"}
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      21    tcp       ftp.cmd.syst  {:username=>"anonymous", :output=>"215 UNIX Type: L8"}
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      2121  tcp       ftp.banner    {:banner=>"220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]"}
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      2121  tcp       ftp.cpe       {:cpe=>"cpe:/a:proftpd:proftpd:1.3.1"}
 2026-05-20 10:13:11 UTC  10.0.0.10  ftp      2121  tcp       ftp.cpe       {:cpe=>"cpe:/o:debian:debian_linux:-"}

msf auxiliary(scanner/ftp/ftp_anonymous) >
```