### PR TITLE
Fix exec payload size crash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,4 +56,3 @@ group :test do
   # stub and set expectations on HTTP requests
   gem 'webmock', '~> 3.18'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -549,7 +549,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.5)
-    rex-text (0.2.62)
+    rex-text (0.2.63)
       bigdecimal
     rex-zip (0.1.6)
       rex-text

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -168,8 +168,8 @@ class PayloadCachedSize
   #
   # @param mod [Msf::Payload] The class of the payload module to update
   # @return [Integer, String]
-  def self.compute_cached_size(framework, mod)
-    return ":dynamic" if is_dynamic?(framework, mod)
+  def self.compute_cached_size(framework, mod, generation_count: 10)
+    return ":dynamic" if is_dynamic?(framework, mod, generation_count: generation_count)
 
     mod.replicant.generate_simple(module_options(mod)).bytesize
   end
@@ -180,7 +180,7 @@ class PayloadCachedSize
   # @param generation_count [Integer] The number of iterations to use to
   #   verify that the size is static.
   # @return [Boolean]
-  def self.is_dynamic?(framework, mod, generation_count=10)
+  def self.is_dynamic?(framework, mod, generation_count: 10)
     return true if mod.class.const_defined?('ForceDynamicCachedSize') && mod.class::ForceDynamicCachedSize
     opts = module_options(mod)
     last_bytesize = nil

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -40,7 +40,6 @@ module MetasploitModule
   def generate(_opts = {})
     cmd = datastore['CMD'] || ''
     cmd_length = cmd.bytesize
-    cmd = cmd.bytes.map { |byte| '0x%02x' % byte }.join(', ')
     nullfreeversion = datastore['NullFreeVersion']
 
     if cmd.empty?
@@ -99,12 +98,14 @@ module MetasploitModule
           raise RangeError, 'CMD length has to be smaller than %d' % 0xffff, caller
         end
 
+        # Null-free: raw bytes without terminator (patched at runtime)
+        cmd_bytes = Rex::Text.to_hex_cstring(cmd, nullbyte: false)
         if cmd_length <= 0xff # 255
           breg = 'bl'
         else
           breg = 'bx'
           if (cmd_length & 0xff) == 0 # let's avoid zeroed bytes
-            cmd += ', 0x20'
+            cmd_bytes += ', 0x20'
             cmd_length += 1
           end
         end
@@ -147,9 +148,11 @@ module MetasploitModule
             syscall                 ; execve("//bin/sh", ["//bin/sh", "-c", "*CMD*"], NULL)
           tocall:
             call afterjmp
-            db #{cmd}               ; arbitrary command
+            db #{cmd_bytes}               ; arbitrary command
         EOS
       else
+        # Non-null-free: null-terminated cstring
+        cmd_cstring = Rex::Text.to_hex_cstring(cmd)
         # 37 bytes without cmd (not null-free)
         payload = <<-EOS
             mov rax, 0x68732f6e69622f
@@ -166,7 +169,7 @@ module MetasploitModule
 
             push rdx                ; NULL
             call continue
-            db #{cmd}, 0x00         ; arbitrary command
+            db #{cmd_cstring}         ; arbitrary command
           continue:
             push rsi                ; "-c"
             push rdi                ; "/bin/sh"

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -36,7 +36,7 @@ module MetasploitModule
     if length > 0xff
       fail_with(Msf::Module::Failure::BadConfig, 'HOSTNAME must be less than 255 characters.')
     end
-    hostname = hostname.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    hostname = Rex::Text.to_hex_cstring(hostname, nullbyte: false)
 
     payload = %^
       push 0xffffffffffffff56 ; sethostname() syscall number.

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -53,7 +53,6 @@ module MetasploitModule
   def generate(_opts = {})
     cmd = datastore['CMD'] || ''
     cmd_length = cmd.bytesize
-    cmd = cmd.bytes.map { |byte| '0x%02x' % byte }.join(', ')
     nullfreeversion = datastore['NullFreeVersion']
     if cmd.empty?
       #
@@ -95,12 +94,14 @@ module MetasploitModule
           raise RangeError, 'CMD length has to be smaller than %d' % 0xffff, caller
         end
 
+        # Null-free: raw bytes without terminator (patched at runtime)
+        cmd_bytes = Rex::Text.to_hex_cstring(cmd, nullbyte: false)
         if cmd_length <= 0xff # 255
           breg = 'bl'
         else
           breg = 'bx'
           if (cmd_length & 0xff) == 0 # let's avoid zeroed bytes
-            cmd += ', 0x20'
+            cmd_bytes += ', 0x20'
             cmd_length += 1
           end
         end
@@ -130,9 +131,11 @@ module MetasploitModule
             int 0x80
           tocall:
             call afterjmp          ; call/pop cmd address
-            db #{cmd}
+            db #{cmd_bytes}
         EOS
       else
+        # Non-null-free: null-terminated cstring
+        cmd_cstring = Rex::Text.to_hex_cstring(cmd)
         # 36 bytes without cmd (not null-free)
         payload = <<-EOS
             push 0xb
@@ -146,7 +149,7 @@ module MetasploitModule
             mov ebx, esp
             push edx
             call continue
-            db #{cmd}, 0x00
+            db #{cmd_cstring}
           continue:
             push edi
             push ebx

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -34,7 +34,7 @@ module MetasploitModule
 
   def generate(_opts = {})
     fd = datastore['FD']
-    path = (datastore['PATH'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    path = Rex::Text.to_hex_cstring(datastore['PATH'] || '')
 
     payload_data = <<-EOS
       jmp file
@@ -66,7 +66,7 @@ module MetasploitModule
 
       file:
         call open
-        db #{path}, 0x00
+        db #{path}
     EOS
 
     Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -43,8 +43,7 @@ module MetasploitModule
       raise ArgumentError, 'LHOST must be in IPv4 format.'
     end
 
-    cmd = (datastore['CMD'] || '') + "\x00"
-    cmd = cmd.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    cmd = Rex::Text.to_hex_cstring(datastore['CMD'] || '')
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack1('N')
     encoded_host = Rex::Socket.addr_aton(lhost).unpack1('V')
     encoded_host_port = format('0x%<encoded_host>.8x%<encoded_port>.8x', { encoded_host: encoded_host, encoded_port: encoded_port })
@@ -81,7 +80,7 @@ module MetasploitModule
       xor rax,rax
       mov eax,0x200003b
       call load_cmd
-      db #{cmd}, 0x00
+      db #{cmd}
     load_cmd:
       pop rdi
       xor rdx,rdx

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -124,9 +124,9 @@ module MetasploitModule
 
     # get protocol specific stuff
 
-    server_uri = server_uri.bytes.map { |byte| '0x%02x' % byte }.join(', ')
-    filename = filename.bytes.map { |byte| '0x%02x' % byte }.join(', ')
-    server_host = server_host.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    server_uri = Rex::Text.to_hex_cstring(server_uri)
+    filename = Rex::Text.to_hex_cstring(filename)
+    server_host = Rex::Text.to_hex_cstring(server_host)
 
     # create actual payload
     payload_data = %^
@@ -226,7 +226,7 @@ module MetasploitModule
       call httpopenrequest
 
     server_uri:
-      db #{server_uri}, 0x00
+      db #{server_uri}
 
     create_file:
       jmp.i8 get_filename
@@ -297,13 +297,13 @@ module MetasploitModule
 
     get_filename:
       call get_filename_return
-      db #{filename}, 0x00
+      db #{filename}
 
     get_server_host:
       call internetconnect
 
     server_host:
-      db #{server_host}, 0x00
+      db #{server_host}
     end:
 ^
     self.assembly = payload_data

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -40,8 +40,8 @@ module MetasploitModule
   # Construct the payload
   #
   def generate(_opts = {})
-    title = (datastore['TITLE'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
-    text = (datastore['TEXT'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    title = Rex::Text.to_hex_cstring(datastore['TITLE'] || '')
+    text = Rex::Text.to_hex_cstring(datastore['TEXT'] || '')
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -91,10 +91,10 @@ module MetasploitModule
       call ebp
       push #{style}
       call get_title
-      db #{title}, 0x00
+      db #{title}
     get_title:
       call get_text
-      db #{text}, 0x00
+      db #{text}
     get_text:
       push 0
       push #{block_api_hash('user32.dll', 'MessageBoxA')}

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -42,8 +42,8 @@ module MetasploitModule
     display = datastore['DISPLAY'] || 'HIDE'
     url_length = url.bytesize
     file_length = file.bytesize
-    url = url.bytes.map { |byte| '0x%02x' % byte }.join(', ')
-    file = file.bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    url = Rex::Text.to_hex_cstring(url, nullbyte: false)
+    file = Rex::Text.to_hex_cstring(file, nullbyte: false)
 
     payload = %^
             cld

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -36,8 +36,8 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    title = (datastore['TITLE'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
-    text = (datastore['TEXT'] || '').bytes.map { |byte| '0x%02x' % byte }.join(', ')
+    title = Rex::Text.to_hex_cstring(datastore['TITLE'] || '')
+    text = Rex::Text.to_hex_cstring(datastore['TEXT'] || '')
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -90,11 +90,11 @@ module MetasploitModule
       call rbp
       mov r9, #{style}
       call get_text
-      db #{text}, 0x00
+      db #{text}
     get_text:
       pop rdx
       call get_title
-      db #{title}, 0x00
+      db #{title}
     get_title:
       pop r8
       xor rcx,rcx

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -99,18 +99,24 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
       end
     end
 
-    it 'can be instantiated' do
-      load_and_create_module(
+    it 'can be instantiated and generated' do
+      pinst = load_and_create_module(
           ancestor_reference_names: ancestor_reference_names,
           module_type: module_type,
           modules_path: modules_path,
           reference_name: reference_name
       )
+
+      next if reference_name =~ /generic|peinject/
+
+      pinst.datastore['CMD'] = '/bin/sh'
+      generated = pinst.generate
+      expect(generated).to_not be_nil
     end
 
     next if reference_name =~ /generic|peinject/
 
-    it 'has a valid cached_size', skip: 'Migrated to Jenkins' do
+    it 'has a valid cached_size' do
       pinst = load_and_create_module(
             ancestor_reference_names: ancestor_reference_names,
             module_type: module_type,
@@ -118,8 +124,7 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
             reference_name: reference_name
       )
 
-      cache_size_errors = Msf::Util::PayloadCachedSize.cache_size_errors_for(framework, pinst)
-      expect(cache_size_errors).to be_nil
+      expect(pinst.cached_size).to eq(:dynamic).or be_a(::Integer).or be_nil
     end
   end
 end

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -107,11 +107,10 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
           reference_name: reference_name
       )
 
-      next if reference_name =~ /generic|peinject/
+      next if reference_name =~ /generic/
 
-      pinst.datastore['CMD'] = '/bin/sh'
-      generated = pinst.generate
-      expect(generated).to_not be_nil
+      generated_size = ::Msf::Util::PayloadCachedSize.compute_cached_size(framework, pinst, generation_count: 1)
+      expect(generated_size).to eq(':dynamic').or be_a(::Integer)
     end
 
     next if reference_name =~ /generic|peinject/


### PR DESCRIPTION
This PR re-enables the recently-migrated CI payload cache size specs.

Follow on from https://github.com/rapid7/metasploit-framework/pull/21411

This PR uses a custom rex-text branch from this PR: https://github.com/rapid7/rex-text/pull/76

This PR fixes issues in modules that use custom copy-pasted logic for converting a string to hex.
This logic was causing issues when the string was empty. It was resulting in broken assembly:
```ruby
db #{server_uri}, 0x00
```
can result in
```ruby
db , 0x00
```

## Verification

- [ ] `bundle exec rspec spec/modules/payloads_spec.rb`