### PR TITLE
implement graceful shutdown for Puma server

### DIFF
--- a/config/mcp_config.yaml.example
+++ b/config/mcp_config.yaml.example
@@ -15,6 +15,10 @@ mcp:
   # MCP server network configuration (for HTTP transport only)
   host: localhost  # Host to bind to (default: localhost)
   port: 3000       # Port to listen on (default: 3000)
+  # Puma server tuning (for HTTP transport only)
+  # min_threads: 0   # Minimum thread pool size (default: 0)
+  # max_threads: 5   # Maximum thread pool size (default: 5)
+  # workers: 0       # Number of worker processes (default: 0, single-process mode)
 
 # Rate limiting (optional - defaults shown)
 rate_limit:

--- a/config/mcp_config_jsonrpc.yaml.example
+++ b/config/mcp_config_jsonrpc.yaml.example
@@ -14,6 +14,10 @@ mcp:
   # MCP server network configuration (for HTTP transport only)
   host: localhost  # Host to bind to (default: localhost)
   port: 3000       # Port to listen on (default: 3000)
+  # Puma server tuning (for HTTP transport only)
+  # min_threads: 0   # Minimum thread pool size (default: 0)
+  # max_threads: 5   # Maximum thread pool size (default: 5)
+  # workers: 0       # Number of worker processes (default: 0, single-process mode)
 
 # Rate limiting (optional - defaults shown)
 rate_limit:

--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -273,10 +273,14 @@ module Msf::MCP
       port = @config.dig(:mcp, :port) || 3000
 
       if transport == :http
+        min_threads = @config.dig(:mcp, :min_threads) || Msf::MCP::Server::PUMA_MIN_THREADS
+        max_threads = @config.dig(:mcp, :max_threads) || Msf::MCP::Server::PUMA_MAX_THREADS
+        workers = @config.dig(:mcp, :workers) || Msf::MCP::Server::PUMA_WORKERS
+
         @output.puts "Starting MCP server on HTTP transport..."
         @output.puts "Server listening on http://#{host}:#{port}"
         @output.puts "Press Ctrl+C to shutdown"
-        @mcp_server.start(transport: :http, host: host, port: port)
+        @mcp_server.start(transport: :http, host: host, port: port, min_threads: min_threads, max_threads: max_threads, workers: workers)
       else
         @output.puts "Starting MCP server on stdio transport..."
         @output.puts "Server ready - waiting for MCP requests"

--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -74,7 +74,9 @@ module Msf::MCP
         context: { signal: "SIG#{signal}" }
       }, LOG_SOURCE, LOG_INFO)
       @mcp_server&.shutdown
+      @mcp_server = nil
       @rpc_manager&.stop_rpc_server
+      @rpc_manager = nil
       @output.puts "\nShutdown complete"
     end
 
@@ -162,10 +164,17 @@ module Msf::MCP
 
     # Install signal handlers for graceful shutdown
     #
+    # Puma installs its own INT/TERM handlers which override Signal.trap,
+    # so we use at_exit to ensure cleanup happens regardless of how the
+    # process terminates.
+    #
     # @return [void]
     def install_signal_handlers
-      Signal.trap('INT') { shutdown('INT'); exit 0 }
-      Signal.trap('TERM') { shutdown('TERM'); exit 0 }
+      at_exit do
+        shutdown('EXIT') if @mcp_server
+      rescue StandardError
+        nil
+      end
     end
 
     # Load configuration from file or use defaults

--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -35,7 +35,7 @@ module Msf::MCP
     # @return [void]
     def run
       parse_arguments
-      install_signal_handlers
+      register_exit_handler
       load_configuration
       validate_configuration
       initialize_logger
@@ -66,12 +66,10 @@ module Msf::MCP
     # - Closes MCP server and Metasploit client connections
     # - Cleans up resources
     #
-    # @param signal [String] Signal name (e.g., 'INT', 'TERM')
     # @return [void]
-    def shutdown(signal = 'INT')
+   def shutdown
       ilog({
-        message: 'Shutting down',
-        context: { signal: "SIG#{signal}" }
+        message: 'Shutting down'
       }, LOG_SOURCE, LOG_INFO)
       @mcp_server&.shutdown
       @mcp_server = nil
@@ -162,16 +160,16 @@ module Msf::MCP
       register_log_source(LOG_SOURCE, sink, threshold)
     end
 
-    # Install signal handlers for graceful shutdown
+    # Register an at_exit hook for graceful shutdown
     #
     # Puma installs its own INT/TERM handlers which override Signal.trap,
     # so we use at_exit to ensure cleanup happens regardless of how the
     # process terminates.
     #
     # @return [void]
-    def install_signal_handlers
+    def register_exit_handler
       at_exit do
-        shutdown('EXIT') if @mcp_server
+        shutdown if @mcp_server
       rescue StandardError
         nil
       end

--- a/lib/msf/core/mcp/config/loader.rb
+++ b/lib/msf/core/mcp/config/loader.rb
@@ -72,6 +72,9 @@ module Msf::MCP
         if config[:mcp][:transport] == 'http'
           config[:mcp][:host] ||= Defaults::MCP_HOST
           config[:mcp][:port] ||= Defaults::MCP_PORT
+          config[:mcp][:min_threads] ||= 0
+          config[:mcp][:max_threads] ||= 5
+          config[:mcp][:workers] ||= 0
         end
 
         config[:rate_limit][:enabled] = config[:rate_limit].fetch(:enabled, true)
@@ -109,6 +112,11 @@ module Msf::MCP
         # MCP server network overrides
         config[:mcp][:host] = ENV['MSF_MCP_HOST'] if ENV['MSF_MCP_HOST']
         config[:mcp][:port] = ENV['MSF_MCP_PORT'].to_i if ENV['MSF_MCP_PORT']
+
+        # MCP Puma server tuning overrides
+        config[:mcp][:min_threads] = ENV['MSF_MCP_MIN_THREADS'].to_i if ENV['MSF_MCP_MIN_THREADS']
+        config[:mcp][:max_threads] = ENV['MSF_MCP_MAX_THREADS'].to_i if ENV['MSF_MCP_MAX_THREADS']
+        config[:mcp][:workers] = ENV['MSF_MCP_WORKERS'].to_i if ENV['MSF_MCP_WORKERS']
       end
 
       # Parse a string value into a boolean

--- a/lib/msf/core/mcp/config/loader.rb
+++ b/lib/msf/core/mcp/config/loader.rb
@@ -72,9 +72,9 @@ module Msf::MCP
         if config[:mcp][:transport] == 'http'
           config[:mcp][:host] ||= Defaults::MCP_HOST
           config[:mcp][:port] ||= Defaults::MCP_PORT
-          config[:mcp][:min_threads] ||= 0
-          config[:mcp][:max_threads] ||= 5
-          config[:mcp][:workers] ||= 0
+          config[:mcp][:min_threads] ||= Msf::MCP::Server::PUMA_MIN_THREADS
+          config[:mcp][:max_threads] ||= Msf::MCP::Server::PUMA_MAX_THREADS
+          config[:mcp][:workers] ||= Msf::MCP::Server::PUMA_WORKERS
         end
 
         config[:rate_limit][:enabled] = config[:rate_limit].fetch(:enabled, true)

--- a/lib/msf/core/mcp/config/validator.rb
+++ b/lib/msf/core/mcp/config/validator.rb
@@ -75,6 +75,34 @@ module Msf::MCP
           end
         end
 
+        # Validate MCP Puma thread/worker settings
+        if config[:mcp].is_a?(Hash)
+          if config[:mcp].key?(:min_threads)
+            unless config[:mcp][:min_threads].is_a?(Integer) && config[:mcp][:min_threads] >= 0
+              errors[:'mcp.min_threads'] = "must be an integer >= 0"
+            end
+          end
+
+          if config[:mcp].key?(:max_threads)
+            unless config[:mcp][:max_threads].is_a?(Integer) && config[:mcp][:max_threads] >= 1
+              errors[:'mcp.max_threads'] = "must be an integer >= 1"
+            end
+          end
+
+          if config[:mcp].key?(:workers)
+            unless config[:mcp][:workers].is_a?(Integer) && config[:mcp][:workers] >= 0
+              errors[:'mcp.workers'] = "must be an integer >= 0"
+            end
+          end
+
+          if config[:mcp].key?(:min_threads) && config[:mcp].key?(:max_threads)
+            if config[:mcp][:min_threads].is_a?(Integer) && config[:mcp][:max_threads].is_a?(Integer) &&
+               config[:mcp][:min_threads] > config[:mcp][:max_threads]
+              errors[:'mcp.min_threads'] = "must be less than or equal to mcp.max_threads"
+            end
+          end
+        end
+
         # Validate conditional requirements based on API type
         if config[:msf_api][:type] == 'messagepack'
           validate_messagepack_auth(config, errors)

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -14,6 +14,11 @@ module Msf::MCP
   #
   class Server
 
+    # Puma thread pool configuration defaults
+    PUMA_MIN_THREADS = 0
+    PUMA_MAX_THREADS = 5
+    PUMA_WORKERS = 0
+
     ##
     # Initialize the MCP server with required dependencies
     #
@@ -64,12 +69,12 @@ module Msf::MCP
     # @return [MCP::Server] The MCP server instance (for testing purposes)
     # @raise [ArgumentError] If an unknown transport is specified
     #
-    def start(transport: :stdio, host: 'localhost', port: 3000)
+    def start(transport: :stdio, host: 'localhost', port: 3000, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
       case transport
       when :stdio
         start_stdio
       when :http
-        start_http(host, port)
+        start_http(host, port, min_threads: min_threads, max_threads: max_threads, workers: workers)
       else
         raise ArgumentError, "Unknown transport: #{transport}. Use :stdio or :http"
       end
@@ -79,6 +84,13 @@ module Msf::MCP
     # Shutdown the MCP server and cleanup resources
     #
     def shutdown
+      @puma_launcher&.stop
+    rescue StandardError => e
+      elog("Error stopping Puma: #{e.message}", LOG_SOURCE)
+    ensure
+      @puma_log_io&.close
+      @puma_launcher = nil
+      @puma_log_io = nil
       @msf_client&.shutdown
       @mcp_server = nil
     end
@@ -108,9 +120,12 @@ module Msf::MCP
     #
     # @return [MCP::Server] The MCP server instance (for testing purposes)
     #
-    def start_http(host, port)
-      require 'rackup'
-      require 'rack/handler/puma'
+    def start_http(host, port, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
+      require 'rack'
+      require 'puma'
+      require 'puma/configuration'
+      require 'puma/launcher'
+      require 'puma/log_writer'
 
       transport = ::MCP::Server::Transports::StreamableHTTPTransport.new(@mcp_server)
 
@@ -121,12 +136,33 @@ module Msf::MCP
         run transport
       end
 
-      Rackup::Handler::Puma.run(
-        rack_app,
-        Port: port,
-        Host: host,
-        Silent: true
-      )
+      # Use Puma's server API directly so we can stop it gracefully on shutdown.
+      bind_host = host.include?(':') ? "[#{host}]" : host
+      @puma_log_io = File.open(File::NULL, 'w')
+      begin
+        puma_config = Puma::Configuration.new do |config|
+          config.bind "tcp://#{bind_host}:#{port}"
+          config.threads min_threads, max_threads
+          config.workers workers
+          config.log_requests false
+          config.app rack_app
+        end
+
+        # Suppress Puma's startup banner by providing a silent log writer
+        log_writer = Puma::LogWriter.new(@puma_log_io, @puma_log_io)
+        @puma_launcher = Puma::Launcher.new(puma_config, log_writer: log_writer)
+        @puma_launcher.run
+      rescue StandardError
+        begin
+          @puma_launcher&.stop
+        rescue StandardError
+          nil
+        end
+        @puma_launcher = nil
+        @puma_log_io&.close
+        @puma_log_io = nil
+        raise
+      end
 
       @mcp_server
     end

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -65,6 +65,9 @@ module Msf::MCP
     # @param transport [Symbol] Transport type (:stdio or :http)
     # @param host [String] Host address for HTTP transport (default: 'localhost')
     # @param port [Integer] Port number for HTTP transport (default: 3000)
+    # @param min_threads [Integer] Minimum number of Puma threads (default: PUMA_MIN_THREADS)
+    # @param max_threads [Integer] Maximum number of Puma threads (default: PUMA_MAX_THREADS)
+    # @param workers [Integer] Number of Puma worker processes (default: PUMA_WORKERS)
     #
     # @return [MCP::Server] The MCP server instance (for testing purposes)
     # @raise [ArgumentError] If an unknown transport is specified
@@ -86,7 +89,7 @@ module Msf::MCP
     def shutdown
       @puma_launcher&.stop
     rescue StandardError => e
-      elog("Error stopping Puma: #{e.message}", LOG_SOURCE)
+      elog({ message: 'Error stopping Puma', exception: e }, LOG_SOURCE, LOG_ERROR)
     ensure
       @puma_log_io&.close
       @puma_launcher = nil
@@ -117,6 +120,9 @@ module Msf::MCP
     #
     # @param host [String] Host address to bind to
     # @param port [Integer] Port to listen on
+    # @param min_threads [Integer] Minimum number of Puma threads
+    # @param max_threads [Integer] Maximum number of Puma threads
+    # @param workers [Integer] Number of Puma worker processes
     #
     # @return [MCP::Server] The MCP server instance (for testing purposes)
     #

--- a/spec/lib/msf/core/mcp/application_spec.rb
+++ b/spec/lib/msf/core/mcp/application_spec.rb
@@ -196,12 +196,10 @@ RSpec.describe Msf::MCP::Application do
   end
 
   describe '#install_signal_handlers' do
-    it 'installs signal handlers for INT and TERM' do
+    it 'registers an at_exit handler for cleanup' do
       app = described_class.new([], output: output)
 
-      # Mock Signal.trap to avoid actually installing handlers in tests
-      expect(Signal).to receive(:trap).with('INT')
-      expect(Signal).to receive(:trap).with('TERM')
+      expect(app).to receive(:at_exit)
 
       app.send(:install_signal_handlers)
     end

--- a/spec/lib/msf/core/mcp/application_spec.rb
+++ b/spec/lib/msf/core/mcp/application_spec.rb
@@ -195,13 +195,13 @@ RSpec.describe Msf::MCP::Application do
     end
   end
 
-  describe '#install_signal_handlers' do
+  describe '#register_exit_handler' do
     it 'registers an at_exit handler for cleanup' do
       app = described_class.new([], output: output)
 
       expect(app).to receive(:at_exit)
 
-      app.send(:install_signal_handlers)
+      app.send(:register_exit_handler)
     end
   end
 
@@ -437,14 +437,14 @@ RSpec.describe Msf::MCP::Application do
   describe '#shutdown' do
     it 'outputs shutdown complete' do
       app = described_class.new([], output: output)
-      app.shutdown('INT')
+      app.shutdown
 
       expect(output.string).to include('Shutdown complete')
     end
 
     it 'does not raise when no Rex sink is registered' do
       app = described_class.new([], output: output)
-      expect { app.shutdown('TERM') }.not_to raise_error
+      expect { app.shutdown }.not_to raise_error
     end
 
     it 'calls shutdown on mcp_server when present' do
@@ -455,7 +455,7 @@ RSpec.describe Msf::MCP::Application do
 
       expect(mock_mcp_server).to receive(:shutdown)
 
-      app.shutdown('INT')
+      app.shutdown
 
       expect(output.string).to include('Shutdown complete')
     end
@@ -468,14 +468,14 @@ RSpec.describe Msf::MCP::Application do
 
       expect(mock_rpc_manager).to receive(:stop_rpc_server)
 
-      app.shutdown('INT')
+      app.shutdown
     end
 
     it 'handles nil mcp_server gracefully' do
       app = described_class.new([], output: output)
       app.instance_variable_set(:@mcp_server, nil)
 
-      expect { app.shutdown('INT') }.not_to raise_error
+      expect { app.shutdown }.not_to raise_error
       expect(output.string).to include('Shutdown complete')
     end
 
@@ -483,7 +483,7 @@ RSpec.describe Msf::MCP::Application do
       app = described_class.new([], output: output)
       app.instance_variable_set(:@rpc_manager, nil)
 
-      expect { app.shutdown('INT') }.not_to raise_error
+      expect { app.shutdown }.not_to raise_error
       expect(output.string).to include('Shutdown complete')
     end
   end

--- a/spec/lib/msf/core/mcp/application_spec.rb
+++ b/spec/lib/msf/core/mcp/application_spec.rb
@@ -396,14 +396,20 @@ RSpec.describe Msf::MCP::Application do
       http_config[:mcp] = {
         transport: 'http',
         host: '0.0.0.0',
-        port: 3000
+        port: 3000,
+        min_threads: 0,
+        max_threads: 5,
+        workers: 0
       }
 
       app = described_class.new([], output: output)
       app.instance_variable_set(:@config, http_config)
       app.instance_variable_set(:@mcp_server, mock_mcp_server)
 
-      expect(mock_mcp_server).to receive(:start).with(transport: :http, host: '0.0.0.0', port: 3000)
+      expect(mock_mcp_server).to receive(:start).with(
+        transport: :http, host: '0.0.0.0', port: 3000,
+        min_threads: 0, max_threads: 5, workers: 0
+      )
 
       app.send(:start_mcp_server)
 
@@ -419,7 +425,12 @@ RSpec.describe Msf::MCP::Application do
       app.instance_variable_set(:@config, http_config)
       app.instance_variable_set(:@mcp_server, mock_mcp_server)
 
-      expect(mock_mcp_server).to receive(:start).with(transport: :http, host: 'localhost', port: 3000)
+      expect(mock_mcp_server).to receive(:start).with(
+        transport: :http, host: 'localhost', port: 3000,
+        min_threads: Msf::MCP::Server::PUMA_MIN_THREADS,
+        max_threads: Msf::MCP::Server::PUMA_MAX_THREADS,
+        workers: Msf::MCP::Server::PUMA_WORKERS
+      )
 
       app.send(:start_mcp_server)
     end

--- a/spec/lib/msf/core/mcp/config/loader_spec.rb
+++ b/spec/lib/msf/core/mcp/config/loader_spec.rb
@@ -317,6 +317,21 @@ RSpec.describe Msf::MCP::Config::Loader do
           config = described_class.load_from_hash(config_hash)
           expect(config[:mcp][:port]).to eq(3000)
         end
+
+        it 'sets default min_threads to 0' do
+          config = described_class.load_from_hash(config_hash)
+          expect(config[:mcp][:min_threads]).to eq(0)
+        end
+
+        it 'sets default max_threads to 5' do
+          config = described_class.load_from_hash(config_hash)
+          expect(config[:mcp][:max_threads]).to eq(5)
+        end
+
+        it 'sets default workers to 0' do
+          config = described_class.load_from_hash(config_hash)
+          expect(config[:mcp][:workers]).to eq(0)
+        end
       end
 
       context 'with http transport and explicit values' do
@@ -531,6 +546,7 @@ RSpec.describe Msf::MCP::Config::Loader do
         MSF_API_TYPE MSF_API_HOST MSF_API_PORT MSF_API_SSL MSF_API_ENDPOINT
         MSF_API_USER MSF_API_PASSWORD MSF_API_TOKEN MSF_AUTO_START_RPC
         MSF_MCP_TRANSPORT MSF_MCP_HOST MSF_MCP_PORT
+        MSF_MCP_MIN_THREADS MSF_MCP_MAX_THREADS MSF_MCP_WORKERS
       ]
     end
 
@@ -739,6 +755,33 @@ RSpec.describe Msf::MCP::Config::Loader do
         it 'overrides the MCP port value as integer' do
           config = described_class.load(config_file)
           expect(config[:mcp][:port]).to eq(8080)
+        end
+      end
+
+      context 'when MSF_MCP_MIN_THREADS is set' do
+        before { ENV['MSF_MCP_MIN_THREADS'] = '2' }
+
+        it 'overrides the MCP min_threads value as integer' do
+          config = described_class.load(config_file)
+          expect(config[:mcp][:min_threads]).to eq(2)
+        end
+      end
+
+      context 'when MSF_MCP_MAX_THREADS is set' do
+        before { ENV['MSF_MCP_MAX_THREADS'] = '16' }
+
+        it 'overrides the MCP max_threads value as integer' do
+          config = described_class.load(config_file)
+          expect(config[:mcp][:max_threads]).to eq(16)
+        end
+      end
+
+      context 'when MSF_MCP_WORKERS is set' do
+        before { ENV['MSF_MCP_WORKERS'] = '4' }
+
+        it 'overrides the MCP workers value as integer' do
+          config = described_class.load(config_file)
+          expect(config[:mcp][:workers]).to eq(4)
         end
       end
     end

--- a/spec/lib/msf/core/mcp/config/validator_spec.rb
+++ b/spec/lib/msf/core/mcp/config/validator_spec.rb
@@ -173,6 +173,80 @@ RSpec.describe Msf::MCP::Config::Validator do
       end
     end
 
+    context 'with Puma thread/worker validation' do
+      let(:valid_base) do
+        {
+          msf_api: {
+            type: 'messagepack',
+            host: 'localhost',
+            user: 'msf',
+            password: 'password'
+          },
+          mcp: { transport: 'http' }
+        }
+      end
+
+      it 'accepts valid min_threads value' do
+        config = valid_base.merge(mcp: { transport: 'http', min_threads: 2 })
+        expect(described_class.validate!(config)).to be true
+      end
+
+      it 'accepts valid max_threads value' do
+        config = valid_base.merge(mcp: { transport: 'http', max_threads: 16 })
+        expect(described_class.validate!(config)).to be true
+      end
+
+      it 'accepts valid workers value' do
+        config = valid_base.merge(mcp: { transport: 'http', workers: 4 })
+        expect(described_class.validate!(config)).to be true
+      end
+
+      it 'rejects negative min_threads' do
+        config = valid_base.merge(mcp: { transport: 'http', min_threads: -1 })
+        expect {
+          described_class.validate!(config)
+        }.to raise_error(Msf::MCP::Config::ValidationError) do |error|
+          expect(error.errors[:'mcp.min_threads']).to include('>= 0')
+        end
+      end
+
+      it 'rejects zero max_threads' do
+        config = valid_base.merge(mcp: { transport: 'http', max_threads: 0 })
+        expect {
+          described_class.validate!(config)
+        }.to raise_error(Msf::MCP::Config::ValidationError) do |error|
+          expect(error.errors[:'mcp.max_threads']).to include('>= 1')
+        end
+      end
+
+      it 'rejects negative workers' do
+        config = valid_base.merge(mcp: { transport: 'http', workers: -1 })
+        expect {
+          described_class.validate!(config)
+        }.to raise_error(Msf::MCP::Config::ValidationError) do |error|
+          expect(error.errors[:'mcp.workers']).to include('>= 0')
+        end
+      end
+
+      it 'rejects min_threads greater than max_threads' do
+        config = valid_base.merge(mcp: { transport: 'http', min_threads: 10, max_threads: 5 })
+        expect {
+          described_class.validate!(config)
+        }.to raise_error(Msf::MCP::Config::ValidationError) do |error|
+          expect(error.errors[:'mcp.min_threads']).to include('less than or equal')
+        end
+      end
+
+      it 'rejects non-integer min_threads' do
+        config = valid_base.merge(mcp: { transport: 'http', min_threads: 'abc' })
+        expect {
+          described_class.validate!(config)
+        }.to raise_error(Msf::MCP::Config::ValidationError) do |error|
+          expect(error.errors[:'mcp.min_threads']).to include('>= 0')
+        end
+      end
+    end
+
     context 'with port validation' do
       it 'accepts port 8080' do
         config = {

--- a/spec/lib/msf/core/mcp/server_spec.rb
+++ b/spec/lib/msf/core/mcp/server_spec.rb
@@ -180,17 +180,63 @@ RSpec.describe Msf::MCP::Server do
       let(:mock_http_transport) do
         instance_double(::MCP::Server::Transports::StreamableHTTPTransport)
       end
-
       let(:rack_app) { double('rack_app') }
+      let(:rack_builder) { double('rack_builder', use: nil, run: nil) }
 
       before do
-        require 'rackup'
-        require 'rack/handler/puma'
+        require 'rack'
+        require 'puma'
+        require 'puma/configuration'
+        require 'puma/launcher'
+        require 'puma/log_writer'
+
+        stub_const('Puma::Configuration', puma_config_class)
+        stub_const('Puma::Launcher', puma_launcher_class)
+        stub_const('Puma::LogWriter', puma_log_writer_class)
 
         allow(::MCP::Server::Transports::StreamableHTTPTransport).to receive(:new).and_return(mock_http_transport)
-        allow(Rack::Builder).to receive(:new).and_return(rack_app)
+        allow(Rack::Builder).to receive(:new) do |&block|
+          rack_builder.instance_eval(&block) if block
+          rack_app
+        end
+        allow(File).to receive(:open).with(File::NULL, 'w').and_return(StringIO.new)
+      end
 
-        allow(Rackup::Handler::Puma).to receive(:run)
+      after do
+        server.shutdown
+      end
+
+      let(:puma_config_class) do
+        Class.new do
+          attr_reader :bound_url
+
+          def initialize(&block)
+            block.call(self) if block
+          end
+
+          def bind(url)
+            @bound_url = url
+          end
+
+          def threads(_min, _max); end
+          def workers(_n); end
+          def log_requests(_v); end
+          def app(_a = nil); end
+        end
+      end
+
+      let(:puma_launcher_class) do
+        Class.new do
+          def initialize(_config, **_opts); end
+          def run; end
+          def stop; end
+        end
+      end
+
+      let(:puma_log_writer_class) do
+        Class.new do
+          def initialize(_stdout, _stderr); end
+        end
       end
 
       it 'creates http transport' do
@@ -199,32 +245,47 @@ RSpec.describe Msf::MCP::Server do
         server.start(transport: :http, port: 3000)
       end
 
-      it 'starts Puma server via Rack handler' do
-        expect(Rackup::Handler::Puma).to receive(:run).with(
-          anything,  # Rack app
-          hash_including(
-            Port: 3000,
-            Host: 'localhost'
-          )
-        )
+      it 'starts Puma via Launcher' do
+        expect(puma_launcher_class).to receive(:new).and_call_original
 
         server.start(transport: :http, port: 3000)
       end
 
-      it 'allows custom port' do
-        expect(Rackup::Handler::Puma).to receive(:run).with(
-          anything,
-          hash_including(Port: 8080)
-        )
+      it 'binds to the configured host and port' do
+        config_instance = nil
+        allow(puma_config_class).to receive(:new) do |&block|
+          config_instance = puma_config_class.allocate
+          config_instance.send(:initialize, &block)
+          config_instance
+        end
 
-        server.start(transport: :http, port: 8080)
+        server.start(transport: :http, port: 8080, host: '0.0.0.0')
+
+        expect(config_instance.bound_url).to eq('tcp://0.0.0.0:8080')
+      end
+
+      it 'wraps IPv6 hosts in brackets for the bind URL' do
+        config_instance = nil
+        allow(puma_config_class).to receive(:new) do |&block|
+          config_instance = puma_config_class.allocate
+          config_instance.send(:initialize, &block)
+          config_instance
+        end
+
+        server.start(transport: :http, port: 3000, host: '::1')
+
+        expect(config_instance.bound_url).to eq('tcp://[::1]:3000')
       end
 
       it 'creates a Rack application' do
-        expect(Rackup::Handler::Puma).to receive(:run) do |rack_app, options|
-          expect(rack_app).to be(rack_app)
-          expect(options).to include(Port: 3000, Host: 'localhost')
-        end
+        expect(Rack::Builder).to receive(:new).and_return(rack_app)
+
+        server.start(transport: :http, port: 3000)
+      end
+
+      it 'wires up the RequestLogger middleware and transport' do
+        expect(rack_builder).to receive(:use).with(Msf::MCP::Middleware::RequestLogger)
+        expect(rack_builder).to receive(:run).with(mock_http_transport)
 
         server.start(transport: :http, port: 3000)
       end
@@ -277,6 +338,37 @@ RSpec.describe Msf::MCP::Server do
         server.shutdown
         server.shutdown
       }.not_to raise_error
+    end
+
+    it 'stops the Puma launcher when HTTP transport was used' do
+      mock_launcher = double('Puma::Launcher', stop: nil)
+      server.instance_variable_set(:@puma_launcher, mock_launcher)
+
+      expect(mock_launcher).to receive(:stop)
+      server.shutdown
+      expect(server.instance_variable_get(:@puma_launcher)).to be_nil
+    end
+
+    it 'closes the log IO handle on shutdown' do
+      mock_io = double('IO', close: nil, closed?: false)
+      server.instance_variable_set(:@puma_log_io, mock_io)
+
+      expect(mock_io).to receive(:close)
+      server.shutdown
+      expect(server.instance_variable_get(:@puma_log_io)).to be_nil
+    end
+
+    it 'still cleans up if puma_launcher.stop raises' do
+      mock_launcher = double('Puma::Launcher')
+      allow(mock_launcher).to receive(:stop).and_raise(StandardError, 'stop failed')
+      mock_io = double('IO', close: nil, closed?: false)
+      server.instance_variable_set(:@puma_launcher, mock_launcher)
+      server.instance_variable_set(:@puma_log_io, mock_io)
+
+      expect(mock_io).to receive(:close)
+      expect { server.shutdown }.not_to raise_error
+      expect(server.instance_variable_get(:@puma_launcher)).to be_nil
+      expect(server.instance_variable_get(:@puma_log_io)).to be_nil
     end
   end
 


### PR DESCRIPTION
While working on #21297 I noticed that puma wasn't shutting down gracefully so I created this PR to address that issue separately 


Refactors the way the MCP server starts and stops its HTTP transport by switching from using Rack's Puma handler to directly managing Puma via its server API. This allows for more graceful shutdowns and better control over the server lifecycle. The test suite is updated accordingly to mock and verify the new Puma integration and shutdown behavior.

# Verifications steps
- [ ] Tests pass
- [ ] The MCP server works as expected https://rapid7.github.io/metasploit-framework/docs/using-metasploit/other/how-to-use-metasploit-mcp-server.html

