### PR TITLE
ssh_identify_pubkeys -> ssh_key_login

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -6,7 +6,7 @@
 ##
 
 require 'net/ssh'
-require 'sshkey' # TODO: Actually include this!
+require 'sshkey'
 require 'net/ssh/pubkey_verifier'
 
 class MetasploitModule < Msf::Auxiliary
@@ -88,16 +88,16 @@ class MetasploitModule < Msf::Auxiliary
 
   def read_keyfile(file)
     if file == :keyfile_b64
-      keyfile = datastore['SSH_KEYFILE_B64'].unpack("m*").first
-    elsif file.kind_of? Array
+      keyfile = datastore['SSH_KEYFILE_B64'].unpack('m*').first
+    elsif file.is_a? Array
       keyfile = ''
       file.each do |dir_entry|
         next unless ::File.readable? dir_entry
 
-        keyfile << ::File.open(dir_entry, "rb") { |f| f.read(f.stat.size) }
+        keyfile << ::File.open(dir_entry, 'rb') { |f| f.read(f.stat.size) }
       end
     else
-      keyfile = ::File.open(file, "rb") { |f| f.read(f.stat.size) }
+      keyfile = ::File.open(file, 'rb') { |f| f.read(f.stat.size) }
     end
     keys = []
     this_key = []
@@ -109,11 +109,11 @@ class MetasploitModule < Msf::Auxiliary
       end
       in_key = true if (line =~ /^-----BEGIN [RD]SA (PRIVATE|PUBLIC) KEY-----/)
       this_key << line if in_key
-      if (line =~ /^-----END [RD]SA (PRIVATE|PUBLIC) KEY-----/)
-        in_key = false
-        keys << (this_key.join("\n") + "\n")
-        this_key = []
-      end
+      next unless (line =~ /^-----END [RD]SA (PRIVATE|PUBLIC) KEY-----/)
+
+      in_key = false
+      keys << (this_key.join("\n") + "\n")
+      this_key = []
     end
     if keys.empty?
       print_error "#{ip}:#{rport} SSH - No valid keys found"
@@ -128,25 +128,17 @@ class MetasploitModule < Msf::Auxiliary
     keys.each do |key|
       if key =~ /ssh-(dss|rsa)/
         # A public key has been provided
-        keepers << { :public => key, :private => "" }
-        next
+        keepers << { public: key, private: '' }
       else
         # Use the mighty SSHKey library from James Miller to convert them on the fly.
         # This is where a PRIVATE key has been provided
-        ssh_version = SSHKey.new(key).ssh_public_key rescue nil
-        keepers << { :public => ssh_version, :private => key } if ssh_version
-        next
+        ssh_version = begin
+          SSHKey.new(key).ssh_public_key
+        rescue StandardError
+          nil
+        end
+        keepers << { public: ssh_version, private: key } if ssh_version
       end
-
-      # Needs a beginning
-      next unless key =~ /^-----BEGIN [RD]SA (PRIVATE|PUBLIC) KEY-----\x0d?\x0a/m
-      # Needs an end
-      next unless key =~ /\n-----END [RD]SA (PRIVATE|PUBLIC) KEY-----\x0d?\x0a?$/m
-      # Shouldn't have binary.
-      next unless key.scan(/[\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xff]/).empty?
-
-      # Add more tests to test
-      keepers << { :public => key, :private => "" }
     end
     if keepers.empty?
       print_error "#{ip}:#{rport} SSH - No valid keys found"
@@ -160,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
       next unless key[:public]
       next if key[:private] =~ /Proc-Type:.*ENCRYPTED/
 
-      this_key = { :public => key[:public].gsub(/\x0d/, ""), :private => key[:private] }
+      this_key = { public: key[:public].gsub(/\x0d/, ''), private: key[:private] }
       next if cleartext_keys.include? this_key
 
       cleartext_keys << this_key
@@ -175,21 +167,19 @@ class MetasploitModule < Msf::Auxiliary
     if key_file && File.readable?(key_file)
       keys = read_keyfile(key_file)
       cleartext_keys = pull_cleartext_keys(keys)
-      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? "s" : ""} per user."
+      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? 's' : ''} per user."
     elsif datastore['SSH_KEYFILE_B64'] && !datastore['SSH_KEYFILE_B64'].empty?
       keys = read_keyfile(:keyfile_b64)
       cleartext_keys = pull_cleartext_keys(keys)
-      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? "s" : ""} per user (read from datastore)."
+      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? 's' : ''} per user (read from datastore)."
     elsif datastore['KEY_DIR']
       return :missing_keyfile unless (File.directory?(key_dir) && File.readable?(key_dir))
 
-      unless @key_files
-        @key_files = Dir.entries(key_dir).reject { |f| f =~ /^\x2e/ }
-      end
+      @key_files ||= Dir.entries(key_dir).reject { |f| f =~ /^\x2e/ }
       these_keys = @key_files.map { |f| File.join(key_dir, f) }
       keys = read_keyfile(these_keys)
       cleartext_keys = pull_cleartext_keys(keys)
-      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? "s" : ""} per user."
+      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? 's' : ''} per user."
     else
       return :missing_keyfile
     end
@@ -200,24 +190,24 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     cleartext_keys.each_with_index do |key_data, key_idx|
-      key_info = ""
-      if key_data[:public] =~ /ssh\-(rsa|dss)\s+([^\s]+)\s+(.*)/
-        key_info = "- #{$3.strip}"
+      key_info = ''
+      if key_data[:public] =~ /ssh-(rsa|dss)\s+([^\s]+)\s+(.*)/
+        key_info = "- #{::Regexp.last_match(3).strip}"
       end
 
       factory = ssh_socket_factory
       opt_hash = {
-        :auth_methods => ['publickey'],
-        :port => port,
-        :key_data => key_data[:public],
-        :use_agent => false,
-        :config => false,
-        :proxy => factory,
-        :non_interactive => true,
-        :verify_host_key => :never
+        auth_methods: ['publickey'],
+        port: port,
+        key_data: key_data[:public],
+        use_agent: false,
+        config: false,
+        proxy: factory,
+        non_interactive: true,
+        verify_host_key: :never
       }
 
-      opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+      opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
       begin
         ssh_socket = nil
@@ -228,34 +218,40 @@ class MetasploitModule < Msf::Auxiliary
           ssh_socket = verifier.connection
         end
 
-        if datastore['SSH_BYPASS'] and ssh_socket
+        if datastore['SSH_BYPASS'] && ssh_socket
           data = nil
 
           print_status("#{ip}:#{rport} SSH - User #{user} is being tested for authentication bypass...")
 
           begin
             ::Timeout.timeout(5) { data = ssh_socket.exec!("help\nid\nuname -a").to_s }
-          rescue ::Exception
+          rescue StandardError
+            nil
           end
 
-          print_brute(:level => :good, :msg => "User #{user} successfully bypassed authentication: #{data.inspect} ") if data
+          print_brute(level: :good, msg: "User #{user} successfully bypassed authentication: #{data.inspect} ") if data
         end
 
-        ::Timeout.timeout(1) { ssh_socket.close if ssh_socket } rescue nil
+        begin
+          ::Timeout.timeout(1) { ssh_socket.close if ssh_socket }
+        rescue StandardError
+          nil
+        end
       rescue Rex::ConnectionError
         return :connection_error
       rescue Net::SSH::Disconnect, ::EOFError
         return :connection_disconnect
       rescue Net::SSH::AuthenticationFailed
+        nil
       rescue Net::SSH::Exception
         return [:fail, nil] # For whatever reason.
       end
 
       unless success
         if @key_files
-          print_brute :level => :verror, :msg => "User #{user} does not accept key #{@key_files[key_idx + 1]} #{key_info}"
+          print_brute level: :verror, msg: "User #{user} does not accept key #{@key_files[key_idx + 1]} #{key_info}"
         else
-          print_brute :level => :verror, :msg => "User #{user} does not accept key #{key_idx + 1} #{key_info}"
+          print_brute level: :verror, msg: "User #{user} does not accept key #{key_idx + 1} #{key_info}"
         end
         return [:fail, nil]
       end
@@ -263,9 +259,9 @@ class MetasploitModule < Msf::Auxiliary
       key = verifier.key
       key_fingerprint = key.fingerprint
       user = verifier.user
-      private_key_present = (key_data[:private] != "") ? 'Yes' : 'No'
+      private_key_present = (key_data[:private] != '') ? 'Yes' : 'No'
 
-      print_brute :level => :good, :msg => "Public key accepted: '#{user}' with key '#{key_fingerprint}' (Private Key: #{private_key_present}) #{key_info}"
+      print_brute level: :good, msg: "Public key accepted: '#{user}' with key '#{key_fingerprint}' (Private Key: #{private_key_present}) #{key_info}"
 
       key_hash = {
         data: key_data,
@@ -280,7 +276,7 @@ class MetasploitModule < Msf::Auxiliary
     return unless framework.db.active
 
     store_public_keyfile(ip, user, key[:fingerprint], key[:data][:public])
-    private_key_present = (key[:data][:private] != "") ? 'Yes' : 'No'
+    private_key_present = (key[:data][:private] != '') ? 'Yes' : 'No'
 
     # Store a note relating to the public key test
     note_information = {
@@ -289,9 +285,9 @@ class MetasploitModule < Msf::Auxiliary
       private_key: private_key_present,
       info: key[:info]
     }
-    report_note(host: ip, port: port, type: "ssh.publickey.accepted", data: note_information, update: :unique_data)
+    report_note(host: ip, port: port, type: 'ssh.publickey.accepted', data: note_information, update: :unique_data)
 
-    if key[:data][:private] != ""
+    if key[:data][:private] != ''
       # Store these keys in loot
       private_keyfile_path = store_private_keyfile(ip, user, key[:fingerprint], key[:data][:private])
 
@@ -305,11 +301,11 @@ class MetasploitModule < Msf::Auxiliary
       }
 
       credential_data = {
-        module_fullname: self.fullname,
+        module_fullname: fullname,
         origin_type: :service,
         private_data: key[:data][:private],
         private_type: :ssh_key,
-        username: key[:key][:user],
+        username: key[:key][:user]
       }.merge(service_data)
 
       login_data = {
@@ -327,18 +323,22 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def store_public_keyfile(ip, user, key_id, key_data)
-    safe_username = user.gsub(/[^A-Za-z0-9]/, "_")
-    ktype = key_data.match(/ssh-(rsa|dss)/)[1] rescue nil
+    safe_username = user.gsub(/[^A-Za-z0-9]/, '_')
+    ktype = begin
+      key_data.match(/ssh-(rsa|dss)/)[1]
+    rescue StandardError
+      nil
+    end
     return unless ktype
 
-    ktype = "dsa" if ktype == "dss"
+    ktype = 'dsa' if ktype == 'dss'
     ltype = "host.unix.ssh.#{user}_#{ktype}_public"
     keyfile = existing_loot(ltype, key_id)
     return keyfile.path if keyfile
 
     keyfile_path = store_loot(
       ltype,
-      "application/octet-stream", # Text, but always want to mime-type attach it
+      'application/octet-stream', # Text, but always want to mime-type attach it
       ip,
       (key_data + "\n"),
       "#{safe_username}_#{ktype}.pub",
@@ -348,8 +348,12 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def store_private_keyfile(ip, user, key_id, key_data)
-    safe_username = user.gsub(/[^A-Za-z0-9]/, "_")
-    ktype = key_data.match(/-----BEGIN ([RD]SA) (?:PRIVATE|PUBLIC) KEY-----/)[1].downcase rescue nil
+    safe_username = user.gsub(/[^A-Za-z0-9]/, '_')
+    ktype = begin
+      key_data.match(/-----BEGIN ([RD]SA) (?:PRIVATE|PUBLIC) KEY-----/)[1].downcase
+    rescue StandardError
+      nil
+    end
     return unless ktype
 
     ltype = "host.unix.ssh.#{user}_#{ktype}_private"
@@ -358,7 +362,7 @@ class MetasploitModule < Msf::Auxiliary
 
     keyfile_path = store_loot(
       ltype,
-      "application/octet-stream", # Text, but always want to mime-type attach it
+      'application/octet-stream', # Text, but always want to mime-type attach it
       ip,
       (key_data + "\n"),
       "#{safe_username}_#{ktype}.private",
@@ -372,8 +376,8 @@ class MetasploitModule < Msf::Auxiliary
     # it doesn't make sense to iteratively go through all the keys
     # individually. So, ignore the pass variable, and try all available keys
     # for all users.
-    each_user_pass do |user, pass|
-      ret, _ = do_login(ip, rport, user)
+    each_user_pass do |user, _pass|
+      ret, = do_login(ip, rport, user)
       case ret
       when :connection_error
         vprint_error "#{ip}:#{rport} SSH - Could not connect"

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -275,7 +275,8 @@ class MetasploitModule < Msf::Auxiliary
   def do_report(ip, port, user, key)
     return unless framework.db.active
 
-    store_public_keyfile(ip, user, key[:fingerprint], key[:data][:public])
+    key_fingerprint = key[:key].fingerprint
+    store_public_keyfile(ip, user, key_fingerprint, key[:data][:public])
     private_key_present = (key[:data][:private] != '') ? 'Yes' : 'No'
 
     # Store a note relating to the public key test
@@ -289,7 +290,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if key[:data][:private] != ''
       # Store these keys in loot
-      private_keyfile_path = store_private_keyfile(ip, user, key[:fingerprint], key[:data][:private])
+      private_keyfile_path = store_private_keyfile(ip, user, key_fingerprint, key[:data][:private])
 
       # Use the proper credential method to store credentials that we have
       service_data = {

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -305,7 +305,7 @@ class MetasploitModule < Msf::Auxiliary
         origin_type: :service,
         private_data: key[:data][:private],
         private_type: :ssh_key,
-        username: key[:key][:user]
+        username: user
       }.merge(service_data)
 
       login_data = {

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -268,13 +268,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login(ip, port, user)
-    cleartext_keys = load_cleartext_keys
-    return :missing_keyfile if cleartext_keys.empty?
+    return :missing_keyfile unless @cleartext_keys&.any?
 
-    unless @alerted_with_msg
-      print_status "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{cleartext_keys.size > 1 ? 's' : ''} per user."
-      @alerted_with_msg = true
-    end
+    cleartext_keys = @cleartext_keys
 
     unless @testable_keys
       if datastore['CHECK_SUPPORTED_KEYS']
@@ -492,6 +488,10 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
+    @cleartext_keys = load_cleartext_keys
+    return if @cleartext_keys.empty?
+
+    print_status("Loaded #{@cleartext_keys.size} cleartext key#{@cleartext_keys.size == 1 ? '' : 's'}")
     super
   end
 

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -22,33 +22,48 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Deprecated
   moved_from 'auxiliary/scanner/ssh/ssh_identify_pubkeys'
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'SSH Public Key Acceptance Scanner',
-      'Description' => %q{
-        This module can determine what public keys are configured for
-        key-based authentication across a range of machines, users, and
-        sets of known keys. The SSH protocol indicates whether a particular
-        key is accepted prior to the client performing the actual signed
-        authentication request. To use this module, a text file containing
-        one or more SSH keys should be provided. These can be private or
-        public, so long as no passphrase is set on the private keys.
+      update_info(
+        info,
+        'Name' => 'SSH Authorized Key Login Check Scanner',
+        'Description' => %q{
+          This module can determine what public keys are configured for
+          key-based authentication across a range of machines, users, and
+          sets of known keys. The SSH protocol indicates whether a particular
+          key is accepted prior to the client performing the actual signed
+          authentication request. To use this module, one or more SSH keys
+          should be provided via KEY_FILE, KEY_DIR, or SSH_KEYFILE_B64. Keys
+          can be private or public, so long as no passphrase is set on the
+          private keys.
 
-        If you have loaded a database plugin and connected to a database
-        this module will record authorized public keys and hosts so you can
-        track your process.
+          If you have loaded a database plugin and connected to a database
+          this module will record authorized public keys and hosts so you can
+          track your progress.
 
-        Key files may be a single public (unencrypted) key, or several public
-        keys concatenated together as an ASCII text file. Non-key data should be
-        silently ignored. Private keys will only utilize the public key component
-        stored within the key file.
-      },
-      'Author' => [
-        'todb',
-        'hdm',
-        'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>', # Reworked the storage (db, credentials, notes, loot) only
-      ],
-      'License' => MSF_LICENSE
+          Key files may be a single public (unencrypted) key, or several public
+          keys concatenated together as an ASCII text file. Non-key data will be
+          silently ignored. Private keys will only utilize the public key component
+          stored within the key file. The module will probe the server banner to
+          skip key types the server does not support, such as Ed25519 on older
+          OpenSSH versions.
+        },
+        'Author' => [
+          'todb',
+          'hdm',
+          'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>', # Reworked the storage (db, credentials, notes, loot) only
+          'g0tmi1k' # @g0tmi1k - additional features
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ]
+        ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Auxiliary
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
         transport = Net::SSH::Transport::Session.new(ip, opt_hash)
       end
-      vprint_status("#{ip}:#{rport} - Banner: #{transport.server_version.version.to_s.strip}")
+      print_status("#{ip}:#{rport} - SSH banner: #{transport.server_version.version.to_s.strip}")
 
       server_data = transport.algorithms.instance_variable_get(:@server_data)
       @server_supported_key_types = server_data[:host_key]
@@ -297,10 +297,7 @@ class MetasploitModule < Msf::Auxiliary
 
     any_accepted = false
     testable_keys.each_with_index do |key_data, key_idx|
-      key_info = ''
-      if key_data[:public] =~ /ssh-(rsa|dss)\s+([^\s]+)\s+(.*)/
-        key_info = "- #{::Regexp.last_match(3).strip}"
-      end
+      key_label = key_data[:source] || "key #{key_idx + 1}"
 
       factory = ssh_socket_factory
 
@@ -362,23 +359,23 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       unless success
-        key_label = key_data[:source] || "key #{key_idx + 1}"
-        print_brute level: :verror, msg: "User #{user} does not accept #{key_label} #{key_info}"
+        print_brute level: :verror, msg: "#{ip}:#{rport} - [#{key_idx + 1}/#{testable_keys.size}] #{key_label}: not accepted for #{user}"
         next
       end
 
       key = verifier.key
       key_fingerprint = key.fingerprint('SHA256')
       user = verifier.user
-      private_key_present = (key_data[:private] != '') ? 'Yes' : 'No'
+      private_key_present = key_data[:private] != ''
 
       any_accepted = true
-      print_brute level: :good, msg: "Public key accepted: '#{user}' with key '#{key_fingerprint}' (Private Key: #{private_key_present}) #{key_info}"
+      key_label = key_data[:source] || "key #{key_idx + 1}"
+      print_good "#{ip}:#{rport} - [#{key_idx + 1}/#{testable_keys.size}] #{key_label}: accepted for #{user} (#{key_fingerprint}) - Private Key: #{private_key_present ? 'Yes' : 'No'}"
 
       key_hash = {
         data: key_data,
         key: key,
-        info: key_info
+        private_key_present: private_key_present
       }
       do_report(ip, rport, user, key_hash)
     end
@@ -513,17 +510,17 @@ class MetasploitModule < Msf::Auxiliary
       ret, = do_login(ip, rport, user)
       case ret
       when :connection_error
-        vprint_error "#{ip}:#{rport} SSH - Could not connect"
+        vprint_error "#{ip}:#{rport} - Could not connect"
         :abort
       when :connection_disconnect
-        vprint_error "#{ip}:#{rport} SSH - Connection timed out"
+        vprint_error "#{ip}:#{rport} - Disconnected by server"
         :abort
       when :fail
-        vprint_error "#{ip}:#{rport} SSH - Failed: '#{user}'"
+        vprint_error "#{ip}:#{rport} - Failed: '#{user}'"
       when :missing_keyfile
-        vprint_error "#{ip}:#{rport} SSH - Cannot read keyfile"
+        vprint_error "#{ip}:#{rport} - Cannot read keyfile"
       when :no_valid_keys
-        vprint_error "#{ip}:#{rport} SSH - No readable keys in keyfile"
+        vprint_error "#{ip}:#{rport} - No readable keys in keyfile"
       end
     end
   end

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -117,11 +117,11 @@ class MetasploitModule < Msf::Auxiliary
         next unless ::File.readable? dir_entry
 
         content = ::File.open(dir_entry, 'rb') { |f| f.read(f.stat.size) }
-        keys.concat(validate_keys(extract_raw_keys(content)))
+        keys.concat(validate_keys(extract_raw_keys(content), source: File.basename(dir_entry)))
       end
     else
       content = ::File.open(file, 'rb') { |f| f.read(f.stat.size) }
-      keys = validate_keys(extract_raw_keys(content))
+      keys = validate_keys(extract_raw_keys(content), source: File.basename(file))
     end
     if keys.empty?
       print_error "#{ip}:#{rport} SSH - No valid keys found"
@@ -131,11 +131,11 @@ class MetasploitModule < Msf::Auxiliary
 
   # Validates that the key isn't total garbage, and converts PEM formatted
   # keys to SSH formatted keys.
-  def validate_keys(keys)
+  def validate_keys(keys, source: nil)
     keepers = []
     keys.each do |key|
       if key =~ /(?:ssh-|ecdsa-)\S+/
-        keepers << { public: key, private: '' }
+        keepers << { public: key, private: '', source: source }
       elsif key =~ /-----BEGIN (?:OPENSSH|EC) PRIVATE KEY-----/
         ssh_key = Tempfile.open('msf_ssh_key') do |f|
           f.write(key)
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Auxiliary
 
         if ssh_key
           public_key = "#{ssh_key.ssh_type} #{[ssh_key.to_blob].pack('m0')}"
-          keepers << { public: public_key, private: key }
+          keepers << { public: public_key, private: key, source: source, converted: true }
         end
       else
         # Use the mighty SSHKey library from James Miller to convert them on the fly.
@@ -160,7 +160,11 @@ class MetasploitModule < Msf::Auxiliary
         rescue StandardError
           nil
         end
-        keepers << { public: ssh_version, private: key } if ssh_version
+
+        if ssh_version
+          print_status("No conversion needed: #{source}")
+          keepers << { public: ssh_version, private: key, source: source }
+        end
       end
     end
     if keepers.empty?
@@ -175,40 +179,41 @@ class MetasploitModule < Msf::Auxiliary
       next unless key[:public]
       next if key[:private] =~ /Proc-Type:.*ENCRYPTED/
 
-      this_key = { public: key[:public].gsub(/\x0d/, ''), private: key[:private] }
-      next if cleartext_keys.include? this_key
-
-      cleartext_keys << this_key
+      cleartext_keys << { public: key[:public].gsub(/\x0d/, ''), private: key[:private], source: key[:source], converted: key[:converted] }
     end
     if cleartext_keys.empty?
       print_error "#{ip}:#{rport} SSH - No valid cleartext keys found"
     end
-    return cleartext_keys
+    cleartext_keys
+  end
+
+  def load_cleartext_keys
+    keys = if key_file && File.readable?(key_file)
+             pull_cleartext_keys(read_keyfile(key_file))
+           elsif datastore['SSH_KEYFILE_B64'] && !datastore['SSH_KEYFILE_B64'].empty?
+             pull_cleartext_keys(read_keyfile(:keyfile_b64))
+           elsif datastore['KEY_DIR']
+             unless File.directory?(key_dir) && File.readable?(key_dir)
+               print_error("Cannot read KEY_DIR: #{key_dir}")
+               return []
+             end
+
+             key_files = Dir.entries(key_dir).reject { |f| f =~ /^\x2e/ }
+             pull_cleartext_keys(read_keyfile(key_files.map { |f| File.join(key_dir, f) }))
+           else
+             []
+           end
+    converted = keys.select { |k| k[:converted] }.map { |k| k[:source] }.compact.uniq
+    print_status("Converting modern OpenSSH key to public key blob: #{converted.join(', ')}") unless converted.empty?
+    keys
   end
 
   def do_login(ip, port, user)
-    if key_file && File.readable?(key_file)
-      keys = read_keyfile(key_file)
-      cleartext_keys = pull_cleartext_keys(keys)
-      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? 's' : ''} per user."
-    elsif datastore['SSH_KEYFILE_B64'] && !datastore['SSH_KEYFILE_B64'].empty?
-      keys = read_keyfile(:keyfile_b64)
-      cleartext_keys = pull_cleartext_keys(keys)
-      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? 's' : ''} per user (read from datastore)."
-    elsif datastore['KEY_DIR']
-      return :missing_keyfile unless (File.directory?(key_dir) && File.readable?(key_dir))
-
-      @key_files ||= Dir.entries(key_dir).reject { |f| f =~ /^\x2e/ }
-      these_keys = @key_files.map { |f| File.join(key_dir, f) }
-      keys = read_keyfile(these_keys)
-      cleartext_keys = pull_cleartext_keys(keys)
-      msg = "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{(cleartext_keys.size > 1) ? 's' : ''} per user."
-    else
-      return :missing_keyfile
-    end
+    cleartext_keys = load_cleartext_keys
+    return :missing_keyfile if cleartext_keys.empty?
 
     unless @alerted_with_msg
-      print_status msg
+      print_status "#{ip}:#{rport} SSH - Trying #{cleartext_keys.size} cleartext key#{cleartext_keys.size > 1 ? 's' : ''} per user."
       @alerted_with_msg = true
     end
 
@@ -271,11 +276,8 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       unless success
-        if @key_files
-          print_brute level: :verror, msg: "User #{user} does not accept key #{@key_files[key_idx + 1]} #{key_info}"
-        else
-          print_brute level: :verror, msg: "User #{user} does not accept key #{key_idx + 1} #{key_info}"
-        end
+        key_label = key_data[:source] || "key #{key_idx + 1}"
+        print_brute level: :verror, msg: "User #{user} does not accept #{key_label} #{key_info}"
         return [:fail, nil]
       end
 

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -337,7 +337,11 @@ class MetasploitModule < Msf::Auxiliary
             nil
           end
 
-          print_brute(level: :good, msg: "User #{user} successfully bypassed authentication: #{data.inspect} ") if data
+          if data
+            print_brute(level: :good, msg: "User #{user} successfully bypassed authentication: #{data.inspect} ")
+          else
+            vprint_status("#{ip}:#{rport} - Bypass attempted for #{user} - no response, bypass not confirmed")
+          end
         end
 
         begin

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -8,6 +8,7 @@
 require 'net/ssh'
 require 'sshkey'
 require 'net/ssh/pubkey_verifier'
+require 'tempfile'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
@@ -67,8 +68,6 @@ class MetasploitModule < Msf::Auxiliary
       'PASSWORD', 'PASS_FILE', 'BLANK_PASSWORDS', 'USER_AS_PASS', 'USERPASS_FILE', 'DB_ALL_PASS', 'DB_ALL_CREDS'
     )
 
-    @good_credentials = {}
-    @good_key = ''
     @strip_passwords = true
   end
 
@@ -88,39 +87,46 @@ class MetasploitModule < Msf::Auxiliary
     datastore['RHOST']
   end
 
-  def read_keyfile(file)
-    if file == :keyfile_b64
-      keyfile = datastore['SSH_KEYFILE_B64'].unpack('m*').first
-    elsif file.is_a? Array
-      keyfile = ''
-      file.each do |dir_entry|
-        next unless ::File.readable? dir_entry
-
-        keyfile << ::File.open(dir_entry, 'rb') { |f| f.read(f.stat.size) }
-      end
-    else
-      keyfile = ::File.open(file, 'rb') { |f| f.read(f.stat.size) }
-    end
+  def extract_raw_keys(content)
     keys = []
     this_key = []
     in_key = false
-    keyfile.split("\n").each do |line|
-      if /(?<key>ssh-(?:dss|rsa)\s+.*)/ =~ line
+    content.split("\n").each do |line|
+      if /(?<key>(?:ssh-|ecdsa-)\S+\s+\S+.*)/ =~ line
         keys << key
         next
       end
-      in_key = true if (line =~ /^-----BEGIN [RD]SA (PRIVATE|PUBLIC) KEY-----/)
+      in_key = true if line =~ /^-----BEGIN (?:[RD]SA|EC|OPENSSH) (?:PRIVATE|PUBLIC) KEY-----/
       this_key << line if in_key
-      next unless (line =~ /^-----END [RD]SA (PRIVATE|PUBLIC) KEY-----/)
+      next unless line =~ /^-----END (?:[RD]SA|EC|OPENSSH) (?:PRIVATE|PUBLIC) KEY-----/
 
       in_key = false
       keys << (this_key.join("\n") + "\n")
       this_key = []
     end
+    keys
+  end
+
+  def read_keyfile(file)
+    if file == :keyfile_b64
+      content = datastore['SSH_KEYFILE_B64'].unpack('m*').first
+      keys = validate_keys(extract_raw_keys(content))
+    elsif file.is_a? Array
+      keys = []
+      file.each do |dir_entry|
+        next unless ::File.readable? dir_entry
+
+        content = ::File.open(dir_entry, 'rb') { |f| f.read(f.stat.size) }
+        keys.concat(validate_keys(extract_raw_keys(content)))
+      end
+    else
+      content = ::File.open(file, 'rb') { |f| f.read(f.stat.size) }
+      keys = validate_keys(extract_raw_keys(content))
+    end
     if keys.empty?
       print_error "#{ip}:#{rport} SSH - No valid keys found"
     end
-    return validate_keys(keys)
+    keys
   end
 
   # Validates that the key isn't total garbage, and converts PEM formatted
@@ -128,9 +134,24 @@ class MetasploitModule < Msf::Auxiliary
   def validate_keys(keys)
     keepers = []
     keys.each do |key|
-      if key =~ /ssh-(dss|rsa)/
-        # A public key has been provided
+      if key =~ /(?:ssh-|ecdsa-)\S+/
         keepers << { public: key, private: '' }
+      elsif key =~ /-----BEGIN (?:OPENSSH|EC) PRIVATE KEY-----/
+        ssh_key = Tempfile.open('msf_ssh_key') do |f|
+          f.write(key)
+          f.flush
+
+          begin
+            Net::SSH::KeyFactory.load_private_key(f.path)
+          rescue StandardError
+            nil
+          end
+        end
+
+        if ssh_key
+          public_key = "#{ssh_key.ssh_type} #{[ssh_key.to_blob].pack('m0')}"
+          keepers << { public: public_key, private: key }
+        end
       else
         # Use the mighty SSHKey library from James Miller to convert them on the fly.
         # This is where a PRIVATE key has been provided
@@ -145,7 +166,7 @@ class MetasploitModule < Msf::Auxiliary
     if keepers.empty?
       print_error "#{ip}:#{rport} SSH - No valid keys found"
     end
-    return keepers.uniq
+    keepers.uniq
   end
 
   def pull_cleartext_keys(keys)
@@ -327,14 +348,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def store_public_keyfile(ip, user, key_id, key_data)
     safe_username = user.gsub(/[^A-Za-z0-9]/, '_')
-    ktype = begin
-      key_data.match(/ssh-(rsa|dss)/)[1]
-    rescue StandardError
-      nil
-    end
+    ktype = case key_data
+            when /ssh-rsa/ then 'rsa'
+            when /ssh-dss/ then 'dsa'
+            when /ssh-ed25519/ then 'ed25519'
+            when /ecdsa-sha2-(\S+)/ then ::Regexp.last_match(1)
+            end
     return unless ktype
 
-    ktype = 'dsa' if ktype == 'dss'
     ltype = "host.unix.ssh.#{user}_#{ktype}_public"
     keyfile = existing_loot(ltype, key_id)
     return keyfile.path if keyfile
@@ -353,7 +374,8 @@ class MetasploitModule < Msf::Auxiliary
   def store_private_keyfile(ip, user, key_id, key_data)
     safe_username = user.gsub(/[^A-Za-z0-9]/, '_')
     ktype = begin
-      key_data.match(/-----BEGIN ([RD]SA) (?:PRIVATE|PUBLIC) KEY-----/)[1].downcase
+      key = Net::SSH::KeyFactory.load_data_private_key(key_data, nil, false)
+      key.ssh_type.delete_prefix('ssh-').sub(/\Aecdsa-sha2-\S+/, 'ecdsa')
     rescue StandardError
       nil
     end

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -443,16 +443,17 @@ class MetasploitModule < Msf::Auxiliary
             end
     return unless ktype
 
-    ltype = "host.unix.ssh.#{user}_#{ktype}_public"
+    # Consistency with: store_private_keyfile()
+    ltype = "ssh.publickey.#{ktype}"
     keyfile = existing_loot(ltype, key_id)
     return keyfile.path if keyfile
 
     keyfile_path = store_loot(
       ltype,
-      'application/octet-stream', # Text, but always want to mime-type attach it
+      'text/plain',
       ip,
       (key_data + "\n"),
-      "#{safe_username}_#{ktype}.pub",
+      "#{safe_username}_id_#{ktype}.pub",
       key_id
     )
     return keyfile_path
@@ -468,16 +469,18 @@ class MetasploitModule < Msf::Auxiliary
     end
     return unless ktype
 
-    ltype = "host.unix.ssh.#{user}_#{ktype}_private"
+    # Consistency with: ./modules/auxiliary/scanner/ssh/ssh_key_login.rb, ./modules/exploits/multi/persistence/ssh_key.rb & ./modules/post/multi/gather/ssh_creds.rb
+    #                   store_public_keyfile()
+    ltype = "ssh.privatekey.#{ktype}"
     keyfile = existing_loot(ltype, key_id)
     return keyfile.path if keyfile
 
     keyfile_path = store_loot(
       ltype,
-      'application/octet-stream', # Text, but always want to mime-type attach it
+      'text/plain',
       ip,
       (key_data + "\n"),
-      "#{safe_username}_#{ktype}.private",
+      "#{safe_username}_id_#{ktype}",
       key_id
     )
     return keyfile_path

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -364,7 +364,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       key = verifier.key
-      key_fingerprint = key.fingerprint
+      key_fingerprint = key.fingerprint('SHA256')
       user = verifier.user
       private_key_present = (key_data[:private] != '') ? 'Yes' : 'No'
 
@@ -384,7 +384,7 @@ class MetasploitModule < Msf::Auxiliary
   def do_report(ip, port, user, key)
     return unless framework.db.active
 
-    key_fingerprint = key[:key].fingerprint
+    key_fingerprint = key[:key].fingerprint('SHA256')
     store_public_keyfile(ip, user, key_fingerprint, key[:data][:public])
     private_key_present = (key[:data][:private] != '') ? 'Yes' : 'No'
 

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -18,6 +18,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::SSH
   include Msf::Sessions::CreateSessionOptions
+  include Msf::Auxiliary::ReportSummary
   include Msf::Exploit::Deprecated
   moved_from 'auxiliary/scanner/ssh/ssh_identify_pubkeys'
 

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -418,7 +418,24 @@ class MetasploitModule < Msf::Auxiliary
       public_key: key[:data][:public],
       private_key: private_key_present
     }
-    report_note(host: ip, port: port, type: 'ssh.publickey.accepted', data: note_information, update: :unique_data)
+
+    report_note(
+    	host: ip,
+    	port: port,
+    	type: 'ssh.publickey.accepted',
+    	data: note_information,
+    	update: :unique_data
+  	)
+
+    report_vuln(
+      host: ip,
+      port: port,
+      proto: 'tcp',
+      sname: 'ssh',
+      name: 'SSH Authorized Key Accepted',
+      info: "Key accepted for user '#{user}' (#{key_fingerprint})",
+      refs: references
+    )
 
     if key[:data][:private] != ''
       # Store these keys in loot

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -117,8 +117,21 @@ class MetasploitModule < Msf::Auxiliary
         next unless ::File.readable? dir_entry
 
         content = ::File.open(dir_entry, 'rb') { |f| f.read(f.stat.size) }
-        keys.concat(validate_keys(extract_raw_keys(content), source: File.basename(dir_entry)))
+        found = validate_keys(extract_raw_keys(content), source: File.basename(dir_entry))
+        if found.empty?
+          print_status("Skipping: #{File.basename(dir_entry)} (no valid keys found)")
+        else
+          keys.concat(found)
+        end
       end
+
+      seen = {}
+      keys.each do |k|
+        key_id = k[:public].to_s.split[0..1].join(' ')
+        existing = seen[key_id]
+        seen[key_id] = k if existing.nil? || (existing[:private].to_s.empty? && !k[:private].to_s.empty?)
+      end
+      keys.replace(seen.values)
     else
       content = ::File.open(file, 'rb') { |f| f.read(f.stat.size) }
       keys = validate_keys(extract_raw_keys(content), source: File.basename(file))
@@ -198,7 +211,8 @@ class MetasploitModule < Msf::Auxiliary
                return []
              end
 
-             key_files = Dir.entries(key_dir).reject { |f| f =~ /^\x2e/ }
+             key_files = Dir.entries(key_dir).reject { |f| f.start_with?('.') || File.directory?(File.join(key_dir, f)) }
+             print_status("#{key_dir}: #{key_files.size} file#{key_files.size == 1 ? '' : 's'} (#{key_files.join(', ')})")
              pull_cleartext_keys(read_keyfile(key_files.map { |f| File.join(key_dir, f) }))
            else
              []

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -91,23 +91,25 @@ class MetasploitModule < Msf::Auxiliary
   def probe_server_capabilities(ip, port)
     return @server_supported_key_types if @server_supported_key_types
 
-    factory = ssh_socket_factory
-    opt_hash = {
+    opt_hash = ssh_client_defaults.merge(
       port: port,
-      use_agent: false,
-      config: false,
-      proxy: factory,
-      non_interactive: true,
-      verify_host_key: :never,
       timeout: datastore['SSH_TIMEOUT']
-    }
+    )
 
     transport = nil
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
         transport = Net::SSH::Transport::Session.new(ip, opt_hash)
       end
-      print_status("#{ip}:#{rport} - SSH banner: #{transport.server_version.version.to_s.strip}")
+      @server_banner = transport.server_version.version.to_s.strip
+      print_status("#{ip}:#{rport} - SSH banner: #{@server_banner}")
+      report_ssh_host(@server_banner, ip, port)
+      begin
+        report_ssh_hostkeys(transport, ip, port)
+      rescue StandardError
+        nil
+      end
+      @reported_hostkeys = true
 
       server_data = transport.algorithms.instance_variable_get(:@server_data)
       @server_supported_key_types = server_data[:host_key]
@@ -277,6 +279,11 @@ class MetasploitModule < Msf::Auxiliary
         supported_key_types = probe_server_capabilities(ip, port)
         return :connection_error unless supported_key_types
 
+        unless @reported_service
+          report_ssh_service(ip, port, info: @server_banner)
+          @reported_service = true
+        end
+
         testable = cleartext_keys.select do |key_data|
           key_type = key_type_from_public(key_data[:public])
           key_type.nil? || supported_key_types.include?(key_type)
@@ -341,6 +348,22 @@ class MetasploitModule < Msf::Auxiliary
           end
         end
 
+        @server_banner ||= verifier.connection&.transport&.server_version&.version.to_s.strip
+        unless @reported_hostkeys
+          report_ssh_host(@server_banner, ip, port) if @server_banner
+          begin
+            report_ssh_hostkeys(verifier.connection, ip, port) if verifier.connection
+          rescue StandardError
+            nil
+          end
+          @reported_hostkeys = true
+        end
+
+        unless @reported_service
+          report_ssh_service(ip, port, info: @server_banner)
+          @reported_service = true
+        end
+
         begin
           ::Timeout.timeout(1) { ssh_socket.close if ssh_socket }
         rescue StandardError
@@ -387,14 +410,13 @@ class MetasploitModule < Msf::Auxiliary
 
     key_fingerprint = key[:key].fingerprint('SHA256')
     store_public_keyfile(ip, user, key_fingerprint, key[:data][:public])
-    private_key_present = (key[:data][:private] != '') ? 'Yes' : 'No'
+    private_key_present = key[:private_key_present]
 
     # Store a note relating to the public key test
     note_information = {
       user: user,
       public_key: key[:data][:public],
-      private_key: private_key_present,
-      info: key[:info]
+      private_key: private_key_present
     }
     report_note(host: ip, port: port, type: 'ssh.publickey.accepted', data: note_information, update: :unique_data)
 
@@ -505,6 +527,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    @reported_service = false
+    @reported_hostkeys = false
+    @banner = grab_ssh_banner(ip, rport)
     # Since SSH collects keys and tries them all on one authentication session,
     # it doesn't make sense to iteratively go through all the keys
     # individually. So, ignore the pass variable, and try all available keys
@@ -514,9 +539,11 @@ class MetasploitModule < Msf::Auxiliary
       case ret
       when :connection_error
         vprint_error "#{ip}:#{rport} - Could not connect"
+        report_ssh_service(ip, rport, info: @banner) if @banner
         :abort
       when :connection_disconnect
         vprint_error "#{ip}:#{rport} - Disconnected by server"
+        report_ssh_service(ip, rport, info: @banner) if @banner
         :abort
       when :fail
         vprint_error "#{ip}:#{rport} - Failed: '#{user}'"

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -61,7 +61,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('SSH_KEYFILE_B64', [false, 'Base64-encoded SSH public or unencrypted private key data (intended for programmatic use only)', '']),
         OptBool.new('SSH_BYPASS', [ false, 'When a key is accepted, test whether the server allows command execution without completing authentication', false]),
         OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
-        OptInt.new('SSH_TIMEOUT', [ false, 'Maximum time in seconds to negotiate an SSH session', 30])
+        OptInt.new('SSH_TIMEOUT', [ false, 'Maximum time in seconds to negotiate an SSH session', 30]),
+        OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true])
       ]
     )
 
@@ -322,21 +323,19 @@ class MetasploitModule < Msf::Auxiliary
       opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
       begin
-        ssh_socket = nil
         success = false
         verifier = Net::SSH::PubkeyVerifier.new(ip, user, opt_hash)
         ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
           success = verifier.verify
-          ssh_socket = verifier.connection
         end
 
-        if datastore['SSH_BYPASS'] && ssh_socket
+        if datastore['SSH_BYPASS'] && verifier.connection
           data = nil
 
           print_status("#{ip}:#{rport} SSH - User #{user} is being tested for authentication bypass...")
 
           begin
-            ::Timeout.timeout(5) { data = ssh_socket.exec!("help\nid\nuname -a").to_s }
+            ::Timeout.timeout(5) { data = verifier.connection.exec!("help\nid\nuname -a").to_s }
           rescue StandardError
             nil
           end
@@ -365,9 +364,34 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         begin
-          ::Timeout.timeout(1) { ssh_socket.close if ssh_socket }
+          ::Timeout.timeout(1) { verifier.connection&.close }
         rescue StandardError
           nil
+        end
+
+        proof = nil
+        if success && datastore['GatherProof'] && !key_data[:private].empty?
+          begin
+            auth_opts = {
+              auth_methods: ['publickey'],
+              port: port,
+              key_data: [key_data[:private]],
+              use_agent: false,
+              config: false,
+              proxy: factory,
+              non_interactive: true,
+              verify_host_key: :never
+            }
+
+            auth_opts[:verbose] = :debug if datastore['SSH_DEBUG']
+            ::Timeout.timeout(10) do
+              Net::SSH.start(ip, user, auth_opts) do |conn|
+                proof = conn.exec!('id && uname -a').to_s
+              end
+            end
+          rescue StandardError
+            nil
+          end
         end
       rescue Rex::ConnectionError
         return :connection_error
@@ -393,12 +417,17 @@ class MetasploitModule < Msf::Auxiliary
 
       any_accepted = true
       key_label = key_data[:source] || "key #{key_idx + 1}"
-      print_good "#{ip}:#{rport} - [#{key_idx + 1}/#{testable_keys.size}] #{key_label}: accepted for #{user} (#{key_fingerprint}) - Private Key: #{private_key_present ? 'Yes' : 'No'}"
+      id_line, uname_line = proof.to_s.split("\n", 2)
+      msg = "#{ip}:#{rport} - [#{key_idx + 1}/#{testable_keys.size}] #{key_label}: accepted for #{user} (#{key_fingerprint}) - Private Key: #{private_key_present ? 'Yes' : 'No'}"
+      msg += " '#{id_line.strip}'" unless id_line.to_s.strip.empty?
+      print_good msg
+      print_brute level: :vgood, ip: ip, msg: uname_line.strip if uname_line
 
       key_hash = {
         data: key_data,
         key: key,
-        private_key_present: private_key_present
+        private_key_present: private_key_present,
+        proof: proof
       }
       do_report(ip, rport, user, key_hash)
     end
@@ -410,22 +439,39 @@ class MetasploitModule < Msf::Auxiliary
 
     key_fingerprint = key[:key].fingerprint('SHA256')
     store_public_keyfile(ip, user, key_fingerprint, key[:data][:public])
-    private_key_present = key[:private_key_present]
 
     # Store a note relating to the public key test
     note_information = {
       user: user,
       public_key: key[:data][:public],
-      private_key: private_key_present
+      private_key: key[:private_key_present]
     }
-
     report_note(
-    	host: ip,
-    	port: port,
-    	type: 'ssh.publickey.accepted',
-    	data: note_information,
-    	update: :unique_data
-  	)
+      host: ip,
+      port: port,
+      proto: 'tcp',
+      sname: 'ssh',
+      type: 'ssh.accepted_keys',
+      data: note_information,
+      update: :unique_data
+    )
+
+    if key[:proof].present?
+      id_part, uname_part = key[:proof].to_s.split("\n", 2)
+      report_note(
+        host: ip,
+        port: port,
+        proto: 'tcp',
+        sname: 'ssh',
+        type: 'ssh.proof',
+        data: {
+          credential: "#{user}:#{key_fingerprint}",
+          id: id_part.to_s.strip,
+          uname: uname_part.to_s.strip
+        },
+        update: :unique_data
+      )
+    end
 
     report_vuln(
       host: ip,

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -295,6 +295,7 @@ class MetasploitModule < Msf::Auxiliary
 
     testable_keys = @testable_keys
 
+    any_accepted = false
     testable_keys.each_with_index do |key_data, key_idx|
       key_info = ''
       if key_data[:public] =~ /ssh-(rsa|dss)\s+([^\s]+)\s+(.*)/
@@ -350,14 +351,16 @@ class MetasploitModule < Msf::Auxiliary
         return :connection_disconnect
       rescue Net::SSH::AuthenticationFailed
         nil
-      rescue Net::SSH::Exception
-        return [:fail, nil] # For whatever reason.
+      rescue Net::SSH::Exception => e
+        key_label = key_data[:source] || "key #{key_idx + 1}"
+        print_brute level: :verror, msg: "#{ip}:#{rport} - #{key_label} raised SSH exception: #{e.message}"
+        next
       end
 
       unless success
         key_label = key_data[:source] || "key #{key_idx + 1}"
         print_brute level: :verror, msg: "User #{user} does not accept #{key_label} #{key_info}"
-        return [:fail, nil]
+        next
       end
 
       key = verifier.key
@@ -365,6 +368,7 @@ class MetasploitModule < Msf::Auxiliary
       user = verifier.user
       private_key_present = (key_data[:private] != '') ? 'Yes' : 'No'
 
+      any_accepted = true
       print_brute level: :good, msg: "Public key accepted: '#{user}' with key '#{key_fingerprint}' (Private Key: #{private_key_present}) #{key_info}"
 
       key_hash = {
@@ -374,6 +378,7 @@ class MetasploitModule < Msf::Auxiliary
       }
       do_report(ip, rport, user, key_hash)
     end
+    return [:fail, nil] unless any_accepted
   end
 
   def do_report(ip, port, user, key)

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -49,17 +49,17 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(22),
-        OptPath.new('KEY_FILE', [true, 'Filename of one or several cleartext public keys.'])
+        OptPath.new('KEY_FILE', [false, 'File containing one or more SSH public or unencrypted private keys']),
+        OptPath.new('KEY_DIR', [false, 'Directory of SSH public or unencrypted private key files (dot-prefixed filenames are ignored)'])
       ]
     )
 
     register_advanced_options(
       [
+        OptString.new('SSH_KEYFILE_B64', [false, 'Base64-encoded SSH public or unencrypted private key data (intended for programmatic use only)', '']),
+        OptBool.new('SSH_BYPASS', [ false, 'When a key is accepted, test whether the server allows command execution without completing authentication', false]),
         OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
-        OptBool.new('SSH_BYPASS', [ false, 'Verify that authentication was not bypassed when keys are found', false]),
-        OptString.new('SSH_KEYFILE_B64', [false, 'Raw data of an unencrypted SSH public key. This should be used by programmatic interfaces to this module only.', '']),
-        OptPath.new('KEY_DIR', [false, 'Directory of several keys. Filenames must not begin with a dot in order to be read.']),
-        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+        OptInt.new('SSH_TIMEOUT', [ false, 'Maximum time in seconds to negotiate an SSH session', 30])
       ]
     )
 
@@ -372,6 +372,20 @@ class MetasploitModule < Msf::Auxiliary
       key_id
     )
     return keyfile_path
+  end
+
+  def run
+    unless key_file || datastore['KEY_DIR'] || !datastore['SSH_KEYFILE_B64'].to_s.empty?
+      print_error('Please set KEY_FILE or KEY_DIR (or SSH_KEYFILE_B64)')
+      return
+    end
+
+    if datastore['USERNAME'].to_s.empty? && datastore['USER_FILE'].to_s.empty? && !datastore['DB_ALL_USERS']
+      print_error('Please set USERNAME or USER_FILE')
+      return
+    end
+
+    super
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -57,6 +57,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
+        OptBool.new('CHECK_SUPPORTED_KEYS', [true, 'Probe the server KEX to skip key types it does not support', true]),
         OptString.new('SSH_KEYFILE_B64', [false, 'Base64-encoded SSH public or unencrypted private key data (intended for programmatic use only)', '']),
         OptBool.new('SSH_BYPASS', [ false, 'When a key is accepted, test whether the server allows command execution without completing authentication', false]),
         OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
@@ -85,6 +86,50 @@ class MetasploitModule < Msf::Auxiliary
 
   def ip
     datastore['RHOST']
+  end
+
+  def probe_server_capabilities(ip, port)
+    return @server_supported_key_types if @server_supported_key_types
+
+    factory = ssh_socket_factory
+    opt_hash = {
+      port: port,
+      use_agent: false,
+      config: false,
+      proxy: factory,
+      non_interactive: true,
+      verify_host_key: :never,
+      timeout: datastore['SSH_TIMEOUT']
+    }
+
+    transport = nil
+    begin
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        transport = Net::SSH::Transport::Session.new(ip, opt_hash)
+      end
+      vprint_status("#{ip}:#{rport} - Banner: #{transport.server_version.version.to_s.strip}")
+
+      server_data = transport.algorithms.instance_variable_get(:@server_data)
+      @server_supported_key_types = server_data[:host_key]
+      vprint_status("#{ip}:#{rport} - Supported key types: #{@server_supported_key_types.join(', ')}")
+    rescue Rex::ConnectionError
+      @server_supported_key_types = nil
+    rescue StandardError => e
+      vprint_status("#{ip}:#{rport} - Could not determine supported key types (#{e.message}), trying all")
+      @server_supported_key_types = nil
+    ensure
+      begin
+        transport&.close
+      rescue StandardError
+        nil
+      end
+    end
+
+    @server_supported_key_types
+  end
+
+  def key_type_from_public(public_key)
+    public_key.to_s.split.first
   end
 
   def extract_raw_keys(content)
@@ -231,13 +276,37 @@ class MetasploitModule < Msf::Auxiliary
       @alerted_with_msg = true
     end
 
-    cleartext_keys.each_with_index do |key_data, key_idx|
+    unless @testable_keys
+      if datastore['CHECK_SUPPORTED_KEYS']
+        supported_key_types = probe_server_capabilities(ip, port)
+        return :connection_error unless supported_key_types
+
+        testable = cleartext_keys.select do |key_data|
+          key_type = key_type_from_public(key_data[:public])
+          key_type.nil? || supported_key_types.include?(key_type)
+        end
+
+        (cleartext_keys - testable).group_by { |k| key_type_from_public(k[:public]) }.each do |key_type, keys|
+          labels = keys.map { |k| k[:source] || k[:public].to_s.split.first }.join(', ')
+          print_status("#{ip}:#{rport} - Server does not support #{key_type}, skipping: #{labels}")
+        end
+
+        @testable_keys = testable
+      else
+        @testable_keys = cleartext_keys
+      end
+    end
+
+    testable_keys = @testable_keys
+
+    testable_keys.each_with_index do |key_data, key_idx|
       key_info = ''
       if key_data[:public] =~ /ssh-(rsa|dss)\s+([^\s]+)\s+(.*)/
         key_info = "- #{::Regexp.last_match(3).strip}"
       end
 
       factory = ssh_socket_factory
+
       opt_hash = {
         auth_methods: ['publickey'],
         port: port,

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -14,6 +14,8 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::AuthBrute
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::SSH
+  include Msf::Exploit::Deprecated
+  moved_from 'auxiliary/scanner/ssh/ssh_identify_pubkeys'
 
   def initialize
     super(

--- a/modules/auxiliary/scanner/ssh/ssh_key_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_key_login.rb
@@ -9,12 +9,15 @@ require 'net/ssh'
 require 'sshkey'
 require 'net/ssh/pubkey_verifier'
 require 'tempfile'
+require 'metasploit/framework/ssh/platform'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::SSH
+  include Msf::Sessions::CreateSessionOptions
   include Msf::Exploit::Deprecated
   moved_from 'auxiliary/scanner/ssh/ssh_identify_pubkeys'
 
@@ -369,8 +372,9 @@ class MetasploitModule < Msf::Auxiliary
           nil
         end
 
+        ssh_socket = nil
         proof = nil
-        if success && datastore['GatherProof'] && !key_data[:private].empty?
+        if success && !key_data[:private].empty? && (datastore['GatherProof'] || datastore['CreateSession'])
           begin
             auth_opts = {
               auth_methods: ['publickey'],
@@ -384,11 +388,27 @@ class MetasploitModule < Msf::Auxiliary
             }
 
             auth_opts[:verbose] = :debug if datastore['SSH_DEBUG']
-            ::Timeout.timeout(10) do
-              Net::SSH.start(ip, user, auth_opts) do |conn|
-                proof = conn.exec!('id && uname -a').to_s
-              end
+            ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+              ssh_socket = Net::SSH.start(ip, user, auth_opts)
             end
+          rescue StandardError
+            nil
+          end
+        end
+
+        if datastore['GatherProof'] && ssh_socket
+          begin
+            ::Timeout.timeout(5) { proof = ssh_socket.exec!('id && uname -a').to_s }
+          rescue StandardError
+            nil
+          end
+        end
+
+        # Only close the socket immediately if we won't need it for a session
+        keep_socket = success && datastore['CreateSession'] && ssh_socket
+        unless keep_socket
+          begin
+            ::Timeout.timeout(1) { ssh_socket&.close }
           rescue StandardError
             nil
           end
@@ -430,8 +450,45 @@ class MetasploitModule < Msf::Auxiliary
         proof: proof
       }
       do_report(ip, rport, user, key_hash)
+
+      if datastore['CreateSession'] && !private_key_present
+        print_warning("#{ip}:#{rport} - Key accepted for #{user} but no private key available - cannot create session (public key only)")
+      end
+
+      next unless datastore['CreateSession'] && private_key_present
+
+      begin
+        session_setup(ip, rport, user, ssh_socket)
+      rescue StandardError => e
+        elog('Failed to setup the session', error: e)
+        print_error("#{ip}:#{rport} - Failed to create session: #{e.class} #{e.message}")
+      end
     end
     return [:fail, nil] unless any_accepted
+  end
+
+  def session_setup(ip, _port, user, ssh_socket)
+    platform = Metasploit::Framework::Ssh::Platform.get_platform(ssh_socket)
+
+    sess = Msf::Sessions::SshCommandShellBind.new(ssh_socket)
+
+    merge_me = {
+      'USERPASS_FILE' => nil,
+      'USER_FILE' => nil,
+      'PASS_FILE' => nil,
+      'PASSWORD' => nil,
+      'USERNAME' => user
+    }
+
+    s = start_session(self, nil, merge_me, false, sess.rstream, sess)
+    sockets.delete(ssh_socket.transport.socket)
+    s.platform = platform
+
+    host_info = { host: ip }
+    host_info[:os_name] = platform.capitalize unless platform == 'unknown'
+    report_host(host_info)
+
+    s
   end
 
   def do_report(ip, port, user, key)


### PR DESCRIPTION
This PR gets `ssh_identify_pubkeys` working:

- In its current state, a successful login, with database, will crash the module
- In its current state, KEY_DIR doesn't work
- In its current state, only legacy OpenSSH key formats are supported
- Add CHECK_SUPPORTED_KEYS support, to see what the server accepts rather than trying everything
- More efficient checking (Load all keys once, check all keys for a user etc)
- Switch to SHA256 fingerprints
- Add report_vuln()
- Add GatherProof - just like ssh_login
- Add CreateSession - just like ssh_login
- Add Msf::Auxiliary::ReportSummary - just like ssh_login
- Update module metadata
- Consistence with how loot and keys are with other modules

Target is Metasploitable 2.

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      1         0      0      2      1
After : *        default  1      2         2      4      9      13
```

## Setup

Going to generate a range of SSH keys. There will be always 2 types, `*_1` (not added/invalided) & `*_2` (added/valid).

```console
$ mkdir -pv /tmp/testkeys/; cd /tmp/testkeys/
mkdir: created directory '/tmp/testkeys/'
$ 
$ ssh-keygen -t rsa -b 1024 -N "" -f rsa_1024_1; ssh-keygen -t rsa -b 1024 -N "" -f rsa_1024_2
[...]
$ ssh-keygen -t rsa -b 2048 -N "" -f rsa_2048_1; ssh-keygen -t rsa -b 2048 -N "" -f rsa_2048_2
[...]
$ ssh-keygen -t rsa -b 4096 -N "" -f rsa_4096_1; ssh-keygen -t rsa -b 4096 -N "" -f rsa_4096_2
[...]
$ ssh-keygen -t rsa -b 2048 -N "" -m PEM -f rsa_2048_legacy_1; ssh-keygen -t rsa -b 2048 -N "" -m PEM -f rsa_2048_legacy_2
[...]
$ ssh-keygen -t rsa         -N "" -f tmp_1; ssh-keygen -t rsa              -N "" -f tmp_2; rm -v tmp_{1,2};
[...]    
$ ssh-keygen -t ecdsa       -N "" -f ecdsa_1; ssh-keygen -t ecdsa       -N "" -f ecdsa_2
[...]    
$ ssh-keygen -t ed25519     -N "" -f ed25519_1; ssh-keygen -t ed25519     -N "" -f ed25519_2
[...]
$ echo "hello world" > foo
$
$ ls *_2.pub
ecdsa_2.pub  ed25519_2.pub  rsa_1024_2.pub  rsa_2048_2.pub  rsa_2048_legacy_2.pub  rsa_4096_2.pub  tmp_2.pub
$ cat *_2.pub
[...]
$
```

Then will add the SSH keys to the target:

```console
$ ssh1 msfadmin@10.0.0.10
/etc/ssh/ssh_config line 52: Unsupported option "gssapiauthentication"
msfadmin@10.0.0.10's password: msfadmin
[...]
msfadmin@metasploitable:~$ cd .ssh/
msfadmin@metasploitable:~/.ssh$ cat <<EOF > authorized_keys
[...output from `$ cat *_2.pub`...]
EOF
msfadmin@metasploitable:~$ chmod -v 0600 authorized_keys
mode of `authorized_keys' changed to 0600 (rw-------)
msfadmin@metasploitable:~$
```

### Quick test

```console
$ ssh1 -i rsa_1024_2 msfadmin@10.0.0.10
/etc/ssh/ssh_config line 52: Unsupported option "gssapiauthentication"
[...]
msfadmin@metasploitable:~$
```



## Before

- All testing was done using master branch
- Would silent fail if there wasn't a username
- KEY_DIR requires a KEY_FILE, thus doesn't ever trigger - and it looks "hidden"
- Module crashes when login was successful
- Workspace only would get updated if successful result

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ssh/ssh_identify_pubkeys;
set RHOSTS 10.0.0.10;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10

Module options (auxiliary/scanner/ssh/ssh_identify_pubkeys):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   KEY_FILE                           yes       Filename of one or several cleartext public keys.
   RHOSTS            10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   USERNAME                           no        A specific username to authenticate as
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
```

```console
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > run RPORT=9999
[-] Msf::OptionValidateError One or more options failed to validate: KEY_FILE.
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > run RPORT=9999 KEY_FILE=/tmp/testkeys/rsa_1024_2
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > 
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > 
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > run RPORT=9999 KEY_FILE=/tmp/testkeys/rsa_1024_2 USERNAME=msfadmin
[-] 10.0.0.10:9999 SSH - No valid keys found
[-] 10.0.0.10:9999 SSH - No valid keys found
[-] 10.0.0.10:9999 SSH - No valid cleartext keys found
[*] 10.0.0.10:9999 SSH - Trying 0 cleartext key per user.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > run RPORT=9999 KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2 USERNAME=msfadmin
[*] 10.0.0.10:9999 SSH - Trying 1 cleartext key per user.
[-] 10.0.0.10:9999 SSH - Could not connect
[-] 10.0.0.10:9999        - [1/1] - Bruteforce cancelled against this service.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
```

```console
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > run RPORT=21 KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2 USERNAME=msfadmin
[*] 10.0.0.10:21 SSH - Trying 1 cleartext key per user.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
```

```console
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > run KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2 USERNAME=msfadmin
[*] 10.0.0.10:22 SSH - Trying 1 cleartext key per user.
[+] 10.0.0.10:22          - [1/1] - Public key accepted: 'msfadmin' with key '6d:5d:df:2c:e6:5e:dd:a6:db:0d:84:4d:7d:bc:4a:19' (Private Key: Yes)
[-] Auxiliary failed: NoMethodError undefined method `[]' for an instance of OpenSSL::PKey::RSA
[-] Call stack:
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:312:in `do_report'
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:275:in `block in do_login'
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:202:in `each'
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:202:in `each_with_index'
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:202:in `do_login'
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:376:in `block in run_host'
[-]   /usr/share/metasploit-framework2/lib/msf/core/auxiliary/auth_brute.rb:321:in `block in each_user_pass'
[-]   /usr/share/metasploit-framework2/lib/msf/core/auxiliary/auth_brute.rb:289:in `each'
[-]   /usr/share/metasploit-framework2/lib/msf/core/auxiliary/auth_brute.rb:289:in `each_user_pass'
[-]   /usr/share/metasploit-framework2/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb:375:in `run_host'
[-]   /usr/share/metasploit-framework2/lib/msf/core/auxiliary/scanner.rb:130:in `block (2 levels) in run'
[-]   /usr/share/metasploit-framework2/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      0      2      1

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > se
[-] Unknown command: se. Did you mean set? Run the help command for more details.
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  22    tcp          open         {}

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > loot

Loot
====

host       service  type                                name                  content                   info  path
----       -------  ----                                ----                  -------                   ----  ----
10.0.0.10           host.unix.ssh.msfadmin_rsa_public   msfadmin_rsa.pub      application/octet-stream        /home/kali/.msf4/loot/20260526223848_default_10.0.0.10_host.unix.ssh.ms_767947.pub
10.0.0.10           host.unix.ssh.msfadmin_rsa_private  msfadmin_rsa.private  application/octet-stream        /home/kali/.msf4/loot/20260526223848_default_10.0.0.10_host.unix.ssh.ms_270923.bin

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type                    Data
 ----                     ----       -------  ----  --------  ----                    ----
 2026-05-26 21:38:48 UTC  10.0.0.10           22    tcp       ssh.publickey.accepted  {:user=>"msfadmin", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIwliRlyg+ZA5R4GmRNHu9i8UyuzIiJdB5P8/8a1SwrjjXvQ
                                                                                      TOjEgXOnw/kMygqAyNlMbSyHj7nUxL5xjLloDmeop9yMCqbVLQ4cV8xmTBQ//ezxYKYAubHa8qRD/aKB3A1s+gI+nkDfRvfzLzYV5SSUoNXKAv93iAn2Clj8
                                                                                      Mr/Rrt81Te3SatvGjdDpu1ke46wwJ+HXBlQXbPa/9IIsT6iJw5RMnr4FaxpvxZPp1evQMjXzYuDWlLlR3HButaRz7CLUeIgQ1ZJwsvCORCnQ25RSjCYho96w
                                                                                      rEioqASc9UUBBGMDeAligv1euoClvaOPHIAgf1D0yrK4l+Pu4wPxfb", :private_key=>"Yes", :info=>""}

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
```

```console
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > advanced

Module advanced options (auxiliary/scanner/ssh/ssh_identify_pubkeys):

   Name                  Current Setting                          Required  Description
   ----                  ---------------                          --------  -----------
   KEY_DIR                                                        no        Directory of several keys. Filenames must not begin with a dot in order to be read.
   MaxGuessesPerService  0                                        no        Maximum number of credentials to try per service instance. If set to zero or a non-number, this option will not be used.
   MaxGuessesPerUser     0                                        no        Maximum guesses for a particular username for the service instance. Note that users are considered unique among different services
                                                                            , so a user at 10.1.1.1:22 is different from one at 10.2.2.2:22, and both will be tried up to the MaxGuessesPerUser limit. If set
                                                                            to zero or a non-number, this option will not be used.
   MaxMinutesPerService  0                                        no        Maximum time in minutes to bruteforce the service instance. If set to zero or a non-number, this option will not be used.
   PASSWORD_SPRAY        false                                    yes       Reverse the credential pairing order. For each password, attempt every possible user.
   REMOVE_PASS_FILE      false                                    yes       Automatically delete the PASS_FILE on module completion
   REMOVE_USERPASS_FILE  false                                    yes       Automatically delete the USERPASS_FILE on module completion
   REMOVE_USER_FILE      false                                    yes       Automatically delete the USER_FILE on module completion
   SSH_BYPASS            false                                    no        Verify that authentication was not bypassed when keys are found
   SSH_DEBUG             false                                    no        Enable SSH debugging output (Extreme verbosity!)
   SSH_IDENT             SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3  yes       SSH client identification string
   SSH_KEYFILE_B64                                                no        Raw data of an unencrypted SSH public key. This should be used by programmatic interfaces to this module only.
   SSH_TIMEOUT           30                                       no        Specify the maximum time to negotiate a SSH session
   SSLKeyLogFile                                                  no        The SSL key log file
   ShowProgress          true                                     yes       Display progress messages during a scan
   ShowProgressPercent   10                                       yes       The interval in percent that progress should be shown
   TRANSITION_DELAY      0                                        no        Amount of time (in minutes) to delay before transitioning to the next user in the array (or password when PASSWORD_SPRAY=true)
   WORKSPACE                                                      no        Specify the workspace for this module


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ssh/ssh_identify_pubkeys) > run KEY_DIR=/tmp/testkeys/
[-] Msf::OptionValidateError One or more options failed to validate: KEY_FILE.
msf auxiliary(scanner/ssh/ssh_identify_pubkeys) >
```



## After

- All testing was done on this branch, with SSH mixin (https://github.com/rapid7/metasploit-framework/pull/21479) and auth_brute_mixin applied (https://github.com/rapid7/metasploit-framework/pull/21396)
- Scanning a valid host, but closed port: 1 host
- Scanning a valid host, open port, but incorrect: 1 host, 1 service
- Scanning a valid host, and valid SSH service: 1 host, 2 services

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ssh/ssh_key_login;
set RHOSTS 10.0.0.10;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 10.0.0.10

Module options (auxiliary/scanner/ssh/ssh_key_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   CreateSession     true             no        Create a new session for every successful login
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   KEY_DIR                            no        Directory of SSH public or unencrypted private key files (dot-prefixed filenames are ignored)
   KEY_FILE                           no        File containing one or more SSH public or unencrypted private keys
   RHOSTS            10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   USERNAME                           no        A specific username to authenticate as
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ssh/ssh_key_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_key_login) > run RPORT=9999
[-] Please set KEY_FILE or KEY_DIR (or SSH_KEYFILE_B64)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) >
msf auxiliary(scanner/ssh/ssh_key_login) > run RPORT=9999 KEY_FILE=/tmp/testkeys/rsa_1024_2
[-] Please set USERNAME or USER_FILE
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) >
msf auxiliary(scanner/ssh/ssh_key_login) >
msf auxiliary(scanner/ssh/ssh_key_login) > run RPORT=9999 KEY_FILE=/tmp/testkeys/rsa_1024_2 USERNAME=msfadmin
[*] Converting modern OpenSSH key to public key blob: rsa_1024_2
[*] Loaded 1 cleartext key
[-] 10.0.0.10:9999 - Could not connect
[-] Bruteforce cancelled against this service.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) >
msf auxiliary(scanner/ssh/ssh_key_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_key_login) >
msf auxiliary(scanner/ssh/ssh_key_login) >
msf auxiliary(scanner/ssh/ssh_key_login) > run RPORT=9999 KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2 USERNAME=msfadmin
[*] No conversion needed: rsa_2048_legacy_2
[*] Loaded 1 cleartext key
[-] 10.0.0.10:9999 - Could not connect
[-] Bruteforce cancelled against this service.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) >
msf auxiliary(scanner/ssh/ssh_key_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_key_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_key_login) > run RPORT=21 KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2 USERNAME=msfadmin
[*] No conversion needed: rsa_2048_legacy_2
[*] Loaded 1 cleartext key
[*] 10.0.0.10:21 - Could not determine supported key types (execution expired), trying all
[-] 10.0.0.10:21 - Could not connect
[-] Bruteforce cancelled against this service.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      0      0      0

msf auxiliary(scanner/ssh/ssh_key_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(scanner/ssh/ssh_key_login) > services
Services
========

host       port  proto  name  state  info                resource  parents
----       ----  -----  ----  -----  ----                --------  -------
10.0.0.10  21    tcp          open   220 (vsFTPd 2.3.4)  {}

msf auxiliary(scanner/ssh/ssh_key_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_key_login) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/ssh/ssh_key_login) > run KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2 USERNAME=msfadmin
[*] No conversion needed: rsa_2048_legacy_2
[*] Loaded 1 cleartext key
[*] 10.0.0.10:22 - SSH banner: SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1
[*] 10.0.0.10:22 - Supported key types: ssh-rsa, ssh-dss
[+] 10.0.0.10:22 - [1/1] rsa_2048_legacy_2: accepted for msfadmin (SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs) - Private Key: Yes 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)'
[+] Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
[*] SSH session 1 opened (10.0.0.1:41357 -> 10.0.0.10:22) at 2026-05-26 22:59:51 +0100
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         2      1      2      4

msf auxiliary(scanner/ssh/ssh_key_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux    Ubuntu     8.04   server

msf auxiliary(scanner/ssh/ssh_key_login) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    tcp   open                                          {}
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)

msf auxiliary(scanner/ssh/ssh_key_login) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                                    References
---------                ----       -------       --------  ----                                    ----------
2026-05-26 21:59:50 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Authorized Key Accepted             ATT&CK-T1021.004
2026-05-26 21:59:51 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Authorized Key Login Check Scanner  ATT&CK-T1021.004

msf auxiliary(scanner/ssh/ssh_key_login) > creds
Credentials
===========

id   host       origin     service       public    private                                          realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------                                          -----  ------------  ----------  ----------------
579  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  6d:5d:df:2c:e6:5e:dd:a6:db:0d:84:4d:7d:bc:4a:19         SSH key

msf auxiliary(scanner/ssh/ssh_key_login) > lo
[-] Unknown command: lo. Did you mean log? Run the help command for more details.
msf auxiliary(scanner/ssh/ssh_key_login) > loot

Loot
====

host       service  type                name                 content     info                                                path
----       -------  ----                ----                 -------     ----                                                ----
10.0.0.10           ssh.publickey.rsa   msfadmin_id_rsa.pub  text/plain  SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs  /home/kali/.msf4/loot/20260526225950_default_10.0.0.10_ssh.publickey.rs_468112.txt
10.0.0.10           ssh.privatekey.rsa  msfadmin_id_rsa      text/plain  SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs  /home/kali/.msf4/loot/20260526225950_default_10.0.0.10_ssh.privatekey.r_449006.txt

msf auxiliary(scanner/ssh/ssh_key_login) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type               Data
 ----                     ----       -------  ----  --------  ----               ----
 2026-05-26 21:59:50 UTC  10.0.0.10  ssh      22    tcp       ssh.cpe            {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}
 2026-05-26 21:59:50 UTC  10.0.0.10  ssh      22    tcp       ssh.hostkey        {:type=>"ssh-rsa", :fingerprint=>"SHA256:BQHm5EoHX9GCiOLuVscegPXLQOsuPs+E9d/rrJB84rk"}
 2026-05-26 21:59:50 UTC  10.0.0.10  tcp      22    tcp       ssh.accepted_keys  {:user=>"msfadmin", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIwliRlyg+ZA5R4GmRNHu9i8UyuzIiJdB5P8/8a1SwrjjXvQTOjEg
                                                                                 XOnw/kMygqAyNlMbSyHj7nUxL5xjLloDmeop9yMCqbVLQ4cV8xmTBQ//ezxYKYAubHa8qRD/aKB3A1s+gI+nkDfRvfzLzYV5SSUoNXKAv93iAn2Clj8Mr/Rrt81Te
                                                                                 3SatvGjdDpu1ke46wwJ+HXBlQXbPa/9IIsT6iJw5RMnr4FaxpvxZPp1evQMjXzYuDWlLlR3HButaRz7CLUeIgQ1ZJwsvCORCnQ25RSjCYho96wrEioqASc9UUBBGM
                                                                                 DeAligv1euoClvaOPHIAgf1D0yrK4l+Pu4wPxfb", :private_key=>true}
 2026-05-26 21:59:50 UTC  10.0.0.10  tcp      22    tcp       ssh.proof          {:credential=>"msfadmin:SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) grou
                                                                                 ps=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(samb
                                                                                 ashare),1000(msfadmin)", :uname=>"Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}

msf auxiliary(scanner/ssh/ssh_key_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_key_login) > run KEY_DIR=/tmp/testkeys
[-] Please set USERNAME or USER_FILE
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) > run KEY_DIR=/tmp/testkeys USERNAME=msfadmin
[*] /tmp/testkeys: 26 files (rsa_4096_2.pub, rsa_4096_2, rsa_4096_1.pub, rsa_4096_1, rsa_2048_legacy_2.pub, rsa_2048_legacy_2, rsa_2048_legacy_1.pub, rsa_2048_legacy_1, rsa_2048_2.pub, rsa_2048_2, rsa_2048_1.pub, rsa_2048_1, rsa_1024_2.pub, rsa_1024_2, rsa_1024_1.pub, rsa_1024_1, tmp_2.pub, tmp_1.pub, ed25519_2.pub, ed25519_2, ed25519_1.pub, ed25519_1, ecdsa_2.pub, ecdsa_2, ecdsa_1.pub, ecdsa_1)
[*] No conversion needed: rsa_2048_legacy_2
[*] No conversion needed: rsa_2048_legacy_1
[*] Converting modern OpenSSH key to public key blob: rsa_4096_2, rsa_4096_1, rsa_2048_2, rsa_2048_1, rsa_1024_2, rsa_1024_1, ed25519_2, ed25519_1, ecdsa_2, ecdsa_1
[*] Loaded 14 cleartext keys
[*] 10.0.0.10:22 - SSH banner: SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1
[*] 10.0.0.10:22 - Supported key types: ssh-rsa, ssh-dss
[*] 10.0.0.10:22 - Server does not support ssh-ed25519, skipping: ed25519_2, ed25519_1
[*] 10.0.0.10:22 - Server does not support ecdsa-sha2-nistp256, skipping: ecdsa_2, ecdsa_1
[+] 10.0.0.10:22 - [1/10] rsa_4096_2: accepted for msfadmin (SHA256:q1yNRnyNODplVm6+I2ioRP9ewE78coWoWbDw2L3dTgw) - Private Key: Yes 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)'
[+] Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
[*] SSH session 2 opened (10.0.0.1:42269 -> 10.0.0.10:22) at 2026-05-26 23:02:11 +0100
[-] 10.0.0.10:22 - [2/10] rsa_4096_1: not accepted for msfadmin
[+] 10.0.0.10:22 - [3/10] rsa_2048_legacy_2: accepted for msfadmin (SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs) - Private Key: Yes 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)'
[+] Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
[*] SSH session 3 opened (10.0.0.1:34445 -> 10.0.0.10:22) at 2026-05-26 23:02:12 +0100
[-] 10.0.0.10:22 - [4/10] rsa_2048_legacy_1: not accepted for msfadmin
[+] 10.0.0.10:22 - [5/10] rsa_2048_2: accepted for msfadmin (SHA256:3mu8YIA99vhhpbrKv8FF1pjAjNRlxHF8DzATM3p7W0M) - Private Key: Yes 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)'
[+] Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
[*] SSH session 4 opened (10.0.0.1:42859 -> 10.0.0.10:22) at 2026-05-26 23:02:13 +0100
[-] 10.0.0.10:22 - [6/10] rsa_2048_1: not accepted for msfadmin
[+] 10.0.0.10:22 - [7/10] rsa_1024_2: accepted for msfadmin (SHA256:G2kiqv3dp9OyEp98YgfEjpRjUpzuVFhxN+7cQkyin88) - Private Key: Yes 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)'
[+] Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
[*] SSH session 5 opened (10.0.0.1:38709 -> 10.0.0.10:22) at 2026-05-26 23:02:14 +0100
[-] 10.0.0.10:22 - [8/10] rsa_1024_1: not accepted for msfadmin
[+] 10.0.0.10:22 - [9/10] tmp_2.pub: accepted for msfadmin (SHA256:qzd4gfzyP8rqfx03wabeTyrWRXgB0ERpA8pLehQxr5o) - Private Key: No
[!] 10.0.0.10:22 - Key accepted for msfadmin but no private key available - cannot create session (public key only)
[-] 10.0.0.10:22 - [10/10] tmp_1.pub: not accepted for msfadmin
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_key_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         2      4      9      13

msf auxiliary(scanner/ssh/ssh_key_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux    Ubuntu     8.04   server

msf auxiliary(scanner/ssh/ssh_key_login) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    tcp   open                                          {}
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)

msf auxiliary(scanner/ssh/ssh_key_login) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                                    References
---------                ----       -------       --------  ----                                    ----------
2026-05-26 21:59:50 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Authorized Key Accepted             ATT&CK-T1021.004
2026-05-26 21:59:51 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Authorized Key Login Check Scanner  ATT&CK-T1021.004

msf auxiliary(scanner/ssh/ssh_key_login) > creds
Credentials
===========

id   host       origin     service       public    private                                          realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------                                          -----  ------------  ----------  ----------------
579  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  6d:5d:df:2c:e6:5e:dd:a6:db:0d:84:4d:7d:bc:4a:19         SSH key
580  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  08:96:70:bd:c8:b1:bc:9b:cd:46:1c:f7:1d:4f:db:92         SSH key
581  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  0c:69:7c:f8:79:8d:2c:83:ca:d4:83:f7:7e:48:81:7f         SSH key
582  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  68:b3:a0:74:2c:4e:e4:ad:a3:06:b0:3f:74:a2:9d:95         SSH key

msf auxiliary(scanner/ssh/ssh_key_login) > loot

Loot
====

host       service  type                name                 content     info                                                path
----       -------  ----                ----                 -------     ----                                                ----
10.0.0.10           ssh.publickey.rsa   msfadmin_id_rsa.pub  text/plain  SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs  /home/kali/.msf4/loot/20260526225950_default_10.0.0.10_ssh.publickey.rs_468112.txt
10.0.0.10           ssh.privatekey.rsa  msfadmin_id_rsa      text/plain  SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs  /home/kali/.msf4/loot/20260526225950_default_10.0.0.10_ssh.privatekey.r_449006.txt
10.0.0.10           ssh.publickey.rsa   msfadmin_id_rsa.pub  text/plain  SHA256:q1yNRnyNODplVm6+I2ioRP9ewE78coWoWbDw2L3dTgw  /home/kali/.msf4/loot/20260526230211_default_10.0.0.10_ssh.publickey.rs_155610.txt
10.0.0.10           ssh.privatekey.rsa  msfadmin_id_rsa      text/plain  SHA256:q1yNRnyNODplVm6+I2ioRP9ewE78coWoWbDw2L3dTgw  /home/kali/.msf4/loot/20260526230211_default_10.0.0.10_ssh.privatekey.r_577896.txt
10.0.0.10           ssh.publickey.rsa   msfadmin_id_rsa.pub  text/plain  SHA256:3mu8YIA99vhhpbrKv8FF1pjAjNRlxHF8DzATM3p7W0M  /home/kali/.msf4/loot/20260526230212_default_10.0.0.10_ssh.publickey.rs_662720.txt
10.0.0.10           ssh.privatekey.rsa  msfadmin_id_rsa      text/plain  SHA256:3mu8YIA99vhhpbrKv8FF1pjAjNRlxHF8DzATM3p7W0M  /home/kali/.msf4/loot/20260526230212_default_10.0.0.10_ssh.privatekey.r_253045.txt
10.0.0.10           ssh.publickey.rsa   msfadmin_id_rsa.pub  text/plain  SHA256:G2kiqv3dp9OyEp98YgfEjpRjUpzuVFhxN+7cQkyin88  /home/kali/.msf4/loot/20260526230213_default_10.0.0.10_ssh.publickey.rs_069247.txt
10.0.0.10           ssh.privatekey.rsa  msfadmin_id_rsa      text/plain  SHA256:G2kiqv3dp9OyEp98YgfEjpRjUpzuVFhxN+7cQkyin88  /home/kali/.msf4/loot/20260526230213_default_10.0.0.10_ssh.privatekey.r_758952.txt
10.0.0.10           ssh.publickey.rsa   msfadmin_id_rsa.pub  text/plain  SHA256:qzd4gfzyP8rqfx03wabeTyrWRXgB0ERpA8pLehQxr5o  /home/kali/.msf4/loot/20260526230214_default_10.0.0.10_ssh.publickey.rs_819024.txt

msf auxiliary(scanner/ssh/ssh_key_login) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type               Data
 ----                     ----       -------  ----  --------  ----               ----
 2026-05-26 21:59:50 UTC  10.0.0.10  ssh      22    tcp       ssh.cpe            {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}
 2026-05-26 21:59:50 UTC  10.0.0.10  ssh      22    tcp       ssh.hostkey        {:type=>"ssh-rsa", :fingerprint=>"SHA256:BQHm5EoHX9GCiOLuVscegPXLQOsuPs+E9d/rrJB84rk"}
 2026-05-26 21:59:50 UTC  10.0.0.10  tcp      22    tcp       ssh.accepted_keys  {:user=>"msfadmin", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCIwliRlyg+ZA5R4GmRNHu9i8UyuzIiJdB5P8/8a1SwrjjXvQTOjEg
                                                                                 XOnw/kMygqAyNlMbSyHj7nUxL5xjLloDmeop9yMCqbVLQ4cV8xmTBQ//ezxYKYAubHa8qRD/aKB3A1s+gI+nkDfRvfzLzYV5SSUoNXKAv93iAn2Clj8Mr/Rrt81Te
                                                                                 3SatvGjdDpu1ke46wwJ+HXBlQXbPa/9IIsT6iJw5RMnr4FaxpvxZPp1evQMjXzYuDWlLlR3HButaRz7CLUeIgQ1ZJwsvCORCnQ25RSjCYho96wrEioqASc9UUBBGM
                                                                                 DeAligv1euoClvaOPHIAgf1D0yrK4l+Pu4wPxfb", :private_key=>true}
 2026-05-26 21:59:50 UTC  10.0.0.10  tcp      22    tcp       ssh.proof          {:credential=>"msfadmin:SHA256:SujbJCC/eVK8R8hQ+/5n4IyJoMwNBIKlyRwKqJUwOEs", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) grou
                                                                                 ps=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(samb
                                                                                 ashare),1000(msfadmin)", :uname=>"Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}
 2026-05-26 22:02:10 UTC  10.0.0.10  tcp      22    tcp       ssh.cpe            {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}
 2026-05-26 22:02:10 UTC  10.0.0.10  tcp      22    tcp       ssh.hostkey        {:type=>"ssh-rsa", :fingerprint=>"SHA256:BQHm5EoHX9GCiOLuVscegPXLQOsuPs+E9d/rrJB84rk"}
 2026-05-26 22:02:11 UTC  10.0.0.10  tcp      22    tcp       ssh.accepted_keys  {:user=>"msfadmin", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDzp7xbi00yMK+feukS9dDFI7p/w6oUPlgba1PO6KI4rRDV/n3Z50P
                                                                                 2zmZ3nEatrFSqtkge12BE0AxH4HjwxHgfnhrEpdziZ1ZNxipkxbjB9vzdGtkHA56s14sPBxNINDmaB+66/99bRBdCRnbuGKNsV9trr+ToM4t7p1ZluP2UXi/AEb1K
                                                                                 K+PW+l9lkw30qOH8pSZO7ga2ZPxjtJoTFt16CniEiQ+S5RqUs3DvmdMypg1UfyWxX5QIcpbqLqUTY1jfNAMGhbBWsIEm3PeZecyGvAr/x9yxvImZwQAn46wqYnG10
                                                                                 zcCYYqs0wA4Vj5ILO6bNpmEJVWVCCiWUi1XDNQDN+UtVc+Gqxc9IThyY2O1KHv7lRHX1qgHEzXnHyoolxUu03N8WhF24dEcN59nn/wu3lnZWkxCgySrwZXAma7Gyl
                                                                                 uaBKkGe6fKz63aPPWaziF6JCrVH8CS0tbvQtUg2ZOYH2FWyQfd6d/85FZKcMBkdlYaF5Mq1Xxvajs4CTAGsLiPXC+rslzvn1vm6qLVISe43NFOngr3AamS3n9Zz/5
                                                                                 HrAKTdjB+AEJ3lk/ye1o7dVkUQw18mR+SxMML92s6mjYsm/NZwUHt5qJq67KMwIkASIgQJrZ40DvBumFesaTx4sWIqksbuZmv1cR+1YR5PO7dspbHA4ldutjViWcT
                                                                                 0hfxbw==", :private_key=>true}
 2026-05-26 22:02:11 UTC  10.0.0.10  tcp      22    tcp       ssh.proof          {:credential=>"msfadmin:SHA256:q1yNRnyNODplVm6+I2ioRP9ewE78coWoWbDw2L3dTgw", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) grou
                                                                                 ps=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(samb
                                                                                 ashare),1000(msfadmin)", :uname=>"Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}
 2026-05-26 22:02:12 UTC  10.0.0.10  tcp      22    tcp       ssh.accepted_keys  {:user=>"msfadmin", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCl2rPtkEPHT3DdilnZVPG7ZtuZWUcjE5croeYFcN+Gth+AvsPikza
                                                                                 PRVMQnGNVuAPL1ng3IgjPSqQzVkhkI3uIwyXgH6+CoOa80coOHDp3RRYsNeNfnjZqaF1WT8a/ZyOAgYc8uwVXuxwWDT+ucDNxFzpZYjeCEnBjHfhVNTJQ/jeeTZ6I
                                                                                 HkBaCcr3AxIzIW7a/935Bgxf6IvdeIB7SMFd6SPuDu8Z4veXFysC/W0jF91I436KNyRjcXX6bOTD6wcy6ShNJjFfPvtfHjSNLhSE+WlRBK0XxYSWoYkPtWe2tMIth
                                                                                 ZdNCv9UqlfY3qipkJ8gFVNcoCweIFks9zTAwsdL", :private_key=>true}
 2026-05-26 22:02:12 UTC  10.0.0.10  tcp      22    tcp       ssh.proof          {:credential=>"msfadmin:SHA256:3mu8YIA99vhhpbrKv8FF1pjAjNRlxHF8DzATM3p7W0M", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) grou
                                                                                 ps=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(samb
                                                                                 ashare),1000(msfadmin)", :uname=>"Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}
 2026-05-26 22:02:13 UTC  10.0.0.10  tcp      22    tcp       ssh.accepted_keys  {:user=>"msfadmin", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCdl6yBo52RztXACkoqOmlbt0rO7Fj4egh9FEPz80JmVLW0LRG9K1C
                                                                                 enSvniyh5am5r6X+PfqQhZ+nDedddciJZQo6zUceOyuJxhbh/AooDpNrbt4qFw8N86GsIJa+1ZknOydjOuIDb6D8PWTKbR+6gFE9gJ/I5xNewsNRTddwT8Q==", :
                                                                                 private_key=>true}
 2026-05-26 22:02:13 UTC  10.0.0.10  tcp      22    tcp       ssh.proof          {:credential=>"msfadmin:SHA256:G2kiqv3dp9OyEp98YgfEjpRjUpzuVFhxN+7cQkyin88", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) grou
                                                                                 ps=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(samb
                                                                                 ashare),1000(msfadmin)", :uname=>"Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}
 2026-05-26 22:02:14 UTC  10.0.0.10  tcp      22    tcp       ssh.accepted_keys  {:user=>"msfadmin", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9P8cr5WzJu+xIu3UZiOetIGdCuRSA4sulMSnP/w8i0+l2gqqcifL
                                                                                 KaZNkdGHyhEL3/2Ux8n8CbPQhOYIKtqPxd3OdxfxTEVp2EmmN0oheWuv9uepV5sLZmPjwXrtdazpYKfj+J86053FqEFQF60SA3KADQe8jrsRh3hTtYLt9hXzzF6Sn
                                                                                 vXyXR5fhx5FyQRfjia91y/lE2Q31mF2htjsgTF0HHP+AAinlBhJhecQMtKwa762mYPZpzs+X+To/O1sDCivkSfEy25VtiXsFIPq+8ZgEOl2kscIa7fblaO0HrIKIQ
                                                                                 Mid2tuQw2p5518oReE20KiseXh3fQa/3oncTlpIPIGaI8ThVFM3GTaESn5TGJQdrSWeZY9t3V4Y83tlrkMSccbBtA8q9yjb+z1GoFfhONYSZ7uPfjm8AS0hQ1LPit
                                                                                 KFPy3Y6U5UrMwmZQDOWfd7BPzWtKl90LZ28IdpI3SyvxwXGNCdtfKkSXTTg7PJv05aZwRKLJwV5nlQX1sUbYs= kali@bdesktop", :private_key=>false}

msf auxiliary(scanner/ssh/ssh_key_login) >
```