### PR TITLE
Fix FTP anonymous login detection when ANONYMOUS_LOGIN option is enabled

### DIFF
--- a/lib/metasploit/framework/ftp/client.rb
+++ b/lib/metasploit/framework/ftp/client.rb
@@ -68,7 +68,7 @@ module Metasploit
         def connect_login(user,pass,global = true)
           ftpsock = connect(global)
 
-          if !(user and pass)
+          if !(user and pass) && !(user == '' && pass == '')
             return false
           end
 

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -105,13 +105,17 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  # Always check for anonymous access by pretending to be a browser.
   def anonymous_creds
     anon_creds = [ ]
+    # Support both ANONYMOUS_LOGIN option and RECORD_GUEST option
     if datastore['RECORD_GUEST']
       ['IEUser@', 'User@', 'mozilla@example.com', 'chrome@example.com' ].each do |password|
         anon_creds << Metasploit::Framework::Credential.new(public: 'anonymous', private: password)
       end
+    end
+    # Also add blank username/password when ANONYMOUS_LOGIN is enabled
+    if datastore['ANONYMOUS_LOGIN']
+      anon_creds << Metasploit::Framework::Credential.new(public: '', private: '', realm: nil, private_type: :password)
     end
     anon_creds
   end


### PR DESCRIPTION
## Description

The `scanner/ftp/ftp_login` module was not properly handling anonymous login detection when `ANONYMOUS_LOGIN` option is enabled because:

1. The `anonymous_creds` method only checked `RECORD_GUEST`, not `ANONYMOUS_LOGIN`
2. The FTP `connect_login` method rejected empty username/password pairs with early return

## Changes

- **modules/auxiliary/scanner/ftp/ftp_login.rb**: Updated `anonymous_creds` to also add blank username/password when `ANONYMOUS_LOGIN` is true
- **lib/metasploit/framework/ftp/client.rb**: Updated `connect_login` to allow empty username/password (for true anonymous FTP)

## Verification

1. Enable `ANONYMOUS_LOGIN true` on an FTP server that allows anonymous access
2. Run the `scanner/ftp/ftp_login` module
3. Verify that blank username/password is attempted and anonymous login is detected

Fixes #21096