### PR TITLE
Add CertificateTrace support to LDAP Schannel authentication

### DIFF
--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -44,10 +44,11 @@ module Msf
           Msf::OptPkcs12Cert.new('LDAP::CertFile', [false, 'The path to the PKCS12 (.pfx) certificate file to authenticate with'], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL]),
           OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0]),
           OptEnum.new('LDAP::Signing', [true, 'Use signed and sealed (encrypted) LDAP', 'auto', %w[ disabled auto required ]]),
-          # Re-register the CertificateTrace option (provided unconditionally by the
-          # CertificateTrace mixin) to gate it on Schannel auth, since LDAP only loads
+          # Re-register the CertificateTrace options (provided unconditionally by the
+          # CertificateTrace mixin) to gate them on Schannel auth, since LDAP only loads
           # a client certificate on that path. This overrides the mixin's registration.
-          OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', %w[off metadata full]], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL])
+          OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', %w[off metadata full]], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL]),
+          OptString.new('CertificateTraceColors', [false, 'Certificate trace color (e.g. red/blu, unset to disable)', 'red/blu'], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL])
         ]
       )
     end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -12,6 +12,7 @@ module Msf
     include Msf::Exploit::Remote::Kerberos::Ticket::Storage
     include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
     include Metasploit::Framework::LDAP::Client
+    include Msf::Exploit::Remote::CertificateTrace
 
     # Initialize the LDAP client and set up the LDAP specific datastore
     # options to allow the client to perform authentication and timeout
@@ -42,7 +43,11 @@ module Msf
           *kerberos_auth_options(protocol: 'LDAP', auth_methods: Msf::Exploit::Remote::AuthOption::LDAP_OPTIONS),
           Msf::OptPkcs12Cert.new('LDAP::CertFile', [false, 'The path to the PKCS12 (.pfx) certificate file to authenticate with'], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL]),
           OptFloat.new('LDAP::ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0]),
-          OptEnum.new('LDAP::Signing', [true, 'Use signed and sealed (encrypted) LDAP', 'auto', %w[ disabled auto required ]])
+          OptEnum.new('LDAP::Signing', [true, 'Use signed and sealed (encrypted) LDAP', 'auto', %w[ disabled auto required ]]),
+          # Re-register the CertificateTrace option (provided unconditionally by the
+          # CertificateTrace mixin) to gate it on Schannel auth, since LDAP only loads
+          # a client certificate on that path. This overrides the mixin's registration.
+          OptEnum.new('CertificateTrace', [false, 'Certificate trace verbosity level', 'off', %w[off metadata full]], conditions: ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL])
         ]
       )
     end
@@ -82,6 +87,13 @@ module Msf
     #    LDAP server.
     def get_connect_opts
       pkcs12_storage = Msf::Exploit::Remote::Pkcs12::Storage.new(framework: framework, framework_module: self)
+      ldap_pkcs12 = datastore['LDAP::CertFile'] ? pkcs12_storage.read_pkcs12_cert_path(datastore['LDAP::CertFile']) : nil
+
+      # Trace the client certificate being submitted for LDAP Schannel authentication.
+      # Surfaces cert details at the moment the certificate is loaded for the LDAP bind.
+      pfx = ldap_pkcs12.is_a?(Hash) ? ldap_pkcs12[:value] : nil
+      certificate_trace(pfx.certificate) if pfx.respond_to?(:certificate)
+
       opts = {
         username: datastore['LDAPUsername'],
         password: datastore['LDAPPassword'],
@@ -89,7 +101,7 @@ module Msf
         base: datastore['BASE_DN'],
         domain_controller_rhost: datastore['DomainControllerRhost'],
         ldap_auth: datastore['LDAP::Auth'],
-        ldap_pkcs12: datastore['LDAP::CertFile'] ? pkcs12_storage.read_pkcs12_cert_path(datastore['LDAP::CertFile']) : nil,
+        ldap_pkcs12: ldap_pkcs12,
         ldap_rhostname: datastore['LDAP::Rhostname'],
         ldap_krb_offered_enc_types: datastore['LDAP::KrbOfferedEncryptionTypes'],
         ldap_krb5_cname: datastore['LDAP::Krb5Ccname'],
@@ -154,7 +166,6 @@ module Msf
         Rex::Proto::LDAP::Client.open(opts, &block)
       end
     end
-
 
     def resolve_connect_opts(connect_opts)
       return connect_opts unless connect_opts.dig(:auth, :initial_credential).is_a?(Proc)

--- a/spec/lib/msf/core/exploit/remote/ldap_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ldap_spec.rb
@@ -227,4 +227,27 @@ RSpec.describe Msf::Exploit::Remote::LDAP do
       end
     end
   end
+
+  describe 'CertificateTrace option registration' do
+    let(:schannel_condition) do
+      ['LDAP::Auth', '==', Msf::Exploit::Remote::AuthOption::SCHANNEL]
+    end
+
+    # Build a module that includes the mixin so its #initialize runs and the
+    # options are actually registered (the shared subject above is extended
+    # onto an already-built instance, so its #initialize never fires).
+    let(:registered_module) do
+      klass = Class.new(Msf::Exploit) { include Msf::Exploit::Remote::LDAP }
+      klass.new
+    end
+
+    # LDAP only loads a client certificate on the Schannel path, so both the
+    # CertificateTrace mixin options are re-registered here gated on that auth
+    # method, overriding the mixin's unconditional registration.
+    %w[CertificateTrace CertificateTraceColors].each do |opt_name|
+      it "gates #{opt_name} on LDAP::Auth == SCHANNEL" do
+        expect(registered_module.options[opt_name].conditions).to eq(schannel_condition)
+      end
+    end
+  end
 end

--- a/spec/lib/msf/core/exploit/remote/ldap_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ldap_spec.rb
@@ -128,4 +128,103 @@ RSpec.describe Msf::Exploit::Remote::LDAP do
       end
     end
   end
+
+  describe '#certificate_trace_enabled?' do
+    context 'when CertificateTrace is off' do
+      before { subject.datastore['CertificateTrace'] = 'off' }
+
+      it { expect(subject.certificate_trace_enabled?).to be false }
+    end
+
+    %w[metadata full].each do |mode|
+      context "when CertificateTrace is #{mode}" do
+        before { subject.datastore['CertificateTrace'] = mode }
+
+        it { expect(subject.certificate_trace_enabled?).to be true }
+      end
+    end
+  end
+
+  describe '#certificate_trace' do
+    let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+    let(:cert) do
+      c = OpenSSL::X509::Certificate.new
+      c.subject = OpenSSL::X509::Name.parse('/CN=Administrator/DC=CONTOSO/DC=LOCAL')
+      c.issuer = OpenSSL::X509::Name.parse('/CN=CONTOSO-CA/DC=CONTOSO/DC=LOCAL')
+      c.public_key = key.public_key
+      c.serial = OpenSSL::BN.new('99999')
+      c.version = 2
+      c.not_before = Time.utc(2026, 1, 1)
+      c.not_after = Time.utc(2027, 1, 1)
+      c.sign(key, OpenSSL::Digest.new('SHA256'))
+      c
+    end
+
+    context 'when CertificateTrace is off' do
+      before { subject.datastore['CertificateTrace'] = 'off' }
+
+      it 'does not call print_line' do
+        expect(subject).not_to receive(:print_line)
+        subject.certificate_trace(cert)
+      end
+    end
+
+    context 'when CertificateTrace is metadata' do
+      before { subject.datastore['CertificateTrace'] = 'metadata' }
+
+      it 'prints output with the [CertificateTrace] header, Subject, and SHA-256' do
+        output = nil
+        allow(subject).to receive(:print_line) { |s| output = s }
+        subject.certificate_trace(cert)
+        expect(output).to include('[CertificateTrace]')
+        expect(output).to include('Administrator')
+        expect(output).to include('SHA-256')
+        expect(output).not_to include('Serial')
+      end
+    end
+
+    context 'when CertificateTrace is full' do
+      before { subject.datastore['CertificateTrace'] = 'full' }
+
+      it 'prints output including Serial and Public Key' do
+        output = nil
+        allow(subject).to receive(:print_line) { |s| output = s }
+        subject.certificate_trace(cert)
+        expect(output).to include('Serial')
+        expect(output).to include('99999')
+        expect(output).to include('Public Key')
+      end
+    end
+  end
+
+  describe '#get_connect_opts certificate trace call site' do
+    let(:fake_cert) { instance_double(OpenSSL::X509::Certificate) }
+    let(:fake_pkcs12) { instance_double(OpenSSL::PKCS12, certificate: fake_cert) }
+
+    before do
+      subject.datastore['CertificateTrace'] = 'metadata'
+      allow(subject).to receive(:ldap_connect_opts).and_return({})
+    end
+
+    context 'when LDAP::CertFile is set' do
+      before do
+        subject.datastore['LDAP::CertFile'] = '/tmp/cert.pfx'
+        allow_any_instance_of(Msf::Exploit::Remote::Pkcs12::Storage)
+          .to receive(:read_pkcs12_cert_path)
+          .and_return({ path: '/tmp/cert.pfx', value: fake_pkcs12 })
+      end
+
+      it 'calls certificate_trace with the cert extracted from the loaded PKCS12' do
+        expect(subject).to receive(:certificate_trace).with(fake_cert)
+        subject.get_connect_opts
+      end
+    end
+
+    context 'when LDAP::CertFile is not set' do
+      it 'does not call certificate_trace (the nil-pfx guard is not dead code)' do
+        expect(subject).not_to receive(:certificate_trace)
+        subject.get_connect_opts
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to #21198. Extends the `CertificateTrace` facility (introduced there for PKINIT) to the LDAP Schannel authentication path so operators can inspect the client certificate used for an LDAPS bind.

When `LDAP::Auth=SCHANNEL` and `LDAP::CertFile` points at a PKCS12, the certificate is rendered through `CertificateTracePresenter` and printed by the module instance before the LDAP bind. Verbosity is controlled by the `CertificateTrace` advanced option (`off` / `metadata` / `full`).

## Implementation

Two files changed:

- `lib/msf/core/exploit/remote/ldap.rb` includes the shared `Msf::Exploit::Remote::CertificateTrace` mixin (landed in #21198) and calls its dispatcher from `get_connect_opts`, with a nil-pfx guard for the `CertFile`-not-set path. The `CertificateTrace` option is re-registered with a `LDAP::Auth == SCHANNEL` condition, overriding the mixin's unconditional registration, since LDAP only loads a client cert on the Schannel path.
- `spec/lib/msf/core/exploit/remote/ldap_spec.rb` adds examples covering both the cert-loaded path (off/metadata/full output) and the no-cert path, so the nil-pfx guard is not dead code in CI.

Rebased onto `master` now that #21198 has merged; the `CertificateTracePresenter` it depended on is already in the tree.

## Verification

Run the LDAP spec (requires a test database):

```
RAILS_ENV=test BUNDLER_VERSION=4.0.9 bundle exec rspec \
  spec/lib/msf/core/exploit/remote/ldap_spec.rb \
  --format documentation
```

Expected: 23 examples, 0 failures.

Rubocop on the changed lib file:

```
bundle exec rubocop lib/msf/core/exploit/remote/ldap.rb
```

No new offenses introduced. The pre-existing offenses on untouched lines (128, 253, 298) are not from this change.

## Test plan

- [x] Spec run: 23 examples, 0 failures
- [x] Rubocop: no new offenses on ldap.rb
- [x] Manual: against a Server 2022 AD CS DC, `ldap_query` with `LDAP::Auth=SCHANNEL`, `LDAP::CertFile=<PKCS12>`, `CertificateTrace=full` - certificate dump rendered before the LDAP bind (output in the comment below)
- [x] Manual: with `LDAP::CertFile` unset, trace path skipped silently (nil-pfx guard)
