### PR TITLE
reload_lib: Misc improvements

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -298,6 +298,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       return print(options.help)
     end
 
+    print_status("Reloading #{files.length} library #{'file'.pluralize(files.length)}...")
     files.each do |file|
       reload_file(file)
     rescue ScriptError, StandardError => e

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -288,7 +288,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     end
 
     # The remaining unparsed arguments are files
-    files.concat(options.order(args))
+    files.concat(options.permute(args))
     files.uniq!
 
     return print(options.help) if files.empty?

--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -271,6 +271,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
   #
   def cmd_reload_lib(*args)
     files = []
+    use_modified = false
     options = OptionParser.new do |opts|
       opts.banner = 'Usage: reload_lib lib/to/reload.rb [...]'
       opts.separator ''
@@ -283,6 +284,7 @@ class Msf::Ui::Console::CommandDispatcher::Developer
 
       opts.on '-a', '--all', 'Reload all* changed files in your current Git working tree.
                                      *Excludes modules and non-Ruby files.' do
+        use_modified = true
         files.concat(modified_file_paths)
       end
     end
@@ -291,7 +293,10 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     files.concat(options.permute(args))
     files.uniq!
 
-    return print(options.help) if files.empty?
+    if files.empty?
+      return print_status('Nothing to reload') if use_modified
+      return print(options.help)
+    end
 
     files.each do |file|
       reload_file(file)


### PR DESCRIPTION
Follow on from https://github.com/rapid7/metasploit-framework/pull/21382

I noticed a bug, it looks like `reload_all` isn't doing `reload_lib`.

There is the following commands:

- `reload`
- `reload_lib`
- `reload_all`

To me, `reload_all` sounds like it should reload _everything_. 
But as far as I can tell, it currently doesn't do `reload_lib`. This PR make sure `reload_all` also does `reload_lib --all`.

## Before

There is no output about library files being reloaded when doing `reload_all`.

```console
$ git status
On branch reload_all
Your branch is up to date with 'origin/reload_all'.

nothing to commit, working tree clean
$
$ echo "# foo" >> lib/msf/base/sessions/command_shell_options.rb
$ $ ./msfconsole -q -x 'reload_all; exit;'
[*] Reloading modules from all module paths...
 ______________________________________
/ it looks like you're trying to run a \
\ module                               /
 --------------------------------------
 \
  \
     __
    /  \
    |  |
    @  @
    |  |
    || |/
    || ||
    |\_/|
    \___/


       =[ metasploit v6.4.133-dev-7c49fee549                    ]
+ -- --=[ 2,645 exploits - 1,334 auxiliary - 2,141 payloads     ]
+ -- --=[ 431 post - 49 encoders - 14 nops - 12 evasion         ]

Metasploit Documentation: https://docs.metasploit.com/
The Metasploit Framework is a Rapid7 Open Source Project

$
```

## After

```console
$ vim lib/msf/ui/console/command_dispatcher/developer.rb
$ vim lib/msf/ui/console/command_dispatcher/modules.rb
$ git diff
diff --git a/lib/msf/base/sessions/command_shell_options.rb b/lib/msf/base/sessions/command_shell_options.rb
index b0b620d041..e1a43e4a11 100644
--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -58,3 +58,4 @@ module CommandShellOptions
 end
 end
 end
+# foo
diff --git a/lib/msf/ui/console/command_dispatcher/developer.rb b/lib/msf/ui/console/command_dispatcher/developer.rb
index 9363601702..7136fe4b7a 100644
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -105,6 +105,14 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     @modified_files
   end

+  def reload_modified_lib_files
+    files = modified_file_paths
+    return if files.empty?
+
+    print_status("Reloading #{files.length} modified library #{'file'.pluralize(files.length)}...")
+    files.each { |file| reload_file(file) }
+  end
+
   def cmd_irb_help
     print_line 'Usage: irb'
     print_line
@@ -283,7 +291,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer

       opts.on '-a', '--all', 'Reload all* changed files in your current Git working tree.
                                      *Excludes modules and non-Ruby files.' do
-        files.concat(modified_file_paths)
+        reload_modified_lib_files
+        return
       end
     end

@@ -557,3 +566,4 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     'master'
   end
 end
+
diff --git a/lib/msf/ui/console/command_dispatcher/modules.rb b/lib/msf/ui/console/command_dispatcher/modules.rb
index bda3662305..a1608334ee 100644
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1081,6 +1081,9 @@ module Msf
             print_status("Reloading modules from all module paths...")
             framework.modules.reload_modules

+            dev = driver.dispatcher_stack.find { |d| d.is_a?(Msf::Ui::Console::CommandDispatcher::Developer) }
+            dev&.reload_modified_lib_files
+
             log_msg = "Please see #{File.join(Msf::Config.log_directory, 'framework.log')} for details."

             # Check for modules that failed to load
@@ -1838,3 +1841,4 @@ module Msf
     end
   end
 end
+
$ ./msfconsole -q -x 'reload_all; exit;'
[*] Reloading modules from all module paths...
[*] Reloading 3 modified library files...
[*] Reloading /usr/share/metasploit-framework2/lib/msf/base/sessions/command_shell_options.rb
[*] Reloading /usr/share/metasploit-framework2/lib/msf/ui/console/command_dispatcher/developer.rb
[*] Reloading /usr/share/metasploit-framework2/lib/msf/ui/console/command_dispatcher/modules.rb

 ______________________________________________________________________________
|                                                                              |
|                          3Kom SuperHack II Logon                             |
|______________________________________________________________________________|
|                                                                              |
|                                                                              |
|                                                                              |
|                 User Name:          [   security    ]                        |
|                                                                              |
|                 Password:           [               ]                        |
|                                                                              |
|                                                                              |
|                                                                              |
|                                   [ OK ]                                     |
|______________________________________________________________________________|
|                                                                              |
|                                                       https://metasploit.com |
|______________________________________________________________________________|


       =[ metasploit v6.4.133-dev-7c49fee549                    ]
+ -- --=[ 2,645 exploits - 1,334 auxiliary - 2,141 payloads     ]
+ -- --=[ 431 post - 49 encoders - 14 nops - 12 evasion         ]

Metasploit Documentation: https://docs.metasploit.com/
The Metasploit Framework is a Rapid7 Open Source Project

$
```