### PR TITLE
ftp: Fix STAT due to unexpected response

### DIFF
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -356,7 +356,7 @@ module Exploit::Remote::Ftp
         if not found_end
           resp << ln
           resp << "\r\n"
-          if ln.length > 3 and ln[3,1] == ' '
+          if ln.length > 3 and ln[3,1] == ' ' and ln[0,3] =~ /\A\d{3}\z/
             found_end = true
           end
         else


### PR DESCRIPTION
Before, it would only checking for "space at position 3" to signal "end".
After, it checks still for space AND a 3x numbers/digits at the start as well.

## Demo

```console
$ nc 10.0.0.10 21
220 (vsFTPd 2.3.4)
USER anonymous
331 Please specify the password.
PASS anonymous
230 Login successful.
STAT
211-FTP server status:
     Connected to 10.0.0.1
     Logged in as ftp
     TYPE: ASCII
     No session bandwidth limit
     Session timeout in seconds is 300
     Control connection is plain text
     Data connections will be plain text
     vsFTPd 2.3.4 - secure, fast, stable
211 End of status
```

- - -

This came about due to:

- https://github.com/rapid7/metasploit-framework/pull/21422
- https://github.com/rapid7/metasploit-framework/pull/21379