### PR TITLE
reload_lib: Stop caching results since startup

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -25,11 +25,6 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     ['-d', '--debug'] => [true,  'Debug the current history manager contexts.']
   )
 
-  def initialize(driver)
-    super
-    @modified_files = modified_file_paths(print_errors: false)
-  end
-
   def name
     'Developer'
   end
@@ -83,13 +78,13 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     load full_path
   end
 
-  # @return [Array<String>] The list of modified file paths since startup
+  # @return [Array<String>] The list of modified file paths relative to upstream
   def modified_file_paths(print_errors: true)
     files, is_success = modified_files
 
     unless is_success
-      print_error("Git is not available") if print_errors
-      files = []
+      print_error('Git is not available') if print_errors
+      return []
     end
 
     ignored_patterns = %w[
@@ -98,11 +93,9 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       **/*_spec.rb
       **/spec_helper.rb
     ]
-    @modified_files ||= []
-    @modified_files |= files.reject do |file|
+    files.reject do |file|
       ignored_patterns.any? { |pattern| File.fnmatch(pattern, file) }
     end
-    @modified_files
   end
 
   def cmd_irb_help


### PR DESCRIPTION
Follow on from https://github.com/rapid7/metasploit-framework/pull/21382

Noticed a bug, it looks like, the results (aka file changed) are cached since starting up, rather than what IS there.


## Before

`lib/msf/ui/console/command_dispatcher/developer.rb` is showing up, as this is from `reload_all` branch, rather than master. Hopefully when #21382 is merged in, this will not show up.

```console
$ git status
On branch reload_all
Your branch is up to date with 'origin/reload_all'.

nothing to commit, working tree clean
$
$ echo "# foo" >> lib/msf/base/sessions/command_shell_options.rb
$ ./msfconsole -q -x 'git restore lib/msf/base/sessions/command_shell_options.rb; reload_lib -a; exit;'
[*] exec: git restore lib/msf/base/sessions/command_shell_options.rb

[*] Reloading /usr/share/metasploit-framework2/lib/msf/base/sessions/command_shell_options.rb
[*] Reloading /usr/share/metasploit-framework2/lib/msf/ui/console/command_dispatcher/developer.rb
$
```

## After

Notice now, how `lib/msf/base/sessions/command_shell_options.rb` doesn't show up, after its been restored, since msfconsole started up?

```console
$ vim lib/msf/ui/console/command_dispatcher/developer.rb
$ git diff
diff --git a/lib/msf/ui/console/command_dispatcher/developer.rb b/lib/msf/ui/console/command_dispatcher/developer.rb
index 9363601702..769b5f4c78 100644
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -25,11 +25,6 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     ['-d', '--debug'] => [true,  'Debug the current history manager contexts.']
   )

-  def initialize(driver)
-    super
-    @modified_files = modified_file_paths(print_errors: false)
-  end
-
   def name
     'Developer'
   end
@@ -83,13 +78,13 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     load full_path
   end

-  # @return [Array<String>] The list of modified file paths since startup
+  # @return [Array<String>] The list of modified file paths relative to upstream
   def modified_file_paths(print_errors: true)
     files, is_success = modified_files

     unless is_success
-      print_error("Git is not available") if print_errors
-      files = []
+      print_error('Git is not available') if print_errors
+      return []
     end

     ignored_patterns = %w[
@@ -98,11 +93,9 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       **/*_spec.rb
       **/spec_helper.rb
     ]
-    @modified_files ||= []
-    @modified_files |= files.reject do |file|
+    files.reject do |file|
       ignored_patterns.any? { |pattern| File.fnmatch(pattern, file) }
     end
-    @modified_files
   end

   def cmd_irb_help
@@ -557,3 +550,4 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     'master'
   end
 end
+
$ echo "# foo" >> lib/msf/base/sessions/command_shell_options.rb
$ ./msfconsole -q -x 'git restore lib/msf/base/sessions/command_shell_options.rb; reload_lib -a; exit;'
[*] exec: git restore lib/msf/base/sessions/command_shell_options.rb

[*] Reloading /usr/share/metasploit-framework2/lib/msf/ui/console/command_dispatcher/developer.rb
$
```