### PR TITLE
SSH mixin: New functions to help populate workspaces

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -52,10 +52,10 @@ module Metasploit
         # @note The caller *must* close {#ssh_socket}
         def attempt_login(credential)
           self.ssh_socket = nil
-          opt_hash = ssh_client_defaults.merge({
+          opt_hash = {
             :port            => port,
             :verbose         => verbosity
-          })
+          }
           case credential.private_type
           when :password, nil
             opt_hash.update(
@@ -75,7 +75,7 @@ module Metasploit
           }
           begin
             ::Timeout.timeout(connection_timeout) do
-              self.ssh_socket = Net::SSH.start(
+              self.ssh_socket = connect_ssh(
                 host,
                 credential.public,
                 opt_hash

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -118,6 +118,8 @@ module Msf::DBManager::Service
     parents = process_service_chain(host, opts.delete(:parents)) if opts[:parents]
     if parents
       parents.each do |parent|
+        next if parent.id == service.id
+
         service.parents << parent if parent && !service.parents.include?(parent)
       end
     end
@@ -214,7 +216,8 @@ module Msf::DBManager::Service
         }
         service_info[:name] = service[:name].downcase if service[:name]
         service_info[:resource] = service[:resource] if service[:resource]
-        service_obj = host.services.find_or_create_by(service_info)
+        service_obj = host.services.find_by(port: service_info[:port], proto: service_info[:proto]) ||
+                      host.services.find_or_create_by(service_info)
         if service_obj.id.nil?
           elog("Failed to create service #{service_info.inspect} for host #{host.name} (#{host.address})")
           return

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -60,6 +60,7 @@ module Msf::Exploit::Remote::SSH
       )
 
       report_ssh_host(banner, host, port)
+      report_ssh_hostkeys(ssh.transport, host, port)
     rescue NameError, NoMethodError
       nil
     end
@@ -98,5 +99,30 @@ module Msf::Exploit::Remote::SSH
 
     report_host({ host: ip }.merge(os_info))
     os_info
+  end
+
+  def report_ssh_hostkeys(transport, ip = rhost, port = rport)
+    host_keys = transport.algorithms.session
+                         .instance_variable_get(:@host_keys)
+                         .instance_variable_get(:@host_keys)
+
+    host_keys.each do |host_key|
+      fingerprint = 'SHA256:' + Base64.strict_encode64(
+        OpenSSL::Digest::SHA256.digest(host_key.to_blob)
+      ).chomp('=')
+
+      report_note(
+        host: ip,
+        port: port,
+        proto: 'tcp',
+        sname: 'ssh',
+        type: 'ssh.hostkey',
+        data: {
+          type: host_key.ssh_type,
+          fingerprint: fingerprint
+        },
+        update: :unique_data
+      )
+    end
   end
 end

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -38,34 +38,32 @@ module Msf::Exploit::Remote::SSH
     }
   end
 
+  # Authenticated session
   def connect_ssh(host, user, opts = {})
     ssh = Net::SSH.start(host, user, ssh_client_defaults.merge(opts))
+    port = opts[:port] || rport
 
     begin
-      banner = ssh.transport.server_version.version.to_s.strip
-      port = opts[:port] || rport
-
-      report_service(
-        host: host,
-        port: port,
-        name: 'ssh',
-        proto: 'tcp',
-        info: banner,
-        parents: {
-          host: host,
-          port: port,
-          proto: 'tcp',
-          name: 'tcp'
-        }
-      )
-
-      report_ssh_host(banner, host, port)
-      report_ssh_hostkeys(ssh.transport, host, port)
+      report_ssh_connection(ssh.transport, host, port)
     rescue NameError, NoMethodError
       nil
     end
 
     ssh
+  end
+
+  # KEX-only transport
+  def connect_ssh_transport(host, opts = {})
+    transport = Net::SSH::Transport::Session.new(host, opts)
+    port = opts[:port] || rport
+
+    begin
+      report_ssh_connection(transport, host, port)
+    rescue NameError, NoMethodError
+      nil
+    end
+
+    transport
   end
 
   def report_ssh_host(banner, ip = rhost, port = rport)
@@ -124,5 +122,28 @@ module Msf::Exploit::Remote::SSH
         update: :unique_data
       )
     end
+  end
+
+  private
+
+  def report_ssh_connection(transport, host, port)
+    banner = transport.server_version.version.to_s.strip
+
+    report_ssh_host(banner, host, port)
+    report_ssh_hostkeys(transport, host, port)
+
+    report_service(
+      host: host,
+      port: port,
+      name: 'ssh',
+      proto: 'tcp',
+      info: banner,
+      parents: {
+        host: host,
+        port: port,
+        proto: 'tcp',
+        name: 'tcp'
+      }
+    )
   end
 end

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -138,6 +138,24 @@ module Msf::Exploit::Remote::SSH
     end
   end
 
+  def grab_ssh_banner(ip, port = rport)
+    sock = Rex::Socket::Tcp.create(
+      'PeerHost' => ip,
+      'PeerPort' => port,
+      'Context' => { 'Msf' => framework },
+      'ConnectTimeout' => datastore['SSH_TIMEOUT']
+    )
+    sock.get_once(256, 10)&.strip
+  rescue StandardError
+    nil
+  ensure
+    begin
+      sock&.close
+    rescue StandardError
+      nil
+    end
+  end
+
   private
 
   def report_ssh_connection(transport, host, port)

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -52,7 +52,7 @@ module Msf::Exploit::Remote::SSH
       report_service(host: host, port: port, proto: 'tcp', name: 'ssh') if respond_to?(:workspace, true)
       raise
     rescue Net::SSH::Exception, EOFError, Errno::ECONNRESET, ::Timeout::ExitException
-      report_service(host: host, port: port, proto: 'tcp') if respond_to?(:workspace, true)
+      report_ssh_service(host, port) if respond_to?(:workspace, true)
       raise
     end
 
@@ -71,7 +71,7 @@ module Msf::Exploit::Remote::SSH
       report_host(host: host) if respond_to?(:workspace, true)
       raise
     rescue Net::SSH::Exception, EOFError, Errno::ECONNRESET, ::Timeout::ExitException
-      report_service(host: host, port: port, proto: 'tcp') if respond_to?(:workspace, true)
+      report_ssh_service(host, port) if respond_to?(:workspace, true)
       raise
     end
 
@@ -156,6 +156,20 @@ module Msf::Exploit::Remote::SSH
     end
   end
 
+  def report_ssh_service(ip, port = rport, info: nil)
+    banner = info.to_s.strip
+    is_ssh = banner.start_with?('SSH-')
+
+    report_service(
+      host: ip,
+      port: port,
+      name: is_ssh ? 'ssh' : nil,
+      proto: 'tcp',
+      info: banner,
+      **( is_ssh ? { parents: { host: ip, port: port, proto: 'tcp', name: 'tcp' } } : {} )
+    )
+  end
+
   private
 
   def report_ssh_connection(transport, host, port)
@@ -165,19 +179,6 @@ module Msf::Exploit::Remote::SSH
 
     report_ssh_host(banner, host, port)
     report_ssh_hostkeys(transport, host, port)
-
-    report_service(
-      host: host,
-      port: port,
-      name: 'ssh',
-      proto: 'tcp',
-      info: banner,
-      parents: {
-        host: host,
-        port: port,
-        proto: 'tcp',
-        name: 'tcp'
-      }
-    )
+    report_ssh_service(host, port, info: banner)
   end
 end

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -170,6 +170,10 @@ module Msf::Exploit::Remote::SSH
     )
   end
 
+  def service_details
+    { service_name: 'ssh', port: rport, protocol: 'tcp' }
+  end
+
   private
 
   def report_ssh_connection(transport, host, port)

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -17,6 +17,7 @@ module Msf::Exploit::Remote::SSH
   #   SSH_TIMEOUT (TODO: Refactor to SSHTimeout)
   #   SSH_DEBUG   (TODO: Refactor to SSHDebug)
   include Msf::Exploit::Remote::SSH::Options
+  include Msf::Auxiliary::Report
 
   def ssh_socket_factory
     unless defined? datastore
@@ -35,5 +36,32 @@ module Msf::Exploit::Remote::SSH
       proxy: ssh_socket_factory,
       append_all_supported_algorithms: true
     }
+  end
+
+  def connect_ssh(host, user, opts = {})
+    ssh = Net::SSH.start(host, user, ssh_client_defaults.merge(opts))
+
+    begin
+      banner = ssh.transport.server_version.version.to_s.strip
+      port = opts[:port] || rport
+
+      report_service(
+        host: host,
+        port: port,
+        name: 'ssh',
+        proto: 'tcp',
+        info: banner,
+        parents: {
+          host: host,
+          port: port,
+          proto: 'tcp',
+          name: 'tcp'
+        }
+      )
+    rescue NameError, NoMethodError
+      nil
+    end
+
+    ssh
   end
 end

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -40,28 +40,42 @@ module Msf::Exploit::Remote::SSH
 
   # Authenticated session
   def connect_ssh(host, user, opts = {})
-    ssh = Net::SSH.start(host, user, ssh_client_defaults.merge(opts))
     port = opts[:port] || rport
 
     begin
-      report_ssh_connection(ssh.transport, host, port)
-    rescue NameError, NoMethodError
-      nil
+      ssh = Net::SSH.start(host, user, ssh_client_defaults.merge(opts))
+    rescue Errno::ECONNREFUSED, Rex::ConnectionRefused
+      report_host(host: host) if respond_to?(:workspace, true)
+      raise
+    rescue Net::SSH::AuthenticationFailed
+      # KEX succeeded so this is definitely SSH, but transport is already closed - no banner available
+      report_service(host: host, port: port, proto: 'tcp', name: 'ssh') if respond_to?(:workspace, true)
+      raise
+    rescue Net::SSH::Exception, EOFError, Errno::ECONNRESET, ::Timeout::ExitException
+      report_service(host: host, port: port, proto: 'tcp') if respond_to?(:workspace, true)
+      raise
     end
+
+    report_ssh_connection(ssh.transport, host, port) if ssh.respond_to?(:transport)
 
     ssh
   end
 
   # KEX-only transport
   def connect_ssh_transport(host, opts = {})
-    transport = Net::SSH::Transport::Session.new(host, opts)
     port = opts[:port] || rport
 
     begin
-      report_ssh_connection(transport, host, port)
-    rescue NameError, NoMethodError
-      nil
+      transport = Net::SSH::Transport::Session.new(host, opts)
+    rescue Errno::ECONNREFUSED, Rex::ConnectionRefused
+      report_host(host: host) if respond_to?(:workspace, true)
+      raise
+    rescue Net::SSH::Exception, EOFError, Errno::ECONNRESET, ::Timeout::ExitException
+      report_service(host: host, port: port, proto: 'tcp') if respond_to?(:workspace, true)
+      raise
     end
+
+    report_ssh_connection(transport, host, port)
 
     transport
   end
@@ -127,6 +141,8 @@ module Msf::Exploit::Remote::SSH
   private
 
   def report_ssh_connection(transport, host, port)
+    return unless respond_to?(:workspace, true)
+
     banner = transport.server_version.version.to_s.strip
 
     report_ssh_host(banner, host, port)

--- a/lib/msf/core/exploit/remote/ssh.rb
+++ b/lib/msf/core/exploit/remote/ssh.rb
@@ -58,10 +58,45 @@ module Msf::Exploit::Remote::SSH
           name: 'tcp'
         }
       )
+
+      report_ssh_host(banner, host, port)
     rescue NameError, NoMethodError
       nil
     end
 
     ssh
+  end
+
+  def report_ssh_host(banner, ip = rhost, port = rport)
+    return unless banner =~ /^SSH-\d+\.\d+-(.*)$/
+
+    recog_match = Recog::Nizer.match('ssh.banner', ::Regexp.last_match(1))
+    return unless recog_match
+
+    os_info = {}
+    recog_match.each_pair do |k, v|
+      next if k == 'matched'
+
+      case k
+      when 'os.product' then os_info[:os_name] = v
+      when 'os.vendor' then os_info[:os_flavor] = v
+      when 'os.version' then os_info[:os_sp] = v
+      when 'os.cpe23'
+        report_note(
+          host: ip,
+          port: port,
+          proto: 'tcp',
+          sname: 'ssh',
+          type: 'ssh.cpe',
+          data: { cpe: v },
+          update: :unique_data
+        )
+      end
+    end
+
+    return if os_info.empty?
+
+    report_host({ host: ip }.merge(os_info))
+    os_info
   end
 end

--- a/modules/auxiliary/gather/progress_moveit_sftp_fileread_cve_2024_5806.rb
+++ b/modules/auxiliary/gather/progress_moveit_sftp_fileread_cve_2024_5806.rb
@@ -2,12 +2,12 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-require 'net/ssh/transport/session'
 require 'net/sftp'
 require 'openssl'
 
 class MetasploitModule < Msf::Auxiliary
 
+  include Msf::Exploit::Remote::SSH
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
@@ -73,15 +73,8 @@ class MetasploitModule < Msf::Auxiliary
   def check
     # Our check method will establish an unauthenticated connection to the remote SFTP (which is an extension of SSH)
     # service and we pull out the servers version string.
-    transport = ::Net::SSH::Transport::Session.new(
-      datastore['RHOST'],
-      {
-        port: datastore['RPORT'],
-        # Use self as a proxy for the net/ssh library, to allow us to use Metasploit's Rex sockets, which will honor pivots.
-        proxy: self
-      }
-    )
-
+    # Use self as a proxy for the net/ssh library, to allow us to use Metasploit's Rex sockets, which will honor pivots.
+    transport = connect_ssh_transport(datastore['RHOST'], port: datastore['RPORT'], proxy: self)
     ident = transport.server_version.version
 
     # We test the SSH version string for a known value of MOVEit SFTP.
@@ -95,6 +88,12 @@ class MetasploitModule < Msf::Auxiliary
     Msf::Exploit::CheckCode::Unknown('Host Unreachable')
   rescue ::Rex::ConnectionTimeout, ::Net::SSH::ConnectionTimeout
     Msf::Exploit::CheckCode::Unknown('Connection Timeout')
+  ensure
+    begin
+      transport&.close
+    rescue StandardError
+      nil
+    end
   end
 
   def run

--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -74,17 +74,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login(user, pass, ip)
-    opts = ssh_client_defaults.merge({
+    opts = {
       :auth_methods => ['password'],
       :port => rport,
       :password => pass,
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(ip, user, opts)
+        connect_ssh(ip, user, opts)
       end
       if ssh
         print_good("#{ip}:#{rport} - Login Successful (#{user}:#{pass})")

--- a/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
@@ -3,11 +3,10 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'net/ssh'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SSH
 
   def initialize(info = {})
     super(
@@ -89,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     begin
-      transport = Net::SSH::Transport::Session.new(ip, opt_hash)
+      transport = connect_ssh_transport(ip, opt_hash)
     rescue Rex::ConnectionError
       return :connection_error
     end
@@ -97,14 +96,7 @@ class MetasploitModule < Msf::Auxiliary
     auth = Net::SSH::Authentication::Session.new(transport, opt_hash)
     auth.authenticate("ssh-connection", Rex::Text.rand_text_alphanumeric(8), Rex::Text.rand_text_alphanumeric(8))
     auth_method = auth.allowed_auth_methods.join('|')
-    print_good "#{peer(ip)} Server Version: #{auth.transport.server_version.version}"
-    report_service(
-      host: ip,
-      port: rport,
-      name: "ssh",
-      proto: "tcp",
-      info: auth.transport.server_version.version
-    )
+    print_good "#{peer(ip)} Server Version: #{transport.server_version.version}"
 
     if auth_method.empty?
       :vulnerable
@@ -126,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
-    transport = Net::SSH::Transport::Session.new(ip, opt_hash)
+    transport = connect_ssh_transport(ip, opt_hash)
     auth = Net::SSH::Authentication::Session.new(transport, opt_hash)
 
     begin

--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     # Specified Kex/Encryption downgrade requirements must be set to connect to the Power Meters.
-    ssh_opts = ssh_client_defaults.merge({
+    ssh_opts = {
       auth_methods: ['publickey'],
       port: rport,
       key_data: [ key_data ],
@@ -66,13 +66,13 @@ class MetasploitModule < Msf::Auxiliary
       encryption: ['aes128-cbc'],
       kex: ['diffie-hellman-group1-sha1'],
       host_key: ['ssh-rsa']
-    })
+    }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(ip, 'admin', ssh_opts)
+        connect_ssh(ip, 'admin', ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")

--- a/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/fortinet_backdoor.rb
@@ -53,20 +53,18 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    factory = ssh_socket_factory
-
-    ssh_opts = ssh_client_defaults.merge({
+    ssh_opts = {
       port: rport,
       # The auth method is converted into a class name for instantiation,
       # so fortinet-backdoor here becomes FortinetBackdoor from the mixin
       auth_methods: ['fortinet-backdoor']
-    })
+    }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(ip, 'Fortimanager_Access', ssh_opts)
+        connect_ssh(ip, 'Fortimanager_Access', ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")

--- a/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
@@ -50,17 +50,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    ssh_opts = ssh_client_defaults.merge({
+    ssh_opts = {
       :port => rport,
       :auth_methods => ['password', 'keyboard-interactive'],
       :password => %q{<<< %s(un='%s') = %u},
-    })
+    }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(
+        connect_ssh(
           ip,
           'admin',
           ssh_opts

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -92,12 +92,12 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::BadConfig, 'Execute action requires CMD to be set')
     end
 
-    ssh_opts = ssh_client_defaults.merge({
+    ssh_opts = {
       port: rport,
       # The auth method is converted into a class name for instantiation,
       # so libssh-auth-bypass here becomes LibsshAuthBypass from the mixin
       auth_methods: ['libssh-auth-bypass']
-    })
+    }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(ip, username, ssh_opts)
+        connect_ssh(ip, username, ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -137,9 +137,9 @@ class MetasploitModule < Msf::Auxiliary
   def check_user(ip, user, port)
     technique = action['Type']
 
-    opts = ssh_client_defaults.merge({
+    opts = {
       port: port
-    })
+    }
 
     # The auth method is converted into a class name for instantiation,
     # so malformed-packet here becomes MalformedPacket from the mixin
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Auxiliary
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(ip, user, opts)
+        connect_ssh(ip, user, opts)
       end
     rescue Rex::ConnectionError
       return :connection_error

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -4,11 +4,11 @@
 ##
 
 require 'recog'
-require 'net/ssh/transport/session'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SSH
 
   def initialize
     super(
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(target_host)
     ::Timeout.timeout(timeout) do
-      transport = Net::SSH::Transport::Session.new(target_host, { port: rport })
+      transport = connect_ssh_transport(target_host, port: rport)
 
       server_data = transport.algorithms.instance_variable_get(:@server_data)
       host_keys = transport.algorithms.session.instance_variable_get(:@host_keys).instance_variable_get(:@host_keys)
@@ -234,10 +234,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       ident = transport.server_version.version
-
       print_status("#{target_host} - SSH server version: #{ident}")
-
-      report_service(host: target_host, port: rport, name: 'ssh', proto: 'tcp', info: ident)
 
       return unless datastore['EXTENDED_CHECKS']
 

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -82,18 +82,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
       password: pass
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, user, opts)
+        ssh = connect_ssh(rhost, user, opts)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
+++ b/modules/exploits/freebsd/http/junos_phprc_auto_prepend_file.rb
@@ -331,15 +331,15 @@ $user->set_var('junos-version',$imageName);
   end
 
   def ssh_login
-    ssh_opts = ssh_client_defaults.merge({
+    ssh_opts = {
       port: datastore['SSH_PORT'],
       auth_methods: ['password'],
       password: datastore['TMP_ROOT_PASSWORD']
-    })
+    }
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(rhost, 'root', ssh_opts)
+        connect_ssh(rhost, 'root', ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{e.class}: #{e.message}")

--- a/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
+++ b/modules/exploits/linux/http/acronis_cyber_infra_cve_2023_45249.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_sshlogin(ip, user, ssh_opts)
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        self.ssh_socket = Net::SSH.start(ip, user, ssh_opts)
+        self.ssh_socket = connect_ssh(ip, user, ssh_opts)
       end
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, 'Disconnected during negotiation')
@@ -342,11 +342,11 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::NoAccess, 'Failed to upload SSH public key.') unless upload_sshkey(k.ssh_public_key, cluster_id)
 
     # login with SSH private key to establish SSH root session
-    ssh_opts = ssh_client_defaults.merge({
+    ssh_opts = {
       auth_methods: ['publickey'],
       key_data: [ k.private_key ],
       port: datastore['SSHPORT']
-    })
+    }
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     print_status('Authenticating with SSH private key.')
@@ -361,5 +361,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
     @timeout ? ssh_socket.shutdown! : ssh_socket.close
+  end
+end
+_socket.close
   end
 end

--- a/modules/exploits/linux/http/alienvault_exec.rb
+++ b/modules/exploits/linux/http/alienvault_exec.rb
@@ -297,16 +297,16 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # We will trigger the rogue policy by doing ssh auth attempt with invalid credential :-)
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password'],
       port: 22,
       password: rand_text_alpha(15)
-    })
+    }
 
     print_status("Triggering the policy by performing SSH login attempt")
 
     begin
-      Net::SSH.start(rhost, "root", opts)
+      connect_ssh(rhost, "root", opts)
     rescue Net::SSH::AuthenticationFailed
       print_good("SSH - Failed authentication. That means our policy and action will be trigged..!")
     rescue Net::SSH::Exception => e

--- a/modules/exploits/linux/http/cisco_firepower_useradd.rb
+++ b/modules/exploits/linux/http/cisco_firepower_useradd.rb
@@ -80,13 +80,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Console is found.")
       vprint_status("Checking SSH service.")
       begin
-        opts = ssh_client_defaults.merge({
+        opts = {
           port: datastore['SSHPORT'],
           password: Rex::Text.rand_text_alpha(5),
           auth_methods: ['password']
-        })
+        }
         ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-          Net::SSH.start(rhost, 'admin', opts)
+          connect_ssh(rhost, 'admin', opts)
         end
       rescue Timeout::Error
         vprint_error('The SSH connection timed out.')
@@ -225,15 +225,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def init_ssh_session(user, pass)
     print_status("Attempting to log into SSH as #{user}:#{pass}")
 
-    factory = ssh_socket_factory
     opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: datastore['SSHPORT'],
-      use_agent: false,
-      config: false,
-      password: pass,
-      proxy: factory,
-      non_interactive: true
+      password: pass
     }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
@@ -241,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        @ssh_socket = Net::SSH.start(rhost, user, opts)
+        @ssh_socket = connect_ssh(rhost, user, opts)
       end
     rescue Net::SSH::Exception => e
       fail_with(Failure::Unknown, e.message)

--- a/modules/exploits/linux/http/fortinet_authentication_bypass_cve_2022_40684.rb
+++ b/modules/exploits/linux/http/fortinet_authentication_bypass_cve_2022_40684.rb
@@ -237,7 +237,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ssh_options[:proxy].proxies = nil if ssh_options[:proxy]
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        self.ssh_socket = Net::SSH.start(rhost, username, ssh_options)
+        self.ssh_socket = connect_ssh(rhost, username, ssh_options)
       end
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, 'Disconnected during negotiation')
@@ -256,15 +256,18 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Executing exploit on #{datastore['RHOST']}:#{datastore['RPORT']} target user: #{username}")
     add_ssh_key
     vprint_status('Establishing SSH connection')
-    ssh_options = ssh_client_defaults.merge({
+    ssh_options = {
       auth_methods: ['publickey'],
       key_data: [ ssh_private_key ],
       port: ssh_rport
-    })
+    }
     ssh_options.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     do_login(ssh_options)
 
     handler(ssh_socket)
+  end
+end
+r(ssh_socket)
   end
 end

--- a/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
+++ b/modules/exploits/linux/http/ubiquiti_airos_file_upload.rb
@@ -133,17 +133,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def ssh_login
-    ssh_opts = ssh_client_defaults.merge({
+    ssh_opts = {
       port: datastore['SSH_PORT'],
       auth_methods: %w[publickey password],
       key_data: [private_key]
-    })
+    }
 
     ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(rhost, username, ssh_opts)
+        connect_ssh(rhost, username, ssh_opts)
       end
     rescue Net::SSH::Exception => e
       vprint_error("#{e.class}: #{e.message}")

--- a/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
+++ b/modules/exploits/linux/http/zyxel_lfi_unauth_ssh_rce.rb
@@ -372,17 +372,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def do_login(ip, user, pass, ssh_port)
     # create SSH session and login
     # if login is successfull, return true else return false. All other errors will trigger an immediate fail
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: ssh_port,
       password: pass
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        self.ssh_socket = Net::SSH.start(ip, user, opts)
+        self.ssh_socket = connect_ssh(ip, user, opts)
       end
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, 'Disconnected during negotiation')

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -82,16 +82,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    opt_hash = ssh_client_defaults.merge({
+    opt_hash = {
       auth_methods: ['publickey'],
       port: rport,
       key_data: [ key_data ]
-    })
+    }
     opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(rhost, user, opt_hash)
+        ssh_socket = connect_ssh(rhost, user, opt_hash)
       end
     rescue Rex::ConnectionError
       return nil

--- a/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
+++ b/modules/exploits/linux/ssh/cisco_ucs_scpuser.rb
@@ -85,18 +85,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
       password: pass
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, user, opts)
+        ssh = connect_ssh(rhost, user, opts)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/exagrid_known_privkey.rb
+++ b/modules/exploits/linux/ssh/exagrid_known_privkey.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(rhost, 'root', ssh_options)
+        ssh_socket = connect_ssh(rhost, 'root', ssh_options)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -80,18 +80,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    opt_hash = ssh_client_defaults.merge({
+    opt_hash = {
       auth_methods: ['publickey'],
       port: rport,
       key_data: [ key_data ]
-    })
+    }
 
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(rhost, user, opt_hash)
+        ssh_socket = connect_ssh(rhost, user, opt_hash)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/ibm_drm_a3user.rb
+++ b/modules/exploits/linux/ssh/ibm_drm_a3user.rb
@@ -89,18 +89,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
       password: pass
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh =
         ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-          Net::SSH.start(rhost, user, opts)
+          connect_ssh(rhost, user, opts)
         end
     rescue Rex::ConnectionError
       fail_with(Failure::Unknown, "#{peer} SSH - Connection error")

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -78,17 +78,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    opt_hash = ssh_client_defaults.merge({
+    opt_hash = {
       auth_methods: ['publickey'],
       port: rport,
       key_data: [ key_data ]
-    })
+    }
 
     opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(rhost, user, opt_hash)
+        ssh_socket = connect_ssh(rhost, user, opt_hash)
       end
     rescue Rex::ConnectionError
       return nil

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -78,11 +78,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    ssh_options = ssh_client_defaults.merge({
+    ssh_options = {
       auth_methods: ['publickey'],
       key_data: [ ssh_priv_key ],
       port: rport
-    })
+    }
 
     ssh_options.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, username, ssh_options)
+        ssh = connect_ssh(rhost, username, ssh_options)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
+++ b/modules/exploits/linux/ssh/microfocus_obr_shrboadmin.rb
@@ -84,18 +84,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
       password: pass
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, user, opts)
+        ssh = connect_ssh(rhost, user, opts)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -77,17 +77,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user)
-    opt_hash = ssh_client_defaults.merge({
+    opt_hash = {
       auth_methods: ['publickey'],
       port: rport,
       key_data: [ key_data ]
-    })
+    }
 
     opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(rhost, user, opt_hash)
+        ssh_socket = connect_ssh(rhost, user, opt_hash)
       end
     rescue Rex::ConnectionError
       return nil

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -80,18 +80,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
       password: pass
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, user, opts)
+        ssh = connect_ssh(rhost, user, opts)
       end
     rescue Rex::ConnectionError
       return nil

--- a/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
+++ b/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
@@ -79,11 +79,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['keyboard-interactive'],
       port: rport,
       password: password
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, username, opts)
+        ssh = connect_ssh(rhost, username, opts)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -72,18 +72,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, pass)
-    opts = ssh_client_defaults.merge({
+    opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
       password: pass
-    })
+    }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
 
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, user, opts)
+        ssh = connect_ssh(rhost, user, opts)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -76,16 +76,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login
-    opt_hash = ssh_client_defaults.merge({
+    opt_hash = {
       auth_methods: ['publickey'],
       port: rport,
       key_data: [ key_data ]
-    })
+    }
     opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(rhost, 'admin', opt_hash)
+        ssh_socket = connect_ssh(rhost, 'admin', opt_hash)
       end
     rescue Rex::ConnectionError
       return

--- a/modules/exploits/linux/ssh/vmware_vrni_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vrni_known_privkey.rb
@@ -112,16 +112,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(user, key_data)
-    opt_hash = ssh_client_defaults.merge({
+    opt_hash = {
       auth_methods: ['publickey'],
       port: rport,
       key_data: [ key_data ]
-    })
+    }
     opt_hash.merge!(verbose: :debug) if datastore['SSH_DEBUG']
     begin
       ssh_socket = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(rhost, user, opt_hash)
+        ssh_socket = connect_ssh(rhost, user, opt_hash)
       end
     rescue Rex::ConnectionError
       print_error "#{Rex::Socket.to_authority(rhost, rport)} SSH - Unable to connect"

--- a/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
+++ b/modules/exploits/linux/ssh/vyos_restricted_shell_privesc.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, username, opts)
+        ssh = connect_ssh(rhost, username, opts)
       end
     rescue Rex::ConnectionError
       return CheckCode::Unknown('Connection failed')
@@ -126,17 +126,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    factory = ssh_socket_factory
-
     opts = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: rport,
-      use_agent: false,
-      config: false,
-      password: password,
-      proxy: factory,
-      non_interactive: true,
-      verify_host_key: :never
+      password: password
     }
 
     opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
@@ -146,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, username, opts)
+        ssh = connect_ssh(rhost, username, opts)
       end
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{rhost}:#{rport} SSH - Connection error or address in use")
@@ -229,6 +222,17 @@ class MetasploitModule < Msf::Exploit::Remote
           channel.send_data("#{payload_cmd}\n")
           payload_executed = true
         end
+      end
+    end
+
+    begin
+      ssh.loop unless session_created?
+    rescue Errno::EBADF => e
+      elog(e)
+    end
+  end
+end
+ end
       end
     end
 

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -186,16 +186,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(ip, user, pass, port)
-    opt_hash = ssh_client_defaults.merge({
+    opt_hash = {
       auth_methods: ['password', 'keyboard-interactive'],
       port: port,
       password: pass
-    })
+    }
 
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 
     begin
-      self.ssh_socket = Net::SSH.start(ip, user, opt_hash)
+      self.ssh_socket = connect_ssh(ip, user, opt_hash)
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, 'Disconnected during negotiation')
     rescue Net::SSH::Disconnect, ::EOFError

--- a/modules/exploits/solaris/ssh/pam_username_bof.rb
+++ b/modules/exploits/solaris/ssh/pam_username_bof.rb
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Yeeting #{datastore['PAYLOAD']} at #{peer}")
 
     # Empty initial username
-    Net::SSH.start(rhost, '', ssh_client_opts)
+    connect_ssh(rhost, '', ssh_client_opts)
   rescue Net::SSH::AuthenticationFailed
     print_error(CheckCode::Safe.message)
   rescue Net::SSH::Disconnect

--- a/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
+++ b/modules/exploits/unix/http/schneider_electric_net55xx_encoder.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(datastore['RHOST'], 'root', opts)
+        ssh = connect_ssh(datastore['RHOST'], 'root', opts)
       end
     rescue Rex::ConnectionError
     rescue Net::SSH::Disconnect, ::EOFError

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        Net::SSH.start(rhost, username, opts)
+        connect_ssh(rhost, username, opts)
       end
     rescue Rex::ConnectionError
       return CheckCode::Safe('Connection failed')
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, username, opts)
+        ssh = connect_ssh(rhost, username, opts)
       end
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{rhost}:#{rport} SSH - Connection error or address in use")

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       ssh = nil
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh = Net::SSH.start(rhost, user, opts)
+        ssh = connect_ssh(rhost, user, opts)
       end
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{rhost}:#{rport} SSH - Connection error or address in use")

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
       :port => rport
     })
     options = Net::SSH::Config.for(rhost, Net::SSH::Config.default_files).merge(opts)
-    transport = Net::SSH::Transport::Session.new(rhost, options)
+    transport = connect_ssh_transport(rhost, options)
     connection = Net::SSH::Connection::Session.new(transport, options)
 
     return transport, connection

--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::SSH
   include Msf::Exploit::Powershell
   include Msf::Exploit::CmdStager
 
@@ -100,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Trying username '#{username}'")
     options[:username] = username
 
-    transport = Net::SSH::Transport::Session.new(datastore['RHOST'], options)
+    transport = connect_ssh_transport(datastore['RHOST'], options)
     auth = Net::SSH::Authentication::Session.new(transport, options)
     auth.authenticate("ssh-connection", username, options[:password])
     connection = Net::SSH::Connection::Session.new(transport, options)

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -194,14 +194,12 @@ class MetasploitModule < Msf::Exploit::Remote
     pass = rand_text_alpha(8)
     begin
       print_status("Sending malicious request to #{Rex::Socket.to_authority(rhost, rport)}...")
-      factory = ssh_socket_factory
-      ssh = Net::SSH.start(
+      ssh = connect_ssh(
         datastore['RHOST'],
         buf,
         password: pass,
         port: datastore['RPORT'],
         timeout: 1,
-        proxy: factory,
         config: false,
         non_interactive: true,
         verify_host_key: :never


### PR DESCRIPTION
This PR adds various new functions, with the goal to help auto update/populate the workspace:

- `connect_ssh()`
- `connect_ssh_transport()` 
- `grab_ssh_banner()`
- `report_ssh_host()` - `report_host()` & `report_note(ssh.cpe)` via Recog (same as FTP mixin)
- `report_ssh_hostkeys()` - `report_note(ssh.hostkey)`
- `report_ssh_service()` - `report_service()`
  - Also able to report_host(), when host is up but the service is down or incorrect

All modules to use `connect_ssh()` & `connect_ssh_transport()` were applicable.

Examples of this being used:

- https://github.com/rapid7/metasploit-framework/pull/21433
- https://github.com/rapid7/metasploit-framework/pull/21438
- https://github.com/rapid7/metasploit-framework/pull/21507
- https://github.com/rapid7/metasploit-framework/pull/21450
- https://github.com/rapid7/metasploit-framework/pull/21508
- https://github.com/rapid7/metasploit-framework/pull/21393

- - -

This is a little older demo

## Before

- Hosts: `10.0.0.10` (Metasploitable 2)
- Servies: Missing banner & parent
- Notes: 0

```console
$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
$ ./msfconsole -q -x 'workspace -D;
use auxiliary/scanner/ssh/ssh_enumusers;
set RHOSTS 10.0.0.10;
set USERNAME msfadmin;
run;'
[*] Deleted workspace: default
[*] Recreated the default workspace
[*] Setting default action Malformed Packet - view all 2 actions with the show actions command
RHOSTS => 10.0.0.10
USERNAME => msfadmin
[*] 10.0.0.10:22 - SSH - Using malformed packet technique
[*] 10.0.0.10:22 - SSH - Checking for false positives
[*] 10.0.0.10:22 - SSH - Starting scan
[+] 10.0.0.10:22 - SSH - User 'msfadmin' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      1      0      0

msf auxiliary(scanner/ssh/ssh_enumusers) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf auxiliary(scanner/ssh/ssh_enumusers) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  22    tcp    ssh   open         {}

msf auxiliary(scanner/ssh/ssh_enumusers) >
```

## After

- Hosts: OS info added
- Servies: SSH banner included & Added parent (matches other modules/mixins)
- Notes: 2x

```console
$ git checkout ssh_mixin
branch 'ssh_mixin' set up to track 'origin/ssh_mixin'.
Switched to a new branch 'ssh_mixin'
$ ./msfconsole -q -x 'workspace -D;
use auxiliary/scanner/ssh/ssh_enumusers;
set RHOSTS 10.0.0.10;
set USERNAME msfadmin;
run;'
[*] Deleted workspace: default
[*] Recreated the default workspace
[*] Setting default action Malformed Packet - view all 2 actions with the show actions command
RHOSTS => 10.0.0.10
USERNAME => msfadmin
[*] 10.0.0.10:22 - SSH - Using malformed packet technique
[*] 10.0.0.10:22 - SSH - Checking for false positives
[*] 10.0.0.10:22 - SSH - Starting scan
[+] 10.0.0.10:22 - SSH - User 'msfadmin' found
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_enumusers) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         0      1      0      2

msf auxiliary(scanner/ssh/ssh_enumusers) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux    Ubuntu     8.04   server

msf auxiliary(scanner/ssh/ssh_enumusers) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)
10.0.0.10  22    tcp    tcp   open                                          {}

msf auxiliary(scanner/ssh/ssh_enumusers) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type         Data
 ----                     ----       -------  ----  --------  ----         ----
 2026-05-19 06:30:57 UTC  10.0.0.10  ssh      22    tcp       ssh.cpe      {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}
 2026-05-19 06:30:57 UTC  10.0.0.10  ssh      22    tcp       ssh.hostkey  {:type=>"ssh-rsa", :fingerprint=>"SHA256:BQHm5EoHX9GCiOLuVscegPXLQOsuPs+E9d/rrJB84rk"}

msf auxiliary(scanner/ssh/ssh_enumusers) >
```