### PR TITLE
Fix msfdb crash on windows

### DIFF
--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -24,7 +24,10 @@ module MsfdbHelpers
       # Try creating a test file at {Dir.tmpdir},
       # Else fallback to creation at @{db}
       # Else fail with error.
-      if test_executable_file("#{Dir.tmpdir}")
+      if Gem.win_platform?
+        # Windows doesn't support Unix sockets; always use TCP
+        @socket_directory = @options[:db_host]
+      elsif test_executable_file("#{Dir.tmpdir}")
         @socket_directory = Dir.tmpdir
       elsif test_executable_file("#{@db}")
         @socket_directory = @db


### PR DESCRIPTION
Fix msfdb crash on windows

## Verification

### Before 🔴 

```
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
Running the 'init' command for the database:
Creating database at C:/Users/user/.msf4/db
[!] Attempt to create DB socket file at Temporary Directory and `~/.msf4/db` failed. Possibly because they are mounted with NOEXEC flags. Database initialization failed.
Starting database at C:/Users/user/.msf4/db...waiting for server to start.... done
server started
success
Creating database users
c:/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/pg-1.5.9/lib/pg/connection.rb:709:in 'PG::Connection#async_connect_or_reset': connection to server at "127.0.0.1", port 5433 failed: server closed the connection unexpectedly (PG::ConnectionBad)
        This probably means the server terminated abnormally
        before or while processing the request.

        from c:/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/pg-1.5.9/lib/pg/connection.rb:844:in 'PG::Connection.connect_to_hosts'
        from c:/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/pg-1.5.9/lib/pg/connection.rb:772:in 'PG::Connection.new'
        from c:/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/pg-1.5.9/lib/pg.rb:63:in 'PG.connect'
        from c:/metasploit-framework/embedded/framework/lib/msfdb_helpers/pg_ctl.rb:159:in 'MsfdbHelpers::PgCtl#create_db_users'
        from c:/metasploit-framework/embedded/framework/lib/msfdb_helpers/pg_ctl.rb:37:in 'MsfdbHelpers::PgCtl#init'
        from c:/metasploit-framework/bin/../embedded/framework/msfdb:201:in 'Object#init_db'
        from c:/metasploit-framework/bin/../embedded/framework/msfdb:943:in 'Object#invoke_command'
        from c:/metasploit-framework/bin/../embedded/framework/msfdb:1072:in '<main>'

c:\metasploit-framework>
```

### After 🟢 

Working