### PR TITLE
update dependencies for Sinatra, Rack, and Thin to support rails 8 upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ PATH
       pdf-reader
       pg
       puma
-      rack (~> 2.2)
+      rack (~> 3.1)
       railties
       rasn1 (= 0.14.0)
       rb-readline
@@ -106,13 +106,13 @@ PATH
       ruby_smb (~> 3.3.17)
       rubyntlm
       rubyzip
-      sinatra (~> 3.2)
+      sinatra (~> 4.1)
       sqlite3 (= 1.7.3)
       sshkey
       stringio (= 3.1.1)
       swagger-blocks
       syslog
-      thin (~> 1.x)
+      thin (~> 2.0)
       tzinfo
       tzinfo-data
       unix-crypt
@@ -445,24 +445,25 @@ GEM
     pry-byebug (3.11.0)
       byebug (~> 12.0)
       pry (>= 0.13, < 0.16)
-    psych (5.2.6)
+    psych (5.3.1)
       date
       stringio
     public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.19)
-    rack-protection (3.2.0)
+    rack (3.1.21)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
-    rack-session (1.0.2)
-      rack (< 3)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -621,10 +622,12 @@ GEM
       simplecov-html (~> 0.11)
     simplecov-html (0.13.1)
     simpleidn (0.2.3)
-    sinatra (3.2.0)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
       mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.2.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
@@ -635,10 +638,11 @@ GEM
     syslog (0.3.0)
       logger
     test-prof (1.4.4)
-    thin (1.8.2)
+    thin (2.0.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
+      logger
+      rack (>= 1, < 4)
     thor (1.4.0)
     tilt (2.6.0)
     timecop (0.9.10)

--- a/lib/msf/core/web_services/http_db_manager_service.rb
+++ b/lib/msf/core/web_services/http_db_manager_service.rb
@@ -1,4 +1,6 @@
 require 'rack'
+require 'thin'
+require 'rackup/handler/thin'
 require 'metasploit/framework/parsed_options/remote_db'
 
 # TODO: This functionality isn't fully used currently, it should be integrated and called from the top level msfdb.rb file
@@ -25,7 +27,7 @@ class Msf::WebServices::HttpDBManagerService
 
   def start_http_server(opts)
 
-    Rack::Handler::Thin.run(Msf::WebServices::MetasploitApiApp, **opts) do |server|
+    Rackup::Handler::Thin.run(Msf::WebServices::MetasploitApiApp, **opts) do |server|
 
       if opts[:ssl] && opts[:ssl] = true
         print_good('SSL Enabled')

--- a/lib/msf/core/web_services/json_rpc_app.rb
+++ b/lib/msf/core/web_services/json_rpc_app.rb
@@ -26,6 +26,10 @@ module Msf::WebServices
       # Disables Sinatra HTML Error Responses
       set :show_exceptions, false
 
+      # Sinatra 4 / rack-protection 4.x enables host authorization by default;
+      # the JSON-RPC service binds to user-specified addresses so all hosts are permitted.
+      set :host_authorization, { permitted_hosts: [] }
+
       set :sessions, {key: 'msf-ws.session', expire_after: 300}
       set :session_secret, ENV.fetch('MSF_WS_SESSION_SECRET', SecureRandom.hex(32))
       set :api_token, ENV.fetch('MSF_WS_JSON_RPC_API_TOKEN', nil)

--- a/lib/msf/core/web_services/metasploit_api_app.rb
+++ b/lib/msf/core/web_services/metasploit_api_app.rb
@@ -35,6 +35,9 @@ class Msf::WebServices::MetasploitApiApp < Sinatra::Base
   configure do
     set :sessions, {key: 'msf-ws.session', expire_after: 300}
     set :session_secret, ENV.fetch('MSF_WS_SESSION_SECRET') { SecureRandom.hex(32) }
+    # Sinatra 4 / rack-protection 4.x enables host authorization by default;
+    # the web service binds to user-specified addresses so all hosts are permitted.
+    set :host_authorization, { permitted_hosts: [] }
   end
 
   before do

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -107,12 +107,12 @@ Gem::Specification.new do |spec|
   # Required for Metasploit Web Services
   spec.add_runtime_dependency 'puma'
   spec.add_runtime_dependency 'ruby-mysql'
-  # webserver - pinned due to: https://github.com/github/secure_headers/issues/514
-  spec.add_runtime_dependency 'thin', '~> 1.x'
-  # rack pinned due to authlogic warnings when setting cookie keys with a / char present: https://github.com/binarylogic/authlogic/issues/779
-  spec.add_runtime_dependency 'rack', '~> 2.2'
-  # 4.x needs tested and verified for JSON RPC service
-  spec.add_runtime_dependency 'sinatra', '~> 3.2'
+
+  spec.add_runtime_dependency 'rack', '~> 3.1'
+  # 4.x supports Rack 3 for JSON RPC service
+  spec.add_runtime_dependency 'sinatra', '~> 4.1'
+  # Web server for msfdb web services; 2.x supports Rack 3
+  spec.add_runtime_dependency 'thin', '~> 2.0'
   spec.add_runtime_dependency 'warden'
   spec.add_runtime_dependency 'swagger-blocks'
   # Required for JSON-RPC client

--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe "Metasploit's json-rpc" do
   before(:example) do
     framework.modules.add_module_path(File.join(FILE_FIXTURES_PATH, 'json_rpc'))
     app.settings.framework = framework
+    # Rack 3 / rack-test requires explicit content type for raw JSON bodies
+    header 'Content-Type', 'application/json'
   end
 
   after(:example) do

--- a/spec/api/metasploit_api_app_spec.rb
+++ b/spec/api/metasploit_api_app_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'rack/test'
+
+RSpec.describe Msf::WebServices::MetasploitApiApp do
+  include Rack::Test::Methods
+  include_context 'Msf::DBManager'
+
+  let(:app) { described_class.new }
+
+  before(:example) do
+    header 'Content-Type', 'application/json'
+  end
+
+  describe 'host authorization' do
+    it 'does not reject requests with a 403 Host not permitted error' do
+      get '/api/v1/hosts'
+      expect(last_response.status).not_to eq(403)
+      expect(last_response.body).not_to include('Host not permitted')
+    end
+  end
+
+  describe 'authentication' do
+    it 'does not return 200 for unauthenticated requests to protected endpoints' do
+      get '/api/v1/hosts'
+      expect(last_response.status).not_to eq(200)
+    end
+
+    it 'returns a JSON response body' do
+      get '/api/v1/hosts'
+      expect { JSON.parse(last_response.body) }.not_to raise_error
+    end
+  end
+
+  describe 'response headers' do
+    it 'uses lowercase header keys' do
+      get '/api/v1/hosts'
+      raw_keys = last_response.headers.keys
+      raw_keys.each do |key|
+        expect(key).to eq(key.downcase), "Expected header '#{key}' to be lowercase"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails 8 has a dependency on rack 3.X which means we also needs to bump the sinatra and thin versions
This is a pre-requisite to an upcoming Pro Pr which will also upgrade to rack 3.X

# Verification
- [ ] CI passes
- [ ] Json RPC works
- [ ] API App works
