### PR TITLE
Replace kernel_arch with get_os_architecture

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -6,6 +6,7 @@ module Msf
       module Kernel
         include ::Msf::Post::Common
         include Msf::Post::File
+        include Msf::Post::Architecture
 
         #
         # Returns uname output
@@ -56,30 +57,7 @@ module Msf
           uname('-m')
         end
 
-        #
-        # Returns the kernel hardware architecture
-        # Based on values from https://en.wikipedia.org/wiki/Uname
-        #
-        # @return [String]
-        #
-        def kernel_arch
-          arch = kernel_hardware
-          return ARCH_X64 if arch == 'x86_64' || arch == 'amd64'
-          return ARCH_AARCH64 if arch == 'aarch64' || arch == 'arm64'
-          return ARCH_ARMLE if arch.start_with? 'arm'
-          return ARCH_X86 if arch.end_with? '86'
-          return ARCH_PPC if arch == 'ppc'
-          return ARCH_PPC64 if arch == 'ppc64'
-          return ARCH_PPC64LE if arch == 'ppc64le'
-          return ARCH_MIPS if arch == 'mips'
-          return ARCH_MIPS64 if arch == 'mips64'
-          return ARCH_SPARC if arch == 'sparc'
-          return ARCH_RISCV32LE if arch == 'riscv32'
-          return ARCH_RISCV64LE if arch == 'riscv64'
-          return ARCH_LOONGARCH64 if arch == 'loongarch64'
-
-          arch
-        end
+        alias :kernel_arch :get_os_architecture
 
         #
         # Returns the kernel boot config with comments removed

--- a/spec/lib/msf/core/post/linux/kernel_spec.rb
+++ b/spec/lib/msf/core/post/linux/kernel_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe Msf::Post::Linux::Kernel do
 
   describe '#kernel_arch' do
     context 'it returns an ubuntu kernel arch' do
+      subject do
+        mod = Msf::Module.new
+        mod.extend(Msf::Post::Linux::Kernel)
+        mod.define_singleton_method(:session) { @session }
+        mod.instance_variable_set(:@session, double('session', type: 'shell', platform: 'linux'))
+        mod
+      end
+
       it 'returns x64' do
         allow(subject).to receive(:cmd_exec).and_return('x86_64 ')
         expect(subject.kernel_arch).to eq('x64')
@@ -62,8 +70,8 @@ RSpec.describe Msf::Post::Linux::Kernel do
         allow(subject).to receive(:cmd_exec).and_return('aarch64 ')
         expect(subject.kernel_arch).to eq('aarch64')
       end
-      it 'returns aarch64' do
-        allow(subject).to receive(:cmd_exec).and_return('arm ')
+      it 'returns armle' do
+        allow(subject).to receive(:cmd_exec).and_return('armv7l ')
         expect(subject.kernel_arch).to eq('armle')
       end
       it 'returns x86' do
@@ -82,9 +90,9 @@ RSpec.describe Msf::Post::Linux::Kernel do
         allow(subject).to receive(:cmd_exec).and_return('ppc64le ')
         expect(subject.kernel_arch).to eq('ppc64le')
       end
-      it 'returns mips' do
+      it 'returns mipsbe' do
         allow(subject).to receive(:cmd_exec).and_return('mips ')
-        expect(subject.kernel_arch).to eq('mips')
+        expect(subject.kernel_arch).to eq('mipsbe')
       end
       it 'returns mips64' do
         allow(subject).to receive(:cmd_exec).and_return('mips64 ')


### PR DESCRIPTION
Now that #21418 has been merged, Metasploit has a platform agnostic way to obtain the OS/Kernel architecture. This technique has the added benefit of supporting meterpreter sessions directly (meaning we don't always run `uname`).
This PR removes the now redundant Linux-specific method so there's a single source of truth that works in a superset of platform / session-type combinations.