### PR TITLE
Add readline support to interactive shells

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -814,17 +814,59 @@ protected
 
     run_single('')
 
-    while self.interacting
-      sd = Rex::ThreadSafe.select(fds, nil, fds, 0.5)
-      next unless sd
+    if !user_input.respond_to?(:pgets)
+      while self.interacting
+        sd = Rex::ThreadSafe.select(fds, nil, fds, 0.5)
+        next unless sd
 
-      if sd[0].include? rstream.fd
-        user_output.print(shell_read)
+        if sd[0].include? rstream.fd
+          user_output.print(shell_read)
+        end
+        if sd[0].include? user_input.fd
+          run_single((user_input.gets || '').chomp("\n"))
+        end
+        Thread.pass
       end
-      if sd[0].include? user_input.fd
-        run_single((user_input.gets || '').chomp("\n"))
+    else
+      old_prompt = user_input.prompt
+      user_input.prompt = ''
+
+      while self.interacting
+        data = ''
+        while self.interacting
+          sd = Rex::ThreadSafe.select([rstream.fd], nil, nil, 0.1)
+          break unless sd
+          begin
+            chunk = shell_read(-1, 0.01)
+            break if chunk.nil? || chunk.empty?
+            data << chunk
+          rescue Exception
+            break
+          end
+        end
+
+        if data.length > 0
+          lines = data.split("\n", -1)
+          prompt_part = lines.pop || ''
+
+          if lines.length > 0
+            user_output.print(lines.join("\n") + "\n")
+          end
+
+          user_input.prompt = prompt_part
+        end
+
+        begin
+          line = user_input.pgets
+          break unless line
+          run_single(line)
+        rescue Exception
+          break
+        end
       end
       Thread.pass
+
+      user_input.prompt = old_prompt if old_prompt
     end
   end
 

--- a/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
+++ b/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
@@ -27,8 +27,51 @@ module Console::InteractiveChannel
         _local_fd.raw do
           interact_stream(self)
         end
-      else
+      elsif !user_input.respond_to?(:pgets)
         interact_stream(self)
+      else
+        old_prompt = user_input.prompt
+        user_input.prompt = ''
+
+        while self.interacting && _remote_fd(self)
+          data = ''
+          while self.interacting && _remote_fd(self)
+            sd = Rex::ThreadSafe.select([_remote_fd(self)], nil, nil, 0.1)
+            break unless sd
+            begin
+              chunk = self.lsock.sysread(16384)
+              break if chunk.nil? || chunk.empty?
+              data << chunk
+            rescue Exception
+              break
+            end
+          end
+
+          if data.length > 0
+            self.on_print_proc.call(data.strip) if self.on_print_proc
+            self.on_log_proc.call(data.strip) if self.on_log_proc
+
+            lines = data.split("\n", -1)
+            prompt_part = lines.pop || ''
+
+            if lines.length > 0
+              user_output.print(lines.join("\n") + "\n")
+            end
+
+            user_input.prompt = prompt_part
+          end
+
+          begin
+            line = user_input.pgets
+            break unless line
+            self.on_command_proc.call(line.strip) if self.on_command_proc
+            self.write(line + "\n")
+          rescue Exception
+            break
+          end
+        end
+
+        user_input.prompt = old_prompt if old_prompt
       end
 
       self.interactive(false)

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -24,6 +24,15 @@ begin
 
       self.extend(::Readline)
 
+      if defined?(RbReadline)
+        begin
+          RbReadline.rl_parse_and_bind('"\e[1;5D": backward-word')
+          RbReadline.rl_parse_and_bind('"\e[1;5C": forward-word')
+          RbReadline.rl_parse_and_bind('"\e[3;5~": kill-word')
+        rescue Exception
+        end
+      end
+
       if tab_complete_proc
         ::Readline.basic_word_break_characters = ""
         @rl_saved_proc = with_error_handling(tab_complete_proc)


### PR DESCRIPTION
Adds readline support to interactive shells (`command_shell` and meterpreter
`interactive_channel`) when the input driver supports it (`pgets`). Falls back
to the existing behavior transparently when readline is not available, so
nothing is broken for existing users.

Also adds Ctrl+Arrow (word jump) and Ctrl+Delete (kill word) key bindings via
`RbReadline` where available.

## Changes

- `lib/msf/base/sessions/command_shell.rb` — readline path in `_interact_stream`,
  drains remote output and updates prompt dynamically before each `pgets` call
- `lib/rex/post/meterpreter/ui/console/interactive_channel.rb` — same pattern
  for meterpreter interactive channels
- `lib/rex/ui/text/input/readline.rb` — registers word-navigation key bindings
  on init if `RbReadline` is present

## Verification

- [ ] Start `msfconsole`
- [x] `use exploit/multi/handler`, set a reverse TCP payload, run
- [ ] Open a session and drop into shell with `shell`
- [ ] **Verify** readline editing (arrow keys, history, Ctrl+Arrow word jump) works in the shell
- [ ] **Verify** session still works normally without readline (piped/non-TTY input)
- [ ] Background and resume session, **verify** prompt is restored correctly

## Testing

Tested on:
- `meterpreter x64/windows` → `shell` on Windows 10 (22H2)
- `shell x64/linux` reverse shell on Linux (root, WSL2-based)

Both readline interaction and fallback path confirmed working. Further testing
may be needed for edge cases such as background jobs (`exploit -j`), raw TTY
mode, and piped input.