### PR TITLE
Bump metasploit-credential to 6.0.24

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
       mutex_m
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.23)
+    metasploit-credential (6.0.24)
       bigdecimal
       csv
       drb


### PR DESCRIPTION
Pulls in changes from: https://github.com/rapid7/metasploit-credential/pull/199 which helps unblock the following: https://github.com/rapid7/metasploit-framework/pull/20881

## Testing
- [ ] CI tests pass