### PR TITLE
TCP mixin: Add report_host() to Exploit::Remote::Tcp

### DIFF
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -52,12 +52,7 @@ module Exploit::Remote::Ftp
 
     print_status("Connecting to FTP server...") if verbose
 
-    begin
-      fd = super(global)
-    rescue ::Rex::ConnectionRefused
-      report_host(host: rhost)
-      raise
-    end
+    fd = super(global)
 
     # Wait for a banner to arrive...
     self.banner = recv_ftp_resp(fd)

--- a/lib/msf/core/exploit/remote/tcp.rb
+++ b/lib/msf/core/exploit/remote/tcp.rb
@@ -46,6 +46,8 @@ end
 ###
 module Exploit::Remote::Tcp
 
+  include Msf::Auxiliary::Report
+
   #
   # Initializes an instance of an exploit module that exploits a
   # vulnerability in a TCP server.
@@ -100,25 +102,32 @@ module Exploit::Remote::Tcp
       end
     end
 
-    nsock = Rex::Socket::Tcp.create(
-      'PeerHost'      =>  opts['RHOST'] || rhost,
-      'PeerHostname'  =>  opts['SSLServerNameIndication'] || opts['VHOST'] || opts['RHOSTNAME'],
-      'PeerPort'      => (opts['RPORT'] || rport).to_i,
-      'LocalHost'     =>  opts['CHOST'] || chost || "0.0.0.0",
-      'LocalPort'     => (opts['CPORT'] || cport || 0).to_i,
-      'SSL'           =>  dossl,
-      'SSLVersion'    =>  opts['SSLVersion'] || ssl_version,
-      'SSLVerifyMode' =>  opts['SSLVerifyMode'] || ssl_verify_mode,
-      'SSLKeyLogFile' =>  opts['SSLKeyLogFile'] || sslkeylogfile,
-      'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
-      'Proxies'       => proxies,
-      'Timeout'       => (opts['ConnectTimeout'] || connect_timeout || 10).to_i,
-      'Comm'          =>  opts['Comm'],
-      'Context'       =>
-        {
-          'Msf'        => framework,
-          'MsfExploit' => self,
-        })
+    begin
+      nsock = Rex::Socket::Tcp.create(
+        'PeerHost'      =>  opts['RHOST'] || rhost,
+        'PeerHostname'  =>  opts['SSLServerNameIndication'] || opts['VHOST'] || opts['RHOSTNAME'],
+        'PeerPort'      => (opts['RPORT'] || rport).to_i,
+        'LocalHost'     =>  opts['CHOST'] || chost || "0.0.0.0",
+        'LocalPort'     => (opts['CPORT'] || cport || 0).to_i,
+        'SSL'           =>  dossl,
+        'SSLVersion'    =>  opts['SSLVersion'] || ssl_version,
+        'SSLVerifyMode' =>  opts['SSLVerifyMode'] || ssl_verify_mode,
+        'SSLKeyLogFile' =>  opts['SSLKeyLogFile'] || sslkeylogfile,
+        'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
+        'Proxies'       => proxies,
+        'Timeout'       => (opts['ConnectTimeout'] || connect_timeout || 10).to_i,
+        'Comm'          =>  opts['Comm'],
+        'Context'       =>
+          {
+            'Msf'        => framework,
+            'MsfExploit' => self,
+          })
+    rescue ::Rex::ConnectionRefused
+      report_host(host: opts['RHOST'] || rhost)
+      raise
+    end
+
+    report_host(host: opts['RHOST'] || rhost)
 
     # enable evasions on this socket
     set_tcp_evasions(nsock)

--- a/spec/lib/msf/core/exploit/remote/tcp_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/tcp_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::Tcp do
+  include_context 'Msf::Simple::Framework'
+
+  subject do
+    mod = ::Msf::Exploit::Remote.new({})
+    mod.extend described_class
+    allow(mod).to receive(:framework).and_return(framework)
+    mod
+  end
+
+  before(:each) do
+    allow(subject).to receive(:rhost).and_return('10.0.0.10')
+    allow(subject).to receive(:rport).and_return(21)
+  end
+
+  describe '#connect' do
+    context 'when the connection is refused' do
+      before(:each) do
+        allow(Rex::Socket::Tcp).to receive(:create).and_raise(Rex::ConnectionRefused.new('10.0.0.10', 21))
+      end
+
+      it 'reports the host as up' do
+        expect(subject).to receive(:report_host).with(host: '10.0.0.10')
+        subject.connect rescue nil
+      end
+
+      it 're-raises the exception' do
+        allow(subject).to receive(:report_host)
+        expect { subject.connect }.to raise_error(Rex::ConnectionRefused)
+      end
+    end
+
+    context 'when the connection succeeds' do
+      let(:mock_socket) { double('Rex::Socket::Tcp') }
+
+      before(:each) do
+        allow(Rex::Socket::Tcp).to receive(:create).and_return(mock_socket)
+      end
+
+      it 'reports the host as up' do
+        expect(subject).to receive(:report_host).with(host: '10.0.0.10')
+        subject.connect
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related: https://github.com/rapid7/metasploit-framework/pull/21380#discussion_r3196236916

The idea is, use report_host to record if the host is up, but the service isn't.
Previously would only record if the host & service was up.

I had put it into the FTP mixin, @cdelafuente-r7 suggested doing it in the TCP.

- - -

# Demo 1

There is telnet service on the target, but its not vulnerable to it:

## Before

...picking a random exploit which will not work (target is metaploitable 2):

```console
$ ./msfconsole -q -x 'db_status; workspace -D;
use exploit/windows/telnet/goodtech_telnet;
set LHOST tap0;
set RHOSTS 10.0.0.10;
run;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
LHOST => tap0
RHOSTS => 10.0.0.10
[*] Started reverse TCP handler on 10.0.0.1:4444
[-] 10.0.0.10:2380 - Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (10.0.0.10:2380).
[*] Exploit completed, but no session was created.
msf exploit(windows/telnet/goodtech_telnet) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf exploit(windows/telnet/goodtech_telnet) >
```

## After

```console
$ git checkout tcp_report_host
Switched to branch 'tcp_report_host'
Your branch is up to date with 'origin/tcp_report_host'.
$ ./msfconsole -q -x 'db_status; workspace -D;
use exploit/windows/telnet/goodtech_telnet;
set LHOST tap0;
set RHOSTS 10.0.0.10;
run;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
LHOST => tap0
RHOSTS => 10.0.0.10
[*] Started reverse TCP handler on 10.0.0.1:4444
[-] 10.0.0.10:2380 - Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (10.0.0.10:2380).
[*] Exploit completed, but no session was created.
msf exploit(windows/telnet/goodtech_telnet) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf exploit(windows/telnet/goodtech_telnet) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf exploit(windows/telnet/goodtech_telnet) >
```

- - - 

# Demo 2

There isn't rdp service on the target at all.

## Before

```console
$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

$ ./msfconsole -q -x 'db_status; workspace -D;
use exploit/windows/rdp/rdp_doublepulsar_rce;
set LHOST tap0;
set RHOSTS 10.0.0.10;
run;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
LHOST => tap0
RHOSTS => 10.0.0.10
[*] Started reverse TCP handler on 10.0.0.1:4444
[-] 10.0.0.10:3389 - Exploit aborted due to failure: disconnected: The connection was refused by the remote host (10.0.0.10:3389).
[*] Exploit completed, but no session was created.
msf exploit(windows/rdp/rdp_doublepulsar_rce) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf exploit(windows/rdp/rdp_doublepulsar_rce) >
```

## After

```console
$ git checkout tcp_report_host
Switched to branch 'tcp_report_host'
Your branch is up to date with 'origin/tcp_report_host'.

$ ./msfconsole -q -x 'db_status; workspace -D;
use exploit/windows/rdp/rdp_doublepulsar_rce;
set LHOST tap0;
set RHOSTS 10.0.0.10;
run;'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
LHOST => tap0
RHOSTS => 10.0.0.10
[*] Started reverse TCP handler on 10.0.0.1:4444
[-] 10.0.0.10:3389 - Exploit aborted due to failure: disconnected: The connection was refused by the remote host (10.0.0.10:3389).
[*] Exploit completed, but no session was created.
msf exploit(windows/rdp/rdp_doublepulsar_rce) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf exploit(windows/rdp/rdp_doublepulsar_rce) >
```