### PR TITLE
Update service creation for login scanners

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,5 @@ group :test do
   # stub and set expectations on HTTP requests
   gem 'webmock', '~> 3.18'
 end
+
+gem 'metasploit-credential', '6.0.24', git: 'https://github.com/sjanusz-r7/metasploit-credential', branch: 'parent-services-when-creadting-creds'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,23 @@
+GIT
+  remote: https://github.com/sjanusz-r7/metasploit-credential
+  revision: 1b9bd214b8a23e9749aec2c84c709806db5701d1
+  branch: parent-services-when-creadting-creds
+  specs:
+    metasploit-credential (6.0.24)
+      bigdecimal
+      csv
+      drb
+      metasploit-concern
+      metasploit-model
+      metasploit_data_models (>= 5.0.0)
+      mutex_m
+      net-ssh
+      pg
+      railties
+      rex-socket
+      rubyntlm
+      rubyzip (< 3.0.0)
+
 PATH
   remote: .
   specs:
@@ -341,20 +361,6 @@ GEM
       mutex_m
       railties (~> 7.0)
       zeitwerk
-    metasploit-credential (6.0.23)
-      bigdecimal
-      csv
-      drb
-      metasploit-concern
-      metasploit-model
-      metasploit_data_models (>= 5.0.0)
-      mutex_m
-      net-ssh
-      pg
-      railties
-      rex-socket
-      rubyntlm
-      rubyzip (< 3.0.0)
     metasploit-model (5.0.4)
       activemodel (~> 7.0)
       activesupport (~> 7.0)
@@ -701,6 +707,7 @@ DEPENDENCIES
   fivemat
   license_finder (= 5.11.1)
   memory_profiler
+  metasploit-credential (= 6.0.24)!
   metasploit-framework!
   octokit
   pry-byebug

--- a/lib/metasploit/framework/login_scanner.rb
+++ b/lib/metasploit/framework/login_scanner.rb
@@ -8,6 +8,7 @@ module Metasploit
     module LoginScanner
       require 'metasploit/framework/login_scanner/result'
       require 'metasploit/framework/login_scanner/invalid'
+      require 'metasploit/framework/login_scanner/report_service'
 
       # Gather a list of LoginScanner classes that can potentially be
       # used for a given `service`, which should usually be an

--- a/lib/metasploit/framework/login_scanner/acpp.rb
+++ b/lib/metasploit/framework/login_scanner/acpp.rb
@@ -22,6 +22,9 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = nil
 
+        def report_acpp_service
+          report_service(host: host, port: port, name: 'ACPP', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        end
 
         # This method attempts a single login with a single credential against the target
         # @param credential [Credential] The credential object to attempt to login with
@@ -48,6 +51,7 @@ module Metasploit
             else
               status = Metasploit::Model::Login::Status::INCORRECT
             end
+            report_acpp_service
             result_options.merge!(
               proof: "Status code #{auth_response.status}",
               status: status

--- a/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
+++ b/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
@@ -10,8 +10,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
-        def report_advantech_service
-          report_service(host: host, port: port, name: 'Advantech WebAccess', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Advantech WebAccess', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is Advantech WebAccess
@@ -28,7 +28,6 @@ module Metasploit
           })
 
           if res && res.body =~ /Welcome to Advantech WebAccess/i
-            report_advantech_service
             return false
           end
 
@@ -55,8 +54,6 @@ module Metasploit
           unless res
             return {status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: 'Connection timed out for signin.asp'}
           end
-
-          report_advantech_service
 
           if res.headers['Location'] && res.headers['Location'] == '/broadweb/bwproj.asp'
             return {status: LOGIN_STATUS::SUCCESSFUL, proof: res.body}

--- a/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
+++ b/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
@@ -10,6 +10,10 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
+        def report_advantech_service
+          report_service(host: host, port: port, name: 'Advantech WebAccess', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is Advantech WebAccess
         #
         # @return [false] Indicates there were no errors
@@ -24,6 +28,7 @@ module Metasploit
           })
 
           if res && res.body =~ /Welcome to Advantech WebAccess/i
+            report_advantech_service
             return false
           end
 
@@ -51,6 +56,8 @@ module Metasploit
             return {status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: 'Connection timed out for signin.asp'}
           end
 
+          report_advantech_service
+
           if res.headers['Location'] && res.headers['Location'] == '/broadweb/bwproj.asp'
             return {status: LOGIN_STATUS::SUCCESSFUL, proof: res.body}
           end
@@ -69,7 +76,8 @@ module Metasploit
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin

--- a/lib/metasploit/framework/login_scanner/afp.rb
+++ b/lib/metasploit/framework/login_scanner/afp.rb
@@ -2,6 +2,7 @@ require 'metasploit/framework/tcp/client'
 require 'metasploit/framework/afp/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 
 module Metasploit
   module Framework
@@ -25,8 +26,8 @@ module Metasploit
         #   @return [Integer] Number of seconds to wait before giving up
         attr_accessor :login_timeout
 
-        def report_afp_service
-          report_service(host: host, port: port, name: 'AFP', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        def service_details
+          super.merge(name: 'AFP', parents: [:tcp])
         end
 
         def attempt_login(credential)
@@ -40,8 +41,6 @@ module Metasploit
             rescue RuntimeError => e
               return {:status => Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, :proof => e.message}
             end
-
-            report_afp_service
 
             status = (success == true) ? Metasploit::Model::Login::Status::SUCCESSFUL : Metasploit::Model::Login::Status::INCORRECT
           end

--- a/lib/metasploit/framework/login_scanner/afp.rb
+++ b/lib/metasploit/framework/login_scanner/afp.rb
@@ -25,6 +25,10 @@ module Metasploit
         #   @return [Integer] Number of seconds to wait before giving up
         attr_accessor :login_timeout
 
+        def report_afp_service
+          report_service(host: host, port: port, name: 'AFP', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        end
+
         def attempt_login(credential)
           begin
             connect
@@ -36,6 +40,8 @@ module Metasploit
             rescue RuntimeError => e
               return {:status => Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, :proof => e.message}
             end
+
+            report_afp_service
 
             status = (success == true) ? Metasploit::Model::Login::Status::SUCCESSFUL : Metasploit::Model::Login::Status::INCORRECT
           end

--- a/lib/metasploit/framework/login_scanner/amqp.rb
+++ b/lib/metasploit/framework/login_scanner/amqp.rb
@@ -1,5 +1,6 @@
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 require 'rex/proto/amqp'
 
 module Metasploit
@@ -16,8 +17,8 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY           = nil
 
-        def report_amqp_service
-          report_service(host: host, port: port, name: 'AMQP', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        def service_details
+          super.merge(name: 'AMQP', parents: [ssl ? :ssl : :tcp])
         end
 
         # (see Base#attempt_login)
@@ -28,7 +29,6 @@ module Metasploit
 
           begin
             result_options.merge!(connect_login(credential.public, credential.private))
-            report_amqp_service
           rescue Rex::Proto::Amqp::Error::NegotiationError => e
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             result_options[:proof] = e.message

--- a/lib/metasploit/framework/login_scanner/amqp.rb
+++ b/lib/metasploit/framework/login_scanner/amqp.rb
@@ -16,6 +16,10 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY           = nil
 
+        def report_amqp_service
+          report_service(host: host, port: port, name: 'AMQP', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_options = {
@@ -24,6 +28,7 @@ module Metasploit
 
           begin
             result_options.merge!(connect_login(credential.public, credential.private))
+            report_amqp_service
           rescue Rex::Proto::Amqp::Error::NegotiationError => e
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             result_options[:proof] = e.message
@@ -38,6 +43,7 @@ module Metasploit
           result.port         = port
           result.protocol     = 'tcp'
           result.service_name = "amqp#{ssl ? 's' : ''}"
+          result.ssl = ssl
           result
         end
 

--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -14,19 +14,20 @@ module Metasploit
         CAN_GET_SESSION = true
         PRIVATE_TYPES   = [ :password ]
 
+        def report_axis2_service
+          report_service(host: host, port: port, name: 'Axis2', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {
+              service_name: 'axis2',
               credential: credential,
               host: host,
               port: port,
-              protocol: 'tcp'
+              protocol: 'tcp',
+              ssl: ssl
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
             # Refactor to access Metasploit::Framework::LoginScanner::HTTP#send_request()
@@ -47,6 +48,8 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: response)
             end
+
+            report_axis2_service
           rescue ::EOFError, Rex::ConnectionError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end

--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -14,8 +14,8 @@ module Metasploit
         CAN_GET_SESSION = true
         PRIVATE_TYPES   = [ :password ]
 
-        def report_axis2_service
-          report_service(host: host, port: port, name: 'Axis2', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Axis2', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#attempt_login)
@@ -48,8 +48,6 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: response)
             end
-
-            report_axis2_service
           rescue ::EOFError, Rex::ConnectionError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -11,6 +11,7 @@ module Metasploit
         extend ActiveSupport::Concern
         include ActiveModel::Validations
         include Msf::Auxiliary::Report
+        include Metasploit::Framework::LoginScanner::ReportService
 
         included do
           # @!attribute framework
@@ -115,6 +116,20 @@ module Metasploit
           #   this scanner can't run
           def check_setup
             false
+          end
+
+          # Returns a hash of service details used for reporting.
+          # Subclasses should override this and merge in their specific
+          # service metadata (e.g. name, parents, resource).
+          #
+          # @return [Hash] service details suitable for passing to `report_service`
+          def service_details
+            {
+              host: host,
+              port: port,
+              proto: 'tcp',
+              workspace_id: myworkspace_id
+            }
           end
 
           def should_report_service?(login_result)

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -10,6 +10,7 @@ module Metasploit
       module Base
         extend ActiveSupport::Concern
         include ActiveModel::Validations
+        include Msf::Auxiliary::Report
 
         included do
           # @!attribute framework
@@ -48,6 +49,10 @@ module Metasploit
           # @!attribute sslkeylogfile
           #   @return [String] The SSL key log file path
           attr_accessor :sslkeylogfile
+          # @!attribute workspace
+          #   @return [String] The workspace name that the login scanner was executed in.
+          attr_accessor :workspace
+          attr_accessor :ssl
 
           validates :connection_timeout,
                     presence: true,
@@ -110,6 +115,10 @@ module Metasploit
           #   this scanner can't run
           def check_setup
             false
+          end
+
+          def should_report_service?(login_result)
+            login_result[:status]&.in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
           end
 
           # @note Override this to set a timeout that makes more sense for

--- a/lib/metasploit/framework/login_scanner/bavision_cameras.rb
+++ b/lib/metasploit/framework/login_scanner/bavision_cameras.rb
@@ -13,9 +13,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
-
-        def report_bavision_service
-          report_service(host: host, port: port, name: 'VAVision Camera web server', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'VAVision Camera web server', parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is BAVision Camera's web server. The login module should call this.
@@ -29,7 +28,6 @@ module Metasploit
             return "Unable to locate \"realm=IPCamera Login\" in headers. (Is this really a BAVision camera?)"
           end
 
-          report_bavision_service
           false
         end
 
@@ -118,7 +116,6 @@ module Metasploit
 
           begin
             result_opts.merge!(try_digest_auth(credential))
-            report_bavision_service
           rescue ::Rex::ConnectionError, BavisionCamerasException => e
             # Something went wrong during login. 'e' knows what's up.
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
@@ -131,4 +128,3 @@ module Metasploit
     end
   end
 end
-

--- a/lib/metasploit/framework/login_scanner/bavision_cameras.rb
+++ b/lib/metasploit/framework/login_scanner/bavision_cameras.rb
@@ -14,6 +14,10 @@ module Metasploit
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
 
+        def report_bavision_service
+          report_service(host: host, port: port, name: 'VAVision Camera web server', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is BAVision Camera's web server. The login module should call this.
         #
         # @return [String] Error message if target is not a BAVision camera, otherwise FalseClass
@@ -25,6 +29,7 @@ module Metasploit
             return "Unable to locate \"realm=IPCamera Login\" in headers. (Is this really a BAVision camera?)"
           end
 
+          report_bavision_service
           false
         end
 
@@ -107,11 +112,13 @@ module Metasploit
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin
             result_opts.merge!(try_digest_auth(credential))
+            report_bavision_service
           rescue ::Rex::ConnectionError, BavisionCamerasException => e
             # Something went wrong during login. 'e' knows what's up.
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -13,6 +13,11 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        def report_buffalo_service
+          report_service(host: host, port: port, name: 'Buffalo Linkstation NAS', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = "/dynamic.pl" if self.uri.nil?
@@ -23,16 +28,14 @@ module Metasploit
 
         def attempt_login(credential)
           result_opts = {
+              service_name: 'Buffalo Linkstation NAS',
               credential: credential,
               host: host,
               port: port,
-              protocol: 'tcp'
+              protocol: 'tcp',
+              ssl: ssl
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
+
           begin
             res = send_request({
               'method'=>'POST',
@@ -50,6 +53,7 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
             end
+            report_buffalo_service
           rescue ::JSON::ParserError
             result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res.body)
           rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -13,9 +13,8 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
-        def report_buffalo_service
-          report_service(host: host, port: port, name: 'Buffalo Linkstation NAS', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
-
+        def service_details
+          super.merge(name: 'Buffalo Linkstation NAS', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#set_sane_defaults)
@@ -53,7 +52,6 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
             end
-            report_buffalo_service
           rescue ::JSON::ParserError
             result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res.body)
           rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error

--- a/lib/metasploit/framework/login_scanner/caidao.rb
+++ b/lib/metasploit/framework/login_scanner/caidao.rb
@@ -11,8 +11,8 @@ module Metasploit
         PRIVATE_TYPES      = [ :password ]
         LOGIN_STATUS       = Metasploit::Model::Login::Status # Shorter name
 
-        def report_caidao_service
-          report_service(host: host, port: port, name: 'Caidao', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Caidao', parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is correct
@@ -28,7 +28,6 @@ module Metasploit
           case uri
           when /php$/mi
             @payload = "$_=\"#{@flag}\";echo \"#{@lmark}\".$_.\"#{@rmark}\";"
-            report_caidao_service
             return false
           when /asp$/mi
             @payload = 'execute("response.write(""'
@@ -38,13 +37,11 @@ module Metasploit
             @payload << '""):response.write(""'
             @payload << "#{@rmark}"
             @payload << '""):response.end")'
-            report_caidao_service
             return false
           when /aspx$/mi
             @payload = "Response.Write(\"#{@lmark}\");"
             @payload << "Response.Write(\"#{@flag}\");"
             @payload << "Response.Write(\"#{@rmark}\")"
-            report_caidao_service
             return false
           end
           "Unable to locate target extension in uri. (Is this really caidao?)"
@@ -72,8 +69,6 @@ module Metasploit
           unless res
             return { :status => LOGIN_STATUS::UNABLE_TO_CONNECT, :proof => res.to_s }
           end
-
-          report_caidao_service
 
           if res && res.code == 200 && res.body.to_s.include?("#{@lmark}#{@flag}#{@rmark}")
             return { :status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.to_s }

--- a/lib/metasploit/framework/login_scanner/caidao.rb
+++ b/lib/metasploit/framework/login_scanner/caidao.rb
@@ -11,6 +11,10 @@ module Metasploit
         PRIVATE_TYPES      = [ :password ]
         LOGIN_STATUS       = Metasploit::Model::Login::Status # Shorter name
 
+        def report_caidao_service
+          report_service(host: host, port: port, name: 'Caidao', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is correct
         #
         # @return [false] Indicates there were no errors
@@ -24,6 +28,7 @@ module Metasploit
           case uri
           when /php$/mi
             @payload = "$_=\"#{@flag}\";echo \"#{@lmark}\".$_.\"#{@rmark}\";"
+            report_caidao_service
             return false
           when /asp$/mi
             @payload = 'execute("response.write(""'
@@ -33,11 +38,13 @@ module Metasploit
             @payload << '""):response.write(""'
             @payload << "#{@rmark}"
             @payload << '""):response.end")'
+            report_caidao_service
             return false
           when /aspx$/mi
             @payload = "Response.Write(\"#{@lmark}\");"
             @payload << "Response.Write(\"#{@flag}\");"
             @payload << "Response.Write(\"#{@rmark}\")"
+            report_caidao_service
             return false
           end
           "Unable to locate target extension in uri. (Is this really caidao?)"
@@ -66,6 +73,8 @@ module Metasploit
             return { :status => LOGIN_STATUS::UNABLE_TO_CONNECT, :proof => res.to_s }
           end
 
+          report_caidao_service
+
           if res && res.code == 200 && res.body.to_s.include?("#{@lmark}#{@flag}#{@rmark}")
             return { :status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.to_s }
           end
@@ -79,19 +88,15 @@ module Metasploit
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Caidao',
             credential:  credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
-
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
             result_opts.merge!(try_login(credential.public, credential.private))

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -19,8 +19,8 @@ module Metasploit
         #   @return [String] Cookie value
         attr_accessor :session_id
 
-        def report_chef_service
-          report_service(host: host, port: port, name: 'Chef WebUI', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http])
+        def service_details
+          super.merge(name: 'Chef WebUI', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Decides which login routine and returns the results
@@ -68,7 +68,6 @@ module Metasploit
             return "Unable to connect to target"
           end
 
-          report_chef_service
           false
         end
 
@@ -143,12 +142,10 @@ module Metasploit
             }
             res = send_request(opts)
             if (res && res.code == 200 && res.body.to_s =~ /New password for the User/)
-              report_chef_service
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             end
           end
 
-          report_chef_service
           {:status => Metasploit::Model::Login::Status::INCORRECT, :proof => res.body}
         end
 

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -19,6 +19,10 @@ module Metasploit
         #   @return [String] Cookie value
         attr_accessor :session_id
 
+        def report_chef_service
+          report_service(host: host, port: port, name: 'Chef WebUI', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http])
+        end
+
         # Decides which login routine and returns the results
         #
         # @param credential [Metasploit::Framework::Credential] The credential object
@@ -30,7 +34,8 @@ module Metasploit
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin
@@ -63,6 +68,7 @@ module Metasploit
             return "Unable to connect to target"
           end
 
+          report_chef_service
           false
         end
 
@@ -137,10 +143,12 @@ module Metasploit
             }
             res = send_request(opts)
             if (res && res.code == 200 && res.body.to_s =~ /New password for the User/)
+              report_chef_service
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             end
           end
 
+          report_chef_service
           {:status => Metasploit::Model::Login::Status::INCORRECT, :proof => res.body}
         end
 

--- a/lib/metasploit/framework/login_scanner/cisco_firepower.rb
+++ b/lib/metasploit/framework/login_scanner/cisco_firepower.rb
@@ -11,6 +11,10 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
+        def report_cisco_service
+          report_service(host: host, port: port, name: 'Cisco FirePower', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http])
+        end
+
         def check_setup
           res = send_request({
             'method' => 'GET',
@@ -18,6 +22,7 @@ module Metasploit
           })
 
           if res && res.code == 200 && res.body.include?('/img/favicon.png?v=6.0.1-1213')
+            report_cisco_service
             return false
           end
 
@@ -43,9 +48,11 @@ module Metasploit
           end
 
           if res.code == 302 && res.get_cookies.include?('CGISESSID')
+            report_cisco_service
             return {status: LOGIN_STATUS::SUCCESSFUL, proof: res.body}
           end
 
+          report_cisco_service
           {status: LOGIN_STATUS::INCORRECT, proof: res.body}
         end
 
@@ -55,12 +62,14 @@ module Metasploit
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Cisco FirePower',
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin

--- a/lib/metasploit/framework/login_scanner/cisco_firepower.rb
+++ b/lib/metasploit/framework/login_scanner/cisco_firepower.rb
@@ -11,8 +11,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
-        def report_cisco_service
-          report_service(host: host, port: port, name: 'Cisco FirePower', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http])
+        def service_details
+          super.merge(name: 'Cisco FirePower', parents: [ssl ? :https : :http])
         end
 
         def check_setup
@@ -22,7 +22,6 @@ module Metasploit
           })
 
           if res && res.code == 200 && res.body.include?('/img/favicon.png?v=6.0.1-1213')
-            report_cisco_service
             return false
           end
 
@@ -48,11 +47,9 @@ module Metasploit
           end
 
           if res.code == 302 && res.get_cookies.include?('CGISESSID')
-            report_cisco_service
             return {status: LOGIN_STATUS::SUCCESSFUL, proof: res.body}
           end
 
-          report_cisco_service
           {status: LOGIN_STATUS::INCORRECT, proof: res.body}
         end
 
@@ -86,4 +83,3 @@ module Metasploit
     end
   end
 end
-

--- a/lib/metasploit/framework/login_scanner/db2.rb
+++ b/lib/metasploit/framework/login_scanner/db2.rb
@@ -21,6 +21,10 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = Metasploit::Model::Realm::Key::DB2_DATABASE
 
+        def report_db2_service
+          report_service(host: host, port: port, name: 'DB2', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        end
+
         # @see Base#attempt_login
         def attempt_login(credential)
           result_options = {
@@ -38,6 +42,7 @@ module Metasploit
               else
                 result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
               end
+              report_db2_service
             end
           rescue ::Rex::ConnectionError, ::Rex::Proto::DRDA::RespError, ::Timeout::Error => e
             result_options.merge!({

--- a/lib/metasploit/framework/login_scanner/db2.rb
+++ b/lib/metasploit/framework/login_scanner/db2.rb
@@ -1,6 +1,7 @@
 require 'metasploit/framework/tcp/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 
 module Metasploit
   module Framework
@@ -21,8 +22,8 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = Metasploit::Model::Realm::Key::DB2_DATABASE
 
-        def report_db2_service
-          report_service(host: host, port: port, name: 'DB2', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        def service_details
+          super.merge(name: 'DB2', parents: [:tcp])
         end
 
         # @see Base#attempt_login
@@ -42,7 +43,6 @@ module Metasploit
               else
                 result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
               end
-              report_db2_service
             end
           rescue ::Rex::ConnectionError, ::Rex::Proto::DRDA::RespError, ::Timeout::Error => e
             result_options.merge!({

--- a/lib/metasploit/framework/login_scanner/directadmin.rb
+++ b/lib/metasploit/framework/login_scanner/directadmin.rb
@@ -9,9 +9,8 @@ module Metasploit
         DEFAULT_PORT  = 443
         PRIVATE_TYPES = [ :password ]
 
-
-        def report_directadmin_service
-          report_service(host: host, port: port, name: 'DirectAdmin', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http])
+        def service_details
+          super.merge(name: 'DirectAdmin', parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is correct
@@ -24,7 +23,6 @@ module Metasploit
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('DirectAdmin Login')
-            report_directadmin_service
             return false
           end
 
@@ -88,11 +86,9 @@ module Metasploit
           @last_sid = sid # Update our SID
 
           if res.headers['Location'].to_s.include?('/') && !sid.blank?
-            report_directadmin_service
             return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.to_s}
           end
 
-          report_directadmin_service
           {:status => Metasploit::Model::Login::Status::INCORRECT, :proof => res.to_s}
         end
 

--- a/lib/metasploit/framework/login_scanner/directadmin.rb
+++ b/lib/metasploit/framework/login_scanner/directadmin.rb
@@ -10,6 +10,10 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
 
 
+        def report_directadmin_service
+          report_service(host: host, port: port, name: 'DirectAdmin', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http])
+        end
+
         # Checks if the target is correct
         #
         # @return [false] Indicates there were no errors
@@ -20,6 +24,7 @@ module Metasploit
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('DirectAdmin Login')
+            report_directadmin_service
             return false
           end
 
@@ -83,9 +88,11 @@ module Metasploit
           @last_sid = sid # Update our SID
 
           if res.headers['Location'].to_s.include?('/') && !sid.blank?
+            report_directadmin_service
             return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.to_s}
           end
 
+          report_directadmin_service
           {:status => Metasploit::Model::Login::Status::INCORRECT, :proof => res.to_s}
         end
 
@@ -102,7 +109,8 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http'
+            service_name: 'DirecTadmin',
+            ssl: ssl
           }
 
           begin

--- a/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
+++ b/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
@@ -21,6 +21,10 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = nil
 
+        def report_freeswitch_service
+          report_service(host: host, port: port, name: 'FreeSWITCH EventSocket', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        end
+
         # This method attempts a single login with a single credential against the target
         # @param credential [Credential] The credential object to attempt to login with
         # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
@@ -54,7 +58,7 @@ module Metasploit
             elsif result_options[:proof]&.include?('+OK accepted')
               result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
             end
-
+            report_freeswitch_service
           rescue Rex::ConnectionError, EOFError, Timeout::Error, Errno::EPIPE, Rex::StreamClosedError => e
             result_options.merge!(
               proof: e.message,

--- a/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
+++ b/lib/metasploit/framework/login_scanner/freeswitch_event_socket.rb
@@ -1,5 +1,6 @@
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/tcp/client'
 
 module Metasploit
@@ -21,8 +22,8 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = nil
 
-        def report_freeswitch_service
-          report_service(host: host, port: port, name: 'FreeSWITCH EventSocket', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        def service_details
+          super.merge(name: 'FreeSWITCH EventSocket', parents: [:tcp])
         end
 
         # This method attempts a single login with a single credential against the target
@@ -58,7 +59,6 @@ module Metasploit
             elsif result_options[:proof]&.include?('+OK accepted')
               result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
             end
-            report_freeswitch_service
           rescue Rex::ConnectionError, EOFError, Timeout::Error, Errno::EPIPE, Rex::StreamClosedError => e
             result_options.merge!(
               proof: e.message,

--- a/lib/metasploit/framework/login_scanner/ftp.rb
+++ b/lib/metasploit/framework/login_scanner/ftp.rb
@@ -32,6 +32,9 @@ module Metasploit
                   }
 
 
+        def report_ftp_service
+          report_service(host: host, port: port, name: 'FTP', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        end
 
         # (see Base#attempt_login)
         def attempt_login(credential)
@@ -49,8 +52,10 @@ module Metasploit
           end
 
           if success
+            report_ftp_service
             result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
           elsif !(result_options.has_key? :status)
+            report_ftp_service
             result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
           end
 

--- a/lib/metasploit/framework/login_scanner/ftp.rb
+++ b/lib/metasploit/framework/login_scanner/ftp.rb
@@ -1,6 +1,7 @@
 require 'metasploit/framework/ftp/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 
 module Metasploit
   module Framework
@@ -32,8 +33,8 @@ module Metasploit
                   }
 
 
-        def report_ftp_service
-          report_service(host: host, port: port, name: 'FTP', proto: 'tcp', workspace_id: myworkspace_id, parents: [:tcp])
+        def service_details
+          super.merge(name: 'FTP', parents: [:tcp])
         end
 
         # (see Base#attempt_login)
@@ -52,10 +53,8 @@ module Metasploit
           end
 
           if success
-            report_ftp_service
             result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
           elsif !(result_options.has_key? :status)
-            report_ftp_service
             result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
           end
 

--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -10,8 +10,8 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
-        def report_gitlab_service
-          report_service(host: host, port: port, name: 'GitLab', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'GitLab', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#set_sane_defaults)
@@ -77,8 +77,6 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
             end
-
-            report_gitlab_service
           rescue ::EOFError, Errno::ETIMEDOUT ,Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end

--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -10,6 +10,10 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        def report_gitlab_service
+          report_service(host: host, port: port, name: 'GitLab', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = '/users/sign_in' if uri.nil?
@@ -24,7 +28,8 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http'
+            service_name: 'GitLab',
+            ssl: ssl
           }
           begin 
             # Get a valid session cookie and authenticity_token for the next step
@@ -72,6 +77,8 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
             end
+
+            report_gitlab_service
           rescue ::EOFError, Errno::ETIMEDOUT ,Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -27,6 +27,10 @@ module Metasploit
         # @!attribute http_password
         attr_accessor :http_password
 
+        def report_glassfish_service
+          report_service(host: host, port: port, name: 'Glassfish', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#check_setup)
         def check_setup
           begin
@@ -68,6 +72,7 @@ module Metasploit
             return "Unable to connect to target"
           end
 
+          report_glassfish_service
           false
         end
 
@@ -217,11 +222,13 @@ module Metasploit
               status = try_glassfish_9(credential)
               result_opts.merge!(status)
             end
+
+            report_glassfish_service
           rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
 
-          Result.new(result_opts)
+          Result.new(result_opts.merge(ssl: ssl))
         end
 
 

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -27,8 +27,8 @@ module Metasploit
         # @!attribute http_password
         attr_accessor :http_password
 
-        def report_glassfish_service
-          report_service(host: host, port: port, name: 'Glassfish', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Glassfish', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#check_setup)
@@ -72,7 +72,6 @@ module Metasploit
             return "Unable to connect to target"
           end
 
-          report_glassfish_service
           false
         end
 
@@ -222,8 +221,6 @@ module Metasploit
               status = try_glassfish_9(credential)
               result_opts.merge!(status)
             end
-
-            report_glassfish_service
           rescue ::EOFError, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -1,5 +1,6 @@
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 
 module Metasploit
   module Framework
@@ -199,8 +200,8 @@ module Metasploit
                   presence: true,
                   length: { minimum: 1 }
 
-        def report_http_service
-          report_service(host: host, port: port, name: ssl ? 'https' : 'http', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ :tcp ])
+        def service_details
+          super.merge(name: ssl ? 'https' : 'http', parents: [:tcp], resource: uri)
         end
 
         # (see Base#check_setup)
@@ -222,7 +223,6 @@ module Metasploit
           end
 
           if authentication_required?(response)
-            report_http_service
             return false
           end
 
@@ -299,7 +299,6 @@ module Metasploit
 
           begin
             response = send_request(request_opts)
-            report_http_service if response
             if response && http_success_codes.include?(response.code)
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -199,6 +199,10 @@ module Metasploit
                   presence: true,
                   length: { minimum: 1 }
 
+        def report_http_service
+          report_service(host: host, port: port, name: ssl ? 'https' : 'http', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ :tcp ])
+        end
+
         # (see Base#check_setup)
         def check_setup
           http_client = Rex::Proto::Http::Client.new(
@@ -218,6 +222,7 @@ module Metasploit
           end
 
           if authentication_required?(response)
+            report_http_service
             return false
           end
 
@@ -277,7 +282,8 @@ module Metasploit
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           if ssl
@@ -293,6 +299,7 @@ module Metasploit
 
           begin
             response = send_request(request_opts)
+            report_http_service if response
             if response && http_success_codes.include?(response.code)
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -15,8 +15,8 @@ module Metasploit
         # @return [String]
         attr_accessor :http_password
 
-        def report_ipboard_service
-          report_service(host: host, port: port, name: 'IPBoard', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'IPBoard', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#attempt_login)
@@ -69,8 +69,6 @@ module Metasploit
               else
                 result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: response)
               end
-
-              report_ipboard_service
 
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: "Server nonce not present, potentially not an IP Board install or bad URI.")

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -15,19 +15,20 @@ module Metasploit
         # @return [String]
         attr_accessor :http_password
 
+        def report_ipboard_service
+          report_service(host: host, port: port, name: 'IPBoard', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {
+              service_name: 'IPBoard',
               credential: credential,
               host: host,
               port: port,
-              protocol: 'tcp'
+              protocol: 'tcp',
+              ssl: ssl
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
 
@@ -68,6 +69,8 @@ module Metasploit
               else
                 result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: response)
               end
+
+              report_ipboard_service
 
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: "Server nonce not present, potentially not an IP Board install or bad URI.")

--- a/lib/metasploit/framework/login_scanner/ivanti_login.rb
+++ b/lib/metasploit/framework/login_scanner/ivanti_login.rb
@@ -18,8 +18,8 @@ module Metasploit
 
         attr_accessor :use_admin_endpoint
 
-        def report_ivanti_service
-          report_service(host: host, port: port, name: 'Ivanti Connect Secure', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Ivanti Connect Secure', resource: uri, parents: [ssl ? :https : :http])
         end
 
         def check_setup
@@ -31,7 +31,6 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Ivanti Connect Secure')
-            report_ivanti_service
             return false
           end
 
@@ -186,8 +185,6 @@ module Metasploit
           else
             login_result = do_login(credential.public, credential.private)
           end
-
-          report_ivanti_service if login_result[:status].in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
 
           result_options.merge!(login_result)
           Result.new(result_options)

--- a/lib/metasploit/framework/login_scanner/ivanti_login.rb
+++ b/lib/metasploit/framework/login_scanner/ivanti_login.rb
@@ -18,6 +18,10 @@ module Metasploit
 
         attr_accessor :use_admin_endpoint
 
+        def report_ivanti_service
+          report_service(host: host, port: port, name: 'Ivanti Connect Secure', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         def check_setup
           request_params = {
             'method' => 'GET',
@@ -27,6 +31,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Ivanti Connect Secure')
+            report_ivanti_service
             return false
           end
 
@@ -172,7 +177,8 @@ module Metasploit
             host: @host,
             port: @port,
             protocol: 'tcp',
-            service_name: 'ivanti'
+            service_name: 'Ivanti Connect Secure',
+            ssl: ssl
           }
 
           if @use_admin_endpoint
@@ -180,6 +186,8 @@ module Metasploit
           else
             login_result = do_login(credential.public, credential.private)
           end
+
+          report_ivanti_service if login_result[:status].in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
 
           result_options.merge!(login_result)
           Result.new(result_options)

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -12,8 +12,8 @@ module Metasploit
         PRIVATE_TYPES = [:password].freeze
         LOGIN_PATH_REGEX = /action="(j_([a-z0-9_]+))"/
 
-        def report_jenkins_service
-          report_service(host: host, port: port, name: 'Jenkins', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Jenkins', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks the setup for the Jenkins Login scanner.
@@ -25,8 +25,6 @@ module Metasploit
           return 'Unable to locate the Jenkins login path' if login_uri.nil?
 
           self.uri = normalize_uri(login_uri)
-
-          report_jenkins_service
 
           false
         end
@@ -53,8 +51,6 @@ module Metasploit
           }
 
           status, proof = jenkins_login(credential.public, credential.private)
-
-          report_jenkins_service if status.in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
 
           result_opts.merge!(status: status, proof: proof)
 

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -12,6 +12,10 @@ module Metasploit
         PRIVATE_TYPES = [:password].freeze
         LOGIN_PATH_REGEX = /action="(j_([a-z0-9_]+))"/
 
+        def report_jenkins_service
+          report_service(host: host, port: port, name: 'Jenkins', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks the setup for the Jenkins Login scanner.
         #
         # @return [String, false] Always returns false.
@@ -21,6 +25,8 @@ module Metasploit
           return 'Unable to locate the Jenkins login path' if login_uri.nil?
 
           self.uri = normalize_uri(login_uri)
+
+          report_jenkins_service
 
           false
         end
@@ -38,19 +44,17 @@ module Metasploit
 
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Jenkins',
             credential: credential,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
-
           status, proof = jenkins_login(credential.public, credential.private)
+
+          report_jenkins_service if status.in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
 
           result_opts.merge!(status: status, proof: proof)
 

--- a/lib/metasploit/framework/login_scanner/jupyter.rb
+++ b/lib/metasploit/framework/login_scanner/jupyter.rb
@@ -12,8 +12,8 @@ module Metasploit
         DEFAULT_PORT    = 8888
         PRIVATE_TYPES   = [ :password ]
 
-        def report_jupyter_service
-          report_service(host: host, port: port, name: 'Jupyter', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Jupyter', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#set_sane_defaults)
@@ -55,8 +55,6 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
             end
-
-            report_jupyter_service
           rescue ::EOFError, Errno::ETIMEDOUT, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end

--- a/lib/metasploit/framework/login_scanner/jupyter.rb
+++ b/lib/metasploit/framework/login_scanner/jupyter.rb
@@ -12,6 +12,10 @@ module Metasploit
         DEFAULT_PORT    = 8888
         PRIVATE_TYPES   = [ :password ]
 
+        def report_jupyter_service
+          report_service(host: host, port: port, name: 'Jupyter', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = '/login' if self.uri.nil?
@@ -26,7 +30,8 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http'
+            service_name: 'Jupyter',
+            ssl: ssl
           }
 
           begin
@@ -50,6 +55,8 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
             end
+
+            report_jupyter_service
           rescue ::EOFError, Errno::ETIMEDOUT, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end

--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -17,6 +17,10 @@ module Metasploit
         PRIVATE_TYPES = %i[ password ].freeze
         CAN_GET_SESSION = true
 
+        def report_kerberos_service
+          report_service(host: host, port: port, name: 'kerberos', proto: 'tcp', workspace_id: myworkspace_id, parents: [ :tcp ])
+        end
+
         def attempt_login(credential)
           result_options = {
             credential: credential,
@@ -55,11 +59,13 @@ module Metasploit
                 proof: res
               }
             )
+            report_kerberos_service
             return Metasploit::Framework::LoginScanner::Result.new(result_options)
           rescue ::EOFError => e
             result_options = result_options.merge({ status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e })
             return Metasploit::Framework::LoginScanner::Result.new(result_options)
           rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
+            report_kerberos_service
             status = self.class.login_status_for_kerberos_error(e)
             result_options = result_options.merge({ status: status, proof: e })
             return Metasploit::Framework::LoginScanner::Result.new(result_options)

--- a/lib/metasploit/framework/login_scanner/kerberos.rb
+++ b/lib/metasploit/framework/login_scanner/kerberos.rb
@@ -1,4 +1,5 @@
 require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/login_scanner/report_service'
 
 module Metasploit
   module Framework
@@ -17,8 +18,8 @@ module Metasploit
         PRIVATE_TYPES = %i[ password ].freeze
         CAN_GET_SESSION = true
 
-        def report_kerberos_service
-          report_service(host: host, port: port, name: 'kerberos', proto: 'tcp', workspace_id: myworkspace_id, parents: [ :tcp ])
+        def service_details
+          super.merge(name: 'kerberos', parents: [:tcp])
         end
 
         def attempt_login(credential)
@@ -59,13 +60,11 @@ module Metasploit
                 proof: res
               }
             )
-            report_kerberos_service
             return Metasploit::Framework::LoginScanner::Result.new(result_options)
           rescue ::EOFError => e
             result_options = result_options.merge({ status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e })
             return Metasploit::Framework::LoginScanner::Result.new(result_options)
           rescue Rex::Proto::Kerberos::Model::Error::KerberosError => e
-            report_kerberos_service
             status = self.class.login_status_for_kerberos_error(e)
             result_options = result_options.merge({ status: status, proof: e })
             return Metasploit::Framework::LoginScanner::Result.new(result_options)

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -36,10 +36,12 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: 'ldap'
+            service_name: 'ldap',
+            ssl: ssl
           }
 
           result_opts.merge!(do_login(credential))
+          report_ldap_service(opts: { host: host, port: port, ssl: ssl }) if result_opts[:status].in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/ldap.rb
+++ b/lib/metasploit/framework/login_scanner/ldap.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/ldap/client'
 
 module Metasploit
@@ -16,6 +17,10 @@ module Metasploit
         PRIVATE_TYPES = [:password, :ntlm_hash]
 
         attr_accessor :opts, :realm_key
+
+        def service_details
+          super.merge(name: 'ldap', parents: [ssl ? :ssl : :tcp])
+        end
         # @!attribute use_client_as_proof
         #   @return [Boolean] If a login is successful and this attribute is true - an LDAP::Client instance is used as proof
         attr_accessor :use_client_as_proof
@@ -41,7 +46,6 @@ module Metasploit
           }
 
           result_opts.merge!(do_login(credential))
-          report_ldap_service(opts: { host: host, port: port, ssl: ssl }) if result_opts[:status].in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
+++ b/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
@@ -11,6 +11,9 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
+        def report_manageengine_service
+          report_service(host: host, port: port, name: 'ManageEngine Desktop Central', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        end
 
         # Checks if the target is ManageEngine Desktop Central.
         #
@@ -23,6 +26,7 @@ module Metasploit
 
           fingerprint = 'ManageEngine Desktop Central'
           if res && res.body.include?(fingerprint)
+            report_manageengine_service
             return false
           end
 
@@ -101,7 +105,6 @@ module Metasploit
           if res.code == 302
             return {:status => LOGIN_STATUS::SUCCESSFUL, :proof => res.to_s}
           end
-
           {:status => LOGIN_STATUS::INCORRECT, :proof => res.to_s}
         end
 
@@ -118,11 +121,13 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http',
+            service_name: 'ManageEngine Desktop Central',
+            ssl: ssl
           }
 
           begin
             result_opts.merge!(get_login_state(credential.public, credential.private))
+            report_manageengine_service
           rescue ::Rex::ConnectionError => e
             # Something went wrong during login. 'e' knows what's up.
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)

--- a/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
+++ b/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
@@ -11,8 +11,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
-        def report_manageengine_service
-          report_service(host: host, port: port, name: 'ManageEngine Desktop Central', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'ManageEngine Desktop Central', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is ManageEngine Desktop Central.
@@ -26,7 +26,6 @@ module Metasploit
 
           fingerprint = 'ManageEngine Desktop Central'
           if res && res.body.include?(fingerprint)
-            report_manageengine_service
             return false
           end
 
@@ -127,7 +126,6 @@ module Metasploit
 
           begin
             result_opts.merge!(get_login_state(credential.public, credential.private))
-            report_manageengine_service
           rescue ::Rex::ConnectionError => e
             # Something went wrong during login. 'e' knows what's up.
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)

--- a/lib/metasploit/framework/login_scanner/mqtt.rb
+++ b/lib/metasploit/framework/login_scanner/mqtt.rb
@@ -1,6 +1,7 @@
 require 'metasploit/framework/tcp/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 
 module Metasploit
   module Framework
@@ -31,8 +32,8 @@ module Metasploit
         #   @return [String] The client identifier to use when connecting to MQTT
         attr_accessor :client_id
 
-        def report_mqtt_service
-          report_service(host: host, port: port, name: 'MQTT', proto: 'tcp', workspace_id: myworkspace_id, parents: [ :tcp ])
+        def service_details
+          super.merge(name: 'MQTT', parents: [:tcp])
         end
 
         # This method attempts a single login with a single credential against the target
@@ -70,8 +71,6 @@ module Metasploit
               status = Metasploit::Model::Login::Status::INCORRECT
               proof = "Failed Connection (#{connect_res.return_code})"
             end
-
-            report_mqtt_service
 
             result_options.merge!(
               proof: proof,

--- a/lib/metasploit/framework/login_scanner/mqtt.rb
+++ b/lib/metasploit/framework/login_scanner/mqtt.rb
@@ -31,6 +31,10 @@ module Metasploit
         #   @return [String] The client identifier to use when connecting to MQTT
         attr_accessor :client_id
 
+        def report_mqtt_service
+          report_service(host: host, port: port, name: 'MQTT', proto: 'tcp', workspace_id: myworkspace_id, parents: [ :tcp ])
+        end
+
         # This method attempts a single login with a single credential against the target
         # @param credential [Credential] The credential object to attempt to login with
         # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
@@ -40,7 +44,8 @@ module Metasploit
               host: host,
               port: port,
               protocol: 'tcp',
-              service_name: 'MQTT'
+              service_name: 'MQTT',
+              ssl: ssl
           }
 
           begin
@@ -65,6 +70,8 @@ module Metasploit
               status = Metasploit::Model::Login::Status::INCORRECT
               proof = "Failed Connection (#{connect_res.return_code})"
             end
+
+            report_mqtt_service
 
             result_options.merge!(
               proof: proof,

--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -57,13 +57,18 @@ module Metasploit
         validates :tdsencryption,
           inclusion: { in: [true, false] }
 
+        def report_mssql_service
+          report_service(host: host, port: port, name: 'MSSQL', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         def attempt_login(credential)
           result_options = {
               credential: credential,
               host: host,
               port: port,
               protocol: 'tcp',
-              service_name: 'mssql'
+              service_name: 'mssql',
+              ssl: ssl
           }
 
           begin
@@ -79,6 +84,7 @@ module Metasploit
             else
               result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
             end
+            report_mssql_service
           rescue ::Rex::ConnectionError => e
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             result_options[:proof] = e

--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -1,6 +1,7 @@
 require 'rex/proto/mssql/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/login_scanner/ntlm'
 
 module Metasploit
@@ -57,8 +58,8 @@ module Metasploit
         validates :tdsencryption,
           inclusion: { in: [true, false] }
 
-        def report_mssql_service
-          report_service(host: host, port: port, name: 'MSSQL', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        def service_details
+          super.merge(name: 'MSSQL', parents: [ssl ? :ssl : :tcp])
         end
 
         def attempt_login(credential)
@@ -84,7 +85,6 @@ module Metasploit
             else
               result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
             end
-            report_mssql_service
           rescue ::Rex::ConnectionError => e
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             result_options[:proof] = e

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -12,6 +12,10 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        def report_mybook_service
+          report_service(host: host, port: port, name: 'MyBook Live', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = '/UI/login' if self.uri.nil?
@@ -22,16 +26,14 @@ module Metasploit
 
         def attempt_login(credential)
           result_opts = {
+            service_name: 'MyBook Live',
             credential: credential,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
+
           begin
             res = send_request({
               'method' => method,
@@ -49,6 +51,7 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res.headers)
             end
+            report_mybook_service
           rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
           end

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -12,8 +12,8 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
-        def report_mybook_service
-          report_service(host: host, port: port, name: 'MyBook Live', proto: 'tcp', resource: uri, workspace_id: myworkspace_id, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'MyBook Live', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#set_sane_defaults)
@@ -51,7 +51,6 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res.headers)
             end
-            report_mybook_service
           rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
           end

--- a/lib/metasploit/framework/login_scanner/mysql.rb
+++ b/lib/metasploit/framework/login_scanner/mysql.rb
@@ -25,6 +25,10 @@ module Metasploit
         PRIVATE_TYPES        = [:password]
         REALM_KEY            = nil
 
+        def report_mysql_service
+          report_service(host: host, port: port, name: 'MySQL', proto: 'tcp', workspace_id: myworkspace_id, parents: [ :tcp ])
+        end
+
         def attempt_login(credential)
           result_options = {
             credential:   credential,
@@ -81,6 +85,8 @@ module Metasploit
               mysql_conn.close
             end
           end
+
+          report_mysql_service if result_options[:status].in? [::Metasploit::Model::Login::Status::SUCCESSFUL, Metasploit::Model::Login::Status::INCORRECT]
 
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end

--- a/lib/metasploit/framework/login_scanner/nessus.rb
+++ b/lib/metasploit/framework/login_scanner/nessus.rb
@@ -13,6 +13,10 @@ module Metasploit
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
 
+        def report_nessus_service
+          report_service(host: host, port: port, name: 'Nessus', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is correct
         #
         # @return [false] Indicates there were no errors
@@ -22,6 +26,7 @@ module Metasploit
           login_uri = "/server/properties"
           res = send_request({'uri'=> login_uri})
           if res && res.body.include?('Nessus')
+            report_nessus_service
             return false
           end
 
@@ -64,12 +69,14 @@ module Metasploit
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Nessus',
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin
@@ -78,6 +85,8 @@ module Metasploit
             # Something went wrong during login. 'e' knows what's up.
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
+
+          report_nessus_service if result_opts[:status].in? [::Metasploit::Model::Login::Status::INCORRECT, ::Metasploit::Model::Login::Status::SUCCESSFUL]
 
           Result.new(result_opts)
         end

--- a/lib/metasploit/framework/login_scanner/nessus.rb
+++ b/lib/metasploit/framework/login_scanner/nessus.rb
@@ -13,8 +13,8 @@ module Metasploit
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
 
-        def report_nessus_service
-          report_service(host: host, port: port, name: 'Nessus', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Nessus', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is correct
@@ -26,7 +26,6 @@ module Metasploit
           login_uri = "/server/properties"
           res = send_request({'uri'=> login_uri})
           if res && res.body.include?('Nessus')
-            report_nessus_service
             return false
           end
 
@@ -85,8 +84,6 @@ module Metasploit
             # Something went wrong during login. 'e' knows what's up.
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
-
-          report_nessus_service if result_opts[:status].in? [::Metasploit::Model::Login::Status::INCORRECT, ::Metasploit::Model::Login::Status::SUCCESSFUL]
 
           Result.new(result_opts)
         end

--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -13,26 +13,28 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        def report_octopus_server
+          report_service(host: host, port: port, name: 'Octopus Deploy', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
-          uri = '/api/users/login' if uri.nil?
-          method = 'POST' if method.nil?
+          @uri = '/api/users/login' if uri.nil?
+          @method = 'POST' if method.nil?
 
           super
         end
 
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Octopus Deploy',
             credential: credential,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
+
           begin
             json_post_data = JSON.pretty_generate({ Username: credential.public, Password: credential.private })
             res = send_request({
@@ -53,6 +55,7 @@ module Metasploit
           rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
           end
+          report_octopus_server if should_report_service?(result_opts)
           Result.new(result_opts)
         end
       end

--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -13,8 +13,8 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
-        def report_octopus_server
-          report_service(host: host, port: port, name: 'Octopus Deploy', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Octopus Deploy', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#set_sane_defaults)
@@ -55,7 +55,6 @@ module Metasploit
           rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
           end
-          report_octopus_server if should_report_service?(result_opts)
           Result.new(result_opts)
         end
       end

--- a/lib/metasploit/framework/login_scanner/opnsense.rb
+++ b/lib/metasploit/framework/login_scanner/opnsense.rb
@@ -9,8 +9,8 @@ module Metasploit
       # and attempting them. It then saves the results.
       class OPNSense < HTTP
 
-        def report_opnsense_service
-          report_service(host: host, port: port, name: 'OPNSense', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'OPNSense', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Retrieve the wanted cookie value by name from the HTTP response.
@@ -40,7 +40,6 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Login | OPNsense')
-            report_opnsense_service
             return false
           end
 
@@ -135,13 +134,11 @@ module Metasploit
           # 200 is incorrect result
           if login_result[:result].code == 200 || login_result[:result].body.include?('Username or Password incorrect')
             result_options.merge!(status: ::Metasploit::Model::Login::Status::INCORRECT, proof: 'Username or Password incorrect')
-            report_opnsense_service if should_report_service?(result_options)
             return Result.new(result_options)
           end
 
           login_status = login_result[:result].code == 302 ? ::Metasploit::Model::Login::Status::SUCCESSFUL : ::Metasploit::Model::Login::Status::INCORRECT
           result_options.merge!(status: login_status, proof: login_result[:result])
-          report_opnsense_service if should_report_service?(result_options)
           Result.new(result_options)
 
         rescue ::Rex::ConnectionError => _e

--- a/lib/metasploit/framework/login_scanner/opnsense.rb
+++ b/lib/metasploit/framework/login_scanner/opnsense.rb
@@ -9,6 +9,10 @@ module Metasploit
       # and attempting them. It then saves the results.
       class OPNSense < HTTP
 
+        def report_opnsense_service
+          report_service(host: host, port: port, name: 'OPNSense', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Retrieve the wanted cookie value by name from the HTTP response.
         #
         # @param [Rex::Proto::Http::Response] response The response from which to extract cookie values
@@ -17,6 +21,14 @@ module Metasploit
           response.get_cookies.split('; ').find { |cookie| cookie.start_with?(wanted_cookie_name) }.split('=').last
         end
 
+        # TODO: Maybe we can have a def check_setup
+        # that calls to super:
+        # if super
+        #   failed the check
+        # else
+        #   report_underlying_service
+        # end
+        # But what about modules that don't have a check_setup method?
         # Checks if the target is OPNSense. The login module should call this.
         #
         # @return [Boolean, String] FalseClass if target is OPNSense, otherwise String
@@ -28,6 +40,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Login | OPNsense')
+            report_opnsense_service
             return false
           end
 
@@ -100,7 +113,8 @@ module Metasploit
             host:         @host,
             port:         @port,
             protocol:     'tcp',
-            service_name: 'opnsense'
+            service_name: 'opnsense',
+            ssl: ssl
           }
 
           # Each login needs its own magic name and value
@@ -121,11 +135,13 @@ module Metasploit
           # 200 is incorrect result
           if login_result[:result].code == 200 || login_result[:result].body.include?('Username or Password incorrect')
             result_options.merge!(status: ::Metasploit::Model::Login::Status::INCORRECT, proof: 'Username or Password incorrect')
+            report_opnsense_service if should_report_service?(result_options)
             return Result.new(result_options)
           end
 
           login_status = login_result[:result].code == 302 ? ::Metasploit::Model::Login::Status::SUCCESSFUL : ::Metasploit::Model::Login::Status::INCORRECT
           result_options.merge!(status: login_status, proof: login_result[:result])
+          report_opnsense_service if should_report_service?(result_options)
           Result.new(result_options)
 
         rescue ::Rex::ConnectionError => _e

--- a/lib/metasploit/framework/login_scanner/pfsense.rb
+++ b/lib/metasploit/framework/login_scanner/pfsense.rb
@@ -10,8 +10,8 @@ module Metasploit
       class PfSense < HTTP
         LOGIN_ENDPOINT = 'index.php'
 
-        def report_pfsense_service
-          report_service(host: host, port: port, name: 'pfSense', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'pfSense', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is pfSense. The login module should call this.
@@ -25,7 +25,6 @@ module Metasploit
           res = send_request(request_params)
 
           if res&.code == 200 && res.body&.include?('Login to pfSense')
-            report_pfsense_service
             return false
           end
 
@@ -105,13 +104,11 @@ module Metasploit
           # 200 is incorrect result
           if login_result[:result].code == 200 || login_result[:result].body.include?('Username or Password incorrect')
             result_options.merge!(status: ::Metasploit::Model::Login::Status::INCORRECT, proof: 'Username or Password incorrect')
-            report_pfsense_service if should_report_service?(result_options)
             return Result.new(result_options)
           end
 
           login_status = login_result[:result].code == 302 ? ::Metasploit::Model::Login::Status::SUCCESSFUL : ::Metasploit::Model::Login::Status::INCORRECT
           result_options.merge!(status: login_status, proof: login_result[:result])
-          report_pfsense_service if should_report_service?(result_options)
           Result.new(result_options)
 
         rescue ::Rex::ConnectionError => _e

--- a/lib/metasploit/framework/login_scanner/pfsense.rb
+++ b/lib/metasploit/framework/login_scanner/pfsense.rb
@@ -10,6 +10,10 @@ module Metasploit
       class PfSense < HTTP
         LOGIN_ENDPOINT = 'index.php'
 
+        def report_pfsense_service
+          report_service(host: host, port: port, name: 'pfSense', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is pfSense. The login module should call this.
         #
         # @return [Boolean, String] FalseClass if target is pfSense, otherwise String
@@ -21,6 +25,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res&.code == 200 && res.body&.include?('Login to pfSense')
+            report_pfsense_service
             return false
           end
 
@@ -78,7 +83,8 @@ module Metasploit
             host:         @host,
             port:         @port,
             protocol:     'tcp',
-            service_name: 'pfsense'
+            service_name: 'pfsense',
+            ssl: ssl
           }
 
           # Each login needs its own csrf magic tokens
@@ -99,11 +105,13 @@ module Metasploit
           # 200 is incorrect result
           if login_result[:result].code == 200 || login_result[:result].body.include?('Username or Password incorrect')
             result_options.merge!(status: ::Metasploit::Model::Login::Status::INCORRECT, proof: 'Username or Password incorrect')
+            report_pfsense_service if should_report_service?(result_options)
             return Result.new(result_options)
           end
 
           login_status = login_result[:result].code == 302 ? ::Metasploit::Model::Login::Status::SUCCESSFUL : ::Metasploit::Model::Login::Status::INCORRECT
           result_options.merge!(status: login_status, proof: login_result[:result])
+          report_pfsense_service if should_report_service?(result_options)
           Result.new(result_options)
 
         rescue ::Rex::ConnectionError => _e

--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -8,6 +8,10 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
+        def report_php_service
+          report_service(host: host, port: port, name: 'PhpMyAdmin', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         def check_setup
           res = send_request({ 'uri' => uri })
 
@@ -15,6 +19,7 @@ module Metasploit
             version = Rex::Version.new($1).to_s
             if version.present?
               framework_module.print_status("PhpMyAdmin Version: #{version}") if framework_module
+              report_php_service
               return false
             end
           end
@@ -69,16 +74,18 @@ module Metasploit
 
         def attempt_login(credential)
           result_opts = {
+            service_name: 'pfSense',
             credential: credential,
             status: LOGIN_STATUS::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           result_opts.merge!(do_login(credential.public, credential.private))
-
+          report_php_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
       end

--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -8,8 +8,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
-        def report_php_service
-          report_service(host: host, port: port, name: 'PhpMyAdmin', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'PhpMyAdmin', resource: uri, parents: [ssl ? :https : :http])
         end
 
         def check_setup
@@ -19,7 +19,6 @@ module Metasploit
             version = Rex::Version.new($1).to_s
             if version.present?
               framework_module.print_status("PhpMyAdmin Version: #{version}") if framework_module
-              report_php_service
               return false
             end
           end
@@ -85,7 +84,6 @@ module Metasploit
           }
 
           result_opts.merge!(do_login(credential.public, credential.private))
-          report_php_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
       end

--- a/lib/metasploit/framework/login_scanner/pop3.rb
+++ b/lib/metasploit/framework/login_scanner/pop3.rb
@@ -20,6 +20,10 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = nil
 
+        def report_pop3_service
+          report_service(host: host, port: port, name: 'POP3', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # This method attempts a single login with a single credential against the target
         # @param credential [Credential] The credential object to attempt to login with
         # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
@@ -30,7 +34,8 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: 'pop3'
+            service_name: 'pop3',
+            ssl: ssl
           }
 
           disconnect if self.sock
@@ -69,7 +74,7 @@ module Metasploit
           end
 
           disconnect if self.sock
-
+          report_pop3_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/pop3.rb
+++ b/lib/metasploit/framework/login_scanner/pop3.rb
@@ -1,5 +1,6 @@
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/tcp/client'
 
 module Metasploit
@@ -20,8 +21,8 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = nil
 
-        def report_pop3_service
-          report_service(host: host, port: port, name: 'POP3', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        def service_details
+          super.merge(name: 'POP3', parents: [ssl ? :ssl : :tcp])
         end
 
         # This method attempts a single login with a single credential against the target
@@ -74,7 +75,6 @@ module Metasploit
           end
 
           disconnect if self.sock
-          report_pop3_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/postgres.rb
+++ b/lib/metasploit/framework/login_scanner/postgres.rb
@@ -1,4 +1,5 @@
 require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/login_scanner/report_service'
 require 'postgres_msf'
 
 module Metasploit
@@ -41,8 +42,8 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = Metasploit::Model::Realm::Key::POSTGRESQL_DATABASE
 
-        def report_postgres_service
-          report_service(host: host, port: port, name: 'Postgres', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        def service_details
+          super.merge(name: 'Postgres', parents: [ssl ? :ssl : :tcp])
         end
 
         # This method attempts a single login with a single credential against the target
@@ -125,7 +126,6 @@ module Metasploit
             result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
           end
 
-          report_postgres_service if should_report_service?(result_options)
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/postgres.rb
+++ b/lib/metasploit/framework/login_scanner/postgres.rb
@@ -41,6 +41,10 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = Metasploit::Model::Realm::Key::POSTGRESQL_DATABASE
 
+        def report_postgres_service
+          report_service(host: host, port: port, name: 'Postgres', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # This method attempts a single login with a single credential against the target
         # @param credential [Credential] The credential object to attempt to login with
         # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
@@ -50,7 +54,8 @@ module Metasploit
               host: host,
               port: port,
               protocol: 'tcp',
-              service_name: 'postgres'
+              service_name: 'postgres',
+              ssl: ssl
           }
 
           db_name = credential.realm || 'template1'
@@ -120,6 +125,7 @@ module Metasploit
             result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
           end
 
+          report_postgres_service if should_report_service?(result_options)
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/redis.rb
+++ b/lib/metasploit/framework/login_scanner/redis.rb
@@ -26,6 +26,10 @@ module Metasploit
         PRIVATE_TYPES         = [ :password ]
         REALM_KEY             = nil
 
+        def report_redis_server
+          report_service(host: host, port: port, name: 'Redis', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # Attempt to login with every {Credential credential} in
         # {#cred_details}, by calling {#attempt_login} once for each.
         #
@@ -70,7 +74,8 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: 'redis'
+            service_name: 'redis',
+            ssl: ssl
           }
 
           disconnect if sock
@@ -102,6 +107,7 @@ module Metasploit
 
           disconnect if sock
 
+          report_redis_server if should_report_service?(result_options)
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/report_service.rb
+++ b/lib/metasploit/framework/login_scanner/report_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Metasploit
+  module Framework
+    module LoginScanner
+      # This module provides automatic service reporting for login scanners.
+      # When included in a login scanner class, it overrides `check_setup` to
+      # automatically call `report_service` with the scanner's `service_details`
+      # when the setup check succeeds (i.e. when `super` returns `false`).
+      #
+      # Each scanner should override `service_details` to merge in its specific
+      # service metadata (name, parents, resource, etc.).
+      #
+      module ReportService
+        # Overrides the base `check_setup` to automatically report the service
+        # when the scanner determines the target is valid.
+        #
+        # @return [false] if setup succeeded (no errors)
+        # @return [String] a human-readable error message if setup failed
+        def check_setup
+          result = super
+          if result == false
+            report_service(service_details)
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/result.rb
+++ b/lib/metasploit/framework/login_scanner/result.rb
@@ -35,6 +35,9 @@ module Metasploit
         # @!attribute connection
         #   @return [Object] the post-authenticated connection object (if the scanner chooses to leave it open)
         attr_accessor :connection
+        # @!attribute ssl
+        #   @return [TrueClass|FalseClass] True if SSL was used for this result
+        attr_accessor :ssl
 
         validates :status,
           inclusion: {

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -67,6 +67,11 @@ module Metasploit
         #   and the socket is not immediately closed
         attr_accessor :use_client_as_proof
 
+        def report_smb_service
+          # TODO: SMB over QUIC runs over UDP port 443
+          report_service(host: host, port: port, name: 'SMB', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # If login is successful and {Result#access_level} is not set
         # then arbitrary credentials are accepted. If it is set to
         # Guest, then arbitrary credentials are accepted, but given
@@ -100,7 +105,8 @@ module Metasploit
               host: host,
               port: port,
               protocol: 'tcp',
-              service_name: 'smb'
+              service_name: 'smb',
+              ssl: ssl
             )
             return result
           end
@@ -194,6 +200,10 @@ module Metasploit
           result.port = port
           result.protocol = 'tcp'
           result.service_name = 'smb'
+          result.ssl = ssl
+
+          report_smb_service if should_report_service?(result)
+
           result
         end
 

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -2,6 +2,7 @@ require 'metasploit/framework'
 require 'metasploit/framework/tcp/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/login_scanner/kerberos'
 require 'ruby_smb'
 
@@ -67,9 +68,9 @@ module Metasploit
         #   and the socket is not immediately closed
         attr_accessor :use_client_as_proof
 
-        def report_smb_service
+        def service_details
           # TODO: SMB over QUIC runs over UDP port 443
-          report_service(host: host, port: port, name: 'SMB', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+          super.merge(name: 'SMB', parents: [ssl ? :ssl : :tcp])
         end
 
         # If login is successful and {Result#access_level} is not set
@@ -201,8 +202,6 @@ module Metasploit
           result.protocol = 'tcp'
           result.service_name = 'smb'
           result.ssl = ssl
-
-          report_smb_service if should_report_service?(result)
 
           result
         end

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -12,8 +12,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         CAN_GET_SESSION = true
 
-        def report_smh_service
-          report_service(host: host, port: port, name: 'HP System Management', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'HP System Management', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#attempt_login)
@@ -49,8 +49,6 @@ module Metasploit
           else
             result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT)
           end
-
-          report_smh_service if should_report_service?(result_opts)
 
           Result.new(result_opts)
         end

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -12,11 +12,15 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         CAN_GET_SESSION = true
 
+        def report_smh_service
+          report_service(host: host, port: port, name: 'HP System Management', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
 
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {
-            credential: credential
+            credential: credential,
+            ssl: ssl
           }
 
           req_opts = {
@@ -45,6 +49,8 @@ module Metasploit
           else
             result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT)
           end
+
+          report_smh_service if should_report_service?(result_opts)
 
           Result.new(result_opts)
         end

--- a/lib/metasploit/framework/login_scanner/softing_sis.rb
+++ b/lib/metasploit/framework/login_scanner/softing_sis.rb
@@ -10,8 +10,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
-        def report_softing_service
-          report_service(host: host, port: port, name: 'Softing Secure Integration Server', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Softing Secure Integration Server', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Check if the target is Softing Secure Integration Server
@@ -30,7 +30,6 @@ module Metasploit
             if res_json['version']
               # report the version
               framework_module.print_brute(level: :good, ip: ip, msg: "Softing Secure Integration Server #{res_json['version']}") if framework_module
-              report_softing_service
               return false
             end
           end
@@ -168,7 +167,6 @@ module Metasploit
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
 
-          report_softing_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/softing_sis.rb
+++ b/lib/metasploit/framework/login_scanner/softing_sis.rb
@@ -10,6 +10,10 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
+        def report_softing_service
+          report_service(host: host, port: port, name: 'Softing Secure Integration Server', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Check if the target is Softing Secure Integration Server
         #
         # @return [Boolean] TrueClass if target is SIS, otherwise FalseClass
@@ -26,6 +30,7 @@ module Metasploit
             if res_json['version']
               # report the version
               framework_module.print_brute(level: :good, ip: ip, msg: "Softing Secure Integration Server #{res_json['version']}") if framework_module
+              report_softing_service
               return false
             end
           end
@@ -146,12 +151,14 @@ module Metasploit
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Softing Secure Integration Server',
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin
@@ -161,6 +168,7 @@ module Metasploit
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
 
+          report_softing_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/sonicwall.rb
+++ b/lib/metasploit/framework/login_scanner/sonicwall.rb
@@ -17,8 +17,8 @@ module Metasploit
 
         attr_accessor :domain
 
-        def report_sonicwall_service
-          report_service(host: host, port: port, name: 'SonicWall Network Security', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'SonicWall Network Security', resource: uri, parents: [ssl ? :https : :http])
         end
 
         def req_params_base
@@ -85,7 +85,6 @@ module Metasploit
           }
           res = send_request(request_params)
           if res&.code == 200 && res.body&.include?('SonicWall')
-            report_sonicwall_service
             return false
           end
 
@@ -151,7 +150,6 @@ module Metasploit
             ssl: ssl
           }
           result_options.merge!(do_login(credential.public, credential.private, 1))
-          report_sonicwall_service if should_report_service?(result_options)
           Result.new(result_options)
         end
       end

--- a/lib/metasploit/framework/login_scanner/sonicwall.rb
+++ b/lib/metasploit/framework/login_scanner/sonicwall.rb
@@ -17,6 +17,10 @@ module Metasploit
 
         attr_accessor :domain
 
+        def report_sonicwall_service
+          report_service(host: host, port: port, name: 'SonicWall Network Security', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         def req_params_base
           {
             'method' => 'POST',
@@ -81,6 +85,7 @@ module Metasploit
           }
           res = send_request(request_params)
           if res&.code == 200 && res.body&.include?('SonicWall')
+            report_sonicwall_service
             return false
           end
 
@@ -142,9 +147,11 @@ module Metasploit
             host: @host,
             port: @port,
             protocol: 'tcp',
-            service_name: 'sonicwall'
+            service_name: 'sonicwall',
+            ssl: ssl
           }
           result_options.merge!(do_login(credential.public, credential.private, 1))
+          report_sonicwall_service if should_report_service?(result_options)
           Result.new(result_options)
         end
       end

--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -1,5 +1,6 @@
 require 'net/ssh'
 require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/ssh/platform'
 require 'rex/socket/ssh_factory'
 
@@ -48,8 +49,8 @@ module Metasploit
           presence: true,
           inclusion: { in: VERBOSITIES }
 
-        def report_ssh_service
-          report_service(host: host, port: port, name: 'SSH', proto: 'tcp', workspace_id: myworkspace_id, parents: [ :tcp ])
+        def service_details
+          super.merge(name: 'SSH', parents: [:tcp])
         end
 
         # (see {Base#attempt_login})
@@ -113,7 +114,6 @@ module Metasploit
           result.port         = port
           result.protocol     = 'tcp'
           result.service_name = 'ssh'
-          report_ssh_service if should_report_service?(result)
           result
         end
 

--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -48,6 +48,10 @@ module Metasploit
           presence: true,
           inclusion: { in: VERBOSITIES }
 
+        def report_ssh_service
+          report_service(host: host, port: port, name: 'SSH', proto: 'tcp', workspace_id: myworkspace_id, parents: [ :tcp ])
+        end
+
         # (see {Base#attempt_login})
         # @note The caller *must* close {#ssh_socket}
         def attempt_login(credential)
@@ -109,6 +113,7 @@ module Metasploit
           result.port         = port
           result.protocol     = 'tcp'
           result.service_name = 'ssh'
+          report_ssh_service if should_report_service?(result)
           result
         end
 

--- a/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
+++ b/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
@@ -11,6 +11,9 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
+        def report_symantec_service
+          report_service(host: host, port: port, name: 'Symantec Web Gateway', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
 
         # Checks if the target is correct
         #
@@ -22,6 +25,7 @@ module Metasploit
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('Symantec Web Gateway')
+            report_symantec_service
             return false
           end
 
@@ -98,12 +102,14 @@ module Metasploit
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Symantec Web Gateway',
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin
@@ -113,6 +119,7 @@ module Metasploit
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
 
+          report_symantec_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
+++ b/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
@@ -11,8 +11,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
 
-        def report_symantec_service
-          report_service(host: host, port: port, name: 'Symantec Web Gateway', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Symantec Web Gateway', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is correct
@@ -25,7 +25,6 @@ module Metasploit
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('Symantec Web Gateway')
-            report_symantec_service
             return false
           end
 
@@ -119,7 +118,6 @@ module Metasploit
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
 
-          report_symantec_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -10,8 +10,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ].freeze
         LOGIN_STATUS = Metasploit::Model::Login::Status # Shorter name
 
-        def report_syncovery_service
-          report_service(host: host, port: port, name: 'Syncovery File Sync Backup', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Syncovery File Sync Backup', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is correct
@@ -24,7 +24,6 @@ module Metasploit
           res = send_request({ 'uri' => login_uri })
 
           if res && res.code == 200 && res.body.include?('Syncovery')
-            report_syncovery_service
             return false
           end
 
@@ -126,7 +125,6 @@ module Metasploit
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
 
-          report_syncovery_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -10,6 +10,10 @@ module Metasploit
         PRIVATE_TYPES = [ :password ].freeze
         LOGIN_STATUS = Metasploit::Model::Login::Status # Shorter name
 
+        def report_syncovery_service
+          report_service(host: host, port: port, name: 'Syncovery File Sync Backup', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is correct
         #
         # @return [false] Indicates there were no errors
@@ -20,6 +24,7 @@ module Metasploit
           res = send_request({ 'uri' => login_uri })
 
           if res && res.code == 200 && res.body.include?('Syncovery')
+            report_syncovery_service
             return false
           end
 
@@ -97,18 +102,21 @@ module Metasploit
           end
         end
 
+        # TODO: Maybe we can override this attempt_login method?
         # Attempts to login to Syncovery File Sync & Backup Software. This is called first.
         #
         # @param credential [Metasploit::Framework::Credential] The credential object
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Syncovery File Sync Backup',
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           begin
@@ -118,6 +126,7 @@ module Metasploit
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
 
+          report_syncovery_service if should_report_service?(result_opts)
           Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/teamcity.rb
+++ b/lib/metasploit/framework/login_scanner/teamcity.rb
@@ -141,6 +141,10 @@ module Metasploit
         class DecryptionError < TeamCityError; end
         class ServerNeedsSetupError < TeamCityError; end
 
+        def report_teamcity_service
+          report_service(host: host, port: port, name: 'TeamCity', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is JetBrains TeamCity. The login module should call this.
         #
         # @return [Boolean] TrueClass if target is TeamCity, otherwise FalseClass
@@ -152,6 +156,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Log in to TeamCity')
+            report_teamcity_service
             return false
           end
 
@@ -268,7 +273,8 @@ module Metasploit
             host:         @host,
             port:         @port,
             protocol:     'tcp',
-            service_name: 'teamcity'
+            service_name: 'teamcity',
+            ssl: ssl
           }
 
           if @public_key.nil?
@@ -279,12 +285,14 @@ module Metasploit
           end
 
           login_result = try_login(credential.public, credential.private, @public_key)
+          report_teamcity_service if should_report_service?(result_options.merge(login_result))
           return Result.new(result_options.merge(login_result)) if login_result[:status] != :success
 
           # Ensure we log the user out, so that our logged in session does not appear under the user's profile.
           logout_with_headers(login_result[:proof].headers)
 
           result_options[:status] = ::Metasploit::Model::Login::Status::SUCCESSFUL
+          report_teamcity_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/teamcity.rb
+++ b/lib/metasploit/framework/login_scanner/teamcity.rb
@@ -141,8 +141,8 @@ module Metasploit
         class DecryptionError < TeamCityError; end
         class ServerNeedsSetupError < TeamCityError; end
 
-        def report_teamcity_service
-          report_service(host: host, port: port, name: 'TeamCity', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'TeamCity', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is JetBrains TeamCity. The login module should call this.
@@ -156,7 +156,6 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Log in to TeamCity')
-            report_teamcity_service
             return false
           end
 
@@ -285,14 +284,12 @@ module Metasploit
           end
 
           login_result = try_login(credential.public, credential.private, @public_key)
-          report_teamcity_service if should_report_service?(result_options.merge(login_result))
           return Result.new(result_options.merge(login_result)) if login_result[:status] != :success
 
           # Ensure we log the user out, so that our logged in session does not appear under the user's profile.
           logout_with_headers(login_result[:proof].headers)
 
           result_options[:status] = ::Metasploit::Model::Login::Status::SUCCESSFUL
-          report_teamcity_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/telnet.rb
+++ b/lib/metasploit/framework/login_scanner/telnet.rb
@@ -53,6 +53,10 @@ module Metasploit
                       greater_than_or_equal_to: 1
                   }
 
+        def report_telnet_service
+          report_service(host: host, port: port, name: 'Telnet', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # (see {Base#attempt_login})
         def attempt_login(credential)
           result_options = {
@@ -60,7 +64,8 @@ module Metasploit
               host: host,
               port: port,
               protocol: 'tcp',
-              service_name: 'telnet'
+              service_name: 'telnet',
+              ssl: ssl
           }
 
           begin
@@ -108,6 +113,7 @@ module Metasploit
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           end
 
+          report_telnet_service if should_report_service?(result_options)
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/telnet.rb
+++ b/lib/metasploit/framework/login_scanner/telnet.rb
@@ -1,6 +1,7 @@
 require 'metasploit/framework/telnet/client'
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 
 module Metasploit
   module Framework
@@ -53,8 +54,8 @@ module Metasploit
                       greater_than_or_equal_to: 1
                   }
 
-        def report_telnet_service
-          report_service(host: host, port: port, name: 'Telnet', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        def service_details
+          super.merge(name: 'Telnet', parents: [ssl ? :ssl : :tcp])
         end
 
         # (see {Base#attempt_login})
@@ -113,7 +114,6 @@ module Metasploit
             result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           end
 
-          report_telnet_service if should_report_service?(result_options)
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/varnish.rb
+++ b/lib/metasploit/framework/login_scanner/varnish.rb
@@ -21,6 +21,10 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY           = nil
 
+        def report_varnish_server
+          report_service(host: host, port: port, name: 'VarnishCLI', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         def attempt_login(credential)
           begin
             connect
@@ -32,13 +36,17 @@ module Metasploit
           rescue Rex::ConnectionError, EOFError, Timeout::Error
             status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           end
-          status = (success == true) ? Metasploit::Model::Login::Status::SUCCESSFUL : Metasploit::Model::Login::Status::INCORRECT
+          status ||= (success == true) ? Metasploit::Model::Login::Status::SUCCESSFUL : Metasploit::Model::Login::Status::INCORRECT
 
           result = Result.new(credential: credential, status: status)
           result.host         = host
           result.port         = port
           result.protocol     = 'tcp'
           result.service_name = 'varnishcli'
+          result.ssl = ssl
+
+          report_varnish_server if should_report_service?(result)
+
           result
         end
 

--- a/lib/metasploit/framework/login_scanner/vmauthd.rb
+++ b/lib/metasploit/framework/login_scanner/vmauthd.rb
@@ -1,5 +1,6 @@
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/tcp/client'
 
 module Metasploit
@@ -20,8 +21,8 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = nil
 
-        def report_vmauthd_service
-          report_service(host: host, port: port, name: 'VMAuthD', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        def service_details
+          super.merge(name: 'VMAuthD', parents: [ssl ? :ssl : :tcp])
         end
 
         # This method attempts a single login with a single credential against the target
@@ -75,7 +76,6 @@ module Metasploit
           end
 
           disconnect if self.sock
-          report_vmauthd_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/vmauthd.rb
+++ b/lib/metasploit/framework/login_scanner/vmauthd.rb
@@ -20,6 +20,10 @@ module Metasploit
         PRIVATE_TYPES        = [ :password ]
         REALM_KEY            = nil
 
+        def report_vmauthd_service
+          report_service(host: host, port: port, name: 'VMAuthD', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # This method attempts a single login with a single credential against the target
         # @param credential [Credential] The credential object to attempt to login with
         # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
@@ -31,7 +35,8 @@ module Metasploit
             host: host,
             port: port,
             service_name: 'vmauthd',
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           disconnect if self.sock
@@ -70,7 +75,7 @@ module Metasploit
           end
 
           disconnect if self.sock
-
+          report_vmauthd_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/vnc.rb
+++ b/lib/metasploit/framework/login_scanner/vnc.rb
@@ -33,6 +33,10 @@ module Metasploit
             VNC4_SERVER_RETRY_ERROR
         ]
 
+        def report_vnc_service
+          report_service(host: host, port: port, name: 'VNC', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         # This method attempts a single login with a single credential against the target
         # @param credential [Credential] The credential object to attempt to login with
         # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
@@ -42,7 +46,8 @@ module Metasploit
               host: host,
               port: port,
               protocol: 'tcp',
-              service_name: 'vnc'
+              service_name: 'vnc',
+              ssl: ssl
           }
 
           begin
@@ -81,6 +86,7 @@ module Metasploit
             disconnect
           end
 
+          report_vnc_service if should_report_service?(result_options)
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -27,8 +27,8 @@ module Metasploit
         # @return [String]
         attr_accessor :wordpress_url_xmlrpc
 
-        def report_wordpress_service
-          report_service(host: host, port: port, name: 'Wordpress Multicall', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Wordpress Multicall', resource: uri, parents: [ssl ? :https : :http])
         end
 
         def set_default
@@ -130,7 +130,6 @@ module Metasploit
                   ssl: ssl
                 }
                 result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL)
-                report_wordpress_service if should_report_service?(result_opts)
                 return Result.new(result_opts)
               end
             end
@@ -146,7 +145,6 @@ module Metasploit
           }
 
           result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT)
-          report_wordpress_service if should_report_service?(result_opts)
           return Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -27,6 +27,9 @@ module Metasploit
         # @return [String]
         attr_accessor :wordpress_url_xmlrpc
 
+        def report_wordpress_service
+          report_service(host: host, port: port, name: 'Wordpress Multicall', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
 
         def set_default
           @wordpress_url_xmlrpc ||= 'xmlrpc.php'
@@ -119,25 +122,31 @@ module Metasploit
                 pass = req_xml.search("data/value/array/data")[i].value[1].text.strip
                 credential.private = pass
                 result_opts = {
+                  service_name: 'Wordpress Multicall',
                   credential: credential,
                   host: host,
                   port: port,
-                  protocol: 'tcp'
+                  protocol: 'tcp',
+                  ssl: ssl
                 }
                 result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL)
+                report_wordpress_service if should_report_service?(result_opts)
                 return Result.new(result_opts)
               end
             end
           end
 
           result_opts = {
+            service_name: 'Wordpress Multicall',
             credential: credential,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT)
+          report_wordpress_service if should_report_service?(result_opts)
           return Result.new(result_opts)
         end
 

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -7,8 +7,8 @@ module Metasploit
       # Wordpress XML RPC login scanner
       class WordpressRPC < HTTP
 
-        def report_wordpress_service
-          report_service(host: host, port: port, name: 'Wordpress XML RPC', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Wordpress XML RPC', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # (see Base#attempt_login)
@@ -42,8 +42,6 @@ module Metasploit
           rescue ::EOFError, Rex::ConnectionError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
-
-          report_wordpress_service if should_report_service?(result_opts)
 
           Result.new(result_opts)
 

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -7,19 +7,20 @@ module Metasploit
       # Wordpress XML RPC login scanner
       class WordpressRPC < HTTP
 
+        def report_wordpress_service
+          report_service(host: host, port: port, name: 'Wordpress XML RPC', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {
+              service_name: 'Wordpress XML RPC',
               credential: credential,
               host: host,
               port: port,
-              protocol: 'tcp'
+              protocol: 'tcp',
+              ssl: ssl
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
 
@@ -41,6 +42,8 @@ module Metasploit
           rescue ::EOFError, Rex::ConnectionError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
+
+          report_wordpress_service if should_report_service?(result_opts)
 
           Result.new(result_opts)
 

--- a/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
+++ b/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
@@ -9,8 +9,8 @@ module Metasploit
         PRIVATE_TYPES = [ :password ].freeze
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
-        def report_wowza_service
-          report_service(host: host, port: port, name: 'Wowza Streaming Engine Manager', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Wowza Streaming Engine Manager', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Checks if the target is Wowza Streaming Engine Manager. The login module should call this.
@@ -20,7 +20,6 @@ module Metasploit
           res = send_request({ 'uri' => normalize_uri('/enginemanager/login.htm') })
 
           if res && res.code == 200 && res.body.include?('Wowza Streaming Engine Manager')
-            report_wowza_service
             return false
           end
 
@@ -65,9 +64,6 @@ module Metasploit
             result_opts.merge!({ status: LOGIN_STATUS::SUCCESSFUL, proof: cookie.to_s }) unless cookie.blank?
           end
 
-          report_wowza_service if should_report_service?(result_opts)
-
-          require 'pry-byebug'; binding.pry;
           # TODO: Check the caller here. Maybe we can extract the service reporting up a level?
           Result.new(result_opts)
         end

--- a/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
+++ b/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
@@ -9,6 +9,10 @@ module Metasploit
         PRIVATE_TYPES = [ :password ].freeze
         LOGIN_STATUS = Metasploit::Model::Login::Status
 
+        def report_wowza_service
+          report_service(host: host, port: port, name: 'Wowza Streaming Engine Manager', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Checks if the target is Wowza Streaming Engine Manager. The login module should call this.
         #
         # @return [Boolean] TrueClass if target is Wowza Streaming Engine Manager, otherwise FalseClass
@@ -16,6 +20,7 @@ module Metasploit
           res = send_request({ 'uri' => normalize_uri('/enginemanager/login.htm') })
 
           if res && res.code == 200 && res.body.include?('Wowza Streaming Engine Manager')
+            report_wowza_service
             return false
           end
 
@@ -30,12 +35,14 @@ module Metasploit
         #
         def attempt_login(credential)
           result_opts = {
+            service_name: 'Wowza Streaming Engine Manager',
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
             host: host,
             port: port,
-            protocol: 'tcp'
+            protocol: 'tcp',
+            ssl: ssl
           }
 
           res = send_request({
@@ -58,6 +65,10 @@ module Metasploit
             result_opts.merge!({ status: LOGIN_STATUS::SUCCESSFUL, proof: cookie.to_s }) unless cookie.blank?
           end
 
+          report_wowza_service if should_report_service?(result_opts)
+
+          require 'pry-byebug'; binding.pry;
+          # TODO: Check the caller here. Maybe we can extract the service reporting up a level?
           Result.new(result_opts)
         end
       end

--- a/lib/metasploit/framework/login_scanner/x3.rb
+++ b/lib/metasploit/framework/login_scanner/x3.rb
@@ -16,6 +16,10 @@ module Metasploit
         DEFAULT_PORT = 1818
         REALM_KEY = nil
 
+        def report_x3_service
+          report_service(host: host, port: port, name: 'X3 AdxAdmin', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        end
+
         def encrypt_pass(inp)
           # check if it's already encrypted
           return inp if inp.start_with?('CRYPT:')
@@ -50,7 +54,8 @@ module Metasploit
             host: host,
             port: port,
             protocol: 'tcp',
-            service_name: 'X3 AdxAdmin'
+            service_name: 'X3 AdxAdmin',
+            ssl: ssl
           }
 
           # encrypt the password
@@ -93,6 +98,7 @@ module Metasploit
 
           disconnect if sock
 
+          report_x3_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/x3.rb
+++ b/lib/metasploit/framework/login_scanner/x3.rb
@@ -2,6 +2,7 @@
 
 require 'metasploit/framework/login_scanner/base'
 require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/login_scanner/report_service'
 require 'metasploit/framework/tcp/client'
 
 module Metasploit
@@ -16,8 +17,8 @@ module Metasploit
         DEFAULT_PORT = 1818
         REALM_KEY = nil
 
-        def report_x3_service
-          report_service(host: host, port: port, name: 'X3 AdxAdmin', proto: 'tcp', workspace_id: myworkspace_id, parents: [ ssl ? :ssl : :tcp ])
+        def service_details
+          super.merge(name: 'X3 AdxAdmin', parents: [ssl ? :ssl : :tcp])
         end
 
         def encrypt_pass(inp)
@@ -98,7 +99,6 @@ module Metasploit
 
           disconnect if sock
 
-          report_x3_service if should_report_service?(result_options)
           Result.new(result_options)
         end
 

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -20,8 +20,8 @@ module Metasploit
         #   @return [String] Cookie session
         attr_accessor :zsession
 
-        def report_zabbix_service
-          report_service(host: host, port: port, name: 'Zabbix', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        def service_details
+          super.merge(name: 'Zabbix', resource: uri, parents: [ssl ? :https : :http])
         end
 
         # Decides which login routine and returns the results
@@ -38,7 +38,6 @@ module Metasploit
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
 
-          report_zabbix_service if result_opts[:status].in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
           Result.new(result_opts)
         end
 
@@ -68,7 +67,6 @@ module Metasploit
             return "Unable to connect to target"
           end
 
-          report_zabbix_service
           false
         end
 

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -20,12 +20,16 @@ module Metasploit
         #   @return [String] Cookie session
         attr_accessor :zsession
 
+        def report_zabbix_service
+          report_service(host: host, port: port, name: 'Zabbix', proto: 'tcp', workspace_id: myworkspace_id, resource: uri, parents: [ ssl ? :https : :http ])
+        end
+
         # Decides which login routine and returns the results
         #
         # @param credential [Metasploit::Framework::Credential] The credential object
         # @return [Result]
         def attempt_login(credential)
-          result_opts = { credential: credential }
+          result_opts = { credential: credential, ssl: ssl }
 
           begin
             status = try_login(credential)
@@ -34,6 +38,7 @@ module Metasploit
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
 
+          report_zabbix_service if result_opts[:status].in? [::Metasploit::Model::Login::Status::SUCCESSFUL, ::Metasploit::Model::Login::Status::INCORRECT]
           Result.new(result_opts)
         end
 
@@ -63,6 +68,7 @@ module Metasploit
             return "Unable to connect to target"
           end
 
+          report_zabbix_service
           false
         end
 

--- a/lib/msf/core/auxiliary/login_scanner.rb
+++ b/lib/msf/core/auxiliary/login_scanner.rb
@@ -24,6 +24,8 @@ module Msf
           framework_module: self,
           local_port: datastore['CPORT'],
           local_host: datastore['CHOST'],
+          workspace: workspace,
+          ssl: datastore['SSL']
         }.merge(conf)
       end
     end

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -40,6 +40,16 @@ module Msf::DBManager::Service
     report_service(opts)
   end
 
+  # Maps well-known protocol symbols to their parent chain.
+  # Each entry lists the immediate parent(s) that should be auto-created.
+  # The chain is resolved recursively, e.g. :https → :ssl → :tcp.
+  SERVICE_PARENT_MAP = {
+    tcp:   [],
+    ssl:   [:tcp],
+    http:  [:tcp],
+    https: [:ssl]
+  }.freeze
+
   #
   # Record a service in the database.
   #
@@ -58,11 +68,15 @@ module Msf::DBManager::Service
   #               base URI for a web application, pipe name for DCERPC service, etc.
   # +:parents+::  a single service Hash or an Array of service Hash representing the parent services this
   #               service is associated with, such as a HTTP service for a web application.
+  #               This can also be an array of symbols, with one or more values from :http, :https, :ssl, :tcp
+  #               This helps avoid the need to explicitly create Mdm::Service objects, and lets this method take care of that
+  #               The symbol and Mdm::Service objects cannot be mix-and-matched.
   #`
   # @return [Mdm::Service,nil]
   def report_service(opts)
     return if !active
-  ::ApplicationRecord.connection_pool.with_connection { |conn|
+
+  ::ApplicationRecord.connection_pool.with_connection do |conn|
     opts = opts.clone() # protect the original caller's opts
     addr  = opts.delete(:host) || return
     hname = opts.delete(:host_name)
@@ -115,10 +129,27 @@ module Msf::DBManager::Service
 
     service.state ||= Msf::ServiceState::Open
     service.info  ||= ""
-    parents = process_service_chain(host, opts.delete(:parents)) if opts[:parents]
-    if parents
-      parents.each do |parent|
-        service.parents << parent if parent && !service.parents.include?(parent)
+
+    # Determine parent services:
+    # 1. If explicit parents are provided, use those
+    # 2. If the service name is a known protocol (http, https, ssl), auto-create the parent chain
+    # 3. If the service proto is 'tcp' and no parents are otherwise determined, auto-create a TCP parent
+    # 4. Otherwise, no parents (current behaviour)
+    explicit_parents = opts.delete(:parents)
+    parent_refs = if explicit_parents
+                    explicit_parents
+                  elsif opts[:name] && SERVICE_PARENT_MAP.key?(opts[:name].to_sym)
+                    SERVICE_PARENT_MAP[opts[:name].to_sym]
+                  elsif proto == 'tcp'
+                    [:tcp]
+                  end
+
+    if parent_refs&.any?
+      parents = process_service_chain(host, parent_refs, port: opts[:port].to_i, proto: proto)
+      if parents
+        parents.each do |parent|
+          service.parents << parent if parent && !service.parents.include?(parent)
+        end
       end
     end
 
@@ -148,7 +179,7 @@ module Msf::DBManager::Service
     end
 
     service
-  }
+  end
   end
 
   # Returns a list of all services in the database
@@ -190,7 +221,19 @@ module Msf::DBManager::Service
   }
   end
 
-  def process_service_chain(host, services)
+  # Resolves an array of parent service references into Mdm::Service objects.
+  #
+  # Each element can be:
+  # - A Symbol (:tcp, :ssl, :http, :https) — auto-created using SERVICE_PARENT_MAP
+  # - An Mdm::Service object — used directly
+  # - A Hash with service attributes — found or created
+  #
+  # @param host [Mdm::Host] the host to associate services with
+  # @param services [Array, Hash, Symbol, Mdm::Service, nil] parent service reference(s)
+  # @param port [Integer] the port to use when resolving symbol parents (inherited from the child)
+  # @param proto [String] the protocol to use when resolving symbol parents
+  # @return [Array<Mdm::Service>, nil] resolved parent service objects
+  def process_service_chain(host, services, port: nil, proto: 'tcp')
     return unless host.is_a?(Mdm::Host)
 
     return if services.nil?
@@ -198,40 +241,81 @@ module Msf::DBManager::Service
     services = [services] unless services.is_a?(Array)
     services.map do |service|
       case service
+      when ::Symbol
+        resolve_symbol_service(host, service, port: port, proto: proto)
       when ::Mdm::Service
-        service_obj = service
+        service
       when ::Hash
         next if service[:port].nil? || service[:proto].nil?
 
         parents = nil
         if service[:parents]&.any?
-          parents = process_service_chain(host, service[:parents])
+          parents = process_service_chain(host, service[:parents], port: service[:port].to_i, proto: service[:proto].to_s.downcase)
         end
 
         service_info = {
           port: service[:port].to_i,
-          proto: service[:proto].to_s.downcase,
+          proto: service[:proto].to_s.downcase
         }
         service_info[:name] = service[:name].downcase if service[:name]
         service_info[:resource] = service[:resource] if service[:resource]
         service_obj = host.services.find_or_create_by(service_info)
         if service_obj.id.nil?
           elog("Failed to create service #{service_info.inspect} for host #{host.name} (#{host.address})")
-          return
+          next
         end
         service_obj.state ||= Msf::ServiceState::Open
-        service_obj.info = service[:info] ? service[:info] : ''
+        service_obj.info = service[:info] || ''
 
         if parents
           parents.each do |parent|
             service_obj.parents << parent if parent && !service_obj.parents.include?(parent)
           end
         end
+
+        service_obj.save! if service_obj.changed?
+        service_obj
       else
         next
       end
-
-      service_obj
     end.compact
+  end
+
+  private
+
+  # Resolves a symbol (e.g. :https, :http, :ssl, :tcp) into an Mdm::Service record,
+  # recursively creating any parent services defined in SERVICE_PARENT_MAP.
+  #
+  # @param host [Mdm::Host] the host to associate the service with
+  # @param sym [Symbol] the service symbol to resolve
+  # @param port [Integer] the port number (inherited from the child service)
+  # @param proto [String] the transport protocol
+  # @return [Mdm::Service] the resolved or created service record
+  def resolve_symbol_service(host, sym, port:, proto: 'tcp')
+    unless SERVICE_PARENT_MAP.key?(sym)
+      elog("Unknown service symbol '#{sym}' passed to resolve_symbol_service")
+      return nil
+    end
+
+    # Recursively resolve this symbol's own parents first
+    parent_syms = SERVICE_PARENT_MAP[sym]
+    parents = if parent_syms.any?
+                process_service_chain(host, parent_syms, port: port, proto: proto)
+              end
+
+    service_info = {
+      port: port,
+      proto: proto,
+      name: sym.to_s
+    }
+    service_obj = host.services.where(service_info).first_or_create!(state: Msf::ServiceState::Open)
+
+    if parents&.any?
+      parents.each do |parent|
+        service_obj.parents << parent if parent && !service_obj.parents.include?(parent)
+      end
+    end
+
+    service_obj
   end
 end

--- a/lib/msf/core/db_manager/web.rb
+++ b/lib/msf/core/db_manager/web.rb
@@ -236,12 +236,9 @@ module Msf::DBManager::Web
       :state     => 'open'
     )
 
-    # Change the service name if it is blank or it has
-    # been explicitly specified.
-    if opts.keys.include?(:ssl) or serv.name.to_s.empty?
-      name = opts[:ssl] ? 'https' : 'http'
-      serv.name = name
-    end
+    # Change the service name only if it is blank.
+    name = opts[:ssl] ? 'https' : 'http'
+    serv.name ||= name
     # Add the info if it's there.
     unless info.to_s.empty?
       serv.info = info

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -975,6 +975,7 @@ module Exploit::Remote::HttpClient
     {
       origin_type: :service,
       protocol: 'tcp',
+      # TODO: This is wrong. This should be the actual software running on the host, not just https/http.
       service_name: (ssl ? 'https' : 'http'),
       address: rhost,
       port: rport

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -253,13 +253,16 @@ module Msf
       end
     end
 
-    def report_ldap_service
-      transport_srv = { name: 'tcp', host: rhost, port: rport, proto: 'tcp', parents: nil }
-      parents = ssl ? { name: 'ssl', host: rhost, port: rport, proto: 'tcp', parents: [transport_srv] } : [transport_srv]
+    def report_ldap_service(opts: {})
+      host = opts[:host] || rhost
+      port = opts[:port] || rport
+      ldap_ssl = opts[:ssl] || ssl
+      transport_srv = { name: 'tcp', host: host, port: port, proto: 'tcp', parents: nil }
+      parents = ldap_ssl ? { name: 'ssl', host: host, port: port, proto: 'tcp', parents: [transport_srv] } : [transport_srv]
 
       report_service(
-        host: rhost,
-        port: rport,
+        host: host,
+        port: port,
         proto: 'tcp',
         name: 'ldap',
         parents: parents

--- a/modules/auxiliary/scanner/http/graphql_introspection_scanner.rb
+++ b/modules/auxiliary/scanner/http/graphql_introspection_scanner.rb
@@ -175,8 +175,11 @@ class MetasploitModule < Msf::Auxiliary
     report_service(
       host: rhost,
       port: rport,
-      name: (ssl ? 'https' : 'http'),
-      proto: 'tcp'
+      name: 'GraphQL',
+      proto: 'tcp',
+      ssl: ssl,
+      resource: target_uri.path,
+      parents: [ ssl ? :https : :http ]
     )
   end
 

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
@@ -1045,7 +1045,7 @@ RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
           import_msf_xml
         }.to(
           change(Mdm::Host, :count).by(1)
-           .and change(Mdm::Service, :count).by(1)
+           .and change(Mdm::Service, :count).by(2)
            .and change(Mdm::Note, :count).by(1)
         )
       end

--- a/spec/support/shared/examples/msf/db_manager/service.rb
+++ b/spec/support/shared/examples/msf/db_manager/service.rb
@@ -30,7 +30,8 @@ RSpec.shared_examples_for 'Msf::DBManager::Service' do
           info: 'banner',
           workspace: workspace
         )
-        expect(subject.services({ workspace: workspace }).count).to eq 1
+        # 2 services: the reported service + auto-created tcp parent
+        expect(subject.services({ workspace: workspace }).count).to eq 2
         expect(service.name).to eq 'test_service'
         expect(service.port).to eq 5000
         expect(service.proto).to eq 'tcp'
@@ -55,7 +56,8 @@ RSpec.shared_examples_for 'Msf::DBManager::Service' do
             task: task
           )
         end.last
-        expect(subject.services({ workspace: workspace }).count).to eq 1
+        # 2 services: the reported service + auto-created tcp parent
+        expect(subject.services({ workspace: workspace }).count).to eq 2
         expect(service.name).to eq 'test_service'
         expect(service.port).to eq 5000
         expect(service.proto).to eq 'tcp'
@@ -227,7 +229,8 @@ RSpec.shared_examples_for 'Msf::DBManager::Service' do
           opts[:resource] = {uri: '/new'}
           service = subject.report_service(opts)
           expect(service).not_to eq(existing_service)
-          expect(host.services.count).to eq 2
+          # 3 services: existing http, new http (different resource), and auto-created tcp parent
+          expect(host.services.count).to eq 3
         end
       end
 

--- a/spec/support/shared/examples/msf/db_manager/vuln.rb
+++ b/spec/support/shared/examples/msf/db_manager/vuln.rb
@@ -225,7 +225,8 @@ RSpec.shared_examples_for 'Msf::DBManager::Vuln' do
         expect {
           result = subject.report_vuln(host: host, name: 'foo', workspace: workspace, service: service_hash)
           expect(result.service).to eq(service)
-        }.to change(Mdm::Service, :count).by(1)
+          # Also creates a tcp parent service for the reported service
+        }.to change(Mdm::Service, :count).by(2)
       end
 
       context 'with parent services' do

--- a/test/modules/auxiliary/test/login.rb
+++ b/test/modules/auxiliary/test/login.rb
@@ -65,7 +65,8 @@ class MetasploitModule < Msf::Auxiliary
         port: port,
         protocol: 'tcp',
         credential: credential,
-        status: Metasploit::Model::Login::Status::SUCCESSFUL
+        status: Metasploit::Model::Login::Status::SUCCESSFUL,
+        ssl: ssl
       )
     end
   end


### PR DESCRIPTION
This PR:
- Allows `report_service` calls to take in `parents: [ :https, :http, :ssl, :tcp ]` values. This is a convenience change, as opposed to `parents: [ { host: host, port: port, proto: 'tcp', parents: [...] }]`. The service hierarchy is generated automatically.
  - Service (e.g. Jenkins) -> HTTPS -> SSL -> TCP
  - Service (e.g. Jenkins) -> HTTP -> TCP
- Adds improved service reporting to Login Scanner modules
  - On successful/failed logins
  - When check_setup confirms the service is running (not all login scanners implement this)
- Updates service tests to account for the automatic parent hierarchy generation (service count changes)

If a Login Scanner is _not_ a HTTP scanner, then it can do one of the following things:
- Report a UDP service
- Report a TCP service
  - If SSL is enabled, reports an SSL service, then TCP (e.g. ServiceName -> SSL -> TCP)
  - If SSL is not enabled or not supported, then reports only a TCP service (e.g. ServiceName -> TCP)

Although some login scanners are _not_ HTTP-based, they can sometimes still utilise the SSL option when making the client connection. This is being handled by the `parents: [ ssl ? :ssl : :tcp ]` option when calling to `report_service`.

## Verification

- TODO
- Also test in Pro