### PR TITLE
Fix frozen string crash

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1575,7 +1575,7 @@ protected
     p = module_info['Compat']['Payload']
 
     CompatDefaults::Payload.each_pair { |k,v|
-      (p[k]) ? p[k] << " #{v}" : p[k] = v
+      p[k] = p[k] ? "#{p[k]} #{v}" : v
     }
 
     #


### PR DESCRIPTION
Fix frozen string crash

## Verification

Use diff:

```diff
diff --git a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
index 78e45b09fd9..073095ac380 100644
--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
```

### Before

Crash

```
msf > use fibeair

Matching Modules
================

   #  Name                                             Disclosure Date  Rank       Check  Description
   -  ----                                             ---------------  ----       -----  -----------
   0  exploit/linux/ssh/ceragon_fibeair_known_privkey  2015-04-01       excellent  No     Ceragon FibeAir IP-10 SSH Private Key Exposure


Interact with a module by name or index. For example info 0, use 0 or use exploit/linux/ssh/ceragon_fibeair_known_privkey

[*] Using exploit/linux/ssh/ceragon_fibeair_known_privkey
[-] Error while running command use: can't modify frozen String: "find"

Call stack:
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/exploit.rb:1578:in `block in init_compat'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/exploit.rb:1577:in `each_pair'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/exploit.rb:1577:in `init_compat'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/module.rb:123:in `initialize'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/exploit.rb:266:in `initialize'
/Us
```

### After

No crash


```
msf > use fibeair

Matching Modules
================

   #  Name                                             Disclosure Date  Rank       Check  Description
   -  ----                                             ---------------  ----       -----  -----------
   0  exploit/linux/ssh/ceragon_fibeair_known_privkey  2015-04-01       excellent  No     Ceragon FibeAir IP-10 SSH Private Key Exposure


Interact with a module by name or index. For example info 0, use 0 or use exploit/linux/ssh/ceragon_fibeair_known_privkey

[*] Using exploit/linux/ssh/ceragon_fibeair_known_privkey
[*] Using configured payload cmd/unix/interact
msf exploit(linux/ssh/ceragon_fibeair_known_privkey) >
```