### PR TITLE
Be more specific in pinning ActionView and pin railties to prevent er…

### DIFF
--- a/lib/metasploit/framework/rails_version_constraint.rb
+++ b/lib/metasploit/framework/rails_version_constraint.rb
@@ -3,7 +3,7 @@
 module Metasploit
   module Framework
     module RailsVersionConstraint
-      RAILS_VERSION = '~> 7.2.0'
+      RAILS_VERSION = '~> 7.2.2.2'
     end
   end
 end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -95,7 +95,7 @@ Gem::Specification.new do |spec|
   # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
   spec.add_runtime_dependency 'pg'
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
-  spec.add_runtime_dependency 'railties'
+  spec.add_runtime_dependency 'railties', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # required for OS fingerprinting
   spec.add_runtime_dependency 'recog'
   # required for bitlocker fvek extraction


### PR DESCRIPTION
WARNING- I don't know what I'm doing.....

When updating the rex-arch gem, my install also updated Actionview to 7.3.2.1, which is a problem because there's a `monkeypatch` in `config/application.rb` that raises an exception if ActionView is not 7.2.2.2:

```
require 'action_view'
# Monkey patch https://github.com/rails/rails/blob/v7.2.2.1/actionview/lib/action_view/helpers/tag_helper.rb#L51
# Might be fixed by 8.x https://github.com/rails/rails/blob/v8.0.2/actionview/lib/action_view/helpers/tag_helper.rb#L51C1-L52C1
raise unless ActionView::VERSION::STRING == '7.2.2.2' # A developer will need to ensure this is still required when bumping rails                                                                                                       
```

Unfortunately, it seems like there's a lot of codependence going on around that, but it all seems to work if we _also_ tag `railties` to the `RAILS_VERSION`, but we need to be more specific on the `RAILS_VERSION`, too.

This fix works for me, but someone with a better understanding of the dependencies here will need to make sure this is right.

### Before:
1. Check out master branch
2. `bundle update`
3. Run ./msfconsole`
```
[ruby-3.3.8@metasploit-framework](upstream-master) tmoose@ubuntu-dev2024:~/rapid7/metasploit-framework$ ./msfconsole
/home/tmoose/rapid7/metasploit-framework/config/application.rb:10:in `<top (required)>': unhandled exception
	from /home/tmoose/.rvm/rubies/ruby-3.3.8/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /home/tmoose/.rvm/rubies/ruby-3.3.8/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/bootsnap-1.24.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
	from /home/tmoose/rapid7/metasploit-framework/config/environment.rb:2:in `<top (required)>'
	from /home/tmoose/.rvm/rubies/ruby-3.3.8/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /home/tmoose/.rvm/rubies/ruby-3.3.8/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/bootsnap-1.24.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
	from /home/tmoose/rapid7/metasploit-framework/lib/msfenv.rb:28:in `<top (required)>'
	from /home/tmoose/.rvm/rubies/ruby-3.3.8/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /home/tmoose/.rvm/rubies/ruby-3.3.8/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /home/tmoose/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/bootsnap-1.24.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
	from ./msfconsole:21:in `<main>'
```
4. Cry

### Fixed:
1. Check out this branch
2. `bundle update`
3. run `./msfconsole`
4. Hack the planet