### PR TITLE
Use #check_simple and #run_simple for datastore option validation

### DIFF
--- a/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass.rb
@@ -248,7 +248,7 @@ class MetasploitModule < Msf::Auxiliary
     file_handle.close
     handler.datastore['USERPASS_FILE'] = 'netgear_pnpx_wordlist.txt'
     print_status("Attempting to log in with #{username}:#{password}. You should get a new telnet session as the root user")
-    handler.run
+    handler.run_simple
     File.delete('netgear_pnpx_wordlist.txt') if File.exist?('netgear_pnpx_wordlist.txt') # Remove the file once we are done.
   end
 end

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -215,7 +215,7 @@ class MetasploitModule < Msf::Post
     results = runnable_exploits.map.with_index do |mod, index|
       print "%bld%blu[*]%clr Running check method for exploit #{index + 1} / #{runnable_exploits.count}\r"
       begin
-        checkcode = mod[:module].check
+        checkcode = mod[:module].check_simple
       rescue StandardError => e
         elog("#Local Exploit Suggester failed with: #{e.class} when using #{mod[:module].shortname}", error: e)
         vprint_error "Check with module #{mod[:module].fullname} failed with error #{e.class}"

--- a/modules/post/multi/recon/persistence_suggester.rb
+++ b/modules/post/multi/recon/persistence_suggester.rb
@@ -239,7 +239,7 @@ class MetasploitModule < Msf::Post
     results = runnable_exploits.map.with_index do |mod, index|
       print "%bld%blu[*]%clr Running check method for exploit #{index + 1} / #{runnable_exploits.count}\r"
       begin
-        checkcode = mod[:module].check
+        checkcode = mod[:module].check_simple
       rescue StandardError => e
         elog("#Local Persistence Suggester failed with: #{e.class} when using #{mod[:module].shortname}", error: e)
         vprint_error "Check with module #{mod[:module].fullname} failed with error #{e.class}"


### PR DESCRIPTION
## Summary

Three modules were invoking check and run methods directly, bypassing datastore option validation. This PR updates them to use the _simple API variants which ensure proper validation occurs before module execution.

## Changes

- `post/multi/recon/persistence_suggester` — replace `mod[:module].check` with `mod[:module].check_simple`
- `post/multi/recon/local_exploit_suggester` — same fix
- `auxiliary/admin/http/netgear_pnpx_getsharefolderlist_auth_bypass` — replace `handler.run` with `handler.run_simple`

## Verification

Changes are minimal and isolated to the three lines identified in the parent issue. No functional logic was altered.

Fixes #21316
Fixes #21317
Fixes #21318
Parent issue: #21313